### PR TITLE
Cache local peers in deprecated form for older versions, try to fix the "tests", continue workaround of dstore

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -237,14 +237,6 @@ static void job_data(struct pmix_peer_t *pr,
                             pmix_client_globals.myserver,
                             nspace, buf);
 
-    /* if anything is left in the buffer, let the
-     * internal hash component have it - e.g., we
-     * may have been passed node and app info for
-     * our own nspace */
-    PMIX_GDS_STORE_JOB_INFO(cb->status,
-                            pmix_globals.mypeer,
-                            nspace, buf);
-
     free(nspace);
     cb->status = PMIX_SUCCESS;
     PMIX_POST_OBJECT(cb);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -86,7 +86,9 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
-    size_t n;
+    size_t n, nfo;
+    pmix_proc_t p;
+    pmix_info_t nodeinfo, *iptr;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -101,7 +103,37 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
                         (NULL == proc) ? "NULL" : PMIX_NAME_PRINT(proc),
                         (NULL == key) ? "NULL" : key);
 
+    memcpy(&p, proc, sizeof(pmix_proc_t));
+    iptr = (pmix_info_t*)info;
+    nfo = ninfo;
+
     if (PMIX_RANK_UNDEF == proc->rank || NULL == key) {
+        goto doget;
+    }
+    /* if they are asking about a node-level piece of info,
+     * then the rank must be UNDEF */
+    if (pmix_check_node_info(key)) {
+        p.rank = PMIX_RANK_UNDEF;
+        /* see if they told us to get node info */
+        if (NULL == info) {
+            /* guess not - better do it */
+            PMIX_INFO_LOAD(&nodeinfo, PMIX_NODE_INFO, NULL, PMIX_BOOL);
+            iptr = &nodeinfo;
+            nfo = 1;
+        }
+        goto doget;
+    }
+    /* if they are asking about an app-level piece of info,
+     * then the rank must be UNDEF */
+    if (pmix_check_app_info(key)) {
+        p.rank = PMIX_RANK_UNDEF;
+        /* see if they told us to get app info */
+        if (NULL == info) {
+            /* guess not - better do it */
+            PMIX_INFO_LOAD(&nodeinfo, PMIX_APP_INFO, NULL, PMIX_BOOL);
+            iptr = &nodeinfo;
+            nfo = 1;
+        }
         goto doget;
     }
 
@@ -112,10 +144,10 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
             PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
             goto doget;
         }
-
     }
+
     /* try to get data directly, without threadshift */
-    if (PMIX_SUCCESS == (rc = _getfn_fastpath(proc, key, info, ninfo, val))) {
+    if (PMIX_SUCCESS == (rc = _getfn_fastpath(&p, key, iptr, nfo, val))) {
         goto done;
     }
 
@@ -124,7 +156,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
-    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(proc, key, info, ninfo, _value_cbfunc, cb))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&p, key, iptr, nfo, _value_cbfunc, cb))) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -576,6 +608,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     pmix_proc_t proc;
     bool optional = false;
     bool immediate = false;
+    bool internal_only = false;
     struct timeval tv;
     pmix_query_caddy_t *cd;
 
@@ -611,6 +644,10 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                 }
             } else if (PMIX_CHECK_KEY(&cb->info[n], PMIX_DATA_SCOPE)) {
                 cb->scope = cb->info[n].value.data.scope;
+            } else if (PMIX_CHECK_KEY(&cb->info[n], PMIX_NODE_INFO) ||
+                       PMIX_CHECK_KEY(&cb->info[n], PMIX_APP_INFO) ||
+                       PMIX_CHECK_KEY(&cb->info[n], PMIX_SESSION_INFO)) {
+                internal_only = true;
             }
         }
     }
@@ -630,7 +667,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
 
     /* if the key is NULL or starts with "pmix", then they are looking
      * for data that was provided by the server at startup */
