### PR TITLE
Update realm checks and fix pmix_get for v4

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1407,11 +1407,11 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename,
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-    /* if I am a client and my server is earlier than v3.1.5, then
+    /* if I am a client and my server is earlier than v3.2.x, then
      * I need to look for this data under rank=PMIX_RANK_WILDCARD
      * with a key equal to the nodename */
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
-        PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5)) {
+        PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 100)) {
         proc.rank = PMIX_RANK_WILDCARD;
         iptr = NULL;
         ninfo = 0;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -575,7 +575,13 @@ PMIX_EXPORT extern pmix_lock_t pmix_global_lock;
 static inline bool pmix_check_node_info(const char* key)
 {
     char *keys[] = {
+    	PMIX_HOSTNAME,
+    	PMIX_HOSTNAME_ALIASES,
+    	PMIX_NODEID,
+    	PMIX_AVAIL_PHYS_MEMORY,
         PMIX_LOCAL_PEERS,
+        PMIX_LOCAL_PROCS,
+        PMIX_LOCAL_CPUSETS,
         PMIX_LOCAL_SIZE,
         PMIX_NODE_SIZE,
         PMIX_LOCALLDR,
@@ -599,6 +605,31 @@ static inline bool pmix_check_app_info(const char* key)
         PMIX_APP_ARGV,
         PMIX_WDIR,
         PMIX_PSET_NAME,
+        PMIX_APP_MAP_TYPE,
+        PMIX_APP_MAP_REGEX,
+        NULL
+    };
+    size_t n;
+
+    for (n=0; NULL != keys[n]; n++) {
+        if (0 == strncmp(key, keys[n], PMIX_MAX_KEYLEN)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline bool pmix_check_session_info(const char* key)
+{
+    char *keys[] = {
+        PMIX_SESSION_ID,
+        PMIX_CLUSTER_ID,
+        PMIX_UNIV_SIZE,
+        PMIX_TMPDIR,
+        PMIX_TDIR_RMCLEAN,
+        PMIX_HOSTNAME_KEEP_FQDN,
+        PMIX_RM_NAME,
+        PMIX_RM_VERSION,
         NULL
     };
     size_t n;

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2790,9 +2790,9 @@ static pmix_status_t _store_job_info(pmix_common_dstore_ctx_t *ds_ctx, ns_map_da
                     }
                 }
     		}
-            /* if the client is earlier than v3.1.5, we also need to store the
+            /* if the client is earlier than v3.2.x, we also need to store the
              * array using the hostname as key */
-            if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 5) &&
+            if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 100) &&
                 NULL != hostname) {
                 kv2.key = hostname;
                 kv2.value = kv->value;

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         exit(rc);
     }
-    pmix_output(0, "CLIENT LOCAL RANK: %u", val->data.uint32);
+    pmix_output(0, "CLIENT LOCAL RANK: %u", val->data.uint16);
     PMIX_VALUE_RELEASE(val);
 
     if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {


### PR DESCRIPTION
PMIx_Get was calling its cbfunc from within the API, which is not allowed by the Standard. Also, update realm recognition for app and node, and add session realm detection

Signed-off-by: Ralph Castain <rhc@pmix.org>