### PR TITLE
Update "make check" tests

### DIFF
--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -48,11 +48,14 @@ typedef struct {
     cli_state_t next_state[CLI_TERM+1];
     pmix_rank_t rank;
     char *ns;
+    int exit_code;
+    bool alive;
 } cli_info_t;
 
 extern cli_info_t *cli_info;
 extern int cli_info_cnt;
 extern bool test_abort;
+extern bool test_complete;
 
 int cli_rank(cli_info_t *cli);
 void cli_init(int nprocs);
@@ -61,7 +64,6 @@ void cli_finalize(cli_info_t *cli);
 void cli_disconnect(cli_info_t *cli);
 void cli_terminate(cli_info_t *cli);
 void cli_cleanup(cli_info_t *cli);
-void cli_wait_all(double timeout);
 void cli_kill_all(void);
 
 bool test_terminated(void);

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     if (myproc.rank != params.rank) {
         TEST_ERROR(("Client ns %s Rank returned in PMIx_Init %d does not match to rank from command line %d.", myproc.nspace, myproc.rank, params.rank));
         FREE_TEST_PARAMS(params);
-        exit(0);
+        exit(1);
     }
     if ( NULL != params.prefix && -1 != params.ns_id) {
         TEST_SET_FILE(params.prefix, params.ns_id, params.rank);
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     if (NULL == val) {
         TEST_ERROR(("rank %d: PMIx_Get universe size returned NULL value", myproc.rank));
         FREE_TEST_PARAMS(params);
-        exit(0);
+        exit(1);
     }
     if (val->type != PMIX_UINT32 || val->data.uint32 != (uint32_t)params.ns_size ) {
         TEST_ERROR(("rank %d: Universe size value or type mismatch,"

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
@@ -45,17 +46,14 @@ int main(int argc, char **argv)
 {
     char **client_env=NULL;
     char **client_argv=NULL;
-    int rc;
+    int rc, i;
     struct stat stat_buf;
-    struct timeval tv;
-    double test_start;
     int test_fail = 0;
     char *tmp;
     int ns_nprocs;
+    sigset_t unblock;
 
     INIT_TEST_PARAMS(params);
-    gettimeofday(&tv, NULL);
-    test_start = tv.tv_sec + 1E-6*tv.tv_usec;
 
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
@@ -89,6 +87,20 @@ int main(int argc, char **argv)
         TEST_ERROR(("Client executable \"%s\": has no executable flag", params.binary));
         FREE_TEST_PARAMS(params);
         return 0;
+    }
+
+    /* ensure that SIGCHLD is unblocked as we need to capture it */
+    if (0 != sigemptyset(&unblock)) {
+        fprintf(stderr, "SIGEMPTYSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigaddset(&unblock, SIGCHLD)) {
+        fprintf(stderr, "SIGADDSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigprocmask(SIG_UNBLOCK, &unblock, NULL)) {
+        fprintf(stderr, "SIG_UNBLOCK FAILED\n");
+        exit(1);
     }
 
     if (PMIX_SUCCESS != (rc = server_init(&params))) {
@@ -138,23 +150,11 @@ int main(int argc, char **argv)
     }
 
     /* hang around until the client(s) finalize */
-    while (!test_terminated()) {
-        // To avoid test hang we want to interrupt the loop each 0.1s
-        double test_current;
-
-        // check if we exceed the max time
-        gettimeofday(&tv, NULL);
-        test_current = tv.tv_sec + 1E-6*tv.tv_usec;
-        if( (test_current - test_start) > params.timeout ){
-            break;
-        }
-        cli_wait_all(0);
-    }
-
-    if( !test_terminated() ){
-        TEST_ERROR(("Test exited by a timeout!"));
-        cli_kill_all();
-        test_fail = 1;
+    while (!test_complete) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
     }
 
     if( test_abort ){
@@ -169,13 +169,17 @@ int main(int argc, char **argv)
     if (0 != params.test_spawn) {
         PMIX_WAIT_FOR_COMPLETION(spawn_wait);
     }
+    for(i=0; i < cli_info_cnt; i++){
+        if (cli_info[i].exit_code != 0) {
+            ++test_fail;
+        }
+    }
 
     /* deregister the errhandler */
     PMIx_Deregister_event_handler(0, op_callbk, NULL);
 
-    cli_wait_all(1.0);
-
-    test_fail += server_finalize(&params);
+    TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
+    test_fail += server_finalize(&params, test_fail);
 
     FREE_TEST_PARAMS(params);
     pmix_argv_free(client_argv);

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
     PMIx_Deregister_event_handler(0, op_callbk, NULL);
 
     TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
-    test_fail += server_finalize(&params, test_fail);
+    test_fail += server_finalize(&params);
 
     FREE_TEST_PARAMS(params);
     pmix_argv_free(client_argv);

--- a/test/run_tests.pl.in
+++ b/test/run_tests.pl.in
@@ -31,6 +31,7 @@ my $cmd;
 my $output;
 my $status = 0;
 my $testnum;
+my $timeout_cmd = "";
 
 # We are running tests against the build tree (vs. the installation
 # tree).  Autogen gives us a full list of all possible component
@@ -63,7 +64,24 @@ $testnum =~ s/.pl//;
 $testnum = substr($testnum, -2);
 $test = @tests[$testnum];
 
-$cmd = "./pmix_test " . $test . " 2>&1";
+# find the timeout or gtimeout cmd so we can timeout the
+# test if it hangs
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 35 30 ";
+        last;
+    } else {
+        my $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 35 30 ";
+            last;
+        }
+    }
+}
+
+$cmd = $timeout_cmd . " ./pmix_test " . $test . " 2>&1";
 print $cmd . "\n";
 $output = `$cmd`;
 print $output . "\n";

--- a/test/test_cd.c
+++ b/test/test_cd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,14 +45,14 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
     rc = PMIx_Connect(&proc, 1, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Connect blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     TEST_VERBOSE(("%s:%d: Connect blocking test succeded", my_nspace, my_rank));
 
     rc = PMIx_Disconnect(&proc, 1, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Disconnect blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     TEST_VERBOSE(("%s:%d: Disconnect blocking test succeded.", my_nspace, my_rank));
 
@@ -64,7 +64,7 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
     }
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Connect non-blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     TEST_VERBOSE(("%s:%d: Connect non-blocking test succeded.", my_nspace, my_rank));
 
@@ -76,7 +76,7 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
     }
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Disconnect non-blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     TEST_VERBOSE(("%s:%d: Disconnect non-blocking test succeded.", my_nspace, my_rank));
     return PMIX_SUCCESS;

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -103,42 +103,42 @@ int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             PUT(int, fence_num+my_rank, PMIX_GLOBAL, fence_num, put_ind++, params.use_same_keys);
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             PUT(float, fence_num+1.1, PMIX_GLOBAL, fence_num, put_ind++, params.use_same_keys);
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             PUT(uint32_t, fence_num+14, PMIX_GLOBAL, fence_num, put_ind++, params.use_same_keys);
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             PUT(uint16_t, fence_num+15, PMIX_GLOBAL, fence_num, put_ind++, params.use_same_keys);
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             /* Submit the data */
             if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
                 TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
-                return rc;
+                exit(rc);
             }
 
             /* setup the fence */
@@ -157,7 +157,7 @@ int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
                 TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
                 PMIX_LIST_DESTRUCT(&test_fences);
                 PMIX_PROC_FREE(pcs, npcs);
-                return rc;
+                exit(rc);
             }
 
             /* replace all items in the list with PMIX_RANK_WILDCARD rank by real ranks to get their data. */
@@ -169,7 +169,7 @@ int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
                     if (PMIX_SUCCESS != rc) {
                         TEST_ERROR(("%s:%d: Can't parse --ns-dist value in order to get ranks for namespace %s", my_nspace, my_rank, p->proc.nspace));
                         PMIX_LIST_DESTRUCT(&test_fences);
-                        return PMIX_ERROR;
+                        exit(PMIX_ERROR);
                     }
                     pmix_list_remove_item(desc->participants, (pmix_list_item_t*)p);
                     for (i = 0; i < nranks; i++) {
@@ -192,35 +192,35 @@ int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, p->proc.nspace, p->proc.rank));
                     PMIX_PROC_FREE(pcs, npcs);
                     PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
+                    exit(rc);
                 }
                 GET(int, (int)(fence_num+p->proc.rank), p->proc.nspace, p->proc.rank, fence_num, put_ind++, params.use_same_keys, 0, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, p->proc.nspace, p->proc.rank));
                     PMIX_PROC_FREE(pcs, npcs);
                     PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
