### PR TITLE
Add storage system support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ src/tools/pevent/pevent
 src/tools/pmix_info/pmix_info
 src/tools/plookup/plookup
 src/tools/pps/pps
-src/tools/ptop/ptop
+src/tools/pquery/pquery
 src/tools/wrapper/generic_wrapper.1
 src/tools/wrapper/pmix.pc
 src/tools/wrapper/pmix_wrapper

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -954,6 +954,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/tools/plookup/Makefile]
         pmix_config_prefix[src/tools/pps/Makefile]
         pmix_config_prefix[src/tools/pattrs/Makefile]
+        pmix_config_prefix[src/tools/pquery/Makefile]
         pmix_config_prefix[src/tools/wrapper/Makefile]
         pmix_config_prefix[src/tools/wrapper/pmixcc-wrapper-data.txt]
         pmix_config_prefix[src/tools/wrapper/pmix.pc]

--- a/config/pmix_check_lustre.m4
+++ b/config/pmix_check_lustre.m4
@@ -1,0 +1,105 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2006 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2008-2018 University of Houston. All rights reserved.
+dnl Copyright (c) 2015-2018 Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
+dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# PMIX_CHECK_LUSTRE(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if LUSTRE support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([PMIX_CHECK_LUSTRE],[
+
+    PMIX_VAR_SCOPE_PUSH([check_lustre_save_LIBS check_lustre_save_LDFLAGS check_lustre_save_CPPFLAGS])
+
+    check_lustre_save_LIBS="$LIBS"
+    check_lustre_save_LDFLAGS="$LDFLAGS"
+    check_lustre_save_CPPFLAGS="$CPPFLAGS"
+
+    pmix_check_lustre_happy="yes"
+
+    # Get some configuration information
+    AC_ARG_WITH([lustre],
+        [AC_HELP_STRING([--with-lustre(=DIR)],
+             [Build Lustre support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    PMIX_CHECK_WITHDIR([lustre], [$with_lustre], [include/lustre/lustreapi.h])
+
+    AS_IF([test "$with_lustre" = "no"],
+        [pmix_check_lustre_happy="no"],
+        [AS_IF([test -z "$with_lustre" || test "$with_lustre" = "yes"],
+                [pmix_check_lustre_dir="/usr"],
+                [pmix_check_lustre_dir=$with_lustre])
+
+            if test -e "$pmix_check_lustre_dir/lib64" ; then
+                pmix_check_lustre_libdir="$pmix_check_lustre_dir/lib64"
+            else
+                pmix_check_lustre_libdir="$pmix_check_lustre_dir/lib"
+            fi
+
+            # Add correct -I and -L flags
+            PMIX_CHECK_PACKAGE([$1],
+                               [lustre/lustreapi.h],
+                               [lustreapi],
+                               [llapi_file_create],
+                               [],
+                               [$pmix_check_lustre_dir],
+                               [$pmix_check_lustre_libdir],
+                               [pmix_check_lustre_happy="yes"],
+                               [pmix_check_lustre_happy="no"])
+
+            AS_IF([test "$pmix_check_lustre_happy" = "yes"],
+                  [AC_MSG_CHECKING([for required lustre data structures])
+                   cat > conftest.c <<EOF
+#include "lustre/lustreapi.h"
+void alloc_lum()
+{
+  int v1, v3;
+  v1 = sizeof(struct lov_user_md_v1) +
+   LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
+  v3 = sizeof(struct lov_user_md_v3) +
+    LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
+}
+EOF
+
+                   # Try the compile
+                   PMIX_LOG_COMMAND(
+                       [$CC $CFLAGS -I$pmix_check_lustre_dir/include -c conftest.c],
+                       [pmix_check_lustre_struct_happy="yes"],
+                       [pmix_check_lustre_struct_happy="no"
+                        pmix_check_lustre_happy="no"]
+                   )
+                       rm -f conftest.c conftest.o
+                       AC_MSG_RESULT([$pmix_check_lustre_struct_happy])])
+    ])
+
+    AS_IF([test "$pmix_check_lustre_happy" = "yes"],
+          [$2],
+          [AS_IF([test ! -z "$with_lustre" && test "$with_lustre" != "no"],
+                 [AC_MSG_ERROR([Lustre support requested but not found.  Aborting])])
+           $3])
+
+    CPPFLAGS=$check_lustre_save_CPPFLAGS
+    LDFLAGS=$check_lustre_save_LDFLAGS
+    LIBS=$check_lustre_save_LIBS
+
+    PMIX_VAR_SCOPE_POP
+])

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
 # Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -30,6 +30,9 @@
 # LDFLAGS, LIBS} as needed and runs action-if-found if there is
 # support, otherwise executes action-if-not-found
 AC_DEFUN([PMIX_CHECK_PSM2],[
+
+    PMIX_VAR_SCOPE_PUSH([pmix_check_psm2_save_CPPFLAGS pmix_check_psm2_save_LDFLAGS pmix_check_psm2_save_LIBS])
+
     if test -z "$pmix_check_psm2_happy" ; then
 	AC_ARG_WITH([psm2],
 		    [AC_HELP_STRING([--with-psm2(=DIR)],
@@ -40,9 +43,9 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
 				    [Search for PSM (Intel PSM2) libraries in DIR])])
 	PMIX_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
 
-	pmix_check_psm2_$1_save_CPPFLAGS="$CPPFLAGS"
-	pmix_check_psm2_$1_save_LDFLAGS="$LDFLAGS"
-	pmix_check_psm2_$1_save_LIBS="$LIBS"
+	pmix_check_psm2_save_CPPFLAGS="$CPPFLAGS"
+	pmix_check_psm2_save_LDFLAGS="$LDFLAGS"
+	pmix_check_psm2_save_LIBS="$LIBS"
 
 	AS_IF([test "$with_psm2" != "no"],
               [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "yes"],
@@ -51,19 +54,19 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
                      [pmix_check_psm2_libdir="$with_psm2_libdir"])
 
                PMIX_CHECK_PACKAGE([pmix_check_psm2],
-				  [psm2.h],
-				  [psm2],
-				  [psm2_mq_irecv2],
-				  [],
-				  [$pmix_check_psm2_dir],
-				  [$pmix_check_psm2_libdir],
-				  [pmix_check_psm2_happy="yes"],
-				  [pmix_check_psm2_happy="no"])],
-              [pmix_check_psm2_happy="no"])
+                                  [psm2.h],
+                                  [psm2],
+                                  [psm2_mq_irecv2],
+                                  [],
+                                  [$pmix_check_psm2_dir],
+                                  [$pmix_check_psm2_libdir],
+                                  [pmix_check_psm2_happy="yes"],
+                                  [pmix_check_psm2_happy="no"])],
+                                  [pmix_check_psm2_happy="no"])
 
-	CPPFLAGS="$pmix_check_psm2_$1_save_CPPFLAGS"
-	LDFLAGS="$pmix_check_psm2_$1_save_LDFLAGS"
-	LIBS="$pmix_check_psm2_$1_save_LIBS"
+	CPPFLAGS="$pmix_check_psm2_save_CPPFLAGS"
+	LDFLAGS="$pmix_check_psm2_save_LDFLAGS"
+	LIBS="$pmix_check_psm2_save_LIBS"
 
 	AS_IF([test "$pmix_check_psm2_happy" = "yes" && test "$enable_progress_threads" = "yes"],
               [AC_MSG_WARN([PSM2 driver does not currently support progress threads.  Disabling MTL.])
@@ -86,4 +89,6 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
           [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "no"],
                  [AC_MSG_ERROR([PSM2 support requested but not found.  Aborting])])
            $3])
+
+    PMIX_VAR_SCOPE_POP
 ])

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -772,6 +772,18 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_GROUP_ENDPT_DATA               "pmix.grp.endpt"        // (pmix_byte_object_t) data collected to be shared during construction
 
 
+/* Storage-Related Attributes */
+#define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"       // (char*) return comma-delimited list of identifiers for all available storage systems
+#define PMIX_STORAGE_CAPACITY               "pmix.strg.cap"        // (float) return overall capacity (in Megabytes) of specified storage system
+#define PMIX_STORAGE_FREE                   "pmix.strg.free"       // (float) return overall free capacity (in Megabytes) of specified storage system
+#define PMIX_STORAGE_AVAIL                  "pmix.strg.avail"      // (float) return overall capacity (in Megabytes) of specified storage
+                                                                   //         system that is available for use by the calling program
+#define PMIX_STORAGE_BW                     "pmix.strg.bw"         // (float) return overall bandwidth (in Megabytes/sec) of specified storage system
+#define PMIX_STORAGE_AVAIL_BW               "pmix.strg.availbw"    // (float) return overall bandwidth (in Megabytes/sec) of specified storage system
+                                                                   //         that is available for use by the calling program
+#define PMIX_STORAGE_ID                     "pmix.strg.id"         // (char*) identifier of the storage system being referenced
+
+
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;
 #define PMIX_PROC_STATE_UNDEF                    0  /* undefined process state */
@@ -1061,6 +1073,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_REGATTR            48
 #define PMIX_REGEX              49
 #define PMIX_JOB_STATE          50
