### PR TITLE
Add missing IOF_deregister function

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -621,8 +621,8 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
  *
  * source - the nspace/rank of the process that generated the data
  *
- * payload - pointer to character array containing the data. Note that
- *           multiple strings may be included, and that the array may
+ * payload - pointer to a PMIx byte object containing the data. Note that
+ *           multiple strings may be included, and that the data may
  *           _not_ be NULL terminated
  *
  * info - an optional array of info provided by the source containing
@@ -631,7 +631,7 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
  * ninfo - number of elements in the optional info array
  */
  typedef void (*pmix_iof_cbfunc_t)(size_t iofhdlr, pmix_iof_channel_t channel,
-                                   pmix_proc_t *source, char *payload,
+                                   pmix_proc_t *source, pmix_byte_object_t *payload,
                                    pmix_info_t info[], size_t ninfo);
 
 
@@ -655,7 +655,9 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
  *           NOTE: STDIN is not supported as it will always
  *           be delivered to the stdin file descriptor
  *
- * cbfunc - function to be called when relevant IO is received
+ * cbfunc - function to be called when relevant IO is received. A
+ *          NULL indicates that the IO is to be written to stdout
+ *          or stderr as per the originating channel
  *
  * regcbfunc - since registration is async, this is the
  *             function to be called when registration is

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -676,7 +676,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the channel it comes from
 #define PMIX_IOF_TIMESTAMP_OUTPUT           "pmix.iof.ts"           // (bool) Timestamp output
 #define PMIX_IOF_XML_OUTPUT                 "pmix.iof.xml"          // (bool) Format output in XML
-
+#define PMIX_IOF_STOP                       "pmix.iof.stop"         // (bool) Stop forwarding the specified channel(s)
 
 /* Attributes for controlling contents of application setup data */
 #define PMIX_SETUP_APP_ENVARS               "pmix.setup.env"        // (bool) harvest and include relevant envars

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -449,7 +449,10 @@ typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(const pmix_proc_t *proc,
  *
  * This call serves as a registration with the host RM for the given IO channels from
  * the specified procs - the host RM is expected to ensure that this local PMIx server
- * is on the distribution list for the channel/proc combination
+ * is on the distribution list for the channel/proc combination. IF the PMIX_IOF_STOP
+ * is included in the directives, then the local PMIx server is requesting that the
+ * host RM remove the server from the distribution list for the specified channel/proc
+ * combination.
  */
 typedef pmix_status_t (*pmix_server_iof_fn_t)(const pmix_proc_t procs[], size_t nprocs,
                                               const pmix_info_t directives[], size_t ndirs,

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -391,14 +391,18 @@ static void client_iof_handler(struct pmix_peer_t *pr,
     pmix_byte_object_t bo;
     int32_t cnt;
     pmix_status_t rc;
+    size_t refid, ninfo=0;
+    pmix_iof_req_t *req;
+    pmix_info_t *info=NULL;
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
-                        "recvd IOF");
+                        "recvd IOF with %d bytes", (int)buf->bytes_used);
 
-    /* if the buffer is empty, they are simply closing the channel */
+    /* if the buffer is empty, they are simply closing the socket */
     if (0 == buf->bytes_used) {
         return;
     }
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &source, &cnt, PMIX_PROC);
@@ -413,13 +417,52 @@ static void client_iof_handler(struct pmix_peer_t *pr,
         return;
     }
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return;
     }