+                    exit(rc);
                 }
                 GET(float, fence_num+1.1, p->proc.nspace, p->proc.rank, fence_num, put_ind++, params.use_same_keys, 1, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, p->proc.nspace, p->proc.rank));
                     PMIX_PROC_FREE(pcs, npcs);
                     PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
+                    exit(rc);
                 }
                 GET(uint32_t, (uint32_t)fence_num+14, p->proc.nspace, p->proc.rank, fence_num, put_ind++, params.use_same_keys, 0, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, p->proc.nspace, p->proc.rank));
                     PMIX_PROC_FREE(pcs, npcs);
                     PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
+                    exit(rc);
                 }
                 GET(uint16_t, fence_num+15, p->proc.nspace, p->proc.rank, fence_num, put_ind++, params.use_same_keys, 1, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, p->proc.nspace, p->proc.rank));
                     PMIX_PROC_FREE(pcs, npcs);
                     PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
+                    exit(rc);
                 }
             }
             /* barrier across participating processes to prevent putting new values with the same key
@@ -249,18 +249,18 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
     /* get number of neighbors on this node */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peer # failed: %d", my_nspace, my_rank, rc));
-        return rc;
+        exit(rc);
     }
     if (NULL == val) {
         TEST_ERROR(("%s:%d: PMIx_Get local peer # returned NULL value", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
 
     if (val->type != PMIX_UINT32  ) {
         TEST_ERROR(("%s:%d: local peer # attribute value type mismatch,"
                 " want %d get %d(%d)",
                 my_nspace, my_rank, PMIX_UINT32, val->type));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     npeers = val->data.uint32;
     peers = malloc(sizeof(pmix_rank_t) * npeers);
@@ -269,12 +269,12 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peers failed: %d", my_nspace, my_rank, rc));
         free(peers);
-        return rc;
+        exit(rc);
     }
     if (NULL == val) {
         TEST_ERROR(("%s:%d: PMIx_Get local peers returned NULL value", my_nspace, my_rank));
         free(peers);
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
 
     if (val->type != PMIX_STRING  ) {
@@ -282,7 +282,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
                 " want %d get %d(%d)",
                 my_nspace, my_rank, PMIX_UINT32, val->type));
         free(peers);
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
 
     *count = 0;
@@ -293,7 +293,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
             TEST_ERROR(("%s:%d: Bad peer ranks number: should be %d, actual %d (%s)",
                 my_nspace, my_rank, npeers, *count, val->data.string));
             free(peers);
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
         token = strtok_r(str, ",", &sptr);
         str = NULL;
@@ -302,7 +302,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
             if( *eptr != '\0' ){
                 TEST_ERROR(("%s:%d: Bad peer ranks string", my_nspace, my_rank));
                 free(peers);
-                return PMIX_ERROR;
+                exit(PMIX_ERROR);
             }
         }
 
@@ -312,7 +312,7 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
         TEST_ERROR(("%s:%d: Bad peer ranks number: should be %d, actual %d (%s)",
                 my_nspace, my_rank, npeers, *count, val->data.string));
         free(peers);
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     *_peers = peers;
     return PMIX_SUCCESS;
@@ -335,38 +335,38 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
         PUT(int, 12340 + i, PMIX_LOCAL, 100, i, 0);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            return rc;
+            exit(rc);
         }
 
         (void)snprintf(sval, 50, "%s:%d", my_nspace, my_rank);
         PUT(string, sval, PMIX_REMOTE, 101, i, 0);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
 
         PUT(float, (float)12.15 + i, PMIX_GLOBAL, 102, i, 0);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
     }
 
     /* Submit the data */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
 
     /* Perform a fence if was requested */
     FENCE(!params.nonblocking, params.collect, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-        return rc;
+        exit(rc);
     }
 
     if (PMIX_SUCCESS != (rc = get_local_peers(my_nspace, my_rank, &peers, &npeers))) {
-        return PMIX_ERROR;
+        exit(rc);
     }
 
     /* Check the predefined output */
