### PR TITLE
 Exclude pmix_config.h from tarball and Protect against zero local procs

### DIFF
--- a/src/include/Makefile.include
+++ b/src/include/Makefile.include
@@ -30,6 +30,9 @@ headers += \
 sources += \
         include/pmix_globals.c
 
+nodist_headers += \
+    include/pmix_config.h
+
 if ! PMIX_EMBEDDED_MODE
 headers += \
         include/align.h \
@@ -48,6 +51,6 @@ headers += \
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
-nobase_pmix_HEADERS += \
+nobase_nodist_pmix_HEADERS = \
     include/pmix_config.h
 endif


### PR DESCRIPTION
 Exclude pmix_config.h from tarball

Protect against zero local procs
Don't generate an error if the local size for the node isn't found as it
may not have any local procs

Signed-off-by: Ralph Castain <rhc@pmix.org>