### PR TITLE
Allow passing of PMIX_PREFIX to PMIx_tool_init

### DIFF
--- a/src/mca/pinstalldirs/base/base.h
+++ b/src/mca/pinstalldirs/base/base.h
@@ -33,7 +33,9 @@ PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pinstalldirs_base_framework;
    also insert the value of the environment variable $PMIX_DESTDIR, if
    it exists/is set.  This function should *only* be used during the
    setup routines of pinstalldirs. */
-char * pmix_pinstall_dirs_expand_setup(const char* input);
+PMIX_EXPORT char * pmix_pinstall_dirs_expand_setup(const char* input);
+
+PMIX_EXPORT int pmix_pinstall_dirs_base_init(pmix_info_t info[], size_t ninfo);
 
 END_C_DECLS
 

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
@@ -34,17 +34,20 @@ pmix_pinstall_dirs_t pmix_pinstall_dirs = {0};
 static int
 pmix_pinstalldirs_base_open(pmix_mca_base_open_flag_t flags)
 {
-    pmix_mca_base_component_list_item_t *component_item;
-    int ret;
+    return pmix_mca_base_framework_components_open(&pmix_pinstalldirs_base_framework, flags);
+}
 
-    ret = pmix_mca_base_framework_components_open(&pmix_pinstalldirs_base_framework, flags);
-    if (PMIX_SUCCESS != ret) {
-        return ret;
-    }
+int pmix_pinstall_dirs_base_init(pmix_info_t info[], size_t ninfo)
+{
+    pmix_mca_base_component_list_item_t *component_item;
 
     PMIX_LIST_FOREACH(component_item, &pmix_pinstalldirs_base_framework.framework_components, pmix_mca_base_component_list_item_t) {
         const pmix_pinstalldirs_base_component_t *component =
             (const pmix_pinstalldirs_base_component_t *) component_item->cli_component;
+
+        if (NULL != component->init) {
+            component->init(info, ninfo);
+        }
 
         /* copy over the data, if something isn't already there */
         CONDITIONAL_COPY(pmix_pinstall_dirs, component->install_dirs_data,

--- a/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
+++ b/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
@@ -18,7 +18,7 @@
 #include "include/pmix_common.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 
-static int pinstalldirs_env_open(void);
+static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo);
 
 
 pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
@@ -32,10 +32,6 @@ pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
         PMIX_MAJOR_VERSION,
         PMIX_MINOR_VERSION,
         PMIX_RELEASE_VERSION,
-
-        /* Component open and close functions */
-        pinstalldirs_env_open,
-        NULL
     },
     {
         /* This component is checkpointable */
@@ -46,6 +42,7 @@ pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
     {
         NULL,
     },
+    .init = pinstalldirs_env_init
 };
 
 
@@ -55,14 +52,27 @@ pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
          if (NULL != tmp && 0 == strlen(tmp)) {                           \
              tmp = NULL;                                                  \
          }                                                                \
-         mca_pinstalldirs_env_component.install_dirs_data.field = tmp;     \
+         mca_pinstalldirs_env_component.install_dirs_data.field = tmp;    \
     } while (0)
 
 
-static int
-pinstalldirs_env_open(void)
+static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo)
 {
-    SET_FIELD(prefix, "PMIX_INSTALL_PREFIX");
+    size_t n;
+    bool prefix_given = false;
+
+    /* check for a prefix value */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_PREFIX)) {
+            mca_pinstalldirs_env_component.install_dirs_data.prefix = info[n].value.data.string;
+            prefix_given = true;
+            break;
+        }
+    }
+
+    if (!prefix_given) {
+        SET_FIELD(prefix, "PMIX_INSTALL_PREFIX");
+    }
     SET_FIELD(exec_prefix, "PMIX_EXEC_PREFIX");
     SET_FIELD(bindir, "PMIX_BINDIR");
     SET_FIELD(sbindir, "PMIX_SBINDIR");
@@ -79,6 +89,4 @@ pinstalldirs_env_open(void)
     SET_FIELD(pmixdatadir, "PMIX_PKGDATADIR");
     SET_FIELD(pmixlibdir, "PMIX_PKGLIBDIR");
     SET_FIELD(pmixincludedir, "PMIX_PKGINCLUDEDIR");
-
-    return PMIX_SUCCESS;
 }

--- a/src/mca/pinstalldirs/pinstalldirs.h
+++ b/src/mca/pinstalldirs/pinstalldirs.h
@@ -15,6 +15,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "include/pmix_common.h"
+
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 
@@ -62,6 +64,9 @@ PMIX_EXPORT extern pmix_pinstall_dirs_t pmix_pinstall_dirs;
 PMIX_EXPORT char * pmix_pinstall_dirs_expand(const char* input);
 
 
+/* optional initialization function */
+typedef void (*pmix_install_dirs_init_fn_t)(pmix_info_t info[], size_t ninfo);
+
 /**
  * Structure for pinstalldirs components.
  */
@@ -72,6 +77,8 @@ struct pmix_pinstalldirs_base_component_2_0_0_t {
     pmix_mca_base_component_data_t component_data;
     /** install directories provided by the given component */
     pmix_pinstall_dirs_t install_dirs_data;
+    /* optional init function */
+    pmix_install_dirs_init_fn_t init;
 };
 /**
  * Convenience typedef

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -135,6 +135,11 @@ int pmix_rte_init(uint32_t type,
                 __FILE__, __LINE__, ret);
         return ret;
     }
+    if (PMIX_SUCCESS != (ret = pmix_pinstall_dirs_base_init(info, ninfo))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, ret);
+        return ret;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();


### PR DESCRIPTION
Tools need to be able to pass an install prefix for the PMIx they want
to use, but cannot always pass it in the environment - e.g., if they are
going to fork/exec a PMIx-based application/launcher that uses a
different PMIx library. Provide a code path that lets them pass the
PMIX_PREFIX attribute down into the installdirs framework where it can
set the PMIX_INSTALL_PREFIX field.

Signed-off-by: Ralph Castain <rhc@pmix.org>