@@ -386,34 +386,34 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
                 GET(int, (12340+j), my_nspace, i+params.base_rank, 100, j, 0, 0, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %s", my_nspace, my_rank, PMIx_Error_string(rc)));
-                    return PMIX_ERROR;
+                    exit(rc);
                 }
 
                 snprintf(sval, 50, "%s:%d", my_nspace, i+params.base_rank);
                 GET(string, sval, my_nspace, i+params.base_rank, 101, j, 0, 1, 1);
                 if (PMIX_SUCCESS == rc && (i+params.base_rank) != my_rank ) {
                     TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
-                    return PMIX_ERROR;
+                    exit(PMIX_ERROR);
                 }
             } else {
                 GET(int, (12340+j), my_nspace, i+params.base_rank, 100, j, 0, 0, 1);
                 if (PMIX_SUCCESS == rc && (i+params.base_rank) != my_rank) {
                     TEST_ERROR(("%s:%d: PMIx_Get of local key on the remote proc", my_nspace, my_rank));
-                    return PMIX_ERROR;
+                    exit(PMIX_ERROR);
                 }
 
                 snprintf(sval, 50, "%s:%d", my_nspace, i+params.base_rank);
                 GET(string, sval, my_nspace, i+params.base_rank, 101, j, 0, 1, 0);
                 if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed (%d)", my_nspace, my_rank, rc));
-                    return PMIX_ERROR;
+                    exit(PMIX_ERROR);
                 }
             }
 
             GET(float, (float)12.15 + j, my_nspace, i+params.base_rank, 102, j, 0, 0, 0);
             if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Get failed (%d)", my_nspace, my_rank, rc));
