### PR TITLE
Define finer-grained proc type flags

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1406,7 +1406,7 @@ typedef struct pmix_proc {
 #define PMIX_PROC_LOAD(m, n, r)                             \
     do {                                                    \
         PMIX_PROC_CONSTRUCT((m));                           \
-        pmix_strncpy((m)->nspace, (n), PMIX_MAX_NSLEN);    \
+        pmix_strncpy((char*)(m)->nspace, (n), PMIX_MAX_NSLEN);    \
         (m)->rank = (r);                                    \
     } while(0)
 
@@ -1416,9 +1416,9 @@ typedef struct pmix_proc {
         memset((t), 0, PMIX_MAX_NSLEN+1);                                   \
         _len = strlen((c));                                                 \
         if ((_len + strlen((n))) < PMIX_MAX_NSLEN) {                        \
-            pmix_strncpy((t), (c), PMIX_MAX_NSLEN);                         \
+            pmix_strncpy((char*)(t), (c), PMIX_MAX_NSLEN);                         \
             (t)[_len] = ':';                                                \
-            pmix_strncpy(&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);         \
+            pmix_strncpy((char*)&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);         \
         }                                                                   \
     } while(0)
 
@@ -1692,7 +1692,7 @@ typedef struct pmix_info {
 #define PMIX_INFO_LOAD(m, k, v, t)                          \
     do {                                                    \
         if (NULL != (k)) {                                  \
-            pmix_strncpy((m)->key, (k), PMIX_MAX_KEYLEN);   \
+            pmix_strncpy((char*)(m)->key, (k), PMIX_MAX_KEYLEN);   \
         }                                                   \
         (m)->flags = 0;                                     \
         pmix_value_load(&((m)->value), (v), (t));           \
@@ -1700,7 +1700,7 @@ typedef struct pmix_info {
 #define PMIX_INFO_XFER(d, s)                                        \
     do {                                                            \
         if (NULL != (s)->key) {                                     \
-            pmix_strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);      \
+            pmix_strncpy((char*)(d)->key, (s)->key, PMIX_MAX_KEYLEN);      \
         }                                                           \
         (d)->flags = (s)->flags;                                    \
         pmix_value_xfer(&(d)->value, (pmix_value_t*)&(s)->value);   \
@@ -1781,9 +1781,9 @@ typedef struct pmix_pdata {
     do {                                                                    \
         if (NULL != (m)) {                                                  \
             memset((m), 0, sizeof(pmix_pdata_t));                           \
-            pmix_strncpy((m)->proc.nspace, (p)->nspace, PMIX_MAX_NSLEN);    \
+            pmix_strncpy((char*)(m)->proc.nspace, (p)->nspace, PMIX_MAX_NSLEN);    \
             (m)->proc.rank = (p)->rank;                                     \
-            pmix_strncpy((m)->key, (k), PMIX_MAX_KEYLEN);                   \
+            pmix_strncpy((char*)(m)->key, (k), PMIX_MAX_KEYLEN);                   \
             pmix_value_load(&((m)->value), (v), (t));                       \
         }                                                                   \
     } while (0)
@@ -1792,9 +1792,9 @@ typedef struct pmix_pdata {
     do {                                                                        \
         if (NULL != (d)) {                                                      \
             memset((d), 0, sizeof(pmix_pdata_t));                               \
-            pmix_strncpy((d)->proc.nspace, (s)->proc.nspace, PMIX_MAX_NSLEN);   \
+            pmix_strncpy((char*)(d)->proc.nspace, (s)->proc.nspace, PMIX_MAX_NSLEN);   \
             (d)->proc.rank = (s)->proc.rank;                                    \
-            pmix_strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);                  \
+            pmix_strncpy((char*)(d)->key, (s)->key, PMIX_MAX_KEYLEN);                  \
             pmix_value_xfer(&((d)->value), &((s)->value));                      \
         }                                                                       \
     } while (0)

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -449,7 +449,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
     if (0 < pmix_globals.init_cntr ||
-        (NULL != pmix_globals.mypeer && PMIX_PROC_IS_SERVER(pmix_globals.mypeer))) {
+        (NULL != pmix_globals.mypeer && PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
         /* since we have been called before, the nspace and
          * rank should be known. So return them here if
          * requested */
@@ -1215,7 +1215,7 @@ static void _commitfn(int sd, short args, void *cbdata)
     }
 
     /* if we are a server, or we aren't connected, don't attempt to send */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_SUCCESS;  // not an error
     }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -732,8 +732,8 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     /* if we got here, then we don't have the data for this proc. If we
      * are a server, or we are a client and not connected, then there is
      * nothing more we can do */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) ||
-        (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+        (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected)) {
         rc = PMIX_ERR_NOT_FOUND;
         goto respond;
     }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -81,7 +81,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected && !PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+    if (!pmix_globals.connected && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_UNREACH;
     }
@@ -143,7 +143,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     /* if we aren't connected, don't attempt to send */
     if (!pmix_globals.connected) {
         /* if I am a tool, we default to local fork/exec */
-        if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
             forkexec = true;
         } else {
             PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -793,7 +793,7 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_SERVER_ATTRIBUTES)) {
                 /* if I am a server, add in my attrs */
-                if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                     _get_attrs(&kyresults, &cd->queries[n].qualifiers[m], &server_attrs);
                  } else {
                     /* we need to ask our server for them */
@@ -804,7 +804,7 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_SERVER_FUNCTIONS)) {
                 /* if I am a server, add in my fns */
-                if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                     _get_fns(&kyresults, &cd->queries[n].qualifiers[m], &server_attrs);
                  } else {
                     /* we need to ask our server for them */
@@ -814,20 +814,20 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
             }
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_TOOL_ATTRIBUTES)) {
-                if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
                     _get_attrs(&kyresults, &cd->queries[n].qualifiers[m], &tool_attrs);
                 }
             }
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_TOOL_FUNCTIONS)) {
-                if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
                     _get_fns(&kyresults, &cd->queries[n].qualifiers[m], &tool_attrs);
                 }
             }
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_HOST_ATTRIBUTES)) {
                 /* if I am a server, add in the host's */
-                if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                     _get_attrs(&kyresults, &cd->queries[n].qualifiers[m], &host_attrs);
                 } else {
                     /* we need to ask our server for them */
@@ -838,7 +838,7 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
             if (NULL == cd->queries[n].qualifiers ||
                 PMIX_CHECK_KEY(&cd->queries[n].qualifiers[m], PMIX_HOST_FUNCTIONS)) {
                 /* if I am a server, add in the host's */
-                if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+                if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                     _get_fns(&kyresults, &cd->queries[n].qualifiers[m], &host_attrs);
                 } else {
                     /* we need to ask our server for them */

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -202,8 +202,8 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_
 
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.job_control) {
             /* nothing we can do */
@@ -366,8 +366,8 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
 
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.monitor) {
             /* nothing we can do */

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,7 +85,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
         return pmix_globals.mypeer;
     }
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         /* see if we know this proc */
         for (i=0; i < pmix_server_globals.clients.size; i++) {
             if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -108,8 +108,8 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
     }
 
     /* if we are a server, we cannot do this */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
@@ -401,8 +401,8 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
 
     /* if we are not a server, then we send the provided
      * data to our server for processing */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) ||
