### PR TITLE
configure: use -iquote for non-system include paths

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -4,7 +4,7 @@
 # Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      IBM Corporation.  All rights reserved.
@@ -275,7 +275,7 @@ sub mca_generate_framework_header(\$\@) {
 #ifndef $ifdef_string
 #define $ifdef_string
 
-#include <src/mca/base/pmix_mca_base_framework.h>
+#include \"src/mca/base/pmix_mca_base_framework.h\"
 
 $framework_decl_output
 static pmix_mca_base_framework_t *pmix_frameworks[] = {

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -873,10 +873,12 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         # rather than have successive assignments to these shell
         # variables, lest the $(foo) names try to get evaluated here.
         # Yuck!
-        CPPFLAGS="-I$PMIX_top_builddir -I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_builddir/include -I$PMIX_top_srcdir/include $CPPFLAGS"
+        cpp_includes="$PMIX_top_builddir $PMIX_top_srcdir $PMIX_top_srcdir/src $PMIX_top_builddir/include"
     else
-        CPPFLAGS="-I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_srcdir/include $CPPFLAGS"
+        cpp_includes="$PMIX_top_srcdir $PMIX_top_srcdir/src"
     fi
+    CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
+    CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
 
     ############################################################################
     # final wrapper compiler config

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -16,7 +16,7 @@ dnl Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
-dnl Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -120,6 +120,28 @@ AC_DEFUN([PMIX_PROG_CC_C11],[
 ])
 
 
+# PMIX_CHECK_CC_IQUOTE()
+# ----------------------
+# Check if the compiler supports the -iquote option. This options
+# removes the specified directory from the search path when using
+# #include <>. This check works around an issue caused by C++20
+# which added a <version> header. This conflicts with the
+# VERSION file at the base of our source directory on case-
+# insensitive filesystems.
+AC_DEFUN([PMIX_CHECK_CC_IQUOTE],[
+    PMIX_VAR_SCOPE_PUSH([pmix_check_cc_iquote_CFLAGS_save])
+    pmix_check_cc_iquote_CFLAGS_save=${CFLAGS}
+    CFLAGS="${CFLAGS} -iquote ."
+    AC_MSG_CHECKING([for $CC option to add a directory only to the search path for the quote form of include])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[])],
+              [pmix_cc_iquote="-iquote"],
+              [pmix_cc_iquote="-I"])
+    CFLAGS=${pmix_check_cc_iquote_CFLAGS_save}
+    PMIX_VAR_SCOPE_POP
+    AC_MSG_RESULT([$pmix_cc_iquote])
+])
+
+
 # PMIX_SETUP_CC()
 # ---------------
 # Do everything required to setup the C compiler.  Safe to AC_REQUIRE
@@ -141,6 +163,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
     AC_SUBST([WRAPPER_CC])
 
     PMIX_PROG_CC_C11
+    PMIX_CHECK_CC_IQUOTE
 
     if test $pmix_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the

