### PR TITLE
Pass additional required values

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -458,6 +458,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //         local processes
 #define PMIX_TIMEOUT_STACKTRACES            "pmix.tim.stack"        // (bool) include process stacktraces in timeout report from a job
 #define PMIX_TIMEOUT_REPORT_STATE           "pmix.tim.state"        // (bool) report process states in timeout report from a job
+#define PMIX_APP_ARGV                       "pmix.app.argv"         // (char*) consolidated argv passed to the spawn command for the given app
+
 
 /* query attributes */
 #define PMIX_QUERY_REFRESH_CACHE            "pmix.qry.rfsh"         // (bool) retrieve updated information from server

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -539,6 +539,9 @@ static inline bool pmix_check_app_info(const char* key)
 {
     char *keys[] = {
         PMIX_APP_SIZE,
+        PMIX_APPLDR,
+        PMIX_APP_ARGV,
+        PMIX_WDIR,
         NULL
     };
     size_t n;


### PR DESCRIPTION
Ensure the programming models get updated with client and nspace info.
Add attribute for passing the original cmd line for an app.

Signed-off-by: Ralph Castain <rhc@pmix.org>