-    if (NULL == cb->key || 0 == strncmp(cb->key, "pmix", 4)) {
+    if (!internal_only && (NULL == cb->key || 0 == strncmp(cb->key, "pmix", 4))) {
         cb->proc = &proc;
         /* fetch the data from my server's module - since we are passing
          * it back to the user, we need a copy of it */

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -101,11 +101,6 @@ static void regevents_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ret, &cnt, PMIX_STATUS);
     if ((PMIX_SUCCESS != rc) ||
         (PMIX_SUCCESS != ret)) {
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        } else {
-            PMIX_ERROR_LOG(ret);
-        }
         /* remove the err handler and call the error handler
          * reg completion callback fn so the requestor
          * doesn't hang */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -173,9 +173,9 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_rank_info_t,
 static void pcon(pmix_peer_t *p)
 {
     p->proc_type.type = PMIX_PROC_UNDEF;
-    p->proc_type.major = 255;
-    p->proc_type.minor = 255;
-    p->proc_type.revision = 255;
+    p->proc_type.major = PMIX_MAJOR_WILDCARD;
+    p->proc_type.minor = PMIX_MINOR_WILDCARD;
+    p->proc_type.release = PMIX_RELEASE_WILDCARD;
     p->proc_type.padding = 0;
     p->protocol = PMIX_PROTOCOL_UNDEF;
     p->finalized = false;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -336,6 +336,8 @@ typedef struct {
     pmix_server_trkr_t *trk;
     pmix_ptl_hdr_t hdr;
     pmix_peer_t *peer;
+    pmix_info_t *info;
+    size_t ninfo;
 } pmix_server_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
 
@@ -510,6 +512,40 @@ PMIX_EXPORT void pmix_execute_epilog(pmix_epilog_t *ep);
 
 PMIX_EXPORT extern pmix_globals_t pmix_globals;
 PMIX_EXPORT extern pmix_lock_t pmix_global_lock;
+
+static inline bool pmix_check_node_info(const char* key)
+{
+    char *keys[] = {
+        PMIX_LOCAL_PEERS,
+        PMIX_LOCAL_SIZE,
+        NULL
+    };
+    size_t n;
+
+    for (n=0; NULL != keys[n]; n++) {
+        if (0 == strncmp(key, keys[n], PMIX_MAX_KEYLEN)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline bool pmix_check_app_info(const char* key)
+{
+    char *keys[] = {
+        PMIX_APP_SIZE,
+        NULL
+    };
+    size_t n;
+
+    for (n=0; NULL != keys[n]; n++) {
+        if (0 == strncmp(key, keys[n], PMIX_MAX_KEYLEN)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 
 END_C_DECLS
 

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2692,22 +2692,23 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
 
     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
     	if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY)) {
-    	pmix_output(0, "STORING NODE ARRAY: %s", kv->key);
     		/* earlier PMIx versions don't know how to handle
     		 * the info arrays - what they need is a key-value
     		 * pair where the key is the name of the node and
     		 * the value is the local peers. So if the peer
     		 * is earlier than 3.1.5, construct the necessary
-    		 * translation */
+    		 * translation. Otherwise, ignore it as the hash
+             * component will handle it for them */
     		if (PMIX_PEER_IS_EARLIER(ds_ctx->clients_peer, 3, 1, 5)) {
 	            pmix_info_t *info;
 	            size_t size, i;
+                bool local = false;
+                /* if it is our local node, then we are going to pass
+                 * all info */
 	            info = kv->value->data.darray->array;
 	            size = kv->value->data.darray->size;
-pmix_output(0, "STORING FOR EARLIER VERSION %u:%u:%u", ds_ctx->clients_peer->proc_type.major, ds_ctx->clients_peer->proc_type.minor,ds_ctx->clients_peer->proc_type.release);
 	            for (i = 0; i < size; i++) {
 	                if (PMIX_CHECK_KEY(&info[i], PMIX_LOCAL_PEERS)) {
-	                	pmix_output(0, "FOUND LOCAL PEERS");
 	                    kv2 = PMIX_NEW(pmix_kval_t);
 	                    kv2->key = strdup(kv->key);
 	                    PMIX_VALUE_XFER(rc, kv2->value, &info[i].value);
@@ -2723,17 +2724,40 @@ pmix_output(0, "STORING FOR EARLIER VERSION %u:%u:%u", ds_ctx->clients_peer->pro
 	                        goto exit;
 	                    }
 	                    PMIX_RELEASE(kv2);
-	                    break;
-	                }
+	                } else if (PMIX_CHECK_KEY(&info[i], PMIX_HOSTNAME)) {
+                        if (0 == strcmp(info[i].value.data.string, pmix_globals.hostname)) {
+                            local = true;
+                        }
+                    }
 	            }
-    		} else {
-    			pmix_output(0, "STORING FOR NEW VERSION");
-	            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv, 1, PMIX_KVAL);
-	            if (PMIX_SUCCESS != rc) {
-	                PMIX_ERROR_LOG(rc);
-	                goto exit;
-	            }
-	        }
+                if (local) {
+                    for (i = 0; i < size; i++) {
+                        if (!PMIX_CHECK_KEY(&info[i], PMIX_LOCAL_PEERS) &&
+                            !PMIX_CHECK_KEY(&info[i], PMIX_HOSTNAME) &&
+                            !PMIX_CHECK_KEY(&info[i], PMIX_NODEID)) {
+                            kv2 = PMIX_NEW(pmix_kval_t);
+                            kv2->key = strdup(kv->key);
+                            PMIX_VALUE_XFER(rc, kv2->value, &info[i].value);
+                            if (PMIX_SUCCESS != rc) {
+                                PMIX_ERROR_LOG(rc);
+                                PMIX_RELEASE(kv2);
+                                goto exit;
+                            }
+                            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv2, 1, PMIX_KVAL);
+                            if (PMIX_SUCCESS != rc) {
+                                PMIX_ERROR_LOG(rc);
+                                PMIX_RELEASE(kv2);
+                                goto exit;
+                            }
+                            PMIX_RELEASE(kv2);
+                        }
+                    }
+                }
+    		}
+        } else if (PMIX_CHECK_KEY(kv, PMIX_APP_INFO_ARRAY) ||
+                   PMIX_CHECK_KEY(kv, PMIX_JOB_INFO_ARRAY) ||
+                   PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY)) {
+            continue;
         } else {
             PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv, 1, PMIX_KVAL);
             if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -127,6 +127,8 @@ pmix_gds_base_module_t pmix_hash_module = {
 #define PMIX_HASH_PROC_MAP      0x00000010
 #define PMIX_HASH_NODE_MAP      0x00000020
 
+static pmix_list_t mysessions, myjobs;
+
 /**********************************************/
 /* struct definitions */
 typedef struct {
@@ -258,6 +260,47 @@ static void ndinfodes(pmix_nodeinfo_t *p)
 static PMIX_CLASS_INSTANCE(pmix_nodeinfo_t,
                            pmix_list_item_t,
                            ndinfocon, ndinfodes);
+
+static pmix_job_t* get_tracker(const pmix_nspace_t nspace, bool create)
+{
+    pmix_job_t *trk, *t;
+    pmix_namespace_t *ns, *nptr;
+
+    /* find the hash table for this nspace */
+    trk = NULL;
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
+        if (0 == strcmp(nspace, t->ns)) {
+            trk = t;
+            break;
+        }
+    }
+    if (NULL == trk && create) {
+        /* create one */
+        trk = PMIX_NEW(pmix_job_t);
+        trk->ns = strdup(nspace);
+        /* see if we already have this nspace */
+        nptr = NULL;
+        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
+            if (0 == strcmp(ns->nspace, nspace)) {
+                nptr = ns;
+                break;
+            }
+        }
+        if (NULL == nptr) {
+            nptr = PMIX_NEW(pmix_namespace_t);
+            if (NULL == nptr) {
+                PMIX_RELEASE(trk);
+                return NULL;
+            }
+            nptr->nspace = strdup(nspace);
+            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+        }
+        PMIX_RETAIN(nptr);
+        trk->nptr = nptr;
+        pmix_list_append(&myjobs, &trk->super);
+    }
+    return trk;
+}
 
 /**********************************************
  *   Forward Declarations
@@ -611,7 +654,103 @@ static pmix_status_t process_job_array(pmix_info_t *info,
     return PMIX_SUCCESS;
 }
 
-static pmix_list_t mysessions, myjobs;
+static pmix_status_t process_session_array(pmix_value_t *val,
+                                           pmix_job_t *trk)
+{
+    pmix_session_t *s = NULL, *sptr;
+    size_t j, size;
+    pmix_info_t *iptr;
+    pmix_list_t cache, ncache;
+    pmix_status_t rc;
+    pmix_kval_t *kp2;
+    pmix_nodeinfo_t *nd;
+    uint32_t sid;
+
+    /* array of session-level info */
+    if (PMIX_DATA_ARRAY != val->type) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_TYPE_MISMATCH;
+    }
+    size = val->data.darray->size;
+    iptr = (pmix_info_t*)val->data.darray->array;
+
+    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    PMIX_CONSTRUCT(&ncache, pmix_list_t);
+    for (j=0; j < size; j++) {
+        if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_LIST_DESTRUCT(&ncache);
+                return rc;
+            }
+            /* see if we already have this session - it could have
+             * been defined by a separate PMIX_SESSION_ID key */
+            PMIX_LIST_FOREACH(sptr, &mysessions, pmix_session_t) {
+                if (sptr->session == sid) {
+                    s = sptr;
+                    break;
+                }
+            }
+            if (NULL == s) {
+                /* wasn't found, so create one */
+                s = PMIX_NEW(pmix_session_t);
+                s->session = sid;
+                pmix_list_append(&mysessions, &s->super);
+            }
+        } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
+            if (PMIX_SUCCESS != (rc = process_node_array(&iptr[j].value, &ncache))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_LIST_DESTRUCT(&ncache);
+                return rc;
+            }
+        } else {
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(iptr[j].key);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_LIST_DESTRUCT(&ncache);
+                return rc;
+            }
+            pmix_list_append(&cache, &kp2->super);
+        }
+    }
+    if (NULL == s) {
+        /* this is not allowed to happen - they are required
+         * to provide us with a session ID per the standard */
+        PMIX_LIST_DESTRUCT(&cache);
+        PMIX_LIST_DESTRUCT(&ncache);
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    /* point the job at it */
+    if (NULL != trk->session) {
+        PMIX_RELEASE(trk->session);
+    }
+    PMIX_RETAIN(s);
+    trk->session = s;
+    /* transfer the data across */
+    kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+    while (NULL != kp2) {
+        pmix_list_append(&s->sessioninfo, &kp2->super);
+        kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+    }
+    PMIX_LIST_DESTRUCT(&cache);
+    nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
+    while (NULL != nd) {
+        pmix_list_append(&s->nodeinfo, &nd->super);
+        nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
+    }
+    PMIX_LIST_DESTRUCT(&ncache);
+    return PMIX_SUCCESS;
+}
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 {
@@ -766,6 +905,31 @@ static pmix_status_t store_map(pmix_job_t *trk,
         /* split the list of procs so we can store their
          * individual location data */
         procs = pmix_argv_split(ppn[n], ',');
+        /* save the local size in case they don't
+         * give it to us */
+        kp2 = PMIX_NEW(pmix_kval_t);
+        if (NULL == kp2) {
+            return PMIX_ERR_NOMEM;
+        }
+        kp2->key = strdup(PMIX_LOCAL_SIZE);
+        kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kp2->value) {
+            PMIX_RELEASE(kp2);
+            return PMIX_ERR_NOMEM;
+        }
+        kp2->value->type = PMIX_UINT32;
+        kp2->value->data.uint32 = pmix_argv_count(procs);
+        /* ensure this item only appears once on the list */
+        PMIX_LIST_FOREACH(kp1, &nd->info, pmix_kval_t) {
+            if (PMIX_CHECK_KEY(kp1, kp2->key)) {
+                pmix_list_remove_item(&nd->info, &kp1->super);
+                PMIX_RELEASE(kp1);
+                break;
+            }
+        }
+        pmix_list_append(&nd->info, &kp2->super);
+        /* track total procs in job in case they
+         * didn't give it to us */
         totalprocs += pmix_argv_count(procs);
         for (m=0; NULL != procs[m]; m++) {
             /* store the hostname for each proc */
@@ -885,7 +1049,7 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                   pmix_info_t info[], size_t ninfo)
 {
     pmix_namespace_t *nptr = (pmix_namespace_t*)ns;
-    pmix_job_t *trk, *t;
+    pmix_job_t *trk;
     pmix_session_t *s = NULL, *sptr;
     pmix_hash_table_t *ht;
     pmix_kval_t *kp2, *kvptr;
@@ -897,32 +1061,17 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     pmix_status_t rc=PMIX_SUCCESS;
     size_t n, j, size, len;
     uint32_t flags = 0;
-    pmix_list_t cache, ncache;
-    pmix_nodeinfo_t *nd;
+    pmix_nodeinfo_t *nd, *ndptr;
+    pmix_apptrkr_t *apptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:cache_job_info for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         nptr->nspace);
 
-    /* find the hash table for this nspace */
-    trk = NULL;
-    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-        if (0 == strcmp(nptr->nspace, t->ns)) {
-            trk = t;
-            break;
-        }
-    }
+    trk = get_tracker(nptr->nspace, true);
     if (NULL == trk) {
-        /* create a tracker as we will likely need it */
-        trk = PMIX_NEW(pmix_job_t);
-        if (NULL == trk) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_RETAIN(nptr);
-        trk->nptr = nptr;
-        trk->ns = strdup(nptr->nspace);
-        pmix_list_append(&myjobs, &trk->super);
+        return PMIX_ERR_NOMEM;
     }
 
     /* if there isn't any data, then be content with just
@@ -959,95 +1108,10 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 trk->session = s;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_INFO_ARRAY)) {
-            /* array of session-level info */
-            if (PMIX_DATA_ARRAY != info[n].value.type) {
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                rc = PMIX_ERR_TYPE_MISMATCH;
-                goto release;
-            }
-            size = info[n].value.data.darray->size;
-            iptr = (pmix_info_t*)info[n].value.data.darray->array;
-            PMIX_CONSTRUCT(&cache, pmix_list_t);
-            PMIX_CONSTRUCT(&ncache, pmix_list_t);
-            for (j=0; j < size; j++) {
-                if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
-                    PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_LIST_DESTRUCT(&cache);
-                        return rc;
-                    }
-                    /* setup a session object */
-                    if (NULL != s) {
-                        /* does this match the one we were previously given? */
-                        if (sid != s->session) {
-                            /* no - see if we already have this session */
-                            PMIX_LIST_FOREACH(sptr, &mysessions, pmix_session_t) {
-                                if (sptr->session == sid) {
-                                    s = sptr;
-                                    break;
-                                }
-                            }
-                            if (sid != s->session) {
-                                /* wasn't found, so create one */
-                                s = PMIX_NEW(pmix_session_t);
-                                s->session = sid;
-                                pmix_list_append(&mysessions, &s->super);
-                            }
-                        }
-                    } else {
-                        s = PMIX_NEW(pmix_session_t);
-                        s->session = sid;
-                        pmix_list_append(&mysessions, &s->super);
-                    }
-                } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
-                    if (PMIX_SUCCESS != (rc = process_node_array(&iptr[j].value, &ncache))) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_LIST_DESTRUCT(&cache);
-                        PMIX_LIST_DESTRUCT(&ncache);
-                        goto release;
-                    }
-                } else {
-                    kp2 = PMIX_NEW(pmix_kval_t);
-                    kp2->key = strdup(iptr[j].key);
-                    kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-                    PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_RELEASE(kp2);
-                        PMIX_LIST_DESTRUCT(&cache);
-                        PMIX_LIST_DESTRUCT(&ncache);
-                        goto release;
-                    }
-                    pmix_list_append(&cache, &kp2->super);
-                }
-            }
-            if (NULL == s) {
-                /* this is not allowed to happen - they are required
-                 * to provide us with a session ID per the standard */
-                PMIX_LIST_DESTRUCT(&cache);
-                rc = PMIX_ERR_BAD_PARAM;
+            if (PMIX_SUCCESS != (rc = process_session_array(&info[n].value, trk))) {
                 PMIX_ERROR_LOG(rc);
                 goto release;
             }
-            /* point the job at it */
-            if (NULL == trk->session) {
-                PMIX_RETAIN(s);
-                trk->session = s;
-            }
-            /* transfer the data across */
-            kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
-            while (NULL != kp2) {
-                pmix_list_append(&s->sessioninfo, &kp2->super);
-                kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
-            }
-            PMIX_LIST_DESTRUCT(&cache);
-            nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
-            while (NULL != nd) {
-                pmix_list_append(&s->nodeinfo, &nd->super);
-                nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
-            }
-            PMIX_LIST_DESTRUCT(&ncache);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_JOB_INFO_ARRAY)) {
             if (PMIX_SUCCESS != (rc = process_job_array(&info[n], trk, &flags, &procs, &nodes))) {
                 PMIX_ERROR_LOG(rc);
@@ -1157,6 +1221,60 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                    PMIX_CHECK_KEY(&info[n], PMIX_MODEL_LIBRARY_VERSION)) {
             // pass this info to the pmdl framework
             pmix_pmdl.setup_nspace(trk->nptr, PMIX_APP_WILDCARD, &info[n]);
+        } else if (pmix_check_node_info(info[n].key)) {
+            /* they are passing us the node-level info for just this
+             * node - start by seeing if our node is on the list */
+            nd = NULL;
+            PMIX_LIST_FOREACH(ndptr, &trk->nodeinfo, pmix_nodeinfo_t) {
+                if (0 == strcmp(pmix_globals.hostname, ndptr->hostname)) {
+                    nd = ndptr;
+                    break;
+                }
+            }
+            /* if not, then add it */
+            if (NULL == nd) {
+                nd = PMIX_NEW(pmix_nodeinfo_t);
+                nd->hostname = strdup(pmix_globals.hostname);
+                pmix_list_append(&trk->nodeinfo, &nd->super);
+            }
+            /* ensure the value isn't already on the node info */
+            PMIX_LIST_FOREACH(kp2, &nd->info, pmix_kval_t) {
+                if (PMIX_CHECK_KEY(kp2, info[n].key)) {
+                    pmix_list_remove_item(&nd->info, &kp2->super);
+                    PMIX_RELEASE(kp2);
+                    break;
+                }
+            }
+            /* add the provided value */
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(info[n].key);
+            PMIX_VALUE_XFER(rc, kp2->value, &info[n].value);
+            pmix_list_append(&nd->info, &kp2->super);
+        } else if (pmix_check_app_info(info[n].key)) {
+            /* they are passing us app-level info for a default
+             * app number - have to assume it is app=0 */
+            if (0 == pmix_list_get_size(&trk->apps)) {
+                apptr = PMIX_NEW(pmix_apptrkr_t);
+                pmix_list_append(&trk->apps, &apptr->super);
+            } else if (1 < pmix_list_get_size(&trk->apps)) {
+                rc = PMIX_ERR_BAD_PARAM;
+                goto release;
+            } else {
+                apptr = (pmix_apptrkr_t*)pmix_list_get_first(&trk->apps);
+            }
+            /* ensure the value isn't already on the app info */
+            PMIX_LIST_FOREACH(kp2, &apptr->appinfo, pmix_kval_t) {
+                if (PMIX_CHECK_KEY(kp2, info[n].key)) {
+                    pmix_list_remove_item(&apptr->appinfo, &kp2->super);
+                    PMIX_RELEASE(kp2);
+                    break;
+                }
+            }
+            /* add the provided value */
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(info[n].key);
+            PMIX_VALUE_XFER(rc, kp2->value, &info[n].value);
+            pmix_list_append(&apptr->appinfo, &kp2->super);
         } else {
             /* just a value relating to the entire job */
             kp2 = PMIX_NEW(pmix_kval_t);
@@ -1254,7 +1372,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
                                    pmix_namespace_t *ns,
                                    pmix_buffer_t *reply)
 {
-    pmix_job_t *trk, *t;
+    pmix_job_t *trk;
     pmix_hash_table_t *ht;
     pmix_value_t *val, blob;
     pmix_status_t rc = PMIX_SUCCESS;
@@ -1265,15 +1383,9 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     pmix_rank_t rank;
     pmix_list_t results;
 
-    trk = NULL;
-    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-        if (0 == strcmp(ns->nspace, t->ns)) {
-            trk = t;
-            break;
-        }
-    }
+    trk = get_tracker(ns->nspace, true);
     if (NULL == trk) {
-        return PMIX_ERR_INVALID_NAMESPACE;
+        return PMIX_ERR_NOMEM;
     }
     /* the job data is stored on the internal hash table */
     ht = &trk->internal;
@@ -1378,7 +1490,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
-    pmix_job_t *trk, *t2;
+    pmix_job_t *trk;
 
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
@@ -1417,25 +1529,9 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
 
     /* setup a tracker for this nspace as we will likely
      * need it again */
-    trk = NULL;
-    PMIX_LIST_FOREACH(t2, &myjobs, pmix_job_t) {
-        if (ns == t2->nptr) {
-            trk = t2;
-            if (NULL == trk->ns) {
-                trk->ns = strdup(ns->nspace);
-            }
-            break;
-        } else if (0 == strcmp(ns->nspace, t2->ns)) {
-            trk = t2;
-            break;
-        }
-    }
+    trk = get_tracker(ns->nspace, true);
     if (NULL == trk) {
-        trk = PMIX_NEW(pmix_job_t);
-        trk->ns = strdup(ns->nspace);
-        PMIX_RETAIN(ns);
-        trk->nptr = ns;
-        pmix_list_append(&myjobs, &trk->super);
+        return PMIX_ERR_NOMEM;
     }
 
     /* the job info for the specified nspace has
@@ -1483,8 +1579,8 @@ static pmix_status_t hash_store_job_info(const char *nspace,
     pmix_job_t *trk;
     pmix_hash_table_t *ht;
     char **nodelist = NULL;
-    pmix_namespace_t *ns, *nptr;
     pmix_nodeinfo_t *nd, *ndptr;
+    pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%u] pmix:gds:hash store job info for nspace %s",
@@ -1504,7 +1600,13 @@ static pmix_status_t hash_store_job_info(const char *nspace,
         return rc;
     }
 
-    /* see if we already have this nspace */
+    trk = get_tracker(nspace, true);
+    if (NULL == trk) {
+        return PMIX_ERR_NOMEM;
+    }
+    ht = &trk->internal;
+
+    /* retrieve the nspace pointer */
     nptr = NULL;
     PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, nspace)) {
@@ -1513,31 +1615,8 @@ static pmix_status_t hash_store_job_info(const char *nspace,
         }
     }
     if (NULL == nptr) {
-        nptr = PMIX_NEW(pmix_namespace_t);
-        if (NULL == nptr) {
-            rc = PMIX_ERR_NOMEM;
-            return rc;
-        }
-        nptr->nspace = strdup(nspace);
-        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
-    }
-
-    /* see if we already have a hash table for this nspace */
-    ht = NULL;
-    PMIX_LIST_FOREACH(trk, &myjobs, pmix_job_t) {
-        if (0 == strcmp(trk->ns, nspace)) {
-            ht = &trk->internal;
-            break;
-        }
-    }
-    if (NULL == ht) {
-        /* nope - create one */
-        trk = PMIX_NEW(pmix_job_t);
-        trk->ns = strdup(nspace);
-        PMIX_RETAIN(nptr);
-        trk->nptr = nptr;
-        pmix_list_append(&myjobs, &trk->super);
-        ht = &trk->internal;
+        /* only can happen if we are out of mem */
+        return PMIX_ERR_NOMEM;
     }
 
     cnt = 1;
