### PR TITLE
Add helper function for allocating info structs

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -776,6 +776,40 @@ cdef int pmix_load_info(pmix_info_t *array, dicts:list):
         n += 1
     return PMIX_SUCCESS
 
+# Allocate memory and load pmix info structs
+#
+# @array [INPUT]
+#          - array of pmix_info_t structs
+#
+# @ninfo [INPUT]
+#          - length of the list of dictionaries
+#
+# @dicts [INPUT]
+#          - a list of dictionaries, where each
+#            dictionary has a key, value, and val_type
+#            defined as such:
+#            [{key:y, value:val, val_type:ty}, … ]
+#
+cdef int pmix_alloc_info(pmix_info_t **info_ptr, size_t *ninfo, dicts:list):
+    # Convert any provided dictionary to an array of pmix_info_t
+    if dicts is not None:
+        ninfo[0] = len(dicts)
+        if 0 < ninfo[0]:
+            info_ptr[0] = <pmix_info_t*> PyMem_Malloc(ninfo[0] * sizeof(pmix_info_t))
+            if not info_ptr[0]:
+                return PMIX_ERR_NOMEM
+            rc = pmix_load_info(info_ptr[0], dicts)
+            if PMIX_SUCCESS != rc:
+                pmix_free_info(info_ptr[0], ninfo[0])
+                return rc
+        else:
+            info_ptr[0] = NULL
+            ninfo[0] = 0
+    else:
+        info_ptr[0] = NULL
+        ninfo[0] = 0
+    return PMIX_SUCCESS
+
 cdef int pmix_unload_info(const pmix_info_t *info, size_t ninfo, ilist:list):
     cdef char* kystr
     cdef size_t n = 0


### PR DESCRIPTION
This change got reverted because we believed it to be the source of the memory corruption we were seeing. Turns out that was in the pmix_load_argv function. I rebuilt the python bindings and ran ./server.py and ./sched.py successfully. So, I believe it to be working. 

Created pmix_alloc_info since most of the info struct
memory allocation and error checking code was the same
in every wrapper. This reduces the amount of code in
each wrapper.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>