### PR TITLE
v3.1/ds21: fixed crash of dstor locks destructor

### DIFF
--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2018      Mellanox Technologies, Inc.
+ * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -88,7 +87,7 @@ static void ncon(lock_item_t *p) {
 static void ldes(lock_item_t *p) {
     uint32_t i;
 
-    if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+    if(PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && (NULL != p->seg_desc)) {
         segment_hdr_t *seg_hdr = (segment_hdr_t *)p->seg_desc->seg_info.seg_base_addr;
         if (p->lockfile) {
             unlink(p->lockfile);


### PR DESCRIPTION
A check was added to avoid locks finalization in the error case
when the dstore segment was not created and its pointer is NULL.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit beddd8859e6723153893c9de2a2e014de18adc59)

Corresponds to #1765 