-    if (NULL != bo.bytes && 0 < bo.size) {
-        pmix_iof_write_output(&source, channel, &bo, NULL);
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* lookup the handler for this IOF package */
+    if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid))) {
+        /* something wrong here - should not happen */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        goto cleanup;
+    }
+    /* if the handler invokes a callback function, do so */
+    if (NULL != req->cbfunc) {
+        req->cbfunc(refid, channel, &source, &bo, info, ninfo);
+    } else {
+        /* otherwise, simply write it out to the specified std IO channel */
+        if (NULL != bo.bytes && 0 < bo.size) {
+            pmix_iof_write_output(&source, channel, &bo, NULL);
+        }
+    }
+
+  cleanup:
+    /* cleanup the memory */
+    if (0 < ninfo) {
+        PMIX_INFO_FREE(info, ninfo);
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -40,24 +40,49 @@ static void msgcbfunc(struct pmix_peer_t *peer,
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
     int32_t m;
     pmix_status_t rc, status;
+    size_t refid = 0;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     /* unpack the return status */
     m=1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &m, PMIX_STATUS);
-    if (PMIX_SUCCESS == rc && PMIX_SUCCESS == status) {
-        /* store the request on our list - we are in an event, and
+    if (NULL != cd->iofreq && PMIX_SUCCESS == rc && PMIX_SUCCESS == status) {
+        /* get the reference ID */
+        m=1;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &m, PMIX_SIZE);
+        /* store the request - we are in an event, and
          * so this is safe */
-        pmix_list_append(&pmix_globals.iof_requests, &cd->iofreq->super);
+        if (NULL == pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid)) {
+            pmix_pointer_array_set_item(&pmix_globals.iof_requests, refid, cd->iofreq);
+        }
+        if (NULL != cd->cbfunc.hdlrregcbfn) {
+            cd->cbfunc.hdlrregcbfn(PMIX_SUCCESS, refid, cd->cbdata);
+        }
     } else if (PMIX_SUCCESS != rc) {
         status = rc;
-        PMIX_RELEASE(cd->iofreq);
     }
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
-                        "pmix:iof_register returned status %s", PMIx_Error_string(status));
+                        "pmix:iof_register/deregister returned status %s", PMIx_Error_string(status));
 
-    if (NULL != cd->cbfunc.opcbfn) {
-        cd->cbfunc.opcbfn(status, cd->cbdata);
+    if (NULL == cd->iofreq) {
+        /* this was a deregistration request */
+        if (NULL == cd->cbfunc.opcbfn) {
+            cd->status = status;
+            PMIX_WAKEUP_THREAD(&cd->lock);
+        } else {
+            cd->cbfunc.opcbfn(status, cd->cbdata);
+        }
+    } else if (NULL == cd->cbfunc.hdlrregcbfn) {
+        cd->status = status;
+        cd->ncodes = refid;
+        PMIX_WAKEUP_THREAD(&cd->lock);
+    } else {
+        cd->cbfunc.hdlrregcbfn(PMIX_SUCCESS, refid, cd->cbdata);
+    }
+    if (PMIX_SUCCESS != rc && NULL != cd->iofreq) {
+        PMIX_RELEASE(cd->iofreq);
     }
     PMIX_RELEASE(cd);
 }
@@ -177,6 +202,97 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cd->iofreq);
+        PMIX_RELEASE(cd);
+    }
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_shift_caddy_t *cd;
+    pmix_cmd_t cmd = PMIX_IOF_DEREG_CMD;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_deregister");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we are a server, we cannot do this */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* send this request to the server */
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->cbfunc.opcbfn = cbfunc;
+    cd->cbdata = cbdata;
+
+    /* setup the registration cmd */
+    msg = PMIX_NEW(pmix_buffer_t);
+    if (NULL == msg) {
+        PMIX_RELEASE(cd->iofreq);
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    if (0 < ndirs) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, directives, ndirs, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+
+    /* pack the handler ID */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &iofhdlr, 1, PMIX_SIZE);
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_dereg sending to server");
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, msgcbfunc, (void*)cd);
+
+  cleanup:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+    } else if (NULL == cbfunc) {
+        PMIX_WAIT_THREAD(&cd->lock);
+        rc = cd->status;
         PMIX_RELEASE(cd);
     }
     return rc;
@@ -315,6 +431,99 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
                                      directives, ndirs,
                                      bo, cbfunc, cbdata);
     return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
+                                   const pmix_proc_t *source,
+                                   const pmix_byte_object_t *bo,
+                                   const pmix_info_t *info, size_t ninfo,
+                                   const pmix_iof_req_t *req)
+{
+    bool match;
+    size_t m;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
+
+    /* if the channel wasn't included, then ignore it */
+    if (!(channels & req->channels)) {
+        return PMIX_SUCCESS;
+    }
+    /* see if the source matches the request */
+    match = false;
+    for (m=0; m < req->nprocs; m++) {
+        if (PMIX_CHECK_PROCID(source, &req->procs[m])) {
+            match = true;
+            break;
+        }
+    }
+    if (!match) {
+        return PMIX_SUCCESS;
+    }
+    /* never forward back to the source! This can happen if the source
+     * is a launcher - also, never forward to a peer that is no
+     * longer with us */
+    if (NULL == req->requestor->info || req->requestor->finalized) {
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_CHECK_PROCID(source, &req->requestor->info->pname)) {
+        return PMIX_SUCCESS;
+    }
+    /* setup the msg */
+    if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    /* provide the source */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, source, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* provide the channel */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &channels, 1, PMIX_IOF_CHANNEL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* provide the handler ID so they know which cbfunc to use */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->refid, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* pack the number of info's provided */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* if some were provided, then pack them too */
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+    }
+    /* pack the data */
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, bo, 1, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    /* send it to the requestor */
+    PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+    }
+    return PMIX_OPERATION_SUCCEEDED;
 }
 
 pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -200,6 +200,11 @@ PMIX_EXPORT void pmix_iof_stdin_write_handler(int fd, short event, void *cbdata)
 PMIX_EXPORT bool pmix_iof_stdin_check(int fd);
 PMIX_EXPORT void pmix_iof_stdin_cb(int fd, short event, void *cbdata);
 PMIX_EXPORT void pmix_iof_read_local_handler(int fd, short event, void *cbdata);
+PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
+                                               const pmix_proc_t *source,
+                                               const pmix_byte_object_t *bo,
+                                               const pmix_info_t *info, size_t ninfo,
+                                               const pmix_iof_req_t *req);
 
 END_C_DECLS
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -232,22 +232,24 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
 
 static void iofreqcon(pmix_iof_req_t *p)
 {
-    p->peer = NULL;
-    memset(&p->pname, 0, sizeof(pmix_name_t));
+    p->requestor = NULL;
+    p->refid = 0;
+    p->procs = NULL;
+    p->nprocs = 0;
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
 }
 static void iofreqdes(pmix_iof_req_t *p)
 {
-    if (NULL != p->peer) {
-        PMIX_RELEASE(p->peer);
+    if (NULL != p->requestor) {
+        PMIX_RELEASE(p->requestor);
     }
-    if (NULL != p->pname.nspace) {
-        free(p->pname.nspace);
+    if (0 < p->nprocs) {
+        PMIX_PROC_FREE(p->procs, p->nprocs);
     }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_iof_req_t,
-                                pmix_list_item_t,
+                                pmix_object_t,
                                 iofreqcon, iofreqdes);
 
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -106,6 +106,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_VALIDATE_CRED_CMD      21
 #define PMIX_IOF_PULL_CMD           22
 #define PMIX_IOF_PUSH_CMD           23
+#define PMIX_IOF_DEREG_CMD          29
 
 /* provide a "pretty-print" function for cmds */
 const char* pmix_command_string(pmix_cmd_t cmd);
@@ -246,9 +247,11 @@ PMIX_CLASS_DECLARATION(pmix_peer_t);
 
 /* tracker for IOF requests */
 typedef struct {
-    pmix_list_item_t super;
-    pmix_peer_t *peer;
-    pmix_name_t pname;
+    pmix_object_t super;
+    pmix_peer_t *requestor;
+    size_t refid;
+    pmix_proc_t *procs;
+    size_t nprocs;
     pmix_iof_channel_t channels;
     pmix_iof_cbfunc_t cbfunc;
 } pmix_iof_req_t;
@@ -468,7 +471,7 @@ typedef struct {
     bool commits_pending;
     struct timeval event_window;
     pmix_list_t cached_events;          // events waiting in the window prior to processing
-    pmix_list_t iof_requests;           // list of pmix_iof_req_t IOF requests
+    pmix_pointer_array_t iof_requests;  // array of pmix_iof_req_t IOF requests
     int max_events;                     // size of the notifications hotel
     int event_eviction_time;            // max time to cache notifications
     pmix_hotel_t notifications;         // hotel of pending notifications
@@ -481,6 +484,7 @@ typedef struct {
     pmix_gds_base_module_t *mygds;
     /* IOF controls */
     bool tag_output;
+    pmix_list_t stdin_targets;          // list of pmix_namelist_t
     bool xml_output;
     bool timestamp_output;
     size_t output_limit;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1920,11 +1920,12 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         goto done;
     }
     PMIX_RETAIN(peer);
-    req->peer = peer;
-    req->pname.nspace = strdup(pmix_globals.myid.nspace);
-    req->pname.rank = pmix_globals.myid.rank;
+    req->requestor = peer;
+    req->nprocs = 1;
+    PMIX_PROC_CREATE(req->procs, req->nprocs);
+    PMIX_LOAD_PROCID(&req->procs[0], pmix_globals.myid.nspace, pmix_globals.myid.rank);
     req->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
-    pmix_list_append(&pmix_globals.iof_requests, &req->super);
+    req->refid = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
 
     /* validate the connection */
     cred.bytes = pnd->cred;

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -54,6 +54,7 @@ void pmix_rte_finalize(void)
 {
     int i;
     pmix_notify_caddy_t *cd;
+    pmix_iof_req_t *req;
 
     if( --pmix_initialized != 0 ) {
         if( pmix_initialized < 0 ) {
@@ -115,7 +116,13 @@ void pmix_rte_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_globals.notifications);
-    PMIX_LIST_DESTRUCT(&pmix_globals.iof_requests);
+    for (i=0; i < pmix_globals.iof_requests.size; i++) {
+        if (NULL != (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, i))) {
+            PMIX_RELEASE(req);
+        }
+    }
+    PMIX_DESTRUCT(&pmix_globals.iof_requests);
+    PMIX_LIST_DESTRUCT(&pmix_globals.stdin_targets);
     free(pmix_globals.hostname);
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -187,7 +187,10 @@ int pmix_rte_init(uint32_t type,
     }
 
     /* and setup the iof request tracking list */
-    PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
+    /* setup the stdin forwarding target list */
+    PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
 
     /* Setup client verbosities as all procs are allowed to
      * access client APIs */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -651,7 +651,7 @@ void pmix_server_purge_events(pmix_peer_t *peer,
 {
     pmix_regevents_info_t *reginfo, *regnext;
     pmix_peer_events_info_t *prev, *pnext;
-    pmix_iof_req_t *req, *nxt;
+    pmix_iof_req_t *req;
     int i;
     pmix_notify_caddy_t *ncd;
     size_t n, m, p, ntgs;
@@ -677,10 +677,13 @@ void pmix_server_purge_events(pmix_peer_t *peer,
 
     /* since the client is finalizing, remove them from any IOF
      * registrations they may still have on our list */
-    PMIX_LIST_FOREACH_SAFE(req, nxt, &pmix_globals.iof_requests, pmix_iof_req_t) {
-        if ((NULL != peer && PMIX_CHECK_PROCID(&req->peer->info->pname, &peer->info->pname)) ||
-            (NULL != proc && PMIX_CHECK_PROCID(&req->peer->info->pname, proc))) {
-            pmix_list_remove_item(&pmix_globals.iof_requests, &req->super);
+    for (i=0; i < pmix_globals.iof_requests.size; i++) {
+        if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, i))) {
+            continue;
+        }
+        if ((NULL != peer && PMIX_CHECK_PROCID(&req->requestor->info->pname, &peer->info->pname)) ||
+            (NULL != proc && PMIX_CHECK_PROCID(&req->requestor->info->pname, proc))) {
+            pmix_pointer_array_set_item(&pmix_globals.iof_requests, i, NULL);
             PMIX_RELEASE(req);
         }
     }
@@ -1766,69 +1769,26 @@ static void _iofdeliver(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_iof_req_t *req;
-    pmix_status_t rc;
-    pmix_buffer_t *msg;
     bool found = false;
-    bool cached = false;
     pmix_iof_cache_t *iof;
+    int i;
+    size_t n;
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "PMIX:SERVER delivering IOF from %s on channel %0x",
                         PMIX_NAME_PRINT(cd->procs), cd->channels);
 
-    /* cycle across our list of IOF requestors and see who wants
+    /* cycle across our list of IOF requests and see who wants
      * this channel from this source */
-    PMIX_LIST_FOREACH(req, &pmix_globals.iof_requests, pmix_iof_req_t) {
-        /* if the channel wasn't included, then ignore it */
-        if (!(cd->channels & req->channels)) {
+    for (i=0; i < pmix_globals.iof_requests.size; i++) {
+        if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, i))) {
             continue;
         }
-        /* see if the source matches the request */
-        if (!PMIX_CHECK_PROCID(cd->procs, &req->pname)) {
-            continue;
-        }
-        /* never forward back to the source! This can happen if the source
-         * is a launcher - also, never forward to a peer that is no
-         * longer with us */
-        if (NULL == req->peer->info || req->peer->finalized) {
-            continue;
-        }
-        if (PMIX_CHECK_PROCID(cd->procs, &req->peer->info->pname)) {
-            continue;
-        }
-        found = true;
-        /* setup the msg */
-        if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-            rc = PMIX_ERR_OUT_OF_RESOURCE;
-            break;
-        }
-        /* provide the source */
-        PMIX_BFROPS_PACK(rc, req->peer, msg, cd->procs, 1, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            break;
-        }
-        /* provide the channel */
-        PMIX_BFROPS_PACK(rc, req->peer, msg, &cd->channels, 1, PMIX_IOF_CHANNEL);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            break;
-        }
-        /* pack the data */
-        PMIX_BFROPS_PACK(rc, req->peer, msg, cd->bo, 1, PMIX_BYTE_OBJECT);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            break;
-        }
-        /* send it to the requestor */
-        PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
+        if (PMIX_OPERATION_SUCCEEDED == pmix_iof_process_iof(cd->channels, cd->procs, cd->bo,
+                                                             cd->info, cd->ninfo, req)) {
+            /* flag that we do have at least one registrant for this info,
+             * so there is no need to cache it */
+            found = true;
         }
     }
 
@@ -1846,18 +1806,33 @@ static void _iofdeliver(int sd, short args, void *cbdata)
         iof = PMIX_NEW(pmix_iof_cache_t);
         memcpy(&iof->source, cd->procs, sizeof(pmix_proc_t));
         iof->channel = cd->channels;
-        iof->bo = cd->bo;
-        cd->bo = NULL;  // protect the data
+        /* copy the data */
+        PMIX_BYTE_OBJECT_CREATE(iof->bo, 1);
+        iof->bo->bytes = (char*)malloc(cd->bo->size);
+        memcpy(iof->bo->bytes, cd->bo->bytes, cd->bo->size);
+        iof->bo->size = cd->bo->size;
+        if (0 < cd->ninfo) {
+            PMIX_INFO_CREATE(iof->info, cd->ninfo);
+            iof->ninfo = cd->ninfo;
+            for (n=0; n < iof->ninfo; n++) {
+                PMIX_INFO_XFER(&iof->info[n], &cd->info[n]);
+            }
+        }
         pmix_list_append(&pmix_server_globals.iof, &iof->super);
     }
 
 
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(rc, cd->cbdata);
+        cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);
     }