+#define PMIX_DIM_VALUE          51
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1568,6 +1581,62 @@ typedef struct pmix_data_array {
 /**** AVOID CIRCULAR DEPENDENCIES                    ****/
 
 
+/****    VALUE UNITS    ****/
+typedef uint16_t pmix_units_t;
+#define PMIX_UNIT_BYTES             1       // Bytes
+#define PMIX_UNIT_KILOBYTES         2       // Kilobytes
+#define PMIX_UNIT_MEGABYTES         3       // Megabytes
+#define PMIX_UNIT_GIGABYTES         4       // Gigabytes
+#define PMIX_UNIT_TERABYTES         5       // Terabytes
+#define PMIX_UNIT_PETABYTES         6       // Petabytes
+#define PMIX_UNIT_EXABYTES          7       // Exabytes
+#define PMIX_UNIT_BSEC              8       // Bytes/sec
+#define PMIX_UNIT_KBSEC             9       // KBytes/sec
+#define PMIX_UNIT_MBSEC            10       // MBytes/sec
+#define PMIX_UNIT_GBSEC            11       // GBytes/sec
+#define PMIX_UNIT_TBSEC            12       // TBytes/sec
+#define PMIX_UNIT_PBSEC            13       // PBytes/sec
+#define PMIX_UNIT_EBSEC            14       // EBytes/sec
+
+
+/****    DIMENSIONED VALUE STRUCT    ****/
+typedef struct pmix_dim_value_t {
+    double dval;
+    pmix_units_t units;
+} pmix_dim_value_t;
+/* allocate and initialize a specified number of dim_value structs */
+#define PMIX_DIM_VALUE_CREATE(m, n)                             \
+    (m) = (pmix_dim_value_t*)pmix_calloc((n), sizeof(pmix_dim_value_t));
+
+/* release a single pmix_dim_value_t struct, including its data */
+#define PMIX_DIM_VALUE_RELEASE(m)       \
+    do {                                \
+        pmix_free((m));                 \
+        (m) = NULL;                     \
+    } while (0)
+
+/* initialize a single dim_value struct */
+#define PMIX_DIM_VALUE_CONSTRUCT(m)             \
+    memset((m), 0, sizeof(pmix_dim_value_t));
+
+/* release the memory in the dim_value struct data field */
+#define PMIX_DIM_VALUE_DESTRUCT(m)
+
+#define PMIX_DIM_VALUE_FREE(m, n)                       \
+    do {                                                \
+        if (NULL != (m)) {                              \
+            pmix_free((m));                             \
+            (m) = NULL;                                 \
+        }                                               \
+    } while (0)
+
+#define PMIX_DIM_VALUE_LOAD(m, d, u) \
+    do {                                \
+        (m)->dval = (double)(d);        \
+        (m)->units = (u);               \
+    } while(0)
+
+
 /* we cannot forward-declare the pmix_regattr_t struct
  * as Cython doesn't know what to do with it. Thus, we
  * will utilize the void* entry of the pmix_value_t to
@@ -1617,6 +1686,7 @@ typedef struct pmix_value {
         pmix_envar_t envar;
         pmix_coord_t *coord;
         pmix_job_state_t jstate;
+        pmix_dim_value_t *dimval;
     } data;
 } pmix_value_t;
 /* allocate and initialize a specified number of value structs */
@@ -2600,6 +2670,7 @@ PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
 PMIX_EXPORT const char* PMIx_Job_state_string(pmix_job_state_t state);
+PMIX_EXPORT const char* PMIx_Units_string(pmix_units_t unit);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -344,6 +344,7 @@ static char *server_fns[] = {
     "PMIx_Connect",
     "PMIx_Connect_nb",
     "PMIx_Register_event_handler",
+    "PMIx_Query_info",
     "PMIx_Query_info_nb",
     "PMIx_Job_control",
     "PMIx_Job_control_nb"
@@ -464,11 +465,33 @@ static pmix_regattr_input_t server_attributes[] = {
         {.name = "PMIX_NSPACE", .string = PMIX_NSPACE, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_RANK", .string = PMIX_RANK, .type = PMIX_PROC_RANK, .description = (char *[]){"UNSIGNED INT32", NULL}},
         {.name = "PMIX_HOSTNAME", .string = PMIX_HOSTNAME, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
+        {.name = "PMIX_QUERY_STORAGE_LIST", .string = PMIX_QUERY_STORAGE_LIST, .type = PMIX_STRING, .description = (char *[]){"comma-delimited list of storage identifiers", NULL}},
+        {.name = "PMIX_STORAGE_CAPACITY", .string = PMIX_STORAGE_CAPACITY, .type = PMIX_FLOAT, .description = (char *[]){"Floating point value in Megabytes", NULL}},
+        {.name = "PMIX_STORAGE_FREE", .string = PMIX_STORAGE_FREE, .type = PMIX_FLOAT, .description = (char *[]){"Currently unused storage capacity", NULL}},
+        {.name = "PMIX_STORAGE_AVAIL", .string = PMIX_STORAGE_AVAIL, .type = PMIX_FLOAT, .description = (char *[]){"Storage capacity available to caller", NULL}},
+        {.name = "PMIX_STORAGE_BW", .string = PMIX_STORAGE_BW, .type = PMIX_FLOAT, .description = (char *[]){"Total storage system bandwidth", NULL}},
+        {.name = "PMIX_STORAGE_AVAIL_BW", .string = PMIX_STORAGE_AVAIL_BW, .type = PMIX_FLOAT, .description = (char *[]){"Storage system bandwidth available to caller", NULL}},
+        {.name = "PMIX_STORAGE_ID", .string = PMIX_STORAGE_ID, .type = PMIX_FLOAT, .description = (char *[]){"Storage ID", NULL}},
+        {.name = ""},
+    // query_nb
+        {.name = "PMIX_QUERY_REFRESH_CACHE", .string = PMIX_QUERY_REFRESH_CACHE, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
+        {.name = "PMIX_PROCID", .string = PMIX_PROCID, .type = PMIX_PROC, .description = (char *[]){"pmix_proc_t*", NULL}},
+        {.name = "PMIX_NSPACE", .string = PMIX_NSPACE, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
+        {.name = "PMIX_RANK", .string = PMIX_RANK, .type = PMIX_PROC_RANK, .description = (char *[]){"UNSIGNED INT32", NULL}},
+        {.name = "PMIX_HOSTNAME", .string = PMIX_HOSTNAME, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
+        {.name = "PMIX_QUERY_STORAGE_LIST", .string = PMIX_QUERY_STORAGE_LIST, .type = PMIX_STRING, .description = (char *[]){"comma-delimited list of storage identifiers", NULL}},
+        {.name = "PMIX_STORAGE_CAPACITY", .string = PMIX_STORAGE_CAPACITY, .type = PMIX_FLOAT, .description = (char *[]){"Total storage capacity", NULL}},
+        {.name = "PMIX_STORAGE_FREE", .string = PMIX_STORAGE_FREE, .type = PMIX_FLOAT, .description = (char *[]){"Currently unused storage capacity", NULL}},
+        {.name = "PMIX_STORAGE_AVAIL", .string = PMIX_STORAGE_AVAIL, .type = PMIX_FLOAT, .description = (char *[]){"Storage capacity available to caller", NULL}},
+        {.name = "PMIX_STORAGE_BW", .string = PMIX_STORAGE_BW, .type = PMIX_FLOAT, .description = (char *[]){"Total storage system bandwidth", NULL}},
+        {.name = "PMIX_STORAGE_AVAIL_BW", .string = PMIX_STORAGE_AVAIL_BW, .type = PMIX_FLOAT, .description = (char *[]){"Storage system bandwidth available to caller", NULL}},
+        {.name = "PMIX_STORAGE_ID", .string = PMIX_STORAGE_ID, .type = PMIX_FLOAT, .description = (char *[]){"Storage ID", NULL}},
         {.name = ""},
     // job_ctrl
         {.name = "PMIX_REGISTER_CLEANUP", .string = PMIX_REGISTER_CLEANUP, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_REGISTER_CLEANUP_DIR", .string = PMIX_REGISTER_CLEANUP_DIR, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_CLEANUP_RECURSIVE", .string = PMIX_CLEANUP_RECURSIVE, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
+        {.name = "PMIX_CLEANUP_EMPTY", .string = PMIX_CLEANUP_EMPTY, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
         {.name = "PMIX_CLEANUP_IGNORE", .string = PMIX_CLEANUP_IGNORE, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_CLEANUP_LEAVE_TOPDIR", .string = PMIX_CLEANUP_LEAVE_TOPDIR, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
         {.name = ""},
@@ -476,9 +499,12 @@ static pmix_regattr_input_t server_attributes[] = {
         {.name = "PMIX_REGISTER_CLEANUP", .string = PMIX_REGISTER_CLEANUP, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_REGISTER_CLEANUP_DIR", .string = PMIX_REGISTER_CLEANUP_DIR, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_CLEANUP_RECURSIVE", .string = PMIX_CLEANUP_RECURSIVE, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
+        {.name = "PMIX_CLEANUP_EMPTY", .string = PMIX_CLEANUP_EMPTY, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
         {.name = "PMIX_CLEANUP_IGNORE", .string = PMIX_CLEANUP_IGNORE, .type = PMIX_STRING, .description = (char *[]){"UNRESTRICTED", NULL}},
         {.name = "PMIX_CLEANUP_LEAVE_TOPDIR", .string = PMIX_CLEANUP_LEAVE_TOPDIR, .type = PMIX_BOOL, .description = (char *[]){"True,False", NULL}},
         {.name = ""},
+    // monitoring
+    // storage
 };
 
 /*****    REGISTER SERVER ATTRS    *****/
@@ -807,7 +833,7 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
                 /* if I am a server, add in my fns */
                 if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
                     _get_fns(&kyresults, &cd->queries[n].qualifiers[m], &server_attrs);
-                 } else {
+                } else {
                     /* we need to ask our server for them */
                     PMIX_LIST_DESTRUCT(&kyresults);
                     goto query;
@@ -931,6 +957,77 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
     }
 
     PMIX_RELEASE(cd);
+}
+
+/*****   LOCATE A GIVEN ATTRIBUTE    *****/
+PMIX_EXPORT const char* pmix_attributes_lookup(char *name)
+{
+    pmix_attribute_trk_t *fnptr;
+    size_t n;
+
+    /* start by searching the client list */
+    PMIX_LIST_FOREACH(fnptr, &client_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].name, name)) {
+                return fnptr->attrs[n].string;
+            }
+        }
+    }
+
+    /* now check the server list */
+    PMIX_LIST_FOREACH(fnptr, &server_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].name, name)) {
+                return fnptr->attrs[n].string;
+            }
+        }
+    }
+
+    /* now check the tool list */
+    PMIX_LIST_FOREACH(fnptr, &tool_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].name, name)) {
+                return fnptr->attrs[n].string;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+PMIX_EXPORT const char* pmix_attributes_reverse_lookup(char *name)
+{
+    pmix_attribute_trk_t *fnptr;
+    size_t n;
+
+    /* start by searching the client list */
+    PMIX_LIST_FOREACH(fnptr, &client_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].string, name)) {
+                return fnptr->attrs[n].name;
+            }
+        }
+    }
+
+    /* now check the server list */
+    PMIX_LIST_FOREACH(fnptr, &server_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].string, name)) {
+                return fnptr->attrs[n].name;
+            }
+        }
+    }
+
+    /* now check the tool list */
+    PMIX_LIST_FOREACH(fnptr, &tool_attrs, pmix_attribute_trk_t) {
+        for (n=0; n < fnptr->nattrs; n++) {
+            if (0 == strcasecmp(fnptr->attrs[n].string, name)) {
+                return fnptr->attrs[n].name;
+            }
+        }
+    }
+
+    return NULL;
 }
 
 /*****   PRINT QUERY FUNCTIONS RESULTS   *****/

--- a/src/common/pmix_attributes.h
+++ b/src/common/pmix_attributes.h
@@ -66,6 +66,8 @@ PMIX_EXPORT void pmix_attributes_print_attrs(char ***ans, char *function,
 PMIX_EXPORT void pmix_attributes_print_headers(char ***ans, char *level);
 
 PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata);
+PMIX_EXPORT const char* pmix_attributes_lookup(char *name);
+PMIX_EXPORT const char* pmix_attributes_reverse_lookup(char *name);
 
 END_C_DECLS
 

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -28,6 +28,7 @@
 #include "src/util/name_fns.h"
 #include "src/util/output.h"
 #include "src/mca/bfrops/bfrops.h"
+#include "src/mca/pstrg/pstrg.h"
 #include "src/mca/ptl/ptl.h"
 #include "src/common/pmix_attributes.h"
 
@@ -117,22 +118,6 @@ static void query_cbfunc(struct pmix_peer_t *peer,
     PMIX_RELEASE(cd);
 }
 
