### PR TITLE
Initialize pinstall info

### DIFF
--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -292,6 +292,11 @@ int main(int argc, char **argv)
                 __FILE__, __LINE__, rc);
         return rc;
     }
+    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -172,6 +172,11 @@ int main(int argc, char **argv)
                 __FILE__, __LINE__, rc);
         return rc;
     }
+    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -165,6 +165,11 @@ int main(int argc, char **argv)
                 __FILE__, __LINE__, rc);
         return rc;
     }
+    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -263,6 +263,11 @@ main(int argc, char *argv[])
                 __FILE__, __LINE__, rc);
         return rc;
     }
+    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();

--- a/src/tools/pquery/help-pquery.txt
+++ b/src/tools/pquery/help-pquery.txt
@@ -21,7 +21,12 @@
 # This is the US/English help file for pquery
 #
 [usage]
-pquery [OPTIONS] KEY1 KEY2...
+pquery [OPTIONS] KEY1[qualifiers] KEY2[qualifiers]...
   PMIx Query tool
 
 %s
+
+Keys passed to pquery may optionally include one or more qualifiers, with the
+individual qualifiers delimited by semi-colons. For example:
+
+PMIX_STORAGE_XFER_SIZE[PMIX_STORAGE_ID=lustre1,lustre2;PMIX_STORAGE_PATH=foo]

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -255,6 +255,11 @@ int main(int argc, char **argv)
                 __FILE__, __LINE__, rc);
         return rc;
     }
+    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
 
     /* initialize the help system */
     pmix_show_help_init();

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -389,7 +389,7 @@ int main(int argc, char **argv)
     for (n=0; NULL != qkeys[n]; n++) {
         qry = PMIX_NEW(pmix_querylist_t);
         PMIX_CONSTRUCT(&qlist, pmix_list_t);
-        /* check for qualifiers: key[qual=foo,qual=bar] */
+        /* check for qualifiers: key[qual=foo;qual=bar] */
         if (NULL != (strt = strchr(qkeys[n], '['))) {
             /* we have qualifiers - find the end */
             *strt = '\0';
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
             }
             *endp = '\0';
             /* break into qual=val pairs */
-            qprs = pmix_argv_split(strt, ',');
+            qprs = pmix_argv_split(strt, ';');
             for (m=0; NULL != qprs[m]; m++) {
                 /* break each pair */
                 if (NULL == (kptr = strchr(qprs[m], '='))) {


### PR DESCRIPTION
Need to call pmix_pinstall_dirs_base_init before initializing show_help
to ensure all values are filled in.

Signed-off-by: Ralph Castain <rhc@pmix.org>