### PR TITLE
Correct return status when trackers are created

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2737,6 +2737,9 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
                     break;
                 }
             }
+            if (NULL == ihost) {
+                continue;
+            }
             if (0 == strcmp(ihost->value.data.string, pmix_globals.hostname)) {
                 /* if this host is us, then store each value as its own key */
                 for (i = 0; i < size; i++) {

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -440,5 +440,6 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
       cleanout:
         TEST_VERBOSE(("%s:%d: rank %d is OK", my_nspace, my_rank, i+params.base_rank));
     }
+    free(peers);
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Better differentiate when we want the switchyard to release the server
caddy.

Signed-off-by: Ralph Castain <rhc@pmix.org>