### PR TITLE
add python query_info client wrapper

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -12,6 +12,7 @@ def main():
     if 0 != my_result:
         print("FAILED TO INIT")
         exit(1)
+
     # try putting something
     print("PUT")
     rc = foo.put(PMIX_GLOBAL, "mykey", {'value':1, 'val_type':PMIX_INT32})
@@ -41,16 +42,20 @@ def main():
     rc = foo.publish(info)
     print("Publish result: ", foo.error_string(rc))
     rc = foo.fence(procs, info)
-    #time.sleep(2)
     pdata_key = [{'key':'ARBITRARY'}]
     rc,pdata = foo.lookup(pdata_key, None)
-    #rc = foo.lookup(pdata_key, None)
-    print("rc lookup: ", rc)
-    print("pdata lookup: ", pdata)
+    rc = foo.lookup(pdata_key, None)
+    print("lookup result: ", rc, pdata)
     pykeys = ['ARBITRARY']
     info = []
     rc = foo.unpublish(pykeys, info)
     print("unpublish result: ", foo.error_string(rc))
+    rc = foo.fence(procs, info)
+    print("QUERY INFO")
+    pyq = [{'keys':[PMIX_QUERY_PSET_NAMES], 'qualifiers':[]}]
+    rc, pyresults = foo.query(pyq)
+    print("query info result: ", foo.error_string(rc))
+    print("pyresults: ", pyresults)
     # finalize
     info = []
     foo.finalize(info)

--- a/bindings/python/sched.py
+++ b/bindings/python/sched.py
@@ -77,6 +77,25 @@ def clientlookup(proc:dict, keys:list, directives:list):
     # return rc and pdata
     return ret_pdata, PMIX_SUCCESS
 
+def query(proc:dict, queries:list):
+    print("SERVER: QUERY")
+    # return a python info list of dictionaries
+    info = {}
+    results = []
+    # find key we passed in to client, and
+    # if it matches return fake PSET_NAME
+    # since RM actually assigns this, we
+    # just return arbitrary name if key is
+    # found
+    find_str = 'pmix.qry.psets'
+    for q in queries:
+        print("Q in server.py QUERY: ", q)
+        for k in q['keys']:
+            if k == find_str:
+                info = {'key': find_str, 'value': 'PSET_NAME', 'val_type': PMIX_STRING}
+                results.append(info)
+    return PMIX_ERR_NOT_FOUND, results
+
 def main():
     try:
         foo = PMIxServer()
@@ -90,7 +109,8 @@ def main():
            'fencenb': clientfence,
            'publish': clientpublish,
            'unpublish': clientunpublish,
-           'lookup': clientlookup}
+           'lookup': clientlookup,
+           'query': query}
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")
     rc = foo.initialized()


### PR DESCRIPTION
Add query client wrapper, and server
module function. This also adds NULL
terminator to pmix_load_argv, and
the alloc_info function was removed.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>