### PR TITLE
Add configury to support REST interface interactions

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -783,6 +783,22 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
 
     ##################################
+    # JANSSON
+    ##################################
+    pmix_show_title "JANSSON"
+
+    PMIX_CHECK_JANSSON
+
+
+    ##################################
+    # CURL
+    ##################################
+    pmix_show_title "CURL"
+
+    PMIX_CHECK_CURL
+
+
+    ##################################
     # Dstore Locking
     ##################################
 
@@ -1350,6 +1366,8 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
         AM_CONDITIONAL(WANT_PMI_BACKWARD, test "$WANT_PMI_BACKWARD" = 1)
         AM_CONDITIONAL(NEED_LIBPMIX, [test "$pmix_need_libpmix" = "1"])
+        AM_CONDITIONAL([PMIX_HAVE_JANSSON], [test "x$pmix_check_jansson_happy" = "xyes"])
+        AM_CONDITIONAL([PMIX_HAVE_CURL], [test "x$pmix_check_curl_happy" = "xyes"])
     ])
     pmix_did_am_conditionals=yes
 ])dnl

--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -1,0 +1,106 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      QLogic Corp. All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PMIX_CHECK_CURL
+# --------------------------------------------------------
+# check if CURL support can be found.  sets curl_{CPPFLAGS,
+# LDFLAGS, LIBS}
+AC_DEFUN([PMIX_CHECK_CURL],[
+
+    PMIX_VAR_SCOPE_PUSH(pmix_check_curl_save_CPPFLAGS pmix_check_curl_save_LDFLAGS pmix_check_curl_save_LIBS)
+	AC_ARG_WITH([curl],
+		    [AC_HELP_STRING([--with-curl(=DIR)],
+				    [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+
+    AC_ARG_WITH([curl-libdir],
+            [AC_HELP_STRING([--with-curl-libdir=DIR],
+                    [Search for Curl libraries in DIR])])
+
+    pmix_check_curl_happy=no
+    pmix_curl_source=unknown
+    pmix_check_curl_dir=unknown
+    pmix_check_curl_libdir=
+    pmix_check_curl_basedir=
+
+    if test "$with_curl" != "no"; then
+        AC_MSG_CHECKING([where to find curl.h])
+        AS_IF([test "$with_curl" = "yes" || test -z "$with_curl"],
+              [AS_IF([test -f /usr/include/curl.h],
+                     [pmix_check_curl_dir=/usr
+                      pmix_check_curl_basedir=/usr
+                      pmix_curl_source=standard],
+                     [AS_IF([test -f /usr/include/curl/curl.h],
+                            [pmix_check_curl_dir=/usr/include/curl
+                             pmix_check_curl_basedir=/usr
+                             pmix_curl_source=standard])])],
+    	      [AS_IF([test -f $with_curl/include/curl.h],
+                     [pmix_check_curl_dir=$with_curl/include
+                      pmix_check_curl_basedir=$with_curl
+                      pmix_curl_source=$with_curl],
+                      [AS_IF([test -f $with_curl/include/curl/curl.h],
+                             [pmix_check_curl_dir=$with_curl/include/curl
+                              pmix_check_curl_basedir=$with_curl
+                              pmix_curl_source=$with_curl])])])
+        AC_MSG_RESULT([$pmix_check_curl_dir])
+
+        AS_IF([test -z "$with_curl_libdir" || test "$with_curl_libdir" = "yes"],
+              [pmix_check_curl_libdir=$pmix_check_curl_basedir],
+    	      [PMIX_CHECK_WITHDIR([curl-libdir], [$with_curl_libdir], [libcurl.*])
+               pmix_check_curl_libdir=$with_curl_libdir])
+
+    	pmix_check_curl_save_CPPFLAGS="$CPPFLAGS"
+    	pmix_check_curl_save_LDFLAGS="$LDFLAGS"
+    	pmix_check_curl_save_LIBS="$LIBS"
+
+        PMIX_CHECK_PACKAGE([pmix_check_curl],
+		   [curl.h],
+		   [curl],
+		   [curl_easy_getinfo],
+		   [],
+		   [$pmix_check_curl_dir],
+		   [$pmix_check_curl_libdir],
+		   [pmix_check_curl_happy="yes"],
+		   [pmix_check_curl_happy="no"])
+
+    	CPPFLAGS="$pmix_check_curl_save_CPPFLAGS"
+    	LDFLAGS="$pmix_check_curl_save_LDFLAGS"
+    	LIBS="$pmix_check_curl_save_LIBS"
+    fi
+
+    AS_IF([test "$pmix_check_curl_happy" = "no" && test ! -z "$with_curl" && test "$with_curl" != "no"],
+          [AC_MSG_ERROR([curl support requested but not found.  Aborting])])
+
+    AC_MSG_CHECKING([libcurl support available])
+    AC_MSG_RESULT([$pmix_check_curl_happy])
+
+    AS_IF([test "$pmix_check_curl_happy" = "yes"],
+          [PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])])
+
+    AC_SUBST(pmix_check_curl_CPPFLAGS)
+    AC_SUBST(pmix_check_curl_LDFLAGS)
+    AC_SUBST(pmix_check_curl_LIBS)
+    PMIX_VAR_SCOPE_POP
+])

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -1,0 +1,96 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      QLogic Corp. All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PMIX_CHECK_JANSSON
+# --------------------------------------------------------
+# check if JANSSON support can be found.  sets jansson_{CPPFLAGS,
+# LDFLAGS, LIBS}
+AC_DEFUN([PMIX_CHECK_JANSSON],[
+
+    PMIX_VAR_SCOPE_PUSH(pmix_check_jansson_save_CPPFLAGS pmix_check_jansson_save_LDFLAGS pmix_check_jansson_save_LIBS)
+	AC_ARG_WITH([jansson],
+		    [AC_HELP_STRING([--with-jansson(=DIR)],
+				    [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+
+    AC_ARG_WITH([jansson-libdir],
+            [AC_HELP_STRING([--with-jansson-libdir=DIR],
+                    [Search for Jansson libraries in DIR])])
+
+    pmix_check_jansson_happy=no
+    pmix_jansson_source=unknown
+    pmix_check_jansson_dir=
+    pmix_check_jansson_libdir=
+    pmix_check_jansson_basedir=
+
+    if test "$with_jansson" != "no"; then
+        AS_IF([test "$with_jansson" = "yes" || test -z "$with_jansson"],
+              [pmix_check_jansson_dir=/usr
+               pmix_check_jansson_basedir=/usr
+               pmix_jansson_source=standard],
+    	      [PMIX_CHECK_WITHDIR([jansson], [$with_jansson], [include/jansson.h])
+               pmix_check_jansson_dir=$with_jansson
+               pmix_check_jansson_basedir=$with_jansson
+               pmix_jansson_source=$with_jansson])
+
+        AS_IF([test -z "$with_jansson_libdir" || test "$with_jansson_libdir" = "yes"],
+              [pmix_check_jansson_libdir=$pmix_check_jansson_basedir],
+    	      [PMIX_CHECK_WITHDIR([jansson-libdir], [$with_jansson_libdir], [libjansson.*])
+               pmix_check_jansson_libdir=$with_jansson_libdir])
+
+    	pmix_check_jansson_save_CPPFLAGS="$CPPFLAGS"
+    	pmix_check_jansson_save_LDFLAGS="$LDFLAGS"
+    	pmix_check_jansson_save_LIBS="$LIBS"
+
+        PMIX_CHECK_PACKAGE([pmix_check_jansson],
+		   [jansson.h],
+	 	   [jansson],
+		   [json_loads],
+		   [],
+		   [$pmix_check_jansson_dir],
+		   [$pmix_check_jansson_libdir],
+		   [pmix_check_jansson_happy="yes"],
+		   [pmix_check_jansson_happy="no"])
+
+    	CPPFLAGS="$pmix_check_jansson_save_CPPFLAGS"
+    	LDFLAGS="$pmix_check_jansson_save_LDFLAGS"
+    	LIBS="$pmix_check_jansson_save_LIBS"
+    fi
+
+    AS_IF([test "$pmix_check_jansson_happy" = "no" && test ! -z "$with_jansson" && test "$with_jansson" != "no"],
+          [AC_MSG_ERROR([Jansson support requested but not found.  Aborting])])
+
+    AC_SUBST(pmix_check_jansson_CPPFLAGS)
+    AC_SUBST(pmix_check_jansson_LDFLAGS)
+    AC_SUBST(pmix_check_jansson_LIBS)
+
+    AC_MSG_CHECKING([Jansson support available])
+    AC_MSG_RESULT([$pmix_check_jansson_happy])
+
+    AS_IF([test "$pmix_check_jansson_happy" = "yes"],
+          [PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])])
+
+    PMIX_VAR_SCOPE_POP
+])


### PR DESCRIPTION
- detect/add libjansson for JSON parsing
- detect/add libcurl for http connections

This only detects the availability of these libraries - future work will
utilize them but only when configured to do so. Note that PMIx is not
going to act as a REST server - this is intended to allow a PMIx server
to request services from a system-level REST server.

Signed-off-by: Ralph Castain <rhc@pmix.org>