-    if (!cached) {
-        PMIX_RELEASE(cd);
-    }
+
+    /* release the caddy */
+    cd->procs = NULL;
+    cd->nprocs = 0;
+    cd->info = NULL;
+    cd->ninfo = 0;
+    cd->bo = NULL;
+    PMIX_RELEASE(cd);
 }
 
 pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
@@ -1867,48 +1842,18 @@ pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_setup_caddy_t *cd;
-    size_t n;
 
     /* need to threadshift this request */
     cd = PMIX_NEW(pmix_setup_caddy_t);
     if (NULL == cd) {
         return PMIX_ERR_NOMEM;
     }
-    /* unfortunately, we need to copy the input because we
-     * might have to cache it for later delivery */
-    PMIX_PROC_CREATE(cd->procs, 1);
-    if (NULL == cd->procs) {
-        PMIX_RELEASE(cd);
-        return PMIX_ERR_NOMEM;
-    }
+    cd->procs = (pmix_proc_t*)source;
     cd->nprocs = 1;
-    pmix_strncpy(cd->procs[0].nspace, source->nspace, PMIX_MAX_NSLEN);
-    cd->procs[0].rank = source->rank;
     cd->channels = channel;
-    PMIX_BYTE_OBJECT_CREATE(cd->bo, 1);
-    if (NULL == cd->bo) {
-        PMIX_RELEASE(cd);
-        return PMIX_ERR_NOMEM;
-    }
-    cd->nbo = 1;
-    cd->bo[0].bytes = (char*)malloc(bo->size);
-    if (NULL == cd->bo[0].bytes) {
-        PMIX_RELEASE(cd);
-        return PMIX_ERR_NOMEM;
-    }
-    memcpy(cd->bo[0].bytes, bo->bytes, bo->size);
-    cd->bo[0].size = bo->size;
-    if (0 < ninfo) {
-        PMIX_INFO_CREATE(cd->info, ninfo);
-        if (NULL == cd->info) {
-            PMIX_RELEASE(cd);
-            return PMIX_ERR_NOMEM;
-        }
-        cd->ninfo = ninfo;
-        for (n=0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&cd->info[n], (pmix_info_t*)&info[n]);
-        }
-    }
+    cd->bo = (pmix_byte_object_t*)bo;
+    cd->info = (pmix_info_t*)info;
+    cd->ninfo = ninfo;
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
     PMIX_THREADSHIFT(cd, _iofdeliver);
