### PR TITLE
Properly support dmodex requests

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2752,6 +2752,17 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
                     }
                 }
     		}
+            /* if the client is earlier than v3.1.5, we also need to store the
+             * array using the hostname as key */
+            if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+                kv2.key = ihost->value.data.string;
+                kv2.value = kv->value;
+                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &kv2, 1, PMIX_KVAL);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    continue;
+                }
+            }
         } else if (PMIX_CHECK_KEY(kv, PMIX_APP_INFO_ARRAY) ||
                    PMIX_CHECK_KEY(kv, PMIX_JOB_INFO_ARRAY) ||
                    PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY)) {

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2719,47 +2719,36 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
 
     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
     	if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY)) {
-    		/* earlier PMIx versions don't know how to handle
-    		 * the info arrays - what they need is a key-value
-    		 * pair where the key is the name of the node and
-    		 * the value is the local peers. So if the peer
-    		 * is earlier than 3.1.5, construct the necessary
-    		 * translation. Otherwise, ignore it as the hash
-             * component will handle it for them */
-    		if (PMIX_PEER_IS_EARLIER(ds_ctx->clients_peer, 3, 1, 5)) {
-	            pmix_info_t *info;
-	            size_t size, i;
-                /* if it is our local node, then we are going to pass
-                 * all info */
-	            info = kv->value->data.darray->array;
-	            size = kv->value->data.darray->size;
-                ihost = NULL;
-	            for (i = 0; i < size; i++) {
-                    if (PMIX_CHECK_KEY(&info[i], PMIX_HOSTNAME)) {
-                        ihost = &info[i];
-                        break;
+    		/* the dstore currently does not understand info arrays,
+             * which causes problems when users query for node/app
+             * info. We cannot fully resolve the problem, but we
+             * can mitigate it by at least storing the info for
+             * the local node and this proc's app number */
+            pmix_info_t *info;
+            size_t size, i;
+            /* if it is our local node, then we are going to pass
+             * all info */
+            info = kv->value->data.darray->array;
+            size = kv->value->data.darray->size;
+            ihost = NULL;
+            for (i = 0; i < size; i++) {
+                if (PMIX_CHECK_KEY(&info[i], PMIX_HOSTNAME)) {
+                    ihost = &info[i];
+                    break;
+                }
+            }
+            if (0 == strcmp(ihost->value.data.string, pmix_globals.hostname)) {
+                /* if this host is us, then store each value as its own key */
+                for (i = 0; i < size; i++) {
+                    if (&info[i] == ihost) {
+                        continue;
                     }
-	            }
-                if (NULL != ihost) {
-                    PMIX_CONSTRUCT(&kv2, pmix_kval_t);
-                    kv2.key = ihost->value.data.string;
-                    kv2.value = kv->value;
+                    kv2.key = info[i].key;
+                    kv2.value = &info[i].value;
                     PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &kv2, 1, PMIX_KVAL);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
-                        goto exit;
-                    }
-                    /* if this host is us, then store each value as its own key */
-                    if (0 == strcmp(kv2.key, pmix_globals.hostname)) {
-                        for (i = 0; i < size; i++) {
-                            kv2.key = info[i].key;
-                            kv2.value = &info[i].value;
-                            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &kv2, 1, PMIX_KVAL);
-                            if (PMIX_SUCCESS != rc) {
-                                PMIX_ERROR_LOG(rc);
-                                goto exit;
-                            }
-                        }
+                        continue;
                     }
                 }
     		}
@@ -2809,8 +2798,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_register_job_info(pmix_common_dstore
         ns_map_data_t *ns_map;
 
         _client_compat_save(ds_ctx, peer);
-        pmix_strncpy(proc.nspace, ns->nspace, PMIX_MAX_NSLEN);
-        proc.rank = PMIX_RANK_WILDCARD;
+        PMIX_LOAD_PROCID(&proc, ns->nspace, PMIX_RANK_WILDCARD);
         if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, proc.nspace))) {
             rc = PMIX_ERROR;
             PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -835,6 +835,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         kp2->value->type = PMIX_UINT32;
         kp2->value->data.uint32 = pmix_argv_count(nodes);
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map adding key %s to job info",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            kp2->key);
         if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
@@ -848,11 +852,6 @@ static pmix_status_t store_map(pmix_job_t *trk,
         nd = NULL;
         PMIX_LIST_FOREACH(ndptr, &trk->nodeinfo, pmix_nodeinfo_t) {
             if (NULL != ndptr->hostname && 0 == strcmp(ndptr->hostname, nodes[n])) {
-                /* we assume that the data is updating the current
-                 * values */
-                if (NULL == ndptr->hostname) {
-                    ndptr->hostname = strdup(nodes[n]);
-                }
                 nd = ndptr;
                 break;
             }
@@ -860,6 +859,7 @@ static pmix_status_t store_map(pmix_job_t *trk,
         if (NULL == nd) {
             nd = PMIX_NEW(pmix_nodeinfo_t);
             nd->hostname = strdup(nodes[n]);
+            nd->nodeid = n;
             pmix_list_append(&trk->nodeinfo, &nd->super);
         }
         /* store the proc list as-is */
@@ -875,6 +875,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         }
         kp2->value->type = PMIX_STRING;
         kp2->value->data.string = strdup(ppn[n]);
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map adding key %s to node %s info",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            kp2->key, nodes[n]);
         /* ensure this item only appears once on the list */
         PMIX_LIST_FOREACH(kp1, &nd->info, pmix_kval_t) {
             if (PMIX_CHECK_KEY(kp1, kp2->key)) {
@@ -899,6 +903,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         }
         kp2->value->type = PMIX_PROC_RANK;
         kp2->value->data.rank = rank;
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map adding key %s to node %s info",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            kp2->key, nodes[n]);
         /* ensure this item only appears once on the list */
         PMIX_LIST_FOREACH(kp1, &nd->info, pmix_kval_t) {
             if (PMIX_CHECK_KEY(kp1, kp2->key)) {
@@ -926,6 +934,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         }
         kp2->value->type = PMIX_UINT32;
         kp2->value->data.uint32 = pmix_argv_count(procs);
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map adding key %s to node %s info",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            kp2->key, nodes[n]);
         /* ensure this item only appears once on the list */
         PMIX_LIST_FOREACH(kp1, &nd->info, pmix_kval_t) {
             if (PMIX_CHECK_KEY(kp1, kp2->key)) {
@@ -963,6 +975,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
                 kp2->key = strdup(PMIX_NODEID);
                 kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
                 kp2->value->type = PMIX_UINT32;
+                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                                    pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                    trk->ns, rank, kp2->key);
                 kp2->value->data.uint32 = n;
                 if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
                     PMIX_ERROR_LOG(rc);
@@ -977,6 +993,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
                 kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
                 kp2->value->type = PMIX_UINT16;
                 kp2->value->data.uint16 = m;
+                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                                    pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                    trk->ns, rank, kp2->key);
                 if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
@@ -991,6 +1011,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
                 kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
                 kp2->value->type = PMIX_UINT16;
                 kp2->value->data.uint16 = m;
+                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                                    pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                    trk->ns, rank, kp2->key);
                 if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
@@ -1011,6 +1035,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
     kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
     kp2->value->type = PMIX_STRING;
     kp2->value->data.string = pmix_argv_join(nodes, ',');
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                        trk->ns, rank, kp2->key);
     if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(kp2);
@@ -1027,6 +1055,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         kp2->value->type = PMIX_UINT32;
         kp2->value->data.uint32 = totalprocs;
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            trk->ns, rank, kp2->key);
         if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
@@ -1046,6 +1078,10 @@ static pmix_status_t store_map(pmix_job_t *trk,
         kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         kp2->value->type = PMIX_UINT32;
         kp2->value->data.uint32 = totalprocs;
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            trk->ns, rank, kp2->key);
         if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -135,7 +135,9 @@ void pmix_rte_finalize(void)
     }
     PMIX_DESTRUCT(&pmix_globals.iof_requests);
     PMIX_LIST_DESTRUCT(&pmix_globals.stdin_targets);
-    free(pmix_globals.hostname);
+    if (NULL != pmix_globals.hostname) {
+        free(pmix_globals.hostname);
+    }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
 
     /* now safe to release the event base */

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -191,6 +191,13 @@ int pmix_rte_init(uint32_t type,
                           pmix_globals.evbase, pmix_globals.event_eviction_time,
                           _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
+    /* need to hold off checking the hotel init return code
+     * until after we construct all the globals so they can
+     * correct finalize */
+    if (PMIX_SUCCESS != ret) {
+        error = "notification hotel init";
+        goto return_error;
+    }
     /* if we were given a hostname in our environment, use it */
     if (NULL != (evar = getenv("PMIX_HOSTNAME"))) {
         pmix_globals.hostname = strdup(evar);
@@ -199,10 +206,6 @@ int pmix_rte_init(uint32_t type,
         pmix_globals.hostname = strdup(hostname);
     }
 
-    if (PMIX_SUCCESS != ret) {
-        error = "notification hotel init";
-        goto return_error;
-    }
     /* and setup the iof request tracking list */
     PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1535,7 +1535,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
     }
 
     /* They are asking for job level data for this process */
-    if (cd->proc.rank == PMIX_RANK_WILDCARD) {
+    if (PMIX_RANK_WILDCARD == cd->proc.rank) {
         /* fetch the job-level info for this nspace */
         /* this is going to a remote peer, so inform the gds
          * that we need an actual copy of the data */
@@ -3441,7 +3441,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    pmix_output_verbose(2, pmix_server_globals.base_output,
+  //  pmix_output_verbose(2, pmix_server_globals.base_output,
+    pmix_output(0,
                         "recvd pmix cmd %s from %s:%u",
                         pmix_command_string(cmd), peer->info->pname.nspace, peer->info->pname.rank);
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -84,16 +84,19 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_reply_caddy_t,
 static void dmdx_cbfunc(pmix_status_t status, const char *data,
                         size_t ndata, void *cbdata,
                         pmix_release_cbfunc_t relfn, void *relcbdata);
-static pmix_status_t _satisfy_request(pmix_namespace_t *ns, pmix_rank_t rank,
-                                      pmix_server_caddy_t *cd, bool refresh_cache,
-                                      pmix_modex_cbfunc_t cbfunc, void *cbdata, bool *scope);
+static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
+                                      pmix_server_caddy_t *cd,
+                                      bool diffnspace, pmix_scope_t scope,
+                                      pmix_modex_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_modex_cbfunc_t cbfunc,
                                           void *cbdata,
                                           pmix_dmdx_local_t **lcd,
                                           pmix_dmdx_request_t **rq);
-
+static pmix_status_t get_job_data(char *nspace,
+                                  pmix_server_caddy_t *cd,
+                                  pmix_buffer_t *pbkt);
 static void get_timeout(int sd, short args, void *cbdata);
 
 
@@ -108,7 +111,52 @@ static void relfn(void *cbdata)
     }
 }
 
+static pmix_status_t defer_response(char *nspace, pmix_rank_t rank,
+                                    pmix_server_caddy_t *cd,
+                                    bool localonly,
+                                    pmix_modex_cbfunc_t cbfunc,
+                                    void *cbdata,
+                                    struct timeval *tv,
+                                    pmix_dmdx_local_t **locald)
+{
+    pmix_status_t rc;
+    pmix_dmdx_request_t *req;
+    pmix_dmdx_local_t *lcd;
 
+    *locald = NULL;
+
+    if (localonly) {
+        /* the client asked that we not wait, so return now */
+        pmix_output_verbose(2, pmix_server_globals.get_output,
+                            "%s:%d CLIENT REQUESTED IMMEDIATE",
+                            pmix_globals.myid.nspace,
+                            pmix_globals.myid.rank);
+        return PMIX_ERR_NOT_FOUND;
+    }
+    /* we cannot do anything further, so just track this request
+     * for now */
+    rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo,
+                              cbfunc, cbdata, &lcd, &req);
+    if (PMIX_ERR_NOMEM == rc || NULL == lcd) {
+        return rc;
+    }
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "%s:%d TRACKER CREATED - WAITING",
+                        pmix_globals.myid.nspace,
+                        pmix_globals.myid.rank);
+    /* if they specified a timeout, set it up now */
+    if (0 < tv->tv_sec) {
+        pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
+                               get_timeout, req);
+        pmix_event_evtimer_add(&req->ev, tv);
+        req->event_active = true;
+    }
+    /* the peer object has been added to the new lcd tracker,
+     * so return success here */
+    *locald = lcd;
+    return rc;
+
+}
 pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                               pmix_modex_cbfunc_t cbfunc,
                               void *cbdata)
