### PR TITLE
SPEC add RPM *-devel packages

### DIFF
--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -229,10 +229,20 @@ APIs to eliminate some current restrictions that impact scalability, and (b) pro
 a reference implementation of the PMI-server that demonstrates the desired level of
 scalability.
 
+%if %{build_all_in_one_rpm}
 This RPM contains all the tools necessary to compile and link against PMIx.
+%endif
 
 # if build_all_in_one_rpm = 0, build split packages
 %if !%{build_all_in_one_rpm}
+%package devel
+Summary: PMIx developpement packages
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+This RPM contains headers and shared objects symbolic links necessary to compile
+and link against PMIx.
+
 %package libpmi
 Summary: PMI-1 and PMI-2 compatibility libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
@@ -245,6 +255,16 @@ into its PMIx equivalent. This is especially targeted at apps/libs that are
 hardcoded to dlopen “libpmi” or “libpmi2”.
 This package conflicts sith slurm-libpmi, which provides its own, incompatible 
 versions of libpmi.so and libpmi2.so.
+
+%package libpmi-devel
+Summary: PMI-1 and PMI-2 compatibility developpement libraryes
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name}-devel%{?_isa} = %{version}-%{release}
+Conflicts: slurm-libpmi
+
+%description libpmi-devel
+The %{name}-libpmi-devel package contains headers and shared objects
+symbolic links of libpmi and libpmi2 libraries.
 %endif
 
 #############################################################################
@@ -513,17 +533,35 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 # if building separate RPMs, split the compatibility libs
 %if !%{build_all_in_one_rpm}
+%exclude %{_includedir}
+%exclude %{_libdir}/*.so
+%exclude %{_libdir}/*.la
+%exclude %{_libdir}/libpmi.*
+%exclude %{_libdir}/libpmi2.*
+
+%files devel
+%{_includedir}
+%{_libdir}/*.so
+%{_libdir}/*.la
+
 %exclude %{_libdir}/libpmi.*
 %exclude %{_libdir}/libpmi2.*
 %exclude %{_includedir}/pmi.*
 %exclude %{_includedir}/pmi2.*
 
 %files libpmi
-%{_libdir}/libpmi.*
-%{_libdir}/libpmi2.*
-%{_includedir}/pmi.*
-%{_includedir}/pmi2.*
-%endif
+%{_libdir}/libpmi.so.*
+%{_libdir}/libpmi2.so.*
+
+%files libpmi-devel
+%{_libdir}/libpmi.so
+%{_libdir}/libpmi2.so
+%{_includedir}/pmi.h
+%{_includedir}/pmi2.h
+
+%endif # build_all_in_one_rpm
+
+
 
 #############################################################################
 #
@@ -531,6 +569,9 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 #
 #############################################################################
 %changelog
+* Mon Sep 21 2020 Piotr Lesnicki <piotr.lesnicki@atos.net>
+- Enable separate -devel rpms
+
 * Tue Apr 30 2019 Kilian Cavalotti <kilian@stanford.edu>
 - Enable multiple RPMs build to allow backward compatibility PMI-1 and PMI-2
   libs to be built separate. "rpmbuild --define 'build_all_in_one_rpm 0' ..."


### PR DESCRIPTION
This proposition adds *-devel RPMs containing headers and shared objects symbolic links when `build_all_in_one_rpm == 0`

With the libpmi split there is therefore 4 package in this situation: `pmix, pmix-devel, pmix-libpmi, pmix-libpmi-devel`

pmix-devel provides:
```
./opt/pmix/3.1.6/include
./opt/pmix/3.1.6/include/pmix.h
./opt/pmix/3.1.6/include/pmix_common.h
./opt/pmix/3.1.6/include/pmix_extend.h
./opt/pmix/3.1.6/include/pmix_rename.h
./opt/pmix/3.1.6/include/pmix_server.h
./opt/pmix/3.1.6/include/pmix_tool.h
./opt/pmix/3.1.6/include/pmix_version.h
./opt/pmix/3.1.6/lib/libmca_common_dstore.la
./opt/pmix/3.1.6/lib/libmca_common_dstore.so
./opt/pmix/3.1.6/lib/libpmix.la
./opt/pmix/3.1.6/lib/libpmix.so

```
In the same way
pmix provides only libpmix.so.* and libmca_common_dstore.so.* and no headers
pmix-libpmi provide libpmi{,2}.so.*
pmix-libpmi-devel provide libpmi{,2}.so pmi{,2}.h

This proposition is on v3.1, same can be done on master but for some reason on master `make_tarball` fails.