-                return PMIX_ERROR;
+                exit(PMIX_ERROR);
             }
         }
 
@@ -422,16 +422,16 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
         if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, "foobar", NULL, 0, &val))) {
             TEST_ERROR(("%s:%d: PMIx_Get returned success instead of failure",
                         my_nspace, my_rank));
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
         if (PMIX_ERR_NOT_FOUND != rc && PMIX_ERR_PROC_ENTRY_NOT_FOUND != rc) {
             TEST_ERROR(("%s:%d [ERROR]: PMIx_Get returned %s instead of not_found",
                         my_nspace, my_rank, PMIx_Error_string(rc)));
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
         if (NULL != val) {
             TEST_ERROR(("%s:%d [ERROR]: PMIx_Get did not return NULL value", my_nspace, my_rank));
-            return PMIX_ERROR;
+            exit(PMIX_ERROR);
         }
         TEST_VERBOSE(("%s:%d: rank %d is OK", my_nspace, my_rank, i+params.base_rank));
     }

--- a/test/test_internal.c
+++ b/test/test_internal.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,7 +50,7 @@ int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&proc, key, &value))) {
             TEST_ERROR(("%s:%d: PMIx_Store_internal failed: %d", my_nspace, my_rank, rc));
             PMIX_PROC_DESTRUCT(&proc);
-            return PMIX_ERROR;
+            exit(rc);
         }
     }
 
@@ -58,7 +58,7 @@ int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
         PMIX_PROC_DESTRUCT(&proc);
-        return PMIX_ERROR;
+        exit(rc);
     }
 
     proc.rank = PMIX_RANK_WILDCARD;
@@ -66,7 +66,7 @@ int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
         PMIX_PROC_DESTRUCT(&proc);
-        return rc;
+        exit(rc);
     }
 
     for (idx = 0; idx < params.test_internal; idx++) {
@@ -77,7 +77,7 @@ int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
             PMIX_PROC_DESTRUCT(&proc);
-            return PMIX_ERROR;
+            exit(rc);
         }
     }
 

--- a/test/test_publish.c
+++ b/test/test_publish.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -150,29 +150,30 @@ static int test_publish_lookup_common(char *my_nspace, int my_rank, int blocking
     rc = test_publish(my_nspace, my_rank, blocking);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: %s failed.", my_nspace, my_rank, blocking ? "PMIX_Publish" : "PMIX_Publish_nb"));
-        return PMIX_ERROR;
+        exit(rc);
     }
     TEST_VERBOSE(("%s:%d: %s succeeded.", my_nspace, my_rank, blocking ? "PMIX_Publish" : "PMIX_Publish_nb"));
 
     rc = test_lookup(my_nspace, my_rank, blocking);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: %s failed.", my_nspace, my_rank, blocking ? "PMIX_Lookup" : "PMIX_Lookup_nb"));
