### PR TITLE
Cleanup a few leftovers from v3.2 sync with master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,13 +62,6 @@ config/mca_library_paths.txt
 
 maint/pmix.pc
 
-bindings/python/pmix.c
-bindings/python/*.so
-bindings/python/build/
-bindings/python/pmix_constants.pxd
-bindings/python/pmix_constants.pxi
-bindings/python/tests/__pycache__/
-
 examples/alloc
 examples/client
 examples/client2
@@ -87,7 +80,6 @@ examples/group
 examples/asyncgroup
 
 include/pmix_version.h
-include/pmix_rename.h
 include/pmix_common.h
 
 src/include/pmix_config.h
@@ -99,18 +91,10 @@ src/mca/pinstalldirs/config/pinstall_dirs.h
 src/mca/pdl/base/static-components.h
 src/mca/pinstalldirs/base/static-components.h
 
-src/tools/pattrs/pattrs
 src/tools/pevent/pevent
 src/tools/pmix_info/pmix_info
 src/tools/plookup/plookup
 src/tools/pps/pps
-src/tools/pquery/pquery
-src/tools/wrapper/generic_wrapper.1
-src/tools/wrapper/pmix.pc
-src/tools/wrapper/pmix_wrapper
-src/tools/wrapper/pmix_wrapper.1
-src/tools/wrapper/pmixcc-wrapper-data.txt
-src/tools/wrapper/pmixcc.1
 
 src/util/show_help_lex.c
 src/util/keyval/keyval_lex.c

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -860,20 +860,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     LIBS="$LIBS $PMIX_FINAL_LIBS"
 
     ############################################################################
-    # final wrapper compiler config
-    ############################################################################
-    pmix_show_subtitle "Wrapper compiler final setup"
-
-    # The PMIx wrapper script (i.e., not the C-compiled
-    # executables) need perl.
-    AC_PATH_PROG(PERL, perl, perl)
-
-    # Need the libtool executable before the rpathify stuff
-    LT_OUTPUT
-
-    PMIX_SETUP_WRAPPER_FINAL
-
-    ############################################################################
     # pmixdatadir, pmixlibdir, and pmixinclude are essentially the same as
     # pkg*dir, but will always be */pmix.
     pmixdatadir='${datadir}/pmix'
@@ -1284,8 +1270,6 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
         AM_CONDITIONAL(WANT_PMI_BACKWARD, test "$WANT_PMI_BACKWARD" = 1)
         AM_CONDITIONAL(NEED_LIBPMIX, [test "$pmix_need_libpmix" = "1"])
-        AM_CONDITIONAL([PMIX_HAVE_JANSSON], [test "x$pmix_check_jansson_happy" = "xyes"])
-        AM_CONDITIONAL([PMIX_HAVE_CURL], [test "x$pmix_check_curl_happy" = "xyes"])
     ])
     pmix_did_am_conditionals=yes
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,6 @@ AS_IF([test ! -z "$enable_static" && test "$enable_static" = "yes"],
 
 AM_ENABLE_SHARED
 AM_DISABLE_STATIC
-PMIX_SETUP_WRAPPER_INIT
 
 # This did not exist pre AM 1.11.x (where x is somewhere >0 and <3),
 # but it is necessary in AM 1.12.x.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -863,12 +863,16 @@ typedef int pmix_status_t;
 #define PMIX_EVENT_ACTION_DEFERRED                  -333
 #define PMIX_EVENT_ACTION_COMPLETE                  -334
 
+/* define a starting point for PMIx internal error codes
+ * that are never exposed outside the library */
+#define PMIX_INTERNAL_ERR_BASE                      -1330
+
 /* define a starting point for user-level defined error
  * constants - negative values larger than this are guaranteed
  * not to conflict with PMIx values. Definitions should always
  * be based on the PMIX_EXTERNAL_ERR_BASE constant and -not- a
  * specific value as the value of the constant may change */
-#define PMIX_INTERNAL_ERR_BASE                      -1330
+#define PMIX_EXTERNAL_ERR_BASE           PMIX_INTERNAL_ERR_BASE-2000
 
 /****    PMIX DATA TYPES    ****/
 typedef uint16_t pmix_data_type_t;
@@ -1855,7 +1859,7 @@ typedef struct pmix_query {
  * except that it only appends the provided argument if it does not already
  * exist in the provided array, or overwrites it if it is.
  */
-#define PMIX_ARGV_APPEND_UNIQUE(r, a, b) \
+#define PMIX_ARGV_APPEND_UNIQUE(r, a, b, c) \
     (r) = pmix_argv_append_unique_nosize(a, b, c)
 
 /* Free a NULL-terminated argv array.

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -378,7 +378,6 @@ static void qcon(pmix_query_caddy_t *p)
     p->relcbfunc = NULL;
     p->credcbfunc = NULL;
     p->validcbfunc = NULL;
-    p->stqcbfunc = NULL;
 }
 static void qdes(pmix_query_caddy_t *p)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -279,10 +279,6 @@ typedef struct {
 } pmix_iof_req_t;
 PMIX_CLASS_DECLARATION(pmix_iof_req_t);
 
-typedef void (*pmix_pstrg_query_cbfunc_t)(pmix_status_t status,
-                                          pmix_list_t *results,
-                                          void *cbdata);
-
 
 /* caddy for query requests */
 typedef struct {
@@ -305,7 +301,6 @@ typedef struct {
     pmix_release_cbfunc_t relcbfunc;
     pmix_credential_cbfunc_t credcbfunc;
     pmix_validation_cbfunc_t validcbfunc;
-    pmix_pstrg_query_cbfunc_t stqcbfunc;
     void *cbdata;
 } pmix_query_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_query_caddy_t);

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -28,11 +28,6 @@
 
  BEGIN_C_DECLS
 
-/* define a starting point for PMIx internal error codes
- * that are never exposed outside the library */
-#define PMIX_INTERNAL_ERR_BASE                      -1330
-
-
 /* internal error codes - never exposed outside of the library */
 #define PMIX_ERR_NOT_AVAILABLE                          (PMIX_INTERNAL_ERR_BASE - 28)
 #define PMIX_ERR_FATAL                                  (PMIX_INTERNAL_ERR_BASE - 29)


### PR DESCRIPTION
 - Remove some leftover references to the wrapper compiler, jansson, curl
 - Move `PMIX_INTERNAL_ERR_BASE` back to `pmix_common.h.in` to make it match
   the v3.1 branch - just in case anyone was trying to use it.
   - Add back the `PMIX_EXTERNAL_ERR_BASE` that was mistakenly taken out
 - Remove a couple of leftover references to `pstrg`