### PR TITLE
Cleanup a few error codes and silence coverity warns

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1074,26 +1074,26 @@ typedef int pmix_status_t;
 #define PMIX_FABRIC_UPDATE_PENDING                  -175
 
 /* job-related errors */
-#define PMIX_ERR_JOB_FAILED_TO_START                -176
-#define PMIX_ERR_JOB_APP_NOT_EXECUTABLE             -177
-#define PMIX_ERR_JOB_NO_EXE_SPECIFIED               -178
-#define PMIX_ERR_JOB_FAILED_TO_MAP                  -179
-#define PMIX_ERR_JOB_CANCELLED                      -180
-#define PMIX_ERR_JOB_FAILED_TO_LAUNCH               -181
-#define PMIX_ERR_JOB_ABORTED                        -182
-#define PMIX_ERR_JOB_KILLED_BY_CMD                  -183
-#define PMIX_ERR_JOB_ABORTED_BY_SIG                 -184
-#define PMIX_ERR_JOB_TERM_WO_SYNC                   -185
-#define PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED          -186
-#define PMIX_ERR_JOB_NEVER_LAUNCHED                 -187
-#define PMIX_ERR_JOB_NON_ZERO_TERM                  -188
-#define PMIX_ERR_JOB_ALLOC_FAILED                   -189
-#define PMIX_ERR_JOB_CANNOT_LAUNCH                  -190
+#define PMIX_ERR_JOB_APP_NOT_EXECUTABLE             -176
+#define PMIX_ERR_JOB_NO_EXE_SPECIFIED               -177
+#define PMIX_ERR_JOB_FAILED_TO_MAP                  -178
+#define PMIX_ERR_JOB_CANCELLED                      -179
+#define PMIX_ERR_JOB_FAILED_TO_LAUNCH               -180
+#define PMIX_ERR_JOB_ABORTED                        -181
+#define PMIX_ERR_JOB_KILLED_BY_CMD                  -182
+#define PMIX_ERR_JOB_ABORTED_BY_SIG                 -183
+#define PMIX_ERR_JOB_TERM_WO_SYNC                   -184
+#define PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED          -185
+#define PMIX_ERR_JOB_NON_ZERO_TERM                  -186
+#define PMIX_ERR_JOB_ALLOC_FAILED                   -187
+#define PMIX_ERR_JOB_ABORTED_BY_SYS_EVENT           -188
 
 /* job-related non-error events */
 #define PMIX_EVENT_JOB_START                        -191
 #define PMIX_ERR_JOB_TERMINATED                     -145    // DEPRECATED NAME - non-error termination
 #define PMIX_EVENT_JOB_END                          -145
+#define PMIX_EVENT_SESSION_START                    -192
+#define PMIX_EVENT_SESSION_END                      -193
 
 /* system failures */
 #define PMIX_ERR_SYS_BASE                           -230

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -564,7 +564,7 @@ pmix_status_t pmix_pnet_base_register_fabric(pmix_fabric_t *fabric,
                 if (NULL != fabric->name) {
                     ft->name = strdup(fabric->name);
                 }
-                ft->module = fabric->module;
+                ft->module = active->module;
                 pmix_list_append(&pmix_pnet_globals.fabrics, &ft->super);
             } else if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
                 /* just return the error */