--- a/configure.ac
+++ b/configure.ac
@@ -143,11 +143,11 @@ AH_TOP([/* -*- c -*-
 #ifndef PMIX_CONFIG_H
 #define PMIX_CONFIG_H
 
-#include <src/include/pmix_config_top.h>
+#include "src/include/pmix_config_top.h"
 
 ])
 AH_BOTTOM([
-#include <src/include/pmix_config_bottom.h>
+#include "src/include/pmix_config_bottom.h"
 #endif /* PMIX_CONFIG_H */
 ])
 

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -24,8 +24,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "../include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/server.c
+++ b/examples/server.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -25,10 +25,10 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_server.h>
-#include <src/include/types.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_config.h"
+#include "../include/pmix_server.h"
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/include/pmix_extend.h
+++ b/include/pmix_extend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
@@ -62,18 +62,6 @@
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {
 #endif
-
-/* declare a convenience macro for checking keys */
-#define PMIX_CHECK_KEY(a, b) \
-    (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
-
-/* define a convenience macro for checking nspaces */
-#define PMIX_CHECK_NSPACE(a, b) \
-    (0 == strncmp((a), (b), PMIX_MAX_NSLEN))
-
-/* define a convenience macro for checking names */
-#define PMIX_CHECK_PROCID(a, b) \
-    (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
 
 /* expose some functions that are resolved in the
  * PMIx library, but part of a header that

--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -21,12 +21,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <limits.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/class/pmix_bitmap.h"
 
 /* The number of bits in the underlying type of the bitmap field

--- a/src/class/pmix_bitmap.h
+++ b/src/class/pmix_bitmap.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +41,7 @@
 #ifndef PMIX_BITMAP_H
 #define PMIX_BITMAP_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -34,8 +34,8 @@
 #ifndef PMIX_HASH_TABLE_H
 #define PMIX_HASH_TABLE_H
 
-#include <src/include/pmix_config.h>
-#include <src/include/prefetch.h>
+#include "src/include/pmix_config.h"
+#include "src/include/prefetch.h"
 
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
@@ -43,7 +43,7 @@
 
 #include "src/class/pmix_list.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <stddef.h>

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
@@ -55,9 +55,9 @@
 #ifndef PMIX_HOTEL_H
 #define PMIX_HOTEL_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/include/prefetch.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/class/pmix_object.h"
 #include PMIX_EVENT_HEADER

--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "include/pmix_common.h"
 #include "src/class/pmix_list.h"
 

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@
 #ifndef PMIX_LIST_H
 #define PMIX_LIST_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #if HAVE_STDBOOL_H

--- a/src/class/pmix_object.c
+++ b/src/class/pmix_object.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -25,7 +25,7 @@
  * Implementation of pmix_object_t, the base pmix foundation class
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 /* Symbol transforms */
 
 

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -120,8 +120,8 @@
 #ifndef PMIX_OBJECT_H
 #define PMIX_OBJECT_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <assert.h>
 #ifdef HAVE_STDLIB_H

--- a/src/class/pmix_pointer_array.c
+++ b/src/class/pmix_pointer_array.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/class/pmix_ring_buffer.c
+++ b/src/class/pmix_ring_buffer.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,13 +19,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/class/pmix_ring_buffer.h"
 #include "src/util/output.h"
 

--- a/src/class/pmix_ring_buffer.h
+++ b/src/class/pmix_ring_buffer.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +25,7 @@
 #ifndef PMIX_RING_BUFFER_H
 #define PMIX_RING_BUFFER_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
 #include "src/util/output.h"

--- a/src/class/pmix_value_array.c
+++ b/src/class/pmix_value_array.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_value_array.h"
 

--- a/src/class/pmix_value_array.h
+++ b/src/class/pmix_value_array.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
 #ifndef PMIX_VALUE_ARRAY_H
 #define PMIX_VALUE_ARRAY_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_STRINGS_H
@@ -31,7 +31,7 @@
 #if PMIX_ENABLE_DEBUG
 #include "src/util/output.h"
 #endif
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -12,10 +12,10 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix.h>
-#include <pmi.h>
+#include "include/pmix.h"
+#include "include/pmi.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -12,7 +12,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>
@@ -25,8 +25,8 @@
 #endif
 #include PMIX_EVENT_HEADER
 
-#include <pmi2.h>
-#include <pmix.h>
+#include "include/pmi2.h"
+#include "include/pmix.h"
 
 #include "src/mca/bfrops/bfrops.h"
 #include "src/util/argv.h"

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -15,13 +15,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
 #ifndef PMIX_CLIENT_OPS_H
 #define PMIX_CLIENT_OPS_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/threads/threads.h"

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -10,12 +10,12 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/gds/base/base.h"

--- a/src/common/pmix_attributes.h
+++ b/src/common/pmix_attributes.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -32,7 +32,7 @@
 #ifndef PMIX_ATTRIBUTES_H
 #define PMIX_ATTRIBUTES_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -12,15 +12,15 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/argv.h"

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STRING_H
@@ -31,8 +31,8 @@
 #include <stdlib.h>
 #endif
 
-#include <pmix.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_rename.h"
 
 #include "src/mca/bfrops/bfrops.h"
 #include "src/include/pmix_globals.h"

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -12,7 +12,7 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
@@ -22,13 +22,13 @@
 #endif
 #endif
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/argv.h"

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -32,7 +32,7 @@
 #ifndef PMIX_IOF_H
 #define PMIX_IOF_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -12,15 +12,15 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/argv.h"

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -12,15 +12,15 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/argv.h"

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -12,15 +12,15 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/argv.h"

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STRING_H
@@ -33,8 +33,8 @@
 #include <stdlib.h>
 #endif
 
-#include <pmix_common.h>
-#include <pmix_rename.h>
+#include "include/pmix_common.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -22,11 +22,11 @@
 #ifndef PMIX_EVENT_H
 #define PMIX_EVENT_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/include/types.h"
 #include PMIX_EVENT_HEADER
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/class/pmix_list.h"
 #include "src/util/output.h"
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -11,12 +11,12 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/error.h"

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -9,12 +9,12 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix.h>
-#include <pmix_common.h>
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 
 #include "src/threads/threads.h"
 #include "src/util/error.h"

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -18,8 +18,8 @@
 #define PMIX_HWLOC_INTERNAL_H
 
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #if PMIX_HAVE_HWLOC
 #include PMIX_HWLOC_HEADER

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      Inria.  All rights reserved.
  * $COPYRIGHT$
@@ -9,8 +9,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -359,10 +359,10 @@
    including stdint.h */
 #define __STDC_LIMIT_MACROS
 #endif
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include <stdint.h>
 #else
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 #endif
 
 /***********************************************************************

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -17,12 +17,12 @@
 
 /* THIS FILE IS INCLUDED SOLELY TO INSTANTIATE AND INIT/FINALIZE THE GLOBAL CLASSES */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
-#include <src/include/types.h>
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "include/pmix_common.h"
+#include "src/include/types.h"
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
 #include "src/include/pmix_globals.h"
 
@@ -45,7 +45,7 @@
 #include <dirent.h>
 #endif  /* HAVE_DIRENT_H */
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/bfrops/bfrops_types.h"
 #include "src/class/pmix_hash_table.h"

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -25,11 +25,11 @@
 #ifndef PMIX_GLOBALS_H
 #define PMIX_GLOBALS_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
-#include <src/include/types.h>
+#include "src/include/types.h"
 
 #include <unistd.h>
 #ifdef HAVE_SYS_TYPES_H
@@ -37,8 +37,8 @@
 #endif
 #include PMIX_EVENT_HEADER
 
-#include <pmix.h>
-#include <pmix_common.h>
+#include "include/pmix.h"
+#include "include/pmix_common.h"
 
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"

--- a/src/include/prefetch.h
+++ b/src/include/prefetch.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
 #ifndef PMIX_PREFETCH_H
 #define PMIX_PREFETCH_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #if PMIX_C_HAVE_BUILTIN_EXPECT
 #define PMIX_LIKELY(expression) __builtin_expect(!!(expression), 1)

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
@@ -24,7 +24,7 @@
 #ifndef PMIX_TYPES_H
 #define PMIX_TYPES_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_STDINT_H
 #include <stdint.h>

--- a/src/mca/base/base.h
+++ b/src/mca/base/base.h
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 #ifndef PMIX_MCA_BASE_H
 #define PMIX_MCA_BASE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/base/pmix_mca_base_close.c
+++ b/src/mca/base/pmix_mca_base_close.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,13 +21,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 extern int pmix_mca_base_opened;
 

--- a/src/mca/base/pmix_mca_base_cmd_line.c
+++ b/src/mca/base/pmix_mca_base_cmd_line.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -28,7 +28,7 @@
 #include "src/util/pmix_environ.h"
 #include "src/util/show_help.h"
 #include "src/mca/base/base.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 
 /*

--- a/src/mca/base/pmix_mca_base_component_compare.c
+++ b/src/mca/base/pmix_mca_base_component_compare.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -55,7 +55,7 @@
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/pdl/base/base.h"
 
 #if PMIX_HAVE_PDL_SUPPORT

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@
  */
 
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -40,7 +40,7 @@
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
 #include "src/mca/pdl/base/base.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/class/pmix_hash_table.h"
 #include "src/util/basename.h"
 #include "src/util/show_help.h"

--- a/src/mca/base/pmix_mca_base_component_repository.h
+++ b/src/mca/base/pmix_mca_base_component_repository.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +37,7 @@
 #ifndef PMIX_MCA_BASE_COMPONENT_REPOSITORY_H
 #define PMIX_MCA_BASE_COMPONENT_REPOSITORY_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/pdl/pdl.h"
 #include "src/mca/pdl/base/base.h"

--- a/src/mca/base/pmix_mca_base_components_close.c
+++ b/src/mca/base/pmix_mca_base_components_close.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,14 +20,14 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 void pmix_mca_base_component_unload (const pmix_mca_base_component_t *component, int output_id)
 {

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -34,7 +34,7 @@
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 /*
  * Local functions

--- a/src/mca/base/pmix_mca_base_components_register.c
+++ b/src/mca/base/pmix_mca_base_components_register.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -36,7 +36,7 @@
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_framework.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 /*
  * Local functions

--- a/src/mca/base/pmix_mca_base_components_select.c
+++ b/src/mca/base/pmix_mca_base_components_select.c
@@ -5,7 +5,7 @@
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -28,7 +28,7 @@
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 
 int pmix_mca_base_select(const char *type_name, int output_id,

--- a/src/mca/base/pmix_mca_base_framework.c
+++ b/src/mca/base/pmix_mca_base_framework.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 
 #include "pmix_mca_base_framework.h"

--- a/src/mca/base/pmix_mca_base_framework.h
+++ b/src/mca/base/pmix_mca_base_framework.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
 
 #if !defined(PMIX_MCA_BASE_FRAMEWORK_H)
 #define PMIX_MCA_BASE_FRAMEWORK_H
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/base/pmix_mca_base_list.c
+++ b/src/mca/base/pmix_mca_base_list.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/base/base.h"

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -38,7 +38,7 @@
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/pmix_environ.h"
 
 /*

--- a/src/mca/base/pmix_mca_base_parse_paramfile.c
+++ b/src/mca/base/pmix_mca_base_parse_paramfile.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -46,7 +46,7 @@
 #include "src/util/error.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_vari.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,7 +60,7 @@
 #ifndef PMIX_MCA_BASE_VAR_H
 #define PMIX_MCA_BASE_VAR_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_value_array.h"

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/base/pmix_mca_base_var_enum.h"
 #include "src/mca/base/base.h"

--- a/src/mca/base/pmix_mca_base_var_enum.h
+++ b/src/mca/base/pmix_mca_base_var_enum.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,10 +24,10 @@
 #if !defined(PMIX_MCA_BASE_VAR_ENUM_H)
 #define PMIX_MCA_BASE_VAR_ENUM_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 typedef struct pmix_mca_base_var_enum_t pmix_mca_base_var_enum_t;
 

--- a/src/mca/base/pmix_mca_base_var_group.c
+++ b/src/mca/base/pmix_mca_base_var_group.c
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -38,7 +38,7 @@
 #include "src/util/show_help.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_vari.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 

--- a/src/mca/base/pmix_mca_base_vari.h
+++ b/src/mca/base/pmix_mca_base_vari.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +37,7 @@
 #ifndef PMIX_MCA_BASE_VAR_INTERNAL_H
 #define PMIX_MCA_BASE_VAR_INTERNAL_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -26,7 +26,7 @@
 #ifndef PMIX_BFROP_BASE_H_
 #define PMIX_BFROP_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/util/argv.h"

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <stdio.h>

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <stdio.h>

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -21,9 +21,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
 #include <stdio.h>
 #ifdef HAVE_TIME_H

--- a/src/mca/bfrops/base/bfrop_base_select.c
+++ b/src/mca/bfrops/base/bfrop_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <stdio.h>

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -22,7 +22,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/util/argv.h"
 #include "src/util/error.h"

--- a/src/mca/bfrops/bfrops.h
+++ b/src/mca/bfrops/bfrops.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -31,9 +31,9 @@
 #ifndef PMIX_BFROP_H_
 #define PMIX_BFROP_H_
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
-#include <src/include/types.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+#include "src/include/types.h"
 
 #include "src/mca/mca.h"
 

--- a/src/mca/bfrops/bfrops_types.h
+++ b/src/mca/bfrops/bfrops_types.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,13 +28,13 @@
 #ifndef PMIX_MCA_BFROP_TYPES_H_
 #define PMIX_MCA_BFROP_TYPES_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/class/pmix_object.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/class/pmix_list.h"
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -13,7 +13,7 @@
  * Copyright (c) 201-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 201-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_v12.h"

--- a/src/mca/bfrops/v12/bfrop_v12_component.c
+++ b/src/mca/bfrops/v12/bfrop_v12_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/include/pmix_globals.h"
 

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -20,7 +20,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/util/argv.h"

--- a/src/mca/bfrops/v12/internal.h
+++ b/src/mca/bfrops/v12/internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -27,7 +27,7 @@
 #ifndef PMIX1_BFROP_INTERNAL_H_
 #define PMIX1_BFROP_INTERNAL_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>

--- a/src/mca/bfrops/v12/print.c
+++ b/src/mca/bfrops/v12/print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -21,9 +21,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
 #include <stdio.h>
 #ifdef HAVE_TIME_H

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/util/argv.h"
 #include "src/util/error.h"

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/util/error.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/bfrops/v20/bfrop_pmix20_component.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/include/pmix_globals.h"
 

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -20,7 +20,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/util/argv.h"

--- a/src/mca/bfrops/v20/internal.h
+++ b/src/mca/bfrops/v20/internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -27,7 +27,7 @@
 #ifndef PMIX20_BFROP_INTERNAL_H_
 #define PMIX20_BFROP_INTERNAL_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -21,9 +21,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
+#include "src/include/pmix_stdint.h"
 
 #include <stdio.h>
 #ifdef HAVE_TIME_H

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
@@ -23,7 +23,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/util/argv.h"
 #include "src/util/error.h"

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_pmix21.h"

--- a/src/mca/bfrops/v21/bfrop_pmix21_component.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/include/pmix_globals.h"
 

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_pmix3.h"

--- a/src/mca/bfrops/v3/bfrop_pmix3_component.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/include/pmix_globals.h"
 

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -23,7 +23,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_pmix4.h"

--- a/src/mca/bfrops/v4/bfrop_pmix4_component.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 #include "src/include/pmix_globals.h"
 

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -35,7 +35,7 @@
 #endif
 #include <time.h>
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/common/dstore/dstore_base.h
+++ b/src/mca/common/dstore/dstore_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -12,7 +12,7 @@
 #ifndef PMIX_DSTORE_H
 #define PMIX_DSTORE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/gds/gds.h"
@@ -20,7 +20,7 @@
 
 BEGIN_C_DECLS
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/class/pmix_value_array.h"
 #include "dstore_common.h"
 #include "dstore_segment.h"

--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -14,8 +14,8 @@
 #define PMIX_GDS_DS_BASE_H_
 
 #include <pthread.h>
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/common/dstore/dstore_segment.c
+++ b/src/mca/common/dstore/dstore_segment.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -37,7 +37,7 @@
 #endif
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/common/dstore/dstore_segment.h
+++ b/src/mca/common/dstore/dstore_segment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -13,8 +13,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -27,7 +27,7 @@
 #ifndef PMIX_GDS_BASE_H_
 #define PMIX_GDS_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -14,9 +14,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"

--- a/src/mca/gds/base/gds_base_frame.c
+++ b/src/mca/gds/base/gds_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/gds/base/gds_base_select.c
+++ b/src/mca/gds/base/gds_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -13,8 +13,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 #include "src/util/error.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds12/gds_ds12_component.c
+++ b/src/mca/gds/ds12/gds_ds12_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -28,8 +28,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/gds.h"

--- a/src/mca/gds/ds12/gds_ds12_file.c
+++ b/src/mca/gds/ds12/gds_ds12_file.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,7 +10,7 @@
  * $HEADER$
  */
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds12/gds_ds12_file.h
+++ b/src/mca/gds/ds12/gds_ds12_file.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +12,8 @@
 #ifndef GDS_DS12_FILE_H
 #define GDS_DS12_FILE_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 extern pmix_common_dstore_file_cbs_t pmix_ds12_file_module;
 extern pmix_common_dstore_file_cbs_t pmix_ds20_file_module;

--- a/src/mca/gds/ds12/gds_ds12_lock.c
+++ b/src/mca/gds/ds12/gds_ds12_lock.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +9,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 

--- a/src/mca/gds/ds12/gds_ds12_lock.h
+++ b/src/mca/gds/ds12/gds_ds12_lock.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +12,8 @@
 #ifndef DS12_LOCK_H
 #define DS12_LOCK_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 

--- a/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
@@ -26,7 +26,7 @@
 #include <sys/stat.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds12/gds_ds20_file.c
+++ b/src/mca/gds/ds12/gds_ds20_file.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,7 +10,7 @@
  * $HEADER$
  */
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -13,8 +13,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 #include "src/util/error.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds21/gds_ds21_component.c
+++ b/src/mca/gds/ds21/gds_ds21_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -28,8 +28,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/gds.h"

--- a/src/mca/gds/ds21/gds_ds21_file.c
+++ b/src/mca/gds/ds21/gds_ds21_file.c
@@ -3,6 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +11,7 @@
  * $HEADER$
  */
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"

--- a/src/mca/gds/ds21/gds_ds21_file.h
+++ b/src/mca/gds/ds21/gds_ds21_file.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +12,8 @@
 #ifndef GDS_DS21_FILE_H
 #define GDS_DS21_FILE_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 extern pmix_common_dstore_file_cbs_t pmix_ds21_file_module;
 

--- a/src/mca/gds/ds21/gds_ds21_lock.c
+++ b/src/mca/gds/ds21/gds_ds21_lock.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +9,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 

--- a/src/mca/gds/ds21/gds_ds21_lock.h
+++ b/src/mca/gds/ds21/gds_ds21_lock.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +12,8 @@
 #ifndef DS21_LOCK_H
 #define DS21_LOCK_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/common/dstore/dstore_common.h"
 

--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -10,8 +10,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -14,10 +14,10 @@
 #ifndef PMIX_GDS_H
 #define PMIX_GDS_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_framework.h"

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -13,7 +13,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -30,7 +30,7 @@
 #endif
 #include <time.h>
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_GDS_HASH_H
 #define PMIX_GDS_HASH_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/gds/gds.h"

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 
 #include "src/mca/gds/gds.h"

--- a/src/mca/mca.h
+++ b/src/mca/mca.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +29,7 @@
 #ifndef PMIX_MCA_H
 #define PMIX_MCA_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 /**
  * Common type for all MCA modules.

--- a/src/mca/pcompress/base/pcompress_base_select.c
+++ b/src/mca/pcompress/base/pcompress_base_select.c
@@ -7,7 +7,7 @@
  *
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
 #include "unistd.h"
 #endif
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +32,7 @@
 #include "src/util/pmix_environ.h"
 #include "src/util/printf.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/basename.h"
 
 #include "src/mca/pcompress/base/base.h"

--- a/src/mca/pcompress/zlib/compress_zlib_component.c
+++ b/src/mca/pcompress/zlib/compress_zlib_component.c
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,7 +14,7 @@
 
 #include "pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/pcompress/base/base.h"
 #include "compress_zlib.h"
 

--- a/src/mca/pdl/base/base.h
+++ b/src/mca/pdl/base/base.h
@@ -3,7 +3,7 @@
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,7 +14,7 @@
 #ifndef PMIX_PDL_BASE_H
 #define PMIX_PDL_BASE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/mca/pdl/pdl.h"
 #include "src/util/pmix_environ.h"
 

--- a/src/mca/pdl/base/pdl_base_close.c
+++ b/src/mca/pdl/base/pdl_base_close.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University.
  *                         All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/pdl/base/pdl_base_fns.c
+++ b/src/mca/pdl/base/pdl_base_fns.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University.
  *                         All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,9 +16,9 @@
  * component; see pdl.h for details).
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include "src/util/output.h"
 #include "src/mca/pdl/base/base.h"

--- a/src/mca/pdl/base/pdl_base_open.c
+++ b/src/mca/pdl/base/pdl_base_open.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/pdl/base/base.h"
 

--- a/src/mca/pdl/base/pdl_base_select.c
+++ b/src/mca/pdl/base/pdl_base_select.c
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  *
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -13,13 +14,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_UNISTD_H
 #include "unistd.h"
 #endif
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/pdl/pdl.h
+++ b/src/mca/pdl/pdl.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +48,7 @@
 #ifndef PMIX_MCA_PDL_PDL_H
 #define PMIX_MCA_PDL_PDL_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/pdl/pdlopen/pdl_pdlopen.h
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015     Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016     Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,7 +11,7 @@
 #ifndef PMIX_PDL_PDLOPEN
 #define PMIX_PDL_PDLOPEN
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/pdl/pdl.h"
 

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/pdl/pdl.h"
 #include "src/util/argv.h"
 

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdlib.h>
 #include <dlfcn.h>
@@ -21,7 +21,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/pdl/pdl.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"

--- a/src/mca/pdl/plibltdl/pdl_libltdl_component.c
+++ b/src/mca/pdl/plibltdl/pdl_libltdl_component.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015       Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015       Los Alamos National Security, Inc.  All rights
  *                          reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,7 @@
 
 #include "pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "pmix/mca/pdl/pdl.h"
 #include "pmix/mca/base/pmix_mca_base_var.h"
 #include "pmix/util/argv.h"

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -58,9 +58,9 @@
 #include <libutil.h>
 #endif
 
-#include <pmix.h>
-#include <pmix_server.h>
-#include "pmix_common.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_stdint.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -25,7 +25,7 @@
 
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 
 #include <string.h>

--- a/src/mca/pfexec/base/pfexec_base_select.c
+++ b/src/mca/pfexec/base/pfexec_base_select.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
 
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/pfexec/linux/pfexec_linux_component.c
+++ b/src/mca/pfexec/linux/pfexec_linux_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pfexec/pfexec.h
+++ b/src/mca/pfexec/pfexec.h
@@ -30,7 +30,7 @@
 #define PMIX_MCA_PFEXEC_H
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/include/types.h"
 
 #include "src/mca/mca.h"

--- a/src/mca/pif/base/pif_base_components.c
+++ b/src/mca/pif/base/pif_base_components.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -13,7 +13,7 @@
 
 #include "pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 #include "src/mca/mca.h"
 #include "src/mca/pif/pif.h"

--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
+++ b/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/pinstalldirs/base/base.h
+++ b/src/mca/pinstalldirs/base/base.h
@@ -3,7 +3,7 @@
  *                         reserved.
  * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,7 +15,7 @@
 #ifndef PMIX_PINSTALLDIRS_BASE_H
 #define PMIX_PINSTALLDIRS_BASE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/mca/base/pmix_mca_base_framework.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2010      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,9 +14,9 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/mca.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include "src/mca/pinstalldirs/base/base.h"

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_expand.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_expand.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007      Sun Microsystem, Inc.  All rights reserved.
  * Copyright (c) 2010      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 

--- a/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
+++ b/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include "src/mca/pinstalldirs/config/pinstall_dirs.h"

--- a/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
+++ b/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,12 +10,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 
 static int pinstalldirs_env_open(void);

--- a/src/mca/pinstalldirs/pinstalldirs.h
+++ b/src/mca/pinstalldirs/pinstalldirs.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,7 @@
 #ifndef PMIX_MCA_PINSTALLDIRS_PINSTALLDIRS_H
 #define PMIX_MCA_PINSTALLDIRS_PINSTALLDIRS_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"

--- a/src/mca/plog/base/base.h
+++ b/src/mca/plog/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PLOG_BASE_H_
 #define PMIX_PLOG_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/plog/base/plog_base_frame.c
+++ b/src/mca/plog/base/plog_base_frame.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; -*- */
 /*
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -9,9 +9,9 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/plog/base/plog_base_select.c
+++ b/src/mca/plog/base/plog_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -9,9 +9,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"

--- a/src/mca/plog/default/plog_default.c
+++ b/src/mca/plog/default/plog_default.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/plog/default/plog_default_component.c
+++ b/src/mca/plog/default/plog_default_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  * includes
  */
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include "plog_default.h"
 

--- a/src/mca/plog/plog.h
+++ b/src/mca/plog/plog.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -26,8 +26,8 @@
 #ifndef PMIX_PLOG_H
 #define PMIX_PLOG_H
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/mca.h"

--- a/src/mca/plog/smtp/plog_smtp.c
+++ b/src/mca/plog/smtp/plog_smtp.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/mca/plog/smtp/plog_smtp_component.c
+++ b/src/mca/plog/smtp/plog_smtp_component.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009     Cisco Systems, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -29,7 +29,7 @@
 
 #include "src/mca/base/pmix_mca_base_var.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/show_help.h"
 
 #include "plog_smtp.h"

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/plog/stdfd/plog_stdfd_component.c
+++ b/src/mca/plog/stdfd/plog_stdfd_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  * includes
  */
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include "plog_stdfd.h"
 

--- a/src/mca/plog/syslog/plog_syslog.c
+++ b/src/mca/plog/syslog/plog_syslog.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_TIME_H

--- a/src/mca/plog/syslog/plog_syslog_component.c
+++ b/src/mca/plog/syslog/plog_syslog_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
  * includes
  */
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_SYSLOG_H
 #include <syslog.h>

--- a/src/mca/pmdl/base/base.h
+++ b/src/mca/pmdl/base/base.h
@@ -24,7 +24,7 @@
 #ifndef PMIX_PMDL_BASE_H_
 #define PMIX_PMDL_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/pmdl/base/pmdl_base_select.c
+++ b/src/mca/pmdl/base/pmdl_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/pmdl/base/pmdl_base_stubs.c
+++ b/src/mca/pmdl/base/pmdl_base_stubs.c
@@ -13,9 +13,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"

--- a/src/mca/pmdl/ompi4/pmdl_ompi4.c
+++ b/src/mca/pmdl/ompi4/pmdl_ompi4.c
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -29,7 +29,7 @@
 #endif
 #include <time.h>
 
-#include <pmix.h>
+#include "include/pmix.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_vari.h"

--- a/src/mca/pmdl/ompi4/pmdl_ompi4.h
+++ b/src/mca/pmdl/ompi4/pmdl_ompi4.h
@@ -11,7 +11,7 @@
 #ifndef PMIX_PMDL_ompi4_H
 #define PMIX_PMDL_ompi4_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pmdl/pmdl.h"

--- a/src/mca/pmdl/ompi4/pmdl_ompi4_component.c
+++ b/src/mca/pmdl/ompi4/pmdl_ompi4_component.c
@@ -21,8 +21,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/pmdl/pmdl.h"
 #include "pmdl_ompi4.h"

--- a/src/mca/pmdl/ompi5/pmdl_ompi5.c
+++ b/src/mca/pmdl/ompi5/pmdl_ompi5.c
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -26,7 +26,7 @@
 #endif
 #include <time.h>
 
-#include <pmix.h>
+#include "include/pmix.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_vari.h"

--- a/src/mca/pmdl/ompi5/pmdl_ompi5.h
+++ b/src/mca/pmdl/ompi5/pmdl_ompi5.h
@@ -11,7 +11,7 @@
 #ifndef PMIX_PMDL_ompi5_H
 #define PMIX_PMDL_ompi5_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pmdl/pmdl.h"

--- a/src/mca/pmdl/ompi5/pmdl_ompi5_component.c
+++ b/src/mca/pmdl/ompi5/pmdl_ompi5_component.c
@@ -21,8 +21,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pmdl/pmdl.h"

--- a/src/mca/pmdl/oshmem/pmdl_oshmem.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem.c
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -26,7 +26,7 @@
 #endif
 #include <time.h>
 
-#include <pmix.h>
+#include "include/pmix.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_vari.h"

--- a/src/mca/pmdl/oshmem/pmdl_oshmem.h
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem.h
@@ -11,7 +11,7 @@
 #ifndef PMIX_PMDL_oshmem_H
 #define PMIX_PMDL_oshmem_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pmdl/pmdl.h"

--- a/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
@@ -21,8 +21,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pmdl/pmdl.h"

--- a/src/mca/pmdl/pmdl.h
+++ b/src/mca/pmdl/pmdl.h
@@ -26,8 +26,8 @@
 #ifndef PMIX_PMDL_H
 #define PMIX_PMDL_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_sched.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_sched.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/mca.h"

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PNET_BASE_H_
 #define PMIX_PNET_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -13,9 +13,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/pnet/base/pnet_base_select.c
+++ b/src/mca/pnet/base/pnet_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -31,7 +31,7 @@
 #include <opamgt/opamgt_sa.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/class/pmix_list.h"

--- a/src/mca/pnet/opa/pnet_opa.h
+++ b/src/mca/pnet/opa/pnet_opa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_PNET_OPA_H
 #define PMIX_PNET_OPA_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
 #ifndef PMIX_PNET_H
 #define PMIX_PNET_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_sched.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_sched.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/mca.h"

--- a/src/mca/pnet/simptest/pnet_simptest.c
+++ b/src/mca/pnet/simptest/pnet_simptest.c
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -26,7 +26,7 @@
 #endif
 #include <time.h>
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/include/pmix_socket_errno.h"

--- a/src/mca/pnet/simptest/pnet_simptest.h
+++ b/src/mca/pnet/simptest/pnet_simptest.h
@@ -11,7 +11,7 @@
 #ifndef PMIX_PNET_simptest_H
 #define PMIX_PNET_simptest_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/simptest/pnet_simptest_component.c
+++ b/src/mca/pnet/simptest/pnet_simptest_component.c
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -10,7 +10,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -27,7 +27,7 @@
 #endif
 #include <time.h>
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/pnet/tcp/pnet_tcp.h
+++ b/src/mca/pnet/tcp/pnet_tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_PNET_OPA_H
 #define PMIX_PNET_OPA_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/tcp/pnet_tcp_component.c
+++ b/src/mca/pnet/tcp/pnet_tcp_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,8 +14,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
@@ -9,7 +9,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -26,7 +26,7 @@
 #endif
 #include <time.h>
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/include/pmix_socket_errno.h"

--- a/src/mca/pnet/test/pnet_test.h
+++ b/src/mca/pnet/test/pnet_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_PNET_test_H
 #define PMIX_PNET_test_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/pnet/test/pnet_test_component.c
+++ b/src/mca/pnet/test/pnet_test_component.c
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/argv.h"
 #include "src/mca/pnet/pnet.h"

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PREG_BASE_H_
 #define PMIX_PREG_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
@@ -24,9 +24,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/preg/base/preg_base_select.c
+++ b/src/mca/preg/base/preg_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -11,7 +11,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>
@@ -26,8 +26,8 @@
 #include <ctype.h>
 
 
-#include <pmix_common.h>
-#include <pmix.h>
+#include "include/pmix_common.h"
+#include "include/pmix.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/preg/compress/preg_compress.h
+++ b/src/mca/preg/compress/preg_compress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_PREG_compress_H
 #define PMIX_PREG_compress_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/preg/preg.h"

--- a/src/mca/preg/compress/preg_compress_component.c
+++ b/src/mca/preg/compress/preg_compress_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -11,7 +11,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>
@@ -26,8 +26,8 @@
 #include <ctype.h>
 
 
-#include <pmix_common.h>
-#include <pmix.h>
+#include "include/pmix_common.h"
+#include "include/pmix.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/preg/native/preg_native.h
+++ b/src/mca/preg/native/preg_native.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_PREG_NATIVE_H
 #define PMIX_PREG_NATIVE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/preg/preg.h"

--- a/src/mca/preg/native/preg_native_component.c
+++ b/src/mca/preg/native/preg_native_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 
 #include "src/mca/preg/preg.h"

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -23,7 +23,7 @@
 #ifndef PMIX_PREG_H
 #define PMIX_PREG_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"

--- a/src/mca/preg/preg_types.h
+++ b/src/mca/preg/preg_types.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -29,7 +29,7 @@
 #ifndef PMIX_MCA_PREG_TYPES_H_
 #define PMIX_MCA_PREG_TYPES_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/class/pmix_object.h"

--- a/src/mca/psec/base/base.h
+++ b/src/mca/psec/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PSEC_BASE_H_
 #define PMIX_PSEC_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/psec/base/psec_base_fns.c
+++ b/src/mca/psec/base/psec_base_fns.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
@@ -11,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"

--- a/src/mca/psec/base/psec_base_frame.c
+++ b/src/mca/psec/base/psec_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/psec/base/psec_base_select.c
+++ b/src/mca/psec/base/psec_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/psec/dummy_handshake/psec_dummy_handshake.c
+++ b/src/mca/psec/dummy_handshake/psec_dummy_handshake.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,14 +10,14 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <unistd.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/util/error.h"

--- a/src/mca/psec/dummy_handshake/psec_dummy_handshake.h
+++ b/src/mca/psec/dummy_handshake/psec_dummy_handshake.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +13,7 @@
 #ifndef PMIX_SIMPLE_H
 #define PMIX_SIMPLE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/dummy_handshake/psec_dummy_handshake_component.c
+++ b/src/mca/psec/dummy_handshake/psec_dummy_handshake_component.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,8 +10,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * NOTE: THE MUNGE CLIENT LIBRARY (libmunge) IS LICENSED AS LGPL
  *
@@ -10,9 +10,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/util/argv.h"

--- a/src/mca/psec/munge/psec_munge.h
+++ b/src/mca/psec/munge/psec_munge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -13,7 +13,7 @@
 
 BEGIN_C_DECLS
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 /* the component must be visible data for the linker to find it */

--- a/src/mca/psec/munge/psec_munge_component.c
+++ b/src/mca/psec/munge/psec_munge_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -10,14 +10,14 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <unistd.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/psec/native/psec_native.h
+++ b/src/mca/psec/native/psec_native.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_NATIVE_H
 #define PMIX_NATIVE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/native/psec_native_component.c
+++ b/src/mca/psec/native/psec_native_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/none/psec_none.c
+++ b/src/mca/psec/none/psec_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -11,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/psec/none/psec_none.h
+++ b/src/mca/psec/none/psec_none.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,7 +11,7 @@
 #ifndef PMIX_NATIVE_H
 #define PMIX_NATIVE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/none/psec_none_component.c
+++ b/src/mca/psec/none/psec_none_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/psec/psec.h"

--- a/src/mca/psec/psec.h
+++ b/src/mca/psec/psec.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -29,7 +29,7 @@
 #ifndef PMIX_PSEC_H
 #define PMIX_PSEC_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"

--- a/src/mca/psensor/base/base.h
+++ b/src/mca/psensor/base/base.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -16,7 +16,7 @@
 #ifndef PMIX_PSENSOR_BASE_H_
 #define PMIX_PSENSOR_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/mca.h"

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -13,9 +13,9 @@
  */
 
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include <pthread.h>
 #include PMIX_EVENT_HEADER

--- a/src/mca/psensor/base/psensor_base_select.c
+++ b/src/mca/psensor/base/psensor_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/psensor/base/psensor_base_stubs.c
+++ b/src/mca/psensor/base/psensor_base_stubs.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,8 +11,8 @@
  */
 
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/util/error.h"
 

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -16,8 +16,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stddef.h>

--- a/src/mca/psensor/file/psensor_file.h
+++ b/src/mca/psensor/file/psensor_file.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  *
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +16,7 @@
 #ifndef PMIX_PSENSOR_FILE_H
 #define PMIX_PSENSOR_FILE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 

--- a/src/mca/psensor/file/psensor_file_component.c
+++ b/src/mca/psensor/file/psensor_file_component.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +8,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/class/pmix_list.h"
 

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
   *
- * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +11,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <errno.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.h
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
  *
- * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,8 +17,8 @@
 #ifndef PMIX_PSENSOR_HEARTBEAT_H
 #define PMIX_PSENSOR_HEARTBEAT_H
 
-#include <src/include/pmix_config.h>
-#include <src/include/types.h>
+#include "src/include/pmix_config.h"
+#include "src/include/types.h"
 
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,8 +9,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/ptl/ptl.h"
 #include "src/mca/psensor/base/base.h"

--- a/src/mca/psensor/psensor.h
+++ b/src/mca/psensor/psensor.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -16,7 +16,7 @@
 #ifndef PMIX_PSENSOR_H_
 #define PMIX_PSENSOR_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/mca/mca.h"

--- a/src/mca/pshmem/base/base.h
+++ b/src/mca/pshmem/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PSHMEM_BASE_H_
 #define PMIX_PSHMEM_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/pshmem/base/pshmem_base_frame.c
+++ b/src/mca/pshmem/base/pshmem_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/pshmem/base/pshmem_base_select.c
+++ b/src/mca/pshmem/base/pshmem_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/pshmem/mmap/pshmem_mmap.c
+++ b/src/mca/pshmem/mmap/pshmem_mmap.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,12 +21,12 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 //#include "pmix_sm.h"
-#include <src/mca/pshmem/pshmem.h>
+#include "src/mca/pshmem/pshmem.h"
 #include "pshmem_mmap.h"
 
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)

--- a/src/mca/pshmem/mmap/pshmem_mmap.h
+++ b/src/mca/pshmem/mmap/pshmem_mmap.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,8 +12,8 @@
 #ifndef PMIX_SM_MMAP_H
 #define PMIX_SM_MMAP_H
 
-#include <src/include/pmix_config.h>
-#include <src/mca/pshmem/pshmem.h>
+#include "src/include/pmix_config.h"
+#include "src/mca/pshmem/pshmem.h"
 
 BEGIN_C_DECLS
 

--- a/src/mca/pshmem/mmap/pshmem_mmap_component.c
+++ b/src/mca/pshmem/mmap/pshmem_mmap_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -28,11 +28,11 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 
-#include <src/mca/pshmem/pshmem.h>
+#include "src/mca/pshmem/pshmem.h"
 #include "pshmem_mmap.h"
 
 static pmix_status_t component_open(void);

--- a/src/mca/pshmem/pshmem.h
+++ b/src/mca/pshmem/pshmem.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,9 +12,9 @@
 #ifndef PMIX_PSHMEM_H
 #define PMIX_PSHMEM_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_framework.h"

--- a/src/mca/psquash/base/base.h
+++ b/src/mca/psquash/base/base.h
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,7 +16,7 @@
 #ifndef PMIX_PSQUASH_BASE_H_
 #define PMIX_PSQUASH_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/psquash/base/psquash_base_frame.c
+++ b/src/mca/psquash/base/psquash_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
@@ -24,9 +24,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/psquash/base/psquash_base_select.c
+++ b/src/mca/psquash/base/psquash_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -20,8 +20,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/psquash/flex128/psquash_flex128.c
+++ b/src/mca/psquash/flex128/psquash_flex128.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/psquash/flex128/psquash_flex128.h
+++ b/src/mca/psquash/flex128/psquash_flex128.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +11,7 @@
 #ifndef PMIX_NATIVE_H
 #define PMIX_NATIVE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/psquash/psquash.h"

--- a/src/mca/psquash/flex128/psquash_flex128_component.c
+++ b/src/mca/psquash/flex128/psquash_flex128_component.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +9,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/psquash/psquash.h"

--- a/src/mca/psquash/native/psquash_native.c
+++ b/src/mca/psquash/native/psquash_native.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"

--- a/src/mca/psquash/native/psquash_native.h
+++ b/src/mca/psquash/native/psquash_native.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserve
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +14,7 @@
 #ifndef PMIX_NATIVE_H
 #define PMIX_NATIVE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/psquash/psquash.h"

--- a/src/mca/psquash/native/psquash_native_component.c
+++ b/src/mca/psquash/native/psquash_native_component.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,8 +12,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/psquash/psquash.h"

--- a/src/mca/psquash/psquash.h
+++ b/src/mca/psquash/psquash.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@
 #ifndef PMIX_PSQUASH_H
 #define PMIX_PSQUASH_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,7 +24,7 @@
 #ifndef PMIX_PTL_BASE_H_
 #define PMIX_PTL_BASE_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "include/pmix_stdint.h"
 
 #include <stdio.h>

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -23,9 +23,9 @@
 /** @file:
  *
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix_server.h>
+#include "include/pmix_server.h"
 #include "src/include/pmix_globals.h"
 
 #ifdef HAVE_STRING_H

--- a/src/mca/ptl/base/ptl_base_select.c
+++ b/src/mca/ptl/base/ptl_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -19,8 +19,8 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -13,10 +13,10 @@
  *
  * $HEADER$
  */
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H

--- a/src/mca/ptl/base/usock.h
+++ b/src/mca/ptl/base/usock.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -32,10 +32,10 @@
 #ifndef USOCK_H
 #define USOCK_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/types.h>
-#include <pmix_common.h>
+#include "src/include/types.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -31,9 +31,9 @@
 #ifndef PMIX_PTL_H_
 #define PMIX_PTL_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/types.h>
+#include "src/include/types.h"
 
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,7 +28,7 @@
 #ifndef PMIX_PTL_TYPES_H_
 #define PMIX_PTL_TYPES_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/include/types.h"
 
 #ifdef HAVE_UNISTD_H

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -23,7 +23,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/include/pmix_globals.h"
 
 #ifdef HAVE_FCNTL_H

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -30,8 +30,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -24,8 +24,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -30,8 +30,8 @@
  * entire components just to query their version and parameters.
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -24,7 +24,7 @@
 
 /** @file **/
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
 #include "src/client/pmix_client_ops.h"

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -27,13 +27,13 @@
 
 /** @file **/
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
-#include <pmix_rename.h>
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/util/output.h"

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -12,7 +12,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -25,7 +25,7 @@
 #define PMIX_RTE_H
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/class/pmix_object.h"
 
 #include <stdio.h>

--- a/src/server/pmix_sched.c
+++ b/src/server/pmix_sched.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -15,15 +15,15 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_sched.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_sched.h"
 
-#include <src/include/types.h>
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/types.h"
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 #include "src/include/pmix_globals.h"
 
 #ifdef HAVE_STRING_H

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -16,14 +16,14 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix_server.h>
-#include <pmix_common.h>
-#include <pmix_rename.h>
+#include "include/pmix_server.h"
+#include "include/pmix_common.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -15,13 +15,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix_server.h>
-#include <pmix_rename.h>
+#include "include/pmix_server.h"
+#include "include/pmix_rename.h"
 #include "src/include/pmix_globals.h"
 
 #ifdef HAVE_STRING_H

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -15,12 +15,12 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_socket_errno.h"
 
-#include <pmix_server.h>
+#include "include/pmix_server.h"
 #include "src/include/pmix_globals.h"
 
 #ifdef HAVE_STRING_H

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -19,12 +19,12 @@
 #include <sys/types.h>
 #endif
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "src/include/types.h"
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
-#include <src/class/pmix_hotel.h>
-#include <pmix_server.h>
+#include "src/class/pmix_hotel.h"
+#include "include/pmix_server.h"
 #include "src/threads/threads.h"
 #include "src/include/pmix_globals.h"
 #include "src/util/hash.h"

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@
 
 #include "src/threads/threads.h"
 #include "src/threads/tsd.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 bool pmix_debug_threads = false;
 

--- a/src/threads/tsd.h
+++ b/src/threads/tsd.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
 
 #include <pthread.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -15,13 +15,13 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_socket_errno.h>
+#include "src/include/pmix_socket_errno.h"
 
 #include "src/client/pmix_client_ops.h"
-#include <pmix_tool.h>
-#include <pmix_rename.h>
+#include "include/pmix_tool.h"
+#include "include/pmix_rename.h"
 
 #include "src/include/pmix_globals.h"
 

--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -24,7 +24,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,7 +32,7 @@
 #include <time.h>
 #include <pthread.h>
 
-#include <pmix_tool.h>
+#include "include/pmix_tool.h"
 #include "src/common/pmix_attributes.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -24,7 +24,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,7 +32,7 @@
 #include <time.h>
 #include <pthread.h>
 
-#include <pmix_tool.h>
+#include "include/pmix_tool.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"
 #include "src/threads/threads.h"

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <pthread.h>
 
-#include <pmix_tool.h>
+#include "include/pmix_tool.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"
 #include "src/threads/threads.h"

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -32,7 +32,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <errno.h>
@@ -66,8 +66,8 @@
 #include "src/runtime/pmix_rte.h"
 
 #include "src/include/pmix_globals.h"
-#include <pmix_tool.h>
-#include <pmix.h>
+#include "include/pmix_tool.h"
+#include "include/pmix.h"
 
 typedef struct {
     pmix_lock_t lock;

--- a/src/tools/wrapper/pmix_wrapper.c
+++ b/src/tools/wrapper/pmix_wrapper.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +46,7 @@
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include "src/mca/pinstalldirs/base/base.h"
 #include "src/runtime/pmix_rte.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/keyval_parse.h"

--- a/src/util/alfg.c
+++ b/src/util/alfg.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,7 +11,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <string.h>
 

--- a/src/util/alfg.h
+++ b/src/util/alfg.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,8 +13,8 @@
 #ifndef PMIX_ALFG_H
 #define PMIX_ALFG_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "src/include/pmix_stdint.h"
 

--- a/src/util/argv.c
+++ b/src/util/argv.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire. All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -22,7 +22,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STDLIB_H

--- a/src/util/argv.h
+++ b/src/util/argv.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire. All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -34,14 +34,14 @@
 #ifndef PMIX_ARGV_H
 #define PMIX_ARGV_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/util/basename.c
+++ b/src/util/basename.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <stdlib.h>

--- a/src/util/basename.h
+++ b/src/util/basename.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,8 +26,8 @@
 #ifndef PMIX_BASENAME_H
 #define PMIX_BASENAME_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -39,7 +39,7 @@
 #include "src/util/pmix_environ.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 
 /*

--- a/src/util/context_fns.c
+++ b/src/util/context_fns.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/util/context_fns.h
+++ b/src/util/context_fns.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 #define _PMIX_CONTEXT_FNS_H_
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/util/crc.c
+++ b/src/util/crc.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,7 +18,7 @@
  */
 
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STDIO_H

--- a/src/util/crc.h
+++ b/src/util/crc.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +23,7 @@
 #ifndef _PMIX_CRC_H_
 #define _PMIX_CRC_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <stddef.h>

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -19,7 +19,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STRING_H
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 #include "src/util/error.h"
 

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,10 +20,10 @@
 #ifndef PMIX_UTIL_ERROR_H
 #define PMIX_UTIL_ERROR_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/util/output.h"
 
  BEGIN_C_DECLS

--- a/src/util/fd.c
+++ b/src/util/fd.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -11,9 +11,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/util/fd.h
+++ b/src/util/fd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -17,7 +17,7 @@
 #ifndef PMIX_UTIL_FD_H_
 #define PMIX_UTIL_FD_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 BEGIN_C_DECLS

--- a/src/util/few.c
+++ b/src/util/few.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +33,7 @@
 #include "src/util/few.h"
 #include "src/util/basename.h"
 #include "src/util/argv.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 int pmix_few(char *argv[], int *status)
 {

--- a/src/util/few.h
+++ b/src/util/few.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
 
 #include "pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 BEGIN_C_DECLS
 

--- a/src/util/getid.c
+++ b/src/util/getid.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
  * Buffer safe printf functions for portability to archaic platforms.
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "include/pmix_common.h"
 #include "src/include/pmix_socket_errno.h"
 

--- a/src/util/getid.h
+++ b/src/util/getid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +10,7 @@
 #ifndef PMIX_GETID_H
 #define PMIX_GETID_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include "include/pmix_common.h"
 
 #ifdef HAVE_UNISTD_H

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -6,7 +6,7 @@
  *                         reserved.
  * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -20,10 +20,10 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <src/include/pmix_stdint.h>
-#include <src/include/hash_string.h>
+#include "src/include/pmix_stdint.h"
+#include "src/include/hash_string.h"
 
 #include <string.h>
 

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -14,7 +14,7 @@
 #ifndef PMIX_HASH_H
 #define PMIX_HASH_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/mca/bfrops/bfrops_types.h"

--- a/src/util/keyval/keyval_lex.h
+++ b/src/util/keyval/keyval_lex.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- # Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
 #ifndef PMIX_UTIL_KEYVAL_LEX_H_
 #define PMIX_UTIL_KEYVAL_LEX_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef malloc
 #undef malloc

--- a/src/util/keyval/keyval_lex.l
+++ b/src/util/keyval/keyval_lex.l
@@ -16,6 +16,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H

--- a/src/util/keyval_parse.c
+++ b/src/util/keyval_parse.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +20,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/util/keyval_parse.h"
 #include "src/util/keyval/keyval_lex.h"
 #include "src/util/output.h"

--- a/src/util/keyval_parse.h
+++ b/src/util/keyval_parse.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
 #ifndef PMIX_UTIL_KEYVAL_PARSE_H
 #define PMIX_UTIL_KEYVAL_PARSE_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 BEGIN_C_DECLS
 

--- a/src/util/name_fns.c
+++ b/src/util/name_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include "src/threads/tsd.h"
 #include "src/include/pmix_globals.h"

--- a/src/util/name_fns.h
+++ b/src/util/name_fns.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #endif
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
 
 BEGIN_C_DECLS

--- a/src/util/net.c
+++ b/src/util/net.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -23,7 +23,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/util/os_dirpath.c
+++ b/src/util/os_dirpath.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +44,7 @@
 #include "src/util/show_help.h"
 #include "src/util/argv.h"
 #include "src/util/os_path.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 static const char path_sep[] = PMIX_PATH_SEP;
 

--- a/src/util/os_path.c
+++ b/src/util/os_path.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +17,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <string.h>

--- a/src/util/os_path.h
+++ b/src/util/os_path.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,8 +42,8 @@
 #ifndef PMIX_OS_PATH_H
 #define PMIX_OS_PATH_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -20,9 +20,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <ctype.h>

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -66,7 +66,7 @@
 #ifndef PMIX_OUTPUT_H_
 #define PMIX_OUTPUT_H_
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #ifdef HAVE_STDARG_H

--- a/src/util/parse_options.c
+++ b/src/util/parse_options.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/util/path.c
+++ b/src/util/path.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -24,7 +24,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/util/path.h
+++ b/src/util/path.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,9 +25,9 @@
 #ifndef PMIX_PATH_H
 #define PMIX_PATH_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/util/pif.c
+++ b/src/util/pif.c
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +25,7 @@
  */
 
 #include "pmix_config.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -23,9 +23,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/util/pmix_environ.h
+++ b/src/util/pmix_environ.h
@@ -31,14 +31,14 @@
 #ifndef PMIX_ENVIRON_H
 #define PMIX_ENVIRON_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <unistd.h>
 #ifdef HAVE_CRT_EXTERNS_H
 #include <crt_externs.h>
 #endif
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 #include "src/class/pmix_list.h"
 
 BEGIN_C_DECLS

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +46,7 @@
  * SUCH DAMAGE.
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #ifdef HAVE_SYS_CDEFS_H
 # include <sys/cdefs.h>

--- a/src/util/pmix_pty.h
+++ b/src/util/pmix_pty.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,8 +20,8 @@
 #ifndef PMIX_UTIL_PTY_H
 #define PMIX_UTIL_PTY_H
 
-#include <src/include/pmix_config.h>
-#include "pmix_common.h"
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #ifdef HAVE_UTIL_H
 #include <util.h>

--- a/src/util/printf.c
+++ b/src/util/printf.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
  * Buffer safe printf functions for portability to archaic platforms.
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include <errno.h>

--- a/src/util/printf.h
+++ b/src/util/printf.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,8 +25,8 @@
 #ifndef PMIX_PRINTF_H
 #define PMIX_PRINTF_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdarg.h>
 #include <stdlib.h>

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -34,7 +34,7 @@
 #include "src/util/argv.h"
 #include "src/util/os_path.h"
 #include "src/util/output.h"
-#include "pmix_common.h"
+#include "include/pmix_common.h"
 
 
 /*

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,8 +90,8 @@
 #ifndef PMIX_SHOW_HELP_H
 #define PMIX_SHOW_HELP_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdarg.h>
 

--- a/src/util/show_help_lex.h
+++ b/src/util/show_help_lex.h
@@ -21,8 +21,8 @@
 #ifndef PMIX_SHOW_HELP_LEX_H
 #define PMIX_SHOW_HELP_LEX_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #ifdef malloc
 #undef malloc

--- a/src/util/show_help_lex.l
+++ b/src/util/show_help_lex.l
@@ -13,7 +13,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H

--- a/src/util/strnlen.h
+++ b/src/util/strnlen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,7 +15,7 @@
 #ifndef PMIX_STRNLEN_H
 #define PMIX_STRNLEN_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 #if defined(HAVE_STRNLEN)
 #define PMIX_STRNLEN(c, a, b)       \

--- a/src/util/timings.c
+++ b/src/util/timings.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,9 +8,9 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
-#include <pmix_common.h>
+#include "include/pmix_common.h"
 
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/util/timings.h
+++ b/src/util/timings.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -13,7 +13,7 @@
 #ifndef PMIX_UTIL_TIMING_H
 #define PMIX_UTIL_TIMING_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 
 
 #include "src/class/pmix_list.h"

--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
@@ -15,7 +15,7 @@
 #ifndef CLI_STAGES_H
 #define CLI_STAGES_H
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include <signal.h>
 #include <fcntl.h>
 #include <sys/types.h>

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -22,8 +22,8 @@
  * $HEADER$
  *
  */
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/doubleget.c
+++ b/test/simple/doubleget.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <pmix.h>
+#include "include/pmix.h"
 #include <sched.h>
 
 static pmix_proc_t allproc = {0};

--- a/test/simple/gwclient.c
+++ b/test/simple/gwclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -25,10 +25,10 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_server.h>
-#include <src/include/types.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/quietclient.c
+++ b/test/simple/quietclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -35,8 +35,8 @@
  * PMIx_Finalize
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -25,8 +25,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpcoord.c
+++ b/test/simple/simpcoord.c
@@ -25,8 +25,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -25,8 +25,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpdie.c
+++ b/test/simple/simpdie.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpdyn.c
+++ b/test/simple/simpdyn.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpft.c
+++ b/test/simple/simpft.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpio.c
+++ b/test/simple/simpio.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -31,7 +31,7 @@
 #include <time.h>
 #include <signal.h>
 
-#include <pmix.h>
+#include "include/pmix.h"
 #include "simptest.h"
 
 static pmix_proc_t myproc;

--- a/test/simple/simplegacy.c
+++ b/test/simple/simplegacy.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,7 +23,7 @@
  *
  */
 
-#include <src/include/pmix_config.h>
+#include "src/include/pmix_config.h"
 #include <pmi.h>
 
 #include <stdio.h>

--- a/test/simple/simppub.c
+++ b/test/simple/simppub.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simpsched.c
+++ b/test/simple/simpsched.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -25,11 +25,11 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_server.h>
-#include <pmix_sched.h>
-#include <src/include/types.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "include/pmix_sched.h"
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,7 +41,7 @@
 #include <signal.h>
 
 #if PMIX_HAVE_HWLOC
-#include <src/hwloc/hwloc-internal.h>
+#include "src/hwloc/hwloc-internal.h"
 #endif
 
 #include "src/class/pmix_list.h"

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -25,10 +25,10 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_server.h>
-#include <src/include/types.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 
 #if PMIX_HAVE_HWLOC
-#include <src/hwloc/hwloc-internal.h>
+#include "src/hwloc/hwloc-internal.h"
 #endif
 
 #include "src/class/pmix_list.h"

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/simptool.c
+++ b/test/simple/simptool.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_tool.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_tool.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/simple/stability.c
+++ b/test/simple/stability.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -25,10 +25,10 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_server.h>
-#include <src/include/types.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +40,7 @@
 #include <signal.h>
 
 #if PMIX_HAVE_HWLOC
-#include <src/hwloc/hwloc-internal.h>
+#include "src/hwloc/hwloc-internal.h"
 #endif
 
 #include "src/class/pmix_list.h"

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -1,6 +1,6 @@
 
 #include <stdio.h>
-#include <pmix.h>
+#include "include/pmix.h"
 #include <assert.h>
 
 int main(int argc, char **argv)

--- a/test/test_cd.h
+++ b/test/test_cd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +8,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
@@ -12,8 +12,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include "test_common.h"
 #include <stdarg.h>

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -17,8 +17,8 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
-#include <src/include/pmix_config.h>
-#include <pmix_common.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/test/test_error.h
+++ b/test/test_error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,8 +8,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_fence.h
+++ b/test/test_fence.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -10,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include <time.h>
 #include "test_common.h"

--- a/test/test_internal.h
+++ b/test/test_internal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_publish.c
+++ b/test/test_publish.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -12,7 +12,7 @@
 
 #include "test_publish.h"
 #include <time.h>
-#include <src/include/pmix_globals.h>
+#include "src/include/pmix_globals.h"
 
 typedef struct {
     int in_progress;

--- a/test/test_publish.h
+++ b/test/test_publish.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -10,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_replace.h
+++ b/test/test_replace.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_resolve_peers.h
+++ b/test/test_resolve_peers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -10,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 

--- a/test/test_spawn.h
+++ b/test/test_spawn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -10,8 +10,8 @@
  *
  */
 
-#include <src/include/pmix_config.h>
-#include <pmix.h>
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
 
 #include "test_common.h"
 


### PR DESCRIPTION
This fixes a bug in the configuration system identified by a
change in the C++ standard. C++20 adds a new mandatory header
named version. This (and any system) header will always be
included with <> and not "". On case-insensitive filesystems
this new header conflicts with the VERSION file at the top
level of the build tree.

To fix this issue PMIx needs to use -iquote instead of -I
for non-system include paths to ensure that these include are
only searched for the quote form of include. This commit also
adds a check to ensure that if the compiler does not support
-iquote that it falls back to -I until support can be added.

Tracks https://github.com/open-mpi/ompi/pull/7169

Fixes #1691

Signed-off-by: Ralph Castain <rhc@pmix.org>