### PR TITLE
Update the "make check" tests

### DIFF
--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -47,11 +47,14 @@ typedef struct {
     cli_state_t next_state[CLI_TERM+1];
     pmix_rank_t rank;
     char *ns;
+    int exit_code;
+    bool alive;
 } cli_info_t;
 
 extern cli_info_t *cli_info;
 extern int cli_info_cnt;
 extern bool test_abort;
+extern bool test_complete;
 
 int cli_rank(cli_info_t *cli);
 void cli_init(int nprocs);
@@ -60,7 +63,6 @@ void cli_finalize(cli_info_t *cli);
 void cli_disconnect(cli_info_t *cli);
 void cli_terminate(cli_info_t *cli);
 void cli_cleanup(cli_info_t *cli);
-void cli_wait_all(double timeout);
 void cli_kill_all(void);
 
 bool test_terminated(void);

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     if (myproc.rank != params.rank) {
         TEST_ERROR(("Client ns %s Rank returned in PMIx_Init %d does not match to rank from command line %d.", myproc.nspace, myproc.rank, params.rank));
         FREE_TEST_PARAMS(params);
-        exit(rc);
+        exit(1);
     }
     if ( NULL != params.prefix && -1 != params.ns_id) {
         TEST_SET_FILE(params.prefix, params.ns_id, params.rank);
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     if (NULL == val) {
         TEST_ERROR(("rank %d: PMIx_Get universe size returned NULL value", myproc.rank));
         FREE_TEST_PARAMS(params);
-        exit(rc);
+        exit(1);
     }
     if (val->type != PMIX_UINT32 || val->data.uint32 != (uint32_t)params.ns_size ) {
         TEST_ERROR(("rank %d: Universe size value or type mismatch,"

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
@@ -45,17 +46,14 @@ int main(int argc, char **argv)
 {
     char **client_env=NULL;
     char **client_argv=NULL;
-    int rc;
+    int rc, i;
     struct stat stat_buf;
-    struct timeval tv;
-    double test_start;
     int test_fail = 0;
     char *tmp;
     int ns_nprocs;
+    sigset_t unblock;
 
     INIT_TEST_PARAMS(params);
-    gettimeofday(&tv, NULL);
-    test_start = tv.tv_sec + 1E-6*tv.tv_usec;
 
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
@@ -89,6 +87,20 @@ int main(int argc, char **argv)
         TEST_ERROR(("Client executable \"%s\": has no executable flag", params.binary));
         FREE_TEST_PARAMS(params);
         return 0;
+    }
+
+    /* ensure that SIGCHLD is unblocked as we need to capture it */
+    if (0 != sigemptyset(&unblock)) {
+        fprintf(stderr, "SIGEMPTYSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigaddset(&unblock, SIGCHLD)) {
+        fprintf(stderr, "SIGADDSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigprocmask(SIG_UNBLOCK, &unblock, NULL)) {
+        fprintf(stderr, "SIG_UNBLOCK FAILED\n");
+        exit(1);
     }
 
     if (PMIX_SUCCESS != (rc = server_init(&params))) {
@@ -138,23 +150,11 @@ int main(int argc, char **argv)
     }
 
     /* hang around until the client(s) finalize */
-    while (!test_terminated()) {
-        // To avoid test hang we want to interrupt the loop each 0.1s
-        double test_current;
-
-        // check if we exceed the max time
-        gettimeofday(&tv, NULL);
-        test_current = tv.tv_sec + 1E-6*tv.tv_usec;
-        if( (test_current - test_start) > params.timeout ){
-            break;
-        }
-        cli_wait_all(0);
-    }
-
-    if( !test_terminated() ){
-        TEST_ERROR(("srv #%d: Test exited by a timeout!", my_server_id));
-        cli_kill_all();
-        test_fail = 1;
+    while (!test_complete) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
     }
 
     if( test_abort ){
@@ -169,12 +169,14 @@ int main(int argc, char **argv)
     if (0 != params.test_spawn) {
         PMIX_WAIT_FOR_COMPLETION(spawn_wait);
     }
+    for(i=0; i < cli_info_cnt; i++){
+        if (cli_info[i].exit_code != 0) {
+            ++test_fail;
+        }
+    }
 
     /* deregister the errhandler */
     PMIx_Deregister_event_handler(0, op_callbk, NULL);
-
-    TEST_VERBOSE(("srv #%d: call cli_wait_all!", my_server_id));
-    cli_wait_all(1.0);
 
     TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
     test_fail += server_finalize(&params, test_fail);


### PR DESCRIPTION
Use SIGCHLD detection to determine that a child has exited as it is more reliable. Track the returned exit codes to help determine success or failure of the overall tests. Minor cleanup of the exit status for pmix_client.

Signed-off-by: Ralph Castain <rhc@pmix.org>