### PR TITLE
add python query_info client wrapper

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -51,6 +51,11 @@ def main():
     info = []
     rc = foo.unpublish(pykeys, info)
     print("unpublish result: ", foo.error_string(rc))
+    print("QUERY INFO")
+    pyq = [{'keys':[PMIX_QUERY_PSET_NAMES], 'qualifiers':[]}]
+    rc, pyresults = foo.query(pyq)
+    print("query info result: ", foo.error_string(rc))
+    print("pyresults: ", pyresults)
     # finalize
     info = []
     foo.finalize(info)


### PR DESCRIPTION
@rhc54 Getting segfault in pmix_query.c when no qualifiers are specified. I want to verify I am running query info correctly in the python client. I believe it should return a function not supported message if it is being called correctly. 

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>