### PR TITLE
Deal with servers using older versions

### DIFF
--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -106,12 +106,16 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
             exit(rc);
         }
 
-        /* then resolve peers from this namespace. */
-        rc = resolve_nspace(nspace, params, my_nspace, my_rank);
-        if (PMIX_SUCCESS == rc) {
-            TEST_VERBOSE(("%s:%d: Resolve peers succeeded for ns %s\n", my_nspace, my_rank, nspace));
-        } else {
-            exit(rc);
+        /* then resolve peers from this namespace - earlier versions cannot handle
+         * cross-nspace peer resolution because their test servers don't provide
+         * the info. So check for a marker of either 3.1.5 or above */
+        if (NULL != getenv("PMIX_VERSION")) {
+            rc = resolve_nspace(nspace, params, my_nspace, my_rank);
+            if (PMIX_SUCCESS == rc) {
+                TEST_VERBOSE(("%s:%d: Resolve peers succeeded for ns %s\n", my_nspace, my_rank, nspace));
+            } else {
+                exit(rc);
+            }
         }
 
         /* disconnect from the processes of this namespace. */


### PR DESCRIPTION
Servers prior to v3.1.5 don't properly track information such as
local_peers on a per-node basis. So ensure we try to access peer info in
a manner consistent with the server's version.

Also, the test servers in older versions just return "not found" for
direct modex requests. This means that resolve_peers is guaranteed to
fail for requests of information about other namespaces, so don't
include such tests in that situation.

Signed-off-by: Ralph Castain <rhc@pmix.org>