### PR TITLE
Add pnet/simptest component

### DIFF
--- a/src/mca/pnet/simptest/Makefile.am
+++ b/src/mca/pnet/simptest/Makefile.am
@@ -1,0 +1,55 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = pnet_simptest.h
+sources = \
+        pnet_simptest_component.c \
+        pnet_simptest.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pnet_simptest_DSO
+lib =
+lib_sources =
+component = mca_pnet_simptest.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_pnet_simptest.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_pnet_simptest_la_SOURCES = $(component_sources)
+mca_pnet_simptest_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_pnet_simptest_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_pnet_simptest_la_SOURCES = $(lib_sources)
+libmca_pnet_simptest_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/simptest/pnet_simptest.c
+++ b/src/mca/pnet/simptest/pnet_simptest.c
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include <pmix_common.h>
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/name_fns.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/show_help.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/pnet/pnet.h"
+#include "src/mca/pnet/base/base.h"
+#include "pnet_simptest.h"
+
+static pmix_status_t simptest_init(void);
+static void simptest_finalize(void);
+static pmix_status_t allocate(pmix_namespace_t *nptr,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist);
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
+                                         pmix_info_t info[],
+                                         size_t ninfo);
+
+pmix_pnet_module_t pmix_simptest_module = {
+    .name = "simptest",
+    .init = simptest_init,
+    .finalize = simptest_finalize,
+    .allocate = allocate,
+    .setup_local_network = setup_local_network
+};
+
+/* internal tracking structures */
+typedef struct {
+    pmix_list_item_t super;
+    char *name;
+    pmix_coord_t coord;
+} pnet_node_t;
+static void ndcon(pnet_node_t *p)
+{
+    p->name = NULL;
+    memset(&p->coord, 0, sizeof(pmix_coord_t));
+    p->coord.fabric = strdup("test");
+    p->coord.plane = strdup("simptest");
+    p->coord.view = PMIX_COORD_LOGICAL_VIEW;
+}
+static void nddes(pnet_node_t *p)
+{
+    if (NULL != p->name) {
+        free(p->name);
+    }
+    free(p->coord.fabric);
+    free(p->coord.plane);
+    if (NULL != p->coord.coord) {
+        free(p->coord.coord);
+    }
+}
+static PMIX_CLASS_INSTANCE(pnet_node_t,
+                           pmix_list_item_t,
+                           ndcon, nddes);
+
+/* internal variables */
+static pmix_list_t mynodes;
+static bool config_in_file = false;
+
+#define PMIX_SIMPTEST_MAX_LINE_LENGTH 1024
+
+static char *localgetline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[PMIX_SIMPTEST_MAX_LINE_LENGTH];
+    int i = 0;
+
+    ret = fgets(input, PMIX_SIMPTEST_MAX_LINE_LENGTH, fp);
+    if (NULL != ret) {
+        if ('\0' != input[0]) {
+            input[strlen(input)-1] = '\0';  /* remove newline */
+            /* strip any leading whitespace */
+             while (' ' == input[i] || '\t' == input[i]) {
+                i++;
+            }
+        }
+       buff = strdup(&input[i]);
+       return buff;
+    }
+
+    return NULL;
+}
+
+static char *getword(char *line)
+{
+    int i = 0;
+    char *ptr;
+
+    if (NULL == line || '\0' == line[0]) {
+        return NULL;
+    }
+    /* scan string for first non-whitespace character */
+    while (' ' != line[i] && '\t' != line[i] && '\0' != line[i]) {
+        ++i;
+    }
+    line[i] = '\0';
+    ptr = line;
+    ++i;
+    if ('\0' == line[i]) {
+        return ptr;
+    }
+    /* scan string for the next whitespace character */
+    while (' ' != line[i] && '\t' != line[i] && '\0' != line[i]) {
+        ++i;
+    }
+    line[i] = '\0';
+    return ptr;
+}
+
+static pmix_status_t simptest_init(void)
+{
+    FILE *fp;
+    char *line, *ptr;
+    pnet_node_t *nd;
+    int n, cache[1024];
+    size_t len, pos;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet: simptest init");
+
+    PMIX_CONSTRUCT(&mynodes, pmix_list_t);
+
+    /* if the configuration was given in a file, then build
+     * the topology so we can respond to requests */
+    if (NULL != mca_pnet_simptest_component.configfile) {
+        config_in_file = true;
+        fp = fopen(mca_pnet_simptest_component.configfile, "r");
+        if (NULL == fp) {
+            pmix_show_help("help-pnet-simptest.txt", "missing-file",
+                           true, mca_pnet_simptest_component.configfile);
+            return PMIX_ERR_FATAL;
+        }
+        while (NULL != (line = localgetline(fp))) {
+            /* if the line starts with a '#' or is blank, then
+             * it is a comment and we ignore it */
+            if (0 == strlen(line) || '#' == line[0]) {
+                free(line);
+                continue;
+            }
+            len = strlen(line);
+            /* we start with the node name */
+            ptr = getword(line);
+            if (NULL == ptr) {
+                /* that is an error */
+                free(line);
+                return PMIX_ERR_FATAL;
+            }
+            nd = PMIX_NEW(pnet_node_t);
+            nd->name = strdup(ptr);
+            pmix_list_append(&mynodes, &nd->super);
+            n = 0;
+            pos = strlen(ptr) + 2;  // move past the NULL terminator
+            if (len <= pos) {
+                /* we are done */
+                return PMIX_ERR_FATAL;
+            }
+            while (n < 1024 && NULL != (ptr = getword(&line[pos]))) {
+                cache[n] = strtol(ptr, NULL, 10);
+                pos += strlen(ptr) + 2;
+                if (len <= pos) {
+                    break;
+                }
+                ++n;
+            }
+            nd->coord.dims = n + 1;
+            nd->coord.coord = (int*)malloc(nd->coord.dims * sizeof(int));
+            memcpy(nd->coord.coord, cache, nd->coord.dims * sizeof(int));
+            free(line);
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static void simptest_finalize(void)
+{
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet: simptest finalize");
+
+    PMIX_LIST_DESTRUCT(&mynodes);
+}
+
+
+/* NOTE: if there is any binary data to be transferred, then
+ * this function MUST pack it for transport as the host will
+ * not know how to do so */
+static pmix_status_t allocate(pmix_namespace_t *nptr,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist)
+{
+    size_t m, n, q;
+    char **procs = NULL;
+    char **nodes = NULL;
+    pmix_status_t rc;
+    pmix_list_t mylist;
+    char **locals;
+    pnet_node_t *nd, *nd2;
+    pmix_kval_t *kv;
+    pmix_info_t *iptr, *ip2;
+    pmix_data_array_t *darray, *d2;
+    pmix_rank_t rank;
+    pmix_buffer_t buf;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:simptest:allocate for nspace %s",
+                        nptr->nspace);
+
+   /* if I am not the scheduler, then ignore this call - should never
+     * happen, but check to be safe */
+    if (!PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
+        return PMIX_SUCCESS;
+    }
+
+    if (NULL == info) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+
+    /* check directives to see if a crypto key and/or
+     * network resource allocations requested */
+    for (n=0; n < ninfo; n++) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet:simptest:allocate processing key %s",
+                            info[n].key);
+        if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_MAP)) {
+            rc = pmix_preg.parse_procs(info[n].value.data.string, &procs);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_MAP)) {
+            rc = pmix_preg.parse_nodes(info[n].value.data.string, &nodes);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+        }
+    }
+
+    if (NULL == procs || NULL == nodes) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet:simptest:allocate missing proc/node map for nspace %s",
+                            nptr->nspace);
+        /* not an error - continue to next active component */
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    PMIX_CONSTRUCT(&mylist, pmix_list_t);
+
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:simptest:allocate assigning endpoints for nspace %s",
+                        nptr->nspace);
+
+    /* cycle across the nodes and add the endpoints
+     * for each proc on the node - we assume the same
+     * list of static endpoints on each node */
+    for (n=0; NULL != nodes[n]; n++) {
+        /* split the procs for this node */
+        locals = pmix_argv_split(procs[n], ',');
+        if (NULL == locals) {
+            /* aren't any on this node */
+            continue;
+        }
+        /* find this node in our list */
+        nd = NULL;
+        PMIX_LIST_FOREACH(nd2, &mynodes, pnet_node_t) {
+            if (0 == strcmp(nd2->name, nodes[n])) {
+                nd = nd2;
+                break;
+            }
+        }
+        if (NULL == nd) {
+            /* should be impossible */
+            rc = PMIX_ERR_NOT_FOUND;
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+        kv = PMIX_NEW(pmix_kval_t);
+        if (NULL == kv) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        kv->key = strdup(PMIX_ALLOC_NETWORK_ENDPTS);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        kv->value->type = PMIX_DATA_ARRAY;
+        /* for each proc, we will assign an endpt
+         * for each NIC on the node */
+        q = pmix_argv_count(locals);
+        PMIX_DATA_ARRAY_CREATE(darray, q, PMIX_INFO);
+        kv->value->data.darray = darray;
+        iptr = (pmix_info_t*)darray->array;
+        for (m=0; NULL != locals[m]; m++) {
+            /* each proc has one endpoint corresponding to the
+             * node they upon which they are executing */
+            PMIX_LOAD_KEY(iptr[m].key, PMIX_PROC_DATA);
+            PMIX_DATA_ARRAY_CREATE(d2, 2, PMIX_INFO);
+            iptr[m].value.type = PMIX_DATA_ARRAY;
+            iptr[m].value.data.darray = d2;
+            ip2 = (pmix_info_t*)d2->array;
+            /* start with the rank */
+            rank = strtoul(locals[m], NULL, 10);
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:simptest:allocate assigning %d endpoints for rank %u",
+                                (int)q, rank);
+            PMIX_INFO_LOAD(&ip2[0], PMIX_RANK, &rank, PMIX_PROC_RANK);
+            /* the second element in this array is the coord */
+            PMIX_INFO_LOAD(&ip2[1], PMIX_NETWORK_COORDINATE, &nd->coord, PMIX_COORD);
+        }
+        pmix_argv_free(locals);
+        locals = NULL;
+        pmix_list_append(&mylist, &kv->super);
+    }
+
+    /* pack all our results into a buffer for xmission to the backend */
+    n = pmix_list_get_size(&mylist);
+    if (0 < n) {
+        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+        /* cycle across the list and pack the kvals */
+        while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&mylist))) {
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv, 1, PMIX_KVAL);
+            PMIX_RELEASE(kv);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DESTRUCT(&buf);
+                goto cleanup;
+            }
+        }
+        kv = PMIX_NEW(pmix_kval_t);
+        kv->key = strdup("pmix-pnet-simptest-blob");
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            PMIX_DESTRUCT(&buf);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        kv->value->type = PMIX_BYTE_OBJECT;
+        PMIX_UNLOAD_BUFFER(&buf, kv->value->data.bo.bytes, kv->value->data.bo.size);
+        PMIX_DESTRUCT(&buf);
+        pmix_list_append(ilist, &kv->super);
+    }
+
+  cleanup:
+    PMIX_LIST_DESTRUCT(&mylist);
+    if (NULL != nodes) {
+        pmix_argv_free(nodes);
+    }
+    if (NULL != procs) {
+        pmix_argv_free(procs);
+    }
+    if (NULL != locals) {
+        pmix_argv_free(locals);
+    }
+    return rc;
+}
+
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
+                                         pmix_info_t info[],
+                                         size_t ninfo)
+{
+    size_t n, nvals;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    pmix_info_t *iptr;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:simptest:setup_local_network with %lu info", (unsigned long)ninfo);
+
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            /* look for my key */
+            if (PMIX_CHECK_KEY(&info[n], "pmix-pnet-simptest-blob")) {
+                pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                    "pnet:simptest:setup_local_network found my blob");
+                /* this macro NULLs and zero's the incoming bo */
+                PMIX_LOAD_BUFFER(pmix_globals.mypeer, &bkt,
+                                 info[n].value.data.bo.bytes,
+                                 info[n].value.data.bo.size);
+                /* cycle thru the blob and extract the kvals */
+                kv = PMIX_NEW(pmix_kval_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                   &bkt, kv, &cnt, PMIX_KVAL);
+                while (PMIX_SUCCESS == rc) {
+                    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                        "recvd KEY %s %s", kv->key, PMIx_Data_type_string(kv->value->type));
+                    /* check for the network ID */
+                    if (PMIX_CHECK_KEY(kv, PMIX_ALLOC_NETWORK_ENDPTS)) {
+                        iptr = (pmix_info_t*)kv->value->data.darray->array;
+                        nvals = kv->value->data.darray->size;
+                        /* each element in this array is itself an array containing
+                         * the rank and the endpts and coords assigned to that rank. This is
+                         * precisely the data we need to cache for the job, so
+                         * just do so) */
+                        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                            "pnet:simptest:setup_local_network caching %d endpts", (int)nvals);
+                        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, iptr, nvals);
+                        if (PMIX_SUCCESS != rc) {
+                            PMIX_RELEASE(kv);
+                            return rc;
+                        }
+                    }
+                    PMIX_RELEASE(kv);
+                    kv = PMIX_NEW(pmix_kval_t);
+                    cnt = 1;
+                    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                       &bkt, kv, &cnt, PMIX_KVAL);
+                }
+                PMIX_RELEASE(kv);
+                /* restore the incoming data */
+                info[n].value.data.bo.bytes = bkt.base_ptr;
+                info[n].value.data.bo.size = bkt.bytes_used;
+                bkt.base_ptr = NULL;
+                bkt.bytes_used = 0;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/simptest/pnet_simptest.h
+++ b/src/mca/pnet/simptest/pnet_simptest.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PNET_simptest_H
+#define PMIX_PNET_simptest_H
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/mca/pnet/pnet.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pnet_base_component_t super;
+    char *configfile;
+} pmix_pnet_simptest_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pnet_simptest_component_t mca_pnet_simptest_component;
+extern pmix_pnet_module_t pmix_simptest_module;
+
+/* define a key for any blob we need to send in a launch msg */
+#define PMIX_PNET_SIMPTEST_BLOB  "pmix.pnet.simptest.blob"
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pnet/simptest/pnet_simptest_component.c
+++ b/src/mca/pnet/simptest/pnet_simptest_component.c
@@ -31,7 +31,7 @@
 
 #include "src/util/argv.h"
 #include "src/mca/pnet/pnet.h"