@@ -117,29 +165,31 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     int32_t cnt;
     pmix_status_t rc;
     pmix_rank_t rank;
-    char *cptr;
+    char *cptr, *key=NULL;
     char nspace[PMIX_MAX_NSLEN+1];
     pmix_namespace_t *ns, *nptr;
     pmix_dmdx_local_t *lcd;
-    pmix_dmdx_request_t *req;
-    bool local;
+    bool local = false;
     bool localonly = false;
     bool diffnspace = false;
     bool refresh_cache = false;
+    bool scope_given = false;
     struct timeval tv = {0, 0};
-    pmix_buffer_t pbkt, pkt;
-    pmix_byte_object_t bo;
+    pmix_buffer_t pbkt;
     pmix_cb_t cb;
     pmix_proc_t proc;
     char *data;
     size_t sz, n;
+    pmix_info_t *info;
+    pmix_scope_t scope = PMIX_SCOPE_UNDEF;
+    pmix_rank_info_t *iptr;
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
                         "%s recvd GET",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
     /* setup */
-    memset(nspace, 0, sizeof(nspace));
+    PMIX_LOAD_NSPACE(nspace, NULL);
 
     /* retrieve the nspace and rank of the requested proc */
     cnt = 1;
@@ -148,7 +198,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    pmix_strncpy(nspace, cptr, PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(nspace, cptr);
     free(cptr);
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &rank, &cnt, PMIX_PROC_RANK);
@@ -176,6 +226,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             return rc;
         }
     }