-static void _local_relcb(void *cbdata)
-{
-    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
-    PMIX_RELEASE(cd);
-}
-
-static void _local_cbfunc(int sd, short args, void *cbdata)
-{
-    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
-    if (NULL != cd->cbfunc) {
-        cd->cbfunc(cd->status, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
-        return;
-    }
-    PMIX_RELEASE(cd);
-}
-
 static void qinfocb(pmix_status_t status, pmix_info_t info[], size_t ninfo,
 					void *cbdata, pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
@@ -153,221 +138,14 @@ static void qinfocb(pmix_status_t status, pmix_info_t info[], size_t ninfo,
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nqueries,
-									      pmix_info_t **results, size_t *nresults)
-{
-    pmix_cb_t cb;
-    pmix_status_t rc;
-
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_INIT;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "%s pmix:query", PMIX_NAME_PRINT(&pmix_globals.myid));
-
-    /* create a callback object as we need to pass it to the
-     * recv routine so we know which callback to use when
-     * the return message is recvd */
-    PMIX_CONSTRUCT(&cb, pmix_cb_t);
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(queries, nqueries,
-                                                 qinfocb, &cb))) {
-        PMIX_DESTRUCT(&cb);
-        return rc;
-    }
-
-    /* wait for the operation to complete */
-    PMIX_WAIT_THREAD(&cb.lock);
-    rc = cb.status;
-    if (NULL != cb.info) {
-    	*results = cb.info;
-    	*nresults = cb.ninfo;
-    	cb.info = NULL;
-    	cb.ninfo = 0;
-    }
-    PMIX_DESTRUCT(&cb);
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:job_ctrl completed");
-
-    return rc;
-}
-PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
-                                             pmix_info_cbfunc_t cbfunc, void *cbdata)
-
+static pmix_status_t request_help(pmix_query_t queries[], size_t nqueries,
+                                  pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_query_caddy_t *cd;
     pmix_cmd_t cmd = PMIX_QUERY_CMD;
     pmix_buffer_t *msg;
     pmix_status_t rc;
-    pmix_cb_t cb;
-    size_t n, p;
-    pmix_list_t results;
-    pmix_kval_t *kv, *kvnxt;
-    pmix_proc_t proc;
-    bool rank_given;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:query non-blocking");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_INIT;
-    }
-
-    if (0 == nqueries || NULL == queries) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_BAD_PARAM;
-    }
-
-    /* do a quick check of the qualifiers array to ensure
-     * the nqual field has been set */
-    for (n=0; n < nqueries; n++) {
-        if (NULL != queries[n].qualifiers && 0 == queries[n].nqual) {
-            /* look for the info marked as "end" */
-            p = 0;
-            while (!(PMIX_INFO_IS_END(&queries[n].qualifiers[p])) && p < SIZE_MAX) {
-                ++p;
-            }
-            if (SIZE_MAX == p) {
-                /* nothing we can do */
-                PMIX_RELEASE_THREAD(&pmix_global_lock);
-                return PMIX_ERR_BAD_PARAM;
-            }
-            queries[n].nqual = p;
-        }
-    }
-
-    /* setup the list of local results */
-    PMIX_CONSTRUCT(&results, pmix_list_t);
-
-    /* check the directives to see if they want us to refresh
-     * the local cached results - if we wanted to optimize this
-     * more, we would check each query and allow those that don't
-     * want to be refreshed to be executed locally, and those that
-     * did would be sent to the host. However, for now we simply
-     * assume that any requirement to refresh will force all to
-     * do so */
-    memset(proc.nspace, 0, PMIX_MAX_NSLEN+1);
-    proc.rank = PMIX_RANK_INVALID;
-    for (n=0; n < nqueries; n++) {
-        rank_given = false;
-        /* check for requests to report supported attributes */
-        if (0 == strcmp(queries[n].keys[0], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
-            cd = PMIX_NEW(pmix_query_caddy_t);
-            cd->queries = queries;
-            cd->nqueries = nqueries;
-            cd->cbfunc = cbfunc;
-            cd->cbdata = cbdata;
-            PMIX_THREADSHIFT(cd, pmix_attrs_query_support);
-            /* regardless of the result of the query, we return
-             * PMIX_SUCCESS here to indicate that the operation
-             * was accepted for processing */
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return PMIX_SUCCESS;
-        }
-        for (p=0; p < queries[n].nqual; p++) {
-            if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_QUERY_REFRESH_CACHE)) {
-                if (PMIX_INFO_TRUE(&queries[n].qualifiers[p])) {
-                    PMIX_LIST_DESTRUCT(&results);
-                    goto query;
-                }
-            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
-                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
-                proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
-                rank_given = true;
-            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
-                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
-            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
-                proc.rank = queries[n].qualifiers[p].value.data.rank;
-                rank_given = true;
-            }
-        }
-        /* we get here if a refresh isn't required - first try a local
-         * "get" on the data to see if we already have it */
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.copy = false;
-        /* if they are querying about node or app values not directly
-         * associated with a proc (i.e., they didn't specify the proc),
-         * then we obtain those by leaving the proc info as undefined */
-        if (!rank_given) {
-            proc.rank = PMIX_RANK_UNDEF;
-            cb.proc = &proc;
-        } else {
-            /* set the proc */
-            if (PMIX_RANK_INVALID == proc.rank &&
-                0 == strlen(proc.nspace)) {
-                /* use our id */
-                cb.proc = &pmix_globals.myid;
-            } else {
-                if (0 == strlen(proc.nspace)) {
-                    /* use our nspace */
-                    PMIX_LOAD_NSPACE(cb.proc->nspace, pmix_globals.myid.nspace);
-                }
-                if (PMIX_RANK_INVALID == proc.rank) {
-                    /* user the wildcard rank */
-                    proc.rank = PMIX_RANK_WILDCARD;
-                }
-                cb.proc = &proc;
-            }
-        }
-        for (p=0; NULL != queries[n].keys[p]; p++) {
-            cb.key = queries[n].keys[p];
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != rc) {
-                /* needs to be passed to the host */
-                PMIX_LIST_DESTRUCT(&results);
-                PMIX_DESTRUCT(&cb);
-                goto query;
-            }
-            /* need to retain this result */
-            PMIX_LIST_FOREACH_SAFE(kv, kvnxt, &cb.kvs, pmix_kval_t) {
-                pmix_list_remove_item(&cb.kvs, &kv->super);
-                pmix_list_append(&results, &kv->super);
-            }
-            PMIX_DESTRUCT(&cb);
-        }
-    }
-
-    /* if we get here, then all queries were completely locally
-     * resolved, so construct the results for return */
-    cd = PMIX_NEW(pmix_query_caddy_t);
-    cd->cbfunc = cbfunc;
-    cd->cbdata = cbdata;
-    cd->status = PMIX_SUCCESS;
-    cd->ninfo = pmix_list_get_size(&results);
-    PMIX_INFO_CREATE(cd->info, cd->ninfo);
-    n = 0;
-    PMIX_LIST_FOREACH_SAFE(kv, kvnxt, &results, pmix_kval_t) {
-        PMIX_LOAD_KEY(cd->info[n].key, kv->key);
-        rc = pmix_value_xfer(&cd->info[n].value, kv->value);
-        if (PMIX_SUCCESS != rc) {
-            cd->status = rc;
-            PMIX_INFO_FREE(cd->info, cd->ninfo);
-            break;
-        }
-        ++n;
-    }
-    /* done with the list of results */
-    PMIX_LIST_DESTRUCT(&results);
-    /* we need to thread-shift as we are not allowed to
-     * execute the callback function prior to returning
-     * from the API */
-    PMIX_THREADSHIFT(cd, _local_cbfunc);
-    /* regardless of the result of the query, we return
-     * PMIX_SUCCESS here to indicate that the operation
-     * was accepted for processing */
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-    return PMIX_SUCCESS;
-
-
-  query:
     /* if we are the server, then we just issue the query and
      * return the response */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
@@ -430,6 +208,318 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         PMIX_RELEASE(cd);
     }
     return rc;
