### PR TITLE
Protect pthread setpshared calls

### DIFF
--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -132,12 +132,14 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             PMIX_ERROR_LOG(rc);
             goto error;
         }
+#ifdef HAVE_PTHREAD_SHARED
         if (0 != pthread_rwlockattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
             pthread_rwlockattr_destroy(&attr);
             rc = PMIX_ERR_INIT;
             PMIX_ERROR_LOG(rc);
             goto error;
         }
+#endif
 #ifdef HAVE_PTHREAD_SETKIND
         if (0 != pthread_rwlockattr_setkind_np(&attr,
                                 PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)) {

--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -182,12 +182,14 @@ pmix_status_t pmix_gds_ds21_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             PMIX_ERROR_LOG(rc);
             goto error;
         }
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
         if (0 != pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
             pthread_mutexattr_destroy(&attr);
             rc = PMIX_ERR_INIT;
             PMIX_ERROR_LOG(rc);
             goto error;
         }
+#endif
 
         segment_hdr_t *seg_hdr = (segment_hdr_t*)lock_item->seg_desc->seg_info.seg_base_addr;
         seg_hdr->num_locks = local_size;

--- a/src/mca/pfexec/base/base.h
+++ b/src/mca/pfexec/base/base.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,7 +70,7 @@ typedef struct {
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_child_t);
 
 typedef struct {
-    pmix_event_t handler;
+    pmix_event_t *handler;
     bool active;
     pmix_list_t children;
     int timeout_before_sigkill;

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -15,7 +15,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +67,9 @@ static int pmix_pfexec_base_close(void)
 {
     PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
     if (pmix_pfexec_globals.active) {
-        pmix_event_del(&pmix_pfexec_globals.handler);
+        pmix_event_del(pmix_pfexec_globals.handler);
     }
+    free(pmix_pfexec_globals.handler);
     pmix_pfexec_globals.active = false;
 
     return pmix_mca_base_framework_components_close(&pmix_pfexec_base_framework, NULL);
@@ -198,13 +199,14 @@ static int pmix_pfexec_base_open(pmix_mca_base_open_flag_t flags)
     }
 
     /* set to catch SIGCHLD events */
+    pmix_pfexec_globals.handler = (pmix_event_t*)malloc(sizeof(pmix_event_t));
     pmix_event_set(pmix_globals.evbase,
-                   &pmix_pfexec_globals.handler,
+                   pmix_pfexec_globals.handler,
                    SIGCHLD, PMIX_EV_SIGNAL|PMIX_EV_PERSIST,
                    wait_signal_callback,
-                   &pmix_pfexec_globals.handler);
+                   pmix_pfexec_globals.handler);
     pmix_pfexec_globals.active = true;
-    pmix_event_add(&pmix_pfexec_globals.handler, NULL);
+    pmix_event_add(pmix_pfexec_globals.handler, NULL);
 
      /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_pfexec_base_framework, flags);


### PR DESCRIPTION
Do not try to set pthread_rwlockattr_setpshared with PTHREAD_PROCESS_SHARED when it is not available.
Do not try to use pthread_mutexattr_setpshared() when it is not available

Thanks to @geowiwi for the report and the patch

Fixes #1577

Signed-off-by: Ralph Castain <rhc@pmix.org>