+    /* if they provided a specific key, get it */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &key, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
 
     /* search for directives we can deal with here */
     for (n=0; n < cd->ninfo; n++) {
@@ -187,10 +244,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             tv.tv_sec = cd->info[n].value.data.uint32;
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GET_REFRESH_CACHE)) {
             refresh_cache = PMIX_INFO_TRUE(&cd->info[n]);
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_DATA_SCOPE)) {
+            scope = cd->info[n].value.data.scope;
+            scope_given = true;
         }
     }
 
-    /* find the nspace object for this client */
+    /* find the nspace object for the target proc */
     nptr = NULL;
     PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(nspace, ns->nspace)) {
@@ -199,17 +259,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         }
     }
 
-    /* check if the nspace of the requestor is different from
-     * the nspace of the target process */
-    diffnspace = !PMIX_CHECK_NSPACE(nspace, cd->peer->info->pname.nspace);
-
     pmix_output_verbose(2, pmix_server_globals.get_output,
-                        "%s EXECUTE GET FOR %s:%d ON BEHALF OF %s",
+                        "%s EXECUTE GET FOR %s:%d WITH KEY %s ON BEHALF OF %s",
                         PMIX_NAME_PRINT(&pmix_globals.myid),
-                        nspace, rank,
+                        nspace, rank, (NULL == key) ? "NULL" : key,
                         PMIX_PNAME_PRINT(&cd->peer->info->pname));
 
-    /* This call flows upward from a local client If we don't
+    /* This call flows upward from a local client. If we don't
      * know about this nspace, then it cannot refer to the
      * nspace of the requestor - i.e., they aren't asking
      * about one of their peers. There are two reasons why we
@@ -240,180 +296,23 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             return PMIX_ERR_NOT_FOUND;
         }
         /* this is for an nspace we don't know about yet, so
-         * record the request for data from this process and
          * give the host server a chance to tell us about it.
          * The cbdata passed here is the pmix_server_caddy_t
          * we were passed - it contains the pmix_peer_t of
          * the original requestor so they will get the data
          * back when we receive it */