@@ -1785,10 +1864,9 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_scope_t scope,
                                 pmix_kval_t *kv)
 {
-    pmix_job_t *trk, *t;
+    pmix_job_t *trk;
     pmix_status_t rc;
     pmix_kval_t *kp;
-    pmix_namespace_t *ns, *nptr;
     pmix_rank_t rank;
     size_t j, size, len;
     pmix_info_t *iptr;
@@ -1805,38 +1883,9 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
     }
 
     /* find the hash table for this nspace */
-    trk = NULL;
-    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-        if (0 == strcmp(proc->nspace, t->ns)) {
-            trk = t;
-            break;
-        }
-    }
+    trk = get_tracker(proc->nspace, true);
     if (NULL == trk) {
-        /* create one */
-        trk = PMIX_NEW(pmix_job_t);
-        trk->ns = strdup(proc->nspace);
-        /* see if we already have this nspace */
-        nptr = NULL;
-        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
-            if (0 == strcmp(ns->nspace, proc->nspace)) {
-                nptr = ns;
-                break;
-            }
-        }
-        if (NULL == nptr) {
-            nptr = PMIX_NEW(pmix_namespace_t);
-            if (NULL == nptr) {
-                rc = PMIX_ERR_NOMEM;
-                PMIX_RELEASE(trk);
-                return rc;
-            }
-            nptr->nspace = strdup(proc->nspace);
-            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
-        }
-        PMIX_RETAIN(nptr);
-        trk->nptr = nptr;
-        pmix_list_append(&myjobs, &trk->super);
+        return PMIX_ERR_NOMEM;
     }
 
     /* see if the proc is me - cannot use CHECK_PROCID as
@@ -2005,10 +2054,9 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        char **kmap,
                                        pmix_buffer_t *pbkt)
 {
-    pmix_job_t *trk, *t;
+    pmix_job_t *trk;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_kval_t *kv;
-    pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_modex for nspace %s",
@@ -2016,38 +2064,9 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                         proc->nspace);
 
     /* find the hash table for this nspace */