@@ -3233,6 +3178,8 @@ static void _iofreg(int sd, short args, void *cbdata)
     pmix_server_caddy_t *scd = (pmix_server_caddy_t*)cd->cbdata;
     pmix_buffer_t *reply;
     pmix_status_t rc;
+    pmix_iof_req_t *req;
+    pmix_iof_cache_t *iof, *inxt;
 
     PMIX_ACQUIRE_OBJECT(cd);
 
@@ -3253,7 +3200,18 @@ static void _iofreg(int sd, short args, void *cbdata)
 
     /* was the request a success? */
     if (PMIX_SUCCESS != cd->status) {
-        /* find and remove the tracker(s) */
+        /* find and remove the tracker */
+        req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, cd->ncodes);
+        PMIX_RELEASE(req);
+        pmix_pointer_array_set_item(&pmix_globals.iof_requests, cd->ncodes, NULL);
+    } else {
+        /* return the reference ID for this handler */
+        PMIX_BFROPS_PACK(rc, scd->peer, reply, &cd->ncodes, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(reply);
+            goto cleanup;
+        }
     }
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
@@ -3262,6 +3220,21 @@ static void _iofreg(int sd, short args, void *cbdata)
     PMIX_SERVER_QUEUE_REPLY(rc, scd->peer, scd->hdr.tag, reply);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(reply);
