### PR TITLE
Added first test to new test_v2 suite

### DIFF
--- a/test/test_v2/Makefile
+++ b/test/test_v2/Makefile
@@ -1,4 +1,4 @@
-INSTALLDIR = /home/cps/pmix-install
+INSTALLDIR = $(HOME)/pmix-install
 INCLUDES = -I. -I../../test -I../../include -I../.. -I../../src/include
 vpath %.h .:../../test:../../include:../..:../../src/include
 LDIR = $(INSTALLDIR)/lib
@@ -9,11 +9,11 @@ LDFLAGS = -Wl,-rpath,$(LDIR)
 LIBS =-lpmix -lpthread -levent
 
 # Executables
-EXE = pmix_test 
+EXE = pmix_test test_init_fin
 
 # List of all .c source files.
 PCFILES = pmix_test.c test_common.c cli_stages.c utils.c test_server.c server_callbacks.c
-TCFILES = 
+TCFILES = test_init_fin.c test_common.c
 CFILES = $(PCFILES) $(TCFILES)
 
 OBJ = $(CFILES:%.c=%.o)
@@ -24,10 +24,13 @@ all: pmix_test test_init_fin
 .PHONY: all
 
 clean:
-	rm -f a.out $(EXE) $(OBJ) $(DEP)
+	rm -f $(EXE) $(OBJ) $(DEP)
 .PHONY: clean
 
 pmix_test: $(POBJ) 
+	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
+
+test_init_fin: $(TOBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 
 %.o : %.c

--- a/test/test_v2/test_init_fin.c
+++ b/test/test_v2/test_init_fin.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* Basic test of PMIx_* functionality: Init, Finalize */
+
+#include "pmix.h"
+#include "test_common.h"
+#include <assert.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+
+extern FILE *file;
+
+int main(int argc, char *argv[]) {
+
+    pmix_proc_t this_proc;
+    size_t ninfo = 1;
+    test_params params;
+
+    /* Handles all setup that's required prior to calling PMIx_Init() */
+    pmixt_pre_init(argc, argv, &params);
+
+    /* initialization */
+    PMIXT_CHECK(PMIx_Init(&this_proc, NULL, ninfo), params);
+
+    /* Handles everything that needs to happen after PMIx_Init() */
+    pmixt_post_init(&this_proc, &params);
+
+    /* finalize */
+    PMIXT_CHECK(PMIx_Finalize(NULL, 0), params);
+
+    /* Handles cleanup */
+    pmixt_post_finalize(&this_proc, &params);
+}


### PR DESCRIPTION
This PR adds a simple Init/Finalize test to the new test_v2 suite.
-The test makes use of the new infrastructure functions.

See issue for test description and expected results for server and client:
https://github.com/openpmix/pmix-tests/issues/60