### PR TITLE
Fixes propagation of the number of local processes to GDS

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -2392,7 +2392,8 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_setup_fork(pmix_common_dstore_ctx_t 
 }
 
 PMIX_EXPORT pmix_status_t pmix_common_dstor_add_nspace(pmix_common_dstore_ctx_t *ds_ctx,
-                                const char *nspace, pmix_info_t info[], size_t ninfo)
+                                                       const char *nspace, uint32_t local_size,
+                                                       pmix_info_t info[], size_t ninfo)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     size_t tbl_idx=0;
@@ -2400,21 +2401,17 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_add_nspace(pmix_common_dstore_ctx_t 
     char setjobuid = ds_ctx->setjobuid;
     size_t n;
     ns_map_data_t *ns_map = NULL;
-    uint32_t local_size = 0;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "gds: dstore add nspace");
+                        "gds: dstore add nspace %s, local_size %d",
+                        nspace, local_size);
 
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strcmp(PMIX_USERID, info[n].key)) {
                 jobuid = info[n].value.data.uint32;
                 setjobuid = 1;
-                continue;
-            }
-            if (0 == strcmp(PMIX_LOCAL_SIZE, info[n].key)) {
-                local_size = info[n].value.data.uint32;
-                continue;
+                break;
             }
         }
     }

--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -50,7 +50,7 @@ PMIX_EXPORT pmix_common_dstore_ctx_t *pmix_common_dstor_init(const char *ds_name
                                                              pmix_common_dstore_file_cbs_t *file_cb);
 PMIX_EXPORT void pmix_common_dstor_finalize(pmix_common_dstore_ctx_t *ds_ctx);
 PMIX_EXPORT pmix_status_t pmix_common_dstor_add_nspace(pmix_common_dstore_ctx_t *ds_ctx,
-                                const char *nspace, pmix_info_t info[], size_t ninfo);
+                                const char *nspace, uint32_t local_size, pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_common_dstor_del_nspace(pmix_common_dstore_ctx_t *ds_ctx, const char* nspace);
 PMIX_EXPORT pmix_status_t pmix_common_dstor_setup_fork(pmix_common_dstore_ctx_t *ds_ctx, const char *base_path_env,
                                            const pmix_proc_t *peer, char ***env);

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -139,11 +139,10 @@ static pmix_status_t ds12_setup_fork(const pmix_proc_t *peer, char ***env)
     return pmix_common_dstor_setup_fork(ds12_ctx, PMIX_DSTORE_ESH_BASE_PATH, peer, env);
 }
 
-static pmix_status_t ds12_add_nspace(const char *nspace,
-                                pmix_info_t info[],
-                                size_t ninfo)
+static pmix_status_t ds12_add_nspace(const char *nspace, uint32_t local_size,
+                                     pmix_info_t info[], size_t ninfo)
 {
-    return pmix_common_dstor_add_nspace(ds12_ctx, nspace, info, ninfo);
+    return pmix_common_dstor_add_nspace(ds12_ctx, nspace, local_size, info, ninfo);
 }
 
 static pmix_status_t ds12_del_nspace(const char* nspace)

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -145,11 +145,10 @@ static pmix_status_t ds21_setup_fork(const pmix_proc_t *peer, char ***env)
     return rc;
 }
 
-static pmix_status_t ds21_add_nspace(const char *nspace,
-                                pmix_info_t info[],
-                                size_t ninfo)
+static pmix_status_t ds21_add_nspace(const char *nspace, uint32_t local_size,
+                                     pmix_info_t info[], size_t ninfo)
 {
-    return pmix_common_dstor_add_nspace(ds21_ctx, nspace, info, ninfo);
+    return pmix_common_dstor_add_nspace(ds21_ctx, nspace, local_size, info, ninfo);
 }
 
 static pmix_status_t ds21_del_nspace(const char* nspace)

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -342,11 +342,12 @@ typedef pmix_status_t (*pmix_gds_base_module_setup_fork_fn_t)(const pmix_proc_t 
 * @return PMIX_SUCCESS on success.
 */
 typedef pmix_status_t (*pmix_gds_base_module_add_nspace_fn_t)(const char *nspace,
+                                                              uint32_t nlocalprocs,
                                                               pmix_info_t info[],
                                                               size_t ninfo);
 
 /* define a convenience macro for add_nspace based on peer */
-#define PMIX_GDS_ADD_NSPACE(s, n, i, ni)                    \
+#define PMIX_GDS_ADD_NSPACE(s, n, ls, i, ni)                \
     do {                                                    \
         pmix_gds_base_active_module_t *_g;                  \
         pmix_status_t _s = PMIX_SUCCESS;                    \
@@ -357,7 +358,7 @@ typedef pmix_status_t (*pmix_gds_base_module_add_nspace_fn_t)(const char *nspace
         PMIX_LIST_FOREACH(_g, &pmix_gds_globals.actives,    \
                           pmix_gds_base_active_module_t) {  \
             if (NULL != _g->module->add_nspace) {           \
-                _s = _g->module->add_nspace(n, i, ni);      \
+                _s = _g->module->add_nspace(n, ls, i, ni);  \
             }                                               \
             if (PMIX_SUCCESS != _s) {                       \
                 (s) = PMIX_ERROR;                           \

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2018-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
  * $COPYRIGHT$
@@ -87,9 +87,8 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
 
 static pmix_status_t setup_fork(const pmix_proc_t *peer, char ***env);
 
-static pmix_status_t nspace_add(const char *nspace,
-                                pmix_info_t info[],
-                                size_t ninfo);
+static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs,
+                                pmix_info_t info[], size_t ninfo);
 
 static pmix_status_t nspace_del(const char *nspace);
 
@@ -3044,9 +3043,8 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t nspace_add(const char *nspace,
-                                pmix_info_t info[],
-                                size_t ninfo)
+static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs,
+                                pmix_info_t info[], size_t ninfo)
 {
     /* we don't need to do anything here */
     return PMIX_SUCCESS;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
- * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
@@ -622,7 +622,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
     }
 
     /* register nspace for each activate components */
-    PMIX_GDS_ADD_NSPACE(rc, nptr->nspace, cd->info, cd->ninfo);
+    PMIX_GDS_ADD_NSPACE(rc, nptr->nspace, cd->nlocalprocs, cd->info, cd->ninfo);
     if (PMIX_SUCCESS != rc) {
         goto release;
     }


### PR DESCRIPTION
Following the issue: https://github.com/openpmix/prrte/issues/505

This commit provides `nlocalprocs`, obtained from
`PMIx_server_register_nspace` to the GDS `add_nspace` handler.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>