### PR TITLE
Cleanup IOF registration

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -235,7 +235,8 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
 static void iofreqcon(pmix_iof_req_t *p)
 {
     p->requestor = NULL;
-    p->refid = 0;
+    p->local_id = 0;
+    p->remote_id = 0;
     p->procs = NULL;
     p->nprocs = 0;
     p->channels = PMIX_FWD_NO_CHANNELS;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -265,7 +265,8 @@ PMIX_CLASS_DECLARATION(pmix_peer_t);
 typedef struct {
     pmix_object_t super;
     pmix_peer_t *requestor;
-    size_t refid;
+    size_t local_id;
+    size_t remote_id;
     pmix_proc_t *procs;
     size_t nprocs;
     pmix_iof_channel_t channels;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1940,7 +1940,8 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     PMIX_PROC_CREATE(req->procs, req->nprocs);
     PMIX_LOAD_PROCID(&req->procs[0], pmix_globals.myid.nspace, pmix_globals.myid.rank);
     req->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
-    req->refid = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    req->remote_id = 0;     // default ID for tool during init
+    req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
 
     /* validate the connection */
     cred.bytes = pnd->cred;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3249,7 +3249,7 @@ static void _iofreg(int sd, short args, void *cbdata)
         PMIX_RELEASE(req);
         pmix_pointer_array_set_item(&pmix_globals.iof_requests, cd->ncodes, NULL);
     } else {
-        /* return the reference ID for this handler */
+        /* return our reference ID for this handler */
         PMIX_BFROPS_PACK(rc, scd->peer, reply, &cd->ncodes, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -319,6 +319,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_cb_t cb;
     pmix_buffer_t *req;
     pmix_cmd_t cmd = PMIX_REQ_CMD;
+    pmix_iof_req_t *iofreq;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -699,6 +700,11 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                          1, PMIX_FWD_STDOUT_CHANNEL, pmix_iof_write_handler);
     PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stderr, &pmix_globals.myid,
                          2, PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
+    /* create the default iof handler */
+    iofreq = PMIX_NEW(pmix_iof_req_t);
+    iofreq->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
+    pmix_pointer_array_set_item(&pmix_globals.iof_requests, 0, iofreq);
+
     if (fwd_stdin) {
         /* setup the read - we don't want to set nonblocking on our
          * stdio stream.  If we do so, we set the file descriptor to


### PR DESCRIPTION
We need to track both the local and remote reference IDs on IOF requests
to avoid causing the pointer array to allocate excessive space. Ensure
we always create the default registration request at the tool to match
what the server is doing.

Fixes https://github.com/openpmix/prrte/issues/259

Signed-off-by: Ralph Castain <rhc@pmix.org>