+    }
+
+    /* if the request succeeded, then process any cached IO - doing it here
+     * guarantees that the IO will be received AFTER the client gets the
+     * refid response */
+    if (PMIX_SUCCESS == cd->status) {
+        /* get the request */
+        req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, cd->ncodes);
+        PMIX_LIST_FOREACH_SAFE(iof, inxt, &pmix_server_globals.iof, pmix_iof_cache_t) {
+            if (PMIX_OPERATION_SUCCEEDED == pmix_iof_process_iof(iof->channel, &iof->source, iof->bo,
+                                                                 iof->info, iof->ninfo, req)) {
+                pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+                PMIX_RELEASE(iof);
+            }
+        }
     }
 
   cleanup:
@@ -3588,6 +3561,14 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
     if (PMIX_IOF_PUSH_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         if (PMIX_SUCCESS != (rc = pmix_server_iofstdin(peer, buf, op_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+
+    if (PMIX_IOF_DEREG_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_iofdereg(peer, buf, op_cbfunc, cd))) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1144,11 +1144,12 @@ static void spcbfunc(pmix_status_t status,
             goto cleanup;
         }
         PMIX_RETAIN(cd->peer);
-        req->peer = cd->peer;
-        req->pname.nspace = strdup(nspace);
-        req->pname.rank = PMIX_RANK_WILDCARD;
+        req->requestor = cd->peer;
+        req->nprocs = 1;
+        PMIX_PROC_CREATE(req->procs, req->nprocs);
+        PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
         req->channels = cd->channels;
-        pmix_list_append(&pmix_globals.iof_requests, &req->super);
+        req->refid = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
         /* process any cached IO */
         PMIX_LIST_FOREACH_SAFE(iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
             /* if the channels don't match, then ignore it */
@@ -1156,18 +1157,19 @@ static void spcbfunc(pmix_status_t status,
                 continue;
             }
             /* if the source does not match the request, then ignore it */
-            if (!PMIX_CHECK_PROCID(&iof->source, &req->pname)) {
+            if (!PMIX_CHECK_PROCID(&iof->source, &req->procs[0])) {
                 continue;
             }
             /* never forward back to the source! This can happen if the source
              * is a launcher */
-            if (PMIX_CHECK_PROCID(&iof->source, &req->peer->info->pname)) {
+            if (PMIX_CHECK_PROCID(&iof->source, &req->requestor->info->pname)) {
                 continue;
             }
             pmix_output_verbose(2, pmix_server_globals.iof_output,
                                 "PMIX:SERVER:SPAWN delivering cached IOF from %s:%d to %s:%d",
                                 iof->source.nspace, iof->source.rank,
-                                req->pname.nspace, req->pname.rank);
+                                req->requestor->info->pname.nspace,
+                                req->requestor->info->pname.rank);
             /* setup the msg */
             if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
                 PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
@@ -1175,28 +1177,28 @@ static void spcbfunc(pmix_status_t status,
                 break;
             }
             /* provide the source */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->source, 1, PMIX_PROC);
+            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->source, 1, PMIX_PROC);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 break;
             }
             /* provide the channel */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
+            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 break;
             }
             /* pack the data */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
+            PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 break;
             }
             /* send it to the requestor */
