### PR TITLE
python: cleaup pyshift structs

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -3,6 +3,8 @@ from distutils.extension import Extension
 from Cython.Build import cythonize
 from sys import platform, maxsize, version_info
 import os
+from Cython.Compiler.Main import default_options
+default_options['emit_linenums'] = True
 from subprocess import check_output, CalledProcessError
 
 def getVersion():


### PR DESCRIPTION
    - merged all pyshift structs into one with all
      of the fields needed to invoke callback functions
      created so far
    - moved callback function wrappers to pmix.pxi
    - added flag to setup.py file in order to see pyx
      file line numbers when warnings and errors are
      printed

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>