### PR TITLE
Fixed uninitialized data bug in pmi_base64_encode_block

### DIFF
--- a/contrib/perf_tools/pmi2_utils.c
+++ b/contrib/perf_tools/pmi2_utils.c
@@ -58,9 +58,14 @@ static inline unsigned char pmi_base64_decsym (unsigned char value) {
 
 static inline void pmi_base64_encode_block (const unsigned char in[3], char out[4], int len) {
     out[0] = pmi_base64_encsym (in[0] >> 2);
-    out[1] = pmi_base64_encsym (((in[0] & 0x03) << 4) | ((in[1] & 0xf0) >> 4));
+
+    /* len is the length of in[] - we need to make sure we don't reference uninitialized data, hence the conditionals */
+    out[1] = 1 < len ? pmi_base64_encsym(((in[0] & 0x03) << 4) | ((in[1] & 0xf0) >> 4)) :
+                       pmi_base64_encsym((in[0] & 0x03) << 4);
     /* Cray PMI doesn't allow = in PMI attributes so pad with spaces */
-    out[2] = 1 < len ? pmi_base64_encsym(((in[1] & 0x0f) << 2) | ((in[2] & 0xc0) >> 6)) : ' ';
+    out[2] = 1 < len ? pmi_base64_encsym((in[1] & 0x0f) << 2) : ' ';
+    out[2] = 2 < len ? pmi_base64_encsym(((in[1] & 0x0f) << 2) | ((in[2] & 0xc0) >> 6)) : out[2];
+
     out[3] = 2 < len ? pmi_base64_encsym(in[2] & 0x3f) : ' ';
 }
 


### PR DESCRIPTION
This code doesn't appear to be utilized under normal build conditions in the master branch, but possibly the function is used elsewhere in other branches? 

I discussed it briefly with Artem and Howard, maybe we can talk about it on the weekly call to see if it is still used somewhere.