### PR TITLE
Silence errors coming out of libtool config check

### DIFF
--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -132,14 +132,20 @@ AC_DEFUN([PMIX_LIBTOOL_CONFIG],[
 
 # Slurp in the libtool config into my environment
 
-# Apparently, "libtoool --config" calls "exit", so we can't source it
+# Apparently, "libtool --config" calls "exit", so we can't source it
 # (because if script A sources script B, and B calls "exit", then both
 # B and A will exit).  Instead, we have to send the output to a file
 # and then source that.
-libtool $3 --config > $rpath_outfile
-
-chmod +x $rpath_outfile
-. ./$rpath_outfile
+pmix_eval="libtool --config 2>&1 > /dev/null"
+pmix_found=`eval $pmix_eval`
+status=$?
+if test "$status" = "0"; then
+    libtool $3 --config 2>&1 > $rpath_outfile
+    chmod +x $rpath_outfile
+    . ./$rpath_outfile
+else
+    exit 1
+fi
 rm -f $rpath_outfile
 
 # Evaluate \$$1, and substitute in LIBDIR for \$libdir


### PR DESCRIPTION
When running on a Mac, Apple's libtool does not support the "--config"
option. This leads to configure generating an error that can be
misleading. We _could_ use "glibtool" to perform the check, but we are
actually using Apple's libtool to do the build, so best to just silently
return the error

Signed-off-by: Ralph Castain <rhc@pmix.org>