### PR TITLE
Re-address the collective tracker problem

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1018,10 +1018,12 @@ static inline void* pmix_calloc(size_t n, size_t m)
     }while(0)
 
 /* define a convenience macro for loading nspaces */
-#define PMIX_LOAD_NSPACE(a, b)                          \
-    do {                                                \
-        memset((a), 0, PMIX_MAX_NSLEN+1);               \
-        pmix_strncpy((char*)(a), (b), PMIX_MAX_NSLEN);  \
+#define PMIX_LOAD_NSPACE(a, b)                              \
+    do {                                                    \
+        memset((a), 0, PMIX_MAX_NSLEN+1);                   \
+        if (NULL != (b)) {                                  \
+            pmix_strncpy((char*)(a), (b), PMIX_MAX_NSLEN);  \
+        }                                                   \
     }while(0)
 
 /* define a convenience macro for checking nspaces */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -1,8 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Research Organization for Information Science
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
@@ -100,7 +99,7 @@ static void nscon(pmix_namespace_t *p)
 {
     p->nspace = NULL;
     p->nprocs = 0;
-    p->nlocalprocs = 0;
+    p->nlocalprocs = SIZE_MAX;
     p->all_registered = false;
     p->version_stored = false;
     p->jobbkt = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -295,6 +295,7 @@ typedef struct {
     bool hybrid;                    // true if participating procs are from more than one nspace
     pmix_proc_t *pcs;               // copy of the original array of participants
     size_t   npcs;                  // number of procs in the array
+    pmix_list_t nslist;             // unique nspace list of participants
     pmix_lock_t lock;               // flag for waiting for completion
     bool def_complete;              // all local procs have been registered and the trk definition is complete
     pmix_list_t local_cbs;          // list of pmix_server_caddy_t for sending result to the local participants

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -682,7 +682,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
      * a remote peer, or due to data from a local client
      * having been committed */
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-    pmix_strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(proc.nspace, nptr->nspace);
 
     if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->peer->info->pname.nspace)) {
         diffnspace = true;
@@ -716,7 +716,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                     break;
                 }
             }
