### PR TITLE
Fix TM detection (Torque / PBS Pro)

### DIFF
--- a/config/pmix_check_tm.m4
+++ b/config/pmix_check_tm.m4
@@ -47,7 +47,7 @@ AC_DEFUN([PMIX_CHECK_TM_LIBS_FLAGS],[
 # --------------------------------------------------------
 AC_DEFUN([PMIX_CHECK_TM],[
     if test -z $pmix_check_tm_happy ; then
-	PMIX_VAR_SCOPE_PUSH([pmix_check_tm_found pmix_check_tm_dir pmix_check_tm_pbs_config pmix_check_tm_LDFLAGS_save pmix_check_tm_CPPFLAGS_save pmix_check_tm_LIBS_save])
+	PMIX_VAR_SCOPE_PUSH([pmix_check_tm_found pmix_check_tm_dir pmix_check_tm_libdir pmix_check_tm_pbs_config pmix_check_tm_LDFLAGS_save pmix_check_tm_CPPFLAGS_save pmix_check_tm_LIBS_save])
 
 	AC_ARG_WITH([tm],
                     [AC_HELP_STRING([--with-tm(=DIR)],
@@ -59,7 +59,8 @@ AC_DEFUN([PMIX_CHECK_TM],[
               [pmix_check_tm_happy="no"],
               [pmix_check_tm_happy="yes"
                AS_IF([test ! -z "$with_tm" && test "$with_tm" != "yes"],
-                     [pmix_check_tm_dir="$with_tm"],
+                     [pmix_check_tm_dir="$with_tm"
+                      pmix_check_tm_libdir="$with_tm/lib"],
                      [pmix_check_tm_dir=""])])
 
 	AS_IF([test "$pmix_check_tm_happy" = "yes"],


### PR DESCRIPTION
I encountered a problem when passing `--with-tm=<pbs-dir>` to OMPI, and traced it back to this file: looks like `pmix_check_tm_libdir` was used but never assigned.

For reference, here's what I've been getting before:
```
…
--- MCA component prm:tm (m4 configuration macro)
checking for MCA component prm:tm compile mode... dso
checking --with-tm value... sanity check ok (/opt/x86_64/pbs/)
checking for pbs-config... not found
looking for header in /opt/x86_64/pbs
checking tm.h usability... no
checking tm.h presence... no
checking for tm.h... no
looking for header in /opt/x86_64/pbs/include
checking tm.h usability... yes
checking tm.h presence... yes
checking for tm.h... yes
looking for library without search path
checking for library containing tm_init... no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
looking for library without search path
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib64
checking for library containing tm_init... (cached) no
looking for library in /opt/x86_64/pbs/lib
checking for library containing tm_init... (cached) no
configure: error: TM support requested but not found.  Aborting
configure: /bin/sh './configure' *failed* for opal/mca/pmix/pmix4x/openpmix
checking if v4.x component is to be used... yes - using the internal v4.x library
configure: WARNING: INTERNAL PMIX FAILED TO CONFIGURE
configure: error: CANNOT CONTINUE
/mnt/central/testing/src
/mnt/central/testing/src/osu /mnt/central/testing/src
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
…
```
