### PR TITLE
Add missing IOF_deregister function

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -630,8 +630,8 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *
  *
  * source - the nspace/rank of the process that generated the data
  *
- * payload - pointer to character array containing the data. Note that
- *           multiple strings may be included, and that the array may
+ * payload - pointer to a PMIx byte object containing the data. Note that
+ *           multiple strings may be included, and that the data may
  *           _not_ be NULL terminated
  *
  * info - an optional array of info provided by the source containing
@@ -640,7 +640,7 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *
  * ninfo - number of elements in the optional info array
  */
  typedef void (*pmix_iof_cbfunc_t)(size_t iofhdlr, pmix_iof_channel_t channel,
-                                   pmix_proc_t *source, char *payload,
+                                   pmix_proc_t *source, pmix_byte_object_t *payload,
                                    pmix_info_t info[], size_t ninfo);
 
 
@@ -664,7 +664,9 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *
  *           NOTE: STDIN is not supported as it will always
  *           be delivered to the stdin file descriptor
  *
- * cbfunc - function to be called when relevant IO is received
+ * cbfunc - function to be called when relevant IO is received. A
+ *          NULL indicates that the IO is to be written to stdout
+ *          or stderr as per the originating channel
  *
  * regcbfunc - since registration is async, this is the
  *             function to be called when registration is

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -724,7 +724,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the channel it comes from
 #define PMIX_IOF_TIMESTAMP_OUTPUT           "pmix.iof.ts"           // (bool) Timestamp output
 #define PMIX_IOF_XML_OUTPUT                 "pmix.iof.xml"          // (bool) Format output in XML
-
+#define PMIX_IOF_STOP                       "pmix.iof.stop"         // (bool) Stop forwarding the specified channel(s)
 
 /* Attributes for controlling contents of application setup data */
 #define PMIX_SETUP_APP_ENVARS               "pmix.setup.env"        // (bool) harvest and include relevant envars

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -449,7 +449,10 @@ typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(const pmix_proc_t *proc,
  *
  * This call serves as a registration with the host RM for the given IO channels from
  * the specified procs - the host RM is expected to ensure that this local PMIx server
- * is on the distribution list for the channel/proc combination
+ * is on the distribution list for the channel/proc combination. IF the PMIX_IOF_STOP
+ * is included in the directives, then the local PMIx server is requesting that the
+ * host RM remove the server from the distribution list for the specified channel/proc
+ * combination.
  */
 typedef pmix_status_t (*pmix_server_iof_fn_t)(const pmix_proc_t procs[], size_t nprocs,
                                               const pmix_info_t directives[], size_t ndirs,

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -388,14 +388,18 @@ static void client_iof_handler(struct pmix_peer_t *pr,
     pmix_byte_object_t bo;
     int32_t cnt;
     pmix_status_t rc;
+    size_t refid, ninfo=0;
+    pmix_iof_req_t *req;
+    pmix_info_t *info=NULL;
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
-                        "recvd IOF");
+                        "recvd IOF with %d bytes", (int)buf->bytes_used);
 
-    /* if the buffer is empty, they are simply closing the channel */
+    /* if the buffer is empty, they are simply closing the socket */
     if (0 == buf->bytes_used) {
         return;
     }
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &source, &cnt, PMIX_PROC);
@@ -410,13 +414,52 @@ static void client_iof_handler(struct pmix_peer_t *pr,
         return;
     }
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return;
     }
-    if (NULL != bo.bytes && 0 < bo.size) {
-        pmix_iof_write_output(&source, channel, &bo, NULL);
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* lookup the handler for this IOF package */
+    if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid))) {
+        /* something wrong here - should not happen */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        goto cleanup;
+    }
+    /* if the handler invokes a callback function, do so */
+    if (NULL != req->cbfunc) {
+        req->cbfunc(refid, channel, &source, &bo, info, ninfo);
+    } else {
+        /* otherwise, simply write it out to the specified std IO channel */
+        if (NULL != bo.bytes && 0 < bo.size) {
+            pmix_iof_write_output(&source, channel, &bo, NULL);
+        }
+    }
+
+  cleanup:
+    /* cleanup the memory */
+    if (0 < ninfo) {
+        PMIX_INFO_FREE(info, ninfo);
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -50,24 +50,49 @@ static void msgcbfunc(struct pmix_peer_t *peer,
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
     int32_t m;
     pmix_status_t rc, status;
+    size_t refid = 0;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     /* unpack the return status */
     m=1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &m, PMIX_STATUS);
-    if (PMIX_SUCCESS == rc && PMIX_SUCCESS == status) {
-        /* store the request on our list - we are in an event, and
+    if (NULL != cd->iofreq && PMIX_SUCCESS == rc && PMIX_SUCCESS == status) {
+        /* get the reference ID */
+        m=1;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &m, PMIX_SIZE);
+        /* store the request - we are in an event, and
          * so this is safe */
-        pmix_list_append(&pmix_globals.iof_requests, &cd->iofreq->super);
+        if (NULL == pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid)) {
+            pmix_pointer_array_set_item(&pmix_globals.iof_requests, refid, cd->iofreq);
+        }
+        if (NULL != cd->cbfunc.hdlrregcbfn) {
+            cd->cbfunc.hdlrregcbfn(PMIX_SUCCESS, refid, cd->cbdata);
+        }
     } else if (PMIX_SUCCESS != rc) {
         status = rc;
-        PMIX_RELEASE(cd->iofreq);
     }
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
-                        "pmix:iof_register returned status %s", PMIx_Error_string(status));
+                        "pmix:iof_register/deregister returned status %s", PMIx_Error_string(status));
 