-        rc = create_local_tracker(nspace, rank,
-                                  cd->info, cd->ninfo,
-                                  cbfunc, cbdata, &lcd, &req);
-        if (PMIX_ERR_NOMEM == rc) {
-            return rc;
-        }
-        if (PMIX_SUCCESS == rc) {
-            pmix_output_verbose(5, pmix_server_globals.get_output,
-                                "%s UNKNOWN NSPACE: DUPLICATE REQUEST - WAITING",
-                                PMIX_NAME_PRINT(&pmix_globals.myid));
-            /* if they specified a timeout for this specific
-             * request, set it up now */
-            if (0 < tv.tv_sec) {
-                pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
-                                       get_timeout, req);
-                pmix_event_evtimer_add(&req->ev, &tv);
-                req->event_active = true;
-            }
-            /* we already asked for this info - no need to
-             * do it again */
-            return PMIX_SUCCESS;
-        }
-        /* only other return code is NOT_FOUND, indicating that
-         * we created a new tracker */
-
-        /* Its possible there will be no local processes on this
-         * host, so lets ask for this explicitly.  There can
-         * be a race condition here if this information shows
-         * up on its own, but at worst the direct modex
-         * will simply overwrite the info later */
-        if (NULL != pmix_host_server.direct_modex) {
-            pmix_output_verbose(5, pmix_server_globals.get_output,
-                                "%s UNKNOWN NSPACE: REQUEST PASSED TO HOST",
-                                PMIX_NAME_PRINT(&pmix_globals.myid));
-            rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
-            if (PMIX_SUCCESS != rc) {
-                pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
-                PMIX_RELEASE(lcd);
-                return rc;
-            }
-            /* if they specified a timeout for this specific
-             * request, set it up now */
-            if (0 < tv.tv_sec) {
-                pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
-                                       get_timeout, req);
-                pmix_event_evtimer_add(&req->ev, &tv);
-                req->event_active = true;
-            }
-        } else {
-            /* if we don't have direct modex feature, just respond with "not found" */
-            pmix_output_verbose(5, pmix_server_globals.get_output,
-                                "%s UNKNOWN NSPACE: NO DMODEX AVAILABLE - NOT FOUND",
-                                PMIX_NAME_PRINT(&pmix_globals.myid));
-            pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
-            PMIX_RELEASE(lcd);
-            return PMIX_ERR_NOT_FOUND;
-        }
-
-        return PMIX_SUCCESS;
+        goto request;
     }
 
     /* the target nspace is known, so we can process the request.
-     * if the rank is wildcard, or the nspace is different, then
-     * they are asking for the job-level info for this nspace - provide it */
-    if (!refresh_cache && (PMIX_RANK_WILDCARD == rank || diffnspace)) {
-        pmix_output_verbose(5, pmix_server_globals.get_output,
-                            "%s LOOKING FOR %s",
-                            PMIX_NAME_PRINT(&pmix_globals.myid),
-                            diffnspace ? "WILDCARD RANK" : "DIFF NSPACE");
-        /* see if we have the job-level info - we won't have it
-         * if we have no local procs and haven't already asked
-         * for it, so there is no guarantee we have it */
-        data = NULL;
-        sz = 0;
-        pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
-        proc.rank = PMIX_RANK_WILDCARD;
-        /* if we have local procs for this nspace, then we
-         * can retrieve the info from that GDS. Otherwise,
-         * we need to retrieve it from our own */
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        pmix_output_verbose(5, pmix_server_globals.get_output,
-                            "%s GETTING JOB-DATA FOR %s",
-                            PMIX_NAME_PRINT(&pmix_globals.myid),
-                            PMIX_NAME_PRINT(&proc));
-        /* this data is for a local client, so give the gds the
-         * option of returning a complete copy of the data,
-         * or returning a pointer to local storage */
-        cb.proc = &proc;
-        cb.scope = PMIX_SCOPE_UNDEF;
-        cb.copy = false;
-        cb.info = cd->info;
-        cb.ninfo = cd->ninfo;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        if (PMIX_SUCCESS != rc) {
-            cb.info = NULL;
-            cb.ninfo = 0;
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* store this as a byte object in the eventual data to
-         * be returned */
+     * if the rank is wildcard, then they are asking for the job-level
+     * info for this nspace - provide it */
+    if (PMIX_RANK_WILDCARD == rank) {
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-        cb.info = NULL;
-        cb.ninfo = 0;
-        PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-        /* assemble the provided data into a byte object */
-        PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
+        rc = get_job_data(nptr->nspace, cd, &pbkt);
         if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
-        PMIX_DESTRUCT(&pkt);
-        /* pack it into the payload */
-        PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
-        free(bo.bytes);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&pbkt);
-            PMIX_DESTRUCT(&cb);
             return rc;
-        }
-        PMIX_DESTRUCT(&cb);
-        /* if the requested rank is not WILDCARD, then retrieve any
-         * posted data for that rank. Anything found will
-         * be added to the cb.kvs list */
-        if (PMIX_RANK_WILDCARD != rank) {
-            PMIX_CONSTRUCT(&cb, pmix_cb_t);
-            proc.rank = rank;
-            cb.proc = &proc;
-            cb.scope = PMIX_LOCAL;
-            cb.copy = false;
-            cb.info = cd->info;
-            cb.ninfo = cd->ninfo;
-            pmix_output_verbose(5, pmix_server_globals.get_output,
-                                "%s GETTING DATA FOR %s",
-                                PMIX_NAME_PRINT(&pmix_globals.myid),
-                                PMIX_NAME_PRINT(&proc));
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != rc) {
-                cb.info = NULL;
-                cb.ninfo = 0;
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            cb.info = NULL;
-            cb.ninfo = 0;
-            PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-            /* assemble the provided data into a byte object */
-            PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
-            PMIX_DESTRUCT(&pkt);
-            /* pack it into the payload */
-            PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
-            free(bo.bytes);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            PMIX_DESTRUCT(&cb);
         }
         /* unload the resulting payload */
         PMIX_UNLOAD_BUFFER(&pbkt, data, sz);
@@ -437,41 +336,106 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                             "%s:%d NSPACE %s not all registered",
                             pmix_globals.myid.nspace,
                             pmix_globals.myid.rank, nspace);