+
+}
+
+static void _local_relcb(void *cbdata)
+{
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
+
+    if (NULL != cd->info) {
+        PMIX_INFO_FREE(cd->info, cd->ninfo);
+    }
+    PMIX_RELEASE(cd);
+}
+
+static void nxtcbfunc(pmix_status_t status,
+                      pmix_list_t *results,
+                      void *cbdata)
+{
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
+    size_t n;
+    pmix_kval_t *kv, *kvnxt;
+    pmix_status_t rc;
+
+    /* if they return success, then all queries were locally
+     * resolved, so construct the results for return */
+    if (PMIX_SUCCESS == status) {
+        cd->status = status;
+        cd->ninfo = pmix_list_get_size(results);
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        n = 0;
+        PMIX_LIST_FOREACH_SAFE(kv, kvnxt, results, pmix_kval_t) {
+            PMIX_LOAD_KEY(cd->info[n].key, kv->key);
+            rc = pmix_value_xfer(&cd->info[n].value, kv->value);
+            if (PMIX_SUCCESS != rc) {
+                cd->status = rc;
+                PMIX_INFO_FREE(cd->info, cd->ninfo);
+                break;
+            }
+            ++n;
+        }
+
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(cd->status, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
+        }
+    } else {
+        /* need to ask our host */
+        rc = request_help(cd->queries, cd->nqueries, cd->cbfunc, cd->cbdata);
+        if (PMIX_SUCCESS != rc) {
+            /* we have to return the error to the caller */
+            if (NULL != cd->cbfunc) {
+                cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+            }
+        }
+        PMIX_RELEASE(cd);
+        return;
+    }
+}
+
+static void localquery(int sd, short args, void *cbdata)
+{
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
+    pmix_query_t *queries = cd->queries;
+    size_t nqueries = cd->nqueries;
+    pmix_status_t rc;
+    pmix_cb_t cb;
+    size_t n, p;
+    pmix_list_t results;
+    pmix_kval_t *kv, *kvnxt;
+    pmix_proc_t proc;
+    bool rank_given;
+
+    /* setup the list of local results */
+    PMIX_CONSTRUCT(&results, pmix_list_t);
+
+    for (n=0; n < nqueries; n++) {
+        PMIX_LOAD_PROCID(&proc, NULL, PMIX_RANK_INVALID);
+        for (p=0; p < queries[n].nqual; p++) {
+            if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
+                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
+                proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
+                rank_given = true;
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
+                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
+                proc.rank = queries[n].qualifiers[p].value.data.rank;
+                rank_given = true;
+            }
+        }
+
+        /* first try a local "get" on the data to see if we already have it */
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.copy = false;
+        /* if they are querying about node or app values not directly
+         * associated with a proc (i.e., they didn't specify the proc),
+         * then we obtain those by leaving the proc info as undefined */
+        if (!rank_given) {
+            proc.rank = PMIX_RANK_UNDEF;
+            cb.proc = &proc;
+        } else {
+            /* set the proc */
+            if (PMIX_RANK_INVALID == proc.rank &&
+                0 == strlen(proc.nspace)) {
+                /* use our id */
+                cb.proc = &pmix_globals.myid;
+            } else {
+                if (0 == strlen(proc.nspace)) {
+                    /* use our nspace */
+                    PMIX_LOAD_NSPACE(cb.proc->nspace, pmix_globals.myid.nspace);
+                }
+                if (PMIX_RANK_INVALID == proc.rank) {
+                    /* user the wildcard rank */
+                    proc.rank = PMIX_RANK_WILDCARD;
+                }
+                cb.proc = &proc;
+            }
+        }
+
+        /* first see if we already have this info */
+        for (p=0; NULL != queries[n].keys[p]; p++) {
+            cb.key = queries[n].keys[p];
+            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+            if (PMIX_SUCCESS != rc) {
+                /* not in our gds */
+                PMIX_DESTRUCT(&cb);
+                goto nextstep;
+            }
+            /* need to retain this result */
+            PMIX_LIST_FOREACH_SAFE(kv, kvnxt, &cb.kvs, pmix_kval_t) {
+                pmix_list_remove_item(&cb.kvs, &kv->super);
+                pmix_list_append(&results, &kv->super);
+            }
+            PMIX_DESTRUCT(&cb);
+        }
+    }
+
+  nextstep:
+    /* pass the queries thru our active plugins with query
+     * interfaces to see if someone can resolve it */
+    rc = pmix_pstrg.query(queries, nqueries, &results, nxtcbfunc, cd);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        /* if we get here, then all queries were locally
+         * resolved, so construct the results for return */
+        cd->status = PMIX_SUCCESS;
+        cd->ninfo = pmix_list_get_size(&results);
+        if (0 < cd->ninfo) {
+            PMIX_INFO_CREATE(cd->info, cd->ninfo);
+            n = 0;
+            PMIX_LIST_FOREACH_SAFE(kv, kvnxt, &results, pmix_kval_t) {
+                PMIX_LOAD_KEY(cd->info[n].key, kv->key);
+                rc = pmix_value_xfer(&cd->info[n].value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    cd->status = rc;
+                    PMIX_INFO_FREE(cd->info, cd->ninfo);
+                    break;
+                }
+                ++n;
+            }
+        }
+        /* done with the list of results */
+        PMIX_LIST_DESTRUCT(&results);
+
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(cd->status, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
+        }
+    } else if (PMIX_SUCCESS != rc) {
+        /* need to ask our host */
+        rc = request_help(cd->queries, cd->nqueries, cd->cbfunc, cd->cbdata);
+        if (PMIX_SUCCESS != rc) {
+            /* we have to return the error to the caller */
+            if (NULL != cd->cbfunc) {
+                cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+            }
+        }
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    /* get here if the query returned PMIX_SUCCESS, which means
+     * that the query is being processed and will call the cbfunc
+     * when complete */
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nqueries,
+									      pmix_info_t **results, size_t *nresults)
+{
+    pmix_cb_t cb;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "%s pmix:query", PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(queries, nqueries,
+                                                 qinfocb, &cb))) {
+        PMIX_DESTRUCT(&cb);
+        return rc;
+    }
+
+    /* wait for the operation to complete */
+    PMIX_WAIT_THREAD(&cb.lock);
+    rc = cb.status;
+    if (NULL != cb.info) {
+    	*results = cb.info;
+    	*nresults = cb.ninfo;
+    	cb.info = NULL;
+    	cb.ninfo = 0;
+    }
+    PMIX_DESTRUCT(&cb);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:job_ctrl completed");
+
+    return rc;
+}
+PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
+                                             pmix_info_cbfunc_t cbfunc, void *cbdata)
+
+{
+    pmix_query_caddy_t *cd;
+    pmix_status_t rc;
+    size_t n, p;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:query non-blocking");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    if (0 == nqueries || NULL == queries) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* do a quick check of the qualifiers array to ensure
+     * the nqual field has been set */
+    for (n=0; n < nqueries; n++) {
+        if (NULL != queries[n].qualifiers && 0 == queries[n].nqual) {
+            /* look for the info marked as "end" */
+            p = 0;
+            while (!(PMIX_INFO_IS_END(&queries[n].qualifiers[p])) && p < SIZE_MAX) {
+                ++p;
+            }
+            if (SIZE_MAX == p) {
+                /* nothing we can do */
+                PMIX_RELEASE_THREAD(&pmix_global_lock);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            queries[n].nqual = p;
+        }
+    }
+
+    /* check the directives to see if they want us to refresh
+     * the local cached results - if we wanted to optimize this
+     * more, we would check each query and allow those that don't
+     * want to be refreshed to be executed locally, and those that
+     * did would be sent to the host. However, for now we simply
+     * assume that any requirement to refresh will force all to
+     * do so */
+    for (n=0; n < nqueries; n++) {
+        /* check for requests to report supported attributes */
+        if (0 == strcmp(queries[n].keys[0], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
+            cd = PMIX_NEW(pmix_query_caddy_t);
+            cd->queries = queries;
+            cd->nqueries = nqueries;
+            cd->cbfunc = cbfunc;
+            cd->cbdata = cbdata;
+            PMIX_THREADSHIFT(cd, pmix_attrs_query_support);
+            /* regardless of the result of the query, we return
+             * PMIX_SUCCESS here to indicate that the operation
+             * was accepted for processing */
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return PMIX_SUCCESS;
+        }
+        for (p=0; p < queries[n].nqual; p++) {
+            if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_QUERY_REFRESH_CACHE)) {
+                if (PMIX_INFO_TRUE(&queries[n].qualifiers[p])) {
+                    /* need to refresh the cache from our host */
+                    rc = request_help(queries, nqueries, cbfunc, cbdata);
+                    return rc;
+                }
+            }
+        }
+        /* we get here if a refresh isn't required - need to
+         * threadshift this to access our internal data */
+        cd = PMIX_NEW(pmix_query_caddy_t);
+        cd->queries = queries;
+        cd->nqueries = nqueries;
+        cd->cbfunc = cbfunc;
+        cd->cbdata = cbdata;
+        PMIX_THREADSHIFT(cd, localquery);
+        /* regardless of the result of the query, we return
+         * PMIX_SUCCESS here to indicate that the operation
+         * was accepted for processing */
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_SUCCESS;
+    }
+
+    return PMIX_OPERATION_SUCCEEDED;
 }
 
 static void acb(pmix_status_t status,

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -300,3 +300,39 @@ PMIX_EXPORT const char* PMIx_Job_state_string(pmix_job_state_t state)
             return "UNKNOWN";
     }
 }
+
+PMIX_EXPORT const char* PMIx_Units_string(pmix_units_t unit)
+{
+    switch(unit) {
+        case PMIX_UNIT_BYTES:
+            return "Bytes";
+        case PMIX_UNIT_KILOBYTES:
+            return "Kilobytes";
+        case PMIX_UNIT_MEGABYTES:
+            return "Megabytes";
+        case PMIX_UNIT_GIGABYTES:
+            return "Gigabytes";
+        case PMIX_UNIT_TERABYTES:
+            return "Terabytes";
+        case PMIX_UNIT_PETABYTES:
+            return "Petabytes";
+        case PMIX_UNIT_EXABYTES:
+            return "Exabytes";
+        case PMIX_UNIT_BSEC:
+            return "Bytes/sec";
+        case PMIX_UNIT_KBSEC:
+            return "KBytes/sec";
+        case PMIX_UNIT_MBSEC:
+            return "MBytes/sec";
+        case PMIX_UNIT_GBSEC:
+            return "GBytes/sec";
+        case PMIX_UNIT_TBSEC:
+            return "TBytes/sec";
+        case PMIX_UNIT_PBSEC:
+            return "PBytes/sec";
+        case PMIX_UNIT_EBSEC:
+            return "EBytes/sec";
+        default:
+            return "Other";
+    }
+}

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -351,6 +351,14 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_infolist_t,
                                 pmix_list_item_t,
                                 ifcon, ifdes);
 
+static void qlcon(pmix_querylist_t *p)
+{
+    PMIX_QUERY_CONSTRUCT(&p->query);
+}
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_querylist_t,
+                                pmix_list_item_t,
+                                qlcon, NULL);
+
 static void qcon(pmix_query_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
@@ -362,12 +370,15 @@ static void qcon(pmix_query_caddy_t *p)
     p->ninfo = 0;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->bo);
     PMIX_CONSTRUCT(&p->results, pmix_list_t);
+    p->nreplies = 0;
+    p->nrequests = 0;
     p->cbfunc = NULL;
     p->valcbfunc = NULL;
     p->cbdata = NULL;
     p->relcbfunc = NULL;
     p->credcbfunc = NULL;
     p->validcbfunc = NULL;
