### PR TITLE
Allow user to request cache refresh

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -345,6 +345,14 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PROC_STATE_STATUS              "pmix.proc.state"       // (pmix_proc_state_t) process state
 #define PMIX_NOTIFY_LAUNCH                  "pmix.note.lnch"        // (bool) notify the requestor upon launch of the child job and return
                                                                     //        its namespace in the event
+#define PMIX_GET_REFRESH_CACHE              "pmix.get.refresh"      // (bool) when retrieving data for a remote process, refresh the existing
+                                                                    //        local data cache for the process in case new values have been
+                                                                    //        put and committed by it since the last refresh
+#define PMIX_GET_WAIT_FOR_KEY               "pmix.get.wkey"         // (char*) do not respond to the PMIx_Get request until the specified key
+                                                                    //         is available or, if PMIX_TIMEOUT is given, the timeout period
+                                                                    //         expires. If used multiple times in a PMIx_Get request, the
+                                                                    //         response will be delayed until ALL keys are available. This
+                                                                    //         behavior can be altered with the PMIX_WAIT attribute.
 
 
 /* attributes used by host server to pass data to the server convenience library - the

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -143,7 +143,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
         for (n=0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(info, PMIX_NODE_INFO) ||
                 PMIX_CHECK_KEY(info, PMIX_APP_INFO) ||
-                PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
+                PMIX_CHECK_KEY(info, PMIX_SESSION_INFO) ||
+                PMIX_CHECK_KEY(info, PMIX_GET_REFRESH_CACHE)) {
                 goto doget;
             }
         }
@@ -660,6 +661,9 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                        PMIX_CHECK_KEY(&cb->info[n], PMIX_APP_INFO) ||
                        PMIX_CHECK_KEY(&cb->info[n], PMIX_SESSION_INFO)) {
                 internal_only = true;
+            } else if (PMIX_CHECK_KEY(&cb->info[n], PMIX_GET_REFRESH_CACHE)) {
+                /* immediately query the server */
+                goto request;
             }
         }
     }


### PR DESCRIPTION
Define a new PMIX_GET_REFRESH_CACHE attribute by which a user can direct
PMIx to perform a dmodex operation, thereby obtaining a new copy of the
remote data. Anything that has been added or changed will be included.
Note that there is no current mechanism for _deleting_ information once
a process has put/commit it.

Signed-off-by: Ralph Castain <rhc@pmix.org>