-    trk = NULL;
-    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-        if (0 == strcmp(proc->nspace, t->ns)) {
-            trk = t;
-            break;
-        }
-    }
+    trk = get_tracker(proc->nspace, true);
     if (NULL == trk) {
-        /* create one */
-        trk = PMIX_NEW(pmix_job_t);
-        trk->ns = strdup(proc->nspace);
-        /* see if we already have this nspace */
-        nptr = NULL;
-        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
-            if (0 == strcmp(ns->nspace, proc->nspace)) {
-                nptr = ns;
-                break;
-            }
-        }
-        if (NULL == nptr) {
-            nptr = PMIX_NEW(pmix_namespace_t);
-            if (NULL == nptr) {
-                rc = PMIX_ERR_NOMEM;
-                PMIX_RELEASE(trk);
-                return rc;
-            }
-            nptr->nspace = strdup(proc->nspace);
-            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
-        }
-        PMIX_RETAIN(nptr);
-        trk->nptr = nptr;
-        pmix_list_append(&myjobs, &trk->super);
+        return PMIX_ERR_NOMEM;
     }
 
     /* this is data returned via the PMIx_Fence call when
@@ -2269,10 +2288,15 @@ static pmix_status_t fetch_nodeinfo(const char *key, pmix_list_t *tgt,
      		}
      		return PMIX_SUCCESS;
 
+        } else {
+            /* assume they want it from this node */
+            hostname = pmix_globals.hostname;
+            goto scan;
         }
         return PMIX_ERR_DATA_VALUE_NOT_FOUND;
     }
 
+  scan:
     /* scan the list of nodes to find the matching entry */
     nd = NULL;
     PMIX_LIST_FOREACH(ndptr, tgt, pmix_nodeinfo_t) {
@@ -2282,8 +2306,7 @@ static pmix_status_t fetch_nodeinfo(const char *key, pmix_list_t *tgt,
                 nd = ndptr;
                 break;
             }
-        }
-        if (NULL == hostname && nid == ndptr->nodeid) {
+        } else if (nid == ndptr->nodeid) {
             nd = ndptr;
             break;
         }
@@ -2292,27 +2315,76 @@ static pmix_status_t fetch_nodeinfo(const char *key, pmix_list_t *tgt,
         return PMIX_ERR_NOT_FOUND;
     }
 
-    /* scan the info list of this node to generate the results */
-    rc = PMIX_ERR_NOT_FOUND;
-    PMIX_LIST_FOREACH(kv, &nd->info, pmix_kval_t) {
-        if (NULL == key || PMIX_CHECK_KEY(kv, key)) {
-            kp2 = PMIX_NEW(pmix_kval_t);
-            kp2->key = strdup(kv->key);
-            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-     		rc = pmix_value_xfer(kp2->value, kv->value);
+    /* if they want it all, give it to them */
+    if (NULL == key) {
+        kv = PMIX_NEW(pmix_kval_t);
+        kv->key = strdup(PMIX_NODE_INFO_ARRAY);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        nds = pmix_list_get_size(&nd->info);
+        if (NULL != nd->hostname) {
+            ++nds;
+        }
+        if (UINT32_MAX != nd->nodeid) {
+            ++nds;
+        }
+        PMIX_DATA_ARRAY_CREATE(darray, nds, PMIX_INFO);
+        if (NULL == darray) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        iptr = (pmix_info_t*)darray->array;
+        n = 0;
+        if (NULL != nd->hostname) {
+            PMIX_INFO_LOAD(&iptr[n], PMIX_HOSTNAME, nd->hostname, PMIX_STRING);
+            ++n;
+        }
+        if (UINT32_MAX != nd->nodeid) {
+            PMIX_INFO_LOAD(&iptr[n], PMIX_NODEID, &nd->nodeid, PMIX_UINT32);
+            ++n;
+        }
+        PMIX_LIST_FOREACH(kp2, &nd->info, pmix_kval_t) {
+            PMIX_LOAD_KEY(iptr[n].key, kp2->key);
+            rc = pmix_value_xfer(&iptr[n].value, kp2->value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(kp2);
+                PMIX_DATA_ARRAY_FREE(darray);
+                PMIX_RELEASE(kv);
                 return rc;
             }
-            pmix_list_append(kvs, &kp2->super);
-            rc = PMIX_SUCCESS;
-            if (NULL != key) {
-                break;
-            }
+            ++n;
         }
+        kv->value->data.darray = darray;
+        kv->value->type = PMIX_DATA_ARRAY;
+        pmix_list_append(kvs, &kv->super);
+        return PMIX_SUCCESS;
     }
 
+    /* scan the info list of this node to find the key they want */
+    rc = PMIX_ERR_NOT_FOUND;
+    PMIX_LIST_FOREACH(kp2, &nd->info, pmix_kval_t) {
+        if (PMIX_CHECK_KEY(kp2, key)) {
+            /* since they only asked for one key, return just that value */
+            kv = PMIX_NEW(pmix_kval_t);
+            kv->key = strdup(kp2->key);
+            kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            if (NULL == kv->value) {
+                PMIX_RELEASE(kv);
+                return PMIX_ERR_NOMEM;
+            }
+            rc = pmix_value_xfer(kv->value, kp2->value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kv);
+                return rc;
+            }
+            pmix_list_append(kvs, &kv->super);
+            break;
+        }
+    }
     return rc;
 }
 
@@ -2436,7 +2508,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                                 pmix_info_t qualifiers[], size_t nqual,
                                 pmix_list_t *kvs)
 {
-    pmix_job_t *trk, *t;
+    pmix_job_t *trk;
     pmix_status_t rc;
     pmix_kval_t *kv, *kvptr;
     pmix_info_t *info, *iptr;
@@ -2461,13 +2533,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     if (NULL == key && PMIX_RANK_WILDCARD == proc->rank) {
         /* see if we have a tracker for this nspace - we will
          * if we already cached the job info for it */
-        trk = NULL;
-        PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-            if (0 == strcmp(proc->nspace, t->ns)) {
-                trk = t;
-                break;
-            }
-        }
+        trk = get_tracker(proc->nspace, false);
         if (NULL == trk) {
             /* let the caller know */
             return PMIX_ERR_INVALID_NAMESPACE;
@@ -2588,13 +2654,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     }
 
     /* find the hash table for this nspace */
-    trk = NULL;
-    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
-        if (0 == strcmp(proc->nspace, t->ns)) {
-            trk = t;
-            break;
-        }
-    }
+    trk = get_tracker(proc->nspace, false);
     if (NULL == trk) {
         return PMIX_ERR_INVALID_NAMESPACE;
     }
@@ -2751,6 +2811,51 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc,
     return rc;
 }
 