+    p->stqcbfunc = NULL;
 }
 static void qdes(pmix_query_caddy_t *p)
 {
@@ -376,7 +387,6 @@ static void qdes(pmix_query_caddy_t *p)
     PMIX_PROC_FREE(p->targets, p->ntargets);
     PMIX_INFO_FREE(p->info, p->ninfo);
     PMIX_LIST_DESTRUCT(&p->results);
-    PMIX_QUERY_FREE(p->queries, p->nqueries);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_query_caddy_t,
                                 pmix_object_t,

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -218,7 +218,7 @@ PMIX_CLASS_DECLARATION(pmix_rank_info_t);
 
 
 /* define a very simple caddy for dealing with pmix_info_t
- * objects when transferring portions of arrays */
+ * and pmix_query_t objects when transferring portions of arrays */
 typedef struct {
     pmix_list_item_t super;
     pmix_info_t *info;
@@ -231,6 +231,13 @@ typedef struct {
     pmix_info_t info;
 } pmix_infolist_t;
 PMIX_CLASS_DECLARATION(pmix_infolist_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_query_t query;
+} pmix_querylist_t;
+PMIX_CLASS_DECLARATION(pmix_querylist_t);
+
 
 /* object for tracking peers - each peer can have multiple
  * connections. This can occur if the initial app executes
@@ -274,6 +281,10 @@ typedef struct {
 } pmix_iof_req_t;
 PMIX_CLASS_DECLARATION(pmix_iof_req_t);
 
+typedef void (*pmix_pstrg_query_cbfunc_t)(pmix_status_t status,
+                                          pmix_list_t *results,
+                                          void *cbdata);
+
 
 /* caddy for query requests */
 typedef struct {
@@ -288,12 +299,15 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
     pmix_list_t results;
+    size_t nreplies;
+    size_t nrequests;
     pmix_byte_object_t bo;
     pmix_info_cbfunc_t cbfunc;
     pmix_value_cbfunc_t valcbfunc;
     pmix_release_cbfunc_t relcbfunc;
     pmix_credential_cbfunc_t credcbfunc;
     pmix_validation_cbfunc_t validcbfunc;
+    pmix_pstrg_query_cbfunc_t stqcbfunc;
     void *cbdata;
 } pmix_query_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_query_caddy_t);

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -482,6 +482,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_regex(pmix_pointer_array_t *regt
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_jobstate(pmix_pointer_array_t *regtypes,
                                                          pmix_buffer_t *buffer, const void *src,
                                                          int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_dimval(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
+                                                       int32_t num_vals, pmix_data_type_t type);
 
 /*
 * "Standard" unpack functions
@@ -625,6 +628,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_regex(pmix_pointer_array_t *re
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_jobstate(pmix_pointer_array_t *regtypes,
                                                            pmix_buffer_t *buffer, void *dest,
                                                            int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_dimval(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
+                                                         int32_t *num_vals, pmix_data_type_t type);
 
 /**** DEPRECATED ****/
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_pointer_array_t *regtypes,
@@ -694,6 +700,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_regattr(pmix_regattr_t **dest,
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_regex(char **dest,
                                                       char *src,
                                                       pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_dimval(pmix_dim_value_t **dest,
+                                                       pmix_dim_value_t *src,
+                                                       pmix_data_type_t type);
 
 /*
 * "Standard" print functions
@@ -812,7 +821,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_regex(char **output, char *pref
                                                        char *src,
                                                        pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_jobstate(char **output, char *prefix,
-                                                          pmix_proc_state_t *src,
+                                                          pmix_job_state_t *src,
+                                                          pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_dimval(char **output, char *prefix,
+                                                          pmix_dim_value_t *src,
                                                           pmix_data_type_t type);
 
 /*

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -1017,3 +1017,18 @@ pmix_status_t pmix_bfrops_base_copy_regex(char **dest,
 
     return pmix_preg.copy(dest, &len, src);
 }
+
+pmix_status_t pmix_bfrops_base_copy_dimval(pmix_dim_value_t **dest,
+                                           pmix_dim_value_t *src,
+                                           pmix_data_type_t type)
+{
+    if (PMIX_DIM_VALUE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_DIM_VALUE_CREATE(*dest, 1);
+    if (NULL == (*dest)) {
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(*dest, src, sizeof(pmix_dim_value_t));
+    return PMIX_SUCCESS;
+}

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -64,6 +64,7 @@ void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
     pmix_status_t rc;
     pmix_coord_t *coord;
     pmix_regattr_t *regattr;
+    pmix_dim_value_t *dimval;
 
     v->type = type;
     if (NULL == data) {
@@ -227,6 +228,13 @@ void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
                 PMIX_ERROR_LOG(rc);
             }
             break;
+        case PMIX_DIM_VALUE:
+            dimval = (pmix_dim_value_t*)data;
+            rc = pmix_bfrops_base_copy_dimval((pmix_dim_value_t**)&v->data.dimval, dimval, PMIX_DIM_VALUE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+            break;
         default:
             /* silence warnings */
             break;
@@ -244,6 +252,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv,
     pmix_data_array_t **darray;
     pmix_coord_t *coord;
     pmix_regattr_t *regattr, *r;
+    pmix_dim_value_t *dimval;
 
     rc = PMIX_SUCCESS;
     if (NULL == data ||
@@ -416,6 +425,13 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv,
                 *sz = 0;
             }
             break;
+        case PMIX_DIM_VALUE:
+            PMIX_DIM_VALUE_CREATE(dimval, 1);
+            if (NULL == dimval) {
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(dimval, kv->data.dimval, sizeof(pmix_dim_value_t));
+            break;
         default:
             /* silence warnings */
             rc = PMIX_ERROR;
@@ -583,6 +599,15 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
                 return PMIX_EQUAL;
             }
             break;
+        case PMIX_DIM_VALUE:
+            if (p->data.dimval->dval > p1->data.dimval->dval) {
+                return PMIX_VALUE1_GREATER;
+            } else if (p1->data.dimval->dval > p->data.dimval->dval) {
+                return PMIX_VALUE2_GREATER;
+            } else {
+                return PMIX_EQUAL;
+            }
+            break;
 
         default:
             pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
@@ -729,6 +754,10 @@ pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
     case PMIX_REGATTR:
         pmix_bfrops_base_copy_regattr((pmix_regattr_t**)&p->data.ptr, src->data.ptr, PMIX_REGATTR);
         break;
+    case PMIX_DIM_VALUE:
+        pmix_bfrops_base_copy_dimval((pmix_dim_value_t**)&p->data.dimval, src->data.dimval, PMIX_DIM_VALUE);
+        break;
+
     default:
         pmix_output(0, "PMIX-XFER-VALUE: UNSUPPORTED TYPE %d", (int)src->type);
         return PMIX_ERROR;

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1380,3 +1380,35 @@ pmix_status_t pmix_bfrops_base_pack_jobstate(pmix_pointer_array_t *regtypes,
     return ret;
 }
 
+pmix_status_t pmix_bfrops_base_pack_dimval(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
+                                           int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_dim_value_t *ptr = (pmix_dim_value_t*)src;
+    int i;
+    pmix_status_t ret;
+
+    if (NULL == regtypes) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (PMIX_DIM_VALUE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    for (i=0; i < num_vals; ++i) {
+        /* pack the value */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].dval, 1, PMIX_DOUBLE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        /* pack the units */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].units, 1, PMIX_UINT16, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1956,7 +1956,7 @@ pmix_status_t pmix_bfrops_base_print_regex(char **output, char *prefix,
 }
 
 pmix_status_t pmix_bfrops_base_print_jobstate(char **output, char *prefix,
-                                              pmix_proc_state_t *src,
+                                              pmix_job_state_t *src,
                                               pmix_data_type_t type)
 {
     char *prefx;
@@ -1987,3 +1987,35 @@ pmix_status_t pmix_bfrops_base_print_jobstate(char **output, char *prefix,
     }
 }
 
+pmix_status_t pmix_bfrops_base_print_dimval(char **output, char *prefix,
+                                            pmix_dim_value_t *src,
+                                            pmix_data_type_t type)
+{
+    char *prefx;
+    int ret;
+
+    if (PMIX_DIM_VALUE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    ret = asprintf(output, "%sData type: PMIX_DIM_VALUE\tValue: %lf\tUnits: %s",
+                   prefx, src->dval, PMIx_Units_string(src->units));
+
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1638,3 +1638,39 @@ pmix_status_t pmix_bfrops_base_unpack_jobstate(pmix_pointer_array_t *regtypes,
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
+
+pmix_status_t pmix_bfrops_base_unpack_dimval(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
+                                             int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_dim_value_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d dimvals", *num_vals);
+
+    if (PMIX_DIM_VALUE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    ptr = (pmix_dim_value_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_DIM_VALUE_CONSTRUCT(&ptr[i]);
+        /* unpack the value */
+        m=1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].dval, &m, PMIX_DOUBLE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+        /* unpack the units */
+        m=1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].units, &m, PMIX_UINT16, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -443,6 +443,14 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_print_jobstate,
                        &mca_bfrops_v4_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_DIM_VALUE",
+                       PMIX_DIM_VALUE,
+                       pmix_bfrops_base_pack_dimval,
+                       pmix_bfrops_base_unpack_dimval,
+                       pmix_bfrops_base_copy_dimval,
+                       pmix_bfrops_base_print_dimval,
+                       &mca_bfrops_v4_component.types);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
-# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -99,8 +99,13 @@ AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
     LIBS="$pmix_check_opamgt_save_LIBS"
 
     AS_IF([test "$pnet_opa_happy" = "yes"],
-          [$1],
-          [$2])
+          [PMIX_SUMMARY_ADD([[Optional Support]],[[OmniPath]], [pnet_opa], [yes ($pmix_check_psm2_dir)])
+           AS_IF([test "$pmix_check_opamgt_happy" = "yes"],
+                 [PMIX_SUMMARY_ADD([[Optional Support]],[[OmniPath Mgmt]], [pnet_opa_mgmt], [yes ($pmix_check_opamgt_dir)])],
+                 [PMIX_SUMMARY_ADD([[Optional Support]],[[OmniPath Mgmt]], [pnet_opa_mgmt], [no])])
+           $1],
+          [PMIX_SUMMARY_ADD([[Optional Support]],[[OmniPath]], [pnet_opa], [no])
+           $2])
 
     # substitute in the things needed to build psm2
     AC_SUBST([pnet_opa_CFLAGS])

--- a/src/mca/pstrg/Makefile.am
+++ b/src/mca/pstrg/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+#
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(LTDLINCL)
+
+# main library setup
+noinst_LTLIBRARIES = libmca_pstrg.la
+libmca_pstrg_la_SOURCES =
+
+# local files
+headers = pstrg.h
+
+libmca_pstrg_la_SOURCES += $(headers)
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+pmixdir = $(pmixincludedir)/$(subdir)
+nobase_pmix_HEADERS = $(headers)
+endif
+
+include base/Makefile.am
+
+distclean-local:
+	rm -f base/static-components.h

--- a/src/mca/pstrg/base/Makefile.am
+++ b/src/mca/pstrg/base/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
+#
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers += \
+        base/base.h
+
+libmca_pstrg_la_SOURCES += \
+        base/pstrg_base_frame.c \
+        base/pstrg_base_select.c \
+        base/pstrg_base_stubs.c

--- a/src/mca/pstrg/base/base.h
+++ b/src/mca/pstrg/base/base.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ */
+
+#ifndef PMIX_PSTRG_BASE_H_
+#define PMIX_PSTRG_BASE_H_
+
+#include "src/include/pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+
+#include "src/mca/pstrg/pstrg.h"
+
+BEGIN_C_DECLS
+
+/*
+ * MCA Framework
+ */
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pstrg_base_framework;
+
+PMIX_EXPORT int pmix_pstrg_base_select(void);
+
+/* define a struct to hold framework-global values */
+typedef struct {
+    pmix_list_t actives;
+    pmix_event_base_t *evbase;
+    bool selected;
+    bool init;
+} pmix_pstrg_base_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_pstrg_base_component_t *component;
+    pmix_pstrg_base_module_t *module;
+    int priority;
+} pmix_pstrg_active_module_t;
+PMIX_CLASS_DECLARATION(pmix_pstrg_active_module_t);
+
+PMIX_EXPORT extern pmix_pstrg_base_t pmix_pstrg_base;
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_key_t key;
+    pmix_list_t results;
+} pmix_pstrg_query_results_t;
+PMIX_CLASS_DECLARATION(pmix_pstrg_query_results_t);
+
+PMIX_EXPORT pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t nqueries,
+                                                pmix_list_t *results,
+                                                pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
+
+
+END_C_DECLS
+#endif

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -1,0 +1,106 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix_common.h"
+
+#include <pthread.h>
+#include PMIX_EVENT_HEADER
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+#include "src/class/pmix_list.h"
+#include "src/runtime/pmix_progress_threads.h"
+#include "src/include/types.h"
+
+#include "src/mca/pstrg/base/base.h"
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "src/mca/pstrg/base/static-components.h"
+
+/*
+ * Global variables
+ */
+pmix_pstrg_API_module_t pmix_pstrg = {
+    pmix_pstrg_base_query
+};
+pmix_pstrg_base_t pmix_pstrg_base = {{{0}}};
+
+
+static int pmix_pstrg_base_close(void)
+{
+    pmix_pstrg_active_module_t *active;
+
+    if (!pmix_pstrg_base.init || !pmix_pstrg_base.selected) {
+        return PMIX_SUCCESS;
+    }
+    pmix_pstrg_base.init = false;
+    pmix_pstrg_base.selected = false;
+
+    PMIX_LIST_FOREACH(active, &pmix_pstrg_base.actives, pmix_pstrg_active_module_t) {
+        if (NULL != active->module->finalize) {
+            active->module->finalize();
+        }
+    }
+    PMIX_LIST_DESTRUCT(&pmix_pstrg_base.actives);
+
+    /* Close all remaining available components */
+    return pmix_mca_base_framework_components_close(&pmix_pstrg_base_framework, NULL);
+}
+
+/**
+ * Function for finding and opening either all MCA components, or the one
+ * that was specifically requested via a MCA parameter.
+ */
+static int pmix_pstrg_base_open(pmix_mca_base_open_flag_t flags)
+{
+    if (pmix_pstrg_base.init) {
+        return PMIX_SUCCESS;
+    }
+    pmix_pstrg_base.init = true;
+
+    /* construct the list of modules */
+    PMIX_CONSTRUCT(&pmix_pstrg_base.actives, pmix_list_t);
+
+    /* Open up all available components */
+    return pmix_mca_base_framework_components_open(&pmix_pstrg_base_framework, flags);
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pstrg, "PMIx Storage Support",
+                                NULL,
+                                pmix_pstrg_base_open, pmix_pstrg_base_close,
+                                mca_pstrg_base_static_components, 0);
+
+PMIX_CLASS_INSTANCE(pmix_pstrg_active_module_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+static void qcon(pmix_pstrg_query_results_t *p)
+{
+    PMIX_CONSTRUCT(&p->results, pmix_list_t);
+}
+static void qdes(pmix_pstrg_query_results_t *p)
+{
+    PMIX_LIST_DESTRUCT(&p->results);
+}
+PMIX_CLASS_INSTANCE(pmix_pstrg_query_results_t,
+                    pmix_list_item_t,
+                    qcon, qdes);

--- a/src/mca/pstrg/base/pstrg_base_select.c
+++ b/src/mca/pstrg/base/pstrg_base_select.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include <string.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/pstrg/base/base.h"
+
+/* Function for selecting a prioritized list of components
+ * from all those that are available. */
+int pmix_pstrg_base_select(void)
+{
+    pmix_mca_base_component_list_item_t *cli = NULL;
+    pmix_pstrg_base_component_t *component = NULL;
+    pmix_pstrg_active_module_t *newactive, *active;
+    pmix_mca_base_module_t *mod;
+    pmix_pstrg_base_module_t *nmod;
+    int pri;
+    bool inserted;
+
+    if (pmix_pstrg_base.selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    pmix_pstrg_base.selected = true;
+
+    /* Query all available components and ask if they have a module */
+    PMIX_LIST_FOREACH(cli, &pmix_pstrg_base_framework.framework_components, pmix_mca_base_component_list_item_t) {
+        component = (pmix_pstrg_base_component_t *) cli->cli_component;
+
+        pmix_output_verbose(5, pmix_pstrg_base_framework.framework_output,
+                            "mca:pstrg:select: checking available component %s",
+                            component->base.pmix_mca_component_name);
+
+        /* get the module for this component */
+        if (PMIX_SUCCESS != component->base.pmix_mca_query_component(&mod, &pri)) {
+            continue;
+        }
+
+        /* give them a chance to initialize */
+        nmod = (pmix_pstrg_base_module_t*)mod;
+        if (NULL != nmod->init) {
+            if (PMIX_SUCCESS != nmod->init()) {
+                /* skip this one */
+                continue;
+            }
+        }
+
+        /* add to our prioritized list of available actives */
+        newactive = PMIX_NEW(pmix_pstrg_active_module_t);
+        newactive->priority = pri;
+        newactive->component = component;
+        newactive->module = nmod;
+
+        /* maintain priority order */
+        inserted = false;
+        PMIX_LIST_FOREACH(active, &pmix_pstrg_base.actives, pmix_pstrg_active_module_t) {
+            if (newactive->priority > active->priority) {
+                pmix_list_insert_pos(&pmix_pstrg_base.actives,
+                                     (pmix_list_item_t*)active, &newactive->super);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            /* must be lowest priority - add to end */
+            pmix_list_append(&pmix_pstrg_base.actives, &newactive->super);
+        }
+    }
+
+    if (4 < pmix_output_get_verbosity(pmix_pstrg_base_framework.framework_output)) {
+        pmix_output(0, "Final PSTRG priorities");
+        /* show the prioritized list */
+        PMIX_LIST_FOREACH(active, &pmix_pstrg_base.actives, pmix_pstrg_active_module_t) {
+            pmix_output(0, "\tPSTRG: %s Priority: %d",
+                        active->component->base.pmix_mca_component_name, active->priority);
+        }
+    }
+
+    return PMIX_SUCCESS;;
+}

--- a/src/mca/pstrg/base/pstrg_base_stubs.c
+++ b/src/mca/pstrg/base/pstrg_base_stubs.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include "src/util/error.h"
+
+#include "src/mca/pstrg/base/base.h"
+
+static void qcbfunc(pmix_status_t status,
+                    pmix_list_t *results,
+                    void *cbdata)
+{
+    pmix_query_caddy_t *rollup = (pmix_query_caddy_t*)cbdata;
+    pmix_kval_t *kv;
+
+    PMIX_ACQUIRE_THREAD(&rollup->lock);
+    /* check if they had an error */
+    if (PMIX_SUCCESS != status && PMIX_SUCCESS == rollup->status) {
+        rollup->status = status;
+    }
+    /* transfer any returned data */
+    if (NULL != results) {
+        while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(results))) {
+            pmix_list_append(&rollup->results, &kv->super);
+        }
+    }
+    /* record that we got a reply */
+    rollup->nreplies++;
+    /* see if all have replied */
+    if (rollup->nreplies < rollup->nrequests) {
+        /* nope - need to wait */
+        PMIX_RELEASE_THREAD(&rollup->lock);
+        return;
+    }
+
+    /* if we get here, then collection is complete */
+    PMIX_RELEASE_THREAD(&rollup->lock);
+    if (NULL != rollup->cbfunc) {
+        rollup->stqcbfunc(rollup->status, &rollup->results, rollup->cbdata);
+    }
+    PMIX_RELEASE(rollup);
+    return;
+}
+
+pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t nqueries,
+                                    pmix_list_t *results,
+                                    pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_pstrg_active_module_t *active;
+    pmix_query_caddy_t *myrollup;
+    pmix_status_t rc;
+
+    if (!pmix_pstrg_base.init) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    /* we cannot block here as each plugin could take some time to
+     * complete the request. So instead, we call each active plugin
+     * and get their immediate response - if "in progress", then
+     * we record that we have to wait for their answer before providing
+     * the caller with a response. If "error", then we know we
+     * won't be getting a response from them */
+
+    /* create the rollup object */
+    myrollup = PMIX_NEW(pmix_query_caddy_t);
+    if (NULL == myrollup) {
+        return PMIX_ERR_NOMEM;
+    }
+    myrollup->lock.active = false;
+    myrollup->status = PMIX_ERR_NOT_FOUND;
+
+    /* hold the lock until all active modules have been called
+     * to avoid race condition where replies come in before
+     * the requests counter has been fully updated */
+    PMIX_ACQUIRE_THREAD(&myrollup->lock);
+    myrollup->stqcbfunc = cbfunc;
+    myrollup->cbdata = cbdata;
+
+    PMIX_LIST_FOREACH(active, &pmix_pstrg_base.actives, pmix_pstrg_active_module_t) {
+        if (NULL != active->module->query) {
+            pmix_output_verbose(5, pmix_pstrg_base_framework.framework_output,
+                                "QUERYING %s", active->module->name);
+            rc = active->module->query(queries, nqueries, results, qcbfunc, (void*)myrollup);
+            /* if they return success, then the values were
+             * placed directly on the payload - nothing
+             * to wait for here */
+            if (PMIX_OPERATION_IN_PROGRESS == rc) {
+                myrollup->nrequests++;
+            } else if (PMIX_OPERATION_SUCCEEDED == rc) {
+                myrollup->status = PMIX_OPERATION_SUCCEEDED;
+            } else if (PMIX_SUCCESS != rc &&
+                       PMIX_ERR_TAKE_NEXT_OPTION != rc &&
+                       PMIX_ERR_NOT_SUPPORTED != rc) {
+                /* a true error - we need to wait for
+                 * all pending requests to complete
+                 * and then notify the caller of the error */
+                if (PMIX_SUCCESS == myrollup->status ||
+                    PMIX_OPERATION_SUCCEEDED == myrollup->status) {
+                    myrollup->status = rc;
+                    break;
+                }
+            }
+        }
+    }
+    if (0 == myrollup->nrequests) {
+        /* all the results (if any) are on the "results" list */
+        PMIX_RELEASE_THREAD(&myrollup->lock);
+        rc = myrollup->status;
+        PMIX_RELEASE(myrollup);
+        return rc;
+    }
+
+    PMIX_RELEASE_THREAD(&myrollup->lock);
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pstrg/lustre/Makefile.am
+++ b/src/mca/pstrg/lustre/Makefile.am
@@ -1,0 +1,59 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(pstrg_lustre_CPPFLAGS)
+
+headers = pstrg_lustre.h
+sources = \
+        pstrg_lustre_component.c \
+        pstrg_lustre.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pstrg_lustre_DSO
+lib =
+lib_sources =
+component = mca_pstrg_lustre.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_pstrg_lustre.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_pstrg_lustre_la_SOURCES = $(component_sources)
+mca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
+mca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)
+if NEED_LIBPMIX
+mca_pstrg_lustre_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_pstrg_lustre_la_SOURCES = $(lib_sources)
+libmca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
+libmca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)

--- a/src/mca/pstrg/lustre/configure.m4
+++ b/src/mca/pstrg/lustre/configure.m4
@@ -1,0 +1,45 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pstrg_lustre_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pstrg_lustre_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pstrg/lustre/Makefile])
+
+    PMIX_CHECK_LUSTRE([pstrg_lustre],
+                      [pstrg_lustre_happy="yes"],
+                      [pstrg_lustre_happy="no"])
+
+
+    AS_IF([test "$pstrg_lustre_happy" = "yes" || test "1" = "1"],
+          [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [yes ($pmix_check_lustre_dir)])
+           $1],
+          [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [no])
+           $2])
+
+    # substitute in the things needed to build lustre support
+    AC_SUBST([pstrg_lustre_CFLAGS])
+    AC_SUBST([pstrg_lustre_CPPFLAGS])
+    AC_SUBST([pstrg_lustre_LDFLAGS])
+    AC_SUBST([pstrg_lustre_LIBS])
+])dnl

