### PR TITLE
dstore: Fix cache size calculation

### DIFF
--- a/src/mca/common/dstore/dstore_segment.c
+++ b/src/mca/common/dstore/dstore_segment.c
@@ -65,16 +65,22 @@ PMIX_EXPORT int pmix_common_dstor_getpagesize(void)
 
 PMIX_EXPORT size_t pmix_common_dstor_getcacheblocksize(void)
 {
-    size_t cache_line = 0;
+    long cache_line = 0;
 
 #if defined(_SC_LEVEL1_DCACHE_LINESIZE)
     cache_line = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
 #endif
 #if (defined(HAVE_SYS_AUXV_H)) && (defined(AT_DCACHEBSIZE))
-    if (0 == cache_line) {
-        cache_line = getauxval(AT_DCACHEBSIZE);
+    if (0 >= cache_line) {
+        unsigned long auxval;
+        if( (auxval = getauxval(AT_DCACHEBSIZE)) ){
+            cache_line = auxval;
+        }
     }
 #endif
+    if (0 >= cache_line) {
+        cache_line = 64;
+    }
     return cache_line;
 }
 


### PR DESCRIPTION
The bug was discovered in #1605. The previous version was returning an
unsigned representation of `-1` which resulted in 0-size mmap argument.
(see #1605 for the details)

Signed-off-by: Artem Polyakov <artpol84@gmail.com>