### PR TITLE
Fix eviction time for cached events

### DIFF
--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,7 +49,7 @@ static void local_eviction_callback(int fd, short flags, void *arg)
 
 pmix_status_t pmix_hotel_init(pmix_hotel_t *h, int num_rooms,
                               pmix_event_base_t *evbase,
-                              uint32_t eviction_timeout,
+                              uint64_t eviction_timeout,
                               pmix_hotel_eviction_callback_fn_t evict_callback_fn)
 {
     int i;

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -161,7 +162,7 @@ PMIX_CLASS_DECLARATION(pmix_hotel_t);
  */
 PMIX_EXPORT pmix_status_t pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
                                           pmix_event_base_t *evbase,
-                                          uint32_t eviction_timeout,
+                                          uint64_t eviction_timeout,
                                           pmix_hotel_eviction_callback_fn_t evict_callback_fn);
 
 /**

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -15,6 +15,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -492,7 +493,7 @@ typedef struct {
     pmix_list_t cached_events;          // events waiting in the window prior to processing
     pmix_pointer_array_t iof_requests;  // array of pmix_iof_req_t IOF requests
     int max_events;                     // size of the notifications hotel
-    int event_eviction_time;            // max time to cache notifications
+    uint64_t event_eviction_time;       // max time to cache notifications
     pmix_hotel_t notifications;         // hotel of pending notifications
     /* processes also need a place where they can store
      * their own internal data - e.g., data provided by

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -256,6 +257,8 @@ pmix_status_t pmix_register_params(void)
                                        PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                        PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                        &pmix_globals.event_eviction_time);
+    // pmix_hotel_init expects this value to be in usec not sec
+    pmix_globals.event_eviction_time *= 1000000;
 
     /* max number of IOF messages to cache */
     pmix_server_globals.max_iof_cache = 1024 * 1024;

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -254,7 +254,7 @@ pmix_status_t pmix_register_params(void)
     pmix_globals.event_eviction_time = 120;
     (void) pmix_mca_base_var_register ("pmix", "pmix", "event", "eviction_time",
                                        "Maximum number of seconds to cache an event",
-                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG, NULL, 0, 0,
                                        PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                        &pmix_globals.event_eviction_time);
     // pmix_hotel_init expects this value to be in usec not sec


### PR DESCRIPTION
 * User facing paramter is in sec, but `pmix_hotel_init` is in usec.
