### PR TITLE
Further cleanups for xversion support

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -52,6 +52,7 @@
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
+#include "src/mca/ptl/base/base.h"
 #include "src/threads/threads.h"
 #include "src/util/argv.h"
 #include "src/util/compress.h"
@@ -406,8 +407,17 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
              * it back to the user, we need a copy of it */
             cb->copy = true;
             if (PMIX_RANK_UNDEF == proc.rank || diffnspace) {
+                if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+                    /* everything is under rank=wildcard */
+                    proc.rank = PMIX_RANK_WILDCARD;
+                }
                 PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
             } else {
+                if (PMIX_RANK_UNDEF == proc.rank &&
+                    PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+                    /* everything is under rank=wildcard */
+                    proc.rank = PMIX_RANK_WILDCARD;
+                }
                 PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
             }
             if (PMIX_SUCCESS == rc) {

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -28,6 +28,7 @@
 #include "src/util/output.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/plog/base/base.h"
+#include "src/mca/ptl/base/base.h"
 
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
@@ -181,15 +182,17 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
             PMIX_RELEASE(cd);
             return rc;
         }
-        /* provide the timestamp - zero will indicate
-         * that it wasn't taken */
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &timestamp, 1, PMIX_TIME);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
+        if (!PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, PMIX_MINOR_WILDCARD, PMIX_RELEASE_WILDCARD)) {
+            /* provide the timestamp - zero will indicate
+             * that it wasn't taken */
+            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                             msg, &timestamp, 1, PMIX_TIME);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                PMIX_RELEASE(cd);
+                return rc;
+            }
         }
         /* pack the number of data entries */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -36,6 +36,7 @@
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
+#include "src/mca/ptl/base/base.h"
 #include "src/util/argv.h"
 #include "src/util/compress.h"
 #include "src/mca/preg/preg.h"
@@ -1384,6 +1385,11 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     pmix_buffer_t buf;
     pmix_rank_t rank;
     pmix_list_t results;
+    char *hname;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "REGISTERING FOR PEER %s type %d.%d.%d", PMIX_PNAME_PRINT(&peer->info->pname),
+                        peer->proc_type.major, peer->proc_type.minor, peer->proc_type.release);
 
     trk = get_tracker(ns->nspace, true);
     if (NULL == trk) {
@@ -1429,7 +1435,37 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     rc = fetch_nodeinfo(NULL, &trk->nodeinfo, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH(kvptr, &results, pmix_kval_t) {
-            PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
+            /* if the peer is earlier than v3.1.5, it is expecting
+             * node info to be in the form of an array, but with the
+             * hostname as the key. Detect and convert that here */
+            if (PMIX_PEER_IS_EARLIER(peer, 3, 1, 5)) {
+                info = (pmix_info_t*)kvptr->value->data.darray->array;
+                ninfo = kvptr->value->data.darray->size;
+                hname = NULL;
+                /* find the hostname */
+                for (n=0; n < ninfo; n++) {
+                    if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+                        free(kvptr->key);
+                        kvptr->key = strdup(info[n].value.data.string);
+                        PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
+                        hname = kvptr->key;
+                        break;
+                    }
+                }
+                if (NULL != hname && 0 == strcmp(pmix_globals.hostname, hname)) {
+                    /* older versions are looking for node-level keys for
+                     * only their own node as standalone keys */
+                    for (n=0; n < ninfo; n++) {
+                        if (pmix_check_node_info(info[n].key)) {
+                            kv.key = strdup(info[n].key);
+                            kv.value = &info[n].value;
+                            PMIX_BFROPS_PACK(rc, peer, reply, &kv, 1, PMIX_KVAL);
+                        }
+                    }
+                }
+            } else {
+                PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
+            }
         }
     }
     PMIX_LIST_DESTRUCT(&results);
