### PR TITLE
Pass nspace/rank on fork/exec and cleanup notify

### DIFF
--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -240,12 +240,22 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
 
             /* we only support fork/exec of tools and servers - not
              * applications. So we don't need to setup anything
-             * special in their environment except for hostname
-             * and version  */
+             * special in their environment except for hostname,
+             * nspace/rank, and version so that the child matches
+             * our expectations */
             env = pmix_argv_copy(app->env);
             /* ensure we agree on our hostname - typically only important in
              * test scenarios where we are faking multiple nodes */
             pmix_setenv("PMIX_HOSTNAME", pmix_globals.hostname, true, &env);
+
+            /* communicate the assigned nspace/rank - could be a server too */
+            pmix_setenv("PMIX_NAMESPACE", child->proc.nspace, true, &env);
+            pmix_setenv("PMIX_SERVER_NSPACE", child->proc.nspace, true, &env);
+            /* communicate the assigned rank */
+            pmix_asprintf(&tmp, "%u", child->proc.rank);
+            pmix_setenv("PMIX_RANK", tmp, true, &env);
+            pmix_setenv("PMIX_SERVER_RANK", tmp, true, &env);
+            free(tmp);
 
             /* communicate our version */
             pmix_setenv("PMIX_VERSION", PMIX_VERSION, true, &env);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -302,7 +302,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_SERVER_NSPACE, PMIX_MAX_KEYLEN)) {
-                pmix_strncpy(pmix_globals.myid.nspace, info[n].value.data.string, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, info[n].value.data.string);
                 nspace_given = true;
             } else if (0 == strncmp(info[n].key, PMIX_SERVER_RANK, PMIX_MAX_KEYLEN)) {
                 pmix_globals.myid.rank = info[n].value.data.rank;
@@ -340,9 +340,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         /* look for our namespace, if one was given */
         if (NULL == (evar = getenv("PMIX_SERVER_NAMESPACE"))) {
             /* use a fake namespace */
-            pmix_strncpy(pmix_globals.myid.nspace, "pmix-server", PMIX_MAX_NSLEN);
+            PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, "pmix-server");
         } else {
-            pmix_strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
+            pmix_output(0, "NSPACE FROM ENV %s", evar);
+            PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, evar);
         }
     }
     if (!rank_given) {


### PR DESCRIPTION
Pass nspace/rank to the fork/exec'd child, taking into account it could
be a server. Add lots of verbose debugging output to the event
notification code for debugging purposes

Signed-off-by: Ralph Castain <rhc@pmix.org>