-
-        if (localonly) {
-            /* the client asked that we not wait, so return now */
-            pmix_output_verbose(2, pmix_server_globals.get_output,
-                                "%s:%d CLIENT REQUESTED IMMEDIATE",
-                                pmix_globals.myid.nspace,
-                                pmix_globals.myid.rank);
-            return PMIX_ERR_NOT_FOUND;
-        }
-        /* we cannot do anything further, so just track this request
-         * for now */
-        rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo,
-                                  cbfunc, cbdata, &lcd, &req);
-        if (PMIX_ERR_NOMEM == rc) {
-            return rc;
-        }
-        pmix_output_verbose(2, pmix_server_globals.get_output,
-                            "%s:%d TRACKER CREATED - WAITING",
-                            pmix_globals.myid.nspace,
-                            pmix_globals.myid.rank);
-        /* if they specified a timeout, set it up now */
-        if (0 < tv.tv_sec) {
-            pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
-                                   get_timeout, req);
-            pmix_event_evtimer_add(&req->ev, &tv);
-            req->event_active = true;
-        }
-        /* the peer object has been added to the new lcd tracker,
-         * so return success here */
-        return PMIX_SUCCESS;
+        return defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
     }
 
-    /* if everyone has registered, see if we already have this data */
-    rc = _satisfy_request(nptr, rank, cd, refresh_cache, cbfunc, cbdata, &local);
-    if( PMIX_SUCCESS == rc ){
+    /* everyone has been registered, so we know who our local procs
+     * are - see if this target is one of them. Note that we cannot reach
+     * this point if rank = WILDCARD */
+    if (0 < nptr->nlocalprocs) {
+        /* if all the procs are local, then this must be a local proc */
+        if (nptr->nprocs == nptr->nlocalprocs) {
+            local = true;
+        } else {
+            /* see if this proc is one of our local ones */
+            PMIX_LIST_FOREACH(iptr, &nptr->ranks, pmix_rank_info_t) {
+                if (rank == iptr->pname.rank) {
+                    if (0 > iptr->peerid) {
+                        /* this rank has not connected yet, so this request needs to be held */
+                        return defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
+                    }
+                    break;
+                }
+            }
+            if (NULL == pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid)) {
+                /* this must be a remote rank */
+                local = false;
+            }
+        }
+    } else {
+        local = false;
+    }
+
+    /* if the proc is local, then we assume that the host/server maintains
+     * updated info - there is no need to ask the host to refresh a cache */
+    if (local && refresh_cache) {
+        return PMIX_OPERATION_SUCCEEDED;
+    } else if (refresh_cache) {
+        if (NULL != key) {
+            free(key);
+            key = NULL;
+        }
+        goto request;
+    }
+
+    /* the target nspace is known - if they asked us to wait for a specific
+     * key to be available, check if it is present. NOTE: key is only
+     * NULL if the request came from an older version */
+    if (NULL != key) {
+        PMIX_LOAD_PROCID(&proc, nspace, rank);
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.proc = &proc;
+        if (scope_given) {
+            cb.scope = scope;
+        } else if (local) {
+            cb.scope = PMIX_LOCAL;
+        } else {
+            cb.scope = PMIX_REMOTE;
+        }
+        cb.copy = false;
+        cb.info = cd->info;
+        cb.ninfo = cd->ninfo;
+        cb.key = key;
+        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+        PMIX_DESTRUCT(&cb);  // does not release info or key
+        if (PMIX_SUCCESS != rc) {
+            /* if the target proc is local, then we just need to wait */
+            if (local) {
+                /* something isn't right about the timeout - the cbfunc
+                 * segfaults due to the cd->peer having been released
+                 * too soon. For now, let's just return NOT FOUND */
+                return PMIX_ERR_NOT_FOUND;
+                /* if they provided a timeout, we need to execute it here
+                 * as we are not going to pass it upwards for the host
+                 * to perform - we default it to 2 sec */
+                if (0 == tv.tv_sec) {
+                    tv.tv_sec = 2;
+                }
+                return defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
+            }
+            /* otherwise, we need to request the info */
+            goto request;
+        }
+        /* we did find it, so go ahead and collect the payload */
+    }
+
+    /* check if the nspace of the requestor is different from
+     * the nspace of the target process */
+    diffnspace = !PMIX_CHECK_NSPACE(nptr->nspace, cd->peer->info->pname.nspace);
+
+    if (!scope_given) {
+        if (PMIX_RANK_UNDEF == rank || diffnspace) {
+            scope = PMIX_GLOBAL;
+        } else if (local) {
+            scope = PMIX_LOCAL;
+        } else {
+            scope = PMIX_REMOTE;
+        }
+    }
+
+    /* since everyone has registered, see if we already have this data */
+    rc = _satisfy_request(nptr, rank, cd, diffnspace, scope, cbfunc, cbdata);
+    if (PMIX_SUCCESS == rc) {
         /* return success as the satisfy_request function
          * calls the cbfunc for us, and it will have
          * released the cbdata object */
@@ -483,31 +447,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                         pmix_globals.myid.nspace,
                         pmix_globals.myid.rank);
 
