### PR TITLE
WIP: Generating a pkg-config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ config/autogen_found_items.m4
 config/py-compile
 config/mca_library_paths.txt
 
+maint/pmix.pc
+
 bindings/python/pmix.c
 bindings/python/*.so
 bindings/python/build/

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,3 +60,6 @@ nroff:
 
 dist-hook:
 	env LS_COLORS= sh "$(top_srcdir)/config/distscript.sh" "$(top_srcdir)" "$(distdir)" "$(PMIX_VERSION)" "$(PMIX_REPO_REV)"
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = maint/pmix.pc

--- a/config/pmix_setup_libev.m4
+++ b/config/pmix_setup_libev.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
@@ -79,8 +79,8 @@ AC_DEFUN([PMIX_LIBEV_CONFIG],[
                  [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libev_CPPFLAGS)
                   PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libev_CPPFLAGS)])
            AS_IF([test "$pmix_libev_standard_lib_location" != "yes"],
-                 [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
-                  PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)])])
+                 [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libev_LDFLAGS)
+                  PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libev_LDFLAGS)])])
 
     AC_MSG_CHECKING([will libev support be built])
     if test $pmix_libev_support -eq 1; then

--- a/configure.ac
+++ b/configure.ac
@@ -260,6 +260,24 @@ AC_MSG_CHECKING([final LIBS])
 AC_MSG_RESULT([$LIBS])
 
 ####################################################################
+# Setup variables for pkg-config file (maint/pmix.pc.in)
+####################################################################
+
+#
+# Dependencies that themselves have a pkg-config file available.
+#
+PC_REQUIRES="hwloc libevent"
+AC_SUBST([PC_REQUIRES], ["$PC_REQUIRES"])
+
+#
+# Dependencies that don't have a pkg-config file available.
+# In this case we need to manually add -L<path> and -l<lib>
+# to the PC_PRIVATE_LIBS variable.
+#
+PC_PRIVATE_LIBS=""
+AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
+
+####################################################################
 # -Werror for CI scripts
 ####################################################################
 
@@ -289,7 +307,8 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[examples/Makefile]
                 pmix_config_prefix[test/Makefile]
                 pmix_config_prefix[test/simple/Makefile]
-                pmix_config_prefix[test/python/Makefile])
+                pmix_config_prefix[test/python/Makefile]
+                pmix_config_prefix[maint/pmix.pc])
 
 pmix_show_title "Configuration complete"
 

--- a/configure.ac
+++ b/configure.ac
@@ -266,13 +266,11 @@ AC_MSG_RESULT([$LIBS])
 #
 # Dependencies that themselves have a pkg-config file available.
 #
-PC_REQUIRES=
+PC_REQUIRES=""
 AS_IF([test "$pmix_hwloc_support_will_build" = "yes"],
       [PC_REQUIRES="$PC_REQUIRES hwloc"])
-AS_IF([test $pmix_libev_support -eq 1],
-      [PC_REQUIRES="$PC_REQUIRES libev"])
 AS_IF([test $pmix_libevent_support -eq 1],
-      [PC_REQUIRES="$PC_REQUIRES libevevent"])
+      [PC_REQUIRES="$PC_REQUIRES libevent"])
 AS_IF([test "$pmix_zlib_support" = "1"],
       [PC_REQUIRES="$PC_REQUIRES zlib"])
 AC_SUBST([PC_REQUIRES], ["$PC_REQUIRES"])
@@ -283,6 +281,8 @@ AC_SUBST([PC_REQUIRES], ["$PC_REQUIRES"])
 # to the PC_PRIVATE_LIBS variable.
 #
 PC_PRIVATE_LIBS=""
+AS_IF([test $pmix_libev_support -eq 1],
+      [PC_PRIVATE_LIBS="$PC_PRIVATE_LIBS $pmix_libev_LDFLAGS $pmix_libev_LIBS"])
 AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
 
 ####################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -266,7 +266,15 @@ AC_MSG_RESULT([$LIBS])
 #
 # Dependencies that themselves have a pkg-config file available.
 #
-PC_REQUIRES="hwloc libevent"
+PC_REQUIRES=
+AS_IF([test "$pmix_hwloc_support_will_build" = "yes"],
+      [PC_REQUIRES="$PC_REQUIRES hwloc"])
+AS_IF([test $pmix_libev_support -eq 1],
+      [PC_REQUIRES="$PC_REQUIRES libev"])
+AS_IF([test $pmix_libevent_support -eq 1],
+      [PC_REQUIRES="$PC_REQUIRES libevevent"])
+AS_IF([test "$pmix_zlib_support" = "1"],
+      [PC_REQUIRES="$PC_REQUIRES zlib"])
 AC_SUBST([PC_REQUIRES], ["$PC_REQUIRES"])
 
 #

--- a/maint/pmix.pc.in
+++ b/maint/pmix.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: pmix
+Description: Process Management Interface for Exascale (PMIx)
+Version: @PACKAGE_VERSION@
+URL: https://pmix.org/
+Requires: @PC_REQUIRES@
+Libs: -L${libdir} -pmix @PC_PRIVATE_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR adds the generation and installation of a pmix.pc file which would allow the PMIx libs and cflags (as well as its dependencies) to be found by pkg-config.

At the moment the generated pmix.pc file contains hard-coded dependencies to hwloc and libevent, so it is appropriate for use only when PMIx is installed with hwloc and libevent support. These dependencies are hard-coded in configure.ac (lines 262 to 279).

The next step would be to make these variables depend on what is actually needed (i.e. not add hwloc if it's not enabled, add the libev libraries instead of libevent if PMIx is compiled with libev, etc.)