### PR TITLE
Correct the gds/dstore configure logic

### DIFF
--- a/.github/actions/mlnx/entrypoint.sh
+++ b/.github/actions/mlnx/entrypoint.sh
@@ -398,10 +398,6 @@ if [ "$jenkins_test_check" = "yes" ]; then
         echo "----dstore/flock----" >> $run_tap
 
         gds_list="hash ds12,hash"
-        # check the existence of ds21 component
-        if [ "$has_gds_ds21" -gt 0 ]; then
-            gds_list="$gds_list ds21,hash"
-        fi
 
         for gds in $gds_list; do
             echo "Checking with $gds:" >> $run_tap

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -786,6 +786,15 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     PMIX_ZLIB_CONFIG
 
     ##################################
+    # Dstore Locking
+    ##################################
+
+    pmix_show_title "Dstore Locking"
+
+    PMIX_CHECK_DSTOR_LOCK
+
+
+    ##################################
     # MCA
     ##################################
 
@@ -823,13 +832,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     PMIX_MCA
 
-    ##################################
-    # Dstore Locking
-    ##################################
-
-    pmix_show_title "Dstore Locking"
-
-    PMIX_CHECK_DSTOR_LOCK
 
     ############################################################################
     # final compiler config

--- a/config/pmix_check_lock.m4
+++ b/config/pmix_check_lock.m4
@@ -5,7 +5,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2017      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -14,35 +14,61 @@ dnl $HEADER$
 dnl
 
 AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
+
+    PMIX_VAR_SCOPE_PUSH(orig_libs pmix_prefer_write_nonrecursive)
+
     orig_libs=$LIBS
     LIBS="-lpthread $LIBS"
 
-    _x_ac_pthread_lock_found="0"
-    _x_ac_fcntl_lock_found="0"
+    _x_ac_pthread_lock_found=0
+    _x_ac_fcntl_lock_found=0
+    pmix_prefer_write_nonrecursive=0
 
-    AC_CHECK_MEMBERS([struct flock.l_type],
-    [
-        AC_DEFINE([HAVE_FCNTL_FLOCK], [1],
-        [Define to 1 if you have the locking by fcntl.])
-        _x_ac_fcntl_lock_found="1"
-    ], [], [#include <fcntl.h>])
+    AC_CHECK_MEMBER([struct flock.l_type],
+                    [pmix_fcntl_flock_happy=yes
+                     _x_ac_fcntl_lock_found=1],
+                    [pmix_fcntl_flock_happy=no],
+                    [#include <fcntl.h>])
 
     if test "$DSTORE_PTHREAD_LOCK" = "1"; then
+
+        AC_MSG_CHECKING([pthread_process_shared])
+        AC_EGREP_CPP([yes],
+                     [#include <pthread.h>
+                      #ifdef PTHREAD_PROCESS_SHARED
+                        yes
+                      #endif
+                     ],
+                     [AC_MSG_RESULT(yes)
+                      pmix_pthread_process_shared=yes],
+                     [AC_MSG_RESULT(no)
+                      pmix_pthread_process_shared=no])
+
         AC_CHECK_FUNC([pthread_rwlockattr_setkind_np],
-            [AC_EGREP_HEADER([PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
-                    [pthread.h],[
-                        AC_DEFINE([HAVE_PTHREAD_SETKIND], [1],
-                            [Define to 1 if you have the `pthread_rwlockattr_setkind_np` function.])])])
+                      [pmix_pthread_rwlockattr_setkind_np=yes
+                       AC_EGREP_CPP([yes],
+                                    [#include <pthread.h>
+                                     #ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
+                                       yes
+                                     #endif
+                                    ],
+                                    [pmix_pthread_rwlock_prefer_writer_nonrecursive_np=yes],
+                                    [pmix_pthread_rwlock_prefer_writer_nonrecursive_np=no])],
+            [pmix_pthread_rwlockattr_setkind_np=no])
 
         AC_CHECK_FUNC([pthread_rwlockattr_setpshared],
-            [AC_EGREP_HEADER([PTHREAD_PROCESS_SHARED],
-                    [pthread.h],[
-                        AC_DEFINE([HAVE_PTHREAD_SHARED], [1],
-                            [Define to 1 if you have the `PTHREAD_PROCESS_SHARED` definition.
-                        ])
-                        _x_ac_pthread_lock_found="1"
-            ])
-        ])
+                      [pmix_pthread_rwlockattr_setpshared=yes
+                       AS_IF([test "$pmix_pthread_process_shared" = "yes"],
+                            [_x_ac_pthread_lock_found=1]]),
+                      [pmix_pthread_rwlockattr_setpshared=no])
+
+        AC_CHECK_FUNC([pthread_mutexattr_setpshared],
+                      [pmix_pthread_mutexattr_setpshared=yes],
+                      [pmix_pthread_mutexattr_setpshared=no])
+
+        AS_IF([test "$pmix_pthread_rwlockattr_setkind_np" = "yes" && test "$pmix_pthread_rwlock_prefer_writer_nonrecursive_np" = "yes"],
+              [pmix_prefer_write_nonrecursive=1],
+              [pmix_prefer_write_nonrecursive=0])
 
         if test "$_x_ac_pthread_lock_found" = "0"; then
             if test "$_x_ac_fcntl_lock_found" = "1"; then
@@ -57,6 +83,12 @@ AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
         fi
     fi
     LIBS="$orig_libs"
+
+    AC_DEFINE_UNQUOTED([PMIX_PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
+                       [$pmix_prefer_write_nonrecursive],
+                       [Whether or not we found the optional write_nonrecursive_np flag])
     AM_CONDITIONAL([HAVE_DSTORE_PTHREAD_LOCK], [test "$_x_ac_pthread_lock_found" = "1"])
     AM_CONDITIONAL([HAVE_DSTORE_FCNTL_LOCK], [test "$_x_ac_fcntl_lock_found" = "1"])
+
+    PMIX_VAR_SCOPE_POP
 ])

--- a/config/pmix_config_pthreads.m4
+++ b/config/pmix_config_pthreads.m4
@@ -10,7 +10,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
@@ -272,11 +272,6 @@ PMIX_INTL_POSIX_THREADS_SPECIAL_FLAGS
 
 # Try the normal linking methods (that's no fun)
 PMIX_INTL_POSIX_THREADS_LIBS
-
-#
-# check to see if we can create shared memory mutexes and conditions
-#
-AC_CHECK_FUNCS([pthread_mutexattr_setpshared pthread_condattr_setpshared])
 
 #
 # check to see if we can set error checking mutexes

--- a/src/mca/gds/ds12/configure.m4
+++ b/src/mca/gds/ds12/configure.m4
@@ -1,0 +1,34 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_gds_ds12_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_gds_ds12_CONFIG],[
+    AC_CONFIG_FILES([src/mca/gds/ds12/Makefile])
+
+    AS_IF([test "$pmix_fcntl_flock_happy" = "yes"],
+          [$1],
+          [AS_IF([test "$pmix_pthread_rwlockattr_setpshared" = "yes" && test "$pmix_pthread_process_shared" = "yes"],
+                 [$1], [$2])])
+
+])dnl