-    if (NULL != cd->cbfunc.opcbfn) {
-        cd->cbfunc.opcbfn(status, cd->cbdata);
+    if (NULL == cd->iofreq) {
+        /* this was a deregistration request */
+        if (NULL == cd->cbfunc.opcbfn) {
+            cd->status = status;
+            PMIX_WAKEUP_THREAD(&cd->lock);
+        } else {
+            cd->cbfunc.opcbfn(status, cd->cbdata);
+        }
+    } else if (NULL == cd->cbfunc.hdlrregcbfn) {
+        cd->status = status;
+        cd->ncodes = refid;
+        PMIX_WAKEUP_THREAD(&cd->lock);
+    } else {
+        cd->cbfunc.hdlrregcbfn(PMIX_SUCCESS, refid, cd->cbdata);
+    }
+    if (PMIX_SUCCESS != rc && NULL != cd->iofreq) {
+        PMIX_RELEASE(cd->iofreq);
     }
     PMIX_RELEASE(cd);
 }
@@ -211,6 +236,97 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         PMIX_RELEASE(cd->iofreq);
         PMIX_RELEASE(cd);
     } else if (NULL == regcbfunc) {
+        PMIX_WAIT_THREAD(&cd->lock);
+        rc = cd->status;
+        PMIX_RELEASE(cd);
+    }
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_shift_caddy_t *cd;
+    pmix_cmd_t cmd = PMIX_IOF_DEREG_CMD;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_deregister");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we are a server, we cannot do this */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* send this request to the server */
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->cbfunc.opcbfn = cbfunc;
+    cd->cbdata = cbdata;
+
+    /* setup the registration cmd */
+    msg = PMIX_NEW(pmix_buffer_t);
+    if (NULL == msg) {
+        PMIX_RELEASE(cd->iofreq);
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    if (0 < ndirs) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, directives, ndirs, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+
+    /* pack the handler ID */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &iofhdlr, 1, PMIX_SIZE);
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_dereg sending to server");
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, msgcbfunc, (void*)cd);
+
+  cleanup:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+    } else if (NULL == cbfunc) {
         PMIX_WAIT_THREAD(&cd->lock);
         rc = cd->status;
         PMIX_RELEASE(cd);
@@ -493,6 +609,99 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
                                      directives, ndirs,
                                      bo, cbfunc, cbdata);
     return rc;
+}
+
+pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
+                                   const pmix_proc_t *source,
+                                   const pmix_byte_object_t *bo,
+                                   const pmix_info_t *info, size_t ninfo,
+                                   const pmix_iof_req_t *req)
+{
+    bool match;
+    size_t m;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
+
+    /* if the channel wasn't included, then ignore it */
+    if (!(channels & req->channels)) {
+        return PMIX_SUCCESS;
+    }
+    /* see if the source matches the request */
+    match = false;
+    for (m=0; m < req->nprocs; m++) {
+        if (PMIX_CHECK_PROCID(source, &req->procs[m])) {
+            match = true;
+            break;
+        }
+    }
+    if (!match) {
+        return PMIX_SUCCESS;
+    }
+    /* never forward back to the source! This can happen if the source
+     * is a launcher - also, never forward to a peer that is no
+     * longer with us */
+    if (NULL == req->requestor->info || req->requestor->finalized) {
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_CHECK_PROCID(source, &req->requestor->info->pname)) {
+        return PMIX_SUCCESS;
+    }
+    /* setup the msg */
+    if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    /* provide the source */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, source, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* provide the channel */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &channels, 1, PMIX_IOF_CHANNEL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* provide the handler ID so they know which cbfunc to use */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->refid, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* pack the number of info's provided */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* if some were provided, then pack them too */
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+    }
+    /* pack the data */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, bo, 1, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* send it to the requestor */
+    PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+    }
+    return PMIX_OPERATION_SUCCEEDED;
 }
 
 pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -242,6 +242,11 @@ PMIX_EXPORT void pmix_iof_write_handler(int fd, short event, void *cbdata);
 PMIX_EXPORT bool pmix_iof_stdin_check(int fd);
 PMIX_EXPORT void pmix_iof_read_local_handler(int unusedfd, short event, void *cbdata);
 PMIX_EXPORT void pmix_iof_stdin_cb(int fd, short event, void *cbdata);
+PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
+                                               const pmix_proc_t *source,
+                                               const pmix_byte_object_t *bo,
+                                               const pmix_info_t *info, size_t ninfo,
+                                               const pmix_iof_req_t *req);
 
 END_C_DECLS
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -234,22 +234,24 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
 
 static void iofreqcon(pmix_iof_req_t *p)
 {
-    p->peer = NULL;
-    memset(&p->pname, 0, sizeof(pmix_name_t));
+    p->requestor = NULL;
+    p->refid = 0;
+    p->procs = NULL;
+    p->nprocs = 0;
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
 }
 static void iofreqdes(pmix_iof_req_t *p)
 {
-    if (NULL != p->peer) {
-        PMIX_RELEASE(p->peer);
+    if (NULL != p->requestor) {
+        PMIX_RELEASE(p->requestor);
     }
-    if (NULL != p->pname.nspace) {
-        free(p->pname.nspace);
+    if (0 < p->nprocs) {
+        PMIX_PROC_FREE(p->procs, p->nprocs);
     }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_iof_req_t,
-                                pmix_list_item_t,
+                                pmix_object_t,
                                 iofreqcon, iofreqdes);
 
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -117,6 +117,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_GROUP_INVITE_CMD       26
 #define PMIX_GROUP_LEAVE_CMD        27
 #define PMIX_GROUP_DESTRUCT_CMD     28
+#define PMIX_IOF_DEREG_CMD          29
 
 /* provide a "pretty-print" function for cmds */
 const char* pmix_command_string(pmix_cmd_t cmd);
@@ -262,9 +263,11 @@ PMIX_CLASS_DECLARATION(pmix_peer_t);
 
 /* tracker for IOF requests */
 typedef struct {
-    pmix_list_item_t super;
-    pmix_peer_t *peer;
-    pmix_name_t pname;
+    pmix_object_t super;
+    pmix_peer_t *requestor;
+    size_t refid;
+    pmix_proc_t *procs;
+    size_t nprocs;
     pmix_iof_channel_t channels;
     pmix_iof_cbfunc_t cbfunc;
 } pmix_iof_req_t;
@@ -486,7 +489,7 @@ typedef struct {
     bool commits_pending;
     struct timeval event_window;
     pmix_list_t cached_events;          // events waiting in the window prior to processing
-    pmix_list_t iof_requests;           // list of pmix_iof_req_t IOF requests
+    pmix_pointer_array_t iof_requests;  // array of pmix_iof_req_t IOF requests
     int max_events;                     // size of the notifications hotel
     int event_eviction_time;            // max time to cache notifications
     pmix_hotel_t notifications;         // hotel of pending notifications

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1935,11 +1935,12 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         goto done;
     }
     PMIX_RETAIN(peer);
-    req->peer = peer;
-    req->pname.nspace = strdup(pmix_globals.myid.nspace);
-    req->pname.rank = pmix_globals.myid.rank;
+    req->requestor = peer;
+    req->nprocs = 1;
+    PMIX_PROC_CREATE(req->procs, req->nprocs);
+    PMIX_LOAD_PROCID(&req->procs[0], pmix_globals.myid.nspace, pmix_globals.myid.rank);
     req->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
-    pmix_list_append(&pmix_globals.iof_requests, &req->super);
+    req->refid = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
 
     /* validate the connection */
     cred.bytes = pnd->cred;

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -56,6 +56,7 @@ void pmix_rte_finalize(void)
 {
     int i;
     pmix_notify_caddy_t *cd;
+    pmix_iof_req_t *req;
 
     if( --pmix_initialized != 0 ) {
         if( pmix_initialized < 0 ) {
@@ -122,7 +123,12 @@ void pmix_rte_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_globals.notifications);
-    PMIX_LIST_DESTRUCT(&pmix_globals.iof_requests);
+    for (i=0; i < pmix_globals.iof_requests.size; i++) {
+        if (NULL != (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, i))) {
+            PMIX_RELEASE(req);
+        }
+    }
+    PMIX_DESTRUCT(&pmix_globals.iof_requests);
     PMIX_LIST_DESTRUCT(&pmix_globals.stdin_targets);
     free(pmix_globals.hostname);
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -190,7 +190,8 @@ int pmix_rte_init(uint32_t type,
         goto return_error;
     }
     /* and setup the iof request tracking list */
-    PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
     /* setup the stdin forwarding target list */
     PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -164,6 +164,8 @@ typedef struct {
     pmix_proc_t source;
     pmix_iof_channel_t channel;
     pmix_byte_object_t *bo;
+    pmix_info_t *info;
+    size_t ninfo;
 } pmix_iof_cache_t;
 PMIX_CLASS_DECLARATION(pmix_iof_cache_t);
 
@@ -336,6 +338,11 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
                                  void *cbdata);
 
 pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
+                                   pmix_buffer_t *buf,
+                                   pmix_op_cbfunc_t cbfunc,
+                                   void *cbdata);
+
+pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer,
                                    pmix_buffer_t *buf,
                                    pmix_op_cbfunc_t cbfunc,
                                    void *cbdata);


### PR DESCRIPTION
Also cleanup the IOF tracking code to ensure we accurately track the
evhandler ID. Implement the ability to return the IO to a specified
cbfunc instead of just printing it to stdout/err

Signed-off-by: Ralph Castain <rhc@pmix.org>