### PR TITLE
Pyeventhandler

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -75,6 +75,16 @@ ctypedef struct pmix_pyshift_query_t:
     pmix_info_cbfunc_t query
     void *cbdata
 
+ctypedef struct pmix_pyshift_event_handler_t:
+    char *op
+    pmix_status_t status
+    pmix_info_t *results
+    size_t nresults
+    pmix_op_cbfunc_t cbfunc
+    void *thiscbdata
+    void *notification_cbdata
+    pmix_event_notification_cbfunc_fn_t event_handler
+
 cdef void pmix_unload_argv(char **keys, argv:list):
     n = 0
     while NULL != keys[n]:

--- a/bindings/python/tests/client.py
+++ b/bindings/python/tests/client.py
@@ -83,7 +83,7 @@ def test_query(client, pyqueries):
         print("QUERY TEST FAILED: ", client.error_string(rc))
     print("QUERY INFO RETURNED: ", pyresults)
 
-def test_pyhandler():
+def test_pyhandler(st:int, pysource:dict, pyinfo:list, pyresults:list):
     status = PMIX_EVENT_ACTION_COMPLETE
     results = [{'key':'eventkey', 'value':'testevent', 'val_type':PMIX_STRING}]
     return status, results
@@ -139,6 +139,7 @@ def main():
     pycodes = []
     code = PMIX_MODEL_DECLARED
     pycodes.append(code)
+    print("REGISTERING")
     info = [{'key': PMIX_EVENT_HDLR_NAME, 'value': 'SIMPCLIENT-MODEL', 'val_type': PMIX_STRING}]
     rc = foo.register_event_handler(pycodes, info, test_pyhandler)
     print("REGISTER EVENT HANDLER RETURNED: ", foo.error_string(rc))

--- a/bindings/python/tests/client.py
+++ b/bindings/python/tests/client.py
@@ -83,6 +83,11 @@ def test_query(client, pyqueries):
         print("QUERY TEST FAILED: ", client.error_string(rc))
     print("QUERY INFO RETURNED: ", pyresults)
 
+def test_pyhandler():
+    status = PMIX_EVENT_ACTION_COMPLETE
+    results = [{'key':'eventkey', 'value':'testevent', 'val_type':PMIX_STRING}]
+    return status, results
+
 def main():
     foo = PMIxClient()
     print("Testing PMIx ", foo.get_version())
@@ -130,6 +135,13 @@ def main():
 
     pyq = [{'keys':[PMIX_QUERY_PSET_NAMES], 'qualifiers':[]}]
     test_query(foo, pyq)
+
+    pycodes = []
+    code = PMIX_MODEL_DECLARED
+    pycodes.append(code)
+    info = [{'key': PMIX_EVENT_HDLR_NAME, 'value': 'SIMPCLIENT-MODEL', 'val_type': PMIX_STRING}]
+    rc = foo.register_event_handler(pycodes, info, test_pyhandler)
+    print("REGISTER EVENT HANDLER RETURNED: ", foo.error_string(rc))
 
     # finalize
     info = []

--- a/bindings/python/tests/client.py
+++ b/bindings/python/tests/client.py
@@ -86,6 +86,7 @@ def test_query(client, pyqueries):
 def test_pyhandler(st:int, pysource:dict, pyinfo:list, pyresults:list):
     status = PMIX_EVENT_ACTION_COMPLETE
     results = [{'key':'eventkey', 'value':'testevent', 'val_type':PMIX_STRING}]
+    print("RESULTS FOR PYHANDLER: ", results)
     return status, results
 
 def main():
@@ -142,7 +143,8 @@ def main():
     print("REGISTERING")
     info = [{'key': PMIX_EVENT_HDLR_NAME, 'value': 'SIMPCLIENT-MODEL', 'val_type': PMIX_STRING}]
     rc = foo.register_event_handler(pycodes, info, test_pyhandler)
-    print("REGISTER EVENT HANDLER RETURNED: ", foo.error_string(rc))
+    print("REGISTER EVENT HANDLER RETURNEDj (STR): ", foo.error_string(rc))
+    print("REGISTER EVENT HANDLER RETURNED (INT): ", rc)
 
     # finalize
     info = []

--- a/bindings/python/tests/server.py
+++ b/bindings/python/tests/server.py
@@ -77,7 +77,7 @@ def main():
                     read = read.decode('utf-8').rstrip()
                     stdout_done = False
                     stdout.append(read)
-            elif fd == p.stderr.fileno():
+            if fd == p.stderr.fileno():
                 read = p.stderr.readline()
                 if read:
                     read = read.decode('utf-8').rstrip()

--- a/bindings/python/tests/server.py
+++ b/bindings/python/tests/server.py
@@ -20,7 +20,8 @@ def main():
            'publish': clientpublish,
            'unpublish': clientunpublish,
            'lookup': clientlookup,
-           'query': clientquery}
+           'query': clientquery,
+           'registerevents': client_register_events}
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")
     rc = foo.initialized()

--- a/bindings/python/tests/server_upcalls.py
+++ b/bindings/python/tests/server_upcalls.py
@@ -89,3 +89,6 @@ def clientquery(proc:dict, queries:list):
                 results.append(info)
     return PMIX_ERR_NOT_FOUND, results
 
+def client_register_events(codes:list, directives:list):
+    print("CLIENT REGISTER EVENTS ", codes)
+    return PMIX_OPERATION_SUCCEEDED

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -127,12 +127,12 @@ static void regevents_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     }
 
     /* call the callback */
