### PR TITLE
Clarify tests to show that Python evhdlrs are being invoked

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -63,6 +63,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
     cdef pmix_info_t **myresults_ptr
     cdef size_t nmyresults
 
+    print("PYEVHDLR INVOKED")
     # convert the source to python
     pysource = {}
     myns = (source.nspace).decode('ascii')
@@ -79,6 +80,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
 
     # find the handler being called
     found = False
+    rc = PMIX_ERR_NOT_FOUND
     for h in myhdlrs:
         try:
             if evhdlr_registration_id == h['refid']:
@@ -104,6 +106,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
     # if we didn't find the handler, cache this event in a timeshift
     # and try it again
     if not found:
+        print("SHIFTING EVENT")
         mycaddy    = <pmix_pyshift_event_handler_t*> PyMem_Malloc(sizeof(pmix_pyshift_event_handler_t))
         mycaddy.op = strdup("event_handler")
         mycaddy.idx                 = evhdlr_registration_id

--- a/bindings/python/tests/client.py
+++ b/bindings/python/tests/client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import time
 from pmix import *
 
 test_count = 0
@@ -152,6 +153,8 @@ def main():
     pycodes.append(code)
     info = [{'key': PMIX_EVENT_HDLR_NAME, 'value': 'SIMPCLIENT-MODEL', 'val_type': PMIX_STRING}]
     test_register_event_handler(foo, pycodes, info, test_pyhandler)
+
+    time.sleep(4)
 
     # finalize
     info = []

--- a/bindings/python/tests/server.py
+++ b/bindings/python/tests/server.py
@@ -76,20 +76,16 @@ def main():
                 if read:
                     read = read.decode('utf-8').rstrip()
                     stdout_done = False
-                    stdout.append(read)
+                    print("stdout:", read)
             if fd == p.stderr.fileno():
                 read = p.stderr.readline()
                 if read:
                     read = read.decode('utf-8').rstrip()
-                    stderr_done = False
-                    stderr.append(read)
+                    stderr_done = False  
+                    print("stderr:", read)
 
         if stdout_done and stderr_done:
             break
-    for p in stdout:
-        print("stdout:", p)
-    for p in stderr:
-        print("stderr:", p)
     print("FINALIZING")
     foo.finalize()
 


### PR DESCRIPTION
The client.py program was finalizing before the event handler had a
chance to actually be invoked. A better solution would be to "hold"
client.py until the handler was invoked and had returned using the
available handshake protocols in the event handler callback, but this
suffices to illustrate the situation

Signed-off-by: Ralph Castain <rhc@pmix.org>