### PR TITLE
Remove event handler registration from tests

### DIFF
--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -268,7 +268,7 @@ void errhandler(size_t evhdlr_registration_id,
                 pmix_event_notification_cbfunc_fn_t cbfunc,
                 void *cbdata)
 {
-    TEST_ERROR((" PMIX server event handler with status = %d", status));
+    TEST_ERROR((" PMIX server event handler for %s:%d with status = %d", source->nspace, source->rank, status));
     /* notify clients of error */
     PMIx_Notify_event(status, source,
                       PMIX_RANGE_NAMESPACE,

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -41,31 +41,6 @@
 #include "test_replace.h"
 #include "test_internal.h"
 
-static void errhandler(size_t evhdlr_registration_id,
-                       pmix_status_t status,
-                       const pmix_proc_t *source,
-                       pmix_info_t info[], size_t ninfo,
-                       pmix_info_t results[], size_t nresults,
-                       pmix_event_notification_cbfunc_fn_t cbfunc,
-                       void *cbdata)
-{
-    TEST_ERROR(("PMIX client: Error handler with status = %d", status))
-}
-
-static void op_callbk(pmix_status_t status,
-               void *cbdata)
-{
-    TEST_VERBOSE(( "OP CALLBACK CALLED WITH STATUS %d", status));
-}
-
-static void errhandler_reg_callbk (pmix_status_t status,
-                                   size_t errhandler_ref,
-                                   void *cbdata)
-{
-    TEST_VERBOSE(("PMIX client ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
-                  status, (unsigned long)errhandler_ref));
-}
-
 int main(int argc, char **argv)
 {
     int rc;
@@ -99,7 +74,6 @@ int main(int argc, char **argv)
         FREE_TEST_PARAMS(params);
         exit(0);
     }
-    PMIx_Register_event_handler(NULL, 0, NULL, 0, errhandler, errhandler_reg_callbk, NULL);
     if (myproc.rank != params.rank) {
         TEST_ERROR(("Client ns %s Rank returned in PMIx_Init %d does not match to rank from command line %d.", myproc.nspace, myproc.rank, params.rank));
         FREE_TEST_PARAMS(params);
@@ -221,7 +195,6 @@ int main(int argc, char **argv)
     }
 
     TEST_VERBOSE(("Client ns %s rank %d: PASSED", myproc.nspace, myproc.rank));
-    PMIx_Deregister_event_handler(1, op_callbk, NULL);
 
     /* In case of direct modex we want to delay Finalize
        until everybody has finished. Otherwise some processes

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -214,7 +214,7 @@ extern pmix_list_t test_fences;
 extern pmix_list_t *noise_range;
 extern pmix_list_t key_replace;
 
-#define NODE_NAME "node1"
+#define NODE_NAME "node0"
 int get_total_ns_number(test_params params);
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
 


### PR DESCRIPTION
The event handler wasn't implemented correctly - it has to thread shift and issue the callback per the standard.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 0cc0c4877aafe80e7d43c83b445af5ed789fa7eb)