### PR TITLE
Silence error log

### DIFF
--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -203,7 +203,6 @@ void pmix_ds12_lock_finalize(pmix_common_dstor_lock_ctx_t *lock_ctx)
         return;
     }
     if (0 != pthread_rwlock_destroy(pthread_lock->rwlock)) {
-        PMIX_ERROR_LOG(PMIX_ERROR);
         return;
     }
 


### PR DESCRIPTION
Don't output an error log if the server has already removed a lock

Signed-off-by: Ralph Castain <rhc@pmix.org>