### PR TITLE
Realign behavior of PMIx_Get and PMIx_Get_nb

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -91,9 +91,6 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
-    size_t n, nfo;
-    pmix_proc_t p;
-    pmix_info_t nodeinfo, *iptr;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -108,62 +105,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
                         (NULL == proc) ? "NULL" : PMIX_NAME_PRINT(proc),
                         (NULL == key) ? "NULL" : key);
 
-    memcpy(&p, proc, sizeof(pmix_proc_t));
-    iptr = (pmix_info_t*)info;
-    nfo = ninfo;
-
-    if (!PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
-        if (PMIX_RANK_UNDEF == proc->rank || NULL == key) {
-            goto doget;
-        }
-        /* if they are asking about a node-level piece of info,
-         * then the rank must be UNDEF */
-        if (pmix_check_node_info(key)) {
-            p.rank = PMIX_RANK_UNDEF;
-            /* see if they told us to get node info */
-            if (NULL == info) {
-                /* guess not - better do it */
-                PMIX_INFO_LOAD(&nodeinfo, PMIX_NODE_INFO, NULL, PMIX_BOOL);
-                iptr = &nodeinfo;
-                nfo = 1;
-            }
-            goto doget;
-        }
-        /* if they are asking about an app-level piece of info,
-         * then the rank must be UNDEF */
-        if (pmix_check_app_info(key)) {
-            p.rank = PMIX_RANK_UNDEF;
-            /* see if they told us to get app info */
-            if (NULL == info) {
-                /* guess not - better do it */
-                PMIX_INFO_LOAD(&nodeinfo, PMIX_APP_INFO, NULL, PMIX_BOOL);
-                iptr = &nodeinfo;
-                nfo = 1;
-            }
-            goto doget;
-        }
-
-        /* see if they are requesting session, node, or app-level info */
-        for (n=0; n < ninfo; n++) {
-            if (PMIX_CHECK_KEY(info, PMIX_NODE_INFO) ||
-                PMIX_CHECK_KEY(info, PMIX_APP_INFO) ||
-                PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
-                goto doget;
-            }
-        }
-    }
-
-    /* try to get data directly, without threadshift */
-    if (PMIX_SUCCESS == (rc = _getfn_fastpath(&p, key, iptr, nfo, val))) {
-        goto done;
-    }
-
-  doget:
-    /* create a callback object as we need to pass it to the
-     * recv routine so we know which callback to use when
-     * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
-    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&p, key, iptr, nfo, _value_cbfunc, cb))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(proc, key, info, ninfo, _value_cbfunc, cb))) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -177,7 +120,6 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
     }
     PMIX_RELEASE(cb);
 
-  done:
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix:client get completed");
 
@@ -189,8 +131,15 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t 
                                       pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_cb_t *cb;
-    int rank;
-    char *nm;
+    pmix_status_t rc;
+    size_t n, nfo;
+    bool wantinfo = false;
+    bool haveid = false;
+    pmix_proc_t p;
+    pmix_info_t *iptr;
+    bool copy = false;
+    uint32_t appnum;
+    pmix_value_t *ival = NULL;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -228,31 +177,182 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t 
     /* if the given proc param is NULL, or the nspace is
      * empty, then the caller is referencing our own nspace */
     if (NULL == proc || 0 == strlen(proc->nspace)) {
-        nm = pmix_globals.myid.nspace;
+        PMIX_LOAD_NSPACE(p.nspace, pmix_globals.myid.nspace);
     } else {
-        nm = (char*)proc->nspace;
+        PMIX_LOAD_NSPACE(p.nspace, proc->nspace);
     }
 
     /* if the proc param is NULL, then we are seeking a key that
      * must be globally unique, so communicate this to the hash
      * functions with the UNDEF rank */
     if (NULL == proc) {
-        rank = PMIX_RANK_UNDEF;
+        p.rank = PMIX_RANK_UNDEF;
     } else {
-        rank = proc->rank;
+        p.rank = proc->rank;
     }
