### PR TITLE
Point to the correct file that wasn't found

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -816,15 +816,19 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                    MCA-variable-setting mechansism).  This MCA variable
                                    controls whether warnings are displayed when an MCA
                                    component fails to load at run time due to an error.
-                                   (default: enabled, meaning that
+                                   (default: enabled in --enable-debug builds, meaning that
                                    mca_base_component_show_load_errors is enabled
-                                   by default])])
+                                   by default when configured with --enable-debug])])
     if test "$enable_show_load_errors_by_default" = "no" ; then
         PMIX_SHOW_LOAD_ERRORS_DEFAULT=0
         AC_MSG_RESULT([disabled by default])
     else
-        PMIX_SHOW_LOAD_ERRORS_DEFAULT=1
-        AC_MSG_RESULT([enabled by default])
+        PMIX_SHOW_LOAD_ERRORS_DEFAULT=$WANT_DEBUG
+        if test "$WANT_DEBUG" = "1"; then
+            AC_MSG_RESULT([enabled by default])
+        else
+            AC_MSG_RESULT([disabled by default])
+        fi
     fi
     AC_DEFINE_UNQUOTED(PMIX_SHOW_LOAD_ERRORS_DEFAULT, $PMIX_SHOW_LOAD_ERRORS_DEFAULT,
                        [Default value for mca_base_component_show_load_errors MCA variable])

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -419,23 +419,22 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
     char *err_msg = NULL;
     if (PMIX_SUCCESS != pmix_pdl_open(ri->ri_path, true, false, &ri->ri_dlhandle, &err_msg)) {
         if (NULL == err_msg) {
-            err_msg = "pmix_dl_open() error message was NULL!";
-        }
-        /* Because libltdl erroneously says "file not found" for any
-           type of error -- which is especially misleading when the file
-           is actually there but cannot be opened for some other reason
-           (e.g., missing symbol) -- do some simple huersitics and if
-           the file [probably] does exist, print a slightly better error
-           message. */
-        if (0 == strcasecmp("file not found", err_msg) &&
-            (file_exists(ri->ri_path, "lo") ||
-             file_exists(ri->ri_path, "so") ||
-             file_exists(ri->ri_path, "dylib") ||
-             file_exists(ri->ri_path, "dll"))) {
-            err_msg = "perhaps a missing symbol, or compiled for a different version of Open MPI?";
+            err_msg = strdup("pmix_dl_open() error message was NULL!");
+        } else if (file_exists(ri->ri_path, "lo") ||
+                   file_exists(ri->ri_path, "so") ||
+                   file_exists(ri->ri_path, "dylib") ||
+                   file_exists(ri->ri_path, "dll")) {
+            /* Because libltdl erroneously says "file not found" for any
+             * type of error -- which is especially misleading when the file
+             * is actually there but cannot be opened for some other reason
+             * (e.g., missing symbol) -- do some simple huersitics and if
+             * the file [probably] does exist, print a slightly better error
+             * message. */
+            err_msg = strdup("perhaps a missing symbol, or compiled for a different version of Open MPI?");
         }
         pmix_output_verbose(vl, 0, "pmix_mca_base_component_repository_open: unable to open %s: %s (ignored)",
                             ri->ri_base, err_msg);
+        free(err_msg);
 
         if( pmix_mca_base_component_track_load_errors ) {
             pmix_mca_base_failed_component_t *f_comp = PMIX_NEW(pmix_mca_base_failed_component_t);

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -92,7 +92,10 @@ static int pdlopen_open(const char *fname, bool use_ext, bool private_namespace,
             if (stat(name, &buf) < 0) {
                 free(name);
                 if (NULL != err_msg) {
-                    *err_msg = "File not found";
+                    rc = asprintf(err_msg, "File %s not found", name);
+                    if (0 > rc) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 continue;
             }

--- a/src/mca/pdl/plibltdl/pdl_libltdl_module.c
+++ b/src/mca/pdl/plibltdl/pdl_libltdl_module.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,7 +66,7 @@ static int plibltpdl_open(const char *fname, bool use_ext, bool private_namespac
     }
 
     if (NULL != err_msg) {
-        *err_msg = (char*) lt_dlerror();
+        *err_msg = strdup((char*) lt_dlerror());
     }
     return PMIX_ERROR;
 }


### PR DESCRIPTION
When doing a dlopen, we apparently strip the extension from the actual
filename to identify the component it relates to, and then add accepted
extensions back to the filename when checking for file existence prior
to loading. Unfortunately, some 3rd party packages (e.g., debuggers)
take our libraries, do a little magic, and then output a copy of the
results into our lib directory - only with a new suffix. So we might get
something like "ourcomponent.so.dbg". We then strip the ".dbg" and add
".so" to it again - and complain that "ourcomponent.so is not found".

Fix the error message so it reports the name of the file it actually
couldn't find, not the name of the component, so it doesn't totally
confuse people.

Signed-off-by: Ralph Castain <rhc@pmix.org>