### PR TITLE
Move from -levent to -levent_core

### DIFF
--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -5,6 +5,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -109,9 +110,9 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
 
         PMIX_CHECK_PACKAGE([pmix_libevent],
                            [event.h],
-                           [event],
+                           [event_core],
                            [event_config_new],
-                           [-levent -levent_pthreads],
+                           [-levent_pthreads],
                            [$pmix_event_dir],
                            [$pmix_event_libdir],
                            [pmix_libevent_support=1],
@@ -128,7 +129,7 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
             # Ensure that this libevent has the symbol
             # "evthread_set_lock_callbacks", which will only exist if
             # libevent was configured with thread support.
-            AC_CHECK_LIB([event], [evthread_set_lock_callbacks],
+            AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
                          [],
                          [AC_MSG_WARN([External libevent does not have thread support])
                           AC_MSG_WARN([PMIx requires libevent to be compiled with])


### PR DESCRIPTION
 * We only need the functionality in `-levent_core`
 * We can avoid a potential conflict with other software (e.g., LSF) that
   also ship a `libevent` that is unrelated.
