### PR TITLE
update README links so build status shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/pmix/pmix.svg?branch=master)](https://travis-ci.org/pmix/pmix)
-
+[[Build Status](https://travis-ci.org/openpmix/openpmix.svg?branch=master)](https://travis-ci.org/openpmix/openpmix)
 The Process Management Interface (PMI) has been used for quite some time as a means of exchanging wireup information needed for interprocess communication. Two versions (PMI-1 and PMI-2) have been released as part of the MPICH effort. While PMI-2 demonstrates better scaling properties than its PMI-1 predecessor, attaining rapid launch and wireup of the roughly 1M processes executing across 100k nodes expected for exascale operations remains challenging.
 
 PMI Exascale (PMIx) represents an attempt to resolve these questions by providing an extended version of the PMI standard specifically designed to support clusters up to and including exascale sizes. The overall objective of the project is not to branch the existing pseudo-standard definitions - in fact, PMIx fully supports both of the existing PMI-1 and PMI-2 APIs - but rather to (a) augment and extend those APIs to eliminate some current restrictions that impact scalability, and (b) provide a reference implementation of the PMI-server that demonstrates the desired level of scalability.


### PR DESCRIPTION
Name of the repo changed from pmix to openpmix, so the
Travis links to the build status were incorrect.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>