### PR TITLE
Avoid adding external libs until done with configure

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -862,7 +862,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         cpp_includes="$PMIX_top_srcdir $PMIX_top_srcdir/src"
     fi
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
-    CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
+    CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS $PMIX_FINAL_CPPFLAGS"
+    LDFLAGS="$LDFLAGS $PMIX_FINAL_LDFLAGS"
+    LIBS="$LIBS $PMIX_FINAL_LIBS"
 
     ############################################################################
     # final wrapper compiler config

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,7 +46,7 @@ AC_DEFUN([_PMIX_HWLOC_EMBEDDED_MODE],[
  ])
 
 AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_hwloc_standard_lib_location pmix_hwloc_standard_header_location])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_hwloc_standard_lib_location pmix_hwloc_standard_header_location pmix_check_hwloc_save_CPPFLAGS pmix_check_hwloc_save_LDFLAGS pmix_check_hwloc_save_LIBS])
 
     AC_ARG_WITH([hwloc],
                 [AC_HELP_STRING([--with-hwloc=DIR],
@@ -57,6 +57,12 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
                                 [Search for hwloc libraries in DIR ])])
 
     pmix_hwloc_support=0
+    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
+    pmix_check_hwloc_save_LDFLAGS="$LDFLAGS"
+    pmix_check_hwloc_save_LIBS="$LIBS"
+    pmix_hwloc_standard_header_location=yes
+    pmix_hwloc_standard_lib_location=yes
+
     AS_IF([test "$with_hwloc" = "internal" || test "$with_hwloc" = "external"],
           [with_hwloc=])
 
@@ -108,14 +114,11 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
                            [pmix_hwloc_support=0])
 
         AS_IF([test "$pmix_hwloc_standard_header_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_hwloc_CPPFLAGS)])
+              [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)])
 
         AS_IF([test "$pmix_hwloc_standard_lib_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_hwloc_LDFLAGS)])
+              [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)])
         PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
-        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_hwloc_LIBS)
     fi
 
     if test ! -z "$with_hwloc" && test "$with_hwloc" != "no" && test "$pmix_hwloc_support" != "1"; then
@@ -137,6 +140,10 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
                AC_MSG_ERROR([Cannot continue])])
     fi
 
+    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
+    LDFLAGS=$pmix_check_hwloc_save_LDFLAGS
+    LIBS=$pmix_check_hwloc_save_LIBS
+
     AC_MSG_CHECKING([will hwloc support be built])
     if test "$pmix_hwloc_support" != "1"; then
         AC_MSG_RESULT([no])
@@ -146,6 +153,16 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
         AC_MSG_RESULT([yes])
         pmix_hwloc_source=$pmix_hwloc_dir
         pmix_hwloc_support_will_build=yes
+        AS_IF([test "$pmix_hwloc_standard_header_location" != "yes"],
+              [AC_MSG_WARN([NONSTD LOC])
+               PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_hwloc_CPPFLAGS)
+               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_hwloc_CPPFLAGS)])
+
+        AS_IF([test "$pmix_hwloc_standard_lib_location" != "yes"],
+              [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_hwloc_LDFLAGS)
+               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_hwloc_LDFLAGS)])
+        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_hwloc_LIBS)
+        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_hwloc_LIBS)
     fi
 
     # Set output variables

--- a/config/pmix_setup_libev.m4
+++ b/config/pmix_setup_libev.m4
@@ -15,7 +15,7 @@
 # MCA_libev_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_LIBEV_CONFIG],[
-    PMIX_VAR_SCOPE_PUSH([pmix_libev_dir pmix_libev_libdir pmix_libev_standard_header_location pmix_libev_standard_lib_location])
+    PMIX_VAR_SCOPE_PUSH([pmix_libev_dir pmix_libev_libdir pmix_libev_standard_header_location pmix_libev_standard_lib_location pmix_check_libev_save_CPPFLAGS pmix_check_libev_save_LDFLAGS pmix_check_libev_save_LIBS])
 
     AC_ARG_WITH([libev],
                 [AC_HELP_STRING([--with-libev=DIR],
@@ -72,14 +72,14 @@ AC_DEFUN([PMIX_LIBEV_CONFIG],[
            LIBS="$pmix_check_libev_save_LIBS"])
 
     AS_IF([test $pmix_libev_support -eq 1],
-          [PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libev_LIBS)
+          [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_libev_LIBS)
            PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libev_LIBS)
 
            AS_IF([test "$pmix_libev_standard_header_location" != "yes"],
-                 [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libev_CPPFLAGS)
+                 [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_libev_CPPFLAGS)
                   PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libev_CPPFLAGS)])
            AS_IF([test "$pmix_libev_standard_lib_location" != "yes"],
-                 [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libev_LDFLAGS)
+                 [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_libev_LDFLAGS)
                   PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libev_LDFLAGS)])])
 
     AC_MSG_CHECKING([will libev support be built])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
@@ -55,7 +55,7 @@ AC_DEFUN([_PMIX_LIBEVENT_EMBEDDED_MODE],[
 ])
 
 AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
-    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_event_defaults])
+    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_event_defaults pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
 
     AC_ARG_WITH([libevent],
                 [AC_HELP_STRING([--with-libevent=DIR],
@@ -68,6 +68,7 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
     pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
     pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
     pmix_check_libevent_save_LIBS="$LIBS"
+    pmix_event_defaults=yes
 
     # get rid of the trailing slash(es)
     libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
@@ -116,13 +117,12 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
                            [pmix_libevent_support=1],
                            [pmix_libevent_support=0])
 
+        # need to add resulting flags to global ones so we can
+        # test for thread support
         AS_IF([test "$pmix_event_defaults" = "no"],
               [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)])
+               PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)])
         PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
-        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
 
         if test $pmix_libevent_support -eq 1; then
             # Ensure that this libevent has the symbol
@@ -159,9 +159,12 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
                            [Location of event.h])
         pmix_libevent_source=$pmix_event_dir
         AS_IF([test "$pmix_event_defaults" = "no"],
-              [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)])
-        PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
+              [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_libevent_CPPFLAGS)
+               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libevent_CPPFLAGS)
+               PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_libevent_LDFLAGS)
+               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)])
+        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_libevent_LIBS)
+        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
     else
         AC_MSG_RESULT([no])
     fi


### PR DESCRIPTION
The HWLOC, libevent, and libev libraries are all external
dependencies. However, we need to delay adding any required CPPFLAGS,
LDFLAGS, and LIBS until we are done with configure so we don't interfere
with any configure tests.

Signed-off-by: Ralph Castain <rhc@pmix.org>