### PR TITLE
Ensure notification upon connect and fix PMIx_Init return code

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -291,6 +291,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_NETWORK_SHAPE                  "pmix.net.shape"        // (pmix_data_array_t*) number of interfaces (uint32_t) on each dimension of the
                                                                     //        specified network plane in the requested view
 #define PMIX_NETWORK_SHAPE_STRING           "pmix.net.shapestr"     // (char*) network shape expressed as a string (e.g., "10x12x2")
+#define PMIX_SWITCH_PEERS                   "pmix.speers"           // (char*) comma-delimited string of peers that share the same switch as the proc
+                                                                    //         specified in the call to PMIx_Get. Multi-NIC environments will return
+                                                                    //         an array of results, each element containing the NIC and the list of
+                                                                    //         peers sharing the switch to which that NIC is connected.
 
 /* size info */
 #define PMIX_UNIV_SIZE                      "pmix.univ.size"        // (uint32_t) #procs in this nspace

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -684,6 +684,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return rc;
         }
+        rc = PMIX_ERR_UNREACH;
     } else {
         /* connect to the server */
         rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -460,9 +460,7 @@ static pmix_status_t process_node_array(pmix_value_t *val,
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kp2);
-                if (NULL != nd) {
-                    PMIX_RELEASE(nd);
-                }
+                PMIX_RELEASE(nd);
                 PMIX_LIST_DESTRUCT(&cache);
                 return rc;
             }


### PR DESCRIPTION
Ensure we check cached notifications upon tool or client connection.
Properly return UNREACH error status from PMIx_Init when no server is
detected so the caller can decide if they want to proceed or terminate.
Silence a Coverity warning in gds/hash.

Signed-off-by: Ralph Castain <rhc@pmix.org>