### PR TITLE
python: add iof_deregiter and update pyiofhandler

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -58,7 +58,7 @@ class myLock(threading.Event):
 
 ctypedef struct pmix_pyshift_t:
     char *op
-    char *payload
+    pmix_byte_object_t *payload
     size_t idx
     pmix_modex_cbfunc_t modex
     pmix_status_t status


### PR DESCRIPTION
1. uncomment iof_deregister wrapper
2. fix/update type of payload input parameter to pyiofhandler

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>