### PR TITLE
Properly handle forwarded output when no handler registered

### DIFF
--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -249,13 +249,8 @@ static void tool_iof_handler(struct pmix_peer_t *pr,
         goto cleanup;
     }
     /* lookup the handler for this IOF package */
-    if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid))) {
-        /* something wrong here - should not happen */
-        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-        goto cleanup;
-    }
-    /* if the handler invokes a callback function, do so */
-    if (NULL != req->cbfunc) {
+    if (NULL != (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid)) &&
+        NULL != req->cbfunc) {
         req->cbfunc(refid, channel, &source, &bo, info, ninfo);
     } else {
         /* otherwise, simply write it out to the specified std IO channel */


### PR DESCRIPTION
Don't complain and drop it on the floor - just print it out

Signed-off-by: Ralph Castain <rhc@pmix.org>