### PR TITLE
Fix fork/exec and provide better tool support

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -150,6 +150,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SERVER_REMOTE_CONNECTIONS      "pmix.srvr.remote"      // (bool) Allow connections from remote tools (do not use loopback device)
 #define PMIX_SERVER_SYSTEM_SUPPORT          "pmix.srvr.sys"         // (bool) The host RM wants to declare itself as being the local
                                                                     //        system server for PMIx connection requests
+#define PMIX_SERVER_SESSION_SUPPORT         "pmix.srvr.sess"        // (bool) The host RM wants to declare itself as being the local
+                                                                    //        session server for PMIx connection requests
 #define PMIX_SERVER_TMPDIR                  "pmix.srvr.tmpdir"      // (char*) temp directory where PMIx server will place
                                                                     //        client rendezvous points and contact info
 #define PMIX_SYSTEM_TMPDIR                  "pmix.sys.tmpdir"       // (char*) temp directory for this system, where PMIx
@@ -181,6 +183,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_RECONNECT_SERVER               "pmix.cnct.recon"       // (bool) tool is requesting to change server connections
 #define PMIX_LAUNCHER                       "pmix.tool.launcher"    // (bool) tool is a launcher and needs rendezvous files created
 #define PMIX_LAUNCHER_RENDEZVOUS_FILE       "pmix.tool.lncrnd"      // (char*) Pathname of file where connection info is to be stored
+#define PMIX_TOOL_ATTACHMENT_FILE           "pmix.tool.attach"      // (char*) File containing connection info to be used for attaching to server
+
 
 /* identification attributes */
 #define PMIX_USERID                         "pmix.euid"             // (uint32_t) effective user id

--- a/src/mca/pfexec/base/base.h
+++ b/src/mca/pfexec/base/base.h
@@ -59,7 +59,7 @@ typedef struct {
 typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
-    pmix_rank_t rank;
+    pmix_proc_t proc;
     pid_t pid;
     bool completed;
     int exitcode;
@@ -74,7 +74,7 @@ typedef struct {
     bool active;
     pmix_list_t children;
     int timeout_before_sigkill;
-    size_t next;
+    size_t nextid;
     bool selected;
 } pmix_pfexec_globals_t;
 
@@ -91,6 +91,7 @@ typedef pmix_status_t (*pmix_pfexec_base_signal_local_fn_t)(pid_t pd, int signum
 typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
+    pmix_nspace_t nspace;
     const pmix_info_t *jobinfo;
     size_t njinfo;
     const pmix_app_t *apps;
@@ -103,7 +104,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_fork_caddy_t);
 typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
-    pmix_rank_t rank;
+    pmix_proc_t *proc;
     int signal;
     pmix_pfexec_base_signal_local_fn_t sigfn;
     pmix_lock_t *lock;
@@ -137,7 +138,7 @@ PMIX_EXPORT void pmix_pfexec_check_complete(int sd, short args, void *cbdata);
 #define PMIX_PFEXEC_KILL(scd, r, fn, lk)                                    \
     do {                                                                    \
         (scd) = PMIX_NEW(pmix_pfexec_signal_caddy_t);                       \
-        (scd)->rank = (r);                                                  \
+        (scd)->proc = (r);                                                  \
         (scd)->sigfn = (fn);                                                \
         (scd)->lock = (lk);                                                 \
         pmix_event_assign(&((scd)->ev), pmix_globals.evbase, -1,            \
@@ -149,7 +150,7 @@ PMIX_EXPORT void pmix_pfexec_check_complete(int sd, short args, void *cbdata);
 #define PMIX_PFEXEC_SIGNAL(scd, r, nm, fn, lk)                              \
     do {                                                                    \
         (scd) = PMIX_NEW(pmix_pfexec_signal_caddy_t);                       \
-        (scd)->rank = (r);                                                  \
+        (scd)->proc = (r);                                                  \
         (scd)->signal = (nm);                                               \
         (scd)->sigfn = (fn);                                                \
         (scd)->lock = (lk);                                                 \

--- a/src/mca/pfexec/pfexec.h
+++ b/src/mca/pfexec/pfexec.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,26 +42,27 @@ BEGIN_C_DECLS
  */
 
 /**
- * Locally fork/exec the provided process
+ * Locally fork/exec the provided job
  */
-typedef pmix_status_t (*pmix_pfexec_base_module_spawn_process_fn_t)(const pmix_info_t job_info[], size_t ninfo,
-                                                                    const pmix_app_t apps[], size_t napps);
+typedef pmix_status_t (*pmix_pfexec_base_module_spawn_job_fn_t)(const pmix_info_t job_info[], size_t ninfo,
+                                                                const pmix_app_t apps[], size_t napps,
+                                                                pmix_nspace_t nspace);
 
 /**
  * Kill the local process we started
  */
-typedef pmix_status_t (*pmix_pfexec_base_module_kill_process_fn_t)(pmix_rank_t rank);
+typedef pmix_status_t (*pmix_pfexec_base_module_kill_process_fn_t)(pmix_proc_t *proc);
 
 /**
  * Signal local process we started
  */
-typedef pmix_status_t (*pmix_pfexec_base_module_signal_process_fn_t)(pmix_rank_t rank, int signum);
+typedef pmix_status_t (*pmix_pfexec_base_module_signal_process_fn_t)(pmix_proc_t *proc, int signum);
 
 /**
  * pfexec module version
  */
 typedef struct {
-    pmix_pfexec_base_module_spawn_process_fn_t       spawn_proc;
+    pmix_pfexec_base_module_spawn_job_fn_t           spawn_job;
     pmix_pfexec_base_module_kill_process_fn_t        kill_proc;
     pmix_pfexec_base_module_signal_process_fn_t      signal_proc;
 } pmix_pfexec_base_module_t;

--- a/src/util/os_dirpath.h
+++ b/src/util/os_dirpath.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,7 +99,7 @@ typedef bool (*pmix_os_dirpath_destroy_callback_fn_t)(const char *root, const ch
  * Destroy a directory
  *
  * @param path A pointer to a string that contains the path name to be destroyed
- * @param recursive Recursively desend the directory removing all files and directories.
+ * @param recursive Recursively descend the directory removing all files and directories.
  *                  if set to 'false' then the directory must be empty to succeed.
  * @param cbfunc A function that will be called before removing a file or directory.
  *               If NULL, then assume all remove.


### PR DESCRIPTION
Fix the internal fork/exec support so it can return the nspace of the
spawned child job. Ensure we give each child job a unique nspace.

Separate rendezvous file generation from attachment to allow for
chaining of connections (e.g., debugger -> launcher -> DVM)

Ensure we cleanup completely upon terminating a tool/server that has
dropped rendezvous files

Signed-off-by: Ralph Castain <rhc@pmix.org>