### PR TITLE
Add manpage build decision to config summary and pmix_info

### DIFF
--- a/config/pmix_setup_man_pages.m4
+++ b/config/pmix_setup_man_pages.m4
@@ -33,6 +33,13 @@ AC_DEFUN([PMIX_SETUP_MAN_PAGES],[
 
     AC_SUBST(PANDOC)
     AM_CONDITIONAL([PMIX_ENABLE_MAN_PAGES], [test $PMIX_ENABLE_MAN_PAGES -eq 1])
+    AC_DEFINE_UNQUOTED([PMIX_ENABLE_MAN_PAGES], [$PMIX_ENABLE_MAN_PAGES],
+                       [Whether or not we will build manpages])
+
+    AS_IF([test $PMIX_ENABLE_MAN_PAGES -eq 1],
+          [PMIX_SUMMARY_ADD([[Options]],[[Manpages built]], [pmix_manpages], [yes])],
+          [PMIX_SUMMARY_ADD([[Options]],[[Manpages built]], [pmix_manpages], [yes])])
+
 ])
 
 dnl Back-end pandoc setup

--- a/src/tools/pmix_info/pmix_info.c
+++ b/src/tools/pmix_info/pmix_info.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -86,6 +86,11 @@ int main(int argc, char *argv[])
     /* initialize install dirs code */
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework, 0))) {
         fprintf(stderr, "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, ret);
+        return ret;
+    }
+    if (PMIX_SUCCESS != (ret = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
                 __FILE__, __LINE__, ret);
         return ret;
     }

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2011-2012 University of Houston. All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -1327,11 +1327,13 @@ void pmix_info_do_config(bool want_all)
     char *debug;
     char *have_dl;
     char *symbol_visibility;
+    char *manpages;
 
     /* setup the strings that don't require allocations*/
     debug = PMIX_ENABLE_DEBUG ? "yes" : "no";
     have_dl = PMIX_HAVE_PDL_SUPPORT ? "yes" : "no";
     symbol_visibility = PMIX_HAVE_VISIBILITY ? "yes" : "no";
+    manpages = PMIX_ENABLE_MAN_PAGES ? "yes" : "no";
 
     /* output values */
     pmix_info_out("Configured by", "config:user", PMIX_CONFIGURE_USER);
@@ -1373,4 +1375,5 @@ void pmix_info_do_config(bool want_all)
     pmix_info_out("Internal debug support", "option:debug", debug);
     pmix_info_out("dl support", "option:dlopen", have_dl);
     pmix_info_out("Symbol vis. support", "options:visibility", symbol_visibility);
+    pmix_info_out("Manpages built", "options:man-pages", manpages);
 }


### PR DESCRIPTION
Indicate whether or not manpages are being built in the configure
summary and in pmix_info

Signed-off-by: Ralph Castain <rhc@pmix.org>