-#include "pnet_test.h"
+#include "pnet_simptest.h"
 
 static pmix_status_t component_open(void);
 static pmix_status_t component_close(void);
@@ -42,13 +42,13 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_test_component_t mca_pnet_test_component = {
+pmix_pnet_simptest_component_t mca_pnet_simptest_component = {
     .super = {
         .base = {
             PMIX_PNET_BASE_VERSION_1_0_0,
 
             /* Component name and version */
-            .pmix_mca_component_name = "test",
+            .pmix_mca_component_name = "simptest",
             PMIX_MCA_BASE_MAKE_VERSION(component,
                                        PMIX_MAJOR_VERSION,
                                        PMIX_MINOR_VERSION,
@@ -65,22 +65,19 @@ pmix_pnet_test_component_t mca_pnet_test_component = {
             PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
         }
     },
-    .planes = NULL,
-    .costmatrix = NULL
+    .configfile = NULL
 };
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_test_component.super.base;
+    pmix_mca_base_component_t *component = &mca_pnet_simptest_component.super.base;
 
-    (void)pmix_mca_base_component_var_register(component, "planes",
-                                               "Comma-delimited list describing each fabric plane in format\n"
-                                               "plane:<(d)ense or (s)parse>:#switches:#ports(defaults to 3+fit) - examples:\n"
-                                               "\tplane:d:3:4,plane:s:2,plane:3",
+    (void)pmix_mca_base_component_var_register(component, "config_file",
+                                               "Path of file containing network coordinate configuration",
                                                PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                PMIX_INFO_LVL_2,
                                                PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                               &mca_pnet_test_component.planes);
+                                               &mca_pnet_simptest_component.configfile);
     return PMIX_SUCCESS;
 }
 
@@ -89,7 +86,7 @@ static pmix_status_t component_open(void)
     int index;
     const pmix_mca_base_var_storage_t *value=NULL;
 
-    if (NULL == mca_pnet_test_component.planes ||
+    if (NULL == mca_pnet_simptest_component.configfile ||
         !PMIX_PROC_IS_SERVER(&pmix_globals.mypeer->proc_type)) {
         /* nothing we can do without a description
          * of the fabric topology */
@@ -103,7 +100,7 @@ static pmix_status_t component_open(void)
     }
     pmix_mca_base_var_get_value(index, &value, NULL, NULL);
     if (NULL != value && NULL != value->stringval && '\0' != value->stringval[0]) {
-        if (NULL != strcasestr(value->stringval, "test")) {
+        if (NULL != strcasestr(value->stringval, "simptest")) {
             return PMIX_SUCCESS;
         }
     }
@@ -114,7 +111,7 @@ static pmix_status_t component_open(void)
 static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
     *priority = 0;
-    *module = (pmix_mca_base_module_t *)&pmix_test_module;
+    *module = (pmix_mca_base_module_t *)&pmix_simptest_module;
     return PMIX_SUCCESS;
 }
 

--- a/test/simple/netconfig.txt
+++ b/test/simple/netconfig.txt
@@ -1,0 +1,10 @@
+# Example coordinate config file for the pnet/simptest component
+# Written as:
+# nodename  x  y  z  group
+
+test000  0  0  0  0
+test001  1  0  0  0
+test002  2  0  0  0
+test003  0  0  0  1
+test004  1  0  0  1
+test005  2  0  0  1

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -198,7 +198,6 @@ static pmix_event_t handler;
 static pmix_list_t children;
 static bool istimeouttest = false;
 static mylock_t globallock;
-static bool nettest = false;
 static bool model = false;
 static bool xversion = false;
 static char *hostnames[] = {
@@ -412,13 +411,8 @@ int main(int argc, char **argv)
             fprintf(stderr, "    -u       Enable legacy usock support\n");
             fprintf(stderr, "    -hwloc   Test hwloc support\n");
             fprintf(stderr, "    -hwloc-file FILE   Use file to import topology\n");
-            fprintf(stderr, "    -net-test  Test network endpt assignments\n");
             fprintf(stderr, "    -xversion  Cross-version test - simulate single node only\n");
             exit(0);
-        } else if (0 == strcmp("-net-test", argv[n]) ||
-                   0 == strcmp("--net-test", argv[n])) {
-            /* test network support */
-            nettest = true;
         }  else if (0 == strcmp("-model", argv[n]) ||
                    0 == strcmp("--model", argv[n])) {
             /* test network support */
@@ -430,11 +424,7 @@ int main(int argc, char **argv)
         }
     }
     if (NULL == executable) {
-        if (nettest) {
-            executable = strdup("./simpcoord");
-        } else {
-            executable = strdup("./simpclient");
-        }
+        executable = strdup("./simpclient");
     }
     /* check for executable existence and permissions */
     if (0 != access(executable, X_OK)) {
@@ -496,20 +486,11 @@ int main(int argc, char **argv)
 #endif
     }
 #endif
-    if (nettest) {
-        /* set a known network configuration for the pnet/test component */
-        putenv("PMIX_MCA_pnet_test_planes=plane:d:3;plane:s:2;plane:d:5:2");
-        putenv("PMIX_MCA_pnet=test");
-    }
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, ninfo))) {
         fprintf(stderr, "Init failed with error %s\n", PMIx_Error_string(rc));
         return rc;
     }
     PMIX_INFO_FREE(info, ninfo);
-    if (nettest) {
-        unsetenv("PMIX_MCA_pnet");
-        unsetenv("PMIX_MCA_pnet_test_planes");
-    }
 
     /* register the default errhandler */
     DEBUG_CONSTRUCT_LOCK(&mylock);


### PR DESCRIPTION
Add a simple pnet component that reads a config file to define
coordinates for each node. Update the simpcoord test to not error out if
endpts are not found as they may not be assigned

Signed-off-by: Ralph Castain <rhc@pmix.org>