### PR TITLE
Fix a race condition during finalize

### DIFF
--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -65,12 +65,12 @@ pmix_pfexec_globals_t pmix_pfexec_globals = {0};
 
 static int pmix_pfexec_base_close(void)
 {
-    PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
     if (pmix_pfexec_globals.active) {
         pmix_event_del(pmix_pfexec_globals.handler);
+        pmix_pfexec_globals.active = false;
     }
+    PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
     free(pmix_pfexec_globals.handler);
-    pmix_pfexec_globals.active = false;
     pmix_pfexec_globals.selected = false;
 
     return pmix_mca_base_framework_components_close(&pmix_pfexec_base_framework, NULL);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1284,6 +1284,10 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         /* if we have launched children, then we need to cleanly
          * terminate them - do this before stopping our progress
          * thread as we need it for terminating procs */
+        if (pmix_pfexec_globals.active) {
+            pmix_event_del(pmix_pfexec_globals.handler);
+            pmix_pfexec_globals.active = false;
+        }
         PMIX_LIST_FOREACH(child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
             pmix_pfexec.kill_proc(&child->proc);
         }


### PR DESCRIPTION
Ensure the sigchld event has been stopped prior to dismantling the list
of pfexec children

 Take a shot at fixing the prun-prte connection creation
Give prte a little more time to create the rendezvous file. Resolve a
race condition where the file may have been created, but prte hasn't yet
had a chance to write its rendezvous info into it.

Signed-off-by: Ralph Castain <rhc@pmix.org>