### PR TITLE
Cleanup example use of pmix_value_t

### DIFF
--- a/examples/alloc.c
+++ b/examples/alloc.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -153,8 +154,7 @@ int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs;
     pmix_info_t *info;

--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,8 +169,7 @@ static void invitefn(size_t evhdlr_registration_id,
 int main(int argc, char **argv)
 {
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc, *procs;
     uint32_t nprocs;
     mylock_t lock;

--- a/examples/client.c
+++ b/examples/client.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,7 +125,7 @@ int main(int argc, char **argv)
 {
     pmix_status_t rc;
     pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     char *tmp;
     pmix_proc_t proc;
     uint32_t nprocs, n;
@@ -197,6 +198,8 @@ int main(int argc, char **argv)
         /* wait for debugger release */
         DEBUG_WAIT_THREAD(&myrel.lock);
         DEBUG_DESTRUCT_MYREL(&myrel);
+
+        PMIX_VALUE_RELEASE(val);
     }
 
     /* get our universe size */
@@ -205,6 +208,8 @@ int main(int argc, char **argv)
         goto done;
     }
     fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, val->data.uint32);
+    PMIX_VALUE_RELEASE(val);
+
     /* get the number of procs in our job - univ size is the total number of allocated
      * slots, not the number of procs in the job */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
@@ -219,6 +224,7 @@ int main(int argc, char **argv)
     if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
         exit(1);
     }
+
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -277,6 +283,7 @@ int main(int argc, char **argv)
         }
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
+            free(tmp);
             goto done;
         }
         if (PMIX_UINT64 != val->type) {
@@ -299,6 +306,7 @@ int main(int argc, char **argv)
         }
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
+            free(tmp);
             goto done;
         }
         if (PMIX_STRING != val->type) {

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ int main(int argc, char **argv)
 {
     int rc;
     pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     char *tmp;
     pmix_proc_t proc;
     uint32_t n, k, nlocal;
@@ -146,36 +147,54 @@ int main(int argc, char **argv)
             }
         }
         if (local) {
-            (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, n);
+            if( 0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, n)) {
+                exit(1);
+            }
             proc.rank = n;
             if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n, tmp, rc);
+                free(tmp);
                 goto done;
             }
             if (PMIX_UINT64 != val->type) {
                 fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %d\n", myproc.nspace, myproc.rank, tmp, val->type);
+                PMIX_VALUE_RELEASE(val);
+                free(tmp);
                 goto done;
             }
             if (1234 != val->data.uint64) {
                 fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong value: %d\n", myproc.nspace, myproc.rank, tmp, (int)val->data.uint64);
+                PMIX_VALUE_RELEASE(val);
+                free(tmp);
                 goto done;
             }
             fprintf(stderr, "%s:%d Local value for %s:%d successfully retrieved\n", myproc.nspace, myproc.rank, proc.nspace, proc.rank);
+            PMIX_VALUE_RELEASE(val);
+                free(tmp);
         } else {
-            (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
+            if( 0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, n)) {
+                exit(1);
+            }
             if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n, tmp, rc);
+                free(tmp);
                 goto done;
             }
             if (PMIX_STRING != val->type) {
                 fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %d\n", myproc.nspace, myproc.rank, tmp, val->type);
+                PMIX_VALUE_RELEASE(val);
+                free(tmp);
                 goto done;
             }
             if (0 != strcmp(val->data.string, "1234")) {
                 fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong value: %s\n", myproc.nspace, myproc.rank, tmp, val->data.string);
+                PMIX_VALUE_RELEASE(val);
+                free(tmp);
                 goto done;
             }
             fprintf(stderr, "%s:%d Remote value for %s:%d successfully retrieved\n", myproc.nspace, myproc.rank, proc.nspace, proc.rank);
+            PMIX_VALUE_RELEASE(val);
+            free(tmp);
         }
         /* if this isn't us, then get the ghex key */
         if (n != myproc.rank) {
@@ -185,13 +204,16 @@ int main(int argc, char **argv)
             }
             if (PMIX_BYTE_OBJECT != val->type) {
                 fprintf(stderr, "%s:%d: PMIx_Get ghex returned wrong type: %d\n", myproc.nspace, myproc.rank, val->type);
+                PMIX_VALUE_RELEASE(val);
                 goto done;
             }
             if (128 != val->data.bo.size) {
                 fprintf(stderr, "%s:%d: PMIx_Get ghex returned wrong size: %d\n", myproc.nspace, myproc.rank, (int)val->data.bo.size);
+                PMIX_VALUE_RELEASE(val);
                 goto done;
             }
             fprintf(stderr, "%s:%d Ghex for %s:%d successfully retrieved\n", myproc.nspace, myproc.rank, proc.nspace, proc.rank);
+            PMIX_VALUE_RELEASE(val);
         }
     }
 

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,8 +43,7 @@ static pmix_proc_t myproc;
 int main(int argc, char **argv)
 {
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs;
     char nsp2[PMIX_MAX_NSLEN+1];

--- a/examples/fault.c
+++ b/examples/fault.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -111,8 +112,7 @@ static void evhandler_reg_callbk(pmix_status_t status,
 int main(int argc, char **argv)
 {
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs;
     pmix_info_t *info;

--- a/examples/group.c
+++ b/examples/group.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,8 +110,7 @@ static void errhandler_reg_callbk(pmix_status_t status,
 int main(int argc, char **argv)
 {
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc, *procs;
     uint32_t nprocs;
     mylock_t lock;

--- a/examples/jctrl.c
+++ b/examples/jctrl.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,8 +96,7 @@ static void infocbfunc(pmix_status_t status,
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs, n;
     pmix_info_t *info, *iptr;

--- a/examples/pub.c
+++ b/examples/pub.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,7 @@ int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs;
     pmix_info_t *info;

--- a/examples/pubi.c
+++ b/examples/pubi.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,7 @@ int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
     int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    pmix_value_t *val = NULL;
     pmix_proc_t proc;
     uint32_t nprocs;
     pmix_info_t *info;


### PR DESCRIPTION
 * Fixes #1133
 * Remove `pmix_value_t *val = &value` where not meaningful.
 * Cleanup a few places where `val` was not released, and a couple
   of other minor memory leaks.