### PR TITLE
configury: Allow to override build date+host+user

### DIFF
--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -94,9 +94,19 @@ EOF
 # Save some stats about this build
 #
 
-PMIX_CONFIGURE_USER="`whoami`"
-PMIX_CONFIGURE_HOST="`(hostname || uname -n) 2> /dev/null | sed 1q`"
-PMIX_CONFIGURE_DATE="`date`"
+DATE_FMT="+%Y-%m-%dT%H:%M:%S"
+if test -n "$SOURCE_DATE_EPOCH" ; then
+  PMIX_CONFIGURE_USER="reproduciblebuild"
+  PMIX_CONFIGURE_HOST="reproduciblebuild"
+  PMIX_CONFIGURE_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT")
+else
+  PMIX_CONFIGURE_USER="`whoami`"
+  PMIX_CONFIGURE_HOST="`(hostname || uname -n) 2> /dev/null | sed 1q`"
+  PMIX_CONFIGURE_DATE="`date $DATE_FMT`"
+fi
+
+AC_SUBST([SOURCE_DATE_EPOCH])
+AM_CONDITIONAL([SOURCE_DATE_EPOCH_SET], [test -n "$SOURCE_DATE_EPOCH"])
 
 #
 # Save these details so that they can be used in pmix_info later

--- a/src/tools/pmix_info/Makefile.am
+++ b/src/tools/pmix_info/Makefile.am
@@ -19,13 +19,22 @@
 # $HEADER$
 #
 
+if SOURCE_DATE_EPOCH_SET
+  USER = @PMIX_CONFIGURE_USER@
+  PMIX_BUILD_HOST = @PMIX_CONFIGURE_HOST@
+  PMIX_BUILD_DATE = @PMIX_CONFIGURE_DATE@
+else
+  PMIX_BUILD_HOST = `(hostname || uname -n) 2> /dev/null | sed 1q`
+  PMIX_BUILD_DATE = `date +%Y-%m-%dT%H:%M:%S`
+endif
+
 AM_CFLAGS = \
             -DPMIX_CONFIGURE_USER="\"@PMIX_CONFIGURE_USER@\"" \
             -DPMIX_CONFIGURE_HOST="\"@PMIX_CONFIGURE_HOST@\"" \
             -DPMIX_CONFIGURE_DATE="\"@PMIX_CONFIGURE_DATE@\"" \
-            -DPMIX_BUILD_USER="\"$$USER\"" \
-            -DPMIX_BUILD_HOST="\"`(hostname || uname -n) 2> /dev/null | sed 1q`\"" \
-            -DPMIX_BUILD_DATE="\"`date`\"" \
+            -DPMIX_BUILD_USER="\"$(USER)\"" \
+            -DPMIX_BUILD_HOST="\"$(PMIX_BUILD_HOST)\"" \
+            -DPMIX_BUILD_DATE="\"$(PMIX_BUILD_DATE)\"" \
             -DPMIX_BUILD_CFLAGS="\"@CFLAGS@\"" \
             -DPMIX_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
             -DPMIX_BUILD_LDFLAGS="\"@LDFLAGS@\"" \


### PR DESCRIPTION
with SOURCE_DATE_EPOCH
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also switch to UTC to be independent of timezone.
Also use ISO 8601 date format to be easier to parse.

Note: This date call is designed to work with different flavors
of date (GNU, BSD and others).
If only GNU (Linux) support is needed, the patch can be simplified.

This PR was done while working on reproducible builds for openSUSE.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>
(cherry picked from commit d028c669e724b6c13b0e0f9ed6fcedae2c1cc7f4)