### PR TITLE
Added test_v2 directory for new version of test suite (#2)

### DIFF
--- a/test/test_v2/Makefile
+++ b/test/test_v2/Makefile
@@ -1,0 +1,35 @@
+INSTALLDIR = /home/cps/pmix-install
+INCLUDES = -I. -I../../test -I../../include -I../.. -I../../src/include
+vpath %.h .:../../test:../../include:../..:../../src/include
+LDIR = $(INSTALLDIR)/lib
+
+CC = gcc
+CFLAGS = $(INCLUDES) -Wfatal-errors #-Wall -Wextra -Wpedantic -Wconversion -Wshadow
+LDFLAGS = -Wl,-rpath,$(LDIR)
+LIBS =-lpmix -lpthread -levent
+
+# Executables
+EXE = pmix_test 
+
+# List of all .c source files.
+PCFILES = pmix_test.c test_common.c cli_stages.c utils.c test_server.c server_callbacks.c
+TCFILES = 
+CFILES = $(PCFILES) $(TCFILES)
+
+OBJ = $(CFILES:%.c=%.o)
+POBJ = $(PCFILES:%.c=%.o)
+TOBJ = $(TCFILES:%.c=%.o)
+
+all: pmix_test test_init_fin
+.PHONY: all
+
+clean:
+	rm -f a.out $(EXE) $(OBJ) $(DEP)
+.PHONY: clean
+
+pmix_test: $(POBJ) 
+	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
+
+%.o : %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+

--- a/test/test_v2/cli_stages.c
+++ b/test/test_v2/cli_stages.c
@@ -1,0 +1,228 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "cli_stages.h"
+
+cli_info_t *cli_info = NULL;
+int cli_info_cnt = 0;
+bool test_abort = false;
+bool test_complete = false;
+
+int cli_rank(cli_info_t *cli)
+{
+    int i;
+    for(i=0; i < cli_info_cnt; i++){
+        if( cli == &cli_info[i] ){
+            return cli->rank;
+        }
+    }
+    return -1;
+}
+
+void cli_init(int nprocs)
+{
+    int n, i;
+    cli_state_t order[CLI_TERM+1];
+
+    cli_info = malloc( sizeof(cli_info_t) * nprocs);
+    cli_info_cnt = nprocs;
+
+    order[CLI_UNINIT] = CLI_FORKED;
+    order[CLI_FORKED] = CLI_FIN;
+    order[CLI_CONNECTED] = CLI_UNDEF;
+    order[CLI_FIN] = CLI_TERM;
+    order[CLI_DISCONN] = CLI_UNDEF;
+    order[CLI_TERM] = CLI_UNDEF;
+
+    for (n=0; n < nprocs; n++) {
+        cli_info[n].sd = -1;
+        cli_info[n].ev = NULL;
+        cli_info[n].pid = -1;
+        cli_info[n].state = CLI_UNINIT;
+        PMIX_CONSTRUCT(&(cli_info[n].modex), pmix_list_t);
+        for (i = 0; i < CLI_TERM+1; i++) {
+            cli_info[n].next_state[i] = order[i];
+        }
+        cli_info[n].rank = -1;
+        cli_info[n].ns = NULL;
+    }
+}
+
+void cli_connect(cli_info_t *cli, int sd, pmix_event_base_t * ebase, event_callback_fn callback)
+{
+    if( CLI_CONNECTED != cli->next_state[cli->state] ){
+        TEST_ERROR(("Rank %d has bad next state: expect %d have %d!",
+                     cli_rank(cli), CLI_CONNECTED, cli->next_state[cli->state]));
+        test_abort = true;
+        return;
+    }
+
+    cli->sd = sd;
+    cli->ev = pmix_event_new(ebase, sd,
+                      EV_READ|EV_PERSIST, callback, cli);
+    pmix_event_add(cli->ev,NULL);
+    pmix_ptl_base_set_nonblocking(sd);
+    TEST_VERBOSE(("Connection accepted from rank %d", cli_rank(cli) ));
+    cli->state = CLI_CONNECTED;
+}
+
+void cli_finalize(cli_info_t *cli)
+{
+    if( CLI_FIN != cli->next_state[cli->state] ){
+        TEST_ERROR(("rank %d: bad client next state: expect %d have %d!",
+                     cli_rank(cli), CLI_FIN, cli->next_state[cli->state]));
+        test_abort = true;
+    }
+
+    cli->state = CLI_FIN;
+}
+
+void cli_disconnect(cli_info_t *cli)
+{
+    if( CLI_DISCONN != cli->next_state[cli->state] ){
+        TEST_ERROR(("rank %d: bad client next state: expect %d have %d!",
+                     cli_rank(cli), CLI_DISCONN, cli->next_state[cli->state]));
+        test_abort = true;
+    }
+
+    if( 0 > cli->sd ){
+        TEST_ERROR(("Bad sd = %d of rank = %d ", cli->sd, cli_rank(cli)));
+        test_abort = true;
+    } else {
+        TEST_VERBOSE(("close sd = %d for rank = %d", cli->sd, cli_rank(cli)));
+        close(cli->sd);
+        cli->sd = -1;
+    }
+
+    if( NULL == cli->ev ){
+        TEST_ERROR(("Bad ev = NULL of rank = %d ", cli_rank(cli)));
+        test_abort = true;
+    } else {
+        TEST_VERBOSE(("remove event of rank %d from event queue", cli_rank(cli)));
+        pmix_event_del(cli->ev);
+        pmix_event_free(cli->ev);
+        cli->ev = NULL;
+    }
+
+    TEST_VERBOSE(("Destruct modex list for the rank %d", cli_rank(cli)));
+    PMIX_LIST_DESTRUCT(&(cli->modex));
+
+    cli->state = CLI_DISCONN;
+}
+
+void cli_terminate(cli_info_t *cli)
+{
+    if( CLI_TERM != cli->next_state[cli->state] ){
+        TEST_ERROR(("rank %d: bad client next state: expect %d have %d!",
+                     cli_rank(cli), CLI_TERM, cli->next_state[cli->state]));
+        test_abort = true;
+    }
+    cli->pid = -1;
+    TEST_VERBOSE(("Client rank = %d terminated", cli_rank(cli)));
+    cli->state = CLI_TERM;
+    if (NULL != cli->ns) {
+        free(cli->ns);
+    }
+}
+
+void cli_cleanup(cli_info_t *cli)
+{
+    if (CLI_TERM < cli->state) {
+        TEST_ERROR(("Bad rank %d state %d", cli_rank(cli), cli->state));
+        test_abort = true;
+        return;
+    }
+    switch( cli->next_state[cli->state] ){
+    case CLI_FORKED:
+        break;
+    case CLI_CONNECTED:
+        /* error - means that process terminated w/o calling finalize */
+        if (!test_abort) {
+            TEST_ERROR(("rank %d with state %d unexpectedly terminated.", cli_rank(cli), cli->state));
+        }
+        cli->state = CLI_TERM;
+        test_abort = true;
+        break;
+    case CLI_FIN:
+        /* error - means that process terminated w/o calling finalize */
+        if (!test_abort) {
+            TEST_ERROR(("rank %d with state %d unexpectedly terminated.", cli_rank(cli), cli->state));
+        }
+        cli_finalize(cli);
+        cli_cleanup(cli);
+        test_abort = true;
+        break;
+    case CLI_DISCONN:
+        cli_disconnect(cli);
+        cli_cleanup(cli);
+        break;
+    case CLI_TERM:
+        cli_terminate(cli);
+        break;
+    default:
+        TEST_ERROR(("Bad rank %d next state %d", cli_rank(cli), cli->next_state[cli->state]));
+        test_abort = true;
+        return;
+    }
+}
+
+
+void cli_kill_all(void)
+{
+    int i;
+    for(i = 0; i < cli_info_cnt; i++){
+        if( CLI_UNINIT == cli_info[i].state ){
+            TEST_ERROR(("Skip rank %d as it wasn't ever initialized (shouldn't happe)",
+                          i));
+            continue;
+        } else if( CLI_TERM <= cli_info[i].state ){
+            TEST_VERBOSE(("Skip rank %d as it was already terminated.", i));
+            continue;
+
+        }
+        TEST_VERBOSE(("Kill rank %d (pid = %d).", i, cli_info[i].pid));
+        kill(cli_info[i].pid, SIGKILL);
+        cli_cleanup(&cli_info[i]);
+    }
+}
+
+void errhandler(size_t evhdlr_registration_id,
+                pmix_status_t status,
+                const pmix_proc_t *source,
+                pmix_info_t info[], size_t ninfo,
+                pmix_info_t results[], size_t nresults,
+                pmix_event_notification_cbfunc_fn_t cbfunc,
+                void *cbdata)
+{
+    TEST_ERROR((" PMIX server event handler for %s:%d with status = %d", source->nspace, source->rank, status));
+    /* notify clients of error */
+    PMIx_Notify_event(status, source,
+                      PMIX_RANGE_NAMESPACE,
+                      NULL, 0,
+                      op_callbk, NULL);
+}
+
+void op_callbk(pmix_status_t status,
+                      void *cbdata)
+{
+    TEST_VERBOSE(( "OP CALLBACK CALLED WITH STATUS %d", status));
+}
+
+void errhandler_reg_callbk (pmix_status_t status,
+                            size_t errhandler_ref,
+                            void *cbdata)
+{
+    TEST_VERBOSE(("ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
+                status, (unsigned long)errhandler_ref));
+}

--- a/test/test_v2/cli_stages.h
+++ b/test/test_v2/cli_stages.h
@@ -1,0 +1,85 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef CLI_STAGES_H
+#define CLI_STAGES_H
+
+#include <src/include/pmix_config.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <time.h>
+#include <errno.h>
+#include "src/include/pmix_globals.h"
+#include "pmix_server.h"
+#include "src/class/pmix_list.h"
+#include "src/mca/ptl/base/base.h"
+
+#include "test_common.h"
+
+// In correct scenario each client has to sequentially pass all of this stages
+typedef enum {
+    CLI_UNINIT, CLI_FORKED, CLI_CONNECTED, CLI_FIN, CLI_DISCONN, CLI_TERM, CLI_UNDEF
+} cli_state_t;
+
+typedef struct {
+    pmix_list_t modex;
+    pid_t pid;
+    int sd;
+    pmix_event_t *ev;
+    cli_state_t state;
+    cli_state_t next_state[CLI_TERM+1];
+    pmix_rank_t rank;
+    char *ns;
+    int exit_code;
+    bool alive;
+} cli_info_t;
+
+extern cli_info_t *cli_info;
+extern int cli_info_cnt;
+extern bool test_abort;
+extern bool test_complete;
+
+int cli_rank(cli_info_t *cli);
+void cli_init(int nprocs);
+void cli_connect(cli_info_t *cli, int sd, struct event_base * ebase, event_callback_fn callback);
+void cli_finalize(cli_info_t *cli);
+void cli_disconnect(cli_info_t *cli);
+void cli_terminate(cli_info_t *cli);
+void cli_cleanup(cli_info_t *cli);
+void cli_kill_all(void);
+
+bool test_terminated(void);
+
+void errhandler(size_t evhdlr_registration_id,
+                pmix_status_t status,
+                const pmix_proc_t *source,
+                pmix_info_t info[], size_t ninfo,
+                pmix_info_t results[], size_t nresults,
+                pmix_event_notification_cbfunc_fn_t cbfunc,
+                void *cbdata);
+
+void op_callbk(pmix_status_t status,
+               void *cbdata);
+
+void errhandler_reg_callbk (pmix_status_t status,
+                            size_t errhandler_ref,
+                            void *cbdata);
+
+#endif // CLI_STAGES_H

--- a/test/test_v2/pmix_regex.c
+++ b/test/test_v2/pmix_regex.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "src/util/argv.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/output.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/mca/preg/preg.h"
+
+#include "server_callbacks.h"
+#include "utils.h"
+
+#define TEST_NODES "odin001,odin002,odin003,odin010,odin011,odin075"
+#define TEST_PROCS "1,2,3,4;5-8;9,11-12;17-20;21-24;100"
+#define TEST_NODES2 "c712f6n01,c712f6n02,c712f6n03"
+
+bool spawn_wait = false;
+
+int main(int argc, char **argv)
+{
+    char *regex;
+    char **nodes, **procs;
+    pmix_status_t rc;
+
+    /* smoke test */
+    if (PMIX_SUCCESS != 0) {
+        TEST_ERROR(("ERROR IN COMPUTING CONSTANTS: PMIX_SUCCESS = %d", PMIX_SUCCESS));
+        exit(1);
+    }
+
+    TEST_VERBOSE(("Testing version %s", PMIx_Get_version()));
+
+    PMIx_server_init(&mymodule, NULL, 0);
+
+    TEST_VERBOSE(("Start PMIx regex smoke test"));
+
+    fprintf(stderr, "NODES: %s\n", TEST_NODES);
+    PMIx_generate_regex(TEST_NODES, &regex);
+    fprintf(stderr, "REGEX: %s\n\n", regex);
+    /* test reverse parsing */
+    rc = pmix_preg.parse_nodes(regex, &nodes);
+    free(regex);
+    if (PMIX_SUCCESS == rc) {
+        regex = pmix_argv_join(nodes, ',');
+        pmix_argv_free(nodes);
+        fprintf(stderr, "NODES: %s\n", TEST_NODES);
+        fprintf(stderr, "RSULT: %s\n\n\n", regex);
+        free(regex);
+    } else {
+        fprintf(stderr, "Node reverse failed: %d\n\n\n", rc);
+    }
+
+    fprintf(stderr, "PROCS: %s\n", TEST_PROCS);
+    PMIx_generate_ppn(TEST_PROCS, &regex);
+    fprintf(stderr, "PPN: %s\n\n", regex);
+    /* test reverse parsing */
+    rc = pmix_preg.parse_procs(regex, &procs);
+    free(regex);
+    if (PMIX_SUCCESS == rc) {
+        regex = pmix_argv_join(procs, ';');
+        pmix_argv_free(procs);
+        fprintf(stderr, "PROCS: %s\n", TEST_PROCS);
+        fprintf(stderr, "RSULT: %s\n", regex);
+        free(regex);
+    } else {
+        fprintf(stderr, "PPN reverse failed: %d\n", rc);
+    }
+
+    fprintf(stderr, "NODES: %s\n", TEST_NODES2);
+    PMIx_generate_regex(TEST_NODES2, &regex);
+    fprintf(stderr, "REGEX: %s\n\n", regex);
+    /* test reverse parsing */
+    rc = pmix_preg.parse_nodes(regex, &nodes);
+    free(regex);
+    if (PMIX_SUCCESS == rc) {
+        regex = pmix_argv_join(nodes, ',');
+        pmix_argv_free(nodes);
+        fprintf(stderr, "NODES: %s\n", TEST_NODES2);
+        fprintf(stderr, "RSULT: %s\n\n\n", regex);
+        free(regex);
+    } else {
+        fprintf(stderr, "Node reverse failed: %d\n\n\n", rc);
+    }
+    return 0;
+}

--- a/test/test_v2/pmix_test.c
+++ b/test/test_v2/pmix_test.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "src/util/pmix_environ.h"
+#include "src/util/output.h"
+
+#include "server_callbacks.h"
+#include "utils.h"
+#include "test_server.h"
+#include "test_common.h"
+
+bool spawn_wait = false;
+
+int main(int argc, char **argv)
+{
+    char **client_env=NULL;
+    char **client_argv=NULL;
+    int rc, i;
+    struct stat stat_buf;
+    int test_fail = 0;
+    char *tmp;
+    int ns_nprocs;
+    sigset_t unblock;
+
+    INIT_TEST_PARAMS(params);
+
+    /* smoke test */
+    if (PMIX_SUCCESS != 0) {
+        TEST_ERROR(("ERROR IN COMPUTING CONSTANTS: PMIX_SUCCESS = %d", PMIX_SUCCESS));
+        exit(1);
+    }
+
+    TEST_VERBOSE(("Testing version %s", PMIx_Get_version()));
+
+    parse_cmd(argc, argv, &params);
+    TEST_VERBOSE(("Start PMIx_lite smoke test (timeout is %d)", params.timeout));
+
+    /* set common argv and env */
+    client_env = pmix_argv_copy(environ);
+    set_client_argv(&params, &client_argv);
+
+    tmp = pmix_argv_join(client_argv, ' ');
+    TEST_VERBOSE(("Executing test: %s", tmp));
+    free(tmp);
+
+    /* verify executable */
+    if( 0 > ( rc = stat(params.binary, &stat_buf) ) ){
+        TEST_ERROR(("Cannot stat() executable \"%s\": %d: %s", params.binary, errno, strerror(errno)));
+        FREE_TEST_PARAMS(params);
+        return 0;
+    } else if( !S_ISREG(stat_buf.st_mode) ){
+        TEST_ERROR(("Client executable \"%s\": is not a regular file", params.binary));
+        FREE_TEST_PARAMS(params);
+        return 0;
+    }else if( !(stat_buf.st_mode & S_IXUSR) ){
+        TEST_ERROR(("Client executable \"%s\": has no executable flag", params.binary));
+        FREE_TEST_PARAMS(params);
+        return 0;
+    }
+
+    /* ensure that SIGCHLD is unblocked as we need to capture it */
+    if (0 != sigemptyset(&unblock)) {
+        fprintf(stderr, "SIGEMPTYSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigaddset(&unblock, SIGCHLD)) {
+        fprintf(stderr, "SIGADDSET FAILED\n");
+        exit(1);
+    }
+    if (0 != sigprocmask(SIG_UNBLOCK, &unblock, NULL)) {
+        fprintf(stderr, "SIG_UNBLOCK FAILED\n");
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = server_init(&params))) {
+        FREE_TEST_PARAMS(params);
+        return rc;
+    }
+
+    cli_init(params.lsize);
+
+    int launched = 0;
+    /* set namespaces and fork clients */
+    if (NULL == params.ns_dist) {
+        uint32_t i;
+        int base_rank = 0;
+
+        /* compute my start counter */
+        for(i = 0; i < (uint32_t)my_server_id; i++) {
+            base_rank += (params.nprocs % params.nservers) > (uint32_t)i ?
+                        params.nprocs / params.nservers + 1 :
+                        params.nprocs / params.nservers;
+        }
+        /* we have a single namespace for all clients */
+        ns_nprocs = params.nprocs;
+        launched += server_launch_clients(params.lsize, params.nprocs, base_rank,
+                                   &params, &client_env, &client_argv);
+    } else {
+        char *pch;
+        pch = strtok(params.ns_dist, ":");
+        while (NULL != pch) {
+            ns_nprocs = (int)strtol(pch, NULL, 10);
+            if (params.nprocs < (uint32_t)(launched+ns_nprocs)) {
+                TEST_ERROR(("srv #%d: Total number of processes doesn't correspond number specified by ns_dist parameter.", my_server_id));
+                FREE_TEST_PARAMS(params);
+                return PMIX_ERROR;
+            }
+            if (0 < ns_nprocs) {
+                launched += server_launch_clients(ns_nprocs, ns_nprocs, 0, &params,
+                                           &client_env, &client_argv);
+            }
+            pch = strtok (NULL, ":");
+        }
+    }
+    if (params.lsize != (uint32_t)launched) {
+        TEST_ERROR(("srv #%d: Total number of processes doesn't correspond number specified by ns_dist parameter.", my_server_id));
+        cli_kill_all();
+        test_fail = 1;
+        goto done;
+    }
+
+    /* hang around until the client(s) finalize */
+    while (!test_complete) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+
+    if( test_abort ){
+        TEST_ERROR(("srv #%d: Test was aborted!", my_server_id));
+        /* do not simply kill the clients as that generates
+         * event notifications which these tests then print
+         * out, flooding the log */
+      //  cli_kill_all();
+        test_fail = 1;
+    }
+
+    if (0 != params.test_spawn) {
+        PMIX_WAIT_FOR_COMPLETION(spawn_wait);
+    }
+    for(i=0; i < cli_info_cnt; i++){
+        if (cli_info[i].exit_code != 0) {
+            ++test_fail;
+        }
+    }
+
+    /* deregister the errhandler */
+    PMIx_Deregister_event_handler(0, op_callbk, NULL);
+
+  done:
+    TEST_VERBOSE(("srv #%d: call server_finalize!", my_server_id));
+    test_fail += server_finalize(&params, test_fail);
+
+    TEST_VERBOSE(("srv #%d: exit sequence!", my_server_id));
+    FREE_TEST_PARAMS(params);
+    pmix_argv_free(client_argv);
+    pmix_argv_free(client_env);
+
+    if (0 == test_fail) {
+        TEST_OUTPUT(("Test SUCCEEDED!"));
+    }
+    return test_fail;
+}

--- a/test/test_v2/server_callbacks.c
+++ b/test/test_v2/server_callbacks.c
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include "server_callbacks.h"
+#include "src/util/argv.h"
+#include "test_server.h"
+
+extern bool spawn_wait;
+
+pmix_server_module_t mymodule = {
+    .client_connected = connected,
+    .client_finalized = finalized,
+    .abort = abort_fn,
+    .fence_nb = fencenb_fn,
+    .direct_modex = dmodex_fn,
+    .publish = publish_fn,
+    .lookup = lookup_fn,
+    .unpublish = unpublish_fn,
+    .spawn = spawn_fn,
+    .connect = connect_fn,
+    .disconnect = disconnect_fn,
+    .register_events = regevents_fn,
+    .deregister_events = deregevents_fn
+};
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_info_t data;
+    char *namespace_published;
+    int rank_published;
+} pmix_test_info_t;
+
+static void tcon(pmix_test_info_t *p)
+{
+    PMIX_INFO_CONSTRUCT(&p->data);
+}
+
+static void tdes(pmix_test_info_t *p)
+{
+    PMIX_INFO_DESTRUCT(&p->data);
+}
+
+PMIX_CLASS_INSTANCE(pmix_test_info_t,
+                          pmix_list_item_t,
+                          tcon, tdes);
+
+pmix_list_t *pmix_test_published_list = NULL;
+
+static int finalized_count = 0;
+
+pmix_status_t connected(const pmix_proc_t *proc, void *server_object,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
+              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    cli_info_t *cli = NULL;
+    int i;
+    for (i = 0; i < cli_info_cnt; i++) {
+        if((proc->rank == cli_info[i].rank) &&
+                (0 == strcmp(proc->nspace, cli_info[i].ns))){
+            cli = &cli_info[i];
+            break;
+        }
+    }
+    if (NULL == cli) {
+        TEST_ERROR(("cannot found rank %d", proc->rank));
+        return PMIX_SUCCESS;
+    }
+    if( CLI_TERM <= cli->state ){
+        TEST_ERROR(("double termination of rank %d", proc->rank));
+        return PMIX_SUCCESS;
+    }
+    TEST_VERBOSE(("Rank %s:%d terminated", proc->nspace, proc->rank));
+    cli_finalize(cli);
+    finalized_count++;
+    if (finalized_count == cli_info_cnt) {
+        if (NULL != pmix_test_published_list) {
+            PMIX_LIST_RELEASE(pmix_test_published_list);
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object,
+             int status, const char msg[],
+             pmix_proc_t procs[], size_t nprocs,
+             pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    TEST_VERBOSE(("Abort is called with status = %d, msg = %s",
+                  status, msg));
+    test_abort = true;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+               const pmix_info_t info[], size_t ninfo,
+               char *data, size_t ndata,
+               pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    TEST_VERBOSE(("Getting data for %s:%d",
+                  procs[0].nspace, procs[0].rank));
+
+    if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, data, ndata, cbdata, NULL, NULL);
+        }
+        return PMIX_SUCCESS;
+    }
+    return server_fence_contrib(data, ndata, cbfunc, cbdata);
+}
+
+pmix_status_t dmodex_fn(const pmix_proc_t *proc,
+              const pmix_info_t info[], size_t ninfo,
+              pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t n;
+
+    TEST_VERBOSE(("Getting data for %s:%d", proc->nspace, proc->rank));
+
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                return PMIX_ERR_NOT_SUPPORTED;
+            }
+        }
+    }
+
+    /* return not_found for single server mode */
+    if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    // TODO: add support tracker for dmodex requests
+    return server_dmdx_get(proc->nspace, proc->rank, cbfunc, cbdata);
+}
+
+pmix_status_t publish_fn(const pmix_proc_t *proc,
+               const pmix_info_t info[], size_t ninfo,
+               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t i;
+    int found;
+    pmix_test_info_t *new_info, *old_info;
+    if (NULL == pmix_test_published_list) {
+        pmix_test_published_list = PMIX_NEW(pmix_list_t);
+    }
+    for (i = 0; i < ninfo; i++) {
+        found = 0;
+        PMIX_LIST_FOREACH(old_info, pmix_test_published_list, pmix_test_info_t) {
+            if (!strcmp(old_info->data.key, info[i].key)) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            new_info = PMIX_NEW(pmix_test_info_t);
+            PMIX_LOAD_KEY(new_info->data.key, info[i].key);
+            pmix_value_xfer(&new_info->data.value, (pmix_value_t*)&info[i].value);
+            new_info->namespace_published = strdup(proc->nspace);
+            new_info->rank_published = proc->rank;
+            pmix_list_append(pmix_test_published_list, &new_info->super);
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+              const pmix_info_t info[], size_t ninfo,
+              pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t i, ndata, ret;
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_pdata_t *pdata;
+    pmix_test_info_t *tinfo;
+    if (NULL == pmix_test_published_list) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    ndata = pmix_argv_count(keys);
+    PMIX_PDATA_CREATE(pdata, ndata);
+    ret = 0;
+    for (i = 0; i < ndata; i++) {
+        PMIX_LIST_FOREACH(tinfo, pmix_test_published_list, pmix_test_info_t) {
+            if (0 == strcmp(tinfo->data.key, keys[i])) {
+                (void)strncpy(pdata[i].proc.nspace, tinfo->namespace_published, PMIX_MAX_NSLEN);
+                pdata[i].proc.rank = tinfo->rank_published;
+                memset(pdata[i].key, 0, PMIX_MAX_KEYLEN+1);
+                (void)strncpy(pdata[i].key, keys[i], PMIX_MAX_KEYLEN);
+                pmix_value_xfer(&pdata[i].value, &tinfo->data.value);
+                ret++;
+                break;
+            }
+        }
+    }
+    if (ret != ndata) {
+        rc = PMIX_ERR_NOT_FOUND;
+        goto error;
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, pdata, ndata, cbdata);
+    }
+error:
+    PMIX_PDATA_FREE(pdata, ndata);
+    return rc;
+}
+
+pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                 const pmix_info_t info[], size_t ninfo,
+                 pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t i;
+    pmix_test_info_t *iptr, *next;
+    if (NULL == pmix_test_published_list) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    PMIX_LIST_FOREACH_SAFE(iptr, next, pmix_test_published_list, pmix_test_info_t) {
+        if (1) {  // if data posted by this process
+            if (NULL == keys) {
+                pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                PMIX_RELEASE(iptr);
+            } else {
+                ninfo = pmix_argv_count(keys);
+                for (i = 0; i < ninfo; i++) {
+                    if (!strcmp(iptr->data.key, keys[i])) {
+                        pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                        PMIX_RELEASE(iptr);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+typedef struct {
+    pmix_status_t status;
+    pmix_spawn_cbfunc_t cbfunc;
+    void *cbdata;
+} release_cbdata;
+
+
+static void * _release_cb(void *arg)
+{
+    release_cbdata *cb = (release_cbdata*)arg;
+    if (NULL != cb->cbfunc) {
+        cb->cbfunc(cb->status, "foobar", cb->cbdata);
+    }
+    free(cb);
+    spawn_wait = false;
+    pthread_exit(NULL);
+}
+
+static void release_cb(pmix_status_t status, void *cbdata)
+{
+    pthread_t thread;
+
+    if (0 > pthread_create(&thread, NULL, _release_cb, cbdata)) {
+        spawn_wait = false;
+        return;
+    }
+    pthread_detach(thread);
+}
+
+pmix_status_t spawn_fn(const pmix_proc_t *proc,
+             const pmix_info_t job_info[], size_t ninfo,
+             const pmix_app_t apps[], size_t napps,
+             pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    release_cbdata *cb = malloc(sizeof(release_cbdata));
+
+    cb->status = PMIX_SUCCESS;
+    cb->cbfunc = cbfunc;
+    cb->cbdata = cbdata;
+
+    spawn_wait = true;
+    PMIx_server_register_nspace("foobar", napps, NULL, 0, release_cb, (void*)cb);
+    return PMIX_SUCCESS;
+}
+static int numconnect = 0;
+
+pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                         const pmix_info_t info[], size_t ninfo,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    numconnect++;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                            const pmix_info_t info[], size_t ninfo,
+                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t regevents_fn (pmix_status_t *codes, size_t ncodes,
+                           const pmix_info_t info[], size_t ninfo,
+                           pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    TEST_VERBOSE ((" pmix host server regevents_fn called "));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t deregevents_fn (pmix_status_t *codes, size_t ncodes,
+                             pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    TEST_VERBOSE ((" pmix host server deregevents_fn called "));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}

--- a/test/test_v2/server_callbacks.h
+++ b/test/test_v2/server_callbacks.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#ifndef PMIX_SERVER_CALLBACK_H
+#define PMIX_SERVER_CALLBACK_H
+
+#include "cli_stages.h"
+
+pmix_status_t connected(const pmix_proc_t *proc, void *server_object,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t abort_fn(const pmix_proc_t *proc,
+                       void *server_object,
+                       int status, const char msg[],
+                       pmix_proc_t procs[], size_t nprocs,
+                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+                         const pmix_info_t info[], size_t ninfo,
+                         char *data, size_t ndata,
+                         pmix_modex_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t dmodex_fn(const pmix_proc_t *proc,
+                        const pmix_info_t info[], size_t ninfo,
+                        pmix_modex_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t publish_fn(const pmix_proc_t *proc,
+                         const pmix_info_t info[], size_t ninfo,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
+                        pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                           const pmix_info_t info[], size_t ninfo,
+                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t spawn_fn(const pmix_proc_t *proc,
+                       const pmix_info_t job_info[], size_t ninfo,
+                       const pmix_app_t apps[], size_t napps,
+                       pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                         const pmix_info_t info[], size_t ninfo,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                            const pmix_info_t info[], size_t ninfo,
+                            pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t regevents_fn(pmix_status_t *codes, size_t ncodes,
+                           const pmix_info_t info[], size_t ninfo,
+                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t deregevents_fn(pmix_status_t *codes, size_t ncodes,
+                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+extern pmix_server_module_t mymodule;
+
+#endif

--- a/test/test_v2/test_common.c
+++ b/test/test_v2/test_common.c
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+
+#include "test_common.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
+
+int pmix_test_verbose = 0;
+test_params params;
+
+FILE *file;
+
+#define OUTPUT_MAX 1024
+char *pmix_test_output_prepare(const char *fmt, ... )
+{
+    static char output[OUTPUT_MAX];
+    va_list args;
+    va_start( args, fmt );
+    memset(output, 0, sizeof(output));
+    vsnprintf(output, OUTPUT_MAX - 1, fmt, args);
+    va_end(args);
+    return output;
+}
+
+void parse_cmd(int argc, char **argv, test_params *params)
+{
+    int i;
+
+    /* set output to stderr by default */
+    file = stdout;
+    if( params->nspace != NULL ) {
+        params->nspace = NULL;
+    }
+
+    /* parse user options */
+    for (i=1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--n") || 0 == strcmp(argv[i], "-n")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->np = strdup(argv[i]);
+                params->nprocs = strtol(argv[i], NULL, 10);
+                if (-1 == params->ns_size) {
+                    params->ns_size = params->nprocs;
+                }
+            }
+        } else if (0 == strcmp(argv[i], "--h") || 0 == strcmp(argv[i], "-h")) {
+            /* print help */
+            fprintf(stderr, "usage: pmix_test [-h] [-e foo] [-b] [-c] [-nb]\n");
+            fprintf(stderr, "\t-n       the job size (for checking purposes)\n");
+            fprintf(stderr, "\t-s       number of servers to emulate\n");
+            fprintf(stderr, "\t-e foo   use foo as test client\n");
+            fprintf(stderr, "\t-v       verbose output\n");
+            fprintf(stderr, "\t-t <>    set timeout\n");
+            fprintf(stderr, "\t-o out   redirect clients logs to file out.<rank>\n");
+            fprintf(stderr, "\t--early-fail    force client process with rank 0 to fail before PMIX_Init.\n");
+            fprintf(stderr, "\t--ns-dist n1:n2:n3   register n namespaces (3 in this example) each with ni ranks (n1, n2 or n3).\n");
+            fprintf(stderr, "\t--fence \"[<data_exchange><blocking> | ns0:ranks;ns1:ranks...][...]\"  specify fences in different configurations.\n");
+            fprintf(stderr, "\t--use-same-keys relative to the --fence option: put the same keys in the interim between multiple fences.\n");
+            fprintf(stderr, "\t--job-fence  test fence inside its own namespace.\n");
+            fprintf(stderr, "\t-c       relative to the --job-fence option: fence[_nb] callback shall include all collected data\n");
+            fprintf(stderr, "\t-nb      relative to the --job-fence option: use non-blocking fence\n");
+            fprintf(stderr, "\t--noise \"[ns0:ranks;ns1:ranks...]\"  add system noise to specified processes.\n");
+            fprintf(stderr, "\t--test-publish     test publish/lookup/unpublish api.\n");
+            fprintf(stderr, "\t--test-spawn       test spawn api.\n");
+            fprintf(stderr, "\t--test-connect     test connect/disconnect api.\n");
+            fprintf(stderr, "\t--test-resolve-peers    test resolve_peers api.\n");
+            fprintf(stderr, "\t--test-error test error handling api.\n");
+            fprintf(stderr, "\t--test-replace N:k0,k1,...,k(N-1)   test key replace for N keys, k0,k1,k(N-1) - key indexes to replace  \n");
+            fprintf(stderr, "\t--test-internal N  test store internal key, N - number of internal keys\n");
+            fprintf(stderr, "\t--gds <external gds name>           set GDS module \"--gds hash|ds12\", default is hash\n");
+            exit(0);
+        } else if (0 == strcmp(argv[i], "--exec") || 0 == strcmp(argv[i], "-e")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->binary = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--nservers") || 0 == strcmp(argv[i], "-s")){
+            i++;
+            if (NULL != argv[i]) {
+                params->nservers = atoi(argv[i]);
+            }
+            if (2 < params->nservers) {
+                fprintf(stderr, "Only support up to 2 servers\n");
+                exit(1);
+            }
+        } else if( 0 == strcmp(argv[i], "--verbose") || 0 == strcmp(argv[i],"-v") ){
+            TEST_VERBOSE_ON();
+            params->verbose = 1;
+        } else if (0 == strcmp(argv[i], "--timeout") || 0 == strcmp(argv[i], "-t")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->timeout = atoi(argv[i]);
+                if( params->timeout == 0 ){
+                    params->timeout = TEST_DEFAULT_TIMEOUT;
+                }
+            }
+        } else if( 0 == strcmp(argv[i], "-o")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->prefix = strdup(argv[i]);
+            }
+        } else if( 0 == strcmp(argv[i], "-s")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->nspace = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--rank") || 0 == strcmp(argv[i], "-r")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->rank = strtol(argv[i], NULL, 10);
+            }
+        } else if( 0 == strcmp(argv[i], "--early-fail") ){
+            params->early_fail = 1;
+        } else if (0 == strcmp(argv[i], "--fence")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->fences = strdup(argv[i]);
+                if (0 != parse_fence(params->fences, 0)) {
+                    fprintf(stderr, "Incorrect --fence option format: %s\n", params->fences);
+                    exit(1);
+                }
+            }
+        } else if (0 == strcmp(argv[i], "--use-same-keys")) {
+            params->use_same_keys = 1;
+        } else if (0 == strcmp(argv[i], "--job-fence")) {
+            params->test_job_fence = 1;
+        } else if (0 == strcmp(argv[i], "--collect-corrupt")) {
+            params->collect_bad = 1;
+        } else if (0 == strcmp(argv[i], "--collect") || 0 == strcmp(argv[i], "-c")) {
+            params->collect = 1;
+        } else if (0 == strcmp(argv[i], "--non-blocking") || 0 == strcmp(argv[i], "-nb")) {
+            params->nonblocking = 1;
+        } else if (0 == strcmp(argv[i], "--noise")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->noise = strdup(argv[i]);
+                if (0 != parse_noise(params->noise, 0)) {
+                    fprintf(stderr, "Incorrect --noise option format: %s\n", params->noise);
+                    exit(1);
+                }
+            }
+        } else if (0 == strcmp(argv[i], "--ns-dist")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_dist = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--ns-size")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_size = strtol(argv[i], NULL, 10);
+            }
+        } else if (0 == strcmp(argv[i], "--ns-id")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_id = strtol(argv[i], NULL, 10);
+            }
+        } else if (0 == strcmp(argv[i], "--base-rank")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->base_rank = strtol(argv[i], NULL, 10);
+            }
+        } else if( 0 == strcmp(argv[i], "--test-publish") ){
+            params->test_publish = 1;
+        } else if( 0 == strcmp(argv[i], "--test-spawn") ){
+            params->test_spawn = 1;
+        } else if( 0 == strcmp(argv[i], "--test-connect") ){
+            params->test_connect = 1;
+        } else if( 0 == strcmp(argv[i], "--test-resolve-peers") ){
+            params->test_resolve_peers = 1;
+        } else if( 0 == strcmp(argv[i], "--test-error") ){
+            params->test_error = 1;
+        } else if(0 == strcmp(argv[i], "--test-replace") ) {
+            i++;
+            if (NULL != argv[i] && (*argv[i] != '-')) {
+                params->key_replace = strdup(argv[i]);
+                if (0 != parse_replace(params->key_replace, 0, NULL)) {
+                    fprintf(stderr, "Incorrect --test-replace option format: %s\n", params->key_replace);
+                    exit(1);
+                }
+            } else {
+                params->key_replace = strdup(TEST_REPLACE_DEFAULT);
+            }
+        } else if(0 == strcmp(argv[i], "--test-internal")) {
+            i++;
+            if ((NULL != argv[i]) && (*argv[i] != '-')) {
+                params->test_internal = strtol(argv[i], NULL, 10);
+            } else {
+                params->test_internal = 1;
+            }
+        } else if(0 == strcmp(argv[i], "--gds") ) {
+            i++;
+            params->gds_mode = strdup(argv[i]);
+        }
+
+        else {
+            fprintf(stderr, "unrecognized option: %s\n", argv[i]);
+            exit(1);
+        }
+    }
+    if (NULL == params->binary) {
+        char *basename = NULL;
+        basename = strrchr(argv[0], '/');
+        if (basename) {
+            *basename = '\0';
+            /* pmix_test and pmix_clients are the shell scripts that
+             * make sure that actual binary placed in "./.libs" directory
+             * is properly linked.
+             * after launch pmix_test you'll find the following process:
+             *      <pmix-root-dir>/test/.libs/lt-pmix_test
+             *
+             * To launch
+             *      <pmix-root-dir>/test/pmix_client
+             * instead of
+             *      <pmix-root-dir>/test/.libs/pmix_client
+             * we need to do a step back in directory tree.
+             */
+            if (0 > asprintf(&params->binary, "%s/../pmix_client", argv[0])) {
+                exit(1);
+            }
+            *basename = '/';
+        } else {
+            if (0 > asprintf(&params->binary, "pmix_client")) {
+                exit(1);
+            }
+        }
+    }
+
+    if( params->collect_bad ){
+        params->collect = params->rank % 2;
+    }
+
+    // Fix rank if running under SLURM
+    if( PMIX_RANK_UNDEF == params->rank ){
+        char *ranklist = getenv("SLURM_GTIDS");
+        char *rankno = getenv("SLURM_LOCALID");
+        if( NULL != ranklist && NULL != rankno ){
+            char **argv = pmix_argv_split(ranklist, ',');
+            int count = pmix_argv_count(argv);
+            int rankidx = strtoul(rankno, NULL, 10);
+            if( rankidx >= count ){
+                fprintf(stderr, "It feels like we are running under SLURM:\n\t"
+                        "SLURM_GTIDS=%s, SLURM_LOCALID=%s\nbut env vars are conflicting\n",
+                        ranklist, rankno);
+                exit(1);
+            }
+            params->rank = strtoul(argv[rankidx], NULL, 10);
+            pmix_argv_free(argv);
+        }
+    }
+
+    // Fix namespace if running under SLURM
+    if( NULL == params->nspace ){
+        char *nspace = getenv("PMIX_NAMESPACE");
+        if( NULL != nspace ){
+            params->nspace = strdup(nspace);
+        }
+    }
+}
+
+static void fcon(fence_desc_t *p)
+{
+    p->blocking = 0;
+    p->data_exchange = 0;
+    p->participants = PMIX_NEW(pmix_list_t);
+}
+
+static void fdes(fence_desc_t *p)
+{
+    PMIX_LIST_RELEASE(p->participants);
+}
+
+PMIX_CLASS_INSTANCE(fence_desc_t,
+                    pmix_list_item_t,
+                    fcon, fdes);
+
+PMIX_CLASS_INSTANCE(participant_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+PMIX_CLASS_INSTANCE(key_replace_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+static int ns_id = -1;
+static fence_desc_t *fdesc = NULL;
+pmix_list_t *participants = NULL;
+pmix_list_t test_fences;
+pmix_list_t *noise_range = NULL;
+pmix_list_t key_replace;
+
+#define CHECK_STRTOL_VAL(val, str, store) do {                  \
+    if (0 == val) {                                             \
+        if (0 != strncmp(str, "0", 1)) {                         \
+            if (!store) {                                       \
+                return 1;                                       \
+            }                                                   \
+        }                                                       \
+    }                                                           \
+} while (0)
+
+static int parse_token(char *str, int step, int store)
+{
+    char *pch;
+    int count = 0;
+    int remember = -1;
+    int i;
+    int rank;
+    participant_t *proc;
+
+    switch (step) {
+    case 0:
+        if (store) {
+            fdesc = PMIX_NEW(fence_desc_t);
+            participants = fdesc->participants;
+        }
+        pch = strchr(str, '|');
+        if (NULL != pch) {
+            while (pch != str) {
+                if ('d' == *str) {
+                    if (store && NULL != fdesc) {
+                        fdesc->data_exchange = 1;
+                    }
+                } else if ('b' == *str) {
+                    if (store && NULL != fdesc) {
+                        fdesc->blocking = 1;
+                    }
+                } else if (' ' != *str) {
+                    if (!store) {
+                        return 1;
+                    }
+                }
+                str++;
+            }
+            if (0 < parse_token(pch+1, 1, store)) {
+                if (!store) {
+                    return 1;
+                }
+            }
+        } else {
+            if (0 < parse_token(str, 1, store)) {
+                if (!store) {
+                    return 1;
+                }
+            }
+        }
+        if (store && NULL != fdesc) {
+            pmix_list_append(&test_fences, &fdesc->super);
+        }
+        break;
+    case 1:
+        if (store && NULL == participants) {
+            participants = PMIX_NEW(pmix_list_t);
+            noise_range = participants;
+        }
+        pch = strtok(str, ";");
+        while (NULL != pch) {
+            if (0 < parse_token(pch, 2, store)) {
+                if (!store) {
+                    return 1;
+                }
+            }
+            pch = strtok (NULL, ";");
+        }
+        break;
+    case 2:
+        pch = strchr(str, ':');
+        if (NULL != pch) {
+            *pch = '\0';
+            pch++;
+            while (' ' == *str) {
+                str++;
+            }
+            ns_id = (int)(strtol(str, NULL, 10));
+            CHECK_STRTOL_VAL(ns_id, str, store);
+            if (0 < parse_token(pch, 3, store)) {
+                if (!store) {
+                    return 1;
+                }
+            }
+        } else {
+            if (!store) {
+                return 1;
+            }
+        }
+        break;
+    case 3:
+        while (' ' == *str) {
+            str++;
+        }
+        if ('\0' == *str) {
+            /* all ranks from namespace participate */
+            if (store && NULL != participants) {
+                proc = PMIX_NEW(participant_t);
+                (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
+                proc->proc.rank = PMIX_RANK_WILDCARD;
+                pmix_list_append(participants, &proc->super);
+            }
+        }
+        while ('\0' != *str) {
+            if (',' == *str && 0 != count) {
+                *str = '\0';
+                if (-1 != remember) {
+                    rank = (int)(strtol(str-count, NULL, 10));
+                    CHECK_STRTOL_VAL(rank, str-count, store);
+                    for (i = remember; i < rank; i++) {
+                        if (store && NULL != participants) {
+                            proc = PMIX_NEW(participant_t);
+                            (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
+                            proc->proc.rank = i;
+                            pmix_list_append(participants, &proc->super);
+                        }
+                    }
+                    remember = -1;
+                }
+                rank = (int)(strtol(str-count, NULL, 10));
+                CHECK_STRTOL_VAL(rank, str-count, store);
+                if (store && NULL != participants) {
+                    proc = PMIX_NEW(participant_t);
+                    (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
+                    proc->proc.rank = rank;
+                    pmix_list_append(participants, &proc->super);
+                }
+                count = -1;
+            } else if ('-' == *str && 0 != count) {
+                *str = '\0';
+                remember = (int)(strtol(str-count, NULL, 10));
+                CHECK_STRTOL_VAL(remember, str-count, store);
+                count = -1;
+            }
+            str++;
+            count++;
+        }
+        if (0 != count) {
+            if (-1 != remember) {
+                rank = (int)(strtol(str-count, NULL, 10));
+                CHECK_STRTOL_VAL(rank, str-count, store);
+                for (i = remember; i < rank; i++) {
+                    if (store && NULL != participants) {
+                        proc = PMIX_NEW(participant_t);
+                        (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
+                        proc->proc.rank = i;
+                        pmix_list_append(participants, &proc->super);
+                    }
+                }
+                remember = -1;
+            }
+            rank = (int)(strtol(str-count, NULL, 10));
+            CHECK_STRTOL_VAL(rank, str-count, store);
+            if (store && NULL != participants) {
+                proc = PMIX_NEW(participant_t);
+                (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
+                proc->proc.rank = rank;
+                pmix_list_append(participants, &proc->super);
+            }
+        }
+        break;
+    default:
+        fprintf(stderr, "Incorrect parsing step.\n");
+        return 1;
+    }
+    return 0;
+}
+
+int parse_fence(char *fence_param, int store)
+{
+    int ret = 0;
+    char *tmp = strdup(fence_param);
+    char * pch, *ech;
+
+    pch = strchr(tmp, '[');
+    while (NULL != pch) {
+        pch++;
+        ech = strchr(pch, ']');
+        if (NULL != ech) {
+            *ech = '\0';
+            ech++;
+            ret += parse_token(pch, 0, store);
+            pch = strchr(ech, '[');
+        } else {
+            ret = 1;
+            break;
+        }
+    }
+    free(tmp);
+    return ret;
+}
+
+int parse_noise(char *noise_param, int store)
+{
+    int ret = 0;
+    char *tmp = strdup(noise_param);
+    char * pch, *ech;
+
+    pch = strchr(tmp, '[');
+    if (NULL != pch) {
+        pch++;
+        ech = strchr(pch, ']');
+        if (NULL != ech) {
+            *ech = '\0';
+            ech++;
+            if ('\0' != *ech) {
+                ret = 1;
+            } else {
+                ret = parse_token(pch, 1, store);
+            }
+        } else {
+            ret = 1;
+        }
+    }
+    free(tmp);
+    return ret;
+}
+
+static int is_digit(const char *str)
+{
+    if (NULL == str)
+        return 0;
+
+    while (0 != *str) {
+        if (!isdigit(*str)) {
+        return 0;
+        }
+        else {
+            str++;
+        }
+    }
+    return 1;
+}
+
+int parse_replace(char *replace_param, int store, int *key_num) {
+    int ret = 0;
+    char *tmp = strdup(replace_param);
+    char tmp_str[32];
+    char * pch, *ech;
+    key_replace_t *item;
+    int cnt = 0;
+
+    if (NULL == replace_param) {
+        free(tmp);
+        return 1;
+    }
+
+    pch = strchr(tmp, ':');
+    snprintf(tmp_str, pch - tmp + 1, "%s", tmp);
+    cnt = atol(tmp_str);
+
+    if (NULL != key_num) {
+        *key_num = cnt;
+    }
+
+    while(NULL != pch) {
+        pch++;
+        ech = strchr(pch, ',');
+        if (strlen(pch) > 0) {
+            if (NULL != ech) {
+                snprintf(tmp_str, ech - pch + 1, "%s", pch);
+            } else {
+                snprintf(tmp_str, strlen(pch) + 1, "%s", pch);
+            }
+            if ((0 == is_digit(tmp_str)) || ((atoi(tmp_str) + 1) > cnt)) {
+                ret = 1;
+                break;
+            }
+            pch = ech;
+            if (store) {
+                item = PMIX_NEW(key_replace_t);
+                item->key_idx = atoi(tmp_str);
+                pmix_list_append(&key_replace, &item->super);
+            }
+        } else {
+            ret = 1;
+            break;
+        }
+    }
+    free(tmp);
+    return ret;
+}
+
+int get_total_ns_number(test_params params)
+{
+    int num = 0;
+    if (NULL == params.ns_dist) {
+        return 1;
+    } else {
+        char *tmp = strdup(params.ns_dist);
+        char *pch = tmp;
+        while (NULL != pch) {
+            num++;
+            pch = strtok((1 == num ) ? tmp : NULL, ":");
+        }
+        num--;
+        free(tmp);
+    }
+    return num;
+}
+
+int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks)
+{
+    size_t num_ranks = 0;
+    int num = -1;
+    size_t j;
+    if (NULL == params.ns_dist) {
+        *nranks = params.ns_size;
+        PMIX_PROC_CREATE(*ranks, params.ns_size);
+        for (j = 0; j < (size_t)params.ns_size; j++) {
+            (void)strncpy((*ranks)[j].nspace, nspace, PMIX_MAX_NSLEN);
+            (*ranks)[j].rank = j;
+        }
+    } else {
+        char *tmp = strdup(params.ns_dist);
+        char *pch = tmp;
+        int ns_id = (int)strtol(nspace + strlen(TEST_NAMESPACE) + 1, NULL, 10);
+        while (NULL != pch && num != ns_id) {
+            pch = strtok((-1 == num ) ? tmp : NULL, ":");
+            if (NULL == pch) {
+                break;
+            }
+            num++;
+            num_ranks = (size_t)strtol(pch, NULL, 10);
+        }
+        if (num == ns_id && 0 != num_ranks) {
+            *nranks = num_ranks;
+            PMIX_PROC_CREATE(*ranks, num_ranks);
+            for (j = 0; j < num_ranks; j++) {
+                (void)strncpy((*ranks)[j].nspace, nspace, PMIX_MAX_NSLEN);
+                (*ranks)[j].rank = j;
+            }
+        } else {
+            free(tmp);
+            return PMIX_ERROR;
+        }
+        free(tmp);
+    }
+    return PMIX_SUCCESS;
+}

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#ifndef TEST_COMMON_H
+#define TEST_COMMON_H
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/argv.h"
+
+#define TEST_NAMESPACE "smoky_nspace"
+#define TEST_CREDENTIAL "dummy"
+
+#define PMIX_WAIT_FOR_COMPLETION(m) \
+    do {                            \
+        while ((m)) {               \
+            usleep(10);             \
+        }                           \
+    } while(0)
+
+
+/* WARNING: pmix_test_output_prepare is currently not threadsafe!
+ * fix it once needed!
+ */
+char *pmix_test_output_prepare(const char *fmt,... );
+extern int pmix_test_verbose;
+extern FILE *file;
+
+#define STRIPPED_FILE_NAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+
+#define TEST_OUTPUT(x) {                            \
+    struct timeval tv;                              \
+    gettimeofday(&tv, NULL);                        \
+    double ts = tv.tv_sec + 1E-6*tv.tv_usec;        \
+    fprintf(file,"==%d== [%lf] %s:%s: %s\n",        \
+            getpid(), ts,STRIPPED_FILE_NAME,        \
+            __func__,                               \
+            pmix_test_output_prepare x );           \
+    fflush(file);                                   \
+}
+
+// Write output without adding anything to it.
+// Need for automate tests to receive "OK" string
+#define TEST_OUTPUT_CLEAR(x) { \
+    fprintf(file, "==%d== %s", getpid(), pmix_test_output_prepare x ); \
+    fflush(file); \
+}
+
+// Always write errors to the stderr
+#define TEST_ERROR(x) { \
+    struct timeval tv;                              \
+    gettimeofday(&tv, NULL);                        \
+    double ts = tv.tv_sec + 1E-6*tv.tv_usec;        \
+    fprintf(stderr,                                 \
+            "==%d== [%lf] ERROR [%s:%d:%s]: %s\n",  \
+            getpid(), ts,                           \
+            STRIPPED_FILE_NAME, __LINE__, __func__, \
+            pmix_test_output_prepare x );           \
+    fflush(stderr);                                 \
+}
+
+#define TEST_VERBOSE_ON() (pmix_test_verbose = 1)
+#define TEST_VERBOSE_GET() (pmix_test_verbose)
+
+#define TEST_VERBOSE(x) { \
+    if( pmix_test_verbose ){ \
+        TEST_OUTPUT(x); \
+    } \
+}
+
+#define TEST_DEFAULT_TIMEOUT 10
+#define MAX_DIGIT_LEN 10
+#define TEST_REPLACE_DEFAULT "3:1"
+
+#define TEST_SET_FILE(prefix, ns_id, rank) { \
+    char *fname = malloc( strlen(prefix) + MAX_DIGIT_LEN + 2 ); \
+    sprintf(fname, "%s.%d.%d", prefix, ns_id, rank); \
+    file = fopen(fname, "w"); \
+    free(fname); \
+    if( NULL == file ){ \
+        fprintf(stderr, "Cannot open file %s for writing!", fname); \
+        exit(1); \
+    } \
+}
+
+#define TEST_CLOSE_FILE() { \
+    if ( stderr != file ) { \
+        fclose(file); \
+    } \
+}
+
+typedef struct {
+    char *binary;
+    char *np;
+    char *prefix;
+    char *nspace;
+    uint32_t nprocs;
+    int timeout;
+    int verbose;
+    pmix_rank_t rank;
+    int early_fail;
+    int test_job_fence;
+    int collect_bad;
+    int use_same_keys;
+    int collect;
+    int nonblocking;
+    char *fences;
+    char *noise;
+    char *ns_dist;
+    int ns_size;
+    int ns_id;
+    pmix_rank_t base_rank;
+    int test_publish;
+    int test_spawn;
+    int test_connect;
+    int test_resolve_peers;
+    int test_error;
+    char *key_replace;
+    int test_internal;
+    char *gds_mode;
+    int nservers;
+    uint32_t lsize;
+} test_params;
+
+extern test_params params;
+
+#define INIT_TEST_PARAMS(params) do { \
+    params.nprocs = 1;                \
+    params.verbose = 0;               \
+    params.rank = PMIX_RANK_UNDEF;    \
+    params.base_rank = 0;             \
+    params.early_fail = 0;            \
+    params.ns_size = -1;              \
+    params.ns_id = -1;                \
+    params.timeout = TEST_DEFAULT_TIMEOUT; \
+    params.test_job_fence = 0;        \
+    params.use_same_keys = 0;         \
+    params.collect = 0;               \
+    params.collect_bad = 0;           \
+    params.nonblocking = 0;           \
+    params.test_publish = 0;          \
+    params.test_spawn = 0;            \
+    params.test_connect = 0;          \
+    params.test_resolve_peers = 0;    \
+    params.binary = NULL;             \
+    params.np = NULL;                 \
+    params.prefix = NULL;             \
+    params.nspace = NULL;             \
+    params.fences = NULL;             \
+    params.noise = NULL;              \
+    params.ns_dist = NULL;            \
+    params.test_error = 0;            \
+    params.key_replace = NULL;        \
+    params.test_internal = 0;         \
+    params.gds_mode = NULL;           \
+    params.nservers = 1;              \
+    params.lsize = 0;                 \
+} while (0)
+
+#define FREE_TEST_PARAMS(params) do { \
+    if (NULL != params.binary) {      \
+        free(params.binary);          \
+    }                                 \
+    if (NULL != params.np) {          \
+        free(params.np);              \
+    }                                 \
+    if (NULL != params.prefix) {      \
+        free(params.prefix);          \
+    }                                 \
+    if (NULL != params.nspace) {      \
+        free(params.nspace);          \
+    }                                 \
+    if (NULL != params.fences) {      \
+        free(params.fences);          \
+    }                                 \
+    if (NULL != params.noise) {       \
+        free(params.noise);           \
+    }                                 \
+    if (NULL != params.ns_dist) {     \
+        free(params.ns_dist);         \
+    }                                 \
+} while (0)
+
+void parse_cmd(int argc, char **argv, test_params *params);
+int parse_fence(char *fence_param, int store);
+int parse_noise(char *noise_param, int store);
+int parse_replace(char *replace_param, int store, int *key_num);
+
+typedef struct {
+    pmix_list_item_t super;
+    int blocking;
+    int data_exchange;
+    pmix_list_t *participants;  // list of participants
+} fence_desc_t;
+PMIX_CLASS_DECLARATION(fence_desc_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t proc;
+} participant_t;
+PMIX_CLASS_DECLARATION(participant_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    int key_idx;
+} key_replace_t;
+PMIX_CLASS_DECLARATION(key_replace_t);
+
+extern pmix_list_t test_fences;
+extern pmix_list_t *noise_range;
+extern pmix_list_t key_replace;
+
+int get_total_ns_number(test_params params);
+int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
+
+typedef struct {
+    int in_progress;
+    pmix_value_t *kv;
+    int status;
+} get_cbdata;
+
+#define SET_KEY(key, fence_num, ind, use_same_keys) do {                                                            \
+    if (use_same_keys) {                                                                                            \
+        (void)snprintf(key, sizeof(key)-1, "key-%d", ind);                                                            \
+    } else {                                                                                                        \
+        (void)snprintf(key, sizeof(key)-1, "key-f%d:%d", fence_num, ind);                                             \
+    }                                                                                                               \
+} while (0)
+
+#define PUT(dtype, data, flag, fence_num, ind, use_same_keys) do {                                                  \
+    char key[50];                                                                                                   \
+    pmix_value_t value;                                                                                             \
+    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
+    PMIX_VAL_SET(&value, dtype, data);                                                                              \
+    TEST_VERBOSE(("%s:%d put key %s", my_nspace, my_rank, key));                                                  \
+    if (PMIX_SUCCESS != (rc = PMIx_Put(flag, key, &value))) {                                                       \
+        TEST_ERROR(("%s:%d: PMIx_Put key %s failed: %s", my_nspace, my_rank, key, PMIx_Error_string(rc)));                             \
+    }                                                                                                               \
+    PMIX_VALUE_DESTRUCT(&value);                                                                                    \
+} while (0)
+
+#define GET(dtype, data, ns, r, fence_num, ind, use_same_keys, blocking, ok_notfnd) do {                        \
+    char key[50];                                                                                                   \
+    pmix_value_t *val;                                                                                              \
+    get_cbdata cbdata;                                                                                              \
+    cbdata.status = PMIX_SUCCESS;                                                                                   \
+    pmix_proc_t foobar; \
+    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
+    PMIX_LOAD_PROCID(&foobar, ns, r); \
+    TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));                          \
+    if (blocking) {                                                                                                 \
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                                         \
+            if( !( (rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_PROC_ENTRY_NOT_FOUND) && ok_notfnd ) ){                                                       \
+                TEST_ERROR(("%s:%d: PMIx_Get failed: %s from %s:%d, key %s", my_nspace, my_rank, PMIx_Error_string(rc), ns, r, key));  \
+            }                                                                                                       \
+        }                                                                                                           \
+    } else {                                                                                                        \
+        int count;                                                                                                  \
+        cbdata.in_progress = 1;                                                                                     \
+        PMIX_VALUE_CREATE(val, 1);                                                                                  \
+        cbdata.kv = val;                                                                                            \
+        if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&foobar, key, NULL, 0, get_cb, (void*)&cbdata))) {                    \
+            TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s", my_nspace, my_rank, PMIx_Error_string(rc), ns, r, key)); \
+        } else {                                                                                                    \
+            count = 0;                                                                                              \
+            while(cbdata.in_progress){                                                                              \
+                struct timespec ts;                                                                                 \
+                ts.tv_sec = 0;                                                                                      \
+                ts.tv_nsec = 100;                                                                                   \
+                nanosleep(&ts,NULL);                                                                                \
+                count++;                                                                                            \
+            }                                                                                                       \
+            rc = cbdata.status;                                                                                     \
+            PMIX_ACQUIRE_OBJECT(&cbdata);                                                                           \
+        }                                                                                                           \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        if( PMIX_SUCCESS != cbdata.status ){                                                                        \
+            if( !( (cbdata.status == PMIX_ERR_NOT_FOUND || cbdata.status == PMIX_ERR_PROC_ENTRY_NOT_FOUND) && ok_notfnd ) ){ \
+                TEST_ERROR(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s",                                     \
+                            my_nspace, my_rank, PMIx_Error_string(rc), my_nspace, r, key));                                            \
+            }                                                                                                       \
+        } else if (NULL == val) {                                                                                   \
+            TEST_VERBOSE(("%s:%d: PMIx_Get returned NULL value", my_nspace, my_rank));                              \
+        }                                                                                                           \
+        else if (val->type != PMIX_VAL_TYPE_ ## dtype || PMIX_VAL_CMP(dtype, PMIX_VAL_FIELD_ ## dtype((val)), data)) {  \
+            TEST_ERROR(("%s:%u: from %s:%d Key %s value or type mismatch,"                                        \
+                        " want type %d get type %d",                                                                \
+                        my_nspace, my_rank, ns, r, key, PMIX_VAL_TYPE_ ## dtype, val->type));                    \
+        }                                                                                                           \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        TEST_VERBOSE(("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, key, ns, r));                 \
+        PMIX_VALUE_RELEASE(val);                                                                                    \
+    }                                                                                                               \
+} while (0)
+
+#define FENCE(blocking, data_ex, pcs, nprocs) do {                              \
+    if( blocking ){                                                             \
+        pmix_info_t *info = NULL;                                               \
+        size_t ninfo = 0;                                                       \
+        if (data_ex) {                                                          \
+            bool value = 1;                                            \
+            PMIX_INFO_CREATE(info, 1);                                          \
+            (void)strncpy(info->key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);       \
+            pmix_value_load(&info->value, &value, PMIX_BOOL);                   \
+            ninfo = 1;                                                          \
+        }                                                                       \
+        rc = PMIx_Fence(pcs, nprocs, info, ninfo);                              \
+        PMIX_INFO_FREE(info, ninfo);                                            \
+    } else {                                                                    \
+        int in_progress = 1, count;                                             \
+        rc = PMIx_Fence_nb(pcs, nprocs, NULL, 0, release_cb, &in_progress);     \
+        if ( PMIX_SUCCESS == rc ) {                                             \
+            count = 0;                                                          \
+            while( in_progress ){                                               \
+                struct timespec ts;                                             \
+                ts.tv_sec = 0;                                                  \
+                ts.tv_nsec = 100;                                               \
+                nanosleep(&ts,NULL);                                            \
+                count++;                                                        \
+            }                                                                   \
+            TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs",    \
+                            count*100*1E-9));                                   \
+        }                                                                       \
+    }                                                                           \
+    if (PMIX_SUCCESS == rc) {                                                   \
+        TEST_VERBOSE(("%s:%d: Fence successfully completed",                    \
+                        my_nspace, my_rank));                                   \
+    }                                                                           \
+} while (0)
+
+/* Key-Value pair management macros */
+// TODO: add all possible types/fields here.
+
+#define PMIX_VAL_FIELD_int(x)       ((x)->data.integer)
+#define PMIX_VAL_FIELD_uint32_t(x)  ((x)->data.uint32)
+#define PMIX_VAL_FIELD_uint16_t(x)  ((x)->data.uint16)
+#define PMIX_VAL_FIELD_string(x)    ((x)->data.string)
+#define PMIX_VAL_FIELD_float(x)     ((x)->data.fval)
+#define PMIX_VAL_FIELD_byte(x)      ((x)->data.byte)
+#define PMIX_VAL_FIELD_flag(x)      ((x)->data.flag)
+
+#define PMIX_VAL_TYPE_int      PMIX_INT
+#define PMIX_VAL_TYPE_uint32_t PMIX_UINT32
+#define PMIX_VAL_TYPE_uint16_t PMIX_UINT16
+#define PMIX_VAL_TYPE_string   PMIX_STRING
+#define PMIX_VAL_TYPE_float    PMIX_FLOAT
+#define PMIX_VAL_TYPE_byte     PMIX_BYTE
+#define PMIX_VAL_TYPE_flag     PMIX_BOOL
+
+#define PMIX_VAL_set_assign(_v, _field, _val )   \
+    do {                                                            \
+        (_v)->type = PMIX_VAL_TYPE_ ## _field;                      \
+        PMIX_VAL_FIELD_ ## _field((_v)) = _val;                     \
+    } while (0)
+
+#define PMIX_VAL_set_strdup(_v, _field, _val )       \
+    do {                                                                \
+        (_v)->type = PMIX_VAL_TYPE_ ## _field;                          \
+        PMIX_VAL_FIELD_ ## _field((_v)) = strdup(_val);                 \
+    } while (0)
+
+#define PMIX_VAL_SET_int        PMIX_VAL_set_assign
+#define PMIX_VAL_SET_uint32_t   PMIX_VAL_set_assign
+#define PMIX_VAL_SET_uint16_t   PMIX_VAL_set_assign
+#define PMIX_VAL_SET_string     PMIX_VAL_set_strdup
+#define PMIX_VAL_SET_float      PMIX_VAL_set_assign
+#define PMIX_VAL_SET_byte       PMIX_VAL_set_assign
+#define PMIX_VAL_SET_flag       PMIX_VAL_set_assign
+
+#define PMIX_VAL_SET(_v, _field, _val )   \
+    PMIX_VAL_SET_ ## _field(_v, _field, _val)
+
+#define PMIX_VAL_cmp_val(_val1, _val2)      ((_val1) != (_val2))
+#define PMIX_VAL_cmp_float(_val1, _val2)    (((_val1)>(_val2))?(((_val1)-(_val2))>0.000001):(((_val2)-(_val1))>0.000001))
+#define PMIX_VAL_cmp_ptr(_val1, _val2)      strncmp(_val1, _val2, strlen(_val1)+1)
+
+#define PMIX_VAL_CMP_int        PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_uint32_t   PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_uint16_t   PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_float      PMIX_VAL_cmp_float
+#define PMIX_VAL_CMP_string     PMIX_VAL_cmp_ptr
+#define PMIX_VAL_CMP_byte       PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_flag       PMIX_VAL_cmp_val
+
+#define PMIX_VAL_ASSIGN(_v, _field, _val) \
+    PMIX_VAL_set_assign(_v, _field, _val)
+
+#define PMIX_VAL_CMP(_field, _val1, _val2) \
+    PMIX_VAL_CMP_ ## _field(_val1, _val2)
+
+#define PMIX_VAL_FREE(_v) \
+     PMIx_free_value_data(_v)
+
+#endif // TEST_COMMON_H

--- a/test/test_v2/test_server.c
+++ b/test/test_v2/test_server.c
@@ -1,0 +1,1119 @@
+ /*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/error.h"
+
+#include "test_server.h"
+#include "test_common.h"
+#include "cli_stages.h"
+#include "server_callbacks.h"
+
+int my_server_id = 0;
+
+server_info_t *my_server_info = NULL;
+pmix_list_t *server_list = NULL;
+pmix_list_t *server_nspace = NULL;
+
+static void sdes(server_info_t *s)
+{
+    close(s->rd_fd);
+    close(s->wr_fd);
+    if (s->evread) {
+        pmix_event_del(s->evread);
+    }
+    s->evread = NULL;
+    if (NULL != s->hostname) {
+        free(s->hostname);
+    }
+}
+
+static void scon(server_info_t *s)
+{
+    s->hostname = NULL;
+    s->idx = 0;
+    s->pid = 0;
+    s->rd_fd = -1;
+    s->wr_fd = -1;
+    s->evread = NULL;
+    s->modex_cbfunc = NULL;
+    s->cbdata = NULL;
+}
+
+PMIX_CLASS_INSTANCE(server_info_t,
+                    pmix_list_item_t,
+                    scon, sdes);
+
+static void nsdes(server_nspace_t *ns)
+{
+    if (ns->task_map) {
+        free(ns->task_map);
+    }
+}
+
+static void nscon(server_nspace_t *ns)
+{
+    memset(ns->name, 0, PMIX_MAX_NSLEN);
+    ns->ntasks = 0;
+    ns->task_map = NULL;
+}
+
+PMIX_CLASS_INSTANCE(server_nspace_t,
+                    pmix_list_item_t,
+                    nscon, nsdes);
+
+static int server_send_procs(void);
+static void server_read_cb(int fd, short event, void *arg);
+static int srv_wait_all(double timeout);
+static int server_fwd_msg(msg_hdr_t *msg_hdr, char *buf, size_t size);
+static int server_send_msg(msg_hdr_t *msg_hdr, char *data, size_t size);
+static void remove_server_item(server_info_t *server);
+static void server_unpack_dmdx(char *buf, int *sender, pmix_proc_t *proc);
+static int server_pack_dmdx(int sender_id, const char *nspace, int rank,
+                            char **buf);
+static void _dmdx_cb(int status, char *data, size_t sz, void *cbdata);
+
+static void release_cb(pmix_status_t status, void *cbdata)
+{
+    int *ptr = (int*)cbdata;
+    *ptr = 0;
+}
+
+static void fill_seq_ranks_array(size_t nprocs, int base_rank, char **ranks)
+{
+    uint32_t i;
+    int len = 0, max_ranks_len;
+    if (0 >= nprocs) {
+        return;
+    }
+    max_ranks_len = nprocs * (MAX_DIGIT_LEN+1);
+    *ranks = (char*) malloc(max_ranks_len);
+    for (i = 0; i < nprocs; i++) {
+        len += snprintf(*ranks + len, max_ranks_len-len-1, "%d", i+base_rank);
+        if (i != nprocs-1) {
+            len += snprintf(*ranks + len, max_ranks_len-len-1, "%c", ',');
+        }
+    }
+    if (len >= max_ranks_len-1) {
+        free(*ranks);
+        *ranks = NULL;
+        TEST_ERROR(("Not enough allocated space for global ranks array."));
+    }
+}
+
+static int server_find_id(const char *nspace, int rank)
+{
+    server_nspace_t *tmp;
+
+    PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
+        if (0 == strcmp(tmp->name, nspace)) {
+            return tmp->task_map[rank];
+        }
+    }
+    return -1;
+}
+
+static void set_namespace(int local_size, int univ_size,
+                          int base_rank, char *name)
+{
+    size_t ninfo;
+    pmix_info_t *info;
+    ninfo = 8;
+    char *regex, *ppn, *tmp;
+    char *ranks = NULL, **nodes = NULL;
+    char **rks=NULL;
+    int i;
+    int rc;
+
+    PMIX_INFO_CREATE(info, ninfo);
+    pmix_strncpy(info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
+    info[0].value.type = PMIX_UINT32;
+    info[0].value.data.uint32 = univ_size;
+
+    pmix_strncpy(info[1].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN);
+    info[1].value.type = PMIX_UINT32;
+    info[1].value.data.uint32 = 0;
+
+    pmix_strncpy(info[2].key, PMIX_LOCAL_SIZE, PMIX_MAX_KEYLEN);
+    info[2].value.type = PMIX_UINT32;
+    info[2].value.data.uint32 = local_size;
+
+    /* generate the array of local peers */
+    fill_seq_ranks_array(local_size, base_rank, &ranks);
+    if (NULL == ranks) {
+        return;
+    }
+    pmix_strncpy(info[3].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
+    info[3].value.type = PMIX_STRING;
+    info[3].value.data.string = strdup(ranks);
+
+    /* assemble the node and proc map info */
+    if (1 == params.nservers) {
+        pmix_argv_append_nosize(&nodes, my_server_info->hostname);
+    } else {
+        char hostname[PMIX_MAXHOSTNAMELEN];
+        for (i = 0; i < params.nservers; i++) {
+            snprintf(hostname, PMIX_MAXHOSTNAMELEN, "node%d", i);
+            pmix_argv_append_nosize(&nodes, hostname);
+        }
+    }
+
+    if (NULL != nodes) {
+        tmp = pmix_argv_join(nodes, ',');
+        pmix_argv_free(nodes);
+        nodes = NULL;
+        if (PMIX_SUCCESS != (rc = PMIx_generate_regex(tmp, &regex) )) {
+            PMIX_ERROR_LOG(rc);
+            return;
+        }
+        free(tmp);
+        PMIX_INFO_LOAD(&info[4], PMIX_NODE_MAP, regex, PMIX_REGEX);
+    }
+
+    /* generate the global proc map - if we have two
+     * servers, then the procs not on this server must
+     * be on the other */
+    if (2 == params.nservers) {
+        pmix_argv_append_nosize(&rks, ranks);
+        free(ranks);
+        nodes = NULL;
+        if (0 == my_server_id) {
+            for (i=base_rank+local_size; i < univ_size; i++) {
+                asprintf(&ppn, "%d", i);
+                pmix_argv_append_nosize(&nodes, ppn);
+                free(ppn);
+            }
+            ppn = pmix_argv_join(nodes, ',');
+            pmix_argv_append_nosize(&rks, ppn);
+            free(ppn);
+        } else {
+            for (i=0; i < base_rank; i++) {
+                asprintf(&ppn, "%d", i);
+                pmix_argv_append_nosize(&nodes, ppn);
+                free(ppn);
+            }
+            ppn = pmix_argv_join(nodes, ',');
+            pmix_argv_prepend_nosize(&rks, ppn);
+            free(ppn);
+        }
+        ranks = pmix_argv_join(rks, ';');
+    }
+    PMIx_generate_ppn(ranks, &ppn);
+    free(ranks);
+    PMIX_INFO_LOAD(&info[5], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    free(ppn);
+
+    pmix_strncpy(info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    info[6].value.type = PMIX_UINT32;
+    info[6].value.data.uint32 = univ_size;
+
+    pmix_strncpy(info[7].key, PMIX_APPNUM, PMIX_MAX_KEYLEN);
+    info[7].value.type = PMIX_UINT32;
+    info[7].value.data.uint32 = getpid ();
+
+    int in_progress = 1;
+    if (PMIX_SUCCESS == (rc = PMIx_server_register_nspace(name, local_size,
+                                    info, ninfo, release_cb, &in_progress))) {
+        PMIX_WAIT_FOR_COMPLETION(in_progress);
+    }
+    PMIX_INFO_FREE(info, ninfo);
+}
+
+static void server_unpack_procs(char *buf, size_t size)
+{
+    char *ptr = buf;
+    size_t i;
+    size_t ns_count;
+    char *nspace;
+
+    while ((size_t)(ptr - buf) < size) {
+        memcpy (&ns_count, ptr, sizeof(size_t));
+        ptr += sizeof(size_t);
+
+        for (i = 0; i < ns_count; i++) {
+            server_nspace_t *tmp, *ns_item = NULL;
+            size_t ltasks, ntasks;
+            int server_id;
+
+            memcpy (&server_id, ptr, sizeof(int));
+            ptr += sizeof(int);
+
+            nspace = ptr;
+            ptr += PMIX_MAX_NSLEN+1;
+
+            memcpy (&ntasks, ptr, sizeof(size_t));
+            ptr += sizeof(size_t);
+
+            memcpy (&ltasks, ptr, sizeof(size_t));
+            ptr += sizeof(size_t);
+
+            PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
+                if (0 == strcmp(nspace, tmp->name)) {
+                    ns_item = tmp;
+                    break;
+                }
+            }
+            if (NULL == ns_item) {
+                ns_item = PMIX_NEW(server_nspace_t);
+                memcpy(ns_item->name, nspace, PMIX_MAX_NSLEN);
+                pmix_list_append(server_nspace, &ns_item->super);
+                ns_item->ltasks = ltasks;
+                ns_item->ntasks = ntasks;
+                ns_item->task_map = (int*)malloc(sizeof(int) * ntasks);
+                memset(ns_item->task_map, -1, sizeof(int) * ntasks);
+            } else {
+                assert(ns_item->ntasks == ntasks);
+            }
+            size_t i;
+            for (i = 0; i < ltasks; i++) {
+                int rank;
+                memcpy (&rank, ptr, sizeof(int));
+                ptr += sizeof(int);
+                if (ns_item->task_map[rank] >= 0) {
+                    continue;
+                }
+                ns_item->task_map[rank] = server_id;
+            }
+        }
+    }
+}
+
+static size_t server_pack_procs(int server_id, char **buf, size_t size)
+{
+    size_t ns_count = pmix_list_get_size(server_nspace);
+    size_t buf_size = sizeof(size_t) + (PMIX_MAX_NSLEN+1)*ns_count;
+    server_nspace_t *tmp;
+    char *ptr;
+
+    if (0 == ns_count) {
+        return 0;
+    }
+
+    buf_size += size;
+    /* compute size: server_id + total + local procs count + ranks */
+    PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
+        buf_size += sizeof(int) + sizeof(size_t) + sizeof(size_t) +
+                sizeof(int) * tmp->ltasks;
+    }
+    *buf = (char*)realloc(*buf, buf_size);
+    memset(*buf + size, 0, buf_size);
+    ptr = *buf + size;
+    /* pack ns count */
+    memcpy(ptr, &ns_count, sizeof(size_t));
+    ptr += sizeof(size_t);
+
+    assert(server_nspace->pmix_list_length);
+
+    PMIX_LIST_FOREACH(tmp, server_nspace, server_nspace_t) {
+        size_t i;
+        /* pack server_id */
+        memcpy(ptr, &server_id, sizeof(int));
+        ptr += sizeof(int);
+        /* pack ns name */
+        memcpy(ptr, tmp->name, PMIX_MAX_NSLEN+1);
+        ptr += PMIX_MAX_NSLEN+1;
+        /* pack ns total size */
+        memcpy(ptr, &tmp->ntasks, sizeof(size_t));
+        ptr += sizeof(size_t);
+        /* pack ns local size */
+        memcpy(ptr, &tmp->ltasks, sizeof(size_t));
+        ptr += sizeof(size_t);
+        /* pack ns ranks */
+        for(i = 0; i < tmp->ntasks; i++) {
+            if (tmp->task_map[i] == server_id) {
+                int rank = (int)i;
+                memcpy(ptr, &rank, sizeof(int));
+                ptr += sizeof(int);
+            }
+        }
+    }
+    assert((size_t)(ptr - *buf) == buf_size);
+    return buf_size;
+}
+
+static void remove_server_item(server_info_t *server)
+{
+    pmix_list_remove_item(server_list, &server->super);
+    PMIX_DESTRUCT_LOCK(&server->lock);
+    PMIX_RELEASE(server);
+}
+
+static int srv_wait_all(double timeout)
+{
+    server_info_t *server, *next;
+    pid_t pid;
+    int status;
+    struct timeval tv;
+    double start_time, cur_time;
+    int ret = 0;
+
+    gettimeofday(&tv, NULL);
+    start_time = tv.tv_sec + 1E-6*tv.tv_usec;
+    cur_time = start_time;
+
+    /* Remove this server from the list */
+    PMIX_LIST_FOREACH_SAFE(server, next, server_list, server_info_t) {
+        if (server->pid == getpid()) {
+            /* remove himself */
+            remove_server_item(server);
+            break;
+        }
+    }
+
+    while (!pmix_list_is_empty(server_list) &&
+                                (timeout >= (cur_time - start_time))) {
+        pid = waitpid(-1, &status, 0);
+        if (pid >= 0) {
+            PMIX_LIST_FOREACH_SAFE(server, next, server_list, server_info_t) {
+                if (server->pid == pid) {
+                    TEST_VERBOSE(("server %d finalize PID:%d with status %d", server->idx,
+                                server->pid, WEXITSTATUS(status)));
+                    ret += WEXITSTATUS(status);
+                    remove_server_item(server);
+                }
+            }
+        }
+        // calculate current timestamp
+        gettimeofday(&tv, NULL);
+        cur_time = tv.tv_sec + 1E-6*tv.tv_usec;
+    }
+
+    return ret;
+}
+
+static int server_fwd_msg(msg_hdr_t *msg_hdr, char *buf, size_t size)
+{
+    server_info_t *tmp_server, *server = NULL;
+    int rc = PMIX_SUCCESS;
+
+    PMIX_LIST_FOREACH(tmp_server, server_list, server_info_t) {
+        if (tmp_server->idx == msg_hdr->dst_id) {
+            server = tmp_server;
+            break;
+        }
+    }
+    if (NULL == server) {
+        return PMIX_ERROR;
+    }
+    rc = write(server->wr_fd, msg_hdr, sizeof(msg_hdr_t));
+    if (rc != sizeof(msg_hdr_t)) {
+        return PMIX_ERROR;
+    }
+    rc = write(server->wr_fd, buf, size);
+    if (rc != (ssize_t)size) {
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+static int server_send_msg(msg_hdr_t *msg_hdr, char *data, size_t size)
+{
+    size_t ret = 0;
+    server_info_t *server = NULL, *server_tmp;
+    if (0 == my_server_id) {
+        PMIX_LIST_FOREACH(server_tmp, server_list, server_info_t) {
+            if (server_tmp->idx == msg_hdr->dst_id) {
+                server = server_tmp;
+                break;
+            }
+        }
+        if (NULL == server) {
+            abort();
+        }
+    } else {
+        server = (server_info_t *)pmix_list_get_first(server_list);
+    }
+
+    ret += write(server->wr_fd, msg_hdr, sizeof(msg_hdr_t));
+    ret += write(server->wr_fd, data, size);
+    if (ret != (sizeof(*msg_hdr) + size)) {
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+static void _send_procs_cb(pmix_status_t status, const char *data,
+                           size_t ndata, void *cbdata,
+                           pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    server_info_t *server = (server_info_t*)cbdata;
+
+    server_unpack_procs((char*)data, ndata);
+    free((char*)data);
+    PMIX_WAKEUP_THREAD(&server->lock);
+}
+
+static int server_send_procs(void)
+{
+    server_info_t *server;
+    msg_hdr_t msg_hdr;
+    int rc = PMIX_SUCCESS;
+    char *buf = NULL;
+
+    if (0 == my_server_id) {
+        server = my_server_info;
+    } else {
+        server = (server_info_t *)pmix_list_get_first(server_list);
+    }
+
+    msg_hdr.cmd = CMD_FENCE_CONTRIB;
+    msg_hdr.dst_id = 0;
+    msg_hdr.src_id = my_server_id;
+    msg_hdr.size = server_pack_procs(my_server_id, &buf, 0);
+    server->modex_cbfunc = _send_procs_cb;
+    server->cbdata = (void*)server;
+
+    server->lock.active = true;
+
+    if (PMIX_SUCCESS != (rc = server_send_msg(&msg_hdr, buf, msg_hdr.size))) {
+        if (buf) {
+            free(buf);
+        }
+        return PMIX_ERROR;
+    }
+    if (buf) {
+        free(buf);
+    }
+
+    PMIX_WAIT_THREAD(&server->lock);
+    return PMIX_SUCCESS;
+}
+
+int server_barrier(void)
+{
+    server_info_t *server;
+    msg_hdr_t msg_hdr;
+    int rc = PMIX_SUCCESS;
+
+    if (0 == my_server_id) {
+        server = my_server_info;
+    } else {
+        server = (server_info_t *)pmix_list_get_first(server_list);
+    }
+
+    msg_hdr.cmd = CMD_BARRIER_REQUEST;
+    msg_hdr.dst_id = 0;
+    msg_hdr.src_id = my_server_id;
+    msg_hdr.size = 0;
+
+    server->lock.active = true;
+
+    if (PMIX_SUCCESS != (rc = server_send_msg(&msg_hdr, NULL, 0))) {
+        return PMIX_ERROR;
+    }
+    PMIX_WAIT_THREAD(&server->lock);
+
+    return PMIX_SUCCESS;
+}
+
+static void _libpmix_cb(void *cbdata)
+{
+    char *ptr = (char*)cbdata;
+    if (ptr) {
+        free(ptr);
+    }
+}
+
+static void server_read_cb(int fd, short event, void *arg)
+{
+    server_info_t *server = (server_info_t*)arg;
+    msg_hdr_t msg_hdr;
+    char *msg_buf = NULL;
+    static char *fence_buf = NULL;
+    int rc;
+    static size_t barrier_cnt = 0;
+    static size_t contrib_cnt = 0;
+    static size_t fence_buf_offset = 0;
+
+    rc = read(server->rd_fd, &msg_hdr, sizeof(msg_hdr_t));
+    if (rc <= 0) {
+        return;
+    }
+    if (msg_hdr.size) {
+        msg_buf = (char*) malloc(sizeof(char) * msg_hdr.size);
+        rc += read(server->rd_fd, msg_buf, msg_hdr.size);
+    }
+    if (rc != (int)(sizeof(msg_hdr_t) + msg_hdr.size)) {
+        TEST_ERROR(("error read from %d", server->idx));
+    }
+
+    if (my_server_id != msg_hdr.dst_id) {
+        server_fwd_msg(&msg_hdr, msg_buf, msg_hdr.size);
+        free(msg_buf);
+        return;
+    }
+
+    switch(msg_hdr.cmd) {
+        case CMD_BARRIER_REQUEST:
+            barrier_cnt++;
+            TEST_VERBOSE(("CMD_BARRIER_REQ req from %d cnt %lu", msg_hdr.src_id,
+                          (unsigned long)barrier_cnt));
+            if (pmix_list_get_size(server_list) == barrier_cnt) {
+                barrier_cnt = 0; /* reset barrier counter */
+                server_info_t *tmp_server;
+                PMIX_LIST_FOREACH(tmp_server, server_list, server_info_t) {
+                    msg_hdr_t resp_hdr;
+                    resp_hdr.dst_id = tmp_server->idx;
+                    resp_hdr.src_id = my_server_id;
+                    resp_hdr.cmd = CMD_BARRIER_RESPONSE;
+                    resp_hdr.size = 0;
+                    server_send_msg(&resp_hdr, NULL, 0);
+                }
+            }
+            break;
+        case CMD_BARRIER_RESPONSE:
+            TEST_VERBOSE(("%d: CMD_BARRIER_RESP", my_server_id));
+            PMIX_WAKEUP_THREAD(&server->lock);
+            break;
+        case CMD_FENCE_CONTRIB:
+            contrib_cnt++;
+            if (msg_hdr.size > 0) {
+                fence_buf = (char*)realloc((void*)fence_buf,
+                                           fence_buf_offset + msg_hdr.size);
+                memcpy(fence_buf + fence_buf_offset, msg_buf, msg_hdr.size);
+                fence_buf_offset += msg_hdr.size;
+                free(msg_buf);
+                msg_buf = NULL;
+            }
+
+            TEST_VERBOSE(("CMD_FENCE_CONTRIB req from %d cnt %lu size %d",
+                        msg_hdr.src_id, (unsigned long)contrib_cnt, msg_hdr.size));
+            if (pmix_list_get_size(server_list) == contrib_cnt) {
+                server_info_t *tmp_server;
+                PMIX_LIST_FOREACH(tmp_server, server_list, server_info_t) {
+                    msg_hdr_t resp_hdr;
+                    resp_hdr.dst_id = tmp_server->idx;
+                    resp_hdr.src_id = my_server_id;
+                    resp_hdr.cmd = CMD_FENCE_COMPLETE;
+                    resp_hdr.size = fence_buf_offset;
+                    server_send_msg(&resp_hdr, fence_buf, fence_buf_offset);
+                }
+                TEST_VERBOSE(("CMD_FENCE_CONTRIB complete, size %lu",
+                              (unsigned long)fence_buf_offset));
+                if (fence_buf) {
+                    free(fence_buf);
+                    fence_buf = NULL;
+                    fence_buf_offset = 0;
+                }
+                contrib_cnt = 0;
+            }
+            break;
+        case CMD_FENCE_COMPLETE:
+            TEST_VERBOSE(("%d: CMD_FENCE_COMPLETE size %d", my_server_id,
+                        msg_hdr.size));
+            server->modex_cbfunc(PMIX_SUCCESS, msg_buf, msg_hdr.size,
+                                 server->cbdata, _libpmix_cb, msg_buf);
+            msg_buf = NULL;
+            break;
+        case CMD_DMDX_REQUEST: {
+            int *sender_id;
+            pmix_proc_t proc;
+            if (NULL == msg_buf) {
+                abort();
+            }
+            sender_id = (int*)malloc(sizeof(int));
+            server_unpack_dmdx(msg_buf, sender_id, &proc);
+            TEST_VERBOSE(("%d: CMD_DMDX_REQUEST from %d: %s:%d", my_server_id,
+                        *sender_id, proc.nspace, proc.rank));
+            rc = PMIx_server_dmodex_request(&proc, _dmdx_cb, (void*)sender_id);
+            break;
+        }
+        case CMD_DMDX_RESPONSE:
+            TEST_VERBOSE(("%d: CMD_DMDX_RESPONSE", my_server_id));
+            server->modex_cbfunc(PMIX_SUCCESS, msg_buf, msg_hdr.size,
+                                 server->cbdata, _libpmix_cb, msg_buf);
+            msg_buf = NULL;
+            break;
+    }
+    if (NULL != msg_buf) {
+        free(msg_buf);
+    }
+}
+
+int server_fence_contrib(char *data, size_t ndata,
+                         pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    server_info_t *server;
+    msg_hdr_t msg_hdr;
+    int rc = PMIX_SUCCESS;
+
+    if (0 == my_server_id) {
+        server = my_server_info;
+    } else {
+        server = (server_info_t *)pmix_list_get_first(server_list);
+    }
+    msg_hdr.cmd = CMD_FENCE_CONTRIB;
+    msg_hdr.dst_id = 0;
+    msg_hdr.src_id = my_server_id;
+    msg_hdr.size = ndata;
+    server->modex_cbfunc = cbfunc;
+    server->cbdata = cbdata;
+
+    if (PMIX_SUCCESS != (rc = server_send_msg(&msg_hdr, data, ndata))) {
+        return PMIX_ERROR;
+    }
+    return rc;
+}
+
+static int server_pack_dmdx(int sender_id, const char *nspace, int rank,
+                            char **buf)
+{
+    size_t buf_size = sizeof(int) + PMIX_MAX_NSLEN +1 + sizeof(int);
+    char *ptr;
+
+    *buf = (char*)malloc(buf_size);
+    ptr = *buf;
+
+    memcpy(ptr, &sender_id, sizeof(int));
+    ptr += sizeof(int);
+
+    memcpy(ptr, nspace, PMIX_MAX_NSLEN+1);
+    ptr += PMIX_MAX_NSLEN +1;
+
+    memcpy(ptr, &rank, sizeof(int));
+    ptr += sizeof(int);
+
+    return buf_size;
+}
+
+static void server_unpack_dmdx(char *buf, int *sender, pmix_proc_t *proc)
+{
+    char *ptr = buf;
+
+    *sender = *(int *)ptr;
+    ptr += sizeof(int);
+
+    memcpy(proc->nspace, ptr, PMIX_MAX_NSLEN +1);
+    ptr += PMIX_MAX_NSLEN +1;
+
+    proc->rank = *(int *)ptr;
+    ptr += sizeof(int);
+}
+
+
+static void _dmdx_cb(int status, char *data, size_t sz, void *cbdata)
+{
+    msg_hdr_t msg_hdr;
+    int *sender_id = (int*)cbdata;
+
+    msg_hdr.cmd = CMD_DMDX_RESPONSE;
+    msg_hdr.src_id = my_server_id;
+    msg_hdr.size = sz;
+    msg_hdr.dst_id = *sender_id;
+    TEST_VERBOSE(("srv #%d: DMDX RESPONSE: receiver=%d, size=%lu,",
+                  my_server_id, *sender_id, (unsigned long)sz));
+    free(sender_id);
+
+    server_send_msg(&msg_hdr, data, sz);
+}
+
+int server_dmdx_get(const char *nspace, int rank,
+                    pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    server_info_t *server = NULL, *tmp;
+    msg_hdr_t msg_hdr;
+    pmix_status_t rc = PMIX_SUCCESS;
+    char *buf = NULL;
+
+
+    if (0 > (msg_hdr.dst_id = server_find_id(nspace, rank))) {
+        TEST_ERROR(("%d: server cannot found for %s:%d", my_server_id, nspace, rank));
+        goto error;
+    }
+
+    if (0 == my_server_id) {
+        PMIX_LIST_FOREACH(tmp, server_list, server_info_t) {
+            if (tmp->idx == msg_hdr.dst_id) {
+                server = tmp;
+                break;
+            }
+        }
+    } else {
+        server = (server_info_t *)pmix_list_get_first(server_list);
+    }
+
+    if (server == NULL) {
+        goto error;
+    }
+
+    msg_hdr.cmd = CMD_DMDX_REQUEST;
+    msg_hdr.src_id = my_server_id;
+    msg_hdr.size = server_pack_dmdx(my_server_id, nspace, rank, &buf);
+    server->modex_cbfunc = cbfunc;
+    server->cbdata = cbdata;
+
+    if (PMIX_SUCCESS != (rc = server_send_msg(&msg_hdr, buf, msg_hdr.size))) {
+        rc = PMIX_ERROR;
+    }
+    free(buf);
+    return rc;
+
+error:
+    cbfunc(PMIX_ERROR, NULL, 0, cbdata, NULL, 0);
+    return PMIX_ERROR;
+}
+
+static void set_handler_default(int sig)
+{
+    struct sigaction act;
+
+    act.sa_handler = SIG_DFL;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+
+    sigaction(sig, &act, (struct sigaction *)0);
+}
+
+static pmix_event_t handler;
+static void wait_signal_callback(int fd, short event, void *arg)
+{
+    pmix_event_t *sig = (pmix_event_t*) arg;
+    int status;
+    pid_t pid;
+    int i;
+
+    if (SIGCHLD != pmix_event_get_signal(sig)) {
+        return;
+    }
+
+    /* we can have multiple children leave but only get one
+     * sigchild callback, so reap all the waitpids until we
+     * don't get anything valid back */
+    while (1) {
+        pid = waitpid(-1, &status, WNOHANG);
+        if (-1 == pid && EINTR == errno) {
+            /* try it again */
+            continue;
+        }
+        /* if we got garbage, then nothing we can do */
+        if (pid <= 0) {
+            goto done;
+        }
+        /* we are already in an event, so it is safe to access the list */
+        for(i=0; i < cli_info_cnt; i++){
+            if( cli_info[i].pid == pid ){
+                /* found it! */
+                if (WIFEXITED(status)) {
+                    cli_info[i].exit_code = WEXITSTATUS(status);
+                } else {
+                    if (WIFSIGNALED(status)) {
+                        cli_info[i].exit_code = WTERMSIG(status) + 128;
+                    }
+                }
+                cli_cleanup(&cli_info[i]);
+                cli_info[i].alive = false;
+                break;
+            }
+        }
+    }
+  done:
+    for(i=0; i < cli_info_cnt; i++){
+        if (cli_info[i].alive) {
+            /* someone is still alive */
+            return;
+        }
+    }
+    /* get here if nobody is still alive */
+    test_complete = true;
+}
+
+int server_init(test_params *params)
+{
+    pmix_info_t info[2];
+    int rc = PMIX_SUCCESS;
+
+    /* fork/init servers procs */
+    if (params->nservers >= 1) {
+        int i;
+        server_info_t *server_info = NULL;
+        server_list = PMIX_NEW(pmix_list_t);
+
+        TEST_VERBOSE(("pmix server %d started PID:%d", my_server_id, getpid()));
+        for (i = params->nservers - 1; i >= 0; i--) {
+            pid_t pid;
+            server_info = PMIX_NEW(server_info_t);
+
+            int fd1[2];
+            int fd2[2];
+
+            pipe(fd1);
+            pipe(fd2);
+
+            if (0 != i) {
+                pid = fork();
+                if (pid < 0) {
+                    TEST_ERROR(("Fork failed"));
+                    return pid;
+                }
+                if (pid == 0) {
+                    server_list = PMIX_NEW(pmix_list_t);
+                    my_server_info = server_info;
+                    my_server_id = i;
+                    asprintf(&server_info->hostname, "node%d", i);
+                    server_info->idx = 0;
+                    server_info->pid = getppid();
+                    server_info->rd_fd = fd1[0];
+                    server_info->wr_fd = fd2[1];
+                    close(fd1[1]);
+                    close(fd2[0]);
+                    PMIX_CONSTRUCT_LOCK(&server_info->lock);
+                    pmix_list_append(server_list, &server_info->super);
+                    break;
+                }
+                asprintf(&server_info->hostname, "node%d", i);
+                server_info->idx = i;
+                server_info->pid = pid;
+                server_info->wr_fd = fd1[1];
+                server_info->rd_fd = fd2[0];
+                PMIX_CONSTRUCT_LOCK(&server_info->lock);
+                close(fd1[0]);
+                close(fd2[1]);
+            } else {
+                my_server_info = server_info;
+                server_info->hostname = strdup("node0");
+                server_info->pid = getpid();
+                server_info->idx  = 0;
+                server_info->rd_fd = fd1[0];
+                server_info->wr_fd = fd1[1];
+                PMIX_CONSTRUCT_LOCK(&server_info->lock);
+                close(fd2[0]);
+                close(fd2[1]);
+            }
+            TEST_VERBOSE(("%d: add server %d", my_server_id, server_info->idx));
+            pmix_list_append(server_list, &server_info->super);
+        }
+    }
+    /* compute local proc size */
+    params->lsize = (params->nprocs % params->nservers) > (uint32_t)my_server_id ?
+                params->nprocs / params->nservers + 1 :
+                params->nprocs / params->nservers;
+    /* setup the server library */
+    uint32_t u32 = 0666;
+    PMIX_INFO_LOAD(&info[0], PMIX_SOCKET_MODE, &u32, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, my_server_info->hostname, PMIX_STRING);
+
+    server_nspace = PMIX_NEW(pmix_list_t);
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 2))) {
+        TEST_ERROR(("Init failed with error %d", rc));
+        goto error;
+    }
+
+    /* register test server read thread */
+    if (params->nservers && pmix_list_get_size(server_list)) {
+        server_info_t *server;
+        PMIX_LIST_FOREACH(server, server_list, server_info_t) {
+            server->evread = pmix_event_new(pmix_globals.evbase, server->rd_fd,
+                                            EV_READ|EV_PERSIST, server_read_cb, server);
+            pmix_event_add(server->evread, NULL);
+        }
+    }
+
+    /* register the errhandler */
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                errhandler, errhandler_reg_callbk, NULL);
+
+    /* setup to see sigchld on the forked tests */
+    pmix_event_assign(&handler, pmix_globals.evbase, SIGCHLD,
+                      EV_SIGNAL|EV_PERSIST, wait_signal_callback, &handler);
+    pmix_event_add(&handler, NULL);
+
+
+    if (0 != (rc = server_barrier())) {
+        goto error;
+    }
+
+    return PMIX_SUCCESS;
+
+error:
+    PMIX_DESTRUCT(server_nspace);
+    return rc;
+}
+
+int server_finalize(test_params *params, int local_fail)
+{
+    int rc = PMIX_SUCCESS;
+    int total_ret = local_fail;
+
+    if (0 != (rc = server_barrier())) {
+        total_ret++;
+        goto exit;
+    }
+
+    if (0 != my_server_id) {
+        server_info_t *server = (server_info_t*)pmix_list_get_first(server_list);
+        remove_server_item(server);
+    }
+
+    if (params->nservers && 0 == my_server_id) {
+        /* wait for all servers are finished */
+        total_ret += srv_wait_all(10.0);
+        PMIX_LIST_RELEASE(server_list);
+        TEST_VERBOSE(("SERVER %d FINALIZE PID:%d with status %d",
+                        my_server_id, getpid(), total_ret));
+        if (0 == total_ret) {
+            TEST_OUTPUT(("Test finished OK!"));
+        } else {
+            rc = PMIX_ERROR;
+        }
+    }
+    PMIX_LIST_RELEASE(server_nspace);
+
+    /* finalize the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_finalize())) {
+        TEST_ERROR(("Finalize failed with error %d", rc));
+        total_ret += rc;
+        goto exit;
+    }
+
+exit:
+    return total_ret;
+}
+
+int server_launch_clients(int local_size, int univ_size, int base_rank,
+                   test_params *params, char *** client_env, char ***base_argv)
+{
+    int n;
+    uid_t myuid;
+    gid_t mygid;
+    char *ranks = NULL;
+    char digit[MAX_DIGIT_LEN];
+    int rc;
+    static int cli_counter = 0;
+    static int num_ns = 0;
+    pmix_proc_t proc;
+    int rank_counter = 0;
+    server_nspace_t *nspace_item = PMIX_NEW(server_nspace_t);
+
+    TEST_VERBOSE(("%d: lsize: %d, base rank %d, local_size %d, univ_size %d",
+                  my_server_id,
+                  params->lsize,
+                  base_rank,
+                  local_size,
+                  univ_size));
+
+    TEST_VERBOSE(("Setting job info"));
+    (void)snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, num_ns);
+    set_namespace(local_size, univ_size, base_rank, proc.nspace);
+    if (NULL != ranks) {
+        free(ranks);
+    }
+    /* add namespace entry */
+    nspace_item->ntasks = univ_size;
+    nspace_item->ltasks = local_size;
+    nspace_item->task_map = (int*)malloc(sizeof(int) * univ_size);
+    memset(nspace_item->task_map, -1, sizeof(int)*univ_size);
+    strcpy(nspace_item->name, proc.nspace);
+    pmix_list_append(server_nspace, &nspace_item->super);
+    for (n = 0; n < local_size; n++) {
+        proc.rank = base_rank + n;
+        nspace_item->task_map[proc.rank] = my_server_id;
+    }
+
+    server_send_procs();
+
+    myuid = getuid();
+    mygid = getgid();
+
+    /* fork/exec the test */
+    for (n = 0; n < local_size; n++) {
+        proc.rank = base_rank + rank_counter;
+        rc = PMIx_server_register_client(&proc, myuid, mygid, NULL, NULL, NULL);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            TEST_ERROR(("Server register client failed with error %d", rc));
+            PMIx_server_finalize();
+            cli_kill_all();
+            return 0;
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, client_env))) {//n
+            TEST_ERROR(("Server fork setup failed with error %d", rc));
+            PMIx_server_finalize();
+            cli_kill_all();
+            return rc;
+        }
+        TEST_VERBOSE(("run %s:%d", proc.nspace, proc.rank));
+
+        cli_info[cli_counter].pid = fork();
+        if (cli_info[cli_counter].pid < 0) {
+            TEST_ERROR(("Fork failed"));
+            PMIx_server_finalize();
+            cli_kill_all();
+            return 0;
+        }
+        cli_info[cli_counter].rank = proc.rank;//n
+        cli_info[cli_counter].ns = strdup(proc.nspace);
+
+        char **client_argv = pmix_argv_copy(*base_argv);
+
+        /* add two last arguments: -r <rank> */
+        sprintf(digit, "%d", proc.rank);
+        pmix_argv_append_nosize(&client_argv, "-r");
+        pmix_argv_append_nosize(&client_argv, digit);
+
+        pmix_argv_append_nosize(&client_argv, "-s");
+        pmix_argv_append_nosize(&client_argv, proc.nspace);
+
+        sprintf(digit, "%d", univ_size);
+        pmix_argv_append_nosize(&client_argv, "--ns-size");
+        pmix_argv_append_nosize(&client_argv, digit);
+
+        sprintf(digit, "%d", num_ns);
+        pmix_argv_append_nosize(&client_argv, "--ns-id");
+        pmix_argv_append_nosize(&client_argv, digit);
+
+        sprintf(digit, "%d", 0);
+        pmix_argv_append_nosize(&client_argv, "--base-rank");
+        pmix_argv_append_nosize(&client_argv, digit);
+
+        if (cli_info[cli_counter].pid == 0) {
+            sigset_t sigs;
+            set_handler_default(SIGTERM);
+            set_handler_default(SIGINT);
+            set_handler_default(SIGHUP);
+            set_handler_default(SIGPIPE);
+            set_handler_default(SIGCHLD);
+            sigprocmask(0, 0, &sigs);
+            sigprocmask(SIG_UNBLOCK, &sigs, 0);
+
+            if( !TEST_VERBOSE_GET() ){
+                // Hide clients stdout
+                if (NULL == freopen("/dev/null","w", stdout)) {
+                    return 0;
+                }
+            }
+            execve(params->binary, client_argv, *client_env);
+            /* Does not return */
+            TEST_ERROR(("execve() failed"));
+            return 0;
+        }
+        cli_info[cli_counter].alive = true;
+        cli_info[cli_counter].state = CLI_FORKED;
+
+        pmix_argv_free(client_argv);
+
+        cli_counter++;
+        rank_counter++;
+    }
+    num_ns++;
+    return rank_counter;
+}

--- a/test/test_v2/test_server.h
+++ b/test/test_v2/test_server.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#ifndef TEST_SERVER_C
+#define TEST_SERVER_C
+
+#include "pmix_server.h"
+#include "test_common.h"
+
+
+typedef enum {
+    CMD_BARRIER_REQUEST,
+    CMD_BARRIER_RESPONSE,
+    CMD_FENCE_CONTRIB,
+    CMD_FENCE_COMPLETE,
+    CMD_DMDX_REQUEST,
+    CMD_DMDX_RESPONSE
+} server_cmd_t;
+
+typedef struct {
+    int dst_id;
+    int src_id;
+    int cmd;
+    size_t size;
+} msg_hdr_t;
+
+struct server_info_t
+{
+    pmix_list_item_t super;
+    char *hostname;
+    pid_t pid;
+    int idx;
+    int rd_fd;
+    int wr_fd;
+    pmix_event_t *evread;
+    pmix_lock_t lock;
+    pmix_modex_cbfunc_t modex_cbfunc;
+    void *cbdata;
+};
+typedef struct server_info_t server_info_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(server_info_t);
+
+struct server_nspace_t
+{
+    pmix_list_item_t super;
+    char name[PMIX_MAX_NSLEN+1];
+    size_t ntasks; /* total number of tasks in this namespace */
+    size_t ltasks; /* local */
+    int *task_map;
+};
+typedef struct server_nspace_t server_nspace_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(server_nspace_t);
+
+extern int my_server_id;
+extern pmix_list_t *server_list;
+extern server_info_t *my_server_info;
+extern pmix_list_t *server_nspace;
+
+int server_init(test_params *params);
+int server_finalize(test_params *params, int local_fail);
+int server_barrier(void);
+int server_fence_contrib(char *data, size_t ndata,
+                         pmix_modex_cbfunc_t cbfunc, void *cbdata);
+int server_dmdx_get(const char *nspace, int rank,
+                    pmix_modex_cbfunc_t cbfunc, void *cbdata);
+int server_launch_clients(int local_size, int univ_size, int base_rank,
+                   test_params *params, char *** client_env, char ***base_argv);
+
+
+#endif // TEST_SERVER_C
+

--- a/test/test_v2/utils.c
+++ b/test/test_v2/utils.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "utils.h"
+#include "test_common.h"
+#include "pmix_server.h"
+#include "cli_stages.h"
+#include "test_server.h"
+
+void set_client_argv(test_params *params, char ***argv)
+{
+    pmix_argv_append_nosize(argv, params->binary);
+    pmix_argv_append_nosize(argv, "-n");
+    if (NULL == params->np) {
+        pmix_argv_append_nosize(argv, "1");
+    } else {
+        pmix_argv_append_nosize(argv, params->np);
+    }
+    if( params->verbose ){
+        pmix_argv_append_nosize(argv, "-v");
+    }
+    if (NULL != params->prefix) {
+        pmix_argv_append_nosize(argv, "-o");
+        pmix_argv_append_nosize(argv, params->prefix);
+    }
+    if( params->early_fail ){
+        pmix_argv_append_nosize(argv, "--early-fail");
+    }
+    if (NULL != params->fences) {
+        pmix_argv_append_nosize(argv, "--fence");
+        pmix_argv_append_nosize(argv, params->fences);
+        if (params->use_same_keys) {
+            pmix_argv_append_nosize(argv, "--use-same-keys");
+        }
+    }
+    if (params->test_job_fence) {
+        pmix_argv_append_nosize(argv, "--job-fence");
+        if (params->nonblocking) {
+            pmix_argv_append_nosize(argv, "-nb");
+        }
+        if (params->collect) {
+            pmix_argv_append_nosize(argv, "-c");
+        }
+        if (params->collect_bad) {
+            pmix_argv_append_nosize(argv, "--collect-corrupt");
+        }
+    }
+    if (NULL != params->noise) {
+        pmix_argv_append_nosize(argv, "--noise");
+        pmix_argv_append_nosize(argv, params->noise);
+    }
+    if (NULL != params->ns_dist) {
+        pmix_argv_append_nosize(argv, "--ns-dist");
+        pmix_argv_append_nosize(argv, params->ns_dist);
+    }
+    if (params->test_publish) {
+        pmix_argv_append_nosize(argv, "--test-publish");
+    }
+    if (params->test_spawn) {
+        pmix_argv_append_nosize(argv, "--test-spawn");
+    }
+    if (params->test_connect) {
+        pmix_argv_append_nosize(argv, "--test-connect");
+    }
+    if (params->test_resolve_peers) {
+        pmix_argv_append_nosize(argv, "--test-resolve-peers");
+    }
+    if (params->test_error) {
+        pmix_argv_append_nosize(argv, "--test-error");
+    }
+    if (params->key_replace) {
+        pmix_argv_append_nosize(argv, "--test-replace");
+        pmix_argv_append_nosize(argv, params->key_replace);
+    }
+    if (params->test_internal) {
+        char tmp[32];
+        snprintf(tmp, 32, "%d", params->test_internal);
+        pmix_argv_append_nosize(argv, "--test-internal");
+        pmix_argv_append_nosize(argv, tmp);
+    }
+    if (params->gds_mode) {
+        pmix_argv_append_nosize(argv, "--gds");
+        pmix_argv_append_nosize(argv, params->gds_mode);
+    }
+}

--- a/test/test_v2/utils.h
+++ b/test/test_v2/utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "src/util/argv.h"
+#include "test_common.h"
+
+void set_client_argv(test_params *params, char ***argv);


### PR DESCRIPTION
This is the start of the new PMIx test suite per @artpol84 's guidance. 

This initial version only includes pmix_test.c and all its dependencies, and nothing else, in a new subdirectory of test called test_v2. 

For now it is built using a custom Makefile and is not touched by configure, so it will not be part of the regular build process, nor enabled, for now. The idea is that for a period of time it will be run independent of/in parallel to the existing test suite.