-            if (PMIX_LOCAL != scope)  {
+            if (NULL == peer)  {
                 /* this must be a remote rank */
                 if (NULL != local) {
                     *local = false;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -373,10 +373,11 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
 {
     pmix_server_trkr_t *trk;
     size_t i;
-    bool all_def;
+    bool all_def, found;
     pmix_namespace_t *nptr, *ns;
     pmix_rank_info_t *info;
-    pmix_rank_t ns_local = 0;
+    pmix_nspace_caddy_t *nm;
+    pmix_nspace_t first;
 
     pmix_output_verbose(5, pmix_server_globals.base_output,
                         "new_tracker called with %d procs", (int)nprocs);
@@ -418,14 +419,8 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
     trk->nlocal = 0;
 
     all_def = true;
+    PMIX_LOAD_NSPACE(first, NULL);
     for (i=0; i < nprocs; i++) {
-        if (NULL == id) {
-            pmix_strncpy(trk->pcs[i].nspace, procs[i].nspace, PMIX_MAX_NSLEN);
-            trk->pcs[i].rank = procs[i].rank;
-        }
-        if (!all_def) {
-            continue;
-        }
         /* is this nspace known to us? */
         nptr = NULL;
         PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
@@ -434,14 +429,96 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
                 break;
             }
         }
-        if (NULL == nptr || nptr->nlocalprocs <= 0) {
-            /* cannot be a local proc */
+        /* check if multiple nspaces are involved in this operation */
+        if (0 == strlen(first)) {
+            PMIX_LOAD_NSPACE(first, procs[i].nspace);
+        } else if (!PMIX_CHECK_NSPACE(first, procs[i].nspace)) {
+            trk->hybrid = true;
+        }
+        if (NULL == nptr) {
+            /* we don't know about this nspace. If there is going to
+             * be at least one local process participating in a fence,
+             * they we require that either at least one process must already
+             * have been registered (via "register client") or that the
+             * nspace itself have been regisered. So either the nspace
+             * wasn't registered because it doesn't include any local
+             * procs, or our host has not been told about this nspace
+             * because it won't host any local procs. We therefore mark
+             * this tracker as including non-local participants.
+             *
+             * NOTE: It is conceivable that someone might want to review
+             * this constraint at a future date. I believe it has to be
+             * required (at least for now) as otherwise we wouldn't have
+             * a way of knowing when all local procs have participated.
+             * It is possible that a new nspace could come along at some
+             * later time and add more local participants - but we don't
+             * know how long to wait.
+             *
+             * The only immediately obvious alternative solutions would
+             * be to either require that RMs always inform all daemons
+             * about the launch of nspaces, regardless of whether or
+             * not they will host local procs; or to drop the aggregation
+             * of local participants and just pass every fence call
+             * directly to the host. Neither of these seems palatable
+             * at this time. */
+            trk->local = false;
+            /* we don't know any more info about this nspace, so
+             * there isn't anything more we can do */
+            continue;
+        }
+        /* it is possible we know about this nspace because the host
+         * has registered one or more clients via "register_client",
+         * but the host has not yet called "register_nspace". There is
+         * a very tiny race condition whereby this can happen due
+         * to event-driven processing, but account for it here */
+        if (SIZE_MAX == nptr->nlocalprocs) {
+            /* delay processing until this nspace is registered */
+            all_def = false;
+            continue;
+        }
+        if (0 == nptr->nlocalprocs) {
+            /* the host has informed us that this nspace has no local procs */
             pmix_output_verbose(5, pmix_server_globals.base_output,
                                 "new_tracker: unknown nspace %s",
                                 procs[i].nspace);
             continue;
         }
-        /* have all the clients for this nspace been defined? */
+        /* check and add uniq ns into trk nslist */
+        found = false;
+        PMIX_LIST_FOREACH(nm, &trk->nslist, pmix_nspace_caddy_t) {
+            if (0 == strcmp(nptr->nspace, nm->ns->nspace)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            nm = PMIX_NEW(pmix_nspace_caddy_t);
+            PMIX_RETAIN(nptr);
+            nm->ns = nptr;
+            pmix_list_append(&trk->nslist, &nm->super);
+        }
+
+        /* if they want all the local members of this nspace, then
+         * add them in here. They told us how many procs will be
+         * local to us from this nspace, but we don't know their
+         * ranks. So as long as they want _all_ of them, we can
+         * handle that case regardless of whether the individual
+         * clients have been "registered" */
+        if (PMIX_RANK_WILDCARD == procs[i].rank) {
+            trk->nlocal += nptr->nlocalprocs;
+            /* the total number of procs in this nspace was provided
+             * in the data blob delivered to register_nspace, so check
+             * to see if all the procs are local */
+            if (nptr->nprocs != nptr->nlocalprocs) {
+                trk->local = false;
+            }
+            continue;
+        }
+
+        /* They don't want all the local clients, or they are at
+         * least listing them individually. Check if all the clients
+         * for this nspace have been registered via "register_client"
+         * so we know the specific ranks on this node */
         if (!nptr->all_registered) {
             /* nope, so no point in going further on this one - we'll
              * process it once all the procs are known */
@@ -449,31 +526,24 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
             pmix_output_verbose(5, pmix_server_globals.base_output,
                                 "new_tracker: all clients not registered nspace %s",
                                 procs[i].nspace);
-            /* we have to continue processing the list of procs
-             * to setup the trk->pcs array, so don't break out
-             * of the loop */
+            continue;
         }
         /* is this one of my local ranks? */
-        ns_local = 0;
+        found = false;
         PMIX_LIST_FOREACH(info, &nptr->ranks, pmix_rank_info_t) {
-            if (procs[i].rank == info->pname.rank ||
-                PMIX_RANK_WILDCARD == procs[i].rank) {
-                    pmix_output_verbose(5, pmix_server_globals.base_output,
-                                        "adding local proc %s.%d to tracker",
-                                        info->pname.nspace, info->pname.rank);
+            if (procs[i].rank == info->pname.rank) {
+                pmix_output_verbose(5, pmix_server_globals.base_output,
+                                    "adding local proc %s.%d to tracker",
+                                    info->pname.nspace, info->pname.rank);
+                found = true;
                 /* track the count */
-                ns_local++;
-                if (PMIX_RANK_WILDCARD != procs[i].rank) {
-                    break;
-                }
+                trk->nlocal++;
+                break;
             }
         }
-
-        trk->nlocal += ns_local;
-    }
-
-    if (trk->nlocal == nptr->nprocs) {
-        trk->local = true;
+        if (!found) {
+            trk->local = false;
+        }
     }
 
     if (all_def) {
@@ -3497,6 +3567,7 @@ static void tcon(pmix_server_trkr_t *t)
     t->pname.rank = PMIX_RANK_UNDEF;
     t->pcs = NULL;
     t->npcs = 0;
+    PMIX_CONSTRUCT(&t->nslist, pmix_list_t);
     PMIX_CONSTRUCT_LOCK(&t->lock);
     t->def_complete = false;
     PMIX_CONSTRUCT(&t->local_cbs, pmix_list_t);
@@ -3515,6 +3586,7 @@ static void tdes(pmix_server_trkr_t *t)
     if (NULL != t->id) {
         free(t->id);
     }
+    PMIX_LIST_DESTRUCT(&t->nslist);
     PMIX_DESTRUCT_LOCK(&t->lock);
     if (NULL != t->pcs) {
         free(t->pcs);


### PR DESCRIPTION
There are several problems needing to be addressed. First, there exists a very small race condition window between registration of nspaces and/or clients and receipt of a collective operation request from a local client. We were trying to do too much in the register_client area, resulting in some potential area to miscount the number of local participants. Sadly, we weren't looking for this race condition at all in the register_nspace code. It could be that this race shouldn't happen, but I decided to protect against it just to be safe.

Second, the code in the "new_tracker" area wasn't correct. Cleanly separating out the various possible scenarios helps clarify the logic and avoid some of the problems.

I added quite a few comments to the code to help people understand the flow.

There remain some issues about detecting local vs non-local procs when
setting up the tracker. I've resolved the ones surfaced by multi-node
testing using PRRTE with both simple PMIx clients and the "double-get"
test case. This is a subset of those changes as the broader ones failed
to pass CI - hopefully, this minimum subset does and then I'll try again
with the remainder.

For this subset, we use the fact that we are being told both the number
of local procs and the total number of procs in a namespace upon call to
"register_nspace". If we are in a collective and have not yet received
the "register_nspace" call, then we defer processing of the collective
until we do.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ce74505cc5912b417492f02daf1a9c3d4f4ced7f)
(cherry picked from commit 7fbae1bc078cca18c9ae92745958b7ced2a08242)