### PR TITLE
Continue repairs of xversion make check tests

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2670,7 +2670,7 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
     pmix_buffer_t buf;
     pmix_kval_t kv2, *kvp;
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_info_t *ihost, *ipeers;
+    pmix_info_t *ihost;
 
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     PMIX_CONSTRUCT(&buf, pmix_buffer_t);
@@ -2708,18 +2708,10 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
 	            info = kv->value->data.darray->array;
 	            size = kv->value->data.darray->size;
                 ihost = NULL;
-                ipeers = NULL;
 	            for (i = 0; i < size; i++) {
                     if (PMIX_CHECK_KEY(&info[i], PMIX_HOSTNAME)) {
                         ihost = &info[i];
-                        if (NULL != ipeers) {
-                            break;
-                        }
-                    } else if (PMIX_CHECK_KEY(&info[i], PMIX_LOCAL_PEERS)) {
-                        ipeers = &info[i];
-                        if (NULL != ihost) {
-                            break;
-                        }
+                        break;
                     }
 	            }
                 if (NULL != ihost) {
@@ -2731,11 +2723,11 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
                         PMIX_ERROR_LOG(rc);
                         goto exit;
                     }
-                    if (NULL != ipeers) {
-                        /* if this host is us, then store this as its own key */
-                        if (0 == strcmp(kv2.key, pmix_globals.hostname)) {
-                            kv2.key = PMIX_LOCAL_PEERS;
-                            kv2.value = &ipeers->value;
+                    /* if this host is us, then store each value as its own key */
+                    if (0 == strcmp(kv2.key, pmix_globals.hostname)) {
+                        for (i = 0; i < size; i++) {
+                            kv2.key = info[i].key;
+                            kv2.value = &info[i].value;
                             PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &kv2, 1, PMIX_KVAL);
                             if (PMIX_SUCCESS != rc) {
                                 PMIX_ERROR_LOG(rc);

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -147,6 +147,7 @@ int main(int argc, char **argv)
         TEST_ERROR(("srv #%d: Total number of processes doesn't correspond number specified by ns_dist parameter.", my_server_id));
         cli_kill_all();
         test_fail = 1;
+        goto done;
     }
 
     /* hang around until the client(s) finalize */
@@ -178,13 +179,17 @@ int main(int argc, char **argv)
     /* deregister the errhandler */
     PMIx_Deregister_event_handler(0, op_callbk, NULL);
 
+  done:
     TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
     test_fail += server_finalize(&params, test_fail);
 
-    TEST_VERBOSE(("srv #%d: exit seqence!", my_server_id));
+    TEST_VERBOSE(("srv #%d: exit sequence!", my_server_id));
     FREE_TEST_PARAMS(params);
     pmix_argv_free(client_argv);
     pmix_argv_free(client_env);
 
+    if (0 == test_fail) {
+        TEST_OUTPUT(("Test SUCCEEDED!"));
+    }
     return test_fail;
 }


### PR DESCRIPTION
Ensure that earlier versions get the full set of node-level info
properly transferred to the dstore. Minor fixes of the tests

Signed-off-by: Ralph Castain <rhc@pmix.org>