+static pmix_status_t store_session_info(pmix_nspace_t nspace,
+                                        pmix_kval_t *kv)
+{
+    pmix_job_t *trk;
+    pmix_status_t rc;
+
+    /* find the hash table for this nspace */
+    trk = get_tracker(nspace, true);
+    if (NULL == trk) {
+        return PMIX_ERR_NOMEM;
+    }
+    rc = process_session_array(kv->value, trk);
+    return rc;
+}
+
+static pmix_status_t store_node_info(pmix_nspace_t nspace,
+                                     pmix_kval_t *kv)
+{
+    pmix_job_t *trk;
+    pmix_status_t rc;
+
+    /* find the hash table for this nspace */
+    trk = get_tracker(nspace, true);
+    if (NULL == trk) {
+        return PMIX_ERR_NOMEM;
+    }
+    rc = process_node_array(kv->value, &trk->nodeinfo);
+    return rc;
+}
+
+static pmix_status_t store_app_info(pmix_nspace_t nspace,
+                                     pmix_kval_t *kv)
+{
+    pmix_job_t *trk;
+    pmix_status_t rc;
+
+    /* find the hash table for this nspace */
+    trk = get_tracker(nspace, true);
+    if (NULL == trk) {
+        return PMIX_ERR_NOMEM;
+    }
+    rc = process_app_array(kv->value, trk);
+    return rc;
+}
+
 static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
 {
     pmix_status_t rc = PMIX_SUCCESS;
@@ -2794,11 +2899,17 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
                            &pbkt, kv, &cnt, PMIX_KVAL);
         while (PMIX_SUCCESS == rc) {
-            /* let the GDS component for this peer store it - if
-             * the kval contains shmem connection info, then the
-             * component will know what to do about it (or else
-             * we selected the wrong component for this peer!) */
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proct, PMIX_INTERNAL, kv);
+            /* if this is an info array, then store it here as dstore
+             * doesn't know how to handle it */
+            if (PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY)) {
+                rc = store_session_info(proct.nspace, kv);
+            } else if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY)) {
+                rc = store_node_info(proct.nspace, kv);
+            } else if (PMIX_CHECK_KEY(kv, PMIX_APP_INFO_ARRAY)) {
+                rc = store_app_info(proct.nspace, kv);
+            } else {
+                rc = hash_store(&proct, PMIX_INTERNAL, kv);
+            }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kv);

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -118,7 +118,7 @@ PMIX_EXPORT void pmix_ptl_base_connection_handler(int sd, short args, void *cbda
 PMIX_EXPORT pmix_status_t pmix_ptl_base_send_connect_ack(int sd);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_recv_connect_ack(int sd);
 PMIX_EXPORT void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err);
-
+PMIX_EXPORT bool pmix_ptl_base_peer_is_earlier(pmix_peer_t *peer, uint8_t major, uint8_t minor, uint8_t release);
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -211,9 +211,9 @@ static void pccon(pmix_pending_connection_t *p)
     p->ptl = NULL;
     p->cred = NULL;
     p->proc_type.type = PMIX_PROC_UNDEF;
-    p->proc_type.major = 255;
-    p->proc_type.minor = 255;
-    p->proc_type.revision = 255;
+    p->proc_type.major = PMIX_MAJOR_WILDCARD;
+    p->proc_type.minor = PMIX_MINOR_WILDCARD;
+    p->proc_type.release = PMIX_RELEASE_WILDCARD;
     p->proc_type.padding = 0;
 }
 static void pcdes(pmix_pending_connection_t *p)

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,48 @@
 #include "src/include/pmix_globals.h"
 
 #include "src/mca/ptl/base/base.h"