-        PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         msg = PMIX_NEW(pmix_buffer_t);
         if (NULL == msg) {
             return PMIX_ERR_NOMEM;

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -160,8 +160,8 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
 
     /* if we are a client or tool, we never do this ourselves - we
      * always pass this request to our server for execution */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* if we aren't connected, don't attempt to send */
         if (!pmix_globals.connected) {
             PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -370,8 +370,8 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
   query:
     /* if we are the server, then we just issue the query and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.query) {
             /* nothing we can do */
@@ -532,8 +532,8 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.allocate) {
             /* nothing we can do */

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -170,8 +170,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_
     }
 
     /* if we are the server */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         /* if the host doesn't support this operation,
          * see if we can generate it ourselves */
@@ -399,8 +399,8 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *
     }
 
     /* if we are the server */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         /* if the host doesn't support this operation,
          * see if we can validate it ourselves */

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -200,7 +200,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
                              (p)->info->pname.rank);                                    \
             /* if I'm a client or tool and this is my server, then we don't */          \
             /* set the targets - otherwise, we do */                                    \
-            if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&                            \
+            if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&                            \
                 !PMIX_CHECK_PROCID(&pmix_client_globals.myserver->info->pname,          \
                                   &(p)->info->pname)) {                                 \
                 PMIX_PROC_CREATE(ch->targets, 1);                                       \

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -51,8 +51,8 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
         return PMIX_ERR_INIT;
     }
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
 
         pmix_output_verbose(2, pmix_server_globals.event_output,
@@ -1271,8 +1271,8 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg)
     pmix_list_remove_item(&pmix_globals.cached_events, &ch->super);
 
     /* process this event thru the regular channels */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         pmix_server_notify_client_of_event(ch->status, &ch->source,
                                            ch->range, ch->info, ch->ninfo,
                                            ch->final_cbfunc, ch->final_cbdata);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -314,9 +314,9 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
      * type with our server, or if we have directives, then we need to notify
      * the server - however, don't do this for a v1 server as the event
      * notification system there doesn't work */
