### PR TITLE
Fix a bug in client/get and in pnet/simptest

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -777,16 +777,10 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                 proc.rank = PMIX_RANK_WILDCARD;
                 goto request;
             } else if (NULL != cb->key) {
-                /* if immediate was given, then we are being directed to
-                 * check with the server even though the caller is looking for
-                 * job-level info. In some cases, a server may elect not
-                 * to provide info at init to save memory */
-                if (!optional) {
-                    pmix_output_verbose(5, pmix_client_globals.get_output,
-                                        "pmix:client not optional - requesting data");
-                    goto request;
-                }
-                /* we should have had this info, so respond with the error */
+                /* => cb->key starts with pmix
+                 * we should have had this info, so respond with the error - if
+                 * they want us to check with the server, they should ask us to
+                 * refresh the cache */
                 pmix_output_verbose(5, pmix_client_globals.get_output,
                                     "pmix:client returning NOT FOUND error");
                 goto respond;

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -179,7 +179,7 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target,
     pmix_peer_t *peer;
 
     if (NULL == (peer = find_peer(target))) {
-        return PMIX_ERR_NOT_SUPPORTED;
+        return PMIX_ERR_NOT_FOUND;
     }
 
     /* setup the host */
@@ -210,7 +210,7 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *source,
     pmix_peer_t *peer;
 
     if (NULL == (peer = find_peer(source))) {
-        return PMIX_ERR_NOT_SUPPORTED;
+        return PMIX_ERR_NOT_FOUND;
     }
 
     /* setup the host */


### PR DESCRIPTION
If job-level info isn't found for our own nspace, then we return an
error. If the user wants us to recheck with the server, then they need
to tell us to "refresh cache".

Fix a bug in parsing of the pnet/simptest config file

Signed-off-by: Ralph Castain <rhc@pmix.org>