+    iptr = (pmix_info_t*)info;
+    nfo = ninfo;
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
-                        "pmix: get_nb value for proc %s:%u key %s",
-                        nm, rank, (NULL == key) ? "NULL" : key);
+                        "pmix: get_nb value for proc %s key %s",
+                        PMIX_NAME_PRINT(&p), (NULL == key) ? "NULL" : key);
 
+    if (!PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+        /* ]don't consider the fastpath option
+         * for undefined rank or NULL keys */
+        if (PMIX_RANK_UNDEF == p.rank || NULL == key) {
+            goto doget;
+        }
+        /* if they are asking about a node-level piece of info,
+         * then the rank must be UNDEF */
+        if (pmix_check_node_info(key)) {
+            p.rank = PMIX_RANK_UNDEF;
+            /* the key is node-related - see if the target node is in the
+             * info array and if they tagged the request accordingly */
+            if (NULL != info) {
+                for (n=0; n < ninfo; n++) {
+                    if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_INFO)) {
+                        wantinfo = true;
+                    } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+                        haveid = true;
+                    } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
+                        haveid = true;
+                    }
+                }
+            }
+            if (wantinfo && haveid) {
+                goto doget;
+            } else if (wantinfo) {
+                /* missing the nodeid/hostname - add our hostname */
+                nfo = ninfo + 1;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+                copy = true;
+                goto doget;
+            } else if (haveid) {
+                /* flag that we want node info */
+                nfo = ninfo + 1;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+                copy = true;
+                goto doget;
+            } else {
+                /* missing both */
+                nfo = ninfo + 2;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+                PMIX_INFO_LOAD(&iptr[ninfo+1], PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+                copy = true;
+                goto doget;
+            }
+        }
+
+        /* see if they are asking about an app-level piece of info */
+        wantinfo = false;
+        haveid = false;
+        if (pmix_check_app_info(key)) {
+            p.rank = PMIX_RANK_UNDEF;
+            /* the key is app-related - see if the target appnum is in the
+             * info array and if they tagged the request accordingly */
+            if (NULL != info) {
+                for (n=0; n < ninfo; n++) {
+                    if (PMIX_CHECK_KEY(&info[n], PMIX_APP_INFO)) {
+                        wantinfo = true;
+                    } else if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM) &&
+                               0 != info[n].value.data.uint32) {
+                        haveid = true;
+                    }
+                }
+            }
+            if (wantinfo && haveid) {
+                goto doget;
+            } else if (wantinfo) {
+                /* missing the appnum - add ours */
+                nfo = ninfo + 1;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                /* try to retrieve it */
+                rc = _getfn_fastpath(&pmix_globals.myid, PMIX_APPNUM, NULL, 0, &ival);
+                if (PMIX_SUCCESS != rc) {
+                    appnum = ival->data.uint32;
+                    PMIX_VALUE_RELEASE(ival);
+                } else {
+                    appnum = 0;
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_APPNUM, &appnum, PMIX_UINT32);
+                copy = true;
+                goto doget;
+            } else if (haveid) {
+                /* flag that we want app info */
+                nfo = ninfo + 1;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_APP_INFO, NULL, PMIX_BOOL);
+                copy = true;
+                goto doget;
+            } else {
+                /* missing both */
+                nfo = ninfo + 2;
+                PMIX_INFO_CREATE(iptr, nfo);
+                for (n=0; n < ninfo; n++) {
+                    PMIX_INFO_XFER(&iptr[n], &info[n]);
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_APP_INFO, NULL, PMIX_BOOL);
+                /* try to retrieve it */
+                rc = _getfn_fastpath(&pmix_globals.myid, PMIX_APPNUM, NULL, 0, &ival);
+                if (PMIX_SUCCESS != rc) {
+                    appnum = ival->data.uint32;
+                    PMIX_VALUE_RELEASE(ival);
+                } else {
+                    appnum = 0;
+                }
+                PMIX_INFO_LOAD(&iptr[ninfo], PMIX_APPNUM, &appnum, PMIX_UINT32);
+                copy = true;
+                goto doget;
+            }
+        }
+
+        /* see if they are requesting session info or requesting cache refresh */
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(info, PMIX_SESSION_INFO) ||
+                PMIX_CHECK_KEY(info, PMIX_GET_REFRESH_CACHE)) {
+                goto doget;
+            }
+        }
+    }
+
+    /* try to get data directly, without threadshift */
+    if (PMIX_SUCCESS == (rc = _getfn_fastpath(&p, key, iptr, nfo, &ival))) {
+        if (NULL != cbfunc) {
+            cbfunc(rc, ival, cbdata);
+            /* ownership of the memory in ival is passed to the
+             * user in the cbfunc, so don't release it here */
+        }
+        return rc;
+    }
+
+  doget:
     /* threadshift this request so we can access global structures */
     cb = PMIX_NEW(pmix_cb_t);
