### PR TITLE
Simplify tracker initialization

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -390,7 +390,6 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
     pmix_server_trkr_t *trk;
     size_t i;
     bool all_def;
-    pmix_rank_t ns_local = 0;
     pmix_namespace_t *nptr, *ns;
     pmix_rank_info_t *info;
     pmix_nspace_caddy_t *nm;
@@ -485,7 +484,6 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
              * of the loop */
         }
         /* is this one of my local ranks? */
-        ns_local = 0;
         PMIX_LIST_FOREACH(info, &nptr->ranks, pmix_rank_info_t) {
             if (procs[i].rank == info->pname.rank ||
                 PMIX_RANK_WILDCARD == procs[i].rank) {
@@ -493,14 +491,12 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
                                         "adding local proc %s.%d to tracker",
                                         info->pname.nspace, info->pname.rank);
                 /* track the count */
-                ns_local++;
+                trk->nlocal++;
                 if (PMIX_RANK_WILDCARD != procs[i].rank) {
                     break;
                 }
             }
         }
-
-        trk->nlocal += ns_local;
     }
 
     if (trk->nlocal == nptr->nprocs) {


### PR DESCRIPTION
After reviewing #1471 I think that there is no need in `ns_local` anymore.
The whole point behind it was to verify that in case of a wildcard all processes in the namespace are located on the local node (on the per namespace basis).

What the code does now - it is filtering all the local ranks from the fence signature, and then this value is compared to the total process count.
I agree this is a cleaner way, so let's get rid of `ns_local`.