-            PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+            PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
@@ -3207,10 +3209,6 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
     pmix_status_t rc;
     pmix_setup_caddy_t *cd;
     pmix_iof_req_t *req;
-    bool notify, match;
-    size_t n;
-    pmix_buffer_t *msg;
-    pmix_iof_cache_t *iof, *ionext;
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "recvd IOF PULL request from client");
@@ -3269,107 +3267,104 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
         goto exit;
     }
 
-    /* check to see if we have already registered this source/channel combination */
-    notify = false;
-    for (n=0; n < cd->nprocs; n++) {
-        match = false;
-        PMIX_LIST_FOREACH(req, &pmix_globals.iof_requests, pmix_iof_req_t) {
-            /* is this request from the same peer? */
-            if (peer != req->peer) {
-                continue;
-            }
-            /* do we already have this source for this peer? */
-            if (PMIX_CHECK_PROCID(&cd->procs[n], &req->pname)) {
-                match = true;
-                if ((req->channels & cd->channels) != cd->channels) {
-                    /* this is a channel update */
-                    req->channels |= cd->channels;
-                    /* we need to notify the host */
-                    notify = true;
-                }
-                break;
-            }
-        }
-        /* if we didn't find the matching entry, then add it */
-        if (!match) {
-            /* record the request */
-            req = PMIX_NEW(pmix_iof_req_t);
-            if (NULL == req) {
-                rc = PMIX_ERR_NOMEM;
-                goto exit;
-            }
-            PMIX_RETAIN(peer);
-            req->peer = peer;
-            req->pname.nspace = strdup(cd->procs[n].nspace);
-            req->pname.rank = cd->procs[n].rank;
-            req->channels = cd->channels;
-            pmix_list_append(&pmix_globals.iof_requests, &req->super);
-        }
-        /* process any cached IO */
-        PMIX_LIST_FOREACH_SAFE(iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
-            /* if the channels don't match, then ignore it */
-            if (!(iof->channel & req->channels)) {
-                continue;
-            }
-            /* if the source does not match the request, then ignore it */
-            if (!PMIX_CHECK_PROCID(&iof->source, &req->pname)) {
-                continue;
-            }
-            /* never forward back to the source! This can happen if the source
-             * is a launcher */
-            if (PMIX_CHECK_PROCID(&iof->source, &req->peer->info->pname)) {
-                continue;
-            }
-            pmix_output_verbose(2, pmix_server_globals.iof_output,
-                                "PMIX:SERVER:IOFREQ delivering cached IOF from %s:%d to %s:%d",
-                                iof->source.nspace, iof->source.rank,
-                                req->peer->info->pname.nspace, req->peer->info->pname.rank);
-            /* setup the msg */
-            if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-                PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                rc = PMIX_ERR_OUT_OF_RESOURCE;
-                break;
-            }
-            /* provide the source */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->source, 1, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* provide the channel */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* pack the data */
-            PMIX_BFROPS_PACK(rc, req->peer, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* send it to the requestor */
-            PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-            }
-            /* remove it from the list since it has now been forwarded */
-            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
-            PMIX_RELEASE(iof);
-        }
+    /* add this peer/source/channel combination */
+    req = PMIX_NEW(pmix_iof_req_t);
+    if (NULL == req) {
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
     }
-    if (notify) {
-        /* ask the host to execute the request */
-        if (PMIX_SUCCESS != (rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
-                                                            cd->info, cd->ninfo,
-                                                            cd->channels,
-                                                            cbfunc, cd))) {
+    PMIX_RETAIN(peer);
+    req->requestor = peer;
+    req->nprocs = cd->nprocs;
+    if (0 < req->nprocs) {
+        PMIX_PROC_CREATE(req->procs, cd->nprocs);
+        memcpy(req->procs, cd->procs, req->nprocs * sizeof(pmix_proc_t));
+    }
+    req->channels = cd->channels;
+    req->refid = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    cd->ncodes = req->refid;
+
+    /* ask the host to execute the request */
+    if (PMIX_SUCCESS != (rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
+                                                        cd->info, cd->ninfo,
+                                                        cd->channels,
+                                                        cbfunc, cd))) {
+        goto exit;
+    }
+    return PMIX_SUCCESS;
+
+  exit:
+    PMIX_RELEASE(cd);
+    return rc;
+}
+
+pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer,
+                                   pmix_buffer_t *buf,
+                                   pmix_op_cbfunc_t cbfunc,
+                                   void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc;
+    pmix_setup_caddy_t *cd;
+    pmix_iof_req_t *req;
+    size_t ninfo, refid;
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "recvd IOF DEREGISTER from client");
+
+    if (NULL == pmix_host_server.iof_pull) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->cbdata = cbdata;  // this is the pmix_server_caddy_t
+
+    /* unpack the number of directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    /* unpack the directives - note that we have to add one
+     * to tell the server to stop forwarding to this channel */
+    cd->ninfo = ninfo + 1;
+    PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    if (0 < ninfo) {
+        cnt = ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             goto exit;
         }
