### PR TITLE
Fix bugs in gds/hash and preg/native

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -650,6 +650,12 @@ static pmix_status_t process_job_array(pmix_info_t *info,
                 return rc;
             }
             pmix_list_append(&trk->jobinfo, &kp2->super);
+            /* check for job size */
+            if (PMIX_CHECK_KEY(&iptr[j], PMIX_JOB_SIZE) &&
+                !(PMIX_HASH_JOB_SIZE & *flags)) {
+                trk->nptr->nprocs = iptr[j].value.data.uint32;
+                *flags |= PMIX_HASH_JOB_SIZE;
+            }
         }
     }
     return PMIX_SUCCESS;
@@ -940,6 +946,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
             kp2->value->type = PMIX_STRING;
             kp2->value->data.string = strdup(nodes[n]);
             rank = strtol(procs[m], NULL, 10);
+            pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                                "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                                pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                trk->ns, rank, kp2->key);
             if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kp2);
@@ -1023,6 +1033,8 @@ static pmix_status_t store_map(pmix_job_t *trk,
             return rc;
         }
         PMIX_RELEASE(kp2);  // maintain acctg
+        flags |= PMIX_HASH_JOB_SIZE;
+        trk->nptr->nprocs = totalprocs;
     }
 
     /* if they didn't provide a value for max procs, just
@@ -1040,6 +1052,7 @@ static pmix_status_t store_map(pmix_job_t *trk,
             return rc;
         }
         PMIX_RELEASE(kp2);  // maintain acctg
+        flags |= PMIX_HASH_MAX_PROCS;
     }
 
 
@@ -1066,9 +1079,9 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     pmix_apptrkr_t *apptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s:%d] gds:hash:cache_job_info for nspace %s",
+                        "[%s:%d] gds:hash:cache_job_info for nspace %s with %lu info",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        nptr->nspace);
+                        nptr->nspace, ninfo);
 
     trk = get_tracker(nptr->nspace, true);
     if (NULL == trk) {
@@ -1135,8 +1148,19 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 return PMIX_ERR_BAD_PARAM;
             }
             /* parse the regex to get the argv array of node names */
-            if (PMIX_SUCCESS != (rc = pmix_preg.parse_nodes(info[n].value.data.bo.bytes, &nodes))) {
-                PMIX_ERROR_LOG(rc);
+            if (PMIX_REGEX == info[n].value.type) {
+                if (PMIX_SUCCESS != (rc = pmix_preg.parse_nodes(info[n].value.data.bo.bytes, &nodes))) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+            } else if (PMIX_STRING == info[n].value.type) {
+                if (PMIX_SUCCESS != (rc = pmix_preg.parse_nodes(info[n].value.data.string, &nodes))) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+            } else {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                rc = PMIX_ERR_TYPE_MISMATCH;
                 goto release;
             }
             /* mark that we got the map */
@@ -1148,8 +1172,19 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 return PMIX_ERR_BAD_PARAM;
             }
             /* parse the regex to get the argv array containing proc ranks on each node */
-            if (PMIX_SUCCESS != (rc = pmix_preg.parse_procs(info[n].value.data.bo.bytes, &procs))) {
-                PMIX_ERROR_LOG(rc);
+            if (PMIX_REGEX == info[n].value.type) {
+                if (PMIX_SUCCESS != (rc = pmix_preg.parse_procs(info[n].value.data.bo.bytes, &procs))) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+            } else if (PMIX_STRING == info[n].value.type) {
+                if (PMIX_SUCCESS != (rc = pmix_preg.parse_procs(info[n].value.data.string, &procs))) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+            } else {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                rc = PMIX_ERR_TYPE_MISMATCH;
                 goto release;
             }
             /* mark that we got the map */
@@ -1202,7 +1237,7 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                     }
                 }
                 pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                    "[%s:%d] gds:hash:cache_job_info data for nspace %s rank %u: key %s",
+                                    "[%s:%d] gds:hash:cache_job_info proc data for [%s:%u]: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank,
                                     trk->ns, rank, kp2->key);
                 /* store it in the hash_table */
@@ -1479,7 +1514,12 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     PMIX_LIST_DESTRUCT(&results);
 
     /* get the proc-level data for each proc in the job */
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING PROC INFO FOR NSPACE %s NPROCS %u",
+                        ns->nspace, ns->nprocs);
     for (rank=0; rank < ns->nprocs; rank++) {
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "FETCHING PROC INFO FOR RANK %s", PMIX_RANK_PRINT(rank));
         val = NULL;
         rc = pmix_hash_fetch(ht, rank, NULL, &val);
         if (PMIX_SUCCESS != rc && PMIX_ERR_PROC_ENTRY_NOT_FOUND != rc) {

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -535,7 +535,7 @@ static pmix_status_t copy(char **dest, size_t *len, const char *input)
     }
 
     *dest = strdup(input);
-    *len = strlen(input);
+    *len = strlen(input) + 1;
     return PMIX_SUCCESS;
 }
 
@@ -607,7 +607,7 @@ static pmix_status_t pmix_regex_extract_nodes(char *regexp, char ***names)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_globals.debug_output,
+    PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
                          "pmix:extract:nodes: checking list: %s", regexp));
 
     do {
@@ -683,7 +683,7 @@ static pmix_status_t pmix_regex_extract_nodes(char *regexp, char ***names)
             } else {
                 suffix = NULL;
             }
-            PMIX_OUTPUT_VERBOSE((1, pmix_globals.debug_output,
+            PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
                                  "regex:extract:nodes: parsing range %s %s %s",
                                  base, base + i, suffix));
 
@@ -757,7 +757,7 @@ static pmix_status_t regex_parse_value_ranges(char *base, char *ranges,
 
     if (start < orig + len) {
 
-        PMIX_OUTPUT_VERBOSE((1, pmix_globals.debug_output,
+        PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
                              "regex:parse:ranges: parse range %s (2)", start));
 
         ret = regex_parse_value_range(base, start, num_digits, suffix, names);

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -155,6 +155,22 @@ int main(int argc, char **argv)
         exit(rc);
     }
     pmix_output(0, "CLIENT SERVER URI: %s", val->data.string);
+    PMIX_VALUE_RELEASE(val);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get LOCAL RANK failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "CLIENT LOCAL RANK: %u", val->data.uint32);
+    PMIX_VALUE_RELEASE(val);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get HOSTNAME failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "CLIENT HOSTNAME: %s", val->data.string);
     PMIX_VALUE_RELEASE(val);
 
     /* register a handler specifically for when models declare */


### PR DESCRIPTION
Ensure we capture the number of procs in the nspace tracker when
registering an nspace so we don't lose proc-specific data.

Check the proc/node map types for string vs regex

Ensure the "pmix" regex string retains the NULL terminator

Signed-off-by: Ralph Castain <rhc@pmix.org>