-    if (NULL != cd && NULL != cd->evregcbfn) {
-        cd->evregcbfn(ret, index, cd->cbdata);
-    }
     if (NULL != cd) {
         /* check this event against anything in our cache */
         check_cached_events(cd);
+        if (NULL != cd->evregcbfn) {
+            cd->evregcbfn(ret, index, cd->cbdata);
+        }
     }
 
     /* release any info we brought along as they are
@@ -626,28 +626,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
         cd->list = NULL;
         cd->hdlr = evhdlr;
         cd->firstoverall = firstoverall;
-        rc = _add_hdlr(cd, &xfer);
-        PMIX_LIST_DESTRUCT(&xfer);
-        if (PMIX_SUCCESS != rc &&
-            PMIX_ERR_WOULD_BLOCK != rc) {
-                /* unable to register */
-            --pmix_globals.events.nhdlrs;
-            rc = PMIX_ERR_EVENT_REGISTRATION;
-            index = UINT_MAX;
-            if (firstoverall) {
-                pmix_globals.events.first = NULL;
-            } else {
-                pmix_globals.events.last = NULL;
-            }
-            PMIX_RELEASE(evhdlr);
-            goto ack;
-        }
-        if (PMIX_ERR_WOULD_BLOCK == rc) {
-            /* the callback will provide our response */
-            PMIX_RELEASE(cd);
-            return;
-        }
-        goto ack;
+        goto addtolist;
     }
 
     /* get here if this isn't an overall first or last event - start
@@ -714,23 +693,8 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     cd->index = index;
     cd->hdlr = evhdlr;
     cd->firstoverall = false;
-    /* tell the server about it, if necessary - any actions
-     * will be deferred until after this event completes */
-    if (PMIX_RANGE_PROC_LOCAL == range) {
-        rc = PMIX_SUCCESS;
-    } else {
-        rc = _add_hdlr(cd, &xfer);
-    }
-    PMIX_LIST_DESTRUCT(&xfer);
-    if (PMIX_SUCCESS != rc &&
-        PMIX_ERR_WOULD_BLOCK != rc) {
-        /* unable to register */
-        --pmix_globals.events.nhdlrs;
-        rc = PMIX_ERR_EVENT_REGISTRATION;
-        index = UINT_MAX;
-        PMIX_RELEASE(evhdlr);
-        goto ack;
-    }
+
+  addtolist:
     /* now add this event to the appropriate list - if the registration
      * subsequently fails, it will be removed */
 
@@ -829,6 +793,32 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
             goto ack;
         }
     }
+
+    /* tell the server about it, if necessary - any actions
+     * will be deferred until after this event completes */
+    if (PMIX_RANGE_PROC_LOCAL == range) {
+        rc = PMIX_SUCCESS;
+    } else if (NULL != cd->evregcbfn) {
+        rc = _add_hdlr(cd, &xfer);
+    } else {
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_LIST_DESTRUCT(&xfer);
+    if (PMIX_SUCCESS != rc &&
+        PMIX_ERR_WOULD_BLOCK != rc) {
+        /* unable to register */
+        --pmix_globals.events.nhdlrs;
+        rc = PMIX_ERR_EVENT_REGISTRATION;
+        index = UINT_MAX;
+        if (firstoverall) {
+            pmix_globals.events.first = NULL;
+        } else if (lastoverall) {
+            pmix_globals.events.last = NULL;
+        } else {
+            pmix_list_remove_item(cd->list, &evhdlr->super);
+        }
+        PMIX_RELEASE(evhdlr);
+    }
     if (PMIX_ERR_WOULD_BLOCK == rc) {
         /* the callback will provide our response */
         PMIX_RELEASE(cd);
@@ -848,9 +838,6 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     if (NULL != cd->evregcbfn) {
         cd->evregcbfn(rc, index, cd->cbdata);
         PMIX_RELEASE(cd);
-    } else {
-        cd->status = rc;
-        PMIX_WAKEUP_THREAD(&cd->lock);
     }
 }
 
@@ -893,16 +880,16 @@ PMIX_EXPORT pmix_status_t PMIx_Register_event_handler(pmix_status_t codes[], siz
     cd->info = info;
     cd->ninfo = ninfo;
     cd->evhdlr = event_hdlr;
-    cd->evregcbfn = cbfunc;
-    cd->cbdata = cbdata;
 
-    pmix_output_verbose(2, pmix_client_globals.event_output,
-                        "pmix_register_event_hdlr shifting to progress thread");
+    if (NULL != cbfunc) {
+        pmix_output_verbose(2, pmix_client_globals.event_output,
+                            "pmix_register_event_hdlr shifting to progress thread");
 
-    PMIX_THREADSHIFT(cd, reg_event_hdlr);
-
-    if (NULL == cbfunc) {
-        PMIX_WAIT_THREAD(&cd->lock);
+        cd->evregcbfn = cbfunc;
+        cd->cbdata = cbdata;
+        PMIX_THREADSHIFT(cd, reg_event_hdlr);
+    } else {
+        reg_event_hdlr(0, 0, (void*)cd);
         rc = cd->status;
         PMIX_RELEASE(cd);
     }

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -557,8 +557,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "SIMPTEST-MODEL", PMIX_STRING);
     code = PMIX_MODEL_DECLARED;
     PMIx_Register_event_handler(&code, 1, info, ninfo,
-                                model_callback, model_registration_callback, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
+                                model_callback, NULL, NULL);
     PMIX_INFO_FREE(info, ninfo);
     if (PMIX_SUCCESS != mylock.status) {
         exit(mylock.status);


### PR DESCRIPTION
The GIL was causing the pyeventhandler to lock up. Occasionally on some test runs the user event handler is not invoked, or the Register_event_handler (blocking) call from the C API returns a -1. So I'm still working on what is going on there. 