@@ -2671,9 +2707,19 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
 
     if (nodeinfo) {
         rc = fetch_nodeinfo(key, &trk->nodeinfo, qualifiers, nqual, kvs);
+        if (PMIX_SUCCESS != rc && PMIX_RANK_WILDCARD == proc->rank) {
+            /* need to check internal as we might have an older peer */
+            ht = &trk->internal;
+            goto doover;
+        }
         return rc;
     } else if (appinfo) {
         rc = fetch_appinfo(key, &trk->apps, qualifiers, nqual, kvs);
+        if (PMIX_SUCCESS != rc && PMIX_RANK_WILDCARD == proc->rank) {
+            /* need to check internal as we might have an older peer */
+            ht = &trk->internal;
+            goto doover;
+        }
         return rc;
     }
 

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -88,6 +88,7 @@ static pmix_status_t generate_node_regex(const char *input,
     pmix_list_t vids;
     char **regexargs = NULL, *tmp, *tmp2;
     char *cptr;
+    pmix_status_t rc;
 
     /* define the default */
     *regexp = NULL;
@@ -302,17 +303,22 @@ static pmix_status_t generate_node_regex(const char *input,
     }
 
     /* assemble final result */
-    tmp = pmix_argv_join(regexargs, ',');
-    if (0 > asprintf(regexp, "pmix[%s]", tmp)) {
-        return PMIX_ERR_NOMEM;
-    }
-    free(tmp);
+    if (NULL != regexargs) {
+        tmp = pmix_argv_join(regexargs, ',');
+        if (0 > asprintf(regexp, "pmix[%s]", tmp)) {
+            return PMIX_ERR_NOMEM;
+        }
+        free(tmp);
 
-    /* cleanup */
-    pmix_argv_free(regexargs);
+        /* cleanup */
+        pmix_argv_free(regexargs);
+        rc = PMIX_SUCCESS;
+    } else {
+        rc = PMIX_ERR_TAKE_NEXT_OPTION;
+    }
 
     PMIX_DESTRUCT(&vids);
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 static pmix_status_t generate_ppn(const char *input,

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -33,14 +33,6 @@
 bool pmix_ptl_base_peer_is_earlier(pmix_peer_t *peer, uint8_t major,
                                    uint8_t minor, uint8_t release)
 {
-    /* if any of the peer's triplets are unknown, then it
-     * must be an earlier value than us as clients from our
-     * version level always have known triplets */
-    if (PMIX_MAJOR_WILDCARD == PMIX_PEER_MAJOR_VERSION(peer) ||
-        PMIX_MINOR_WILDCARD == PMIX_PEER_MINOR_VERSION(peer) ||
-        PMIX_RELEASE_WILDCARD == PMIX_PEER_REL_VERSION(peer)) {
-        return true;
-    }
     /* if they don't care, then don't check */
     if (PMIX_MAJOR_WILDCARD != major) {
         if (PMIX_PEER_MAJOR_VERSION(peer) > major) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -56,6 +56,7 @@
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/plog/plog.h"
 #include "src/mca/psensor/psensor.h"
+#include "src/mca/ptl/base/base.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/output.h"
@@ -2536,12 +2537,16 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer,
     }
     cd->cbfunc.opcbfn = cbfunc;
     cd->cbdata = cbdata;
-    /* unpack the timestamp */
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &timestamp, &cnt, PMIX_TIME);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto exit;
+    if (PMIX_PEER_IS_EARLIER(peer, 3, 0, 0)) {
+        timestamp = -1;
+    } else {
+        /* unpack the timestamp */
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, &timestamp, &cnt, PMIX_TIME);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
     }
 
     /* unpack the number of data */

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -34,6 +34,7 @@
 #include "src/class/pmix_object.h"
 #include "src/util/output.h"
 #include "src/util/printf.h"
+#include "src/include/pmix_globals.h"
 
 #define MAXCNT 1
 
@@ -154,7 +155,7 @@ int main(int argc, char **argv)
         exit(rc);
     }
     PMIX_INFO_FREE(iptr, 2);
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    pmix_output(0, "Client ns %s rank %d: Running on node %s", myproc.nspace, myproc.rank, pmix_globals.hostname);
 
     /* test something */
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);


### PR DESCRIPTION
Deal with earlier versions and their expectations for node-level info

Tested against v2.2 and v3.1

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit cbf3da75def731cc5770c794ccc237f59d5cde98)