### PR TITLE
Fix cross-version for v3.1.6+

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -242,7 +242,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t 
                     }
                 }
             }
-            if (PMIX_PEER_TRIPLET(pmix_client_globals.myserver, 3, 1, 5)) {
+            if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 2, PMIX_RELEASE_WILDCARD)) {
                 p.rank = PMIX_RANK_UNDEF;
                /* see if they told us to get node info */
                 if (!wantinfo) {
@@ -333,7 +333,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t 
                     }
                 }
             }
-            if (PMIX_PEER_TRIPLET(pmix_client_globals.myserver, 3, 1, 5)) {
+            if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 2, PMIX_RELEASE_WILDCARD)) {
                 p.rank = PMIX_RANK_UNDEF;
                /* see if they told us to get app info */
                 if (!wantinfo) {


### PR DESCRIPTION
We hadn't really planned on releasing anything beyond rel=5 in the 3.1.x
series, so we hard-coded a check for 3.1.5 in client get. This must be
updated to allow 3.1.6 (plus any future releases in the v3.1.x series)
to pass cross-version tests when the v3.1.x release is acting as the
server.

Signed-off-by: Ralph Castain <rhc@pmix.org>