### PR TITLE
Enable cycling of init/finalize calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ test/simple/simpcoord
 test/python/run_sched.sh
 test/python/run_server.sh
 test/simple/pmitest
+test/simple/simpcycle
 
 # coverity
 cov-int

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -137,6 +137,7 @@ PMIX_EXPORT void pmix_release_registered_attrs(void)
         PMIX_LIST_DESTRUCT(&host_attrs);
         PMIX_LIST_DESTRUCT(&tool_attrs);
     }
+    initialized = false;
 }
 
 /* sadly, we cannot dynamically register our supported attributes

--- a/src/mca/base/pmix_mca_base_var_group.c
+++ b/src/mca/base/pmix_mca_base_var_group.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2019 Research Organization for Information Science
+ * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -74,6 +74,7 @@ PMIX_CLASS_DECLARATION(pmix_bfrops_base_active_module_t);
 struct pmix_bfrops_globals_t {
   pmix_list_t actives;
   bool initialized;
+  bool selected;
   size_t initial_size;
   size_t threshold_size;
   pmix_bfrop_buffer_type_t default_type;

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2018 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,6 +103,7 @@ static pmix_status_t pmix_bfrop_close(void)
         return PMIX_SUCCESS;
     }
     pmix_bfrops_globals.initialized = false;
+    pmix_bfrops_globals.selected = false;
 
     /* the components will cleanup when closed */
     PMIX_LIST_DESTRUCT(&pmix_bfrops_globals.actives);

--- a/src/mca/bfrops/base/bfrop_base_select.c
+++ b/src/mca/bfrops/base/bfrop_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +31,6 @@
 
 #include "src/mca/bfrops/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_bfrop_base_select(void)
@@ -43,11 +43,11 @@ int pmix_bfrop_base_select(void)
     int rc, priority;
     bool inserted;
 
-    if (selected) {
+    if (pmix_bfrops_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_bfrops_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_bfrops_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -95,24 +95,6 @@ pmix_bfrops_module_t pmix_bfrops_pmix4_module = {
 
 static pmix_status_t init(void)
 {
-    pmix_status_t rc;
-
-    if( PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_psquash_base_framework, 0)) ) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-
-    if( PMIX_SUCCESS != (rc = pmix_psquash_base_select()) ) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-
-    rc = pmix_psquash.init();
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL,
                        pmix_bfrops_base_pack_bool,
@@ -459,19 +441,12 @@ static void finalize(void)
 {
     int n;
     pmix_bfrop_type_info_t *info;
-    pmix_status_t rc;
 
     for (n=0; n < mca_bfrops_v4_component.types.size; n++) {
         if (NULL != (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v4_component.types, n))) {
             PMIX_RELEASE(info);
             pmix_pointer_array_set_item(&mca_bfrops_v4_component.types, n, NULL);
         }
-    }
-
-    /* close the psquash framework */
-    pmix_psquash.finalize();
-    if( PMIX_SUCCESS != (rc = pmix_mca_base_framework_close(&pmix_psquash_base_framework)) ) {
-        PMIX_ERROR_LOG(rc);
     }
 }
 

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -75,6 +75,7 @@ PMIX_CLASS_DECLARATION(pmix_gds_base_active_module_t);
 struct pmix_gds_globals_t {
   pmix_list_t actives;
   bool initialized;
+  bool selected;
   char *all_mods;
 };
 

--- a/src/mca/gds/base/gds_base_frame.c
+++ b/src/mca/gds/base/gds_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,6 +57,7 @@ static pmix_status_t pmix_gds_close(void)
         return PMIX_SUCCESS;
     }
     pmix_gds_globals.initialized = false;
