### PR TITLE
Remove the "optimized" platform file

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -9,7 +9,7 @@ Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 Copyright (c) 2004-2005 The Regents of the University of California.
                         All rights reserved.
 Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
-Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -27,7 +27,7 @@ checkout).
 Debugging vs. Optimized Builds
 ==============================
 
-If you are building PMIx from a Git checkout, the default build
+**If you are building PMIx from a Git checkout**, the default build
 includes a lot of debugging features.  This happens automatically when
 when configure detects the hidden ".git" Git meta directory (that is
 present in all Git checkouts) in your source tree, and therefore
@@ -38,6 +38,11 @@ By definition, debugging builds will perform [much] slower than
 optimized builds of PMIx.  You should *NOT* conduct timing tests
 or try to run production performance numbers with debugging builds.
 
+**REMEMBER** that you need to add appropriate -O directives
+to your CFLAGS so your compiler will optimize the code! Otherwise,
+while we will have disabled various debug code paths, the resulting
+binary will not have been optimized.
+
 NOTE: this version of PMIx requires the Libevent package to build
 and operate. Any version of Libevent greater than or equal to
 2.0.21 is acceptable. It optionally supports the HWLOC package
@@ -47,17 +52,18 @@ processes. Any version of HWLOC greater than 1.10 is supported,
 although versions in the 2.x series are recommended.
 
 If you wish to build an optimized version of PMIx from a
-developer's checkout, you have three main options:
+developer's checkout, you have a couple of options:
 
-1. Use the "--with-platform=optimized" switch to configure.  This is
-   the preferred (and probably easiest) method.  For example:
+1. Manually specify configure options to disable the debugging
+   option.  You'll need to carefully examine the output of
+   "./configure --help" to see which options to disable.
+   They are all listed, but some are less obvious than others (they
+   are not listed here because it is a changing set of flags; by
+   Murphy's Law, listing them here will pretty much guarantee that
+   this file will get out of date):
 
-     shell$ git clone https://github.com/pmix/pmix.git pmix
-     shell$ cd pmix
      shell$ ./autogen.pl
-     shell$ mkdir build
-     shell$ cd build
-     shell$ ./configure --with-platform=optimized ...
+     shell$ ./configure --disable-debug ...
      [...lots of output...]
      shell$ make all install
 
@@ -65,7 +71,7 @@ developer's checkout, you have three main options:
    directory than the source tree -- one where the .git subdirectory
    is not present.  For example:
 
-     shell$ git clone https://github.com/pmix/pmix.git pmix
+     shell$ git clone https://github.com/openpmix/openpmix.git pmix
      shell$ cd pmix
      shell$ ./autogen.pl
      shell$ mkdir build
@@ -74,21 +80,7 @@ developer's checkout, you have three main options:
      [...lots of output...]
      shell$ make all install
 
-3. Manually specify configure options to disable all the debugging
-   options (note that this is exactly what "--with-platform=optimized"
-   does behind the scenes).  You'll need to carefully examine the
-   output of "./configure --help" to see which options to disable.
-   They are all listed, but some are less obvious than others (they
-   are not listed here because it is a changing set of flags; by
-   Murphy's Law, listing them here will pretty much guarantee that
-   this file will get out of date):
-
-     shell$ ./configure --disable-debug ...
-     [...lots of output...]
-     shell$ make all install
-
-
-Note that in all cases you must point configure at the libevent
+Note that in both cases you must point configure at the libevent
 installation using the --with-libevent=<dir> option if it is in
 a non-standard location. Similarly, non-standard locations for
 the HWLOC package must be specified using the --with-hwloc=<dir>
@@ -222,17 +214,17 @@ NOTE: On MacOS/X, the default "libtool" program is different than the
    m4, Autoconf and Automake build and install very quickly; Libtool will
    take a minute or two.
 
-5. You can now run PMIx’s top-level "autogen.sh" script.  This script
+5. You can now run PMIx’s top-level "autogen.pl" script.  This script
    will invoke the GNU Autoconf, Automake, and Libtool commands in the
    proper order and setup to run PMIx's top-level "configure" script.
 
-   5a. You generally need to run autogen.sh only when the top-level
+   5a. You generally need to run autogen.pl only when the top-level
        file "configure.ac" changes, or any files in the config/ or
        <project>/config/ directories change (these directories are
        where a lot of "include" files for PMI’xs configure script
        live).
 
-   5b. You do *NOT* need to re-run autogen.sh if you modify a
+   5b. You do *NOT* need to re-run autogen.pl if you modify a
        Makefile.am.
 
 Use of Flex

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2013-2016 Los Alamos National Security, Inc.  All rights
 #                         reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,13 +25,12 @@
 EXTRA_DIST = \
 	make_dist_tarball \
 	buildrpm.sh \
-	platform/optimized \
-        pmix_jenkins.sh \
-        pmix-release.sh \
-        pmix.spec \
-        update-my-copyright.pl \
-        whitespace-purge.sh \
-        make_manpage.pl
+    pmix_jenkins.sh \
+    pmix-release.sh \
+    pmix.spec \
+    update-my-copyright.pl \
+    whitespace-purge.sh \
+    make_manpage.pl
 
 include perf_tools/Makefile.include
 

--- a/contrib/platform/optimized
+++ b/contrib/platform/optimized
@@ -1,3 +1,0 @@
-enable_mem_debug=no
-enable_mem_profile=no
-enable_debug=no


### PR DESCRIPTION
It wasn't actually optimizing the code other than to set the
--disable-debug flag. If you truly want to optimize, you also need to
set the appropriate -O compiler flags, so this was just misleading
people.

Signed-off-by: Ralph Castain <rhc@pmix.org>