-    cb->pname.nspace = strdup(nm);
-    cb->pname.rank = rank;
+    cb->pname.nspace = strdup(p.nspace);
+    cb->pname.rank = p.rank;
     cb->key = (char*)key;
-    cb->info = (pmix_info_t*)info;
-    cb->ninfo = ninfo;
+    cb->info = iptr;
+    cb->ninfo = nfo;
+    cb->infocopy = copy;
     cb->cbfunc.valuefn = cbfunc;
     cb->cbdata = cbdata;
     PMIX_THREADSHIFT(cb, _getnbfn);
@@ -469,7 +569,7 @@ static pmix_status_t process_values(pmix_value_t **v, pmix_cb_t *cb)
     }
     /* we will return the data as an array of pmix_info_t
      * in the kvs pmix_value_t */
-    val = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    PMIX_VALUE_CREATE(val, 1);
     if (NULL == val) {
         return PMIX_ERR_NOMEM;
     }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -307,6 +307,7 @@ static void cbcon(pmix_cb_t *p)
     p->nprocs = 0;
     p->info = NULL;
     p->ninfo = 0;
+    p->infocopy = false;
     p->nvals = 0;
     PMIX_CONSTRUCT(&p->kvs, pmix_list_t);
     p->copy = false;
@@ -321,6 +322,9 @@ static void cbdes(pmix_cb_t *p)
         free(p->pname.nspace);
     }
     PMIX_DESTRUCT(&p->data);
+    if (p->infocopy) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
     PMIX_LIST_DESTRUCT(&p->kvs);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cb_t,

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -11,6 +11,10 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -391,6 +395,7 @@ typedef struct {
     size_t nprocs;
     pmix_info_t *info;
     size_t ninfo;
+    bool infocopy;
     size_t nvals;
     pmix_list_t kvs;
     bool copy;


### PR DESCRIPTION
 Realign behavior of PMIx_Get and PMIx_Get_nb

When the "fastpath" code was added, it was put in the PMIx_Get call.
This broke the model of PMIx_Get acting as a wrapper for PMIx_Get_nb,
resulting in calls to PMIx_Get_nb behaving differently than its
non-blocking form. Furthering the problem, the code to detect and
resolve requests for node and app-level info also went into PMIx_Get as
it was intended to protect the call to "fastpath".

Realigning the two "get" functions requires moving the "fastpath" and
node/app info code down into PMIx_Get_nb. The "fastpath" code still
avoids the threadshift, which was the original intent. However, now the
two APIs behave the same again.

 Avoid an unnecessary malloc in a critical path

The callback object used to release PMIx_Get doesn't need to be
dynamically allocated - it can stay on the stack as we block in that
function until complete.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 1a44ec7)
(cherry picked from commit 3da4c4b)
