### PR TITLE
configury: fix final wrapper setup

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -879,6 +879,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # executables) need perl.
     AC_PATH_PROG(PERL, perl, perl)
 
+    # Need the libtool executable before the rpathify stuff
+    LT_OUTPUT
+
     PMIX_SETUP_WRAPPER_FINAL
 
     ############################################################################

--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -136,7 +136,7 @@ AC_DEFUN([PMIX_LIBTOOL_CONFIG],[
 # (because if script A sources script B, and B calls "exit", then both
 # B and A will exit).  Instead, we have to send the output to a file
 # and then source that.
-libtool $3 --config > $rpath_outfile
+$PMIX_TOP_BUILDDIR/libtool $3 --config > $rpath_outfile
 
 chmod +x $rpath_outfile
 . ./$rpath_outfile


### PR DESCRIPTION
The final wrapper setup needs the "libtool" executable to be available
to check for rpath kinds of things.  So make sure we call LT_OUTPUT to
ensure that it exists before we do the final wrapper compiler setup.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>