--- a/src/mca/pstrg/lustre/pstrg_lustre.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "include/pmix_common.h"
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+#include "src/hwloc/hwloc-internal.h"
+
+#include "src/mca/pstrg/pstrg.h"
+#include "src/mca/pstrg/base/base.h"
+#include "pstrg_lustre.h"
+
+static pmix_status_t lustre_init(void);
+static void lustre_finalize(void);
+static pmix_status_t query(pmix_query_t queries[], size_t nqueries,
+                           pmix_list_t *results,
+                           pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
+
+pmix_pstrg_base_module_t pmix_pstrg_lustre_module = {
+    .name = "lustre",
+    .init = lustre_init,
+    .finalize = lustre_finalize,
+    .query = query
+};
+
+typedef struct {
+    char *name;
+    pmix_dim_value_t cap;
+    pmix_dim_value_t free;
+    pmix_dim_value_t avail;
+    pmix_dim_value_t bw;
+    pmix_dim_value_t availbw;
+} lustre_storage_t;
+
+static lustre_storage_t availsys[] = {
+    {.name = "lustre1", .cap = {1234.56, PMIX_UNIT_PETABYTES}, .free = {56.78, PMIX_UNIT_PETABYTES},
+     .avail = {13.1, PMIX_UNIT_GIGABYTES}, .bw = {100.0, PMIX_UNIT_GBSEC}, .availbw = {13.2, PMIX_UNIT_MBSEC}},
+
+    {.name = "lustre2", .cap = {789.12, PMIX_UNIT_MEGABYTES}, .free = {1.78, PMIX_UNIT_MEGABYTES},
+     .avail = {100.1, PMIX_UNIT_KILOBYTES}, .bw = {10.0, PMIX_UNIT_KBSEC}, .availbw = {2.2, PMIX_UNIT_BSEC}},
+
+    {.name = "lustre3", .cap = {9.1, PMIX_UNIT_TERABYTES}, .free = {3.5, PMIX_UNIT_GIGABYTES},
+     .avail = {81.0, PMIX_UNIT_BYTES}, .bw = {5.0, PMIX_UNIT_EBSEC}, .availbw = {4.2, PMIX_UNIT_PBSEC}},
+    {.name = NULL}
+};
+
+static pmix_status_t lustre_init(void)
+{
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre init");
+
+    /* ADD HERE:
+     *
+     * Discover/connect to any available Lustre systems. Return an error
+     * if none are preset, or you are unable to connect to them
+     */
+    return PMIX_SUCCESS;
+}
+
+static void lustre_finalize(void)
+{
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre finalize");
+
+    /* ADD HERE:
+     *
+     * Disconnect from any Lustre systems to which you have connected
+     */
+}
+
+static pmix_status_t query(pmix_query_t queries[], size_t nqueries,
+                           pmix_list_t *results,
+                           pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t n, m, k, nvals;
+    pmix_kval_t *kv;
+    pmix_info_t *iptr;
+    pmix_list_t qres;
+    pmix_data_array_t *darray;
+    char *sid;
+    char **ans = NULL;
+
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre query");
+
+    for (n=0; n < nqueries; n++) {
+        for (m=0; NULL != queries[n].keys[m]; m++) {
+            if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
+                /* ADD HERE:
+                 *
+                 * Obtain a list of all available Lustre storage systems. The IDs
+                 * we return should be those that we want the user to provide when
+                 * asking about a specific Lustre system.
+                 */
+
+                /* add the IDs of the available storage systems */
+                kv = PMIX_NEW(pmix_kval_t);
+                kv->key = strdup(PMIX_QUERY_STORAGE_LIST);
+                kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                kv->value->type = PMIX_STRING;
+                for (k=0; NULL != availsys[k].name; k++) {
+                    pmix_argv_append_nosize(&ans, availsys[k].name);
+                }
+                kv->value->data.string = pmix_argv_join(ans, ',');
+                pmix_argv_free(ans);
+                pmix_list_append(results, &kv->super);
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY)) {
+                /* ADD HERE:
+                 *
+                 * Get the capacity of the Lustre storage systems. If they ask for
+                 * a specific one, then get just that one.
+                 */
+
+                /* did they specify a storage ID? */
+                sid = NULL;
+                for (k=0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[m].key, PMIX_STORAGE_ID)) {
+                        sid = queries[n].qualifiers[m].value.data.string;
+                        break;
+                    }
+                }
+                PMIX_CONSTRUCT(&qres, pmix_list_t);
+                for (k=0; NULL != availsys[k].name; k++) {
+                    if (NULL == sid || 0 == strcmp(sid, availsys[k].name)) {
+                        kv = PMIX_NEW(pmix_kval_t);
+                        kv->key = strdup(availsys[k].name);
+                        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                        kv->value->type = PMIX_DIM_VALUE;
+                        kv->value->data.dimval = (pmix_dim_value_t*)malloc(sizeof(pmix_dim_value_t));
+                        PMIX_DIM_VALUE_LOAD(kv->value->data.dimval, availsys[k].cap.dval, availsys[k].cap.units);
+                        pmix_list_append(&qres, &kv->super);
+                    }
+                }
+                nvals = pmix_list_get_size(&qres);
+                if (0 < nvals) {
+                    kv = PMIX_NEW(pmix_kval_t);
+                    kv->key = strdup(PMIX_STORAGE_CAPACITY);
+                    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_DATA_ARRAY_CREATE(darray, nvals, PMIX_INFO);
+                    kv->value->type = PMIX_DATA_ARRAY;
+                    kv->value->data.darray = darray;
+                    pmix_list_append(results, &kv->super);
+                    iptr = (pmix_info_t*)darray->array;
+                    k = 0;
+                    PMIX_LIST_FOREACH(kv, &qres, pmix_kval_t) {
+                        PMIX_LOAD_KEY(&iptr[k], kv->key);
+                        iptr[k].value.type = PMIX_DIM_VALUE;
+                        iptr[k].value.data.dimval = kv->value->data.dimval;
+                        kv->value = NULL;
+                        ++k;
+                    }
+                }
+                PMIX_LIST_DESTRUCT(&qres);
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_FREE)) {
+                /* ADD HERE:
+                 *
+                 * Get the amount of free capacity of the Lustre storage systems. If they ask for
+                 * a specific one, then get just that one.
+                 */
+
+                /* did they specify a storage ID? */
+                sid = NULL;
+                for (k=0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[m].key, PMIX_STORAGE_ID)) {
+                        sid = queries[n].qualifiers[m].value.data.string;
+                        break;
+                    }
+                }
+                PMIX_CONSTRUCT(&qres, pmix_list_t);
+                for (k=0; NULL != availsys[k].name; k++) {
+                    if (NULL == sid || 0 == strcmp(sid, availsys[k].name)) {
+                        kv = PMIX_NEW(pmix_kval_t);
+                        kv->key = strdup(availsys[k].name);
+                        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                        kv->value->type = PMIX_DIM_VALUE;
+                        kv->value->data.dimval = (pmix_dim_value_t*)malloc(sizeof(pmix_dim_value_t));
+                        PMIX_DIM_VALUE_LOAD(kv->value->data.dimval, availsys[k].free.dval, availsys[k].free.units);
+                        pmix_list_append(&qres, &kv->super);
+                    }
+                }
+                nvals = pmix_list_get_size(&qres);
+                if (0 < nvals) {
+                    kv = PMIX_NEW(pmix_kval_t);
+                    kv->key = strdup(PMIX_STORAGE_FREE);
+                    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_DATA_ARRAY_CREATE(darray, nvals, PMIX_INFO);
+                    kv->value->type = PMIX_DATA_ARRAY;
+                    kv->value->data.darray = darray;
+                    pmix_list_append(results, &kv->super);
+                    iptr = (pmix_info_t*)darray->array;
+                    k = 0;
+                    PMIX_LIST_FOREACH(kv, &qres, pmix_kval_t) {
+                        PMIX_LOAD_KEY(&iptr[k], kv->key);
+                        iptr[k].value.type = PMIX_DIM_VALUE;
+                        iptr[k].value.data.dimval = kv->value->data.dimval;
+                        kv->value = NULL;
+                        ++k;
+                    }
+                }
+                PMIX_LIST_DESTRUCT(&qres);
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_AVAIL)) {
+                /* ADD HERE:
+                 *
+                 * Get the capacity of the Lustre storage systems that is available to the
+                 * caller's userid/grpid. If you need further info, please let me know - e.g.,
+                 * we could provide the app's jobid or argv[0]. If they ask for
+                 * a specific storage system, then get just that one.
+                 */
+
+                /* did they specify a storage ID? */
+                sid = NULL;
+                for (k=0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[m].key, PMIX_STORAGE_ID)) {
+                        sid = queries[n].qualifiers[m].value.data.string;
+                        break;
+                    }
+                }
+                PMIX_CONSTRUCT(&qres, pmix_list_t);
+                for (k=0; NULL != availsys[k].name; k++) {
+                    if (NULL == sid || 0 == strcmp(sid, availsys[k].name)) {
+                        kv = PMIX_NEW(pmix_kval_t);
+                        kv->key = strdup(availsys[k].name);
+                        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                        kv->value->type = PMIX_DIM_VALUE;
+                        kv->value->data.dimval = (pmix_dim_value_t*)malloc(sizeof(pmix_dim_value_t));
+                        PMIX_DIM_VALUE_LOAD(kv->value->data.dimval, availsys[k].avail.dval, availsys[k].avail.units);
+                        pmix_list_append(&qres, &kv->super);
+                    }
+                }
+                nvals = pmix_list_get_size(&qres);
+                if (0 < nvals) {
+                    kv = PMIX_NEW(pmix_kval_t);
+                    kv->key = strdup(PMIX_STORAGE_AVAIL);
+                    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_DATA_ARRAY_CREATE(darray, nvals, PMIX_INFO);
+                    kv->value->type = PMIX_DATA_ARRAY;
+                    kv->value->data.darray = darray;
+                    pmix_list_append(results, &kv->super);
+                    iptr = (pmix_info_t*)darray->array;
+                    k = 0;
+                    PMIX_LIST_FOREACH(kv, &qres, pmix_kval_t) {
+                        PMIX_LOAD_KEY(&iptr[k], kv->key);
+                        iptr[k].value.type = PMIX_DIM_VALUE;
+                        iptr[k].value.data.dimval = kv->value->data.dimval;
+                        kv->value = NULL;
+                        ++k;
+                    }
+                }
+                PMIX_LIST_DESTRUCT(&qres);
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
+                /* ADD HERE:
+                 *
+                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
+                 * a specific one, then get just that one.
+                 */
+
+                /* did they specify a storage ID? */
+                sid = NULL;
+                for (k=0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[m].key, PMIX_STORAGE_ID)) {
+                        sid = queries[n].qualifiers[m].value.data.string;
+                        break;
+                    }
+                }
+                PMIX_CONSTRUCT(&qres, pmix_list_t);
+                for (k=0; NULL != availsys[k].name; k++) {
+                    if (NULL == sid || 0 == strcmp(sid, availsys[k].name)) {
+                        kv = PMIX_NEW(pmix_kval_t);
+                        kv->key = strdup(availsys[k].name);
+                        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                        kv->value->type = PMIX_DIM_VALUE;
+                        kv->value->data.dimval = (pmix_dim_value_t*)malloc(sizeof(pmix_dim_value_t));
+                        PMIX_DIM_VALUE_LOAD(kv->value->data.dimval, availsys[k].bw.dval, availsys[k].bw.units);
+                        pmix_list_append(&qres, &kv->super);
+                    }
+                }
+                nvals = pmix_list_get_size(&qres);
+                if (0 < nvals) {
+                    kv = PMIX_NEW(pmix_kval_t);
+                    kv->key = strdup(PMIX_STORAGE_BW);
+                    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_DATA_ARRAY_CREATE(darray, nvals, PMIX_INFO);
+                    kv->value->type = PMIX_DATA_ARRAY;
+                    kv->value->data.darray = darray;
+                    pmix_list_append(results, &kv->super);
+                    iptr = (pmix_info_t*)darray->array;
+                    k = 0;
+                    PMIX_LIST_FOREACH(kv, &qres, pmix_kval_t) {
+                        PMIX_LOAD_KEY(&iptr[k], kv->key);
+                        iptr[k].value.type = PMIX_DIM_VALUE;
+                        iptr[k].value.data.dimval = kv->value->data.dimval;
+                        kv->value = NULL;
+                        ++k;
+                    }
+                }
+                PMIX_LIST_DESTRUCT(&qres);
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_AVAIL_BW)) {
+                /* ADD HERE:
+                 *
+                 * Get the bandwidth of the Lustre storage systems that is available to the
+                 * caller's userid/grpid. If you need further info, please let me know - e.g.,
+                 * we could provide the app's jobid or argv[0]. If they ask for
+                 * a specific storage system, then get just that one.
+                 */
+
+                /* did they specify a storage ID? */
+                sid = NULL;
+                for (k=0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[m].key, PMIX_STORAGE_ID)) {
+                        sid = queries[n].qualifiers[m].value.data.string;
+                        break;
+                    }
+                }
+                PMIX_CONSTRUCT(&qres, pmix_list_t);
+                for (k=0; NULL != availsys[k].name; k++) {
+                    if (NULL == sid || 0 == strcmp(sid, availsys[k].name)) {
+                        kv = PMIX_NEW(pmix_kval_t);
+                        kv->key = strdup(availsys[k].name);
+                        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                        kv->value->type = PMIX_DIM_VALUE;
+                        kv->value->data.dimval = (pmix_dim_value_t*)malloc(sizeof(pmix_dim_value_t));
+                        PMIX_DIM_VALUE_LOAD(kv->value->data.dimval, availsys[k].availbw.dval, availsys[k].availbw.units);
+                        pmix_list_append(&qres, &kv->super);
+                    }
+                }
+                nvals = pmix_list_get_size(&qres);
+                if (0 < nvals) {
+                    kv = PMIX_NEW(pmix_kval_t);
+                    kv->key = strdup(PMIX_STORAGE_AVAIL_BW);
+                    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_DATA_ARRAY_CREATE(darray, nvals, PMIX_INFO);
+                    kv->value->type = PMIX_DATA_ARRAY;
+                    kv->value->data.darray = darray;
+                    pmix_list_append(results, &kv->super);
+                    iptr = (pmix_info_t*)darray->array;
+                    k = 0;
+                    PMIX_LIST_FOREACH(kv, &qres, pmix_kval_t) {
+                        PMIX_LOAD_KEY(&iptr[k], kv->key);
+                        iptr[k].value.type = PMIX_DIM_VALUE;
+                        iptr[k].value.data.dimval = kv->value->data.dimval;
+                        kv->value = NULL;
+                        ++k;
+                    }
+                }
+                PMIX_LIST_DESTRUCT(&qres);
+            }
+        }
+    }
+    return PMIX_OPERATION_SUCCEEDED;
+}

