### PR TITLE
Setup a new RM framework

### DIFF
--- a/config/pmix_check_tm.m4
+++ b/config/pmix_check_tm.m4
@@ -1,0 +1,174 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2015-2017 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# PMIX_CHECK_TM_LIBS_FLAGS(prefix, [LIBS or LDFLAGS])
+# ---------------------------------------------------
+AC_DEFUN([PMIX_CHECK_TM_LIBS_FLAGS],[
+    PMIX_VAR_SCOPE_PUSH([pmix_check_tm_flags])
+    pmix_check_tm_flags=`$pmix_check_tm_pbs_config --libs`
+    for pmix_check_tm_val in $pmix_check_tm_flags; do
+        if test "`echo $pmix_check_tm_val | cut -c1-2`" = "-l"; then
+            if test "$2" = "LIBS"; then
+                $1_$2="$$1_$2 $pmix_check_tm_val"
+            fi
+        else
+            if test "$2" = "LDFLAGS"; then
+                $1_$2="$$1_$2 $pmix_check_tm_val"
+            fi
+        fi
+    done
+    PMIX_VAR_SCOPE_POP
+])
+
+
+# PMIX_CHECK_TM(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([PMIX_CHECK_TM],[
+    if test -z $pmix_check_tm_happy ; then
+	PMIX_VAR_SCOPE_PUSH([pmix_check_tm_found pmix_check_tm_dir pmix_check_tm_pbs_config pmix_check_tm_LDFLAGS_save pmix_check_tm_CPPFLAGS_save pmix_check_tm_LIBS_save])
+
+	AC_ARG_WITH([tm],
+                    [AC_HELP_STRING([--with-tm(=DIR)],
+                                    [Build TM (Torque, PBSPro, and compatible) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+	PMIX_CHECK_WITHDIR([tm], [$with_tm], [include/tm.h])
+
+	pmix_check_tm_found=no
+	AS_IF([test "$with_tm" = "no"],
+              [pmix_check_tm_happy="no"],
+              [pmix_check_tm_happy="yes"
+               AS_IF([test ! -z "$with_tm" && test "$with_tm" != "yes"],
+                     [pmix_check_tm_dir="$with_tm"],
+                     [pmix_check_tm_dir=""])])
+
+	AS_IF([test "$pmix_check_tm_happy" = "yes"],
+              [AC_MSG_CHECKING([for pbs-config])
+               pmix_check_tm_pbs_config="not found"
+               AS_IF([test "$pmix_check_tm_dir" != "" && test -d "$pmix_check_tm_dir" && test -x "$pmix_check_tm_dir/bin/pbs-config"],
+                     [pmix_check_tm_pbs_config="$pmix_check_tm_dir/bin/pbs-config"],
+                     [AS_IF([pbs-config --prefix >/dev/null 2>&1],
+                            [pmix_check_tm_pbs_config="pbs-config"])])
+               AC_MSG_RESULT([$pmix_check_tm_pbs_config])])
+
+	# If we have pbs-config, get the flags we need from there and then
+	# do simplistic tests looking for the tm headers and symbols
+
+	AS_IF([test "$pmix_check_tm_happy" = "yes" && test "$pmix_check_tm_pbs_config" != "not found"],
+              [pmix_check_tm_CPPFLAGS=`$pmix_check_tm_pbs_config --cflags`
+               PMIX_LOG_MSG([pmix_check_tm_CPPFLAGS from pbs-config: $pmix_check_tm_CPPFLAGS], 1)
+
+               PMIX_CHECK_TM_LIBS_FLAGS([pmix_check_tm], [LDFLAGS])
+               PMIX_LOG_MSG([pmix_check_tm_LDFLAGS from pbs-config: $pmix_check_tm_LDFLAGS], 1)
+
+               PMIX_CHECK_TM_LIBS_FLAGS([pmix_check_tm], [LIBS])
+               PMIX_LOG_MSG([pmix_check_tm_LIBS from pbs-config: $pmix_check_tm_LIBS], 1)
+
+               # Now that we supposedly have the right flags, try them out.
+
+               pmix_check_tm_CPPFLAGS_save="$CPPFLAGS"
+               pmix_check_tm_LDFLAGS_save="$LDFLAGS"
+               pmix_check_tm_LIBS_save="$LIBS"
+
+               CPPFLAGS="$CPPFLAGS $pmix_check_tm_CPPFLAGS"
+               LIBS="$LIBS $pmix_check_tm_LIBS"
+               LDFLAGS="$LDFLAGS $pmix_check_tm_LDFLAGS"
+
+               AC_CHECK_HEADER([tm.h],
+			       [AC_CHECK_FUNC([tm_finalize],
+					      [pmix_check_tm_found="yes"])])
+
+               CPPFLAGS="$pmix_check_tm_CPPFLAGS_save"
+               LDFLAGS="$pmix_check_tm_LDFLAGS_save"
+               LIBS="$pmix_check_tm_LIBS_save"])
+
+	# If we don't have pbs-config, then we have to look around
+	# manually.
+
+	# Note that Torque 2.1.0 changed the name of their back-end
+	# library to "libtorque".  So we have to check for both libpbs and
+	# libtorque.  First, check for libpbs.
+
+	pmix_check_package_$1_save_CPPFLAGS="$CPPFLAGS"
+	pmix_check_package_$1_save_LDFLAGS="$LDFLAGS"
+	pmix_check_package_$1_save_LIBS="$LIBS"
+
+	AS_IF([test "$pmix_check_tm_found" = "no"],
+              [AS_IF([test "$pmix_check_tm_happy" = "yes"],
+                     [_PMIX_CHECK_PACKAGE_HEADER([pmix_check_tm],
+						 [tm.h],
+						 [$pmix_check_tm_dir],
+						 [pmix_check_tm_found="yes"],
+						 [pmix_check_tm_found="no"])])
+
+               AS_IF([test "$pmix_check_tm_found" = "yes"],
+                     [_PMIX_CHECK_PACKAGE_LIB([pmix_check_tm],
+					      [pbs],
+					      [tm_init],
+					      [],
+					      [$pmix_check_tm_dir],
+					      [$pmix_check_tm_libdir],
+					      [pmix_check_tm_found="yes"],
+                                              [_PMIX_CHECK_PACKAGE_LIB([pmix_check_tm],
+					                               [pbs],
+					                               [tm_init],
+					                               [-lcrypto],
+					                               [$pmix_check_tm_dir],
+					                               [$pmix_check_tm_libdir],
+					                               [pmix_check_tm_found="yes"],
+					                               [_PMIX_CHECK_PACKAGE_LIB([pmix_check_tm],
+								                                [torque],
+								                                [tm_init],
+								                                [],
+								                                [$pmix_check_tm_dir],
+								                                [$pmix_check_tm_libdir],
+								                                [pmix_check_tm_found="yes"],
+								                                [pmix_check_tm_found="no"])])])])])
+
+	CPPFLAGS="$pmix_check_package_$1_save_CPPFLAGS"
+	LDFLAGS="$pmix_check_package_$1_save_LDFLAGS"
+	LIBS="$pmix_check_package_$1_save_LIBS"
+
+	if test "$pmix_check_tm_found" = "no" ; then
+	    pmix_check_tm_happy=no
+	fi
+
+	PMIX_SUMMARY_ADD([[Resource Managers]],[[Torque]],[$1],[$pmix_check_tm_happy])
+
+	PMIX_VAR_SCOPE_POP
+    fi
+
+    # Did we find the right stuff?
+    AS_IF([test "$pmix_check_tm_happy" = "yes"],
+          [$1_LIBS="[$]$1_LIBS $pmix_check_tm_LIBS"
+	       $1_LDFLAGS="[$]$1_LDFLAGS $pmix_check_tm_LDFLAGS"
+	       $1_CPPFLAGS="[$]$1_CPPFLAGS $pmix_check_tm_CPPFLAGS"
+	       # add the TM libraries to static builds as they are required
+	       $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
+	       $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
+	       $2],
+          [AS_IF([test ! -z "$with_tm" && test "$with_tm" != "no"],
+                 [AC_MSG_ERROR([TM support requested but not found.  Aborting])])
+	       pmix_check_tm_happy="no"
+	       $3])
+])

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -990,7 +990,6 @@ typedef int pmix_status_t;
 
 /* operational */
 #define PMIX_ERR_EVENT_REGISTRATION                 -144
-#define PMIX_ERR_JOB_TERMINATED                     -145
 #define PMIX_ERR_UPDATE_ENDPOINTS                   -146
 #define PMIX_MODEL_DECLARED                         -147
 #define PMIX_GDS_ACTION_COMPLETE                    -148
@@ -1038,6 +1037,11 @@ typedef int pmix_status_t;
 #define PMIX_ERR_JOB_NON_ZERO_TERM                  -188
 #define PMIX_ERR_JOB_ALLOC_FAILED                   -189
 #define PMIX_ERR_JOB_CANNOT_LAUNCH                  -190
+
+/* job-related non-error events */
+#define PMIX_EVENT_JOB_START                        -191
+#define PMIX_ERR_JOB_TERMINATED                     -145    // DEPRECATED NAME - non-error termination
+#define PMIX_EVENT_JOB_END                          -145
 
 /* system failures */
 #define PMIX_ERR_SYS_BASE                           -230

--- a/src/mca/prm/Makefile.am
+++ b/src/mca/prm/Makefile.am
@@ -1,0 +1,44 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(LTDLINCL)
+
+# main library setup
+noinst_LTLIBRARIES = libmca_prm.la
+libmca_prm_la_SOURCES =
+
+# local files
+headers = prm.h
+sources =
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+pmixdir = $(pmixincludedir)/$(subdir)
+nobase_pmix_HEADERS = $(headers)
+endif
+
+include base/Makefile.include
+
+libmca_prm_la_SOURCES += $(headers) $(sources)
+
+distclean-local:
+	rm -f base/static-components.h

--- a/src/mca/prm/base/Makefile.include
+++ b/src/mca/prm/base/Makefile.include
@@ -1,0 +1,34 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from
+# src/Makefile.am
+
+headers += \
+         base/base.h
+
+sources += \
+        base/prm_base_frame.c \
+        base/prm_base_select.c \
+        base/prm_base_stubs.c
+
+dist_pmixdata_DATA = base/help-prm.txt

--- a/src/mca/prm/base/base.h
+++ b/src/mca/prm/base/base.h
@@ -1,0 +1,103 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+#ifndef PMIX_PRM_BASE_H_
+#define PMIX_PRM_BASE_H_
+
+#include "src/include/pmix_config.h"
+
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h> /* for struct timeval */
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+
+#include "src/mca/prm/prm.h"
+
+
+BEGIN_C_DECLS
+
+/*
+ * MCA Framework
+ */
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_prm_base_framework;
+/**
+ * PRM select function
+ *
+ * Cycle across available components and construct the list
+ * of active modules
+ */
+PMIX_EXPORT pmix_status_t pmix_prm_base_select(void);
+
+/**
+ * Track an active component / module
+ */
+struct pmix_prm_base_active_module_t {
+    pmix_list_item_t super;
+    int pri;
+    pmix_prm_module_t *module;
+    pmix_prm_base_component_t *component;
+};
+typedef struct pmix_prm_base_active_module_t pmix_prm_base_active_module_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_prm_base_active_module_t);
+
+/* define an object for rolling up operations */
+typedef struct {
+    pmix_object_t super;
+    pmix_lock_t lock;
+    pmix_event_t ev;
+    pmix_status_t status;
+    int requests;
+    int replies;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_prm_rollup_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_prm_rollup_t);
+
+/* framework globals */
+struct pmix_prm_globals_t {
+    pmix_lock_t lock;
+    pmix_list_t actives;
+    bool initialized;
+    bool selected;
+};
+typedef struct pmix_prm_globals_t pmix_prm_globals_t;
+
+PMIX_EXPORT extern pmix_prm_globals_t pmix_prm_globals;
+
+PMIX_EXPORT pmix_status_t pmix_prm_base_notify(pmix_status_t status,
+                                               const pmix_proc_t *source,
+                                               pmix_data_range_t range,
+                                               const pmix_info_t info[], size_t ninfo,
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+END_C_DECLS
+
+#endif

--- a/src/mca/prm/base/help-prm.txt
+++ b/src/mca/prm/base/help-prm.txt
@@ -1,0 +1,56 @@
+# -*- text -*-
+#
+# Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is a US/English help file
+#
+[reqd-not-found]
+The plog_base_order MCA parameter included a required logging
+channel that is not available:
+
+  Channel:  %s
+
+Please update the parameter and try again.
+#
+[syslog:unrec-level]
+An unrecognized syslog level was given:
+
+  Level:  %s
+
+Please see "man syslog" for a list of defined levels. Input
+parameter strings and their corresponding syslog levels
+recognized by PMIx include:
+
+  Parameter       Level
+   err           LOG_ERR  (default)
+   alert         LOG_ALERT
+   crit          LOG_CRIT
+   emerg         LOG_EMERG
+   warn          LOG_WARNING
+   not           LOG_NOTICE
+   info          LOG_INFO
+   debug         LOG_DEBUG
+
+Please redefine the MCA parameter and try again.
+#
+[syslog:unrec-facility]
+An unsupported or unrecognized value was given for the
+syslog facility (i.e., the type of program calling syslog):
+
+  Value:  %s
+
+Please see "man syslog" for a list of defined facility values.
+PMIx currently supports only the following designations:
+
+   Parameter       Level
+    auth          LOG_AUTH
+    priv          LOG_AUTHPRIV
+    daemon        LOG_DAEMON
+    user          LOG_USER  (default)
+
+Please redefine the MCA parameter and try again.

--- a/src/mca/prm/base/prm_base_frame.c
+++ b/src/mca/prm/base/prm_base_frame.c
@@ -1,0 +1,111 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ *
+ */
+#include "src/include/pmix_config.h"
+
+#include "include/pmix_common.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include "src/class/pmix_list.h"
+#include "src/mca/base/base.h"
+#include "src/mca/prm/base/base.h"
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "src/mca/prm/base/static-components.h"
+
+/* Instantiate the global vars */
+pmix_prm_globals_t pmix_prm_globals = {{0}};
+pmix_prm_API_module_t pmix_prm = {
+    .notify = pmix_prm_base_notify
+};
+
+static pmix_status_t pmix_prm_close(void)
+{
+  pmix_prm_base_active_module_t *active, *prev;
+
+    if (!pmix_prm_globals.initialized) {
+        return PMIX_SUCCESS;
+    }
+    pmix_prm_globals.initialized = false;
+    pmix_prm_globals.selected = false;
+
+    PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_prm_globals.actives, pmix_prm_base_active_module_t) {
+      pmix_list_remove_item(&pmix_prm_globals.actives, &active->super);
+      if (NULL != active->module->finalize) {
+        active->module->finalize();
+      }
+      PMIX_RELEASE(active);
+    }
+    PMIX_DESTRUCT(&pmix_prm_globals.actives);
+
+    PMIX_DESTRUCT_LOCK(&pmix_prm_globals.lock);
+    return pmix_mca_base_framework_components_close(&pmix_prm_base_framework, NULL);
+}
+
+static pmix_status_t pmix_prm_open(pmix_mca_base_open_flag_t flags)
+{
+    /* initialize globals */
+    pmix_prm_globals.initialized = true;
+    PMIX_CONSTRUCT_LOCK(&pmix_prm_globals.lock);
+    pmix_prm_globals.lock.active = false;
+    PMIX_CONSTRUCT(&pmix_prm_globals.actives, pmix_list_t);
+
+    /* Open up all available components */
+    return pmix_mca_base_framework_components_open(&pmix_prm_base_framework, flags);
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, prm, "PMIx Network Operations",
+                                NULL, pmix_prm_open, pmix_prm_close,
+                                mca_prm_base_static_components, 0);
+
+PMIX_CLASS_INSTANCE(pmix_prm_base_active_module_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+static void rlcon(pmix_prm_rollup_t *p)
+{
+    PMIX_CONSTRUCT_LOCK(&p->lock);
+    p->lock.active = false;
+    p->status = PMIX_SUCCESS;
+    p->requests = 0;
+    p->replies = 0;
+    p->cbfunc = NULL;
+    p->cbdata = NULL;
+}
+static void rldes(pmix_prm_rollup_t *p)
+{
+    PMIX_DESTRUCT_LOCK(&p->lock);
+}
+PMIX_CLASS_INSTANCE(pmix_prm_rollup_t,
+                    pmix_object_t,
+                    rlcon, rldes);

--- a/src/mca/prm/base/prm_base_select.c
+++ b/src/mca/prm/base/prm_base_select.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include <string.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/prm/base/base.h"
+
+/* Function for selecting a prioritized list of components
+ * from all those that are available. */
+int pmix_prm_base_select(void)
+{
+    pmix_mca_base_component_list_item_t *cli = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_prm_module_t *nmodule;
+    pmix_prm_base_active_module_t *newmodule, *mod;
+    int rc, priority;
+    bool inserted;
+
+    if (pmix_prm_globals.selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    pmix_prm_globals.selected = true;
+
+    /* Query all available components and ask if they have a module */
+    PMIX_LIST_FOREACH(cli, &pmix_prm_base_framework.framework_components, pmix_mca_base_component_list_item_t) {
+        component = (pmix_mca_base_component_t *) cli->cli_component;
+
+        pmix_output_verbose(5, pmix_prm_base_framework.framework_output,
+                            "mca:prm:select: checking available component %s", component->pmix_mca_component_name);
+
+        /* If there's no query function, skip it */
+        if (NULL == component->pmix_mca_query_component) {
+            pmix_output_verbose(5, pmix_prm_base_framework.framework_output,
+                                "mca:prm:select: Skipping component [%s]. It does not implement a query function",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* Query the component */
+        pmix_output_verbose(5, pmix_prm_base_framework.framework_output,
+                            "mca:prm:select: Querying component [%s]",
+                            component->pmix_mca_component_name);
+        rc = component->pmix_mca_query_component(&module, &priority);
+
+        /* If no module was returned, then skip component */
+        if (PMIX_SUCCESS != rc || NULL == module) {
+            pmix_output_verbose(5, pmix_prm_base_framework.framework_output,
+                                "mca:prm:select: Skipping component [%s]. Query failed to return a module",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* If we got a module, keep it */
+        nmodule = (pmix_prm_module_t*) module;
+        /* let it initialize */
+        if (NULL != nmodule->init && PMIX_SUCCESS != nmodule->init()) {
+            continue;
+        }
+        /* add to the list of selected modules */
+        newmodule = PMIX_NEW(pmix_prm_base_active_module_t);
+        newmodule->pri = priority;
+        newmodule->module = nmodule;
+        newmodule->component = (pmix_prm_base_component_t*)cli->cli_component;
+
+        /* maintain priority order */
+        inserted = false;
+        PMIX_LIST_FOREACH(mod, &pmix_prm_globals.actives, pmix_prm_base_active_module_t) {
+            if (priority > mod->pri) {
+                pmix_list_insert_pos(&pmix_prm_globals.actives,
+                                     (pmix_list_item_t*)mod, &newmodule->super);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            /* must be lowest priority - add to end */
+            pmix_list_append(&pmix_prm_globals.actives, &newmodule->super);
+        }
+    }
+
+    if (4 < pmix_output_get_verbosity(pmix_prm_base_framework.framework_output)) {
+        pmix_output(0, "Final prm priorities");
+        /* show the prioritized list */
+        PMIX_LIST_FOREACH(mod, &pmix_prm_globals.actives, pmix_prm_base_active_module_t) {
+            pmix_output(0, "\tprm: %s Priority: %d", mod->component->base.pmix_mca_component_name, mod->pri);
+        }
+    }
+
+    return PMIX_SUCCESS;;
+}

--- a/src/mca/prm/base/prm_base_stubs.c
+++ b/src/mca/prm/base/prm_base_stubs.c
@@ -1,0 +1,144 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+#include <time.h>
+
+#include "include/pmix_common.h"
+#include "src/include/pmix_globals.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/pmix_environ.h"
+#include "src/server/pmix_server_ops.h"
+
+#include "src/mca/prm/base/base.h"
+
+static void cicbfunc(pmix_status_t status,
+                     void *cbdata)
+{
+    pmix_prm_rollup_t *rollup = (pmix_prm_rollup_t*)cbdata;
+
+    PMIX_ACQUIRE_THREAD(&rollup->lock);
+    /* check if they had an error */
+    if (PMIX_SUCCESS != status && PMIX_SUCCESS == rollup->status) {
+        rollup->status = status;
+    }
+    /* record that we got a reply */
+    rollup->replies++;
+    /* see if all have replied */
+    if (rollup->replies < rollup->requests) {
+        /* nope - need to wait */
+        PMIX_RELEASE_THREAD(&rollup->lock);
+        return;
+    }
+
+    /* if we get here, then operation is complete */
+    PMIX_RELEASE_THREAD(&rollup->lock);
+    if (NULL != rollup->cbfunc) {
+        rollup->cbfunc(rollup->status, rollup->cbdata);
+    }
+    PMIX_RELEASE(rollup);
+    return;
+}
+
+pmix_status_t pmix_prm_base_notify(pmix_status_t status,
+                                   const pmix_proc_t *source,
+                                   pmix_data_range_t range,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_prm_base_active_module_t *active;
+    pmix_prm_rollup_t *myrollup;
+    pmix_status_t rc;
+
+    /* we cannot block here as each plugin could take some time to
+     * complete the request. So instead, we call each active plugin
+     * and get their immediate response - if "in progress", then
+     * we record that we have to wait for their answer before providing
+     * the caller with a response. If "error", then we know we
+     * won't be getting a response from them */
+
+    if (!pmix_prm_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    /* create the rollup object */
+    myrollup = PMIX_NEW(pmix_prm_rollup_t);
+    if (NULL == myrollup) {
+        return PMIX_ERR_NOMEM;
+    }
+    myrollup->cbfunc = cbfunc;
+    myrollup->cbdata = cbdata;
+
+    /* hold the lock until all active modules have been called
+     * to avoid race condition where replies come in before
+     * the requests counter has been fully updated */
+    PMIX_ACQUIRE_THREAD(&myrollup->lock);
+
+    PMIX_LIST_FOREACH(active, &pmix_prm_globals.actives, pmix_prm_base_active_module_t) {
+        if (NULL != active->module->notify) {
+            pmix_output_verbose(5, pmix_prm_base_framework.framework_output,
+                                "NOTIFYING %s", active->module->name);
+            rc = active->module->notify(status, source, range, info, ninfo, cicbfunc, (void*)myrollup);
+            /* if they return succeeded, then nothing
+             * to wait for here */
+            if (PMIX_OPERATION_IN_PROGRESS == rc) {
+                myrollup->requests++;
+            } else if (PMIX_OPERATION_SUCCEEDED == rc ||
+                       PMIX_ERR_TAKE_NEXT_OPTION == rc ||
+                       PMIX_ERR_NOT_SUPPORTED == rc) {
+                continue;
+            } else {
+                /* a true error - we need to wait for
+                 * all pending requests to complete
+                 * and then notify the caller of the error */
+                if (PMIX_SUCCESS == myrollup->status) {
+                    myrollup->status = rc;
+                }
+            }
+        }
+    }
+    if (0 == myrollup->requests) {
+        /* report back */
+        PMIX_RELEASE_THREAD(&myrollup->lock);
+        rc = myrollup->status;
+        PMIX_RELEASE(myrollup);
+        return PMIX_OPERATION_SUCCEEDED;
+    }
+
+    PMIX_RELEASE_THREAD(&myrollup->lock);
+    /* return success to indicate we are processing it */
+    return PMIX_SUCCESS;
+}

--- a/src/mca/prm/default/Makefile.am
+++ b/src/mca/prm/default/Makefile.am
@@ -1,0 +1,42 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = prm_default.h
+sources = \
+        prm_default_component.c \
+        prm_default.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_prm_default_DSO
+lib =
+lib_sources =
+component = mca_prm_default.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_prm_default.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_prm_default_la_SOURCES = $(component_sources)
+mca_prm_default_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_prm_default_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_prm_default_la_SOURCES = $(lib_sources)
+libmca_prm_default_la_LDFLAGS = -module -avoid-version

--- a/src/mca/prm/default/prm_default.c
+++ b/src/mca/prm/default/prm_default.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "include/pmix_common.h"
+
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/parse_options.h"
+#include "src/util/pif.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/prm/base/base.h"
+#include "prm_default.h"
+
+static pmix_status_t default_notify(pmix_status_t status,
+                                    const pmix_proc_t *source,
+                                    pmix_data_range_t range,
+                                    const pmix_info_t info[], size_t ninfo,
+                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+pmix_prm_module_t pmix_prm_default_module = {
+    .name = "default",
+    .notify = default_notify
+};
+
+
+static pmix_status_t default_notify(pmix_status_t status,
+                                    const pmix_proc_t *source,
+                                    pmix_data_range_t range,
+                                    const pmix_info_t info[], size_t ninfo,
+                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+
+    /* if the server has provided the notify_event function
+     * entry, then just call it */
+    if (NULL != pmix_host_server.notify_event) {
+        rc = pmix_host_server.notify_event(status, source, range,
+                                           (pmix_info_t*)info, ninfo, cbfunc, cbdata);
+    } else {
+        rc = PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    return rc;
+}

--- a/src/mca/prm/default/prm_default.h
+++ b/src/mca/prm/default/prm_default.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PRM_DEFAULT_H
+#define PMIX_PRM_DEFAULT_H
+
+#include "src/include/pmix_config.h"
+
+
+#include "src/mca/prm/prm.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_default_component;
+extern pmix_prm_module_t pmix_prm_default_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/prm/default/prm_default_component.c
+++ b/src/mca/prm/default/prm_default_component.c
@@ -1,0 +1,56 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include "src/mca/prm/prm.h"
+#include "prm_default.h"
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_prm_base_component_t mca_prm_default_component = {
+    .base = {
+        PMIX_PRM_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "default",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    }
+};
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority)
+{
+    *priority = 5;
+    *module = (pmix_mca_base_module_t *)&pmix_prm_default_module;
+    return PMIX_SUCCESS;
+}

--- a/src/mca/prm/hpesmf/Makefile.am
+++ b/src/mca/prm/hpesmf/Makefile.am
@@ -1,0 +1,45 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(prm_hpesmf_CPPFLAGS)
+
+headers = prm_hpesmf.h
+sources = \
+        prm_hpesmf_component.c \
+        prm_hpesmf.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_prm_hpesmf_DSO
+lib =
+lib_sources =
+component = mca_prm_hpesmf.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_prm_hpesmf.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_prm_hpesmf_la_SOURCES = $(component_sources)
+mca_prm_hpesmf_la_LIBADD = $(prm_hpesmf_LIBS)
+mca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)
+if NEED_LIBPMIX
+mca_prm_hpesmf_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_prm_hpesmf_la_SOURCES = $(lib_sources)
+libmca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)

--- a/src/mca/prm/hpesmf/prm_hpesmf.c
+++ b/src/mca/prm/hpesmf/prm_hpesmf.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "include/pmix_common.h"
+
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/parse_options.h"
+#include "src/util/pif.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/prm/base/base.h"
+#include "prm_hpesmf.h"
+
+static pmix_status_t hpesmf_notify(pmix_status_t status,
+                               const pmix_proc_t *source,
+                               pmix_data_range_t range,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+pmix_prm_module_t pmix_prm_hpesmf_module = {
+    .name = "hpesmf",
+    .notify = hpesmf_notify
+};
+
+
+static pmix_status_t hpesmf_notify(pmix_status_t status,
+                               const pmix_proc_t *source,
+                               pmix_data_range_t range,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}

--- a/src/mca/prm/hpesmf/prm_hpesmf.h
+++ b/src/mca/prm/hpesmf/prm_hpesmf.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PRM_HPESMF_H
+#define PMIX_PRM_HPESMF_H
+
+#include "src/include/pmix_config.h"
+
+
+#include "src/mca/prm/prm.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_hpesmf_component;
+extern pmix_prm_module_t pmix_prm_hpesmf_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/prm/hpesmf/prm_hpesmf_component.c
+++ b/src/mca/prm/hpesmf/prm_hpesmf_component.c
@@ -1,0 +1,56 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include "src/mca/prm/prm.h"
+#include "prm_hpesmf.h"
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_prm_base_component_t mca_prm_hpesmf_component = {
+    .base = {
+        PMIX_PRM_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "hpesmf",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    }
+};
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority)
+{
+    *priority = 30;
+    *module = (pmix_mca_base_module_t *)&pmix_prm_hpesmf_module;
+    return PMIX_SUCCESS;
+}

--- a/src/mca/prm/prm.h
+++ b/src/mca/prm/prm.h
@@ -1,0 +1,109 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * This interface is for use by PMIx servers to interpret/translate/interact
+ * from/to/with their host environment
+ *
+ * Available plugins may be defined at runtime via the typical MCA parameter
+ * syntax.
+ */
+
+#ifndef PMIX_PRM_H
+#define PMIX_PRM_H
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_sched.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+BEGIN_C_DECLS
+
+/******    MODULE DEFINITION    ******/
+
+/**
+ * Initialize the module. Returns an error if the module cannot
+ * run, success if it can and wants to be used.
+ */
+typedef pmix_status_t (*pmix_prm_base_module_init_fn_t)(void);
+
+/**
+ * Finalize the module. Tear down any allocated storage, disconnect
+ * from any system support (e.g., LDAP server)
+ */
+typedef void (*pmix_prm_base_module_fini_fn_t)(void);
+
+/**
+ * Pass an event to the host system for transport. If the host system
+ * has called PMIx_server_init and provided an entry for the event
+ * notification upcall, then the default plugin will execute that
+ * pathway. However, some systems have chosen to utilize a "backdoor"
+ * channel for transporting the event - e.g., by calling some RM-provided
+ * API to inject the event into their transport.
+ */
+typedef pmix_status_t (*pmix_prm_base_module_notify_fn_t)(pmix_status_t status,
+                                                          const pmix_proc_t *source,
+                                                          pmix_data_range_t range,
+                                                          const pmix_info_t info[], size_t ninfo,
+                                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/**
+ * Base structure for a PRM module. Each component should malloc a
+ * copy of the module structure for each fabric plane they support.
+ */
+typedef struct {
+    char *name;
+    /* init/finalize */
+    pmix_prm_base_module_init_fn_t                 init;
+    pmix_prm_base_module_fini_fn_t                 finalize;
+    pmix_prm_base_module_notify_fn_t               notify;
+} pmix_prm_module_t;
+
+
+/**
+ * Base structure for a PRM API - don't expose the init/finalize fns
+ */
+typedef struct {
+    pmix_prm_base_module_notify_fn_t               notify;
+} pmix_prm_API_module_t;
+
+
+/* declare the global APIs */
+PMIX_EXPORT extern pmix_prm_API_module_t pmix_prm;
+
+/*
+ * the standard component data structure
+ */
+struct pmix_prm_base_component_t {
+    pmix_mca_base_component_t                        base;
+    pmix_mca_base_component_data_t                   data;
+};
+typedef struct pmix_prm_base_component_t pmix_prm_base_component_t;
+
+/*
+ * Macro for use in components that are of type prm
+ */
+#define PMIX_PRM_BASE_VERSION_1_0_0 \
+    PMIX_MCA_BASE_VERSION_1_0_0("prm", 1, 0, 0)
+
+END_C_DECLS
+
+#endif

--- a/src/mca/prm/tm/Makefile.am
+++ b/src/mca/prm/tm/Makefile.am
@@ -1,0 +1,45 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(prm_tm_CPPFLAGS)
+
+headers = prm_tm.h
+sources = \
+        prm_tm_component.c \
+        prm_tm.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_prm_tm_DSO
+lib =
+lib_sources =
+component = mca_prm_tm.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_prm_tm.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_prm_tm_la_SOURCES = $(component_sources)
+mca_prm_tm_la_LIBADD = $(prm_tm_LIBS)
+mca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)
+if NEED_LIBPMIX
+mca_prm_tm_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_prm_tm_la_SOURCES = $(lib_sources)
+libmca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)

--- a/src/mca/prm/tm/configure.m4
+++ b/src/mca/prm/tm/configure.m4
@@ -1,0 +1,41 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_prm_tm_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_pmix_prm_tm_CONFIG],[
+    AC_CONFIG_FILES([src/mca/prm/tm/Makefile])
+
+    PMIX_CHECK_TM([prm_tm], [prm_tm_good=1], [prm_tm_good=0])
+
+    # if check worked, set wrapper flags if so.
+    # Evaluate succeed / fail
+    AS_IF([test "$prm_tm_good" = "1"],
+          [$1],
+          [$2])
+
+    # set build flags to use in makefile
+    AC_SUBST([prm_tm_CPPFLAGS])
+    AC_SUBST([prm_tm_LDFLAGS])
+    AC_SUBST([prm_tm_LIBS])
+])dnl

--- a/src/mca/prm/tm/prm_tm.c
+++ b/src/mca/prm/tm/prm_tm.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "include/pmix_common.h"
+
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/parse_options.h"
+#include "src/util/pif.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/prm/base/base.h"
+#include "prm_tm.h"
+
+static pmix_status_t tm_notify(pmix_status_t status,
+                               const pmix_proc_t *source,
+                               pmix_data_range_t range,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+pmix_prm_module_t pmix_prm_tm_module = {
+    .name = "tm",
+    .notify = tm_notify
+};
+
+
+static pmix_status_t tm_notify(pmix_status_t status,
+                               const pmix_proc_t *source,
+                               pmix_data_range_t range,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}

--- a/src/mca/prm/tm/prm_tm.h
+++ b/src/mca/prm/tm/prm_tm.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PRM_TM_H
+#ifndef PMIX_PRM_TM_H
+
+#include "src/include/pmix_config.h"
+
+
+#include "src/mca/prm/prm.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_tm_component;
+extern pmix_prm_module_t pmix_prm_tm_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/prm/tm/prm_tm_component.c
+++ b/src/mca/prm/tm/prm_tm_component.c
@@ -1,0 +1,56 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+#include "src/mca/prm/prm.h"
+#include "prm_tm.h"
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_prm_base_component_t mca_prm_tm_component = {
+    .base = {
+        PMIX_PRM_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "tm",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    }
+};
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority)
+{
+    *priority = 25;
+    *module = (pmix_mca_base_module_t *)&pmix_prm_tm_module;
+    return PMIX_SUCCESS;
+}

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -55,6 +55,7 @@
 #include "src/common/pmix_attributes.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/plog/plog.h"
+#include "src/mca/prm/prm.h"
 #include "src/mca/psensor/psensor.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/util/argv.h"
@@ -2548,14 +2549,9 @@ static void intermed_step(pmix_status_t status, void *cbdata)
         goto complete;
     }
 
-    if (NULL == pmix_host_server.notify_event) {
-        rc = PMIX_ERR_NOT_SUPPORTED;
-        goto complete;
-    }
-
     /* pass it to our host RM for distribution */
-    rc = pmix_host_server.notify_event(cd->status, &cd->source, cd->range,
-                                       cd->info, cd->ninfo, local_cbfunc, cd);
+    rc = pmix_prm.notify(cd->status, &cd->source, cd->range,
+                         cd->info, cd->ninfo, local_cbfunc, cd);
     if (PMIX_SUCCESS == rc) {
         /* let the callback function respond for us */
         return;


### PR DESCRIPTION
Enable support for "backdoor" implementations of operations such as
event notification. These channels will be used whenever the host
environment provides a "backdoor" method for implementing an operation
that would normally be handled by "upcalling" the corresponding server
module function.

Obviously, we would prefer the "upcall" mechanism - but it sometimes
just isn't feasible, or may represent an early approach that eventually
gets replaced by the "upcall" method.

Signed-off-by: Ralph Castain <rhc@pmix.org>