### PR TITLE
Remove all references to autogen.sh

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -8,7 +8,7 @@ Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2005 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
 Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 $COPYRIGHT$
 
@@ -205,17 +205,17 @@ NOTE: On MacOS/X, the default "libtool" program is different than the
    m4, Autoconf and Automake build and install very quickly; Libtool will
    take a minute or two.
 
-5. You can now run PMIx’s top-level "autogen.sh" script.  This script
+5. You can now run PMIx’s top-level "autogen.pl" script.  This script
    will invoke the GNU Autoconf, Automake, and Libtool commands in the
    proper order and setup to run PMIx's top-level "configure" script.
 
-   5a. You generally need to run autogen.sh only when the top-level
+   5a. You generally need to run autogen.pl only when the top-level
        file "configure.ac" changes, or any files in the config/ or
        <project>/config/ directories change (these directories are
        where a lot of "include" files for PMI’xs configure script
        live).
 
-   5b. You do *NOT* need to re-run autogen.sh if you modify a
+   5b. You do *NOT* need to re-run autogen.pl if you modify a
        Makefile.am.
 
 Use of Flex

--- a/INSTALL
+++ b/INSTALL
@@ -8,7 +8,7 @@ Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2005 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
 Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 $COPYRIGHT$
 
@@ -37,7 +37,7 @@ build PMIx.  You must then run:
 shell$ ./autogen.pl
 
 You will need very recent versions of GNU Autoconf, Automake, and
-Libtool.  If autogen.sh fails, read the HACKING file.  If anything
+Libtool.  If autogen.pl fails, read the HACKING file.  If anything
 else fails, read the HACKING file.  Finally, we suggest reading the
 HACKING file.
 

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -270,7 +270,7 @@ make_tarball() {
     #
     echo "*** Running autogen $autogen_args..."
     rm -f success
-    (./autogen.sh $autogen_args 2>&1 && touch success) | tee auto.out
+    (./autogen.pl $autogen_args 2>&1 && touch success) | tee auto.out
     if test ! -f success; then
         echo "Autogen failed.  Aborting"
         exit 1

--- a/contrib/nightly/create_tarball.sh
+++ b/contrib/nightly/create_tarball.sh
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -231,7 +231,7 @@ USER="pmixbuilder"
 export USER
 
 # autogen is our friend
-do_command "./autogen.sh"
+do_command "./autogen.pl"
 
 # do config
 CONFIG_FLAGS="--with-libevent=$LIBEVENT"

--- a/contrib/pmix_jenkins.sh
+++ b/contrib/pmix_jenkins.sh
@@ -195,19 +195,13 @@ if [ "$jenkins_test_build" = "yes" ]; then
     tar zxf libevent-2.0.22-stable.tar.gz
     cd libevent-2.0.22-stable
     libevent_dir=$PWD/install
-    ./autogen.sh && ./configure --prefix=$libevent_dir && make && make install
+    ./autogen.pl && ./configure --prefix=$libevent_dir && make && make install
 
     cd $WORKSPACE
-    if [ -x "autogen.sh" ]; then
-        autogen_script=./autogen.sh
-    else
-        autogen_script=./autogen.pl
-    fi
-
     configure_args="--with-libevent=$libevent_dir"
 
     # build pmix
-    $autogen_script
+    ./autogen.pl
     echo ./configure --prefix=$pmix_dir $configure_args | bash -xeE
     make $make_opt install
     jenkins_build_passed=1
@@ -270,7 +264,7 @@ if [ "$jenkins_test_src_rpm" = "yes" ]; then
 
     # check distclean
     make $make_opt distclean
-    $autogen_script
+    ./autogen.pl
     echo ./configure --prefix=$pmix_dir $configure_args | bash -xeE || exit 11
 
     if [ -x /usr/bin/dpkg-buildpackage ]; then
@@ -316,7 +310,7 @@ if [ -n "$JENKINS_RUN_TESTS" -a "$JENKINS_RUN_TESTS" -ne "0" ]; then
     rm -rf $run_tap
 
     # build pmix
-    $autogen_script
+    ./autogen.pl
     echo ./configure --prefix=$pmix_dir $configure_args --disable-visibility | bash -xeE
     make $make_opt install
 


### PR DESCRIPTION
There's never been a shell script for Autogen in PMIx -- it's always
been autogen.pl.  Update all references from autogen.sh to autogen.pl.

Follow-on to 69f929919813fe1facb13e80c686d791e5598f7d.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>