### PR TITLE
Complete debugging of the collective tracker

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -665,6 +665,12 @@ static void _register_nspace(int sd, short args, void *cbdata)
              * we handle this case here */
             if (PMIX_RANK_WILDCARD == trk->pcs[i].rank) {
             	trk->nlocal = nptr->nlocalprocs;
+                /* the total number of procs in this nspace was provided
+                 * in the data blob delivered to register_nspace, so check
+                 * to see if all the procs are local */
+                if (nptr->nprocs != nptr->nlocalprocs) {
+                    trk->local = false;
+                }
                 continue;
             }
         }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -681,7 +681,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
      * a remote peer, or due to data from a local client
      * having been committed */
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-    pmix_strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(proc.nspace, nptr->nspace);
 
     if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->peer->info->pname.nspace)) {
         diffnspace = true;
@@ -715,7 +715,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                     break;
                 }
             }
-            if (PMIX_LOCAL != scope)  {
+            if (NULL == peer)  {
                 /* this must be a remote rank */
                 if (NULL != local) {
                     *local = false;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -522,6 +522,12 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
          * clients have been "registered" */
         if (PMIX_RANK_WILDCARD == procs[i].rank) {
             trk->nlocal += nptr->nlocalprocs;
+            /* the total number of procs in this nspace was provided
+             * in the data blob delivered to register_nspace, so check
+             * to see if all the procs are local */
+            if (nptr->nprocs != nptr->nlocalprocs) {
+                trk->local = false;
+            }
             continue;
         }
 


### PR DESCRIPTION
There remain some issues about detecting local vs non-local procs when
setting up the tracker. I've resolved the ones surfaced by multi-node
testing using PRRTE with both simple PMIx clients and the "double-get"
test case. This is a subset of those changes as the broader ones failed
to pass CI - hopefully, this minimum subset does and then I'll try again
with the remainder.

For this subset, we use the fact that we are being told both the number
of local procs and the total number of procs in a namespace upon call to
"register_nspace". If we are in a collective and have not yet received
the "register_nspace" call, then we defer processing of the collective
until we do.

Signed-off-by: Ralph Castain <rhc@pmix.org>