### PR TITLE
ptl_usock.c: Fix RESOURCE_LEAK issues

### DIFF
--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -161,9 +161,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     /* set the server rank */
     pmix_client_globals.myserver->info->pname.rank = strtoull(uri[1], NULL, 10);
 
-    nspace = strdup(pmix_client_globals.myserver->nptr->nspace);
     rank = pmix_client_globals.myserver->info->pname.rank;
-    suri = strdup(evar);
 
     /* setup the path to the daemon rendezvous point */
     memset(&mca_ptl_usock_component.connection, 0, sizeof(struct sockaddr_storage));
@@ -208,6 +206,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "sock_peer_try_connect: Connection across to server succeeded");
+
+    nspace = strdup(pmix_client_globals.myserver->nptr->nspace);
+    suri = strdup(evar);
 
     /* mark the connection as made */
     pmix_globals.connected = true;


### PR DESCRIPTION
Issue was found by coverity.

pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: var_assign: Assigning: "nspace" = storage returned from "strdup(pmix_client_globals.myserver->nptr->nspace)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:177: leaked_storage: Variable "nspace" going out of scope leaks the storage it points to.
|#  175|           pmix_argv_free(uri);
|#  176|           PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
|#  177|->         return PMIX_ERR_NOT_FOUND;
|#  178|       }
|#  179|       pmix_argv_free(uri);

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: var_assign: Assigning: "suri" = storage returned from "strdup(evar)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:177: leaked_storage: Variable "suri" going out of scope leaks the storage it points to.
|#  175|           pmix_argv_free(uri);
|#  176|           PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
|#  177|->         return PMIX_ERR_NOT_FOUND;
|#  178|       }
|#  179|       pmix_argv_free(uri);

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: var_assign: Assigning: "nspace" = storage returned from "strdup(pmix_client_globals.myserver->nptr->nspace)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:186: leaked_storage: Variable "nspace" going out of scope leaks the storage it points to.
|#  184|       if (PMIX_SUCCESS != (rc = pmix_ptl_base_connect(&mca_ptl_usock_component.connection, len, &sd))) {
|#  185|           PMIX_ERROR_LOG(rc);
|#  186|->         return rc;
|#  187|       }
|#  188|       pmix_client_globals.myserver->sd = sd;

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: var_assign: Assigning: "suri" = storage returned from "strdup(evar)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:186: leaked_storage: Variable "suri" going out of scope leaks the storage it points to.
|#  184|       if (PMIX_SUCCESS != (rc = pmix_ptl_base_connect(&mca_ptl_usock_component.connection, len, &sd))) {
|#  185|           PMIX_ERROR_LOG(rc);
|#  186|->         return rc;
|#  187|       }
|#  188|       pmix_client_globals.myserver->sd = sd;

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: var_assign: Assigning: "nspace" = storage returned from "strdup(pmix_client_globals.myserver->nptr->nspace)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:193: leaked_storage: Variable "nspace" going out of scope leaks the storage it points to.
|#  191|       if (PMIX_SUCCESS != (rc = send_connect_ack(sd))) {
|#  192|           CLOSE_THE_SOCKET(sd);
|#  193|->         return rc;
|#  194|       }
|#  195|

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: var_assign: Assigning: "suri" = storage returned from "strdup(evar)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:193: leaked_storage: Variable "suri" going out of scope leaks the storage it points to.
|#  191|       if (PMIX_SUCCESS != (rc = send_connect_ack(sd))) {
|#  192|           CLOSE_THE_SOCKET(sd);
|#  193|->         return rc;
|#  194|       }
|#  195|

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:164: var_assign: Assigning: "nspace" = storage returned from "strdup(pmix_client_globals.myserver->nptr->nspace)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:206: leaked_storage: Variable "nspace" going out of scope leaks the storage it points to.
|#  204|               }
|#  205|           }
|#  206|->         return rc;
|#  207|       }
|#  208|

Error: RESOURCE_LEAK (CWE-772):
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: alloc_fn: Storage is returned from allocation function "strdup".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:166: var_assign: Assigning: "suri" = storage returned from "strdup(evar)".
pmix-2.2.3/src/mca/ptl/usock/ptl_usock.c:206: leaked_storage: Variable "suri" going out of scope leaks the storage it points to.
|#  204|               }
|#  205|           }
|#  206|->         return rc;
|#  207|       }
|#  208|

Signed-off-by: Honggang Li <honli@redhat.com>