--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -132,29 +132,30 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             PMIX_ERROR_LOG(rc);
             goto error;
         }
-#ifdef HAVE_PTHREAD_SHARED
         if (0 != pthread_rwlockattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
             pthread_rwlockattr_destroy(&attr);
             rc = PMIX_ERR_INIT;
             PMIX_ERROR_LOG(rc);
             goto error;
         }
-#endif
-#ifdef HAVE_PTHREAD_SETKIND
+#if PMIX_PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
         if (0 != pthread_rwlockattr_setkind_np(&attr,
                                 PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)) {
             pthread_rwlockattr_destroy(&attr);
-            PMIX_ERROR_LOG(PMIX_ERR_INIT);
+            rc = PMIX_ERR_INIT;
+            PMIX_ERROR_LOG(rc);
             goto error;
         }
 #endif
         if (0 != pthread_rwlock_init(lock_ctx->rwlock, &attr)) {
             pthread_rwlockattr_destroy(&attr);
-            PMIX_ERROR_LOG(PMIX_ERR_INIT);
+            rc = PMIX_ERR_INIT;
+            PMIX_ERROR_LOG(rc);
             goto error;
         }
         if (0 != pthread_rwlockattr_destroy(&attr)) {
-            PMIX_ERROR_LOG(PMIX_ERR_INIT);
+            rc = PMIX_ERR_INIT;
+            PMIX_ERROR_LOG(rc);
             goto error;
         }
 

--- a/src/mca/gds/ds21/configure.m4
+++ b/src/mca/gds/ds21/configure.m4
@@ -1,0 +1,32 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_gds_ds21_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_gds_ds21_CONFIG],[
+    AC_CONFIG_FILES([src/mca/gds/ds21/Makefile])
+
+    AS_IF([test "$pmix_pthread_mutexattr_setpshared" = "yes" && test "$pmix_pthread_process_shared" = "yes"],
+          [$1], [$2])
+
+])dnl

--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -182,14 +182,12 @@ pmix_status_t pmix_gds_ds21_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             PMIX_ERROR_LOG(rc);
             goto error;
         }
-#ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
         if (0 != pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
             pthread_mutexattr_destroy(&attr);
             rc = PMIX_ERR_INIT;
             PMIX_ERROR_LOG(rc);
             goto error;
         }
-#endif
 
         segment_hdr_t *seg_hdr = (segment_hdr_t*)lock_item->seg_desc->seg_info.seg_base_addr;
         seg_hdr->num_locks = local_size;


### PR DESCRIPTION
After digging deeper into two reports of error log outputs from dstore
components that were built but could not run, it turned out that there
were a few compensating errors in the dstore configure code. First, the
use of AC_EGREP_HEADER was incorrect as it always failed - that function
looks for an exact match of the output from "egrep" and the provided
pattern. Instead, egrep was outputting the entire line that contained
the provided string, resulting in it always failing.

Someone clearly realized things were failing as the result of that test
was never being used. This led to error logs being emitted by ds21 when
attempting to run on systems that actually didn't support that specific
option.

What needed to happen was to correctly test for the existence of the
option and the corresponding function, and then to disable the build of
the ds21 component if either were not found. A similar test was required
for the ds21 component, albeit for a different function.

The revised logic breaks things apart a little more so it is clearer
what precisely is and isn't available, and adds configure.m4 code for
each of the dsN components. The ds12 component builds if either the
flock is available OR rwlock_setpshared and the PROCESS_SHARED attribute
are available. The ds21 component builds if mutexattr_setpshared and
PROCESS_SHARED are available.

This corrects the change originally committed in PR #1578.

Refs #1577
Refs https://www.mail-archive.com/devel@lists.open-mpi.org/msg21000.html.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit bf2a49eb78d53581764b73e7e3dbeb990b2b2c6b)