### PR TITLE
python: add missing data conversions for types

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1789,27 +1789,8 @@ cdef class PMIxServer(PMIxClient):
         else:
             pyhosts = hosts
         rc = PMIx_generate_regex(pyhosts, &regex)
-        if "pmix" == regex[:4].decode("ascii"):
-            # remove null characters
-            if b'\x00' in regex:
-                regex.replace(b'\x00', '')
-            ba = bytearray(regex)
-        elif "blob" == regex[:4].decode("ascii"):
-            sz_str    = len(regex)
-            sz_prefix = 5
-            # extract length of bytearray
-            regex.split(b'\x00')
-            len_bytearray = regex[1]
-            length = len(len_bytearray) + sz_prefix + sz_str
-            ba = bytearray(length)
-            pyregex = <bytes> regex[:length]
-            index = 0
-            while index < length:
-                ba[index] = pyregex[index]
-                index += 1
-        else:
-            # last case with no ':' in string
-            ba = bytearray(regex)
+        # load regex appropriately into python bytearray
+        ba = pmix_convert_regex(regex)
         return (rc, ba)
 
     def generate_ppn(self, procs):

--- a/bindings/python/tests/cython/test_cython.py
+++ b/bindings/python/tests/cython/test_cython.py
@@ -25,14 +25,15 @@ def main():
     parser.add_argument("-t", "--test", help="pass string name of test function (i.e test_alloc_info)")
     parser.add_argument("-a", "--all", action="store_true")
     args = parser.parse_args()
+    unload = True
     if len(sys.argv) < 2:
         print("no arguments provided")
     if args.test == "test_alloc_info":
         test_alloc_info()
     elif args.test == "test_load_value":
-        test_load_value()
+        test_load_value(unload)
     elif args.all:
-        test_load_value()
+        test_load_value(unload)
         test_alloc_info()
 
 if __name__ == '__main__':

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -36,6 +36,8 @@ static const char* basic_type_string(pmix_data_type_t type)
     switch(type) {
         case PMIX_BOOL:
             return "PMIX_BOOL";
+        case PMIX_REGEX:
+            return "PMIX_REGEX";
         case PMIX_BYTE:
             return "PMIX_BYTE";
         case PMIX_STRING:


### PR DESCRIPTION
    - add missing data conversion function for PMIX_REGEX
    - add tests for pmix_value_unload on all type values

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>