### PR TITLE
Cleanup topology support a bit

### DIFF
--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -267,7 +267,7 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *topo,
 
     /* see if I can support this myself */
     cb->status = pmix_ploc.compute_distances(topo, cpuset, types, &cb->dist, &cb->nvals);
-    if (PMIX_SUCCESS == cb->status) {
+    if (PMIX_SUCCESS == cb->status || PMIX_ERR_NOT_AVAILABLE == cb->status) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         /* threadshift to return the result */
         PMIX_THREADSHIFT(cb, dcbfunc);

--- a/src/mca/ploc/base/ploc_base_stubs.c
+++ b/src/mca/ploc/base/ploc_base_stubs.c
@@ -280,16 +280,18 @@ pmix_status_t pmix_ploc_base_compute_distances(pmix_topology_t *topo,
 
     /* process the request */
     PMIX_LIST_FOREACH(active, &pmix_ploc_globals.actives, pmix_ploc_base_active_module_t) {
-        pmix_output(0, "CHECKING %s", active->component->base.pmix_mca_component_name);
         if (NULL != active->module->compute_distances) {
-            pmix_output(0, "CALLING");
             rc = active->module->compute_distances(topo, cpuset, types, dist, ndist);
             if (PMIX_SUCCESS == rc) {
                 return rc;
             }
             if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
-                /* true error */
-                return rc;
+                /* indicate that we were able to process the
+                 * request, but didn't get a successful answer.
+                 * We need to return a PMIX_ERR_NOT_AVAILABLE
+                 * response so the caller knows not to raise
+                 * the request to our host */
+                return PMIX_ERR_NOT_AVAILABLE;
             }
         }
     }

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -38,7 +38,7 @@
 #define PMIX_ERR_FATAL                                  (PMIX_INTERNAL_ERR_BASE - 29)
 #define PMIX_ERR_VALUE_OUT_OF_BOUNDS                    (PMIX_INTERNAL_ERR_BASE - 30)
 #define PMIX_ERR_PERM                                   (PMIX_INTERNAL_ERR_BASE - 31)
-#define PMIX_ERR_FABRIC_NOT_PARSEABLE                  (PMIX_INTERNAL_ERR_BASE - 33)
+#define PMIX_ERR_FABRIC_NOT_PARSEABLE                   (PMIX_INTERNAL_ERR_BASE - 33)
 #define PMIX_ERR_FILE_OPEN_FAILURE                      (PMIX_INTERNAL_ERR_BASE - 34)
 #define PMIX_ERR_FILE_READ_FAILURE                      (PMIX_INTERNAL_ERR_BASE - 35)
 #define PMIX_ERR_TAKE_NEXT_OPTION                       (PMIX_INTERNAL_ERR_BASE - 36)

--- a/test/simple/simpfabric.c
+++ b/test/simple/simpfabric.c
@@ -142,10 +142,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "Get of my topology failed: %s\n", PMIx_Error_string(rc));
         goto cleanup;
     }
-    mytopo = val->data.ptr;
-    val->data.ptr = NULL;
+    mytopo = val->data.topo;
+    val->data.topo = NULL;
     PMIX_VALUE_FREE(val, 1);
-    fprintf(stderr, "Got my topology\n");
+    fprintf(stderr, "Got my topology: Source = %s\n", (NULL == mytopo->source) ? "NULL" : mytopo->source);
 
     /* get my cpuset */
     fprintf(stderr, "GETTING CPUSET\n");
@@ -164,12 +164,11 @@ int main(int argc, char **argv)
                                 &distances, &ndist);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Compute distances failed: %s\n", PMIx_Error_string(rc));
-        goto cleanup;
-    }
-
-    for (n=0; n < ndist; n++) {
-        fprintf(stderr, "Device[%d]: UUID %s OSname: %s Type %s MinDist %u MaxDist %u\n", (int)n, distances[n].uuid,
-                distances[n].osname, PMIx_Device_type_string(distances[n].type), distances[n].mindist, distances[n].maxdist);
+    } else {
+        for (n=0; n < ndist; n++) {
+            fprintf(stderr, "Device[%d]: UUID %s OSname: %s Type %s MinDist %u MaxDist %u\n", (int)n, distances[n].uuid,
+                    distances[n].osname, PMIx_Device_type_string(distances[n].type), distances[n].mindist, distances[n].maxdist);
+        }
     }
 
     /* setup an application */


### PR DESCRIPTION
Finally identify the source of the problems and ensure we set the name
of the source when copying the topology. Allocate the bitmap prior to
getting the cpuset. Avoid raising a request to compute distances to the
host if we already tried but can't.

Signed-off-by: Ralph Castain <rhc@pmix.org>