### PR TITLE
Add option to bypass local-only fence optimization

### DIFF
--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -205,6 +206,13 @@ pmix_status_t pmix_register_params(void)
                                        PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                        PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                        &pmix_server_globals.base_verbose);
+
+    pmix_server_globals.fence_localonly_opt = true;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "fence_localonly_opt",
+                                       "Optimize local-only fence opteration by eliminating the upcall to the RM (default: true)",
+                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.fence_localonly_opt);
 
     /* check for maximum number of pending output messages */
     pmix_globals.output_limit = (size_t) INT_MAX;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -734,7 +734,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
                             "fence LOCALLY complete");
         /* if this is a purely local fence (i.e., all participants are local),
          * then it is done and we notify accordingly */
-        if (trk->local) {
+        if (pmix_server_globals.fence_localonly_opt && trk->local) {
             /* the modexcbfunc thread-shifts the call prior to processing,
              * so it is okay to call it directly from here. The switchyard
              * will acknowledge successful acceptance of the fence request,

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -166,6 +166,7 @@ typedef struct {
     bool tool_connections_allowed;
     char *tmpdir;                           // temporary directory for this server
     char *system_tmpdir;                    // system tmpdir
+    bool fence_localonly_opt;               // local-only fence optimization
     // verbosity for server get operations
     int get_output;
     int get_verbose;


### PR DESCRIPTION
 * If all processes participating in the fence are local to the node
   then there is an optimization that allows the PMIx Server side
   library to complete the call internally without the upcall into
   the RM. For RMs that need to monitor the fence calls this poses a
   problem as they do not see the upcall.
   - This really only became an issue when a RM is trying to support
     a protocol like MPIR where they are taking advantage of a
     global fence in, in this case, MPI_Init to hold the processes
     in that fence operation by preventing it from completing until
     the debugger is attached and ready.
   - If this optimization is enabled and the fence participants are
     all local then the RM does not get the opportunity to hold that
     fence since they never receive the upcall.
 * This commit adds the `PMIX_MCA_pmix_server_fence_localonly_opt`
   MCA parameter that can be used to optionally disable this optimization.
   - By default the optimization is enabled so that there is no default
     behavior change.
   - For RMs that need it they can disable this optimization by
     setting this MCA parater to `0` (false) before calling the server
     initialization function.

(cherry picked from commit 8e58229a3c80e40ebd18e061d356e3ccc4addef7)