-        return PMIX_ERROR;
+        exit(rc);
     }
     TEST_VERBOSE(("%s:%d: %s succeeded.\n", my_nspace, my_rank, blocking ? "PMIX_Lookup" : "PMIX_Lookup_nb"));
 
     rc = test_unpublish(my_nspace, my_rank, blocking);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: %s failed.", my_nspace, my_rank, blocking ? "PMIX_Unpublish" : "PMIX_Unpublish_nb"));
-        return PMIX_ERROR;
+        exit(rc);
     }
     TEST_VERBOSE(("%s:%d: %s succeeded.", my_nspace, my_rank, blocking ? "PMIX_Unpublish" : "PMIX_Unpublish_nb"));
 
     rc = test_lookup(my_nspace, my_rank, blocking);
     if (PMIX_ERR_NOT_FOUND != rc) {
         TEST_ERROR(("%s:%d: %s function returned %d instead of PMIX_ERR_NOT_FOUND.", my_nspace, my_rank, blocking ? "PMIX_Lookup" : "PMIX_Lookup_nb", rc));
-        return PMIX_ERROR;
+        exit(rc);
     }
+    TEST_VERBOSE(("%s:%d: %s succeeded.", my_nspace, my_rank, blocking ? "PMIX_Lookup of non-existent key" : "PMIX_Lookup_nb of non-existent key"));
     return PMIX_SUCCESS;
 }
 
@@ -183,13 +184,13 @@ int test_publish_lookup(char *my_nspace, int my_rank)
     rc = test_publish_lookup_common(my_nspace, my_rank, 1);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Publish/Lookup blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(rc);
     }
     /* test non-blocking */
     rc = test_publish_lookup_common(my_nspace, my_rank, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Publish/Lookup non-blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(rc);
     }
     return PMIX_SUCCESS;
 }

--- a/test/test_replace.c
+++ b/test/test_replace.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,7 +57,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
             PMIX_LIST_DESTRUCT(&key_replace);
-            return rc;
+            exit(rc);
         }
     }
 
@@ -69,7 +70,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
         PMIX_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
-        return PMIX_ERROR;
+        exit(rc);
     }
 
     FENCE(1, 1, (&proc), 1);
@@ -77,7 +78,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
         PMIX_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
-        return rc;
+        exit(rc);
     }
 
     PMIX_LIST_FOREACH(item, &key_replace, key_replace_t) {
@@ -89,7 +90,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
             PMIX_LIST_DESTRUCT(&key_replace);
             PMIX_PROC_DESTRUCT(&proc);
-            return rc;
+            exit(rc);
         }
     }
 
@@ -99,7 +100,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
         PMIX_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
-        return PMIX_ERROR;
+        exit(rc);
     }
 
     FENCE(1, 1, (&proc), 1);
@@ -107,7 +108,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
         PMIX_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