-    /* If we get here, then we don't have the data at this time. If
-     * the user doesn't want to look for it, then we are done */
-    if (localonly) {
-        pmix_output_verbose(2, pmix_server_globals.get_output,
-                            "%s:%d CLIENT REQUESTED IMMEDIATE",
-                            pmix_globals.myid.nspace,
-                            pmix_globals.myid.rank);
-        return PMIX_ERR_NOT_FOUND;
-    }
-
-    /* Check to see if we already have a pending request for the data - if
-     * we do, then we can just wait for it to arrive */
-    rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo,
-                              cbfunc, cbdata, &lcd, &req);
-    if (PMIX_ERR_NOMEM == rc || NULL == lcd) {
-        /* we have a problem */
-        return PMIX_ERR_NOMEM;
-    }
-    /* if they specified a timeout, set it up now */
-    if (0 < tv.tv_sec) {
-        pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
-                               get_timeout, req);
-        pmix_event_evtimer_add(&req->ev, &tv);
-        req->event_active = true;
-    }
+  request:
+    rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
     if (PMIX_SUCCESS == rc) {
        /* we are already waiting for the data - nothing more
         * for us to do as the function added the new request
@@ -528,6 +469,19 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * resource manager server to please get the info for us from
      * whomever is hosting the target process */
     if (NULL != pmix_host_server.direct_modex) {
+        if (NULL != key) {
+            sz = cd->ninfo;
+            PMIX_INFO_CREATE(info, sz+1);
+            for (n=0; n < sz; n++) {
+                PMIX_INFO_XFER(&info[n], &cd->info[n]);
+            }
+            PMIX_INFO_LOAD(&info[sz], PMIX_REQUIRED_KEY, key, PMIX_STRING);
+            if (NULL != cd->info) {
+                PMIX_INFO_FREE(cd->info, cd->ninfo);
+            }
+            cd->info = info;
+            cd->ninfo = sz + 1;
+        }
         rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
         if (PMIX_SUCCESS != rc) {
             /* may have a function entry but not support the request */
@@ -567,8 +521,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
      * from this namespace/rank */
     lcd = NULL;
     PMIX_LIST_FOREACH(cd, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
-        if (0 != strncmp(nspace, cd->proc.nspace, PMIX_MAX_NSLEN) ||
-                rank != cd->proc.rank ) {
+        if (!PMIX_CHECK_NSPACE(nspace, cd->proc.nspace) || rank != cd->proc.rank ) {
             continue;
         }
         lcd = cd;
@@ -578,6 +531,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
         /* we already have a request, so just track that someone
          * else wants data from the same target */
         rc = PMIX_SUCCESS; // indicates we found an existing request
+        PMIX_RETAIN(lcd);
         goto complete;
     }
     /* we do not have an existing request, so let's create
@@ -594,7 +548,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
     rc = PMIX_ERR_NOT_FOUND;  // indicates that we created a new request tracker
 
   complete:
-    /* track this specific requestor so we return the
+    /* track this specific requester so we return the
      * data to them */
     req = PMIX_NEW(pmix_dmdx_request_t);
     if (NULL == req) {
@@ -656,138 +610,161 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
     }
 }
 
+static pmix_status_t get_job_data(char *nspace,
+                                  pmix_server_caddy_t *cd,
+                                  pmix_buffer_t *pbkt)
+{
+    pmix_status_t rc;
+    pmix_buffer_t pkt;
+    pmix_proc_t proc;
+    pmix_cb_t cb;
+    pmix_byte_object_t bo;
+
+    PMIX_LOAD_PROCID(&proc, nspace, PMIX_RANK_WILDCARD);
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    /* this data is requested by a local client, so give the gds the option
+     * of returning a copy of the data, or a pointer to
+     * local storage */
+    cb.proc = &proc;
+    cb.scope = PMIX_INTERNAL;
+    cb.copy = false;
+    cb.info = cd->info;
+    cb.ninfo = cd->ninfo;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    cb.info = NULL;
+    cb.ninfo = 0;
+    if (PMIX_SUCCESS == rc) {
+        PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
+        /* assemble the provided data into a byte object */
+        PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
+        if (rc != PMIX_SUCCESS) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&pkt);
+            PMIX_DESTRUCT(&pbkt);
+            PMIX_DESTRUCT(&cb);
+            return rc;
+        }
+        if (PMIX_PEER_IS_V1(cd->peer)) {
+            /* if the client is using v1, then it expects the
+             * data returned to it as the rank followed by abyte object containing
+             * a buffer - so we have to do a little gyration */
+            pmix_buffer_t xfer;
+            PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
+            PMIX_BFROPS_PACK(rc, cd->peer, &xfer, &pkt, 1, PMIX_BUFFER);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&pkt);
+                PMIX_DESTRUCT(&xfer);
+                PMIX_DESTRUCT(&cb);
+                return rc;
+            }
+            PMIX_UNLOAD_BUFFER(&xfer, bo.bytes, bo.size);
+            PMIX_DESTRUCT(&xfer);
+        } else {
+            PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
+        }
+        PMIX_DESTRUCT(&pkt);
+        /* pack it for transmission */
+        PMIX_BFROPS_PACK(rc, cd->peer, pbkt, &bo, 1, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&cb);
+            return rc;
+        }
+    }
+    PMIX_DESTRUCT(&cb);
+
+    return PMIX_SUCCESS;
+}
+
 static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                                       pmix_server_caddy_t *cd,
-                                      bool refresh_cache,
-                                      pmix_modex_cbfunc_t cbfunc,
-                                      void *cbdata, bool *local)
+                                      bool diffnspace, pmix_scope_t scope,
+                                      pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t rc;
     bool found = false;
     pmix_buffer_t pbkt, pkt;
-    pmix_rank_info_t *iptr;
     pmix_proc_t proc;
     pmix_cb_t cb;
-    pmix_peer_t *peer = NULL;
     pmix_byte_object_t bo;
     char *data = NULL;
     size_t sz = 0;
-    pmix_scope_t scope = PMIX_SCOPE_UNDEF;
-    bool diffnspace = false;
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
-                        "%s:%d SATISFY REQUEST CALLED",
+                        "%s:%d SATISFY REQUEST CALLED FOR %s:%d",
                         pmix_globals.myid.nspace,
-                        pmix_globals.myid.rank);
+                        pmix_globals.myid.rank,
+                        nptr->nspace, rank);
 
-    /* check to see if this data already has been
-     * obtained as a result of a prior direct modex request from
-     * a remote peer, or due to data from a local client
-     * having been committed */
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
     PMIX_LOAD_NSPACE(proc.nspace, nptr->nspace);
 
