### PR TITLE
Cleanup a bit and ensure ompi5 sets envars

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -1600,10 +1600,12 @@ pmix_common_dstore_ctx_t *pmix_common_dstor_init(const char *ds_name, pmix_info_
         goto err_exit;
     }
 
-    rc = pmix_pshmem.init();
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto err_exit;
+    if (NULL != pmix_pshmem.init) {
+        rc = pmix_pshmem.init();
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto err_exit;
+        }
     }
 
     _set_constants_from_env(ds_ctx);
@@ -1778,7 +1780,9 @@ PMIX_EXPORT void pmix_common_dstor_finalize(pmix_common_dstore_ctx_t *ds_ctx)
     _esh_ns_map_cleanup(ds_ctx);
     _esh_ns_track_cleanup(ds_ctx);
 
-    pmix_pshmem.finalize();
+    if (NULL != pmix_pshmem.finalize) {
+        pmix_pshmem.finalize();
+    }
 
     if (NULL != ds_ctx->base_path){
         if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {

--- a/src/mca/pmdl/pmdl.h
+++ b/src/mca/pmdl/pmdl.h
@@ -80,7 +80,9 @@ typedef pmix_status_t (*pmix_pmdl_base_module_setup_client_fn_t)(pmix_namespace_
  * Give the plugins an opportunity to add any envars to the
  * environment of a local application process prior to fork/exec
  */
-typedef pmix_status_t (*pmix_pmdl_base_module_setup_fork_fn_t)(const pmix_proc_t *peer, char ***env);
+typedef pmix_status_t (*pmix_pmdl_base_module_setup_fork_fn_t)(const pmix_proc_t *peer,
+                                                               char ***env,
+                                                               char ***priors);
 
 /**
  * Provide an opportunity for the fabric components to cleanup any
@@ -110,6 +112,8 @@ typedef struct {
 typedef pmix_status_t (*pmix_pmdl_base_API_harvest_envars_fn_t)(char *nspace,
                                                                 const pmix_info_t info[], size_t ninfo,
                                                                 pmix_list_t *ilist);
+typedef pmix_status_t (*pmix_pmdl_base_API_setup_fork_fn_t)(const pmix_proc_t *peer,
+                                                            char ***env);
 typedef void (*pmix_pmdl_base_API_dregister_nspace_fn_t)(const char *nptr);
 typedef struct {
     char *name;
@@ -120,7 +124,7 @@ typedef struct {
     pmix_pmdl_base_module_setup_ns_kv_fn_t          setup_nspace_kv;
     pmix_pmdl_base_module_reg_nspace_fn_t           register_nspace;
     pmix_pmdl_base_module_setup_client_fn_t         setup_client;
-    pmix_pmdl_base_module_setup_fork_fn_t           setup_fork;
+    pmix_pmdl_base_API_setup_fork_fn_t              setup_fork;
     pmix_pmdl_base_API_dregister_nspace_fn_t        deregister_nspace;
 } pmix_pmdl_API_module_t;
 

--- a/src/mca/pshmem/mmap/pshmem_mmap.c
+++ b/src/mca/pshmem/mmap/pshmem_mmap.c
@@ -33,32 +33,18 @@
 #    define MAP_ANONYMOUS MAP_ANON
 #endif /* MAP_ANONYMOUS and MAP_ANON */
 
-static int _mmap_init(void);
-static void _mmap_finalize(void);
 static int _mmap_segment_create(pmix_pshmem_seg_t *sm_seg, const char *file_name, size_t size);
 static int _mmap_segment_attach(pmix_pshmem_seg_t *sm_seg, pmix_pshmem_access_mode_t sm_mode);
 static int _mmap_segment_detach(pmix_pshmem_seg_t *sm_seg);
 static int _mmap_segment_unlink(pmix_pshmem_seg_t *sm_seg);
 
 pmix_pshmem_base_module_t pmix_mmap_module = {
-    "mmap",
-    _mmap_init,
-    _mmap_finalize,
-    _mmap_segment_create,
-    _mmap_segment_attach,
-    _mmap_segment_detach,
-    _mmap_segment_unlink
+    .name = "mmap",
+    .segment_create = _mmap_segment_create,
+    .segment_attach = _mmap_segment_attach,
+    .segment_detach = _mmap_segment_detach,
+    .segment_unlink = _mmap_segment_unlink
 };
-
-static int _mmap_init(void)
-{
-    return PMIX_SUCCESS;
-}
-
-static void _mmap_finalize(void)
-{
-    ;
-}
 
 static int _mmap_segment_create(pmix_pshmem_seg_t *sm_seg, const char *file_name, size_t size)
 {


### PR DESCRIPTION
OMPI expects to see some envars. The ompi4 component already knows to
set them, but OMPI5 did not as it was expecting them to be set in PRRTE.
However, we are going to move all that across anyway, so have it done in
PMIx now.

Signed-off-by: Ralph Castain <rhc@pmix.org>