+
+bool pmix_ptl_base_peer_is_earlier(pmix_peer_t *peer, uint8_t major,
+                                   uint8_t minor, uint8_t release)
+{
+    /* if any of the peer's triplets are unknown, then it
+     * must be an earlier value than us as clients from our
+     * version level always have known triplets */
+    if (PMIX_MAJOR_WILDCARD == PMIX_PEER_MAJOR_VERSION(peer) ||
+        PMIX_MINOR_WILDCARD == PMIX_PEER_MINOR_VERSION(peer) ||
+        PMIX_RELEASE_WILDCARD == PMIX_PEER_REL_VERSION(peer)) {
+        return true;
+    }
+    /* if they don't care, then don't check */
+    if (PMIX_MAJOR_WILDCARD != major) {
+        if (PMIX_PEER_MAJOR_VERSION(peer) > major) {
+            return false;
+        }
+        if (PMIX_PEER_MAJOR_VERSION(peer) < major) {
+            return true;
+        }
+    }
+    /* major value must be equal, so check minor */
+    if (PMIX_MINOR_WILDCARD != minor) {
+        if (PMIX_PEER_MINOR_VERSION(peer) > minor) {
+            return false;
+        }
+        if (PMIX_PEER_MINOR_VERSION(peer) < minor) {
+            return true;
+        }
+    }
+    /* major and minor must be equal - check release */
+    if (PMIX_RELEASE_WILDCARD != release) {
+        if (PMIX_PEER_REL_VERSION(peer) > release) {
+            return false;
+        }
+        if (PMIX_PEER_REL_VERSION(peer) < release) {
+            return true;
+        }
+    }
+    /* must be equal */
+    return false;
+}
 
 pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env)
 {

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -66,18 +66,22 @@ typedef struct {
     uint32_t type;
     uint8_t major;
     uint8_t minor;
-    uint8_t revision;
+    uint8_t release;
     uint8_t padding;  // make the struct be 64-bits for addressing
 } pmix_proc_type_t;
 
+#define PMIX_MAJOR_WILDCARD         255
+#define PMIX_MINOR_WILDCARD         255
+#define PMIX_RELEASE_WILDCARD       255
+
 /* use 255 as WILDCARD for the release triplet values */
-#define PMIX_PROC_TYPE_STATIC_INIT      \
-    {                                   \
-        .type = PMIX_PROC_UNDEF,        \
-        .major = 255,                   \
-        .minor = 255,                   \
-        .revision = 255,                \
-        .padding = 0                    \
+#define PMIX_PROC_TYPE_STATIC_INIT          \
+    {                                       \
+        .type = PMIX_PROC_UNDEF,            \
+        .major = PMIX_MAJOR_WILDCARD,       \
+        .minor = PMIX_MINOR_WILDCARD,       \
+        .release = PMIX_RELEASE_WILDCARD,   \
+        .padding = 0                        \
     }
 
 /* Define process types - we use a bit-mask as procs can
@@ -126,23 +130,40 @@ typedef struct {
     (p)->proc_type.major = (a)
 #define PMIX_SET_PEER_MINOR(p, a)   \
     (p)->proc_type.minor = (a)
-#define PMIX_SET_PEER_REVISION(p, a)   \
-    (p)->proc_type.revision = (a)
+#define PMIX_SET_PEER_RELEASE(p, a)   \
+    (p)->proc_type.release = (a)
 #define PMIX_SET_PROC_MAJOR(p, a)   \
     (p)->major = (a)
 #define PMIX_SET_PROC_MINOR(p, a)   \
     (p)->minor = (a)
-#define PMIX_SET_PROC_REVISION(p, a)   \
-    (p)->revision = (a)
+#define PMIX_SET_PROC_RELEASE(p, a)   \
+    (p)->release = (a)
 
 /* define some convenience macros for testing version */
-#define PMIX_PROC_MAJOR_VERSION(p)     (p)->proc_type.major
-#define PMIX_PROC_MINOR_VERSION(p)     (p)->proc_type.minor
-#define PMIX_PROC_REL_VERSION(p)       (p)->proc_type.revision
+#define PMIX_PEER_MAJOR_VERSION(p)     (p)->proc_type.major
+#define PMIX_PEER_MINOR_VERSION(p)     (p)->proc_type.minor
+#define PMIX_PEER_REL_VERSION(p)       (p)->proc_type.release
+#define PMIX_PROC_MAJOR_VERSION(p)     (p)->major
+#define PMIX_PROC_MINOR_VERSION(p)     (p)->minor
+#define PMIX_PROC_REL_VERSION(p)       (p)->release
 #define PMIX_PEER_IS_V1(p)             ((p)->proc_type.major == 1)
 #define PMIX_PEER_IS_V20(p)            ((p)->proc_type.major == 2 && (p)->proc_type.minor == 0)
 #define PMIX_PEER_IS_V21(p)            ((p)->proc_type.major == 2 && (p)->proc_type.minor == 1)
 #define PMIX_PEER_IS_V3(p)             ((p)->proc_type.major == 3)
+
+
+#define PMIX_PEER_TRIPLET(p, a, b, c)               \
+    ((PMIX_PEER_MAJOR_VERSION(p) == PMIX_MAJOR_WILDCARD || (a) == PMIX_MAJOR_WILDCARD || PMIX_PEER_MAJOR_VERSION(p) == (a)) &&    \
+     (PMIX_PEER_MINOR_VERSION(p) == PMIX_MINOR_WILDCARD || (b) == PMIX_MINOR_WILDCARD || PMIX_PEER_MINOR_VERSION(p) == (b)) &&    \
+     (PMIX_PEER_REL_VERSION(p) == PMIX_RELEASE_WILDCARD || (c) == PMIX_RELEASE_WILDCARD || PMIX_PEER_REL_VERSION(p) == (c)))
+
+#define PMIX_PROC_TRIPLET(p, a, b, c)               \
+    ((PMIX_PROC_MAJOR_VERSION(p) == PMIX_MAJOR_WILDCARD || PMIX_PROC_MAJOR_VERSION(p) == (a)) &&    \
+     (PMIX_PROC_MINOR_VERSION(p) == PMIX_MINOR_WILDCARD || PMIX_PROC_MINOR_VERSION(p) == (b)) &&    \
+     (PMIX_PROC_REL_VERSION(p) == PMIX_RELEASE_WILDCARD || PMIX_PROC_REL_VERSION(p) == (c)))
+
+#define PMIX_PEER_IS_EARLIER(p, a, b, c)            \
+    pmix_ptl_base_peer_is_earlier(p, a, b, c)
 
 
 /****    MESSAGING STRUCTURES    ****/

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -744,7 +744,7 @@ static pmix_status_t parse_uri_file(char *filename,
     pmix_event_t ev;
     struct timeval tv;
     int retries;
-    int major, minor, revision;
+    int major, minor, release;
 
     fp = fopen(filename, "r");
     if (NULL == fp) {
@@ -807,11 +807,11 @@ static pmix_status_t parse_uri_file(char *filename,
             major = strtoul(p2, &p3, 10);
         }
         minor = strtoul(p3, &p3, 10);
-        revision = strtoul(p3, NULL, 10);
+        release = strtoul(p3, NULL, 10);
         PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, PMIX_PROC_SERVER);
         PMIX_SET_PEER_MAJOR(pmix_client_globals.myserver, major);
         PMIX_SET_PEER_MINOR(pmix_client_globals.myserver, minor);
-        PMIX_SET_PEER_REVISION(pmix_client_globals.myserver, revision);
+        PMIX_SET_PEER_RELEASE(pmix_client_globals.myserver, release);
         if (2 <= major) {
             pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1345,24 +1345,12 @@ static void connection_handler(int sd, short args, void *cbdata)
     PMIX_SET_PROC_MINOR(&proc_type, minor);
     PMIX_SET_PROC_RELEASE(&proc_type, release);
 
-    if (0 == strncmp(version, "2.0", 3)) {
+    if (2 == major && 0 == minor) {
         /* the 2.0 release handshake ends with the version string */
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
         gds = "ds12,hash";
     } else {
-        int major;
-        major = strtoul(version, NULL, 10);
-        if (2 == major) {
-            PMIX_SET_PROC_MAJOR(&proc_type, 2);
-        } else if (3 <= major) {
-            PMIX_SET_PROC_MAJOR(&proc_type, 3);
-        } else {
-            free(msg);
-            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
-            rc = PMIX_ERR_NOT_SUPPORTED;
-            goto error;
-        }
         /* extract the name of the bfrops module they used */
         PMIX_STRNLEN(msglen, mg, cnt);
         if (msglen < cnt) {

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1045,6 +1045,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_proc_type_t proc_type = PMIX_PROC_TYPE_STATIC_INIT;
     pmix_byte_object_t cred;
     pmix_buffer_t buf;
+    uint8_t major, minor, release;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -1335,10 +1336,17 @@ static void connection_handler(int sd, short args, void *cbdata)
         rc = PMIX_ERR_BAD_PARAM;
         goto error;
     }
+    major = strtoul(version, &version, 10);
+    ++version;
+    minor = strtoul(version, &version, 10);
+    ++version;
+    release = strtoul(version, NULL, 10);
+    PMIX_SET_PROC_MAJOR(&proc_type, major);
+    PMIX_SET_PROC_MINOR(&proc_type, minor);
+    PMIX_SET_PROC_RELEASE(&proc_type, release);
 
     if (0 == strncmp(version, "2.0", 3)) {
         /* the 2.0 release handshake ends with the version string */
-        PMIX_SET_PROC_MAJOR(&proc_type, 2);
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
         gds = "ds12,hash";
@@ -1347,7 +1355,6 @@ static void connection_handler(int sd, short args, void *cbdata)
         major = strtoul(version, NULL, 10);
         if (2 == major) {
             PMIX_SET_PROC_MAJOR(&proc_type, 2);
-            PMIX_SET_PROC_MINOR(&proc_type, 1);
         } else if (3 <= major) {
             PMIX_SET_PROC_MAJOR(&proc_type, 3);
         } else {

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -595,7 +595,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     PMIX_SET_PROC_TYPE(&psave->proc_type, PMIX_PROC_CLIENT);
     PMIX_SET_PROC_MAJOR(&psave->proc_type, major);
     PMIX_SET_PROC_MINOR(&psave->proc_type, minor);
-    PMIX_SET_PROC_REVISION(&psave->proc_type, rel);
+    PMIX_SET_PROC_RELEASE(&psave->proc_type, rel);
 
     /* save the protocol */
     psave->protocol = pnd->protocol;

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -177,7 +177,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     pmix_status_t rc;
     socklen_t addrlen;
     struct sockaddr_un *address;
-    bool disabled = false;
+    bool disabled = true;
     char *pmix_pid;
     pid_t mypid;
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -253,7 +253,7 @@ int pmix_rte_init(uint32_t type,
     PMIX_SET_PEER_TYPE(pmix_globals.mypeer, type);
     PMIX_SET_PEER_MAJOR(pmix_globals.mypeer, PMIX_VERSION_MAJOR);
     PMIX_SET_PEER_MINOR(pmix_globals.mypeer, PMIX_VERSION_MINOR);
-    PMIX_SET_PEER_REVISION(pmix_globals.mypeer, PMIX_VERSION_RELEASE);
+    PMIX_SET_PEER_RELEASE(pmix_globals.mypeer, PMIX_VERSION_RELEASE);
     /* create an nspace object for ourselves - we will
      * fill in the nspace name later */
     pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -164,8 +164,6 @@ int pmix_rte_init(uint32_t type,
     }
 
     /* setup the globals structure */
-    gethostname(hostname, PMIX_MAXHOSTNAMELEN-1);
-    pmix_globals.hostname = strdup(hostname);
     pmix_globals.pid = getpid();
     memset(&pmix_globals.myid.nspace, 0, PMIX_MAX_NSLEN+1);
     pmix_globals.myid.rank = PMIX_RANK_INVALID;
@@ -179,6 +177,13 @@ int pmix_rte_init(uint32_t type,
                           pmix_globals.evbase, pmix_globals.event_eviction_time,
                           _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
+    /* if we were given a hostname in our environment, use it */
+    if (NULL != (evar = getenv("PMIX_HOSTNAME"))) {
+        pmix_globals.hostname = strdup(evar);
+    } else {
+        gethostname(hostname, PMIX_MAXHOSTNAMELEN-1);
+        pmix_globals.hostname = strdup(hostname);
+    }
 
     if (PMIX_SUCCESS != ret) {
         error = "notification hotel init";

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3356,9 +3356,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
     pmix_server_caddy_t *cd;
     pmix_proc_t proc;
     pmix_buffer_t *reply;
-    pmix_cb_t cb;
-    pmix_info_t info;
-    pmix_kval_t *kv;
 
     /* retrieve the cmd */
     cnt = 1;
@@ -3381,74 +3378,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
-        }
-        /* if this peer is using dstore, then we let the gds/hash
-         * component add node- and app-level info for the peer's
-         * own nspace so that functions like "resolve_peers" and
-         * "resolve_nodes" can properly respond */
-        if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
-            /* get the node info */
-            PMIX_CONSTRUCT(&cb, pmix_cb_t);
-            PMIX_LOAD_NSPACE(&proc, peer->info->pname.nspace);
-            proc.rank = PMIX_RANK_UNDEF;
-            cb.proc = &proc;
-            PMIX_INFO_LOAD(&info, PMIX_NODE_INFO, NULL, PMIX_BOOL);
-            cb.info = &info;
-            cb.ninfo = 1;
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                cb.proc = NULL;
-                cb.info = NULL;
-                cb.ninfo = 0;
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-                PMIX_BFROPS_PACK(rc, peer, reply, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    cb.proc = NULL;
-                    cb.info = NULL;
-                    cb.ninfo = 0;
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-            }
-            cb.proc = NULL;
-            cb.info = NULL;
-            cb.ninfo = 0;
-            PMIX_DESTRUCT(&cb);
-            /* get the app info */
-            PMIX_CONSTRUCT(&cb, pmix_cb_t);
-            cb.proc = &proc;
-            PMIX_INFO_LOAD(&info, PMIX_APP_INFO, NULL, PMIX_BOOL);
-            cb.info = &info;
-            cb.ninfo = 1;
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                cb.proc = NULL;
-                cb.info = NULL;
-                cb.ninfo = 0;
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-                PMIX_BFROPS_PACK(rc, peer, reply, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    cb.proc = NULL;
-                    cb.info = NULL;
-                    cb.ninfo = 0;
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-            }
-            cb.proc = NULL;
-            cb.info = NULL;
-            cb.ninfo = 0;
-            PMIX_DESTRUCT(&cb);
         }
         PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, reply);
         if (PMIX_SUCCESS != rc) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1379,6 +1379,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
         return rc;
     }
 
+    /* ensure we agree on our hostname - typically only important in
+     * test scenarios where we are faking multiple nodes */
+    pmix_setenv("PMIX_HOSTNAME", pmix_globals.hostname, true, env);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -120,8 +120,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     char *cptr;
     char nspace[PMIX_MAX_NSLEN+1];
     pmix_namespace_t *ns, *nptr;
-    pmix_info_t *info=NULL;
-    size_t ninfo=0;
     pmix_dmdx_local_t *lcd;
     pmix_dmdx_request_t *req;
     bool local;
@@ -159,34 +157,33 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     }
     /* retrieve any provided info structs */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninfo, &cnt, PMIX_SIZE);
+    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    if (0 < ninfo) {
-        PMIX_INFO_CREATE(info, ninfo);
-        if (NULL == info) {
+    if (0 < cd->ninfo) {
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        if (NULL == cd->info) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
         }
-        cnt = ninfo;
-        PMIX_BFROPS_UNPACK(rc, cd->peer, buf, info, &cnt, PMIX_INFO);
+        cnt = cd->ninfo;
+        PMIX_BFROPS_UNPACK(rc, cd->peer, buf, cd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_INFO_FREE(info, ninfo);
             return rc;
         }
     }
 
     /* search for directives we can deal with here */
-    for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_IMMEDIATE, PMIX_MAX_KEYLEN)) {
+    for (n=0; n < cd->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&cd->info[n], PMIX_IMMEDIATE)) {
             /* just check our own data - don't wait
              * or request it from someone else */
-            localonly = PMIX_INFO_TRUE(&info[n]);
-        } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-            tv.tv_sec = info[n].value.data.uint32;
+            localonly = PMIX_INFO_TRUE(&cd->info[n]);
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_TIMEOUT)) {
+            tv.tv_sec = cd->info[n].value.data.uint32;
         }
     }
 
@@ -247,10 +244,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * the original requestor so they will get the data
          * back when we receive it */
         rc = create_local_tracker(nspace, rank,
-                                  info, ninfo,
+                                  cd->info, cd->ninfo,
                                   cbfunc, cbdata, &lcd, &req);
         if (PMIX_ERR_NOMEM == rc) {
-            PMIX_INFO_FREE(info, ninfo);
             return rc;
         }
         if (PMIX_SUCCESS == rc) {
@@ -281,9 +277,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             pmix_output_verbose(5, pmix_server_globals.get_output,
                                 "%s UNKNOWN NSPACE: REQUEST PASSED TO HOST",
                                 PMIX_NAME_PRINT(&pmix_globals.myid));
-            rc = pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
+            rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
             if (PMIX_SUCCESS != rc) {
-                PMIX_INFO_FREE(info, ninfo);
                 pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
                 PMIX_RELEASE(lcd);
                 return rc;
@@ -301,7 +296,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             pmix_output_verbose(5, pmix_server_globals.get_output,
                                 "%s UNKNOWN NSPACE: NO DMODEX AVAILABLE - NOT FOUND",
                                 PMIX_NAME_PRINT(&pmix_globals.myid));
-            PMIX_INFO_FREE(info, ninfo);
             pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
             PMIX_RELEASE(lcd);
             return PMIX_ERR_NOT_FOUND;
@@ -329,18 +323,22 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * can retrieve the info from that GDS. Otherwise,
          * we need to retrieve it from our own */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
-            pmix_output_verbose(5, pmix_server_globals.get_output,
-                                "%s GETTING JOB-DATA FOR %s",
-                                PMIX_NAME_PRINT(&pmix_globals.myid),
-                                PMIX_NAME_PRINT(&proc));
+        pmix_output_verbose(5, pmix_server_globals.get_output,
+                            "%s GETTING JOB-DATA FOR %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIX_NAME_PRINT(&proc));
         /* this data is for a local client, so give the gds the
          * option of returning a complete copy of the data,
          * or returning a pointer to local storage */
         cb.proc = &proc;
         cb.scope = PMIX_SCOPE_UNDEF;
         cb.copy = false;
+        cb.info = cd->info;
+        cb.ninfo = cd->ninfo;
         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
         if (PMIX_SUCCESS != rc) {
+            cb.info = NULL;
+            cb.ninfo = 0;
             PMIX_DESTRUCT(&cb);
             return rc;
         }
@@ -356,10 +354,14 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                                 PMIX_NAME_PRINT(&proc));
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS != rc) {
+                cb.info = NULL;
+                cb.ninfo = 0;
                 PMIX_DESTRUCT(&cb);
                 return rc;
             }
         }
+        cb.info = NULL;
+        cb.ninfo = 0;
         PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
         /* assemble the provided data into a byte object */
         PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
@@ -413,10 +415,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         }
         /* we cannot do anything further, so just track this request
          * for now */