-    if ((!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) || PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) &&
+    if ((!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) || PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) &&
         pmix_globals.connected &&
-        !PMIX_PROC_IS_V1(pmix_client_globals.myserver) &&
+        !PMIX_PEER_IS_V1(pmix_client_globals.myserver) &&
        (need_register || 0 < pmix_list_get_size(xfer))) {
         pmix_output_verbose(2, pmix_client_globals.event_output,
                             "pmix: _add_hdlr sending to server");
@@ -336,8 +336,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
 
     /* if we are a server and are registering for events, then we only contact
      * our host if we want environmental events */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer) && cd->enviro &&
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) && cd->enviro &&
         NULL != pmix_host_server.register_events) {
         pmix_output_verbose(2, pmix_client_globals.event_output,
                             "pmix: _add_hdlr registering with server");
@@ -944,7 +944,7 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
 
     /* if I am not the server, and I am connected, then I need
      * to notify the server to remove my registration */
-    if ((!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) || PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) &&
+    if ((!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) || PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) &&
         pmix_globals.connected) {
         msg = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -172,7 +172,11 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_rank_info_t,
 
 static void pcon(pmix_peer_t *p)
 {
-    p->proc_type = PMIX_PROC_UNDEF;
+    p->proc_type.type = PMIX_PROC_UNDEF;
+    p->proc_type.major = 255;
+    p->proc_type.minor = 255;
+    p->proc_type.revision = 255;
+    p->proc_type.padding = 0;
     p->protocol = PMIX_PROTOCOL_UNDEF;
     p->finalized = false;
     p->info = NULL;

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -89,7 +89,6 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
         *num_vals = 0;
         /* don't error log here as the user may be unpacking past
          * the end of the buffer, which isn't necessarily an error */
-        PMIX_ERROR_LOG(rc);
         return rc;
     }
 

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -516,7 +516,7 @@ static int _esh_session_init(pmix_common_dstore_ctx_t *ds_ctx, size_t idx, ns_ma
     s->jobuid = jobuid;
     s->nspace_path = strdup(ds_ctx->base_path);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         if (0 != mkdir(s->nspace_path, 0770)) {
             if (EEXIST != errno) {
                 pmix_output(0, "session init: can not create session directory \"%s\": %s",
@@ -568,7 +568,7 @@ static void _esh_session_release(pmix_common_dstore_ctx_t *ds_ctx, size_t idx)
     ds_ctx->lock_cbs->finalize(&_ESH_SESSION_lock(ds_ctx->session_array, idx));
 
     if (NULL != s->nspace_path) {
-        if(PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
             _esh_dir_del(s->nspace_path);
         }
         free(s->nspace_path);
@@ -651,7 +651,7 @@ static int _update_ns_elem(pmix_common_dstore_ctx_t *ds_ctx, ns_track_elem_t *ns
 
     /* synchronize number of meta segments for the target namespace. */
     for (i = ns_elem->num_meta_seg; i < info->num_meta_seg; i++) {
-        if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
             seg = pmix_common_dstor_create_new_segment(PMIX_DSTORE_NS_META_SEGMENT, ds_ctx->base_path,
                                                        info->ns_map.name, i, ds_ctx->jobuid,
                                                        ds_ctx->setjobuid);
@@ -686,7 +686,7 @@ static int _update_ns_elem(pmix_common_dstore_ctx_t *ds_ctx, ns_track_elem_t *ns
     }
     /* synchronize number of data segments for the target namespace. */
     for (i = ns_elem->num_data_seg; i < info->num_data_seg; i++) {
-        if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
             seg = pmix_common_dstor_create_new_segment(PMIX_DSTORE_NS_DATA_SEGMENT, ds_ctx->base_path,
                                                        info->ns_map.name, i, ds_ctx->jobuid,
                                                        ds_ctx->setjobuid);
@@ -1593,7 +1593,7 @@ pmix_common_dstore_ctx_t *pmix_common_dstor_init(const char *ds_name, pmix_info_
     ds_ctx->ds_name = strdup(ds_name);
 
     /* find the temp dir */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         ds_ctx->session_map_search = (session_map_search_fn_t)_esh_session_map_search_server;
 
         /* scan incoming info for directives */
@@ -1764,7 +1764,7 @@ PMIX_EXPORT void pmix_common_dstor_finalize(pmix_common_dstore_ctx_t *ds_ctx)
     pmix_pshmem.finalize();
 
     if (NULL != ds_ctx->base_path){
-        if(PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
             /* coverity[toctou] */
             if (lstat(ds_ctx->base_path, &st) >= 0){
                 if (PMIX_SUCCESS != (rc = _esh_dir_del(ds_ctx->base_path))) {
@@ -1881,7 +1881,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store(pmix_common_dstore_ctx_t *ds_c
                         "[%s:%d] gds: dstore store for key '%s' scope %d",
                         proc->nspace, proc->rank, kv->key, scope);
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         rc = PMIX_ERR_NOT_SUPPORTED;
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -1968,7 +1968,7 @@ static pmix_status_t _dstore_fetch(pmix_common_dstore_ctx_t *ds_ctx,
                          __FILE__, __LINE__, __func__, nspace, rank, key));
 
     /* protect info of dstore segments before it will be updated */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         if (0 != (rc = pthread_mutex_lock(&ds_ctx->lock))) {
             goto error;
         }
@@ -2691,7 +2691,7 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
     }
 
     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-        if ((PMIX_PROC_IS_V1(_client_peer(ds_ctx)) || PMIX_PROC_IS_V20(_client_peer(ds_ctx))) &&
+        if ((PMIX_PEER_IS_V1(_client_peer(ds_ctx)) || PMIX_PEER_IS_V20(_client_peer(ds_ctx))) &&
            0 != strncmp("pmix.", kv->key, 4) &&
            kv->value->type == PMIX_DATA_ARRAY) {
             pmix_info_t *info;

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -33,7 +33,7 @@ static pmix_status_t ds12_init(pmix_info_t info[], size_t ninfo)
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_common_dstore_file_cbs_t *dstore_file_cbs = NULL;
 
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         dstore_file_cbs = &pmix_ds20_file_module;
     }
     ds12_ctx = pmix_common_dstor_init("ds12", info, ninfo,
@@ -94,7 +94,7 @@ static pmix_status_t ds12_cache_job_info(struct pmix_namespace_t *ns,
 static pmix_status_t ds12_register_job_info(struct pmix_peer_t *pr,
                                             pmix_buffer_t *reply)
 {
-    if (PMIX_PROC_IS_V1(pr)) {
+    if (PMIX_PEER_IS_V1(pr)) {
         ds12_ctx->file_cbs = &pmix_ds12_file_module;
     } else {
         ds12_ctx->file_cbs = &pmix_ds20_file_module;

--- a/src/mca/gds/ds12/gds_ds12_component.c
+++ b/src/mca/gds/ds12/gds_ds12_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -75,7 +75,7 @@ static int component_open(void)
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     /* launchers cannot use the dstore */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         *priority = 0;
         *module = NULL;
         return PMIX_ERROR;

--- a/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -112,7 +112,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
     PMIX_OUTPUT_VERBOSE((10, pmix_gds_base_framework.framework_output,
         "%s:%d:%s _lockfile_name: %s", __FILE__, __LINE__, __func__, lock_ctx->lockfile));
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         lock_ctx->lockfd = open(lock_ctx->lockfile, O_CREAT | O_RDWR | O_EXCL, 0600);
 
         /* if previous launch was crashed, the lockfile might not be deleted and unlocked,
@@ -157,7 +157,7 @@ error:
         }
         if (0 > lock_ctx->lockfd) {
             close(lock_ctx->lockfd);
-            if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+            if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                 unlink(lock_ctx->lockfile);
             }
         }
@@ -180,7 +180,7 @@ void pmix_ds12_lock_finalize(pmix_common_dstor_lock_ctx_t *lock_ctx)
 
     close(fcntl_lock->lockfd);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         unlink(fcntl_lock->lockfile);
     }
     free(fcntl_lock);

--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -105,7 +105,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
     PMIX_OUTPUT_VERBOSE((10, pmix_gds_base_framework.framework_output,
         "%s:%d:%s _lockfile_name: %s", __FILE__, __LINE__, __func__, lock_ctx->lockfile));
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         if (PMIX_SUCCESS != (rc = pmix_pshmem.segment_create(lock_ctx->segment,
                                             lock_ctx->lockfile, size))) {
             PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/ds21/gds_ds21_component.c
+++ b/src/mca/gds/ds21/gds_ds21_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -75,7 +75,7 @@ static int component_open(void)
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     /* launchers cannot use the dstore */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         *priority = 0;
         *module = NULL;
         return PMIX_ERROR;

--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +88,7 @@ static void ncon(lock_item_t *p) {
 static void ldes(lock_item_t *p) {
     uint32_t i;
 
-    if(PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         segment_hdr_t *seg_hdr = (segment_hdr_t *)p->seg_desc->seg_info.seg_base_addr;
         if (p->lockfile) {
             unlink(p->lockfile);
@@ -150,7 +150,7 @@ pmix_status_t pmix_gds_ds21_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
     PMIX_OUTPUT_VERBOSE((10, pmix_gds_base_framework.framework_output,
         "%s:%d:%s local_size %d", __FILE__, __LINE__, __func__, local_size));
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         size_t seg_align_size;
         size_t seg_hdr_size;
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1380,8 +1380,8 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     pmix_status_t rc;
     pmix_job_t *trk, *t2;
 
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* this function is only available on servers */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
@@ -1406,7 +1406,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
         }
         /* now see if we have delivered it to all our local
          * clients for this nspace */
-        if (!PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer) && ns->ndelivered == ns->nlocalprocs) {
+        if (!PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) && ns->ndelivered == ns->nlocalprocs) {
             /* we have, so let's get rid of the packed
              * copy of the data */
             PMIX_RELEASE(ns->jobbkt);
@@ -1456,7 +1456,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     if (PMIX_SUCCESS == rc) {
         /* if we have more than one local client for this nspace,
          * save this packed object so we don't do this again */
-        if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer) || 1 < ns->nlocalprocs) {
+        if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) || 1 < ns->nlocalprocs) {
             PMIX_RETAIN(reply);
             ns->jobbkt = reply;
         }
@@ -1490,8 +1490,8 @@ static pmix_status_t hash_store_job_info(const char *nspace,
                         "[%s:%u] pmix:gds:hash store job info for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, nspace);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* this function is NOT available on servers */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
@@ -2727,7 +2727,7 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc,
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
     pmix_kval_t *kv;
 
-    if (!PMIX_PROC_IS_V1(cd->peer)) {
+    if (!PMIX_PEER_IS_V1(cd->peer)) {
         PMIX_BFROPS_PACK(rc, cd->peer, buf, proc, 1, PMIX_PROC);
         if (PMIX_SUCCESS != rc) {
             return rc;

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,7 +83,7 @@ static pmix_status_t mylog(const pmix_proc_t *source,
     }
 
     /* if we are not a gateway, then we don't handle this */
-    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 

--- a/src/mca/plog/syslog/plog_syslog.c
+++ b/src/mca/plog/syslog/plog_syslog.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,7 +129,7 @@ static pmix_status_t mylog(const pmix_proc_t *source,
             }
         } else if (0 == strncmp(data[n].key, PMIX_LOG_GLOBAL_SYSLOG, PMIX_MAX_KEYLEN)) {
             /* only do this if we are a gateway server */
-            if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+            if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
                 rc = write_local(source, timestamp, pri, data[n].value.data.string, data, ndata);
                 if (PMIX_SUCCESS == rc) {
                     /* flag that we did this one */

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -56,7 +56,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
     if (NULL == nspace || NULL == ilist) {
         return PMIX_ERR_BAD_PARAM;
     }
-    if (PMIX_PROC_IS_SCHEDULER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
         nptr = NULL;
         /* find this nspace - note that it may not have
          * been registered yet */

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -641,7 +641,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
   query:
 #if 0
 #if PMIX_WANT_OPAMGT
-    if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         /* collect the switch information from the FM */
         OMGT_STATUS_T status = OMGT_STATUS_SUCCESS;
         struct omgt_port * port = NULL;
@@ -679,7 +679,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
 #else  // have_hwloc
 #if 0
 #if PMIX_WANT_OPAMGT
-    if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         /* query the FM for the inventory */
     }
 

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -200,7 +200,7 @@ static pmix_status_t tcp_init(void)
 
     /* if we are not the "gateway", then there is nothing
      * for us to do */
-    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return PMIX_SUCCESS;
     }
 
@@ -258,7 +258,7 @@ static void tcp_finalize(void)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet: tcp finalize");
-    if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         PMIX_LIST_DESTRUCT(&allocations);
         PMIX_LIST_DESTRUCT(&available);
     }
@@ -320,7 +320,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
 
     /* if I am not the gateway, then ignore this call - should never
      * happen, but check to be safe */
-    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return PMIX_SUCCESS;
     }
 
@@ -856,7 +856,7 @@ static void deregister_nspace(pmix_namespace_t *nptr)
 
     /* if we are not the "gateway", then there is nothing
      * for us to do */
-    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return;
     }
 

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -534,7 +534,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
 
     /* if I am not the scheduler, then ignore this call - should never
      * happen, but check to be safe */
-    if (!PMIX_PROC_IS_SCHEDULER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
         return PMIX_SUCCESS;
     }
 

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -43,6 +43,7 @@
 #include "src/mca/base/pmix_mca_base_framework.h"
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"
+#include "src/mca/ptl/ptl_types.h"
 #include "src/mca/ptl/base/base.h"
 
 /*
@@ -209,7 +210,11 @@ static void pccon(pmix_pending_connection_t *p)
     p->gds = NULL;
     p->ptl = NULL;
     p->cred = NULL;
-    p->proc_type = PMIX_PROC_UNDEF;
+    p->proc_type.type = PMIX_PROC_UNDEF;
+    p->proc_type.major = 255;
+    p->proc_type.minor = 255;
+    p->proc_type.revision = 255;
+    p->proc_type.padding = 0;
 }
 static void pcdes(pmix_pending_connection_t *p)
 {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -88,8 +88,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     }
     CLOSE_THE_SOCKET(peer->sd);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
          * we properly account for the loss of this client
          * from any local collectives in which it was
@@ -186,7 +186,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         /* purge any notifications cached for this client */
         pmix_server_purge_events(peer, NULL);
 
-        if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
             /* only connection I can lose is to my server, so mark it */
             pmix_globals.connected = false;
         } else {
@@ -194,7 +194,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
             pmix_psensor.stop(peer, NULL);
         }
 
-        if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer) && !pmix_globals.mypeer->finalized) {
+        if (!peer->finalized && !PMIX_PEER_IS_TOOL(peer) && !pmix_globals.mypeer->finalized) {
             /* if this peer already called finalize, then
              * we are just seeing their connection go away
              * when they terminate - so do not generate

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -151,12 +151,13 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
 
     /* if I am a client, then we need to look for the appropriate
      * connection info in the environment */
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         if (NULL != (evar = getenv("PMIX_SERVER_URI4"))) {
-            /* we are talking to a v3 server */
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V3;
+            /* we are talking to a v4 server */
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+            PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, 4);
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "V3 SERVER DETECTED");
+                                "V4 SERVER DETECTED");
             /* must use the v3 bfrops module */
             pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
             if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
@@ -164,7 +165,8 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             }
         } else if (NULL != (evar = getenv("PMIX_SERVER_URI3"))) {
             /* we are talking to a v3 server */
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V3;
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+            PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, 3);
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "V3 SERVER DETECTED");
             /* must use the v3 bfrops module */
@@ -174,7 +176,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             }
         } else if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
             /* we are talking to a v2.1 server */
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V21;
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+            PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, 2);
+            PMIX_SET_PEER_MINOR(pmix_client_globals.myserver, 1);
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "V21 SERVER DETECTED");
             /* must use the v21 bfrops module */
@@ -184,7 +188,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             }
         } else if (NULL != (evar = getenv("PMIX_SERVER_URI2"))) {
             /* we are talking to a v2.0 server */
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V20;
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+            PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, 2);
+            PMIX_SET_PEER_MINOR(pmix_client_globals.myserver, 0);
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "V20 SERVER DETECTED");
             /* must use the v20 bfrops module */
@@ -304,7 +310,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     pmix_list_append(&ilist, &kv->super);
 
     /* if I am a launcher, tell them so */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         kv = PMIX_NEW(pmix_info_caddy_t);
         PMIX_INFO_LOAD(&launcher, PMIX_LAUNCHER, NULL, PMIX_BOOL);
         kv->info = &launcher;
@@ -610,7 +616,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
 
     /* tools setup their server info in try_connect because they
      * utilize a broader handshake */
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         /* setup the server info */
         if (NULL == pmix_client_globals.myserver->info) {
             pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
@@ -733,12 +739,12 @@ static pmix_status_t parse_uri_file(char *filename,
                                     pmix_rank_t *rank)
 {
     FILE *fp;
-    char *srvr, *p, *p2;
+    char *srvr, *p, *p2, *p3;
     pmix_lock_t lock;
     pmix_event_t ev;
     struct timeval tv;
     int retries;
-    int major;
+    int major, minor, revision;
 
     fp = fopen(filename, "r");
     if (NULL == fp) {
@@ -787,27 +793,29 @@ static pmix_status_t parse_uri_file(char *filename,
     /* see if this file contains the server's version */
     p2 = pmix_getline(fp);
     if (NULL == p2) {
-        pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V20;
+        PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+        PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, 2);
+        PMIX_SET_PEER_MINOR(pmix_client_globals.myserver, 0);
         pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "V20 SERVER DETECTED");
     } else {
         /* convert the version to a number */
         if ('v' == p2[0]) {
-            major = strtoul(&p2[1], NULL, 10);
+            major = strtoul(&p2[1], &p3, 10);
         } else {
-            major = strtoul(p2, NULL, 10);
+            major = strtoul(p2, &p3, 10);
         }
-        if (2 == major) {
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V21;
+        minor = strtoul(p3, &p3, 10);
+        revision = strtoul(p3, NULL, 10);
+        PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
+        PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, major);
+        PMIX_SET_PEER_MINOR(pmix_client_globals.myserver, minor);
+        PMIX_SET_PEER_REVISION(pmix_client_globals.myserver, revision);
+        if (2 <= major) {
             pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "V21 SERVER DETECTED");
-        } else if (3 <= major) {
-            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V3;
-            pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
-            pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "V3 SERVER DETECTED");
+                                "V2 PROTOCOL SERVER DETECTED");
         }
     }
     if (NULL != p2) {
@@ -974,8 +982,8 @@ static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
                         "pmix:tcp SEND CONNECT ACK");
 
     /* if we are a server, then we shouldn't be here */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
     }
@@ -1013,8 +1021,8 @@ static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
      * 7 => self-started launcher that was given an identifier by caller
      * 8 => launcher that was started by a PMIx server - identifier specified by server
      */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
-        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
             /* if we are both launcher and client, then we need
              * to tell the server we are both */
             flag = 8;
@@ -1035,8 +1043,8 @@ static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
             }
         }
 
-    } else if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer) &&
-               !PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+    } else if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
+               !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         /* we are a simple client */
         flag = 0;
         /* reserve space for our nspace and rank info */