-        return rc;
+        exit(rc);
     }
 
     for (key_idx = 0; key_idx < key_cnt; key_idx++) {
@@ -125,7 +126,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
             TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
             PMIX_LIST_DESTRUCT(&key_replace);
             PMIX_PROC_DESTRUCT(&proc);
-            return PMIX_ERROR;
+            exit(rc);
         }
     }
 

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -25,30 +25,29 @@ static int resolve_nspace(char *nspace, test_params params, char *my_nspace, int
     rc = PMIx_Resolve_peers(pmix_globals.hostname, nspace, &procs, &nprocs);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Resolve peers test failed: rc = %d", my_nspace, my_rank, rc));
-        return rc;
+        exit(rc);
     }
     if (NULL == procs || 0 == nprocs) {
         TEST_ERROR(("%s:%d: Resolve peers didn't find any process from ns %s at this node\n", my_nspace, my_rank,my_nspace));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     rc = get_all_ranks_from_namespace(params, nspace, &ranks, &nranks);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: get_all_ranks_from_namespace function failed", my_nspace, my_rank));
         PMIX_PROC_FREE(procs, nprocs);
-        return rc;
+        exit(rc);
     }
     if (nprocs != nranks) {
         TEST_ERROR(("%s:%d: Resolve peers returned incorect result: returned %lu processes, expected %lu", my_nspace, my_rank, nprocs, nranks));
         PMIX_PROC_FREE(procs, nprocs);
         PMIX_PROC_FREE(ranks, nranks);
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     for (i = 0; i < nprocs; i++) {
         if (procs[i].rank != ranks[i].rank) {
             TEST_ERROR(("%s:%d: Resolve peers returned incorrect result: returned value %s:%d, expected rank %d",
                         my_nspace, my_rank, procs[i].nspace, procs[i].rank, ranks[i].rank));
-            rc = PMIX_ERROR;
-            break;
+            exit(PMIX_ERROR);
         }
     }
     PMIX_PROC_FREE(procs, nprocs);
@@ -69,14 +68,14 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         TEST_VERBOSE(("%s:%d: Resolve peers succeeded for the own namespace\n", my_nspace, my_rank));
     } else {
         TEST_ERROR(("%s:%d: Resolve peers failed for the own namespace\n", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(rc);
     }
 
     /* then get number of namespaces and try to resolve peers from them. */
     ns_num = get_total_ns_number(params);
     if (0 >= ns_num) {
         TEST_ERROR(("%s:%d: get_total_ns_number function failed", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     for (n = 0; n < ns_num; n++) {
         memset(nspace, 0, PMIX_MAX_NSLEN+1);
@@ -104,7 +103,7 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
             TEST_VERBOSE(("%s:%d: Connect to %s succeeded.", my_nspace, my_rank, nspace));
         } else {
             TEST_ERROR(("%s:%d: Connect to %s failed.", my_nspace, my_rank, nspace));
-            return PMIX_ERROR;
+            exit(rc);
         }
 
         /* then resolve peers from this namespace. */
@@ -112,8 +111,7 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         if (PMIX_SUCCESS == rc) {
             TEST_VERBOSE(("%s:%d: Resolve peers succeeded for ns %s\n", my_nspace, my_rank, nspace));
         } else {
-            PMIx_Disconnect(procs, 2, NULL, 0);
-            break;
+            exit(rc);
         }
 
         /* disconnect from the processes of this namespace. */
@@ -121,8 +119,8 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         if (PMIX_SUCCESS == rc) {
             TEST_VERBOSE(("%s:%d: Disconnect from %s succeeded %s.", my_nspace, my_rank, nspace));
         } else {
-            TEST_ERROR(("%s:%d: Disconnect from %s failed %s.", my_nspace, my_rank, nspace));
-            return PMIX_ERROR;
+            TEST_ERROR(("%s:%d: Disconnect from %s failed.", my_nspace, my_rank, nspace));
+            exit(rc);
         }
     }
     if (PMIX_SUCCESS == rc) {

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -764,6 +764,70 @@ error:
     return PMIX_ERROR;
 }
 
+static void set_handler_default(int sig)
+{
+    struct sigaction act;
+
+    act.sa_handler = SIG_DFL;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+
+    sigaction(sig, &act, (struct sigaction *)0);
+}
+
+static pmix_event_t handler;
+static void wait_signal_callback(int fd, short event, void *arg)
+{
+    pmix_event_t *sig = (pmix_event_t*) arg;
+    int status;
+    pid_t pid;
+    int i;
+
+    if (SIGCHLD != pmix_event_get_signal(sig)) {
+        return;
+    }
+
+    /* we can have multiple children leave but only get one
+     * sigchild callback, so reap all the waitpids until we
+     * don't get anything valid back */
+    while (1) {
+        pid = waitpid(-1, &status, WNOHANG);
+        if (-1 == pid && EINTR == errno) {
+            /* try it again */
+            continue;
+        }
+        /* if we got garbage, then nothing we can do */
+        if (pid <= 0) {
+            goto done;
+        }
+        /* we are already in an event, so it is safe to access the list */
+        for(i=0; i < cli_info_cnt; i++){
+            if( cli_info[i].pid == pid ){
+                /* found it! */
+                if (WIFEXITED(status)) {
+                    cli_info[i].exit_code = WEXITSTATUS(status);
+                } else {
+                    if (WIFSIGNALED(status)) {
+                        cli_info[i].exit_code = WTERMSIG(status) + 128;
+                    }
+                }
+                cli_cleanup(&cli_info[i]);
+                cli_info[i].alive = false;
+                break;
+            }
+        }
+    }
+  done:
+    for(i=0; i < cli_info_cnt; i++){
+        if (cli_info[i].alive) {
+            /* someone is still alive */
+            return;
+        }
+    }
+    /* get here if nobody is still alive */
+    test_complete = true;
+}
+
 int server_init(test_params *params)
 {
     pmix_info_t info[2];
@@ -860,6 +924,12 @@ int server_init(test_params *params)
     /* register the errhandler */
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
                                 errhandler, errhandler_reg_callbk, NULL);
+
+    /* setup to see sigchld on the forked tests */
+    pmix_event_assign(&handler, pmix_globals.evbase, SIGCHLD,
+                      EV_SIGNAL|EV_PERSIST, wait_signal_callback, &handler);
+    pmix_event_add(&handler, NULL);
+
 
     if (0 != (rc = server_barrier())) {
         goto error;
@@ -1011,6 +1081,15 @@ int server_launch_clients(int local_size, int univ_size, int base_rank,
         pmix_argv_append_nosize(&client_argv, digit);
 
         if (cli_info[cli_counter].pid == 0) {
+            sigset_t sigs;
+            set_handler_default(SIGTERM);
+            set_handler_default(SIGINT);
+            set_handler_default(SIGHUP);
+            set_handler_default(SIGPIPE);
+            set_handler_default(SIGCHLD);
+            sigprocmask(0, 0, &sigs);
+            sigprocmask(SIG_UNBLOCK, &sigs, 0);
+
             if( !TEST_VERBOSE_GET() ){
                 // Hide clients stdout
                 if (NULL == freopen("/dev/null","w", stdout)) {
@@ -1022,6 +1101,7 @@ int server_launch_clients(int local_size, int univ_size, int base_rank,
             TEST_ERROR(("execve() failed"));
             return 0;
         }
+        cli_info[cli_counter].alive = true;
         cli_info[cli_counter].state = CLI_FORKED;
 
         pmix_argv_free(client_argv);

--- a/test/test_spawn.c
+++ b/test/test_spawn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -39,7 +39,7 @@ static int test_spawn_common(char *my_nspace, int my_rank, int blocking)
     if (blocking) {
         if (PMIX_SUCCESS != (rc = PMIx_Spawn(NULL, 0, apps, napps, nspace))) {
             PMIX_APP_FREE(apps, napps);
-            return rc;
+            exit(rc);
         }
     } else {
         spawn_cbdata cbdata;
@@ -48,14 +48,14 @@ static int test_spawn_common(char *my_nspace, int my_rank, int blocking)
         rc = PMIx_Spawn_nb(NULL, 0, apps, napps, spawn_cb, (void*)&cbdata);
         if (PMIX_SUCCESS != rc) {
             PMIX_APP_FREE(apps, napps);
-            return rc;
+            exit(rc);
         }
         PMIX_WAIT_FOR_COMPLETION(cbdata.in_progress);
         strncpy(nspace, cbdata.nspace, strlen(cbdata.nspace)+1);
     }
     PMIX_APP_FREE(apps, napps);
     if (strncmp(nspace, "foobar", strlen(nspace)+1)) {
-        return PMIX_ERROR;
+        exit(PMIX_ERROR);
     }
     return rc;
 }
@@ -66,13 +66,13 @@ int test_spawn(char *my_nspace, int my_rank)
     rc = test_spawn_common(my_nspace, my_rank, 1);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Spawn blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(rc);
     }
     TEST_VERBOSE(("%s:%d: Spawn blocking test succeded.", my_nspace, my_rank));
     rc = test_spawn_common(my_nspace, my_rank, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Spawn non-blocking test failed.", my_nspace, my_rank));
-        return PMIX_ERROR;
+        exit(rc);
     }
     TEST_VERBOSE(("%s:%d: Spawn non-blocking test succeded.", my_nspace, my_rank));
     return PMIX_SUCCESS;


### PR DESCRIPTION
Update the "make check" tests
Use SIGCHLD detection to determine that a child has exited as it is more reliable. Track the returned exit codes to help determine success or failure of the overall tests. Minor cleanup of the exit status for pmix_client.

Add timeout capability to make check

Take a pass thru tests ensuring they exit with error