### PR TITLE
Complete debugging of the collective tracker

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -345,6 +345,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PROC_STATE_STATUS              "pmix.proc.state"       // (pmix_proc_state_t) process state
 #define PMIX_NOTIFY_LAUNCH                  "pmix.note.lnch"        // (bool) notify the requestor upon launch of the child job and return
                                                                     //        its namespace in the event
+#define PMIX_GET_REFRESH_CACHE              "pmix.get.refresh"      // (bool) when retrieving data for a remote process, refresh the existing
+                                                                    //        local data cache for the process in case new values have been
+                                                                    //        put and committed by it since the last refresh
 
 
 /* attributes used by host server to pass data to the server convenience library - the

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -628,8 +628,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cb);
 
     /* set the proc object identifier */
-    pmix_strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
-    proc.rank = cb->pname.rank;
+    PMIX_LOAD_PROCID(&proc, cb->pname.nspace, cb->pname.rank);
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix: getnbfn value for proc %s key %s",

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -188,7 +188,6 @@ static void pcon(pmix_peer_t *p)
     PMIX_CONSTRUCT(&p->send_queue, pmix_list_t);
     p->send_msg = NULL;
     p->recv_msg = NULL;
-    p->commit_cnt = 0;
     PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
@@ -254,7 +254,6 @@ typedef struct pmix_peer_t {
     pmix_list_t send_queue;         /**< list of messages to send */
     pmix_ptl_send_t *send_msg;      /**< current send in progress */
     pmix_ptl_recv_t *recv_msg;      /**< current recv in progress */
-    int commit_cnt;
     pmix_epilog_t epilog;           /**< things to be performed upon
                                          termination of this peer */
 } pmix_peer_t;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -665,6 +665,12 @@ static void _register_nspace(int sd, short args, void *cbdata)
              * we handle this case here */
             if (PMIX_RANK_WILDCARD == trk->pcs[i].rank) {
             	trk->nlocal = nptr->nlocalprocs;
+                /* the total number of procs in this nspace was provided
+                 * in the data blob delivered to register_nspace, so check
+                 * to see if all the procs are local */
+                if (nptr->nprocs != nptr->nlocalprocs) {
+                    trk->local = false;
+                }
                 continue;
             }
         }
@@ -2432,7 +2438,6 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     bool found;
 
     PMIX_ACQUIRE_OBJECT(scd);
-
     if (NULL == tracker) {
         /* give them a release if they want it - this should
          * never happen, but protect against the possibility */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -245,9 +245,6 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
     /* mark us as having successfully received a blob from this proc */
     info->modex_recvd = true;
 
-    /* update the commit counter */
-    peer->commit_cnt++;
-
     /* see if anyone remote is waiting on this data - could be more than one */
     PMIX_LIST_FOREACH_SAFE(dcd, dcdnext, &pmix_server_globals.remote_pnd, pmix_dmdx_remote_t) {
         if (0 != strncmp(dcd->cd->proc.nspace, nptr->nspace, PMIX_MAX_NSLEN)) {
@@ -522,6 +519,12 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
          * clients have been "registered" */
         if (PMIX_RANK_WILDCARD == procs[i].rank) {
             trk->nlocal += nptr->nlocalprocs;
+            /* the total number of procs in this nspace was provided
+             * in the data blob delivered to register_nspace, so check
+             * to see if all the procs are local */
+            if (nptr->nprocs != nptr->nlocalprocs) {
+                trk->local = false;
+            }
             continue;
         }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -113,6 +113,7 @@ typedef struct {
                                     // all local ranks that are interested in this namespace-rank
     pmix_info_t *info;              // array of info structs for this request
     size_t ninfo;                   // number of info structs
+    pmix_scope_t scope;
 } pmix_dmdx_local_t;
 PMIX_CLASS_DECLARATION(pmix_dmdx_local_t);
 


### PR DESCRIPTION
There remain some issues about detecting local vs non-local procs when
setting up the tracker. I've resolved the ones surfaced by multi-node
testing using PRRTE with both simple PMIx clients and the "double-get"
test case.

For the latter, I cannot find any solution that is totally transparent
to the user. The local daemon has no way of knowing if the remote daemon
has received more info or updated info. So we cannot know if we should
go ask for the info or not - we have a blob and that is all we can
return.

Only solution I can find is to define a new attribute
(PMIX_GET_REFRESH_CACHE) that tells the local server to go get
potentially updated remote info. Note that this in itself doesn't mean
that we will wait for that info to appear - that remains for another
day.

Signed-off-by: Ralph Castain <rhc@pmix.org>