--- a/src/mca/pstrg/lustre/pstrg_lustre.h
+++ b/src/mca/pstrg/lustre/pstrg_lustre.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PSTRG_LUSTRE_H
+#define PMIX_PSTRG_LUSTRE_H
+
+#include "src/include/pmix_config.h"
+
+
+#include "src/mca/pstrg/pstrg.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pstrg_base_component_t super;
+} pmix_pstrg_lustre_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pstrg_lustre_component_t mca_pstrg_lustre_component;
+extern pmix_pstrg_base_module_t pmix_pstrg_lustre_module;
+
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pstrg/lustre/pstrg_lustre_component.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre_component.c
@@ -1,0 +1,95 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include "src/util/argv.h"
+#include "src/mca/pstrg/pstrg.h"
+#include "pstrg_lustre.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_status_t component_register(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pstrg_lustre_component_t mca_pstrg_lustre_component = {
+    .super = {
+        .base = {
+            PMIX_PSTRG_BASE_VERSION_1_0_0,
+
+            /* Component name and version */
+            .pmix_mca_component_name = "lustre",
+            PMIX_MCA_BASE_MAKE_VERSION(component,
+                                       PMIX_MAJOR_VERSION,
+                                       PMIX_MINOR_VERSION,
+                                       PMIX_RELEASE_VERSION),
+
+            /* Component open and close functions */
+            .pmix_mca_open_component = component_open,
+            .pmix_mca_close_component = component_close,
+            .pmix_mca_register_component_params = component_register,
+            .pmix_mca_query_component = component_query,
+        },
+        .data = {
+            /* The component is checkpoint ready */
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        }
+    },
+};
+
+static pmix_status_t component_register(void)
+{
+  //  pmix_mca_base_component_t *component = &mca_pstrg_lustre_component.super.base;
+
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 10;
+    *module = (pmix_mca_base_module_t *)&pmix_pstrg_lustre_module;
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pstrg/pstrg.h
+++ b/src/mca/pstrg/pstrg.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * @file:
+ *
+ */
+
+#ifndef PMIX_PSTRG_H_
+#define PMIX_PSTRG_H_
+
+#include "src/include/pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/include/pmix_globals.h"
+
+BEGIN_C_DECLS
+
+/* initialization */
+typedef pmix_status_t (*pmix_pstrg_base_module_init_fn_t)(void);
+
+/* finalization */
+typedef void (*pmix_pstrg_base_module_fini_fn_t)(void);
+
+/* query support
+ *
+ * If the operation can be performed immediately, then the module should just
+ * add the results (as pmix_kval_t's) to the provided list and
+ * return PMIX_SUCCESS.
+ *
+ * If the module needs to perform some non-atomic operation
+ * (e.g., query a storage manager), then it should shift to its own internal
+ * thread, return PMIX_OPERATION_IN_PROGRESS, and execute the provided
+ * callback function when the operation is completed.
+ *
+ * If there is no support for the given keys, then just return PMIX_SUCCESS.
+ *
+ * If the module should be providing a response but encounters an error,
+ * then immediately return an error code if the error is immediately detected,
+ * or execute the callback function with an error code if it is detected later.
+ */
+typedef pmix_status_t (*pmix_pstrg_base_module_query_fn_t)(pmix_query_t queries[], size_t nqueries,
+                                                           pmix_list_t *results,
+                                                           pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
+
+
+/*
+ * Ver 1.0
+ */
+typedef struct pmix_pstrg_base_module_1_0_0_t {
+    char *name;
+    pmix_pstrg_base_module_init_fn_t        init;
+    pmix_pstrg_base_module_fini_fn_t        finalize;
+    pmix_pstrg_base_module_query_fn_t       query;
+} pmix_pstrg_base_module_t;
+
+
+/*
+ * the standard component data structure
+ */
+typedef struct pmix_pstrg_base_component_1_0_0_t {
+    pmix_mca_base_component_t base;
+    pmix_mca_base_component_data_t data;
+} pmix_pstrg_base_component_t;
+
+
+
+typedef struct pmix_pstrg_API_module_1_0_0_t {
+    pmix_pstrg_base_module_query_fn_t       query;
+} pmix_pstrg_API_module_t;
+
+
+/*
+ * Macro for use in components that are of type storage v1.0.0
+ */
+#define PMIX_PSTRG_BASE_VERSION_1_0_0 \
+  PMIX_MCA_BASE_VERSION_1_0_0("pstrg", 1, 0, 0)
+
+/* Global structure for accessing storage functions
+ */
+PMIX_EXPORT extern pmix_pstrg_API_module_t pmix_pstrg;  /* holds API function pointers */
+
+END_C_DECLS
+
+#endif /* MCA_PSTRG_H */

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -105,6 +105,7 @@ int pmix_rte_init(uint32_t type,
     char *error = NULL, *evar;
     size_t n;
     char hostname[PMIX_MAXHOSTNAMELEN] = {0};
+    char *gds = NULL;
 
     if( ++pmix_initialized != 1 ) {
         if( pmix_initialized < 1 ) {
@@ -302,6 +303,8 @@ int pmix_rte_init(uint32_t type,
                 if (PMIX_SUCCESS != ret) {
                     goto return_error;
                 }
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_GDS_MODULE)) {
+                gds = info[n].value.data.string;
             }
         }
     }
@@ -380,7 +383,9 @@ int pmix_rte_init(uint32_t type,
     }
 
     /* open the gds and select the active plugins */
-    if (NULL != (evar = getenv("PMIX_GDS_MODULE"))) {
+    if (NULL != gds) {
+        pmix_setenv("PMIX_MCA_gds", gds, true, &environ);
+    } else if (NULL != (evar = getenv("PMIX_GDS_MODULE"))) {
         /* convert to an MCA param, but don't overwrite something already there */
         pmix_setenv("PMIX_MCA_gds", evar, false, &environ);
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -60,14 +60,15 @@
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pinstalldirs/base/base.h"
-#include "src/mca/pnet/base/base.h"
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
 #include "src/mca/pmdl/base/base.h"
+#include "src/mca/pnet/base/base.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/psensor/base/base.h"
+#include "src/mca/pstrg/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/hwloc/hwloc-internal.h"
 
@@ -414,6 +415,16 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         return rc;
     }
 
+    /* open the pstrg framework */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pstrg_base_framework, 0))) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return rc;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_pstrg_base_select())) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return rc;
+    }
+
     /* setup the wildcard recv for inbound messages from clients */
     req = PMIX_NEW(pmix_ptl_posted_recv_t);
     req->tag = UINT32_MAX;