+    pmix_gds_globals.selected = false;
 
     PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_gds_globals.actives, pmix_gds_base_active_module_t) {
       pmix_list_remove_item(&pmix_gds_globals.actives, &active->super);

--- a/src/mca/gds/base/gds_base_select.c
+++ b/src/mca/gds/base/gds_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,8 +32,6 @@
 
 #include "src/mca/gds/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_gds_base_select(pmix_info_t info[], size_t ninfo)
@@ -45,11 +45,11 @@ int pmix_gds_base_select(pmix_info_t info[], size_t ninfo)
     bool inserted;
     char **mods = NULL;
 
-    if (selected) {
+    if (pmix_gds_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_gds_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_gds_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/pcompress/base/base.h
+++ b/src/mca/pcompress/base/base.h
@@ -54,6 +54,7 @@ extern "C" {
 
 typedef struct {
     size_t compress_limit;
+    bool selected;
 } pmix_compress_base_t;
 
 PMIX_EXPORT extern pmix_compress_base_t pmix_compress_base;

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -81,6 +81,7 @@ static int pmix_compress_base_open(pmix_mca_base_open_flag_t flags)
 
 static int pmix_compress_base_close(void)
 {
+    pmix_compress_base.selected = false;
     /* Call the component's finalize routine */
     if( NULL != pmix_compress.finalize ) {
         pmix_compress.finalize();

--- a/src/mca/pcompress/base/pcompress_base_select.c
+++ b/src/mca/pcompress/base/pcompress_base_select.c
@@ -33,6 +33,11 @@ int pmix_compress_base_select(void)
     pmix_compress_base_component_t *best_component = NULL;
     pmix_compress_base_module_t *best_module = NULL;
 
+    if (pmix_compress_base.selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    pmix_compress_base.selected = true;
     /*
      * Select the best component
      */

--- a/src/mca/pfexec/base/base.h
+++ b/src/mca/pfexec/base/base.h
@@ -75,6 +75,7 @@ typedef struct {
     pmix_list_t children;
     int timeout_before_sigkill;
     size_t next;
+    bool selected;
 } pmix_pfexec_globals_t;
 
 PMIX_EXPORT extern pmix_pfexec_globals_t pmix_pfexec_globals;

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -71,6 +71,7 @@ static int pmix_pfexec_base_close(void)
     }
     free(pmix_pfexec_globals.handler);
     pmix_pfexec_globals.active = false;
+    pmix_pfexec_globals.selected = false;
 
     return pmix_mca_base_framework_components_close(&pmix_pfexec_base_framework, NULL);
 }

--- a/src/mca/pfexec/base/pfexec_base_select.c
+++ b/src/mca/pfexec/base/pfexec_base_select.c
@@ -39,6 +39,12 @@ int pmix_pfexec_base_select(void)
     pmix_pfexec_base_component_t *best_component = NULL;
     pmix_pfexec_base_module_t *best_module = NULL;
 
+    if (pmix_pfexec_globals.selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    pmix_pfexec_globals.selected = true;
+
     /*
      * Select the best component
      */

--- a/src/mca/plog/base/base.h
+++ b/src/mca/plog/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,6 +77,7 @@ struct pmix_plog_globals_t {
     pmix_lock_t lock;
     pmix_pointer_array_t actives;
     bool initialized;
+    bool selected;
     char **channels;
 };
 typedef struct pmix_plog_globals_t pmix_plog_globals_t;

--- a/src/mca/plog/base/plog_base_frame.c
+++ b/src/mca/plog/base/plog_base_frame.c
@@ -1,6 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; -*- */
 /*
  * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,6 +62,7 @@ static pmix_status_t pmix_plog_close(void)
         return PMIX_SUCCESS;
     }
     pmix_plog_globals.initialized = false;
+    pmix_plog_globals.selected = false;
 
     for (n=0; n < pmix_plog_globals.actives.size; n++) {
         if (NULL == (active = (pmix_plog_base_active_module_t*)pmix_pointer_array_get_item(&pmix_plog_globals.actives, n))) {

--- a/src/mca/plog/base/plog_base_select.c
+++ b/src/mca/plog/base/plog_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,8 +30,6 @@
 
 #include "src/mca/plog/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized array of components
  * from all those that are available. */
 int pmix_plog_base_select(void)
@@ -45,11 +45,11 @@ int pmix_plog_base_select(void)
     char *ptr;
     size_t len;
 
-    if (selected) {
+    if (pmix_plog_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_plog_globals.selected = true;
 
     PMIX_CONSTRUCT(&actives, pmix_list_t);
 

--- a/src/mca/pmdl/base/base.h
+++ b/src/mca/pmdl/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,6 +73,7 @@ struct pmix_pmdl_globals_t {
     pmix_lock_t lock;
     pmix_list_t actives;
     bool initialized;
+    bool selected;
 };
 typedef struct pmix_pmdl_globals_t pmix_pmdl_globals_t;
 

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +62,7 @@ static pmix_status_t pmix_pmdl_close(void)
         return PMIX_SUCCESS;
     }
     pmix_pmdl_globals.initialized = false;
+    pmix_pmdl_globals.selected = false;
 
     PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
       pmix_list_remove_item(&pmix_pmdl_globals.actives, &active->super);

--- a/src/mca/pmdl/base/pmdl_base_select.c
+++ b/src/mca/pmdl/base/pmdl_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,8 +29,6 @@
 
 #include "src/mca/pmdl/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_pmdl_base_select(void)
@@ -41,11 +41,11 @@ int pmix_pmdl_base_select(void)
     int rc, priority;
     bool inserted;
 
-    if (selected) {
+    if (pmix_pmdl_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_pmdl_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_pmdl_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,6 +116,7 @@ struct pmix_pnet_globals_t {
     pmix_lock_t lock;
     pmix_list_t actives;
     bool initialized;
+    bool selected;
     pmix_list_t jobs;
     pmix_list_t nodes;
 };

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,6 +64,7 @@ static pmix_status_t pmix_pnet_close(void)
         return PMIX_SUCCESS;
     }
     pmix_pnet_globals.initialized = false;
+    pmix_pnet_globals.selected = false;
 
     PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
       pmix_list_remove_item(&pmix_pnet_globals.actives, &active->super);

--- a/src/mca/pnet/base/pnet_base_select.c
+++ b/src/mca/pnet/base/pnet_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,8 +29,6 @@
 
 #include "src/mca/pnet/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_pnet_base_select(void)
@@ -41,11 +41,11 @@ int pmix_pnet_base_select(void)
     int rc, priority;
     bool inserted;
 
-    if (selected) {
+    if (pmix_pnet_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_pnet_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_pnet_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,6 +72,7 @@ PMIX_CLASS_DECLARATION(pmix_preg_base_active_module_t);
 struct pmix_preg_globals_t {
   pmix_list_t actives;
   bool initialized;
+  bool selected;
 };
 typedef struct pmix_preg_globals_t pmix_preg_globals_t;
 

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -62,6 +62,7 @@ static pmix_status_t pmix_preg_close(void)
         return PMIX_SUCCESS;
     }
     pmix_preg_globals.initialized = false;
+    pmix_preg_globals.selected = false;
 
     PMIX_LIST_DESTRUCT(&pmix_preg_globals.actives);
 

--- a/src/mca/preg/base/preg_base_select.c
+++ b/src/mca/preg/base/preg_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +31,6 @@
 
 #include "src/mca/preg/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_preg_base_select(void)
@@ -43,11 +43,11 @@ int pmix_preg_base_select(void)
     int rc, priority;
     bool inserted;
 
-    if (selected) {
+    if (pmix_preg_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_preg_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_preg_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/psec/base/base.h
+++ b/src/mca/psec/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,10 +72,11 @@ PMIX_CLASS_DECLARATION(pmix_psec_base_active_module_t);
 struct pmix_psec_globals_t {
   pmix_list_t actives;
   bool initialized;
+  bool selected;
 };
 typedef struct pmix_psec_globals_t pmix_psec_globals_t;
 
-extern pmix_psec_globals_t pmix_psec_globals;
+PMIX_EXPORT extern pmix_psec_globals_t pmix_psec_globals;
 
 PMIX_EXPORT char* pmix_psec_base_get_available_modules(void);
 PMIX_EXPORT pmix_psec_module_t* pmix_psec_base_assign_module(const char *options);

--- a/src/mca/psec/base/psec_base_frame.c
+++ b/src/mca/psec/base/psec_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +54,7 @@ static pmix_status_t pmix_psec_close(void)
         return PMIX_SUCCESS;
     }
     pmix_psec_globals.initialized = false;
+    pmix_psec_globals.selected = false;
 
     PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_psec_globals.actives, pmix_psec_base_active_module_t) {
       pmix_list_remove_item(&pmix_psec_globals.actives, &active->super);

--- a/src/mca/psec/base/psec_base_select.c
+++ b/src/mca/psec/base/psec_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +31,6 @@
 
 #include "src/mca/psec/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_psec_base_select(void)
@@ -43,11 +43,11 @@ int pmix_psec_base_select(void)
     int rc, priority;
     bool inserted;
 
-    if (selected) {
+    if (pmix_psec_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_psec_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_psec_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/psensor/base/base.h
+++ b/src/mca/psensor/base/base.h
@@ -1,8 +1,9 @@
 /*
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
- *
  * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +37,7 @@ PMIX_EXPORT int pmix_psensor_base_select(void);
 typedef struct {
     pmix_list_t actives;
     pmix_event_base_t *evbase;
+    bool selected;
 } pmix_psensor_base_t;
 
 typedef struct {

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -2,8 +2,9 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- *
  * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,6 +62,7 @@ static int pmix_psensor_register(pmix_mca_base_register_flag_t flags)
 
 static int pmix_psensor_base_close(void)
 {
+    pmix_psensor_base.selected = false;
     PMIX_LIST_DESTRUCT(&pmix_psensor_base.actives);
 
     if (use_separate_thread && NULL != pmix_psensor_base.evbase) {

--- a/src/mca/psensor/base/psensor_base_select.c
+++ b/src/mca/psensor/base/psensor_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,8 +29,6 @@
 
 #include "src/mca/psensor/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_psensor_base_select(void)
@@ -40,11 +40,11 @@ int pmix_psensor_base_select(void)
     int pri;
     bool inserted;
 
-    if (selected) {
+    if (pmix_psensor_base.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_psensor_base.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_psensor_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/pshmem/base/base.h
+++ b/src/mca/pshmem/base/base.h
@@ -55,6 +55,16 @@ PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pshmem_base_framework;
  */
 PMIX_EXPORT pmix_status_t pmix_pshmem_base_select(void);
 
+/* framework globals */
+struct pmix_pshmem_globals_t {
+  bool initialized;
+  bool selected;
+};
+
+typedef struct pmix_pshmem_globals_t pmix_pshmem_globals_t;
+
+PMIX_EXPORT extern pmix_pshmem_globals_t pmix_pshmem_globals;
+
 END_C_DECLS
 
 #endif

--- a/src/mca/pshmem/base/pshmem_base_frame.c
+++ b/src/mca/pshmem/base/pshmem_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,28 +43,28 @@
 
 #include "src/mca/pshmem/base/static-components.h"
 
-static bool initialized = false;
-
 /* Instantiate the global vars */
+pmix_pshmem_globals_t pmix_pshmem_globals = {0};
 pmix_pshmem_base_module_t pmix_pshmem = {0};
 
 static pmix_status_t pmix_pshmem_close(void)
 {
-    if (!initialized) {
+    if (!pmix_pshmem_globals.initialized) {
         return PMIX_SUCCESS;
     }
-    initialized = false;
+    pmix_pshmem_globals.initialized = false;
+    pmix_pshmem_globals.selected = false;
 
     return pmix_mca_base_framework_components_close(&pmix_pshmem_base_framework, NULL);
 }
 
 static pmix_status_t pmix_pshmem_open(pmix_mca_base_open_flag_t flags)
 {
-    if (initialized) {
+    if (pmix_pshmem_globals.initialized) {
         return PMIX_SUCCESS;
     }
     /* initialize globals */
-    initialized = true;
+    pmix_pshmem_globals.initialized = true;
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_pshmem_base_framework, flags);

--- a/src/mca/pshmem/base/pshmem_base_select.c
+++ b/src/mca/pshmem/base/pshmem_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,8 +29,6 @@
 
 #include "src/mca/pshmem/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_pshmem_base_select(void)
@@ -40,11 +40,11 @@ int pmix_pshmem_base_select(void)
     int rc, priority, best_pri = -1;
     bool inserted = false;
 
-    if (selected) {
+    if (pmix_pshmem_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_pshmem_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_pshmem_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/psquash/base/base.h
+++ b/src/mca/psquash/base/base.h
@@ -3,7 +3,8 @@
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,10 +64,18 @@ do {                                                        \
     }                                                       \
 } while (0)
 
+struct pmix_psquash_globals_t {
+  bool initialized;
+  bool selected;
+};
+
+typedef struct pmix_psquash_globals_t pmix_psquash_globals_t;
 
 PMIX_EXPORT extern pmix_mca_base_framework_t pmix_psquash_base_framework;
 
 PMIX_EXPORT pmix_status_t pmix_psquash_base_select(void);
+
+PMIX_EXPORT extern pmix_psquash_globals_t pmix_psquash_globals;
 
 END_C_DECLS
 

--- a/src/mca/psquash/base/psquash_base_frame.c
+++ b/src/mca/psquash/base/psquash_base_frame.c
@@ -44,27 +44,27 @@
 
 #include "src/mca/psquash/base/static-components.h"
 
-static bool initialized = false;
-
 pmix_psquash_base_module_t pmix_psquash = {0};
+pmix_psquash_globals_t pmix_psquash_globals = {0};
 
 static pmix_status_t pmix_psquash_close(void)
 {
-    if (!initialized) {
+    if (!pmix_psquash_globals.initialized) {
         return PMIX_SUCCESS;
     }
-    initialized = false;
+    pmix_psquash_globals.initialized = false;
+    pmix_psquash_globals.selected = false;
 
     return pmix_mca_base_framework_components_close(&pmix_psquash_base_framework, NULL);
 }
 
 static pmix_status_t pmix_psquash_open(pmix_mca_base_open_flag_t flags)
 {
-    if (initialized) {
+    if (pmix_psquash_globals.initialized) {
         return PMIX_SUCCESS;
     }
     /* initialize globals */
-    initialized = true;
+    pmix_psquash_globals.initialized = true;
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_psquash_base_framework, flags);

--- a/src/mca/psquash/base/psquash_base_select.c
+++ b/src/mca/psquash/base/psquash_base_select.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,8 +32,6 @@
 
 #include "src/mca/psquash/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_psquash_base_select(void)
@@ -43,11 +43,11 @@ int pmix_psquash_base_select(void)
     int rc, priority, best_pri = -1;
     bool inserted = false;
 
-    if (selected) {
+    if (pmix_psquash_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_psquash_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_psquash_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,6 +73,7 @@ PMIX_CLASS_DECLARATION(pmix_ptl_base_active_t);
 struct pmix_ptl_globals_t {
     pmix_list_t actives;
     bool initialized;
+    bool selected;
     pmix_list_t posted_recvs;     // list of pmix_ptl_posted_recv_t
     pmix_list_t unexpected_msgs;
     int stop_thread[2];

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,6 +81,7 @@ static pmix_status_t pmix_ptl_close(void)
         return PMIX_SUCCESS;
     }
     pmix_ptl_globals.initialized = false;
+    pmix_ptl_globals.selected = false;
 
     /* ensure the listen thread has been shut down */
     pmix_ptl_base_stop_listening();

--- a/src/mca/ptl/base/ptl_base_select.c
+++ b/src/mca/ptl/base/ptl_base_select.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +31,6 @@
 
 #include "src/mca/ptl/base/base.h"
 
-static bool selected = false;
-
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
 int pmix_ptl_base_select(void)
@@ -42,11 +42,11 @@ int pmix_ptl_base_select(void)
     int pri;
     bool inserted;
 
-    if (selected) {
+    if (pmix_ptl_globals.selected) {
         /* ensure we don't do this twice */
         return PMIX_SUCCESS;
     }
-    selected = true;
+    pmix_ptl_globals.selected = true;
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &pmix_ptl_base_framework.framework_components, pmix_mca_base_component_list_item_t) {

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -43,6 +43,7 @@
 #include "src/mca/pnet/base/base.h"
 #include "src/mca/preg/base/base.h"
 #include "src/mca/psec/base/base.h"
+#include "src/mca/psquash/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include PMIX_EVENT_HEADER
 
@@ -83,6 +84,10 @@ void pmix_rte_finalize(void)
 
     /* close bfrops */
     (void)pmix_mca_base_framework_close(&pmix_bfrops_base_framework);
+
+    /* close the psquash framework */
+    pmix_psquash.finalize();
+    pmix_mca_base_framework_close(&pmix_psquash_base_framework);
 
     /* close compress */
     (void)pmix_mca_base_framework_close(&pmix_pcompress_base_framework);

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -266,7 +266,6 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
 pmix_event_base_t *pmix_progress_thread_init(const char *name)
 {
     pmix_progress_tracker_t *trk;
-    int rc;
 
     if (!inited) {
         PMIX_CONSTRUCT(&tracking, pmix_list_t);
@@ -320,17 +319,45 @@ pmix_event_base_t *pmix_progress_thread_init(const char *name)
     /* construct the thread object */
     PMIX_CONSTRUCT(&trk->engine, pmix_thread_t);
     trk->engine_constructed = true;
-    if (PMIX_SUCCESS != (rc = start_progress_engine(trk))) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(trk);
-        return NULL;
-    }
     pmix_list_append(&tracking, &trk->super);
 
     return trk->ev_base;
 }
 
-int pmix_progress_thread_stop(const char *name)
+pmix_status_t pmix_progress_thread_start(const char *name)
+{
+    pmix_progress_tracker_t *trk;
+    pmix_status_t rc;
+
+    if (!inited) {
+        /* nothing we can do */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    PMIX_LIST_FOREACH(trk, &tracking, pmix_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            /* If the progress thread is active, ignore the request */
+            if (trk->ev_active) {
+                return PMIX_SUCCESS;
+            }
+            if (PMIX_SUCCESS != (rc = start_progress_engine(trk))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(trk);
+            }
+            return rc;
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}
+
+
+pmix_status_t pmix_progress_thread_stop(const char *name)
 {
     pmix_progress_tracker_t *trk;
 
@@ -367,7 +394,7 @@ int pmix_progress_thread_stop(const char *name)
     return PMIX_ERR_NOT_FOUND;
 }
 
-int pmix_progress_thread_finalize(const char *name)
+pmix_status_t pmix_progress_thread_finalize(const char *name)
 {
     pmix_progress_tracker_t *trk;
 
@@ -400,7 +427,7 @@ int pmix_progress_thread_finalize(const char *name)
 /*
  * Stop the progress thread, but don't delete the tracker (or event base)
  */
-int pmix_progress_thread_pause(const char *name)
+pmix_status_t pmix_progress_thread_pause(const char *name)
 {
     pmix_progress_tracker_t *trk;
 
@@ -442,7 +469,7 @@ static pmix_progress_tracker_t* pmix_progress_tracker_get_by_base(pmix_event_bas
 }
 #endif
 
-int pmix_progress_thread_resume(const char *name)
+pmix_status_t pmix_progress_thread_resume(const char *name)
 {
     pmix_progress_tracker_t *trk;
 

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -32,7 +32,9 @@
  * already-running progress thread will be returned (i.e., no new
  * progress thread will be started).
  */
-pmix_event_base_t *pmix_progress_thread_init(const char *name);
+PMIX_EXPORT pmix_event_base_t *pmix_progress_thread_init(const char *name);
+
+PMIX_EXPORT pmix_status_t pmix_progress_thread_start(const char *name);
 
 /**
  * Stop a progress thread name (reference counted).
@@ -45,7 +47,7 @@ pmix_event_base_t *pmix_progress_thread_init(const char *name);
  * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
  * exist; PMIX_SUCCESS otherwise.
  */
-int pmix_progress_thread_stop(const char *name);
+PMIX_EXPORT pmix_status_t pmix_progress_thread_stop(const char *name);
 
 /**
  * Finalize a progress thread name (reference counted).
@@ -57,7 +59,7 @@ int pmix_progress_thread_stop(const char *name);
  * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
  * exist; PMIX_SUCCESS otherwise.
  */
-int pmix_progress_thread_finalize(const char *name);
+PMIX_EXPORT pmix_status_t pmix_progress_thread_finalize(const char *name);
 
 /**
  * Temporarily pause the progress thread associated with this name.
@@ -70,7 +72,7 @@ int pmix_progress_thread_finalize(const char *name);
  * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
  * exist; PMIX_SUCCESS otherwise.
  */
-int pmix_progress_thread_pause(const char *name);
+PMIX_EXPORT pmix_status_t pmix_progress_thread_pause(const char *name);
 
 /**
  * Restart a previously-paused progress thread associated with this
@@ -79,6 +81,6 @@ int pmix_progress_thread_pause(const char *name);
  * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
  * exist; PMIX_SUCCESS otherwise.
  */
-int pmix_progress_thread_resume(const char *name);
+PMIX_EXPORT pmix_status_t pmix_progress_thread_resume(const char *name);
 
 #endif

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -454,6 +454,7 @@ void pmix_output_finalize(void)
         free (output_prefix);
         free (output_dir);
         PMIX_DESTRUCT(&verbose);
+        initialized = false;
     }
 }
 

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,7 +26,7 @@ headers = simptest.h
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simplegacy simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
-                  simpcoord pmitest
+                  simpcoord pmitest simpcycle
 
 simptest_SOURCES = \
         simptest.c
@@ -147,3 +147,9 @@ pmitest_SOURCES = \
 pmitest_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmitest_LDADD = \
     $(top_builddir)/src/libpmi.la
+
+simpcycle_SOURCES = \
+        simpcycle.c
+simpcycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpcycle_LDADD = \
+    $(top_builddir)/src/libpmix.la

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+#include "src/include/pmix_globals.h"
+
+#define MAXCNT 1
+
+static volatile bool completed = false;
+static pmix_proc_t myproc;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    pmix_output(0, "Client %s:%d NOTIFIED with status %s", myproc.nspace, myproc.rank, PMIx_Error_string(status));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+    completed = true;
+}
+
+/* this is an event notification function that we explicitly request
+ * be called when the PMIX_MODEL_DECLARED notification is issued.
+ * We could catch it in the general event notification function and test
+ * the status to see if the status matched, but it often is simpler
+ * to declare a use-specific notification callback point. In this case,
+ * we are asking to know whenever a model is declared as a means
+ * of testing server self-notification */
+static void model_callback(size_t evhdlr_registration_id,
+                           pmix_status_t status,
+                           const pmix_proc_t *source,
+                           pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc,
+                           void *cbdata)
+{
+    size_t n;
+
+    /* just let us know it was received */
+    fprintf(stderr, "%s:%d Model event handler called with status %d(%s)\n",
+            myproc.nspace, myproc.rank, status, PMIx_Error_string(status));
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_STRING == info[n].value.type) {
+            fprintf(stderr, "%s:%d\t%s:\t%s\n",
+                    myproc.nspace, myproc.rank,
+                    info[n].key, info[n].value.data.string);
+        }
+    }
+
+    /* we must NOT tell the event handler state machine that we
+     * are the last step as that will prevent it from notifying
+     * anyone else that might be listening for declarations */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int rc, nprocs;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    char *tmp;
+    pmix_proc_t proc;
+    pmix_info_t *iptr;
+    size_t ninfo;
+    pmix_status_t code;
+
+    /* init us and declare we are a test programming model */
+    PMIX_INFO_CREATE(iptr, 2);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_PROGRAMMING_MODEL, "TEST", PMIX_STRING);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_MODEL_LIBRARY_NAME, "PMIX", PMIX_STRING);
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, iptr, 2))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    PMIX_INFO_FREE(iptr, 2);
+    pmix_output(0, "Client ns %s rank %d: Running on node %s", myproc.nspace, myproc.rank, pmix_globals.hostname);
+    goto testpoint;
+
+    /* test something */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
+
+   /* register a handler specifically for when models declare */
+    ninfo = 1;
+    PMIX_INFO_CREATE(iptr, ninfo);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "SIMPCLIENT-MODEL", PMIX_STRING);
+    code = PMIX_MODEL_DECLARED;
+    PMIx_Register_event_handler(&code, 1, iptr, ninfo,
+                                model_callback, NULL, NULL);
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /* register our errhandler */
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, NULL, NULL);
+
+    /* put a few values */
+    (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    value.type = PMIX_UINT32;
+    value.data.uint32 = 1234;
+    if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+
+    /* get a list of our local peers */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    PMIX_VALUE_RELEASE(val);
+
+  testpoint:
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing(1)", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+
+    /* initialize us again */
+    fprintf(stderr, "Client Init(2)\n");
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "Client ns %s rank %d: Finalizing(2)", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+
+    fflush(stderr);
+    return(rc);
+}

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -116,7 +116,6 @@ int main(int argc, char **argv)
     }
     PMIX_INFO_FREE(iptr, 2);
     pmix_output(0, "Client ns %s rank %d: Running on node %s", myproc.nspace, myproc.rank, pmix_globals.hostname);
-    goto testpoint;
 
     /* test something */
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
@@ -161,7 +160,6 @@ int main(int argc, char **argv)
     }
     PMIX_VALUE_RELEASE(val);
 
-  testpoint:
     /* finalize us */
     pmix_output(0, "Client ns %s rank %d: Finalizing(1)", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {


### PR DESCRIPTION
The PMIx library needs to be able to support multiple calls to
PMIx_Init/PMIx_Finalize as an app might cycle thru these calls prior to
entering a PMIx-enabled library. We could set a rule prohibiting calling
init if the library has been completely finalized (i.e., if the number
of calls to finalize equals the number of calls to init, thus driving
the refcount to zero and causing the library to fully close down), but
that seems overly restrictive.

Fixes #1558 

Signed-off-by: Ralph Castain <rhc@pmix.org>