-    if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->peer->info->pname.nspace)) {
-        diffnspace = true;
-    }
-
-    /* if rank is PMIX_RANK_UNDEF or is from a different nspace,
-     * then it was stored in our GDS */
-    if (PMIX_RANK_UNDEF == rank || diffnspace) {
-        scope = PMIX_GLOBAL;  // we have to search everywhere
-        peer = pmix_globals.mypeer;
-    } else if (0 < nptr->nlocalprocs) {
-        /* if we have local clients of this nspace, then we use
-         * the corresponding GDS to retrieve the data. Otherwise,
-         * the data will have been stored under our GDS */
-        if (NULL != local) {
-            *local = true;
-        }
-        if (PMIX_RANK_WILDCARD != rank) {
-            peer = NULL;
-            /* see if the requested rank is local */
-            PMIX_LIST_FOREACH(iptr, &nptr->ranks, pmix_rank_info_t) {
-                if (rank == iptr->pname.rank) {
-                    scope = PMIX_LOCAL;
-                    if (0 <= iptr->peerid) {
-                        peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid);
-                    }
-                    if (NULL == peer) {
-                        /* this rank has not connected yet, so this request needs to be held */
-                        return PMIX_ERR_NOT_FOUND;
-                    }
-                    break;
-                }
-            }
-            if (NULL == peer)  {
-                /* this must be a remote rank */
-                if (NULL != local) {
-                    *local = false;
-                }
-                scope = PMIX_REMOTE;
-                peer = pmix_globals.mypeer;
-            }
-        }
-    } else {
-        if (NULL != local) {
-            *local = false;
-        }
-        peer = pmix_globals.mypeer;
-        scope = PMIX_REMOTE;
-    }
-
-    if (refresh_cache && !(*local)) {
-        return PMIX_ERR_NOT_FOUND;
-    }
-
-    /* if they are asking about a rank from an nspace different
-     * from their own, or they gave a rank of "wildcard", then
-     * include a copy of the job-level info */
+    /* if the rank is WILDCARD or the target is in an nspace different
+     * from the requester, include a copy of the job-level data */
     if (PMIX_RANK_WILDCARD == rank || diffnspace) {
-        proc.rank = PMIX_RANK_WILDCARD;
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        /* this data is requested by a local client, so give the gds the option
-         * of returning a copy of the data, or a pointer to
-         * local storage */
-        cb.proc = &proc;
-        cb.scope = PMIX_INTERNAL;
-        cb.copy = false;
-        cb.info = cd->info;
-        cb.ninfo = cd->ninfo;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        cb.info = NULL;
-        cb.ninfo = 0;
-        if (PMIX_SUCCESS == rc) {
-            PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-            /* assemble the provided data into a byte object */
+        rc = get_job_data(nptr->nspace, cd, &pbkt);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DESTRUCT(&pbkt);
+            return rc;
+        }
+    }
+
+    /* retrieve the data for the specific rank they are asking about */
+    proc.rank = rank;
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    /* this is a local request, so give the gds the option
+     * of returning a copy of the data, or a pointer to
+     * local storage */
+    cb.proc = &proc;
+    cb.scope = scope;
+    cb.copy = false;
+    cb.info = cd->info;
+    cb.ninfo = cd->ninfo;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    cb.info = NULL;
+    cb.ninfo = 0;
+    if (PMIX_SUCCESS == rc) {
+        found = true;
+        PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
+        /* assemble the provided data into a byte object */
+        if (PMIX_RANK_UNDEF == rank || diffnspace) {
             PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
-            if (rc != PMIX_SUCCESS) {
+        } else {
+            PMIX_GDS_ASSEMB_KVS_REQ(rc, cd->peer, &proc, &cb.kvs, &pkt, cd);
+        }
+        if (rc != PMIX_SUCCESS) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&pkt);
+            PMIX_DESTRUCT(&pbkt);
+            PMIX_DESTRUCT(&cb);
+            return rc;
+        }
+        if (PMIX_PEER_IS_V1(cd->peer)) {
+            /* if the client is using v1, then it expects the
+             * data returned to it in a different order than v2
+             * - so we have to do a little gyration */
+            /* pack the rank */
+            PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &rank, 1, PMIX_PROC_RANK);
+            if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT(&pkt);
                 PMIX_DESTRUCT(&pbkt);
                 PMIX_DESTRUCT(&cb);
                 return rc;
             }
-            if (PMIX_PEER_IS_V1(cd->peer)) {
-                /* if the client is using v1, then it expects the
-                 * data returned to it as the rank followed by abyte object containing
-                 * a buffer - so we have to do a little gyration */
-                pmix_buffer_t xfer;
-                PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
-                PMIX_BFROPS_PACK(rc, cd->peer, &xfer, &pkt, 1, PMIX_BUFFER);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&pkt);
-                    PMIX_DESTRUCT(&pbkt);
-                    PMIX_DESTRUCT(&xfer);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-                PMIX_UNLOAD_BUFFER(&xfer, bo.bytes, bo.size);
-                PMIX_DESTRUCT(&xfer);
-            } else {
-                PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
+            /* now pack the data itself as a buffer */
+            PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &pkt, 1, PMIX_BUFFER);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&pkt);
+                PMIX_DESTRUCT(&pbkt);
+                PMIX_DESTRUCT(&cb);
+                return rc;
             }
+            PMIX_DESTRUCT(&pkt);
+        } else {
+            PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
             PMIX_DESTRUCT(&pkt);
             /* pack it for transmission */
             PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
@@ -798,91 +775,8 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                 return rc;
             }
         }
-        PMIX_DESTRUCT(&cb);
-        if (rank == PMIX_RANK_WILDCARD) {
-            found = true;
-        }
     }
