### PR TITLE
Python: Cache events if evhdlr not found

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -77,7 +77,11 @@ ctypedef struct pmix_pyshift_query_t:
 
 ctypedef struct pmix_pyshift_event_handler_t:
     char *op
+    size_t idx
     pmix_status_t status
+    pmix_proc_t source
+    pmix_info_t *info
+    size_t ninfo
     pmix_info_t *results
     size_t nresults
     pmix_op_cbfunc_t cbfunc


### PR DESCRIPTION
There can be a race condition between registration and recording the
event handler in the myevhdlr list. If we lose that race, then just
cache the event in a timeshift and try again.

Signed-off-by: Ralph Castain <rhc@pmix.org>