### PR TITLE
Correctly handle endpt simulation

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -292,7 +292,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_NETWORK_PLANE                  "pmix.net.plane"        // (char*) string ID of a network plane
 #define PMIX_NETWORK_SWITCH                 "pmix.net.switch"       // (char*) string ID of a network switch
 #define PMIX_NETWORK_NIC                    "pmix.net.nic"          // (char*) string ID of a NIC
-#define PMIX_NETWORK_ENDPT                  "pmix.net.endpt"        // (pmix_byte_object_t) network endpt for process
+#define PMIX_NETWORK_ENDPT                  "pmix.net.endpt"        // (pmix_data_array_t*) array of network endpts for process
 #define PMIX_NETWORK_SHAPE                  "pmix.net.shape"        // (pmix_data_array_t*) number of interfaces (uint32_t) on each dimension of the
                                                                     //        specified network plane in the requested view
 #define PMIX_NETWORK_SHAPE_STRING           "pmix.net.shapestr"     // (char*) network shape expressed as a string (e.g., "10x12x2")

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -130,8 +130,8 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
                 (void**)&proc_data, (void**)&node);
         if (PMIX_SUCCESS != rc) {
             pmix_output_verbose(10, pmix_globals.debug_output,
-                                "HASH:FETCH proc data for rank %d not found",
-                                rank);
+                                "HASH:FETCH[%s:%d] proc data for rank %d not found",
+                                __func__, __LINE__, rank);
             return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
         }
     }
@@ -140,8 +140,8 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
         proc_data = lookup_proc(table, id, false);
         if (NULL == proc_data) {
             pmix_output_verbose(10, pmix_globals.debug_output,
-                                "HASH:FETCH proc data for rank %d not found",
-                                rank);
+                                "HASH:FETCH[%s:%d] proc data for rank %d not found",
+                                __func__, __LINE__, rank);
             return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
         }
 
@@ -203,7 +203,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
                 (void**)&proc_data, node, (void**)&node);
         if (PMIX_SUCCESS != rc) {
             pmix_output_verbose(10, pmix_globals.debug_output,
-                                "HASH:FETCH data for key %s not found", key);
+                                "%s:%d HASH:FETCH data for key %s not found", __func__, __LINE__, key);
             return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
         }
     }

--- a/test/simple/simpcoord.c
+++ b/test/simple/simpcoord.c
@@ -46,10 +46,11 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     char *tmp;
     pmix_proc_t proc;
-    uint32_t nprocs, n, *u32;
+    uint32_t nprocs, n;
     size_t ninfo, m;
     pmix_coord_t *coords;
     char *hostname;
+    pmix_byte_object_t *bptr;
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
@@ -90,16 +91,15 @@ int main(int argc, char **argv)
                 myproc.nspace, myproc.rank,
                 (unsigned long)val->data.darray->size);
 
-    u32 = (uint32_t*)val->data.darray->array;
+    bptr = (pmix_byte_object_t*)val->data.darray->array;
     ninfo = val->data.darray->size;
     /* print them out for diagnostics - someday we can figure
-     * out an automated way of testing the answer */
+     * out an automated way of testing the answer. We know that
+     * the simptest pnet component returns strings */
     {
         char **foo = NULL;
         for (n=0; n < ninfo; n++) {
-            asprintf(&tmp, "%d", u32[n]);
-            pmix_argv_append_nosize(&foo, tmp);
-            free(tmp);
+            pmix_argv_append_nosize(&foo, bptr[0].bytes);
         }
         tmp = pmix_argv_join(foo, ',');
         pmix_argv_free(foo);


### PR DESCRIPTION
Endpts are returned as an array since they can contain multiple endpt
assignments if there are multiple NICs available to the proc. Ensure
that the pnet/simptest component returns at least one endpt since the
simpcoord test/example is looking for it.

Signed-off-by: Ralph Castain <rhc@pmix.org>