### PR TITLE
Fix support for older servers

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -57,7 +57,7 @@
 #include "src/util/name_fns.h"
 #include "src/util/output.h"
 #include "src/mca/gds/gds.h"
-#include "src/mca/ptl/ptl.h"
+#include "src/mca/ptl/base/base.h"
 
 #include "pmix_client_ops.h"
 
@@ -108,42 +108,44 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
     iptr = (pmix_info_t*)info;
     nfo = ninfo;
 
-    if (PMIX_RANK_UNDEF == proc->rank || NULL == key) {
-        goto doget;
-    }
-    /* if they are asking about a node-level piece of info,
-     * then the rank must be UNDEF */
-    if (pmix_check_node_info(key)) {
-        p.rank = PMIX_RANK_UNDEF;
-        /* see if they told us to get node info */
-        if (NULL == info) {
-            /* guess not - better do it */
-            PMIX_INFO_LOAD(&nodeinfo, PMIX_NODE_INFO, NULL, PMIX_BOOL);
-            iptr = &nodeinfo;
-            nfo = 1;
-        }
-        goto doget;
-    }
-    /* if they are asking about an app-level piece of info,
-     * then the rank must be UNDEF */
-    if (pmix_check_app_info(key)) {
-        p.rank = PMIX_RANK_UNDEF;
-        /* see if they told us to get app info */
-        if (NULL == info) {
-            /* guess not - better do it */
-            PMIX_INFO_LOAD(&nodeinfo, PMIX_APP_INFO, NULL, PMIX_BOOL);
-            iptr = &nodeinfo;
-            nfo = 1;
-        }
-        goto doget;
-    }
-
-    /* see if they are requesting session, node, or app-level info */
-    for (n=0; n < ninfo; n++) {
-        if (PMIX_CHECK_KEY(info, PMIX_NODE_INFO) ||
-            PMIX_CHECK_KEY(info, PMIX_APP_INFO) ||
-            PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
+    if (!PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+        if (PMIX_RANK_UNDEF == proc->rank || NULL == key) {
             goto doget;
+        }
+        /* if they are asking about a node-level piece of info,
+         * then the rank must be UNDEF */
+        if (pmix_check_node_info(key)) {
+            p.rank = PMIX_RANK_UNDEF;
+            /* see if they told us to get node info */
+            if (NULL == info) {
+                /* guess not - better do it */
+                PMIX_INFO_LOAD(&nodeinfo, PMIX_NODE_INFO, NULL, PMIX_BOOL);
+                iptr = &nodeinfo;
+                nfo = 1;
+            }
+            goto doget;
+        }
+        /* if they are asking about an app-level piece of info,
+         * then the rank must be UNDEF */
+        if (pmix_check_app_info(key)) {
+            p.rank = PMIX_RANK_UNDEF;
+            /* see if they told us to get app info */
+            if (NULL == info) {
+                /* guess not - better do it */
+                PMIX_INFO_LOAD(&nodeinfo, PMIX_APP_INFO, NULL, PMIX_BOOL);
+                iptr = &nodeinfo;
+                nfo = 1;
+            }
+            goto doget;
+        }
+
+        /* see if they are requesting session, node, or app-level info */
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(info, PMIX_NODE_INFO) ||
+                PMIX_CHECK_KEY(info, PMIX_APP_INFO) ||
+                PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
+                goto doget;
+            }
         }
     }
 

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -177,14 +177,14 @@ int main(int argc, char **argv)
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %s",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-        goto done;
+        exit(rc);
     }
 
     /* get a list of our local peers */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-        goto done;
+        exit(rc);
     }
     /* split the returned string to get the rank of each local peer */
     peers = pmix_argv_split(val->data.string, ',');
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %s",
                         myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-            goto done;
+            exit(rc);
         }
 
         (void)asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt);
@@ -218,13 +218,13 @@ int main(int argc, char **argv)
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %s",
                         myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-            goto done;
+            exit(rc);
         }
 
         if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
             pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Commit failed: %s",
                         myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
-            goto done;
+            exit(rc);
         }
 
         /* call fence to ensure the data is received */
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
         if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
             pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Fence failed: %s",
                         myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
-            goto done;
+            exit(rc);
         }
 
         /* check the returned data */
@@ -264,19 +264,19 @@ int main(int argc, char **argv)
                     if (NULL == val) {
                         pmix_output(0, "Client ns %s rank %d: NULL value returned",
                                     myproc.nspace, myproc.rank);
-                        break;
+                        exit(1);
                     }
                     if (PMIX_UINT64 != val->type) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong type: %d", myproc.nspace, myproc.rank, j, tmp, val->type);
                         PMIX_VALUE_RELEASE(val);
                         free(tmp);
-                        continue;
+                        exit(1);
                     }
                     if (1234 != val->data.uint64) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong value: %d", myproc.nspace, myproc.rank, j, tmp, (int)val->data.uint64);
                         PMIX_VALUE_RELEASE(val);
                         free(tmp);
-                        continue;
+                        exit(1);
                     }
                     pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
                     PMIX_VALUE_RELEASE(val);
@@ -293,6 +293,7 @@ int main(int argc, char **argv)
                         } else {
                             pmix_output(0, "ERROR: Client ns %s rank %d cnt %d: PMIx_Get %s returned remote data for a local proc",
                                         myproc.nspace, myproc.rank, j, tmp);
+                            exit(1);
                         }
                         if (NULL != val) {
                             PMIX_VALUE_RELEASE(val);
@@ -307,6 +308,7 @@ int main(int argc, char **argv)
                     } else {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed for remote proc",
                                     myproc.nspace, myproc.rank, j, tmp);
+                        exit(1);
                     }
                     if (NULL != val) {
                         PMIX_VALUE_RELEASE(val);
@@ -325,14 +327,17 @@ int main(int argc, char **argv)
             pmix_output(0, "Client ns %s rank %d did not return an array for its internal modex blob",
                         myproc.nspace, myproc.rank);
             PMIX_VALUE_RELEASE(val);
+            exit(1);
         } else if (PMIX_INFO != val->data.darray->type) {
             pmix_output(0, "Client ns %s rank %d returned an internal modex array of type %s instead of PMIX_INFO",
                         myproc.nspace, myproc.rank, PMIx_Data_type_string(val->data.darray->type));
             PMIX_VALUE_RELEASE(val);
+            exit(1);
         } else if (0 == val->data.darray->size) {
             pmix_output(0, "Client ns %s rank %d returned an internal modex array of zero length",
                         myproc.nspace, myproc.rank);
             PMIX_VALUE_RELEASE(val);
+            exit(1);
         } else {
             pmix_info_t *iptr = (pmix_info_t*)val->data.darray->array;
             for (n=0; n < val->data.darray->size; n++) {
@@ -343,6 +348,7 @@ int main(int argc, char **argv)
     } else {
         pmix_output(0, "Client ns %s rank %d internal modex blob FAILED with error %s(%d)",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc), rc);
+        exit(rc);
     }
 
     /* log something */
@@ -353,6 +359,7 @@ int main(int argc, char **argv)
     if (PMIX_SUCCESS != rc) {
         pmix_output(0, "Client ns %s rank %d - log_nb returned %s",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
     } else {
         while (active) {
             usleep(10);
@@ -371,7 +378,6 @@ int main(int argc, char **argv)
         }
     }
 
- done:
     /* finalize us */
     pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {


### PR DESCRIPTION
Ensure we only look at rank=wildcard locations for node-level data when
dealing with older servers. Update simpclient to exit with errors.

Signed-off-by: Ralph Castain <rhc@pmix.org>