@@ -1045,7 +1053,7 @@ static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
     } else {  // must be a tool of some sort
         /* add space for our uid/gid for ACL purposes */
         sdsize += 2*sizeof(uint32_t);
-        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+        if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
             /* if we are both tool and client, then we need
              * to tell the server we are both */
             flag = 5;

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -151,7 +151,7 @@ pmix_status_t component_close(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
-    if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
     *module = (pmix_mca_base_module_t*)&pmix_ptl_usock_module;
@@ -185,7 +185,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
                         "ptl:usock setup_listener");
 
     /* if we are not a server, then we shouldn't be doing this */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -592,24 +592,11 @@ static void connection_handler(int sd, short args, void *cbdata)
         goto error;
     }
     /* mark it as being a client of the correct type */
-    if (1 == major) {
-        psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V1;
-    } else if (2 == major && 0 == minor) {
-        psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V20;
-    } else if (2 == major && 1 == minor) {
-        psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V21;
-    } else if (3 == major) {
-        psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V3;
-    } else {
-        /* we don't recognize this version */
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "connection request from client of unrecognized version %s", version);
-        free(msg);
-        PMIX_RELEASE(psave);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        return;
-    }
+    PMIX_SET_PROC_TYPE(&psave->proc_type, PMIX_PROC_CLIENT);
+    PMIX_SET_PROC_MAJOR(&psave->proc_type, major);
+    PMIX_SET_PROC_MINOR(&psave->proc_type, minor);
+    PMIX_SET_PROC_REVISION(&psave->proc_type, rel);
+
     /* save the protocol */
     psave->protocol = pnd->protocol;
     /* add the nspace tracker */

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -96,7 +96,7 @@ static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel,
 }
 
 
