### PR TITLE
Remove fake nodenames as it confuses earlier versions

### DIFF
--- a/test/test_common.h
+++ b/test/test_common.h
@@ -215,7 +215,6 @@ extern pmix_list_t test_fences;
 extern pmix_list_t *noise_range;
 extern pmix_list_t key_replace;
 
-#define NODE_NAME "node0"
 int get_total_ns_number(test_params params);
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
 

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -21,7 +21,11 @@ static int resolve_nspace(char *nspace, test_params params, char *my_nspace, int
     pmix_proc_t *procs;
     size_t nprocs, nranks, i;
     pmix_proc_t *ranks;
-    rc = PMIx_Resolve_peers(NODE_NAME, nspace, &procs, &nprocs);
+    char hostname[1024];
+
+    gethostname(hostname, 1024);
+
+    rc = PMIx_Resolve_peers(hostname, nspace, &procs, &nprocs);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Resolve peers test failed: rc = %d", my_nspace, my_rank, rc));
         return rc;

--- a/test/utils.c
+++ b/test/utils.c
@@ -51,7 +51,9 @@ static void set_namespace(int nprocs, char *ranks, char *name)
     pmix_info_t *info;
     ninfo = 8;
     char *regex, *ppn;
+    char hostname[1024];
 
+    gethostname(hostname, 1024);
     PMIX_INFO_CREATE(info, ninfo);
     (void)strncpy(info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_UINT32;
@@ -69,7 +71,7 @@ static void set_namespace(int nprocs, char *ranks, char *name)
     info[3].value.type = PMIX_STRING;
     info[3].value.data.string = strdup(ranks);
 
-    PMIx_generate_regex(NODE_NAME, &regex);
+    PMIx_generate_regex(hostname, &regex);
     (void)strncpy(info[4].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
     info[4].value.type = PMIX_STRING;
     info[4].value.data.string = regex;


### PR DESCRIPTION
When performing xversion tests, earlier versions don't understand that a
fake node name is in use.

Signed-off-by: Ralph Castain <rhc@pmix.org>