### PR TITLE
 Remove fake nodenames as it confuses earlier versions

### DIFF
--- a/test/test_common.h
+++ b/test/test_common.h
@@ -233,7 +233,6 @@ extern pmix_list_t test_fences;
 extern pmix_list_t *noise_range;
 extern pmix_list_t key_replace;
 
-#define NODE_NAME "node1"
 int get_total_ns_number(test_params params);
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
 

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -830,7 +830,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
 
 int server_init(test_params *params)
 {
-    pmix_info_t info[2];
+    pmix_info_t info[1];
     int rc = PMIX_SUCCESS;
 
     /* fork/init servers procs */
@@ -902,11 +902,10 @@ int server_init(test_params *params)
     (void)strncpy(info[0].key, PMIX_SOCKET_MODE, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_UINT32;
     info[0].value.data.uint32 = 0666;
-    PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, my_server_info->hostname, PMIX_STRING);
 
     server_nspace = PMIX_NEW(pmix_list_t);
 
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 2))) {
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
         TEST_ERROR(("Init failed with error %d", rc));
         goto error;
     }


### PR DESCRIPTION
When performing xversion tests, earlier versions don't understand that a
fake node name is in use.

Signed-off-by: Ralph Castain <rhc@pmix.org>