### PR TITLE
Fix race condition between pfexec and iof

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1189,7 +1189,7 @@ void pmix_iof_read_local_handler(int unusedfd, short event, void *cbdata)
         bo.bytes = (char*)data;
         bo.size = numbytes;
         pmix_iof_write_output(&rev->name, rev->channel, &bo, NULL);
-        if (0 == numbytes) {
+        if (0 == numbytes && child->completed) {
             PMIX_PFEXEC_CHK_COMPLETE(child);
             return;
         }

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -283,7 +283,7 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
     /* find the process */
     child = NULL;
     PMIX_LIST_FOREACH(cd, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
-        if (PMIX_CHECK_PROCID(scd->proc, &child->proc)) {
+        if (PMIX_CHECK_PROCID(scd->proc, &cd->proc)) {
             child = cd;
             break;
         }
@@ -357,7 +357,7 @@ void pmix_pfexec_base_signal_proc(int sd, short args, void *cbdata)
     /* find the process */
     child = NULL;
     PMIX_LIST_FOREACH(cd, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
-        if (PMIX_CHECK_PROCID(scd->proc, &child->proc)) {
+        if (PMIX_CHECK_PROCID(scd->proc, &cd->proc)) {
             child = cd;
             break;
         }

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -307,7 +307,6 @@ static void send_error_show_help(int fd, int exit_status,
 /* close all open file descriptors w/ exception of stdin/stdout/stderr
    and the pipe up to the parent. */
 static int close_open_file_descriptors(int write_fd) {
-    return PMIX_SUCCESS;
     DIR *dir = opendir("/proc/self/fd");
     if (NULL == dir) {
         return PMIX_ERR_FILE_OPEN_FAILURE;


### PR DESCRIPTION
Only remove the child object once from the tracker list

Signed-off-by: Ralph Castain <rhc@pmix.org>