@@ -534,6 +545,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     (void)pmix_mca_base_framework_close(&pmix_psensor_base_framework);
     /* close the pnet framework */
     (void)pmix_mca_base_framework_close(&pmix_pnet_base_framework);
+    /* close the pstrg framework */
+    (void)pmix_mca_base_framework_close(&pmix_pstrg_base_framework);
 
     PMIX_RELEASE_THREAD(&pmix_global_lock);
     PMIX_DESTRUCT_LOCK(&pmix_global_lock);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -62,6 +62,7 @@
 #include "src/mca/pfexec/base/base.h"
 #include "src/mca/pmdl/base/base.h"
 #include "src/mca/pnet/base/base.h"
+#include "src/mca/pstrg/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/mca/psec/psec.h"
 #include "src/include/pmix_globals.h"
@@ -904,6 +905,15 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
             return rc;
         }
 
+        /* open the pstrg framework */
+        if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pstrg_base_framework, 0))) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        if (PMIX_SUCCESS != (rc = pmix_pstrg_base_select())) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
         /* start listening for connections */
         if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
             pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
@@ -1377,6 +1387,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         (void)pmix_mca_base_framework_close(&pmix_pfexec_base_framework);
         (void)pmix_mca_base_framework_close(&pmix_pmdl_base_framework);
         (void)pmix_mca_base_framework_close(&pmix_pnet_base_framework);
+        (void)pmix_mca_base_framework_close(&pmix_pstrg_base_framework);
     }
 
     pmix_rte_finalize();

--- a/src/tools/Makefile.include
+++ b/src/tools/Makefile.include
@@ -13,7 +13,7 @@
 # Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
 #                         reserved.
-# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +30,7 @@ SUBDIRS += \
     tools/plookup \
     tools/pps \
     tools/pattrs \
+    tools/pquery \
     tools/wrapper
 
 DIST_SUBDIRS += \
@@ -38,4 +39,5 @@ DIST_SUBDIRS += \
     tools/plookup \
     tools/pps \
     tools/pattrs \
+    tools/pquery \
     tools/wrapper

--- a/src/tools/pquery/Makefile.am
+++ b/src/tools/pquery/Makefile.am
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+if PMIX_INSTALL_BINARIES
+
+bin_PROGRAMS = pquery
+
+dist_pmixdata_DATA = help-pquery.txt
+
+endif # PMIX_INSTALL_BINARIES
+
+pquery_SOURCES = pquery.c
+pquery_LDADD = \
+    $(PMIX_EXTRA_LTLIB) \
+	$(top_builddir)/src/libpmix.la

--- a/src/tools/pquery/help-pquery.txt
+++ b/src/tools/pquery/help-pquery.txt
@@ -1,0 +1,27 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for pquery
+#
+[usage]
+pquery [OPTIONS] KEY1 KEY2...
+  PMIx Query tool
+
+%s


### PR DESCRIPTION
Initially support simple queries for storage system capabilities as
defined by the PMIx Storage WG. Create a new pmix_dim_value_t data type
for reporting values with units, and define an initial set of unit
designators. Provide a pretty-print function for outputing units.

Include a new "pquery" tool for querying info from the system. Add
storage attributes to the pattrs arrays.

Add a new "pstrg" (PMIx Storage) framework with a "lustre" component.
For initial prototyping work, rig it to always compile. Once the Lustre
team has added the required interface code, the normal configure logic
will be enabled.

Signed-off-by: Ralph Castain <rhc@pmix.org>