+    }
+    /* add the directive to stop forwarding */
+    PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_IOF_STOP, NULL, PMIX_BOOL);
+
+    /* unpack the handler ID */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+
+    /* get the referenced handler */
+    req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid);
+    if (NULL == req) {
+        /* already gone? */
+        rc = PMIX_ERR_NOT_FOUND;
+        goto exit;
+    }
+    /* tell the server to stop */
+    if (PMIX_SUCCESS != (rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
+                                                        cd->info, cd->ninfo,
+                                                        cd->channels,
+                                                        cbfunc, cd))) {
+        goto exit;
     }
     return PMIX_SUCCESS;
 
@@ -3756,10 +3751,15 @@ PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t,
 static void iocon(pmix_iof_cache_t *p)
 {
     p->bo = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
 }
 static void iodes(pmix_iof_cache_t *p)
 {
     PMIX_BYTE_OBJECT_FREE(p->bo, 1);  // macro protects against NULL
+    if (0 < p->ninfo) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
 }
 PMIX_CLASS_INSTANCE(pmix_iof_cache_t,
                     pmix_list_item_t,

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -148,6 +148,8 @@ typedef struct {
     pmix_proc_t source;
     pmix_iof_channel_t channel;
     pmix_byte_object_t *bo;
+    pmix_info_t *info;
+    size_t ninfo;
 } pmix_iof_cache_t;
 PMIX_CLASS_DECLARATION(pmix_iof_cache_t);
 
@@ -319,6 +321,11 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
                                  void *cbdata);
 
 pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
+                                   pmix_buffer_t *buf,
+                                   pmix_op_cbfunc_t cbfunc,
+                                   void *cbdata);
+
+pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer,
                                    pmix_buffer_t *buf,
                                    pmix_op_cbfunc_t cbfunc,
                                    void *cbdata);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -196,14 +196,18 @@ static void tool_iof_handler(struct pmix_peer_t *pr,
     pmix_byte_object_t bo;
     int32_t cnt;
     pmix_status_t rc;
+    size_t refid, ninfo=0;
+    pmix_iof_req_t *req;
+    pmix_info_t *info;
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
                         "recvd IOF with %d bytes", (int)buf->bytes_used);
 
-    /* if the buffer is empty, they are simply closing the channel */
+    /* if the buffer is empty, they are simply closing the socket */
     if (0 == buf->bytes_used) {
         return;
     }
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &source, &cnt, PMIX_PROC);
@@ -218,13 +222,52 @@ static void tool_iof_handler(struct pmix_peer_t *pr,
         return;
     }
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return;
     }
-    if (NULL != bo.bytes && 0 < bo.size) {
-        pmix_iof_write_output(&source, channel, &bo, NULL);
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* lookup the handler for this IOF package */
+    if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid))) {
+        /* something wrong here - should not happen */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        goto cleanup;
+    }
+    /* if the handler invokes a callback function, do so */
+    if (NULL != req->cbfunc) {
+        req->cbfunc(refid, channel, &source, &bo, info, ninfo);
+    } else {
+        /* otherwise, simply write it out to the specified std IO channel */
+        if (NULL != bo.bytes && 0 < bo.size) {
+            pmix_iof_write_output(&source, channel, &bo, NULL);
+        }
+    }
+
+  cleanup:
+    /* cleanup the memory */
+    if (0 < ninfo) {
+        PMIX_INFO_FREE(info, ninfo);
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }


### PR DESCRIPTION
Also cleanup the IOF tracking code to ensure we accurately track the
evhandler ID. Implement the ability to return the IO to a specified
cbfunc instead of just printing it to stdout/err

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit a9635049211befa15dd80f2e967287fa49d126f1)