### PR TITLE
Remove fake nodenames as it confuses earlier versions

### DIFF
--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -48,7 +48,6 @@ int main(int argc, char **argv)
     char **client_argv=NULL;
     int rc, i;
     struct stat stat_buf;
-    int test_fail = 0;
     char *tmp;
     int ns_nprocs;
     sigset_t unblock;

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -221,7 +221,6 @@ extern pmix_list_t test_fences;
 extern pmix_list_t *noise_range;
 extern pmix_list_t key_replace;
 
-#define NODE_NAME "node1"
 int get_total_ns_number(test_params params);
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
 

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -29,6 +29,7 @@
 #include "server_callbacks.h"
 
 int my_server_id = 0;
+int test_fail = 0;
 
 server_info_t *my_server_info = NULL;
 pmix_list_t *server_list = NULL;
@@ -948,6 +949,7 @@ int server_finalize(test_params *params)
     int rc = PMIX_SUCCESS;
     int total_ret = 0;
 
+    total_ret = test_fail;
     if (0 != (rc = server_barrier())) {
         total_ret++;
         goto exit;
@@ -968,11 +970,6 @@ int server_finalize(test_params *params)
         PMIX_LIST_RELEASE(server_list);
         TEST_VERBOSE(("SERVER %d FINALIZE PID:%d with status %d",
                     my_server_id, getpid(), ret));
-        if (0 == total_ret) {
-            TEST_OUTPUT(("Test finished OK!"));
-        } else {
-            rc = PMIX_ERROR;
-        }
     }
     PMIX_LIST_RELEASE(server_nspace);
 
@@ -981,6 +978,11 @@ int server_finalize(test_params *params)
         TEST_ERROR(("Finalize failed with error %d", rc));
         total_ret += rc;
         goto exit;
+    }
+    if (0 == total_ret) {
+        TEST_OUTPUT(("Test finished OK!"));
+    } else {
+        TEST_OUTPUT(("Test FAILED!"));
     }
 
 exit:

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -830,7 +830,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
 
 int server_init(test_params *params)
 {
-    pmix_info_t info[2];
+    pmix_info_t info[1];
     int rc = PMIX_SUCCESS;
 
     /* fork/init servers procs */
@@ -902,11 +902,10 @@ int server_init(test_params *params)
     (void)strncpy(info[0].key, PMIX_SOCKET_MODE, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_UINT32;
     info[0].value.data.uint32 = 0666;
-    PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, my_server_info->hostname, PMIX_STRING);
 
     server_nspace = PMIX_NEW(pmix_list_t);
 
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 2))) {
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
         TEST_ERROR(("Init failed with error %d", rc));
         goto error;
     }

--- a/test/test_server.h
+++ b/test/test_server.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,7 @@ extern int my_server_id;
 extern pmix_list_t *server_list;
 extern server_info_t *my_server_info;
 extern pmix_list_t *server_nspace;
+extern int test_fail;
 
 int server_init(test_params *params);
 int server_finalize(test_params *params);


### PR DESCRIPTION
When performing xversion tests, earlier versions don't understand that a
fake node name is in use.

Signed-off-by: Ralph Castain <rhc@pmix.org>