-int pmix_rte_init(pmix_proc_type_t type,
+int pmix_rte_init(uint32_t type,
                   pmix_info_t info[], size_t ninfo,
                   pmix_ptl_cbfunc_t cbfunc)
 {
@@ -250,7 +250,10 @@ int pmix_rte_init(pmix_proc_type_t type,
         goto return_error;
     }
     /* whatever our declared proc type, we are definitely v3.0 */
-    pmix_globals.mypeer->proc_type = type | PMIX_PROC_V3;
+    PMIX_SET_PEER_TYPE(pmix_globals.mypeer, type);
+    PMIX_SET_PEER_MAJOR(pmix_globals.mypeer, PMIX_VERSION_MAJOR);
+    PMIX_SET_PEER_MINOR(pmix_globals.mypeer, PMIX_VERSION_MINOR);
+    PMIX_SET_PEER_REVISION(pmix_globals.mypeer, PMIX_VERSION_RELEASE);
     /* create an nspace object for ourselves - we will
      * fill in the nspace name later */
     pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,7 +59,7 @@ extern const char pmix_version_string[];
  * @retval PMIX_ERROR Upon failure.
  *
  */
-PMIX_EXPORT pmix_status_t pmix_rte_init(pmix_proc_type_t type,
+PMIX_EXPORT pmix_status_t pmix_rte_init(uint32_t type,
                                         pmix_info_t info[], size_t ninfo,
                                         pmix_ptl_cbfunc_t cbfunc);
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -730,7 +730,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                 PMIX_DESTRUCT(&cb);
                 return rc;
             }
-            if (PMIX_PROC_IS_V1(cd->peer)) {
+            if (PMIX_PEER_IS_V1(cd->peer)) {
                 /* if the client is using v1, then it expects the
                  * data returned to it as the rank followed by abyte object containing
                  * a buffer - so we have to do a little gyration */
@@ -768,7 +768,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
 
     /* retrieve the data for the specific rank they are asking about */
     if (PMIX_RANK_WILDCARD != rank) {
-        if (!PMIX_PROC_IS_SERVER(peer) && 0 == peer->commit_cnt) {
+        if (!PMIX_PEER_IS_SERVER(peer) && 0 == peer->commit_cnt) {
             /* this condition works only for local requests, server does
              * count commits for local ranks, and check this count when
              * local request.
@@ -803,7 +803,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                 PMIX_DESTRUCT(&cb);
                 return rc;
             }
-            if (PMIX_PROC_IS_V1(cd->peer)) {
+            if (PMIX_PEER_IS_V1(cd->peer)) {
                 /* if the client is using v1, then it expects the
                  * data returned to it in a different order than v2
                  * - so we have to do a little gyration */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1582,7 +1582,7 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
          * as we need the nspace of the spawned application! */
     }
     /* add the directive to the end */
-    if (PMIX_PROC_IS_TOOL(peer)) {
+    if (PMIX_PEER_IS_TOOL(peer)) {
         PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_REQUESTOR_IS_TOOL, NULL, PMIX_BOOL);
         /* if the requestor is a tool, we default to forwarding all
          * output IO channels */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -298,7 +298,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
 
     /* parse the input directives */
     gdsfound = false;
-    ptype = PMIX_PROC_TOOL;
+    PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_TOOL);
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {
@@ -326,7 +326,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                 fwd_stdin = PMIX_INFO_TRUE(&info[n]);
             } else if (0 == strncmp(info[n].key, PMIX_LAUNCHER, PMIX_MAX_KEYLEN)) {
                 if (PMIX_INFO_TRUE(&info[n])) {
-                    ptype |= PMIX_PROC_LAUNCHER;
+                    PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_LAUNCHER);
                 }
             } else if (0 == strncmp(info[n].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
@@ -390,7 +390,11 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                 return PMIX_ERR_BAD_PARAM;
             }
             /* flag that this tool is also a client */
-            ptype |= PMIX_PROC_CLIENT_TOOL;
+            if (PMIX_PROC_IS_LAUNCHER(&ptype)) {
+                PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_CLIENT_LAUNCHER);
+            } else {
+                PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_CLIENT_TOOL);
+            }
         } else if (nspace_in_enviro) {
             /* this is an error - we can't have one and not
              * the other */
@@ -408,7 +412,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
 
     /* setup the runtime - this init's the globals,
      * opens and initializes the required frameworks */
-    if (PMIX_SUCCESS != (rc = pmix_rte_init(ptype, info, ninfo,
+    if (PMIX_SUCCESS != (rc = pmix_rte_init(ptype.type, info, ninfo,
                                             pmix_tool_notify_recv))) {
         PMIX_ERROR_LOG(rc);
         if (NULL != nspace) {
@@ -469,7 +473,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: init called");
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         /* if we are a client, then we need to pickup the
          * rest of the envar-based server assignments */
         pmix_globals.pindex = -1;
@@ -561,7 +565,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
 
     /* if we are a launcher, then we also need to act as a server,
      * so setup the server-related structures here */
-    if (PMIX_PROC_LAUNCHER_ACT & ptype) {
+    if (PMIX_PROC_IS_LAUNCHER(&ptype) ||
+        PMIX_PROC_IS_CLIENT_LAUNCHER(&ptype)) {
         if (PMIX_SUCCESS != (rc = pmix_server_initialize())) {
             PMIX_ERROR_LOG(rc);
             if (NULL != nspace) {
@@ -630,7 +635,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
 
     /* if we are acting as a server, then start listening */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* setup the wildcard recv for inbound messages from clients */
         rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
         rcv->tag = UINT32_MAX;
@@ -729,7 +734,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
      * job info - we do this as a non-blocking
      * transaction because some systems cannot handle very large
      * blocking operations and error out if we try them. */
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
          req = PMIX_NEW(pmix_buffer_t);
          PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
                           req, &cmd, 1, PMIX_COMMAND);
@@ -799,7 +804,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
 
     /* if we are acting as a server, then start listening */
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* start listening for connections */
         if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
             pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
@@ -1238,7 +1243,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         }
     }
 
-    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         pmix_ptl_base_stop_listening();
 
         for (n=0; n < pmix_server_globals.clients.size; n++) {

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
         putenv("PMIX_MCA_pnet=test");
     }
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, ninfo))) {
-        fprintf(stderr, "Init failed with error %d\n", rc);
+        fprintf(stderr, "Init failed with error %s\n", PMIx_Error_string(rc));
         return rc;
     }
     PMIX_INFO_FREE(info, ninfo);


### PR DESCRIPTION
We are getting to a point where cross-version compatibility requires
knowing the client's version down to the release level. Rather than
creating an increasing number of version-specific tests, let's encode
the release triplet into the proc_type field so we can just examine
it numerically when needed.