### PR TITLE
Check for active event before deleting

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1189,7 +1189,9 @@ void pmix_iof_read_local_handler(int unusedfd, short event, void *cbdata)
         bo.bytes = (char*)data;
         bo.size = numbytes;
         pmix_iof_write_output(&rev->name, rev->channel, &bo, NULL);
-        if (0 == numbytes && child->completed) {
+        if (0 == numbytes && child->completed &&
+            (NULL == child->stdoutev || !child->stdoutev->active) &&
+            (NULL == child->stderrev || !child->stderrev->active)) {
             PMIX_PFEXEC_CHK_COMPLETE(child);
             return;
         }

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1313,7 +1313,9 @@ static void iof_read_event_construct(pmix_iof_read_event_t* rev)
 }
 static void iof_read_event_destruct(pmix_iof_read_event_t* rev)
 {
-    pmix_event_del(&rev->ev);
+    if (rev->active) {
+        pmix_event_del(&rev->ev);
+    }
     if (0 <= rev->fd) {
         PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
                              "%s iof: closing fd %d",
@@ -1344,14 +1346,16 @@ static void iof_write_event_construct(pmix_iof_write_event_t* wev)
 }
 static void iof_write_event_destruct(pmix_iof_write_event_t* wev)
 {
-    pmix_event_del(&wev->ev);
+    if (wev->pending) {
+        pmix_event_del(&wev->ev);
+    }
     if (2 < wev->fd) {
         PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
                              "%s iof: closing fd %d for write event",
                              PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd));
         close(wev->fd);
     }
-    PMIX_DESTRUCT(&wev->outputs);
+    PMIX_LIST_DESTRUCT(&wev->outputs);
 }
 PMIX_CLASS_INSTANCE(pmix_iof_write_event_t,
                     pmix_list_item_t,

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -137,7 +137,7 @@ pmix_iof_fd_always_ready(int fd)
         PMIX_POST_OBJECT(wev);                                          \
         if (wev->always_writable) {                                     \
             /* Regular is always write ready. Use timer to activate */  \
-            tv = &wev->tv;                                        \
+            tv = &wev->tv;                                              \
         }                                                               \
         if (pmix_event_add(&wev->ev, tv)) {                             \
             PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);                         \

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -230,6 +230,7 @@ static void chcon(pmix_pfexec_child_t *p)
     p->stdoutev = NULL;
     p->stderrev = NULL;
     p->pid = 0;
+    p->completed = false;
 }
 static void chdes(pmix_pfexec_child_t *p)
 {


### PR DESCRIPTION
libevent can get upset if you delete an event that is not active

Fix IOF race condition
Ensure we only call "check_complete" once both stdout **and** stderr read
events have terminated.

Signed-off-by: Ralph Castain <rhc@pmix.org>