### PR TITLE
Properly handle forwarded output when no handler registered

### DIFF
--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -245,13 +245,8 @@ static void tool_iof_handler(struct pmix_peer_t *pr,
         goto cleanup;
     }
     /* lookup the handler for this IOF package */
-    if (NULL == (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid))) {
-        /* something wrong here - should not happen */
-        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-        goto cleanup;
-    }
-    /* if the handler invokes a callback function, do so */
-    if (NULL != req->cbfunc) {
+    if (NULL != (req = (pmix_iof_req_t*)pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid)) &&
+        NULL != req->cbfunc) {
         req->cbfunc(refid, channel, &source, &bo, info, ninfo);
     } else {
         /* otherwise, simply write it out to the specified std IO channel */


### PR DESCRIPTION
Don't complain and drop it on the floor - just print it out

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit abe0e35a6c6e29e7a6609cf2d88ed1d1499fbd4e)