-
-    /* retrieve the data for the specific rank they are asking about */
-    if (PMIX_RANK_WILDCARD != rank) {
-        if (!PMIX_PEER_IS_SERVER(peer) && 0 == peer->commit_cnt) {
-            /* this condition works only for local requests, server does
-             * count commits for local ranks, and check this count when
-             * local request.
-             * if that request performs for remote rank on the remote
-             * node (by direct modex) so `peer->commit_cnt` should be ignored,
-             * it is can not be counted for the remote side and this condition
-             * does not matter for remote case */
-            return PMIX_ERR_NOT_FOUND;
-        }
-        proc.rank = rank;
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        /* this is a local request, so give the gds the option
-         * of returning a copy of the data, or a pointer to
-         * local storage */
-        cb.proc = &proc;
-        cb.scope = scope;
-        cb.copy = false;
-        cb.info = cd->info;
-        cb.ninfo = cd->ninfo;
-        PMIX_GDS_FETCH_KV(rc, peer, &cb);
-        cb.info = NULL;
-        cb.ninfo = 0;
-        if (PMIX_SUCCESS == rc) {
-            found = true;
-            PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-            /* assemble the provided data into a byte object */
-            if (PMIX_RANK_UNDEF == rank || diffnspace) {
-                PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
-            } else {
-                PMIX_GDS_ASSEMB_KVS_REQ(rc, cd->peer, &proc, &cb.kvs, &pkt, cd);
-            }
-            if (rc != PMIX_SUCCESS) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&pkt);
-                PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-            if (PMIX_PEER_IS_V1(cd->peer)) {
-                /* if the client is using v1, then it expects the
-                 * data returned to it in a different order than v2
-                 * - so we have to do a little gyration */
-                /* pack the rank */
-                PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &rank, 1, PMIX_PROC_RANK);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&pkt);
-                    PMIX_DESTRUCT(&pbkt);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-                /* now pack the data itself as a buffer */
-                PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &pkt, 1, PMIX_BUFFER);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&pkt);
-                    PMIX_DESTRUCT(&pbkt);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-                PMIX_DESTRUCT(&pkt);
-            } else {
-                PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
-                PMIX_DESTRUCT(&pkt);
-                /* pack it for transmission */
-                PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&pbkt);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
-            }
-        }
-        PMIX_DESTRUCT(&cb);
-    }
+    PMIX_DESTRUCT(&cb);
 
     PMIX_UNLOAD_BUFFER(&pbkt, data, sz);
     PMIX_DESTRUCT(&pbkt);
@@ -939,7 +833,7 @@ pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
         }
     } else if (NULL != nptr) {
         /* if we've got the blob - try to satisfy requests */
-        /* run through all the requests to this rank */
+        /* run through all the requests for this rank */
         /* this info is going back to one of our peers, so provide a server
          * caddy with our peer in it so the data gets packed correctly */
         scd = PMIX_NEW(pmix_server_caddy_t);
@@ -947,7 +841,8 @@ pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
         scd->peer = pmix_globals.mypeer;
         PMIX_LIST_FOREACH(req, &ptr->loc_reqs, pmix_dmdx_request_t) {
             pmix_status_t rc;
-            rc = _satisfy_request(nptr, rank, scd, false, req->cbfunc, req->cbdata, NULL);
+            bool diffnspace = !PMIX_CHECK_NSPACE(nptr->nspace, req->lcd->proc.nspace);
+            rc = _satisfy_request(nptr, rank, scd, diffnspace, PMIX_REMOTE, req->cbfunc, req->cbdata);
             if( PMIX_SUCCESS != rc ){
                 /* if we can't satisfy this particular request (missing key?) */
                 req->cbfunc(rc, NULL, 0, req->cbdata, NULL, NULL);

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -140,7 +140,17 @@ pmix_status_t dmodex_fn(const pmix_proc_t *proc,
               const pmix_info_t info[], size_t ninfo,
               pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
+    size_t n;
+
     TEST_VERBOSE(("Getting data for %s:%d", proc->nspace, proc->rank));
+
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                return PMIX_ERR_NOT_SUPPORTED;
+            }
+        }
+    }
 
     /* return not_found for single server mode */
     if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -137,8 +137,7 @@ int main(int argc, char **argv)
     pmix_output(0, "Client ns %s rank %d: Running on node %s", myproc.nspace, myproc.rank, pmix_globals.hostname);
 
     /* test something */
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -700,8 +700,6 @@ static void set_namespace(int nprocs, char *nspace,
     pmix_info_t *isv1, *isv2;
     myxfer_t cd, lock;
     pmix_status_t rc;
-    char **map[3] = {NULL, NULL, NULL};
-    char *peers[3] = {NULL, NULL, NULL};
     char tmp[50] , **agg = NULL;
 
     /* everything on one node */

--- a/test/simple/simptest.h
+++ b/test/simple/simptest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,3 +51,11 @@ typedef struct {
         pthread_cond_broadcast(&(lck)->cond);           \
         pthread_mutex_unlock(&(lck)->mutex);            \
     } while(0)
+
+#define SIMPTEST_THREADSHIFT(r, c)                          \
+ do {                                                       \
+    pmix_event_assign(&((r)->ev), simptest_evbase,          \
+                      -1, EV_WRITE, (c), (r));              \
+    PMIX_POST_OBJECT((r));                                  \
+    pmix_event_active(&((r)->ev), EV_WRITE, 1);             \
+} while (0)


### PR DESCRIPTION
A dmodex operation is triggered whenever the key being requested is not
found in the local cache. Include the specified key in the request
passed from the client to the local server. Have the server check for
that key in its own storage - if it isn't present, then pass the request
to the host thru the dmodex interface with the key being identified by
including the PMIX_REQUIRED_KEY attribute in the info array.

The rest of this fix is in the PRRTE PR that cannot be filed until this
one has been committed due to the new attribute definition.

Signed-off-by: Ralph Castain <rhc@pmix.org>