@@ -583,8 +583,8 @@ pmix_status_t pmix_pnet_base_register_fabric(pmix_fabric_t *fabric,
 pmix_status_t pmix_pnet_base_update_fabric(pmix_fabric_t *fabric)
 {
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_pnet_fabric_t *active = NULL;
-    pmix_pnet_module_t *module;
+    pmix_pnet_fabric_t *active;
+    pmix_pnet_module_t *module = NULL;
     pmix_pnet_fabric_t *ft;
 
     /* protect against bozo input */
@@ -596,19 +596,19 @@ pmix_status_t pmix_pnet_base_update_fabric(pmix_fabric_t *fabric)
          * see if we have one with the matching index */
         PMIX_LIST_FOREACH(ft, &pmix_pnet_globals.fabrics, pmix_pnet_fabric_t) {
             if (fabric->index == ft->index) {
-                active = fabric->module;
+                module = ft->module;
             } else if (NULL != fabric->name && NULL != ft->name
                        && 0 == strcmp(ft->name, fabric->name)) {
-                active = fabric->module;
+                module = ft->module;
             }
-        }
-        if (NULL == active) {
-            return PMIX_ERR_BAD_PARAM;
         }
     } else {
         active = (pmix_pnet_fabric_t*)fabric->module;
+        module = (pmix_pnet_module_t*)active->module;
     }
-    module = (pmix_pnet_module_t*)active->module;
+    if (NULL == module) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     if (NULL != module->update_fabric) {
         rc = module->update_fabric(fabric);
@@ -619,8 +619,8 @@ pmix_status_t pmix_pnet_base_update_fabric(pmix_fabric_t *fabric)
 pmix_status_t pmix_pnet_base_deregister_fabric(pmix_fabric_t *fabric)
 {
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_pnet_fabric_t *active = NULL;
-    pmix_pnet_module_t *module;
+    pmix_pnet_fabric_t *active;
+    pmix_pnet_module_t *module = NULL;
     pmix_pnet_fabric_t *ft;
 
     /* protect against bozo input */
@@ -632,19 +632,19 @@ pmix_status_t pmix_pnet_base_deregister_fabric(pmix_fabric_t *fabric)
          * see if we have one with the matching index */
         PMIX_LIST_FOREACH(ft, &pmix_pnet_globals.fabrics, pmix_pnet_fabric_t) {
             if (fabric->index == ft->index) {
-                active = fabric->module;
+                module = ft->module;
             } else if (NULL != fabric->name && NULL != ft->name
                        && 0 == strcmp(ft->name, fabric->name)) {
-                active = fabric->module;
+                module = ft->module;
             }
-        }
-        if (NULL == active) {
-            return PMIX_ERR_BAD_PARAM;
         }
     } else {
         active = (pmix_pnet_fabric_t*)fabric->module;
+        module = (pmix_pnet_module_t*)active->module;
     }
-    module = (pmix_pnet_module_t*)active->module;
+    if (NULL == module) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     if (NULL != module->deregister_fabric) {
         rc = module->deregister_fabric(fabric);
@@ -657,8 +657,8 @@ pmix_status_t pmix_pnet_base_get_vertex_info(pmix_fabric_t *fabric,
                                              pmix_info_t **info, size_t *ninfo)
 {
     pmix_status_t ret;
-    pmix_pnet_fabric_t *active = NULL;
-    pmix_pnet_module_t *module;
+    pmix_pnet_fabric_t *active;
+    pmix_pnet_module_t *module = NULL;
     pmix_pnet_fabric_t *ft;
 
     /* protect against bozo input */
@@ -670,19 +670,19 @@ pmix_status_t pmix_pnet_base_get_vertex_info(pmix_fabric_t *fabric,
          * see if we have one with the matching index */
         PMIX_LIST_FOREACH(ft, &pmix_pnet_globals.fabrics, pmix_pnet_fabric_t) {
             if (fabric->index == ft->index) {
-                active = fabric->module;
+                module = ft->module;
             } else if (NULL != fabric->name && NULL != ft->name
                        && 0 == strcmp(ft->name, fabric->name)) {
-                active = fabric->module;
+                module = ft->module;
             }
-        }
-        if (NULL == active) {
-            return PMIX_ERR_BAD_PARAM;
         }
     } else {
         active = (pmix_pnet_fabric_t*)fabric->module;
+        module = (pmix_pnet_module_t*)active->module;
     }
-    module = (pmix_pnet_module_t*)ft->module;
+    if (NULL == module) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     if (NULL == module->get_vertex_info) {
         return PMIX_ERR_NOT_SUPPORTED;
@@ -698,8 +698,7 @@ pmix_status_t pmix_pnet_base_get_device_index(pmix_fabric_t *fabric,
                                               uint32_t *i)
 {
     pmix_status_t ret;
-    pmix_pnet_fabric_t *active = NULL;
-    pmix_pnet_module_t *module;
+    pmix_pnet_module_t *module = NULL;
     pmix_pnet_fabric_t *ft;
 
     /* protect against bozo input */
@@ -711,19 +710,18 @@ pmix_status_t pmix_pnet_base_get_device_index(pmix_fabric_t *fabric,
          * see if we have one with the matching index */
         PMIX_LIST_FOREACH(ft, &pmix_pnet_globals.fabrics, pmix_pnet_fabric_t) {
             if (fabric->index == ft->index) {
-                active = fabric->module;
+                module = ft->module;
             } else if (NULL != fabric->name && NULL != ft->name
                        && 0 == strcmp(ft->name, fabric->name)) {
-                active = fabric->module;
+                module = ft->module;
             }
         }
-        if (NULL == active) {
-            return PMIX_ERR_BAD_PARAM;
-        }
     } else {
-        active = (pmix_pnet_fabric_t*)fabric->module;
+        module = (pmix_pnet_module_t*)fabric->module;
     }
-    module = (pmix_pnet_module_t*)ft->module;
+    if (NULL == module) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     if (NULL == module->get_device_index) {
         return PMIX_ERR_NOT_SUPPORTED;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3824,6 +3824,14 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         return rc;
     }
 
+    if (PMIX_FABRIC_UPDATE_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_fabric_update(cd, buf, fabric_cbfunc))) {
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+
     if (PMIX_FABRIC_GET_VERTEX_INFO_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         if (PMIX_SUCCESS != (rc = pmix_server_fabric_get_vertex_info(cd, buf, fabric_cbfunc))) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4612,7 +4612,6 @@ pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd,
     return PMIX_SUCCESS;
 
   exit:
-    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -4686,7 +4685,6 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd,
     return PMIX_SUCCESS;
 
   exit:
-    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -4756,7 +4754,6 @@ pmix_status_t pmix_server_fabric_get_vertex_info(pmix_server_caddy_t *cd,
     return PMIX_SUCCESS;
 
   exit:
-    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -4839,7 +4836,6 @@ pmix_status_t pmix_server_fabric_get_device_index(pmix_server_caddy_t *cd,
     return PMIX_SUCCESS;
 
   exit:
-    PMIX_RELEASE(cd);
     return rc;
 }
 

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -281,8 +281,6 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
     case PMIX_MAX_ERR_CONSTANT:
         return "PMIX_ERR_WILDCARD";
 
-    case PMIX_ERR_JOB_FAILED_TO_START:
-        return "JOB FAILED TO START";
     case PMIX_ERR_JOB_APP_NOT_EXECUTABLE:
         return "APPLICATION NOT EXECUTABLE";
     case PMIX_ERR_JOB_NO_EXE_SPECIFIED:
@@ -303,14 +301,10 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
         return "TERMINATED WITHOUT SYNC";
     case PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED:
         return "SENSOR BOUND EXCEEDED";
-    case PMIX_ERR_JOB_NEVER_LAUNCHED:
-        return "NEVER LAUNCHED";
     case PMIX_ERR_JOB_NON_ZERO_TERM:
         return "NON-ZERO TERMINATION";
     case PMIX_ERR_JOB_ALLOC_FAILED:
         return "FAILED TO OBTAIN ALLOCATION";
-    case PMIX_ERR_JOB_CANNOT_LAUNCH:
-        return "COULD NOT BE LAUNCHED";
 
     default:
         return "ERROR STRING NOT FOUND";


### PR DESCRIPTION
Remove a few error codes that are somewhat duplicative or getting too
detailed. Silence a few Coverity warnings. Cleanup a few errors in the
pnet base.

Signed-off-by: Ralph Castain <rhc@pmix.org>