### PR TITLE
python: add callbacks and client wrappers

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -80,9 +80,20 @@ ctypedef struct pmix_pyshift_t:
     pmix_event_notification_cbfunc_fn_t event_handler
     pmix_tool_connection_cbfunc_t toolconnected
     pmix_credential_cbfunc_t getcredential
+    pmix_validation_cbfunc_t validationcredential
     pmix_info_cbfunc_t allocate
     void *notification_cbdata
     void *cbdata
+
+cdef void validationcredential_cb(capsule, ret):
+    cdef pmix_pyshift_t *shifter
+    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "validationcredential")
+    shifter[0].validationcredential(shifter[0].status, shifter[0].info, shifter[0].ndata,
+            shifter[0].cbdata)
+    print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        pmix_free_info(shifter[0].info, shifter[0].ndata)
+    return
 
 cdef void getcredential_cb(capsule, ret):
     cdef pmix_pyshift_t *shifter

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -62,6 +62,7 @@ ctypedef struct pmix_pyshift_t:
     pmix_modex_cbfunc_t modex
     pmix_status_t status
     pmix_byte_object_t bo
+    pmix_byte_object_t *cred
     pmix_nspace_t nspace
     pmix_proc_t source
     pmix_proc_t *proc
@@ -78,9 +79,20 @@ ctypedef struct pmix_pyshift_t:
     pmix_release_cbfunc_t release_fn
     pmix_event_notification_cbfunc_fn_t event_handler
     pmix_tool_connection_cbfunc_t toolconnected
+    pmix_credential_cbfunc_t getcredential
     pmix_info_cbfunc_t allocate
     void *notification_cbdata
     void *cbdata
+
+cdef void getcredential_cb(capsule, ret):
+    cdef pmix_pyshift_t *shifter
+    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "getcredential")
+    shifter[0].getcredential(shifter[0].status, shifter[0].cred, shifter[0].info, 
+                        shifter[0].ndata, shifter[0].cbdata)
+    print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        pmix_free_info(shifter[0].info, shifter[0].ndata)
+    return
 
 cdef void allocate_cb(capsule, ret):
     cdef pmix_pyshift_t *shifter

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -64,6 +64,7 @@ ctypedef struct pmix_pyshift_t:
     pmix_byte_object_t bo
     pmix_nspace_t nspace
     pmix_proc_t source
+    pmix_proc_t *proc
     pmix_pdata_t *pdata
     pmix_info_t *results
     size_t nresults
@@ -76,8 +77,28 @@ ctypedef struct pmix_pyshift_t:
     pmix_lookup_cbfunc_t lookup
     pmix_release_cbfunc_t release_fn
     pmix_event_notification_cbfunc_fn_t event_handler
+    pmix_tool_connection_cbfunc_t toolconnected
+    pmix_info_cbfunc_t allocate
     void *notification_cbdata
     void *cbdata
+
+cdef void allocate_cb(capsule, ret):
+    cdef pmix_pyshift_t *shifter
+    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "allocate")
+    shifter[0].allocate(shifter[0].status, shifter[0].info, shifter[0].ndata, 
+                        shifter[0].cbdata, shifter[0].release_fn, 
+                        shifter[0].notification_cbdata)
+    print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        pmix_free_info(shifter[0].info, shifter[0].ndata)
+    return
+
+cdef void toolconnected_cb(capsule, ret):
+    cdef pmix_pyshift_t *shifter
+    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "toolconnected")
+    shifter[0].toolconnected(shifter[0].status, shifter[0].proc, shifter[0].cbdata)
+    print("SHIFTER:", shifter[0].op)
+    return
 
 cdef void spawn_cb(capsule, ret):
     cdef pmix_pyshift_t *shifter
@@ -110,6 +131,8 @@ cdef void query_cb(capsule, ret):
     shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "query")
     shifter[0].query(ret, shifter[0].info, shifter[0].ndata, shifter[0].cbdata, NULL, NULL)
     print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        pmix_free_info(shifter[0].info, shifter[0].ndata)
     return
 
 cdef void lookup_cb(capsule, ret):
@@ -117,6 +140,8 @@ cdef void lookup_cb(capsule, ret):
     shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "lookup")
     shifter[0].lookup(ret, shifter[0].pdata, shifter[0].ndata, shifter[0].cbdata)
     print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        pmix_free_pdata(shifter[0].pdata, shifter[0].ndata)
     return
 
 cdef void fence_cb(capsule, ret):
@@ -133,6 +158,8 @@ cdef void dmodex_cb(capsule, ret):
     shifter[0].modex(shifter[0].status, shifter[0].data, shifter[0].ndata,
                      shifter[0].cbdata, NULL, NULL)
     print("SHIFTER:", shifter[0].op)
+    if 0 < shifter[0].ndata:
+        PyMem_Free(&(shifter[0].data))
     return
 
 cdef void pmix_unload_argv(char **keys, argv:list):
@@ -797,7 +824,6 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         print("Unload_value: provided type is unknown")
         return PMIX_ERR_TYPE_MISMATCH
 
-
 cdef void pmix_destruct_value(pmix_value_t *value):
     if value[0].type == PMIX_STRING:
         free(value[0].data.string);
@@ -805,7 +831,6 @@ cdef void pmix_destruct_value(pmix_value_t *value):
 cdef void pmix_free_value(self, pmix_value_t *value):
     pmix_destruct_value(value);
     PyMem_Free(value)
-
 
 # Convert a dictionary of key-value pairs into an
 # array of pmix_info_t structs
@@ -948,7 +973,7 @@ cdef int pmix_unload_pdata(const pmix_pdata_t *pdata, size_t npdata, ilist:list)
         free(kystr)
         d['key']      = pykey
         myns = (pdata[n].proc.nspace).decode('ascii')
-        proc = {'nspace':myns, 'rank':pdata[n].proc.rank}
+        proc = {'nspace':myns, 'rank': pdata[n].proc.rank}
         d['proc']     = proc
         d['value']    = val['value']
         d['val_type'] = val['val_type']


### PR DESCRIPTION
1. Add toolconnected and allocate callbacks, invocations,
and return correct data from their servermodule functions

2. Add client wrapper for PMIx_Process_monitor

3. Add client wrapper for PMIx_Get_credential and server cb to server module function

4. Add client wrapper for PMIx_Validate_credential and server cb to server module function

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>