### PR TITLE
configure.ac: use "pax" tar format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ pmix_show_title "Configuring PMIx"
 AC_CANONICAL_TARGET
 
 # Init automake
-AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-pax])
 
 # SILENT_RULES is new in AM 1.11, but we require 1.13.4 or higher via
 # autogen.  Limited testing shows that calling SILENT_RULES directly


### PR DESCRIPTION
The default "ustar" tar format (POSIX.1-1988) imposes a restriction that the
UID/GID is at most 2097151. Unfortunately, the configure step will *not fail*
if this condition is not met - from the GNU Automake documentation:

> "configure knows several ways to construct these formats. It will not abort if it cannot find a tool up to the task (so that the package can still be built), but 'make dist' will fail."

The "ustar" tar format has the UID/GID restriction, but it also has a maximum
8GB file size and a 256 character maximum filename length.

The "pax" tar format (POSIX.1-2001) supports "unlimited" UID/GID value and also
supports unlimited filename lengths and an unlimited file size.

This commit will switch automake to use the "pax" tar format to generate
distribution tar files.

Signed-off-by: Michael Blocksome <michael.blocksome@intel.com>