-        rc = create_local_tracker(nspace, rank, info, ninfo,
+        rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo,
                                   cbfunc, cbdata, &lcd, &req);
         if (PMIX_ERR_NOMEM == rc) {
-            PMIX_INFO_FREE(info, ninfo);
             return rc;
         }
         pmix_output_verbose(2, pmix_server_globals.get_output,
@@ -438,8 +439,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     /* if everyone has registered, see if we already have this data */
     rc = _satisfy_request(nptr, rank, cd, cbfunc, cbdata, &local);
     if( PMIX_SUCCESS == rc ){
-        /* request was successfully satisfied */
-        PMIX_INFO_FREE(info, ninfo);
         /* return success as the satisfy_request function
          * calls the cbfunc for us, and it will have
          * released the cbdata object */
@@ -463,11 +462,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
 
     /* Check to see if we already have a pending request for the data - if
      * we do, then we can just wait for it to arrive */
-    rc = create_local_tracker(nspace, rank, info, ninfo,
+    rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo,
                               cbfunc, cbdata, &lcd, &req);
     if (PMIX_ERR_NOMEM == rc || NULL == lcd) {
         /* we have a problem */
-        PMIX_INFO_FREE(info, ninfo);
         return PMIX_ERR_NOMEM;
     }
     /* if they specified a timeout, set it up now */
@@ -497,10 +495,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * resource manager server to please get the info for us from
      * whomever is hosting the target process */
     if (NULL != pmix_host_server.direct_modex) {
-        rc = pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
+        rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
         if (PMIX_SUCCESS != rc) {
             /* may have a function entry but not support the request */
-            PMIX_INFO_FREE(info, ninfo);
             pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
             PMIX_RELEASE(lcd);
         }
@@ -510,7 +507,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                             pmix_globals.myid.nspace,
                             pmix_globals.myid.rank);
         /* if we don't have direct modex feature, just respond with "not found" */
-        PMIX_INFO_FREE(info, ninfo);
         pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
         PMIX_RELEASE(lcd);
         rc = PMIX_ERR_NOT_FOUND;
@@ -718,7 +714,11 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
         cb.proc = &proc;
         cb.scope = PMIX_INTERNAL;
         cb.copy = false;
+        cb.info = cd->info;
+        cb.ninfo = cd->ninfo;
         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+        cb.info = NULL;
+        cb.ninfo = 0;
         if (PMIX_SUCCESS == rc) {
             PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
             /* assemble the provided data into a byte object */
@@ -786,7 +786,11 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
         cb.proc = &proc;
         cb.scope = scope;
         cb.copy = false;
+        cb.info = cd->info;
+        cb.ninfo = cd->ninfo;
         PMIX_GDS_FETCH_KV(rc, peer, &cb);
+        cb.info = NULL;
+        cb.ninfo = 0;
         if (PMIX_SUCCESS == rc) {
             found = true;
             PMIX_CONSTRUCT(&pkt, pmix_buffer_t);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4515,6 +4515,8 @@ static void cdcon(pmix_server_caddy_t *cd)
     cd->event_active = false;
     cd->trk = NULL;
     cd->peer = NULL;
+    cd->info = NULL;
+    cd->ninfo = 0;
 }
 static void cddes(pmix_server_caddy_t *cd)
 {
@@ -4526,6 +4528,9 @@ static void cddes(pmix_server_caddy_t *cd)
     }
     if (NULL != cd->peer) {
         PMIX_RELEASE(cd->peer);
+    }
+    if (NULL != cd->info) {
+        PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
 }
 PMIX_CLASS_INSTANCE(pmix_server_caddy_t,

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -49,12 +49,11 @@ int main(int argc, char **argv)
     struct stat stat_buf;
     struct timeval tv;
     double test_start;
-    test_params params;
-    INIT_TEST_PARAMS(params);
     int test_fail = 0;
     char *tmp;
     int ns_nprocs;
 
+    INIT_TEST_PARAMS(params);
     gettimeofday(&tv, NULL);
     test_start = tv.tv_sec + 1E-6*tv.tv_usec;
 

--- a/test/run_tests.pl.in
+++ b/test/run_tests.pl.in
@@ -23,8 +23,8 @@ my @tests = ("-n 4 --ns-dist 3:1 --fence \"[db | 0:0-2;1:0]\"",
              "-n 5 --test-resolve-peers --ns-dist \"1:2:2\"",
              "-n 5 --test-replace 100:0,1,10,50,99",
              "-n 5 --test-internal 10",
-             "-s 2 -n 2 --job-fence",
-             "-s 2 -n 2 --job-fence -c");
+             "-s 1 -n 2 --job-fence",
+             "-s 1 -n 2 --job-fence -c");
 
 my $test;
 my $cmd;

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 
 int pmix_test_verbose = 0;
+test_params params;
 
 FILE *file;
 
@@ -92,6 +93,10 @@ void parse_cmd(int argc, char **argv, test_params *params)
             i++;
             if (NULL != argv[i]) {
                 params->nservers = atoi(argv[i]);
+            }
+            if (2 < params->nservers) {
+                fprintf(stderr, "Only support up to 2 servers\n");
+                exit(1);
             }
         } else if( 0 == strcmp(argv[i], "--verbose") || 0 == strcmp(argv[i],"-v") ){
             TEST_VERBOSE_ON();

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -145,6 +145,8 @@ typedef struct {
     uint32_t lsize;
 } test_params;
 
+extern test_params params;
+
 #define INIT_TEST_PARAMS(params) do { \
     params.nprocs = 1;                \
     params.verbose = 0;               \

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -246,7 +246,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
 
     (void)strncpy(proc.nspace, my_nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    /* get number of neighbours on this node */
+    /* get number of neighbors on this node */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peer # failed: %d", my_nspace, my_rank, rc));
         return rc;
@@ -265,7 +265,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
     npeers = val->data.uint32;
     peers = malloc(sizeof(pmix_rank_t) * npeers);
 
-    /* get ranks of neighbours on this node */
+    /* get ranks of neighbors on this node */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peers failed: %d", my_nspace, my_rank, rc));
         free(peers);
@@ -379,6 +379,7 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
             for(k=0; k<npeers; k++){
                 if( peers[k] == i+params.base_rank){
                     local = 1;
+                    break;
                 }
             }
             if( local ){

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -21,7 +21,8 @@ static int resolve_nspace(char *nspace, test_params params, char *my_nspace, int
     pmix_proc_t *procs;
     size_t nprocs, nranks, i;
     pmix_proc_t *ranks;
-    rc = PMIx_Resolve_peers(NODE_NAME, nspace, &procs, &nprocs);
+
+    rc = PMIx_Resolve_peers(pmix_globals.hostname, nspace, &procs, &nprocs);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Resolve peers test failed: rc = %d", my_nspace, my_rank, rc));
         return rc;

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -41,10 +41,14 @@ static void sdes(server_info_t *s)
         pmix_event_del(s->evread);
     }
     s->evread = NULL;
+    if (NULL != s->hostname) {
+        free(s->hostname);
+    }
 }
 
 static void scon(server_info_t *s)
 {
+    s->hostname = NULL;
     s->idx = 0;
     s->pid = 0;
     s->rd_fd = -1;
@@ -115,6 +119,18 @@ static void fill_seq_ranks_array(size_t nprocs, int base_rank, char **ranks)
     }
 }
 
+static int server_find_id(const char *nspace, int rank)
+{
+    server_nspace_t *tmp;
+
+    PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
+        if (0 == strcmp(tmp->name, nspace)) {
+            return tmp->task_map[rank];
+        }
+    }
+    return -1;
+}
+
 static void set_namespace(int local_size, int univ_size,
                           int base_rank, char *name)
 {
@@ -122,7 +138,9 @@ static void set_namespace(int local_size, int univ_size,
     pmix_info_t *info;
     ninfo = 8;
     char *regex, *ppn;
-    char *ranks = NULL;
+    char *ranks = NULL, **nodes = NULL;
+    char **rks=NULL;
+    int i;
 
     PMIX_INFO_CREATE(info, ninfo);
     pmix_strncpy(info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
@@ -145,19 +163,56 @@ static void set_namespace(int local_size, int univ_size,
     pmix_strncpy(info[3].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
     info[3].value.type = PMIX_STRING;
     info[3].value.data.string = strdup(ranks);
-    free(ranks);
 
-    PMIx_generate_regex(NODE_NAME, &regex);
+    /* if we have two servers any rank not on us,
+     * must be on the other */
+    if (1 == params.nservers) {
+        ppn = strdup(my_server_info->hostname);
+    } else {
+        if (local_size < univ_size) {
+            pmix_argv_append_nosize(&nodes, "node0");
+            pmix_argv_append_nosize(&nodes, "node1");
+        }
+        ppn = pmix_argv_join(nodes, ',');
+    }
+
+    pmix_argv_free(nodes);
+    PMIx_generate_regex(ppn, &regex);
     PMIX_INFO_LOAD(&info[4], PMIX_NODE_MAP, regex, PMIX_REGEX);
+    free(ppn);
 
-    /* generate the global proc map */
-    fill_seq_ranks_array(univ_size, 0, &ranks);
-    if (NULL == ranks) {
-        return;
+    /* generate the global proc map - if we have two
+     * servers, then the procs not on this server must
+     * be on the other */
+    if (2 == params.nservers) {
+        pmix_argv_append_nosize(&rks, ranks);
+        free(ranks);
+        nodes = NULL;
+        if (0 == my_server_id) {
+            for (i=base_rank+1; i < univ_size; i++) {
+                asprintf(&ppn, "%d", i);
+                pmix_argv_append_nosize(&nodes, ppn);
+                free(ppn);
+            }
+            ppn = pmix_argv_join(nodes, ',');
+            pmix_argv_append_nosize(&rks, ppn);
+            free(ppn);
+        } else {
+            for (i=0; i < base_rank; i++) {
+                asprintf(&ppn, "%d", i);
+                pmix_argv_append_nosize(&nodes, ppn);
+                free(ppn);
+            }
+            ppn = pmix_argv_join(nodes, ',');
+            pmix_argv_prepend_nosize(&rks, ppn);
+            free(ppn);
+        }
+        ranks = pmix_argv_join(rks, ';');
     }
     PMIx_generate_ppn(ranks, &ppn);
     free(ranks);
     PMIX_INFO_LOAD(&info[5], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    free(ppn);
 
     pmix_strncpy(info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
     info[6].value.type = PMIX_UINT32;
@@ -610,18 +665,6 @@ int server_fence_contrib(char *data, size_t ndata,
     return rc;
 }
 
-static int server_find_id(const char *nspace, int rank)
-{
-    server_nspace_t *tmp;
-
-    PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
-        if (0 == strcmp(tmp->name, nspace)) {
-            return tmp->task_map[rank];
-        }
-    }
-    return -1;
-}
-
 static int server_pack_dmdx(int sender_id, const char *nspace, int rank,
                             char **buf)
 {
@@ -722,7 +765,7 @@ error:
 
 int server_init(test_params *params)
 {
-    pmix_info_t info[1];
+    pmix_info_t info[2];
     int rc = PMIX_SUCCESS;
 
     /* fork/init servers procs */
@@ -750,7 +793,9 @@ int server_init(test_params *params)
                 }
                 if (pid == 0) {
                     server_list = PMIX_NEW(pmix_list_t);
+                    my_server_info = server_info;
                     my_server_id = i;
+                    asprintf(&server_info->hostname, "node%d", i);
                     server_info->idx = 0;
                     server_info->pid = getppid();
                     server_info->rd_fd = fd1[0];
@@ -761,6 +806,7 @@ int server_init(test_params *params)
                     pmix_list_append(server_list, &server_info->super);
                     break;
                 }
+                asprintf(&server_info->hostname, "node%d", i);
                 server_info->idx = i;
                 server_info->pid = pid;
                 server_info->wr_fd = fd1[1];
@@ -770,6 +816,7 @@ int server_init(test_params *params)
                 close(fd2[1]);
             } else {
                 my_server_info = server_info;
+                server_info->hostname = strdup("node0");
                 server_info->pid = getpid();
                 server_info->idx  = 0;
                 server_info->rd_fd = fd1[0];
@@ -790,10 +837,11 @@ int server_init(test_params *params)
     (void)strncpy(info[0].key, PMIX_SOCKET_MODE, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_UINT32;
     info[0].value.data.uint32 = 0666;
+    PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, my_server_info->hostname, PMIX_STRING);
 
     server_nspace = PMIX_NEW(pmix_list_t);
 
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 2))) {
         TEST_ERROR(("Init failed with error %d", rc));
         goto error;
     }

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -12,6 +12,7 @@
  *
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/test/test_server.h
+++ b/test/test_server.h
@@ -36,6 +36,7 @@ typedef struct {
 struct server_info_t
 {
     pmix_list_item_t super;
+    char *hostname;
     pid_t pid;
     int idx;
     int rd_fd;


### PR DESCRIPTION
**Provide some handy definitions for comparing release versions.** 
Update the dbase store_job_info function to check for an earlier version and translate the node info array, extracting and storing just the local peers for each node.

**Try to fix the "test" area**
The tests do not correctly compute the node and proc maps when running
with multiple servers - they only compute those values for the local
server. This wasn't detected in the past because we weren't using that
info. However, now that we are correctly tracking info by node, this
causes the tests to become confused and fail.

I was unable to get the tests to correctly compute the pattern of proc
assignments for multiple servers, so just tell the tests to only run one
server until someone with more knowledge of this code can fix the
problems.

**Continue to work around the dstore's limitations**
There are additional places where we need to get node or app-specific
info, so test for those keys and redirect to the hash component when
found. Note that this is impacting overall latency as these checks must
be done in the critical path prior to looking at the dstore.

Allow the server to pass its hostname to be used by its clients so that
a test can establish a "fake" hostname.

Signed-off-by: Ralph Castain <rhc@pmix.org>