### PR TITLE
Continue repairs of xversion make check tests

### DIFF
--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
         TEST_ERROR(("Total number of processes doesn't correspond number specified by ns_dist parameter."));
         cli_kill_all();
         test_fail = 1;
+        goto done;
     }
 
     /* hang around until the client(s) finalize */
@@ -177,6 +178,7 @@ int main(int argc, char **argv)
     /* deregister the errhandler */
 //    PMIx_Deregister_event_handler(0, op_callbk, NULL);
 
+  done:
     TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
     test_fail += server_finalize(&params);
 
@@ -184,5 +186,8 @@ int main(int argc, char **argv)
     pmix_argv_free(client_argv);
     pmix_argv_free(client_env);
 
+    if (0 == test_fail) {
+        TEST_OUTPUT(("Test SUCCEEDED!"));
+    }
     return test_fail;
 }


### PR DESCRIPTION
Ensure that earlier versions get the full set of node-level info
properly transferred to the dstore. Minor fixes of the tests

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit b2162a7ae5f984b6d49a0d48acbe32385fffda22)