### PR TITLE
Complete slingshot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ test/sshot/daemon
 test/sshot/generate
 test/sshot/server
 test/sshot/mytopo.json
+test/sshot/testcoord
 
 # coverity
 cov-int

--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -96,8 +96,7 @@ AC_DEFUN([PMIX_CHECK_CURL],[
     AC_MSG_CHECKING([libcurl support available])
     AC_MSG_RESULT([$pmix_check_curl_happy])
 
-    AS_IF([test "$pmix_check_curl_happy" = "yes"],
-          [PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])])
+    PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])
 
     AC_SUBST(pmix_check_curl_CPPFLAGS)
     AC_SUBST(pmix_check_curl_LDFLAGS)

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -107,8 +107,7 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
 
     AM_CONDITIONAL([HAVE_JANSSON], [test "$pmix_check_jansson_happy" = "yes"])
 
-    AS_IF([test "$pmix_check_jansson_happy" = "yes"],
-          [PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])])
+    PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])
 
     PMIX_VAR_SCOPE_POP
 ])

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -374,7 +374,10 @@ typedef uint32_t pmix_rank_t;
  * data will then be parsed and provided to the local clients. Not generally accessible by users */
 #define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_NODE_MAP                       "pmix.nmap"             // (char*) regex of nodes containing procs for this job
+#define PMIX_NODE_MAP_RAW                   "pmix.nmap.raw"         // (char*) comma-delimited list of nodes containing procs for this job
 #define PMIX_PROC_MAP                       "pmix.pmap"             // (char*) regex describing procs on each node within this job
+#define PMIX_PROC_MAP_RAW                   "pmix.pmap.raw"         // (char*) semi-colon delimited list of strings, each string containing
+                                                                    //         a comma-delimited list of ranks on the corresponding node
 #define PMIX_ANL_MAP                        "pmix.anlmap"           // (char*) process mapping in ANL notation (used in PMI-1/PMI-2)
 #define PMIX_APP_MAP_TYPE                   "pmix.apmap.type"       // (char*) type of mapping used to layout the application (e.g., cyclic)
 #define PMIX_APP_MAP_REGEX                  "pmix.apmap.regex"      // (char*) regex describing the result of the mapping
@@ -1246,67 +1249,68 @@ typedef int pmix_status_t;
 
 /****    PMIX DATA TYPES    ****/
 typedef uint16_t pmix_data_type_t;
-#define PMIX_UNDEF               0
-#define PMIX_BOOL                1  // converted to/from native true/false to uint8 for pack/unpack
-#define PMIX_BYTE                2  // a byte of data
-#define PMIX_STRING              3  // NULL-terminated string
-#define PMIX_SIZE                4  // size_t
-#define PMIX_PID                 5  // OS-pid
-#define PMIX_INT                 6
-#define PMIX_INT8                7
-#define PMIX_INT16               8
-#define PMIX_INT32               9
-#define PMIX_INT64              10
-#define PMIX_UINT               11
-#define PMIX_UINT8              12
-#define PMIX_UINT16             13
-#define PMIX_UINT32             14
-#define PMIX_UINT64             15
-#define PMIX_FLOAT              16
-#define PMIX_DOUBLE             17
-#define PMIX_TIMEVAL            18
-#define PMIX_TIME               19
-#define PMIX_STATUS             20  // needs to be tracked separately from integer for those times
-                                    // when we are embedded and it needs to be converted to the
-                                    // host error definitions
-#define PMIX_VALUE              21
-#define PMIX_PROC               22
-#define PMIX_APP                23
-#define PMIX_INFO               24
-#define PMIX_PDATA              25
-#define PMIX_BUFFER             26
-#define PMIX_BYTE_OBJECT        27
-#define PMIX_KVAL               28
+#define PMIX_UNDEF                       0
+#define PMIX_BOOL                        1  // converted to/from native true/false to uint8 for pack/unpack
+#define PMIX_BYTE                        2  // a byte of data
+#define PMIX_STRING                      3  // NULL-terminated string
+#define PMIX_SIZE                        4  // size_t
+#define PMIX_PID                         5  // OS-pid
+#define PMIX_INT                         6
+#define PMIX_INT8                        7
+#define PMIX_INT16                       8
+#define PMIX_INT32                       9
+#define PMIX_INT64                      10
+#define PMIX_UINT                       11
+#define PMIX_UINT8                      12
+#define PMIX_UINT16                     13
+#define PMIX_UINT32                     14
+#define PMIX_UINT64                     15
+#define PMIX_FLOAT                      16
+#define PMIX_DOUBLE                     17
+#define PMIX_TIMEVAL                    18
+#define PMIX_TIME                       19
+#define PMIX_STATUS                     20  // needs to be tracked separately from integer for those times
+                                            // when we are embedded and it needs to be converted to the
+                                            // host error definitions
+#define PMIX_VALUE                      21
+#define PMIX_PROC                       22
+#define PMIX_APP                        23
+#define PMIX_INFO                       24
+#define PMIX_PDATA                      25
+#define PMIX_BUFFER                     26
+#define PMIX_BYTE_OBJECT                27
+#define PMIX_KVAL                       28
 // Hole left by deprecation/removal of PMIX_MODEX
-#define PMIX_PERSIST            30
-#define PMIX_POINTER            31
-#define PMIX_SCOPE              32
-#define PMIX_DATA_RANGE         33
-#define PMIX_COMMAND            34
-#define PMIX_INFO_DIRECTIVES    35
-#define PMIX_DATA_TYPE          36
-#define PMIX_PROC_STATE         37
-#define PMIX_PROC_INFO          38
-#define PMIX_DATA_ARRAY         39
-#define PMIX_PROC_RANK          40
-#define PMIX_QUERY              41
-#define PMIX_COMPRESSED_STRING  42  // string compressed with zlib
-#define PMIX_ALLOC_DIRECTIVE    43
+#define PMIX_PERSIST                    30
+#define PMIX_POINTER                    31
+#define PMIX_SCOPE                      32
+#define PMIX_DATA_RANGE                 33
+#define PMIX_COMMAND                    34
+#define PMIX_INFO_DIRECTIVES            35
+#define PMIX_DATA_TYPE                  36
+#define PMIX_PROC_STATE                 37
+#define PMIX_PROC_INFO                  38
+#define PMIX_DATA_ARRAY                 39
+#define PMIX_PROC_RANK                  40
+#define PMIX_QUERY                      41
+#define PMIX_COMPRESSED_STRING          42  // string compressed with zlib
+#define PMIX_ALLOC_DIRECTIVE            43
 // Hole left by deprecation/removal of PMIX_INFO_ARRAY
-#define PMIX_IOF_CHANNEL        45
-#define PMIX_ENVAR              46
-#define PMIX_COORD              47
-#define PMIX_REGATTR            48
-#define PMIX_REGEX              49
-#define PMIX_JOB_STATE          50
-#define PMIX_LINK_STATE         51
-#define PMIX_PROC_CPUSET        52
-#define PMIX_GEOMETRY           53
-#define PMIX_DEVICE_DIST        54
-#define PMIX_ENDPOINT           55
-#define PMIX_TOPO               56
-#define PMIX_DEVTYPE            57
-#define PMIX_LOCTYPE            58
+#define PMIX_IOF_CHANNEL                45
+#define PMIX_ENVAR                      46
+#define PMIX_COORD                      47
+#define PMIX_REGATTR                    48
+#define PMIX_REGEX                      49
+#define PMIX_JOB_STATE                  50
+#define PMIX_LINK_STATE                 51
+#define PMIX_PROC_CPUSET                52
+#define PMIX_GEOMETRY                   53
+#define PMIX_DEVICE_DIST                54
+#define PMIX_ENDPOINT                   55
+#define PMIX_TOPO                       56
+#define PMIX_DEVTYPE                    57
+#define PMIX_LOCTYPE                    58
+#define PMIX_COMPRESSED_BYTE_OBJECT     59
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1469,18 +1473,18 @@ typedef uint8_t pmix_coord_view_t;
 /* define a structure for a proc's fabric coordinate */
 typedef struct pmix_coord {
     pmix_coord_view_t view;
-    int *coord;
+    uint32_t *coord;
     size_t dims;
 } pmix_coord_t;
 
 #define PMIX_COORD_CREATE(m, d, n)                                      \
     do {                                                                \
         pmix_coord_t *_m;                                               \
-        _m = (pmix_coord_t*)pmix_calloc((n), sizeof(pmix_coord_t));     \
+        _m = (pmix_coord_t*)pmix_calloc((d), sizeof(pmix_coord_t));     \
         if (NULL != _m) {                                               \
             _m->view = PMIX_COORD_VIEW_UNDEF;                           \
-            _m->dims = (d);                                             \
-            _m->coord = (int*)pmix_calloc((m)->dims, sizeof(int));      \
+            _m->dims = (n);                                             \
+            _m->coord = (uint32_t*)pmix_calloc((n), sizeof(uint32_t));  \
             (m) = _m;                                                   \
         }                                                               \
     } while(0)

--- a/src/include/dictionary.h
+++ b/src/include/dictionary.h
@@ -513,8 +513,17 @@ pmix_regattr_input_t dictionary[] = {
     {.name = "PMIX_NODE_MAP", .string = "pmix.nmap", .type = PMIX_STRING,
      .description = (char *[]){"regex of nodes containing procs for this job", NULL}},
 
+    {.name = "PMIX_NODE_MAP_RAW", .string = "pmix.nmap.raw", .type = PMIX_STRING,
+     .description = (char *[]){"comma-delimited list of nodes containing procs for",
+                               "this job", NULL}},
+
     {.name = "PMIX_PROC_MAP", .string = "pmix.pmap", .type = PMIX_STRING,
      .description = (char *[]){"regex describing procs on each node within this job", NULL}},
+
+    {.name = "PMIX_PROC_MAP_RAW", .string = "pmix.pmap.raw", .type = PMIX_STRING,
+     .description = (char *[]){"semi-colon delimited list of strings, each string",
+                               "containing a comma-delimited list of ranks on the",
+                               "corresponding node", NULL}},
 
     {.name = "PMIX_ANL_MAP", .string = "pmix.anlmap", .type = PMIX_STRING,
      .description = (char *[]){"process mapping in ANL notation (used in PMI-1/PMI-2)", NULL}},

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -354,7 +354,8 @@ pmix_status_t pmix_bfrops_base_copy_bo(pmix_byte_object_t **dest,
                                        pmix_byte_object_t *src,
                                        pmix_data_type_t type)
 {
-    if (PMIX_BYTE_OBJECT != type) {
+    if (PMIX_BYTE_OBJECT != type &&
+        PMIX_COMPRESSED_BYTE_OBJECT != type) {
         return PMIX_ERR_BAD_PARAM;
     }
     *dest = (pmix_byte_object_t*)malloc(sizeof(pmix_byte_object_t));
@@ -414,11 +415,11 @@ static pmix_status_t fill_coord(pmix_coord_t *dst,
     dst->view = src->view;
     dst->dims = src->dims;
     if (0 < dst->dims) {
-        dst->coord = (int*)malloc(dst->dims * sizeof(int));
+        dst->coord = (uint32_t*)malloc(dst->dims * sizeof(uint32_t));
         if (NULL == dst->coord) {
             return PMIX_ERR_NOMEM;
         }
-        memcpy(dst->coord, src->coord, dst->dims * sizeof(int));
+        memcpy(dst->coord, src->coord, dst->dims * sizeof(uint32_t));
     }
     return PMIX_SUCCESS;
 }
@@ -920,7 +921,7 @@ pmix_status_t pmix_bfrops_base_copy_darray(pmix_data_array_t **dest,
             }
             break;
         case PMIX_GEOMETRY:
-            PMIX_CPUSET_CREATE(p->array, src->size);
+            PMIX_GEOMETRY_CREATE(p->array, src->size);
             if (NULL == p->array) {
                 free(p);
                 return PMIX_ERR_NOMEM;

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -154,6 +154,7 @@ void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
             break;
         case PMIX_BYTE_OBJECT:
         case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
             bo = (pmix_byte_object_t*)data;
             v->data.bo.bytes = (char*)malloc(bo->size);
             if (NULL == v->data.bo.bytes) {
@@ -407,6 +408,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv,
             break;
         case PMIX_BYTE_OBJECT:
         case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
             if (NULL != kv->data.bo.bytes && 0 < kv->data.bo.size) {
                 *data = kv->data.bo.bytes;
                 *sz = kv->data.bo.size;
@@ -823,6 +825,7 @@ pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
     case PMIX_BYTE_OBJECT:
     case PMIX_COMPRESSED_STRING:
     case PMIX_REGEX:
+    case PMIX_COMPRESSED_BYTE_OBJECT:
         memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
         if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
             p->data.bo.bytes = malloc(src->data.bo.size);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -576,7 +576,8 @@ pmix_status_t pmix_bfrops_base_pack_bo(pmix_pointer_array_t *regtypes,
     if (NULL == regtypes) {
         return PMIX_ERR_BAD_PARAM;
     }
-    if (PMIX_BYTE_OBJECT != type) {
+    if (PMIX_BYTE_OBJECT != type &&
+        PMIX_COMPRESSED_BYTE_OBJECT != type) {
         return PMIX_ERR_BAD_PARAM;
     }
     bo = (pmix_byte_object_t*)src;
@@ -1266,7 +1267,7 @@ pmix_status_t pmix_bfrops_base_pack_coord(pmix_pointer_array_t *regtypes,
             return ret;
         }
         /* pack the array of coordinates */
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].coord, ptr[i].dims, PMIX_INT, regtypes);
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].coord, ptr[i].dims, PMIX_UINT32, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1474,7 +1474,8 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix,
     char *prefx;
     int ret;
 
-    if (PMIX_BYTE_OBJECT != type) {
+    if (PMIX_BYTE_OBJECT != type &&
+        PMIX_COMPRESSED_BYTE_OBJECT != type) {
         return PMIX_ERR_BAD_PARAM;
     }
     /* deal with NULL prefix */
@@ -1488,7 +1489,8 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx);
+        ret = asprintf(output, "%sData type: %s\tValue: NULL pointer", prefx,
+                       (PMIX_COMPRESSED_BYTE_OBJECT == type) ? "PMIX_COMPRESSED_BYTE_OBJECT" : "PMIX_BYTE_OBJECT");
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1499,7 +1501,9 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix,
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long)src->size);
+    ret = asprintf(output, "%sData type: %s\tSize: %ld", prefx,
+                   (PMIX_COMPRESSED_BYTE_OBJECT == type) ? "PMIX_COMPRESSED_BYTE_OBJECT" : "PMIX_BYTE_OBJECT",
+                   (long)src->size);
     if (prefx != prefix) {
         free(prefx);
     }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1123,7 +1123,8 @@ pmix_status_t pmix_bfrops_base_unpack_bo(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d byte_object", *num_vals);
 
-    if (PMIX_BYTE_OBJECT != type) {
+    if (PMIX_BYTE_OBJECT != type &&
+        PMIX_COMPRESSED_BYTE_OBJECT != type) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1526,10 +1527,10 @@ pmix_status_t pmix_bfrops_base_unpack_coord(pmix_pointer_array_t *regtypes,
             return ret;
         }
         if (0 < ptr[i].dims) {
-            ptr[i].coord = (int*)malloc(ptr[i].dims * sizeof(int));
+            ptr[i].coord = (uint32_t*)malloc(ptr[i].dims * sizeof(uint32_t));
             /* unpack the coords */
             m=ptr[i].dims;
-            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coord, &m, PMIX_INT, regtypes);
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coord, &m, PMIX_UINT32, regtypes);
             if (PMIX_SUCCESS != ret) {
                 return ret;
             }

--- a/src/mca/bfrops/bfrops_types.h
+++ b/src/mca/bfrops/bfrops_types.h
@@ -66,6 +66,13 @@ typedef struct {
 } pmix_kval_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_kval_t);
 
+/* helpful macro extension of the usual PMIX_NEW */
+#define PMIX_KVAL_NEW(k, s)                                         \
+    do {                                                            \
+        (k) = PMIX_NEW(pmix_kval_t);                                \
+        (k)->key = strdup((s));                                     \
+        (k)->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));   \
+    } while(0)
 
 /**
  * Structure for holding a buffer */

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -507,6 +507,14 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_print_locality,
                        &mca_bfrops_v4_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_COMPRESSED_BYTE_OBJECT",
+    				   PMIX_COMPRESSED_BYTE_OBJECT,
+                       pmix_bfrops_base_pack_bo,
+                       pmix_bfrops_base_unpack_bo,
+                       pmix_bfrops_base_copy_bo,
+                       pmix_bfrops_base_print_bo,
+                       &mca_bfrops_v4_component.types);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/common/sse/Makefile.am
+++ b/src/mca/common/sse/Makefile.am
@@ -9,7 +9,7 @@
 
 # Header files
 
-AM_CPPFLAGS = $(LTDLINCL) -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
+AM_CPPFLAGS = $(LTDLINCL) -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix $(pmix_check_curl_CPPFLAGS)
 AM_LFLAGS = -Ppmix_util_sse_yy
 LEX_OUTPUT_ROOT = lex.pmix_util_sse_yy
 
@@ -35,7 +35,8 @@ noinst_LTLIBRARIES += $(comp_noinst)
 endif
 
 libmca_common_sse_la_SOURCES = $(headers) $(sources)
-libmca_common_sse_la_LDFLAGS = -version-info $(libmca_common_sse_so_version)
+libmca_common_sse_la_LDFLAGS = -version-info $(libmca_common_sse_so_version) $(pmix_check_curl_LDFLAGS)
+libmca_common_sse_la_LIBADD = $(pmix_check_curl_LIBS)
 libmca_common_sse_noinst_la_SOURCES = $(headers) $(sources)
 
 # Conditionally install the header files

--- a/src/mca/common/sse/configure.m4
+++ b/src/mca/common/sse/configure.m4
@@ -14,7 +14,15 @@
 AC_DEFUN([MCA_pmix_common_sse_CONFIG], [
     AC_CONFIG_FILES([src/mca/common/sse/Makefile])
 
+    AC_REQUIRE([PMIX_CHECK_CURL])
+    AC_REQUIRE([PMIX_CHECK_JANSSON])
+
     AS_IF([test "$pmix_check_jansson_happy" = "yes" && test "$pmix_check_curl_happy" = "yes"],
-          [$1], [$2])
+          [$1
+           pmix_common_sse_happy=yes],
+          [$2
+           pmix_common_sse_happy=no])
+
+    PMIX_SUMMARY_ADD([[Optional Support]],[[SSE]], [common_sse], [$pmix_check_curl_happy])
 
 ])dnl

--- a/src/mca/common/sse/sse.h
+++ b/src/mca/common/sse/sse.h
@@ -28,6 +28,7 @@
 #include <stdio.h>
 
 #include "src/class/pmix_object.h"
+#include "src/threads/threads.h"
 
 typedef enum {
     PMIX_HTTP_UNDEF = -1,
@@ -50,6 +51,8 @@ typedef void (*pmix_sse_on_data_cbfunc_fn_t)(const char *ptr, char **result, voi
  */
 typedef struct {
     pmix_object_t                   super;
+    pmix_lock_t                     lock;                               // thread lock so requesters can wait for completion
+    pmix_status_t                   status;                             // return status of operation
     pmix_sse_verb_t                 verb;                               // operation to perform
     const char                      *url;                               // URL to get
     int                             max_retries;                        // max number of times to try to connect
@@ -80,8 +83,9 @@ PMIX_EXPORT void pmix_sse_common_init(void);
  * request and providing a callback function to be executed whenever data
  * becomes available on the specified channel */
 PMIX_EXPORT pmix_status_t pmix_sse_register_request(pmix_sse_request_t *req,
-                                                    pmix_sse_on_data_cbfunc_fn_t ondata,
                                                     pmix_sse_register_cbfunc_fn_t regcbfunc,
-                                                    void *cbdata);
+                                                    void *reqcbdata,
+                                                    pmix_sse_on_data_cbfunc_fn_t ondata,
+                                                    void *datcbdata);
 
 #endif /* PMIX_SSE_H */

--- a/src/mca/common/sse/sse_internal.h
+++ b/src/mca/common/sse/sse_internal.h
@@ -32,8 +32,8 @@
 /* response limit: 128 kByte */
 #define PMIX_COMMON_SSE_RESPONSE_LIMIT  128 * 1024
 
-extern void pmix_common_sse_parse_sse(char *ptr, size_t size, void *cbdata);
+PMIX_EXPORT void pmix_common_sse_parse_sse(char *ptr, size_t size, void *cbdata);
 
-extern void pmix_common_on_sse_event(char** headers, const char* data, const char* reply_url, void *cbdata);
+PMIX_EXPORT void pmix_common_on_sse_event(char** headers, const char* data, const char* reply_url, void *cbdata);
 
 #endif /* PMIX_SSE_INTERNAL_H */

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -2138,6 +2138,20 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
         return PMIX_ERR_NOMEM;
     }
 
+    /* if this is node/app data, then process it accordingly */
+    if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY)) {
+        rc = process_node_array(kv->value, &trk->nodeinfo);
+        return rc;
+    } else if (PMIX_CHECK_KEY(kv, PMIX_APP_INFO_ARRAY)) {
+        rc = process_app_array(kv->value, trk);
+        return rc;
+    } else if (PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY)) {
+        rc = process_session_array(kv->value, trk);
+        return rc;
+    } else if (PMIX_CHECK_KEY(kv, PMIX_JOB_INFO_ARRAY)) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
     /* see if the proc is me - cannot use CHECK_PROCID as
      * we don't want rank=wildcard to match */
     if (proc->rank == pmix_globals.myid.rank &&

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -6,7 +6,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,9 +24,30 @@
 /*
  * Globals
  */
-static bool compress_block(char *instring,
+static bool compress_block(uint8_t *inblock, size_t size,
                            uint8_t **outbytes,
                            size_t *nbytes)
+{
+    (void)inblock;
+    (void)size;
+    (void)outbytes;
+    (void)nbytes;
+    return false;
+}
+
+static bool decompress_block(uint8_t **outbytes, size_t *outlen,
+                             uint8_t *inbytes, size_t len)
+{
+    (void)outbytes;
+    (void)outlen;
+    (void)inbytes;
+    (void)len;
+    return false;
+}
+
+static bool compress_string(char *instring,
+                            uint8_t **outbytes,
+                            size_t *nbytes)
 {
     (void)instring;
     (void)outbytes;
@@ -34,8 +55,8 @@ static bool compress_block(char *instring,
     return false;
 }
 
-static bool decompress_block(char **outstring,
-                             uint8_t *inbytes, size_t len)
+static bool decompress_string(char **outstring,
+                              uint8_t *inbytes, size_t len)
 {
     (void)outstring;
     (void)inbytes;
@@ -44,14 +65,10 @@ static bool decompress_block(char **outstring,
 }
 
 pmix_compress_base_module_t pmix_compress = {
-    NULL, /* init             */
-    NULL, /* finalize         */
-    NULL, /* compress         */
-    NULL, /* compress_nb      */
-    NULL, /* decompress       */
-    NULL,  /* decompress_nb    */
-    compress_block,
-    decompress_block
+    .compress = compress_block,
+    .decompress = decompress_block,
+    .compress_string = compress_string,
+    .decompress_string = decompress_string
 };
 pmix_compress_base_t pmix_compress_base = {0};
 

--- a/src/mca/pcompress/base/pcompress_base_select.c
+++ b/src/mca/pcompress/base/pcompress_base_select.c
@@ -52,8 +52,10 @@ int pmix_compress_base_select(void)
 
     /* Initialize the winner */
     if (NULL != best_module) {
-        if (PMIX_SUCCESS != (ret = best_module->init()) ) {
-            goto cleanup;
+        if (NULL != best_module->init) {
+            if (PMIX_SUCCESS != (ret = best_module->init()) ) {
+                goto cleanup;
+            }
         }
         pmix_compress = *best_module;
     }

--- a/src/mca/pcompress/pcompress.h
+++ b/src/mca/pcompress/pcompress.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,36 +54,6 @@ typedef int (*pmix_compress_base_module_finalize_fn_t)
      (void);
 
 /**
- * Compress the file provided
- *
- * Arguments:
- *   fname   = Filename to compress
- *   cname   = Compressed filename
- *   postfix = postfix added to filename to create compressed filename
- * Returns:
- *   PMIX_SUCCESS on success, ow PMIX_ERROR
- */
-typedef int (*pmix_compress_base_module_compress_fn_t)
-    (char * fname, char **cname, char **postfix);
-
-typedef int (*pmix_compress_base_module_compress_nb_fn_t)
-    (char * fname, char **cname, char **postfix, pid_t *child_pid);
-
-/**
- * Decompress the file provided
- *
- * Arguments:
- *   fname = Filename to compress
- *   cname = Compressed filename
- * Returns:
- *   PMIX_SUCCESS on success, ow PMIX_ERROR
- */
-typedef int (*pmix_compress_base_module_decompress_fn_t)
-    (char * cname, char **fname);
-typedef int (*pmix_compress_base_module_decompress_nb_fn_t)
-    (char * cname, char **fname, pid_t *child_pid);
-
-/**
  * Compress a string
  *
  * Arguments:
@@ -94,6 +64,20 @@ typedef bool (*pmix_compress_base_module_compress_string_fn_t)(char *instring,
                                                                size_t *nbytes);
 typedef bool (*pmix_compress_base_module_decompress_string_fn_t)(char **outstring,
                                                                  uint8_t *inbytes, size_t len);
+
+/**
+ * Compress a block
+ *
+ * Arguments:
+ *
+ */
+typedef bool (*pmix_compress_base_module_compress_fn_t)(uint8_t *inbytes,
+                                                        size_t size,
+                                                        uint8_t **outbytes,
+                                                        size_t *nbytes);
+
+typedef bool (*pmix_compress_base_module_decompress_fn_t)(uint8_t **outbytes, size_t *outlen,
+                                                          uint8_t *inbytes, size_t len);
 
 
 /**
@@ -126,11 +110,9 @@ struct pmix_compress_base_module_1_0_0_t {
 
     /** Compress interface */
     pmix_compress_base_module_compress_fn_t       compress;
-    pmix_compress_base_module_compress_nb_fn_t    compress_nb;
 
     /** Decompress Interface */
     pmix_compress_base_module_decompress_fn_t     decompress;
-    pmix_compress_base_module_decompress_nb_fn_t  decompress_nb;
 
     /* COMPRESS STRING */
     pmix_compress_base_module_compress_string_fn_t      compress_string;

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -26,6 +26,7 @@
 #endif  /* HAVE_UNISTD_H */
 #include <zlib.h>
 
+#include "src/include/pmix_stdint.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
 #include "src/util/argv.h"
@@ -39,31 +40,44 @@
 
 #include "compress_zlib.h"
 
-int pmix_compress_zlib_module_init(void)
-{
-    return PMIX_SUCCESS;
-}
+static bool zlib_compress(uint8_t *inbytes,
+                          size_t inlen,
+                          uint8_t **outbytes,
+                          size_t *outlen);
 
-int pmix_compress_zlib_module_finalize(void)
-{
-    return PMIX_SUCCESS;
-}
+static bool zlib_decompress(uint8_t **outbytes, size_t *outlen,
+                            uint8_t *inbytes, size_t inlen);
 
-bool pmix_compress_zlib_compress_block(char *instring,
-                                       uint8_t **outbytes,
-                                       size_t *nbytes)
+static bool compress_string(char *instring,
+                            uint8_t **outbytes,
+                            size_t *nbytes);
+
+static bool decompress_string(char **outstring,
+                              uint8_t *inbytes, size_t len);
+
+pmix_compress_base_module_t pmix_pcompress_zlib_module = {
+    .compress = zlib_compress,
+    .decompress = zlib_decompress,
+    .compress_string = compress_string,
+    .decompress_string = decompress_string,
+};
+
+
+static bool zlib_compress(uint8_t *inbytes,
+                          size_t inlen,
+                          uint8_t **outbytes,
+                          size_t *outlen)
 {
     z_stream strm;
-    size_t len, outlen;
+    size_t len, len2;
     uint8_t *tmp, *ptr;
-    uint32_t inlen;
     int rc;
 
     /* set default output */
     *outbytes = NULL;
+    *outlen = 0;
 
     /* setup the stream */
-    inlen = strlen(instring);
     memset (&strm, 0, sizeof (strm));
     deflateInit (&strm, 9);
 
@@ -80,8 +94,8 @@ bool pmix_compress_zlib_compress_block(char *instring,
         (void)deflateEnd(&strm);
         return false;
     }
-    strm.next_in = (uint8_t*)instring;
-    strm.avail_in = strlen(instring);
+    strm.next_in = inbytes;
+    strm.avail_in = inlen;
 
     /* allocating the upper bound guarantees zlib will
      * always successfully compress into the available space */
@@ -96,70 +110,127 @@ bool pmix_compress_zlib_compress_block(char *instring,
     }
 
     /* allocate 4 bytes beyond the size reqd by zlib so we
-     * can pass the size of the uncompressed string to the
+     * can pass the size of the uncompressed block to the
      * decompress side */
-    outlen = len - strm.avail_out + sizeof(uint32_t);
-    ptr = (uint8_t*)malloc(outlen);
+    len2 = len - strm.avail_out + sizeof(uint32_t);
+    ptr = (uint8_t*)malloc(len2);
     if (NULL == ptr) {
         free(tmp);
         return false;
     }
     *outbytes = ptr;
-    *nbytes = outlen;
+    *outlen = len2;
 
     /* fold the uncompressed length into the buffer */
     memcpy(ptr, &inlen, sizeof(uint32_t));
     ptr += sizeof(uint32_t);
     /* bring over the compressed data */
-    memcpy(ptr, tmp, outlen-sizeof(uint32_t));
+    memcpy(ptr, tmp, len2-sizeof(uint32_t));
     free(tmp);
     pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
-                        "COMPRESS INPUT STRING OF LEN %d OUTPUT SIZE %lu",
-                        inlen, outlen-sizeof(uint32_t));
+                        "COMPRESS INPUT BLOCK OF LEN %"PRIsize_t" OUTPUT SIZE %"PRIsize_t"",
+                        inlen, len2-sizeof(uint32_t));
     return true;  // we did the compression
 }
 
-bool pmix_compress_zlib_uncompress_block(char **outstring,
-                                         uint8_t *inbytes, size_t len)
+static bool compress_string(char *instring,
+                            uint8_t **outbytes,
+                            size_t *nbytes)
+{
+    uint32_t inlen;
+
+    /* setup the stream */
+    inlen = strlen(instring);
+
+    /* compress the string */
+    return zlib_compress((uint8_t*)instring, inlen, outbytes, nbytes);
+}
+
+static bool doit(uint8_t **outbytes, size_t len2,
+                 uint8_t *inbytes, size_t inlen)
 {
     uint8_t *dest;
-    int32_t len2;
     z_stream strm;
     int rc;
 
     /* set the default error answer */
-    *outstring = NULL;
+    *outbytes = NULL;
 
-    /* the first 4 bytes contains the uncompressed size */
-    memcpy(&len2, inbytes, sizeof(uint32_t));
-
-    pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
-                        "DECOMPRESSING INPUT OF LEN %lu OUTPUT %d", len, len2);
-
-    /* setting destination to the fully decompressed size, +1 to
-     * hold the NULL terminator */
-    dest = (uint8_t*)malloc(len2+1);
+    /* setting destination to the fully decompressed size */
+    dest = (uint8_t*)malloc(len2);
     if (NULL == dest) {
         return false;
     }
-    memset(dest, 0, len2+1);
+    memset(dest, 0, len2);
 
     memset (&strm, 0, sizeof (strm));
     if (Z_OK != inflateInit(&strm)) {
         free(dest);
         return false;
     }
-    strm.avail_in = len;
-    strm.next_in = (uint8_t*)(inbytes + sizeof(uint32_t));
+    strm.avail_in = inlen;
+    strm.next_in = inbytes;
     strm.avail_out = len2;
-    strm.next_out = (uint8_t*)dest;
+    strm.next_out = dest;
 
     rc = inflate (&strm, Z_FINISH);
     inflateEnd (&strm);
-    /* ensure this is NULL terminated! */
-    dest[len2] = '\0';
-    *outstring = (char*)dest;
+    if (Z_OK == rc) {
+        *outbytes = dest;
+        return true;
+    }
+    free(dest);
+    return false;
+
+}
+static bool zlib_decompress(uint8_t **outbytes, size_t *outlen,
+                            uint8_t *inbytes, size_t inlen)
+{
+    int32_t len2;
+    bool rc;
+    uint8_t *input;
+
+    /* set the default error answer */
+    *outlen = 0;
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+
     pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
-                        "\tFINAL LEN: %lu CODE: %d", strlen(*outstring), rc);
-    return true;
+                        "DECOMPRESSING INPUT OF LEN %"PRIsize_t" OUTPUT %d", inlen, len2);
+
+    input = (uint8_t*)(inbytes + sizeof(uint32_t));  // step over the size
+    rc = doit(outbytes, len2, input, inlen);
+    if (rc) {
+        *outlen = len2;
+        return true;
+    }
+    return false;
+}
+
+static bool decompress_string(char **outstring,
+                              uint8_t *inbytes, size_t len)
+{
+    int32_t len2;
+    bool rc;
+    uint8_t *input;
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+    /* add one to hold the NULL terminator */
+    ++len2;
+
+    /* decompress the bytes */
+    input = (uint8_t*)(inbytes + sizeof(uint32_t));  // step over the size
+    rc = doit((uint8_t**)outstring, len2, input, len);
+
+    if (rc) {
+        /* ensure this is NULL terminated! */
+        outstring[len2-1] = NULL;
+        return true;
+    }
+
+    /* set the default error answer */
+    *outstring = NULL;
+    return false;
 }

--- a/src/mca/pcompress/zlib/compress_zlib.h
+++ b/src/mca/pcompress/zlib/compress_zlib.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2004-2010 The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,22 +31,9 @@
 extern "C" {
 #endif
 
-    extern pmix_mca_base_component_t mca_pcompress_zlib_component;
-
-    /*
-     * Module functions
-     */
-    int pmix_compress_zlib_module_init(void);
-    int pmix_compress_zlib_module_finalize(void);
-
-    /*
-     * Actual funcationality
-     */
-    bool pmix_compress_zlib_compress_block(char *instring,
-                                           uint8_t **outbytes,
-                                           size_t *nbytes);
-    bool pmix_compress_zlib_uncompress_block(char **outstring,
-                                             uint8_t *inbytes, size_t len);
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_mca_base_component_t mca_pcompress_zlib_component;
+extern pmix_compress_base_module_t pmix_pcompress_zlib_module;
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/src/mca/pcompress/zlib/compress_zlib_component.c
+++ b/src/mca/pcompress/zlib/compress_zlib_component.c
@@ -27,8 +27,6 @@ const char *pmix_compress_zlib_component_version_string =
 /*
  * Local functionality
  */
-static int compress_zlib_open(void);
-static int compress_zlib_close(void);
 static int compress_zlib_query(pmix_mca_base_module_t **module, int *priority);
 
 /*
@@ -47,40 +45,12 @@ PMIX_EXPORT pmix_mca_base_component_t mca_pcompress_zlib_component = {
                                PMIX_RELEASE_VERSION),
 
     /* Component open and close functions */
-    .pmix_mca_open_component = compress_zlib_open,
-    .pmix_mca_close_component = compress_zlib_close,
     .pmix_mca_query_component = compress_zlib_query
 };
 
-/*
- * Zlib module
- */
-static pmix_compress_base_module_t loc_module = {
-    /** Initialization Function */
-    .init = pmix_compress_zlib_module_init,
-    /** Finalization Function */
-    .finalize = pmix_compress_zlib_module_finalize,
-
-    /** Compress Function */
-    .compress_string = pmix_compress_zlib_compress_block,
-
-    /** Decompress Function */
-    .decompress_string = pmix_compress_zlib_uncompress_block,
-};
-
-static int compress_zlib_open(void)
-{
-    return PMIX_SUCCESS;
-}
-
-static int compress_zlib_close(void)
-{
-    return PMIX_SUCCESS;
-}
-
 static int compress_zlib_query(pmix_mca_base_module_t **module, int *priority)
 {
-    *module   = (pmix_mca_base_module_t *)&loc_module;
+    *module   = (pmix_mca_base_module_t *)&pmix_pcompress_zlib_module;
     *priority = 50;
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -148,7 +148,8 @@ PMIX_EXPORT pmix_status_t pmix_pnet_base_harvest_envars(char **incvars, char **e
 
 PMIX_EXPORT pmix_status_t pmix_pnet_base_register_fabric(pmix_fabric_t *fabric,
                                                          const pmix_info_t directives[],
-                                                         size_t ndirs);
+                                                         size_t ndirs,
+                                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_deregister_fabric(pmix_fabric_t *fabric);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_update_fabric(pmix_fabric_t *fabric);
 

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -156,7 +156,8 @@ typedef pmix_status_t (*pmix_pnet_base_module_deliver_inventory_fn_t)(pmix_info_
  */
 typedef pmix_status_t (*pmix_pnet_base_module_register_fabric_fn_t)(pmix_fabric_t *fabric,
                                                                     const pmix_info_t directives[],
-                                                                    size_t ndirs);
+                                                                    size_t ndirs,
+                                                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Update the fabric information */

--- a/src/mca/pnet/sshot/configure.m4
+++ b/src/mca/pnet/sshot/configure.m4
@@ -14,7 +14,59 @@
 AC_DEFUN([MCA_pmix_pnet_sshot_CONFIG], [
     AC_CONFIG_FILES([src/mca/pnet/sshot/Makefile])
 
-    AS_IF([test "$pmix_check_jansson_happy" = "yes"],
+    AC_ARG_WITH([slingshot], [AC_HELP_STRING([--with-slingshot], [Include Slingshot fabric support])],
+                [pmix_want_sshot=yes], [pmix_want_sshot=no])
+
+    AC_ARG_WITH([cxi], [AC_HELP_STRING([--with-cxi(=DIR)],
+                                       [Include CXI service library support, optionally adding DIR/include, DIR/include/cxi, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
+                [], [with_cxi=no])
+
+    AC_ARG_WITH([cxi-libdir],
+                [AC_HELP_STRING([--with-cxi-libdir=DIR],
+                                [Search for CXI libraries in DIR])])
+
+    AS_IF([test "$with_cxi" = "no"],
+          [AC_MSG_RESULT([no])
+           pmix_check_cxi_happy=no],
+          [AC_MSG_RESULT([yes])
+           PMIX_CHECK_WITHDIR([cxi-libdir], [$with_cxi_libdir], [libcxi.*])
+           AS_IF([test ! -z "$with_cxi" && test "$with_cxi" != "yes"],
+                 [pmix_check_cxi_dir="$with_cxi"
+                  AS_IF([test ! -d "$pmix_check_cxi_dir" || test ! -f "$pmix_check_cxi_dir/cxi.h"],
+                         [$pmix_check_cxi_dir=$pmix_check_cxi_dir/include
+                          AS_IF([test ! -d "$pmix_check_cxi_dir" || test ! -f "$pmix_check_cxi_dir/cxi.h"],
+                                [$pmix_check_cxi_dir=$pmix_check_cxi_dir/cxi
+                                 AS_IF([test ! -d "$pmix_check_cxi_dir" || test ! -f "$pmix_check_cxi_dir/cxi.h"],
+                                       [AC_MSG_WARN([CXI library support requested, but])
+                                        AC_MSG_WARN([required header file cxi.h not found. Locations tested:])
+                                        AC_MSG_WARN([    $with_cxi])
+                                        AC_MSG_WARN([    $with_cxi/include])
+                                        AC_MSG_WARN([    $with_cxi/include/cxi])
+                                        AC_MSG_ERROR([Cannot continue])])])])],
+                 [pmix_check_cxi_dir="/usr/include/cxi"])
+
+           AS_IF([test ! -z "$with_cxi_libdir" && test "$with_cxi_libdir" != "yes"],
+                 [pmix_check_cxi_libdir="$with_cxi_libdir"])
+
+           PMIX_CHECK_PACKAGE([pnet_cxi],
+                              [cxi.h],
+                              [cxi],
+                              [CXI_FUNCTION],
+                              [],
+                              [$pmix_check_cxi_dir],
+                              [$pmix_check_cxi_libdir],
+                              [pmix_check_cxi_happy="yes"
+                               pnet_cxi_CFLAGS="$pnet_cxi_CFLAGS $pnet_cxi_CFLAGS"
+                               pnet_cxi_CPPFLAGS="$pnet_cxi_CPPFLAGS $pnet_cxi_CPPFLAGS"
+                               pnet_cxi_LDFLAGS="$pnet_cxi_LDFLAGS $pnet_cxi_LDFLAGS"
+                               pnet_cxi_LIBS="$pnet_cxi_LIBS $pnet_cxi_LIBS"],
+                              [pmix_check_cxi_happy="no"])
+           ])
+
+    # for NOW, hardwire cxi support to be happy
+    pmix_check_cxi_happy=yes
+
+    AS_IF([test "$pmix_want_sshot" = "yes" && test "$pmix_common_sse_happy" = "yes" && test "$pmix_check_cxi_happy" = "yes"],
           [$1
            pnet_sshot_happy=yes],
           [$2

--- a/src/mca/pnet/sshot/pnet_fabric.c
+++ b/src/mca/pnet/sshot/pnet_fabric.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+#include <jansson.h>
+
+#include "include/pmix_common.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_bitmap.h"
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/threads/threads.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/name_fns.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/printf.h"
+#include "src/util/show_help.h"
+#include "src/mca/preg/preg.h"
+#include "src/mca/common/sse/sse.h"
+
+#include "src/mca/pnet/pnet.h"
+#include "src/mca/pnet/base/base.h"
+#include "pnet_sshot.h"
+
+/* internal variables */
+static pmix_pointer_array_t mygroups, mynodes, myvertices;
+static int mynswitches = 100, mynnics = 80000;
+
+/* internal tracking structures */
+typedef struct {
+    pmix_object_t super;
+    int grpID;
+    pmix_bitmap_t switches;
+    pmix_bitmap_t nics;
+    char **members;
+} pnet_fabricgroup_t;
+static void ncon(pnet_fabricgroup_t *p)
+{
+    /* initialize the switch bitmap */
+    PMIX_CONSTRUCT(&p->switches, pmix_bitmap_t);
+    pmix_bitmap_set_max_size(&p->switches, mynswitches);
+    pmix_bitmap_init(&p->switches, mynswitches);
+    /* initialize the nic bitmap */
+    PMIX_CONSTRUCT(&p->nics, pmix_bitmap_t);
+    pmix_bitmap_set_max_size(&p->nics, mynnics);
+    pmix_bitmap_init(&p->nics, mynnics);
+    /* initialize the argv array of members */
+    p->members = NULL;
+}
+static void ndes(pnet_fabricgroup_t *p)
+{
+    PMIX_DESTRUCT(&p->switches);
+    PMIX_DESTRUCT(&p->nics);
+    if (NULL != p->members) {
+        pmix_argv_free(p->members);
+    }
+}
+static PMIX_CLASS_INSTANCE(pnet_fabricgroup_t,
+                           pmix_object_t,
+                           ncon, ndes);
+
+typedef struct {
+    pmix_object_t super;
+    char *name;
+    pnet_fabricgroup_t *grp;
+    pmix_pointer_array_t nics;
+} pnet_node_t;
+static void ndcon(pnet_node_t *p)
+{
+    p->name = NULL;
+    p->grp = NULL;
+    PMIX_CONSTRUCT(&p->nics, pmix_pointer_array_t);
+    pmix_pointer_array_init(&p->nics, 8, INT_MAX, 8);
+}
+static void nddes(pnet_node_t *p)
+{
+    pmix_object_t *item;
+    int n;
+
+    if (NULL != p->name) {
+        free(p->name);
+    }
+    if (NULL != p->grp) {
+        PMIX_RELEASE(p->grp);
+    }
+    for (n=0; n < p->nics.size; n++) {
+        if (NULL != (item = pmix_pointer_array_get_item(&p->nics, n))) {
+            PMIX_RELEASE(item);
+        }
+    }
+    PMIX_DESTRUCT(&p->nics);
+}
+static PMIX_CLASS_INSTANCE(pnet_node_t,
+                           pmix_object_t,
+                           ndcon, nddes);
+
+typedef struct {
+    pmix_object_t super;
+    uint32_t index;
+    pnet_node_t *host;
+    char *addr;
+    pmix_coord_t coord;
+} pnet_vertex_t;
+static void vtcon(pnet_vertex_t *p)
+{
+    p->host = NULL;
+    p->addr = NULL;
+    PMIX_COORD_CONSTRUCT(&p->coord);
+    p->coord.view = PMIX_COORD_LOGICAL_VIEW;
+}
+static void vtdes(pnet_vertex_t *p)
+{
+    if (NULL != p->host) {
+        PMIX_RELEASE(p->host);
+    }
+    if (NULL != p->addr) {
+        free(p->addr);
+    }
+    PMIX_COORD_DESTRUCT(&p->coord);
+}
+static PMIX_CLASS_INSTANCE(pnet_vertex_t,
+                           pmix_object_t,
+                           vtcon, vtdes);
+
+
+/* internal functions */
+static pmix_status_t ask_fabric_controller(pmix_fabric_t *fabric,
+                                           const pmix_info_t directives[],
+                                           size_t ndirs,
+                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+pmix_status_t pmix_pnet_sshot_register_fabric(pmix_fabric_t *fabric,
+                                              const pmix_info_t directives[],
+                                              size_t ndirs,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    json_t *root, *switches, *ndarray, *sw, *nd, *nic, *nics;
+    json_error_t error;
+    int nswitches, nnodes, m, n, p, grpID, swcNum, nnics;
+    const char *str;
+    pnet_fabricgroup_t *grp;
+    pnet_node_t *node;
+    pnet_vertex_t *vtx;
+    char **grps = NULL, *grpmems, *gmem;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet: sshot init");
+
+    /* if we were given a fabric topology configuration file, then parse
+     * it to get the fabric groups and switches */
+    if (NULL == mca_pnet_sshot_component.configfile) {
+        /* we were not given a file - see if we can get it
+         * from the fabric controller via REST interface */
+        return ask_fabric_controller(fabric, directives, ndirs, cbfunc, cbdata);
+    }
+
+    /* setup to parse the configuration file */
+    PMIX_CONSTRUCT(&mygroups, pmix_pointer_array_t);
+    pmix_pointer_array_init(&mygroups, 3, INT_MAX, 2);
+    PMIX_CONSTRUCT(&mynodes, pmix_pointer_array_t);
+    pmix_pointer_array_init(&mynodes, 128, INT_MAX, 64);
+    PMIX_CONSTRUCT(&myvertices, pmix_pointer_array_t);
+    pmix_pointer_array_init(&myvertices, 128, INT_MAX, 64);
+
+    /* load the file */
+    root = json_load_file(mca_pnet_sshot_component.configfile, 0, &error);
+    if (NULL == root) {
+        /* the error object contains info on the error */
+        pmix_show_help("help-pnet-sshot.txt", "json-load", true,
+                       error.text, error.source, error.line,
+                       error.column, error.position,
+                       json_error_code(&error));
+        return PMIX_ERROR;
+    }
+
+    /* unpack the switch information and assemble them
+     * into Dragonfly groups */
+    switches = json_object_get(root, "switches");
+    if (!json_is_array(switches)) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        json_decref(root);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    nswitches = json_array_size(switches);
+
+    for (n=0; n < nswitches; n++) {
+        sw = json_array_get(switches, n);
+        json_unpack(sw, "{s:i, s:i}", "grpID", &grpID, "swcNum", &swcNum);
+        /* see if we already have this group */
+        if (NULL == (grp = (pnet_fabricgroup_t*)pmix_pointer_array_get_item(&mygroups, grpID))) {
+            /* nope - better add it */
+            grp = PMIX_NEW(pnet_fabricgroup_t);
+            grp->grpID = grpID;
+            pmix_pointer_array_set_item(&mygroups, grpID, grp);
+            /* adjust the bitmap, if necessary */
+            if (pmix_bitmap_size(&grp->switches) < nswitches) {
+                pmix_bitmap_set_max_size(&grp->switches, nswitches);
+            }
+            /* indicate that this switch belongs to this group */
+            pmix_bitmap_set_bit(&grp->switches, swcNum);
+        } else {
+            /* indicate that this switch belongs to this group */
+            pmix_bitmap_set_bit(&grp->switches, swcNum);
+        }
+    }
+
+    /* get the total number of NICs in each group */
+    ndarray = json_object_get(root, "nodes");
+    if (!json_is_array(ndarray)) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        json_decref(root);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    nnodes = json_array_size(ndarray);
+
+    for (n=0; n < nnodes; n++) {
+        nd = json_array_get(ndarray, n);
+        node = PMIX_NEW(pnet_node_t);
+        json_unpack(nd, "{s:s}", "name", &str);
+        node->name = strdup(str);
+        pmix_pointer_array_add(&mynodes, node);
+        nics = json_object_get(nd, "nics");
+        nnics = json_array_size(nics);
+        /* adjust the bitmaps, if necessary */
+        for (p=0; p < mygroups.size; p++) {
+            if (NULL != (grp = (pnet_fabricgroup_t*)pmix_pointer_array_get_item(&mygroups, p))) {
+                if (pmix_bitmap_size(&grp->nics) < nnics) {
+                    pmix_bitmap_set_max_size(&grp->nics, nnics);
+                }
+            }
+        }
+        /* cycle thru the NICs to get the switch
+         * to which they are connected */
+        for (m=0; m < nnics; m++) {
+            nic = json_array_get(nics, m);
+            json_unpack(nic, "{s:s, s:i}", "id", &str, "switch", &swcNum);
+            /* add the vertex to our array */
+            vtx = PMIX_NEW(pnet_vertex_t);
+            PMIX_RETAIN(node);
+            vtx->host = node;
+            vtx->addr = strdup(str);
+            vtx->index = pmix_pointer_array_add(&myvertices, vtx);
+            /* add the NIC to the node */
+            PMIX_RETAIN(vtx);
+            pmix_pointer_array_add(&node->nics, vtx);
+            /* look for this switch in our groups */
+            for (p=0; p < mygroups.size; p++) {
+                if (NULL != (grp = (pnet_fabricgroup_t*)pmix_pointer_array_get_item(&mygroups, p))) {
+                    if (pmix_bitmap_is_set_bit(&grp->switches, swcNum)) {
+                        /* mark that this NIC is part of this group */
+                        pmix_bitmap_set_bit(&grp->nics, vtx->index);
+                        /* record that this node is in this group */
+                        if (NULL == node->grp) {
+                            PMIX_RETAIN(grp);
+                            node->grp = grp;
+                            pmix_argv_append_nosize(&grp->members, node->name);
+                        }
+                        /* record a coordinate for this NIC */
+                        /* we are done */
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /* assemble the groups and add them to the fabric object */
+    for (p=0; p < mygroups.size; p++) {
+        if (NULL != (grp = (pnet_fabricgroup_t*)pmix_pointer_array_get_item(&mygroups, p))) {
+            if (NULL == grp->members) {
+                continue;
+            }
+            grpmems = pmix_argv_join(grp->members, ',');
+            pmix_asprintf(&gmem, "%d:%s", grp->grpID, grpmems);
+            pmix_argv_append_nosize(&grps, gmem);
+            free(gmem);
+            free(grpmems);
+        }
+    }
+    if (NULL != grps) {
+        gmem = pmix_argv_join(grps, ';');
+        PMIX_INFO_CREATE(fabric->info, 1);
+        fabric->ninfo = 1;
+        PMIX_INFO_LOAD(&fabric->info[0], PMIX_FABRIC_GROUPS, gmem, PMIX_STRING);
+        free(gmem);
+    }
+
+    return PMIX_OPERATION_SUCCEEDED;
+}
+
+static void regcbfunc(long response_code,
+                      const char *effective_url,
+                      void *cbdata)
+{
+    pmix_sse_request_t *req = (pmix_sse_request_t*)cbdata;
+
+    PMIX_ACQUIRE_OBJECT(req);  // ensure the object has been updated
+
+    req->status = response_code;
+    PMIX_POST_OBJECT(req);  // ensure changes to the object are pushed into memory
+    PMIX_WAKEUP_THREAD(&req->lock);  // wakeup the waiting thread
+}
+
+/* the following function will be called whenever a data stream
+ * is received. It will receive a NULL stream when the channel
+ * has been closed
+ */
+static void ondata(const char *stream, char **result, void *userdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)userdata;
+
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    /* if the stream is NULL, then the REST server terminated the
+     * connection and there is nothing to return
+     */
+    if (NULL == stream) {
+        cb->status = PMIX_ERR_NOT_AVAILABLE;
+    } else {
+        /* parse the stream to populate the fabric object - see above
+         * parsing of the config file for an example */
+        PMIX_INFO_CREATE(cb->fabric->info, 1);
+        cb->fabric->ninfo = 1;
+        PMIX_INFO_LOAD(&cb->fabric->info[0], PMIX_FABRIC_GROUPS, "0:nodeA,nodeB;1:nodeC,nodeD", PMIX_STRING);
+    }
+
+    /* pass back the status - the results are in the fabric
+     * object whose pointer we were given */
+    cb->cbfunc.opfn(cb->status, cb->cbdata);
+    PMIX_RELEASE(cb);
+    return;
+}
+
+static pmix_status_t ask_fabric_controller(pmix_fabric_t *fabric,
+                                           const pmix_info_t directives[],
+                                           size_t ndirs,
+                                           pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_sse_request_t *req;
+    pmix_cb_t *cb;
+    pmix_status_t rc;
+
+    /* initialize the sse support - it is protected,
+     * so it doesn't matter if it was already
+     * initialized */
+    pmix_sse_common_init();
+
+    /* setup the request */
+    req = PMIX_NEW(pmix_sse_request_t);
+    req->verb = PMIX_HTTP_GET;
+    /* not sure where one gets the actual URL - this is obviously a fake one */
+    req->url = "https://10.25.24.156:8080/v1/stream/cray-logs-containers?batchsize=4&count=2&streamID=stream1";
+    req->max_retries = 10;
+    req->debug = true;
+    req->allow_insecure = true;
+    /* not sure we really want a stream - consider this a placeholder */
+    req->expected_content_type = "text/event-stream";
+    req->ssl_cert = NULL;   // replace with appropriate access certificate
+    req->ca_info = NULL;    // replace with appropriate CA certificate file
+
+    /* setup the object to return the info */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->fabric = fabric;
+    cb->cbfunc.opfn = cbfunc;
+    cb->cbdata = cbdata;
+
+    /* perform the request */
+    rc = pmix_sse_register_request(req, regcbfunc, req, ondata, cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(req);
+        return rc;
+    }
+    /* wait for registration to complete */
+    PMIX_WAIT_THREAD(&req->lock);
+    if (PMIX_SUCCESS != req->status) {
+        PMIX_RELEASE(cb);
+        return PMIX_ERROR;
+    }
+
+    return rc;
+}

--- a/src/mca/pnet/sshot/pnet_sshot.h
+++ b/src/mca/pnet/sshot/pnet_sshot.h
@@ -21,16 +21,22 @@ BEGIN_C_DECLS
 typedef struct {
     pmix_pnet_base_component_t super;
     char *configfile;
-    char *pipe;
-    bool simulate;
+    int numnodes;
+    int numdevs;
+    int ppn;
 } pmix_pnet_sshot_component_t;
 
 /* the component must be visible data for the linker to find it */
 PMIX_EXPORT extern pmix_pnet_sshot_component_t mca_pnet_sshot_component;
-extern pmix_pnet_module_t pmix_sshot_module;
+PMIX_EXPORT extern pmix_pnet_module_t pmix_sshot_module;
 
 /* define a key for any blob we need to send in a launch msg */
 #define PMIX_PNET_SSHOT_BLOB  "pmix.pnet.sshot.blob"
+
+PMIX_EXPORT pmix_status_t pmix_pnet_sshot_register_fabric(pmix_fabric_t *fabric,
+                                                          const pmix_info_t directives[],
+                                                          size_t ndirs,
+                                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 END_C_DECLS
 

--- a/src/mca/preg/raw/Makefile.am
+++ b/src/mca/preg/raw/Makefile.am
@@ -12,8 +12,6 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2017      Research Organization for Information Science
-#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,27 +19,22 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = $(pmix_check_jansson_CPPFLAGS)
-
-dist_pmixdata_DATA = help-pnet-sshot.txt
-
-headers = pnet_sshot.h
+headers = preg_raw.h
 sources = \
-        pnet_sshot_component.c \
-        pnet_sshot.c \
-        pnet_fabric.c
+        preg_raw_component.c \
+        preg_raw.c
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
 # (for static builds).
 
-if MCA_BUILD_pmix_pnet_sshot_DSO
+if MCA_BUILD_pmix_preg_raw_DSO
 lib =
 lib_sources =
-component = mca_pnet_sshot.la
+component = mca_preg_raw.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_sshot.la
+lib = libmca_preg_raw.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -49,15 +42,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_sshot_la_SOURCES = $(component_sources)
-mca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS) \
-    $(PMIX_TOP_BUILDDIR)/src/mca/common/sse/libmca_common_sse.la
-mca_pnet_sshot_la_LIBADD = -ljansson
+mca_preg_raw_la_SOURCES = $(component_sources)
+mca_preg_raw_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pnet_sshot_la_LIBADD += $(top_builddir)/src/libpmix.la
+mca_preg_raw_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_sshot_la_SOURCES = $(lib_sources)
-libmca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS)
-libmca_pnet_sshot_la_LIBADD = -ljansson
+libmca_preg_raw_la_SOURCES = $(lib_sources)
+libmca_preg_raw_la_LDFLAGS = -module -avoid-version

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#include <fcntl.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#include <ctype.h>
+
+
+#include "include/pmix_common.h"
+#include "include/pmix.h"
+
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/printf.h"
+#include "src/mca/bfrops/base/base.h"
+
+#include "src/mca/preg/base/base.h"
+#include "preg_raw.h"
+
+static pmix_status_t generate_node_regex(const char *input,
+                                         char **regex);
+static pmix_status_t generate_ppn(const char *input,
+                                  char **ppn);
+static pmix_status_t parse_nodes(const char *regexp,
+                                 char ***names);
+static pmix_status_t parse_procs(const char *regexp,
+                                 char ***procs);
+static pmix_status_t copy(char **dest, size_t *len, const char *input);
+static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
+static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+
+pmix_preg_module_t pmix_preg_raw_module = {
+    .name = "raw",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack
+};
+
+static pmix_status_t generate_node_regex(const char *input,
+                                         char **regexp)
+{
+    if (0 == strncmp(input, "raw:", 4)) {
+        *regexp = strdup(input);
+    } else {
+        pmix_asprintf(regexp, "raw:%s", input);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t generate_ppn(const char *input,
+                                  char **regexp)
+{
+    if (0 == strncmp(input, "raw:", 4)) {
+        *regexp = strdup(input);
+    } else {
+        pmix_asprintf(regexp, "raw:%s", input);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t parse_nodes(const char *regexp,
+                                 char ***names)
+{
+    if (0 != strncmp(regexp, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *names = pmix_argv_split(&regexp[4], ',');
+    return PMIX_SUCCESS;
+
+}
+static pmix_status_t parse_procs(const char *regexp,
+                                 char ***procs)
+{
+    if (0 != strncmp(regexp, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *procs = pmix_argv_split(&regexp[4], ';');
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t copy(char **dest, size_t *len, const char *input)
+{
+    if (0 != strncmp(input, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *dest = strdup(input);
+    *len = strlen(input) + 1;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t pack(pmix_buffer_t *buffer, const char *input)
+{
+    size_t slen;
+    char *ptr;
+
+    if (0 != strncmp(input, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    /* extract the size */
+    slen = strlen(input) + 1;  // retain the NULL terminator
+
+    /* ensure the buffer has enough space */
+    ptr = pmix_bfrop_buffer_extend(buffer, slen);
+    if (NULL == ptr) {
+        return PMIX_ERR_NOMEM;
+    }
+
+    /* xfer the data */
+    memcpy(ptr, input, slen);
+    buffer->bytes_used += slen;
+    buffer->pack_ptr += slen;
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex)
+{
+    char *ptr;
+
+    ptr = buffer->unpack_ptr;
+
+    if (0 != strncmp(ptr, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *regex = strdup(ptr);
+    buffer->unpack_ptr += strlen(ptr) + 1;
+
+    if (NULL == *regex) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}

--- a/src/mca/preg/raw/preg_raw.h
+++ b/src/mca/preg/raw/preg_raw.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PREG_RAW_H
+#define PMIX_PREG_RAW_H
+
+#include "src/include/pmix_config.h"
+
+
+#include "src/mca/preg/preg.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_mca_base_component_t mca_preg_raw_component;
+extern pmix_preg_module_t pmix_preg_raw_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/preg/raw/preg_raw_component.c
+++ b/src/mca/preg/raw/preg_raw_component.c
@@ -1,0 +1,78 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+
+#include "src/mca/preg/preg.h"
+#include "preg_raw.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_mca_base_component_t mca_preg_raw_component = {
+    PMIX_PREG_BASE_VERSION_1_0_0,
+
+    /* Component name and version */
+    .pmix_mca_component_name = "raw",
+    PMIX_MCA_BASE_MAKE_VERSION(component,
+                               PMIX_MAJOR_VERSION,
+                               PMIX_MINOR_VERSION,
+                               PMIX_RELEASE_VERSION),
+
+    /* Component open and close functions */
+    .pmix_mca_open_component = component_open,
+    .pmix_mca_close_component = component_close,
+    .pmix_mca_query_component = component_query,
+};
+
+
+static int component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+
+static int component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 40;
+    *module = (pmix_mca_base_module_t *)&pmix_preg_raw_module;
+    return PMIX_SUCCESS;
+}
+
+
+static int component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -317,6 +317,9 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars,
                 /* see if we already have this envar on the list */
                 duplicate = false;
                 PMIX_LIST_FOREACH(kv, ilist, pmix_kval_t) {
+                    if (PMIX_ENVAR != kv->value->type) {
+                        continue;
+                    }
                     if (0 == strcmp(kv->value->data.envar.envar, cs_env)) {
                         /* if the value is the same, then ignore it */
                         if (0 != strcmp(kv->value->data.envar.value, string_key)) {

--- a/test/sshot/Makefile.am
+++ b/test/sshot/Makefile.am
@@ -10,7 +10,7 @@
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix $(pmix_check_jansson_CPPFLAGS)
 
 if HAVE_JANSSON
-noinst_PROGRAMS = generate server daemon
+noinst_PROGRAMS = generate server daemon testcoord
 
 generate_SOURCES = \
         generate.c
@@ -26,5 +26,11 @@ daemon_SOURCES = \
         daemon.c
 daemon_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 daemon_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+testcoord_SOURCES = \
+        testcoord.c
+testcoord_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+testcoord_LDADD = \
     $(top_builddir)/src/libpmix.la
 endif

--- a/test/sshot/testcoord.c
+++ b/test/sshot/testcoord.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+#include <getopt.h>
+
+#include <pmix_server.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
+
+typedef struct {
+    mylock_t lock;
+    pmix_status_t status;
+    pmix_info_t *info;
+    size_t ninfo;
+} mycaddy_t;
+
+static void local_cbfunc(pmix_status_t status, void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void setup_cbfunc(pmix_status_t status,
+                         pmix_info_t info[], size_t ninfo,
+                         void *provided_cbdata,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    mycaddy_t *mq = (mycaddy_t*)provided_cbdata;
+    size_t n;
+
+    /* transfer it to the caddy for return to the main thread */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(mq->info, ninfo);
+        mq->ninfo = ninfo;
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&mq->info[n], &info[n]);
+        }
+    }
+
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+
+    DEBUG_WAKEUP_THREAD(&mq->lock);
+}
+
+static int help = 0;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    mycaddy_t cd;
+    mylock_t lock;
+    pmix_proc_t proc;
+    int tclass;
+    pmix_value_t *val;
+    pmix_geometry_t *geos;
+    size_t ngeos, n, m;
+    char *tmp;
+    pmix_info_t info[2];
+    static struct option myoptions[] = {
+        {"num_nodes", required_argument, NULL, 'n'},
+        {"num_devs", required_argument, NULL, 'd'},
+        {"ppn", required_argument, NULL, 'p'},
+        {"help", no_argument, &help, 1},
+        {0, 0, 0, 0}
+    };
+    int option_index;
+    int opt;
+    int nnodes = 2;
+    int ndevs = 8;
+    int ppn = 4;
+
+    while ((opt = getopt_long(argc, argv, "n:d:p:",
+                              myoptions, &option_index)) != -1) {
+        switch (opt) {
+            case 'n':
+                nnodes = strtol(optarg, NULL, 10);
+                break;
+            case 'd':
+                ndevs = strtol(optarg, NULL, 10);
+                break;
+            case 'p':
+                ppn = strtol(optarg, NULL, 10);
+                break;
+            default:
+                fprintf(stderr, "Usage: %s\n    Options:\n"
+                        "        [-n] [number of nodes]\n"
+                        "        [-d] [number of devices/node]\n"
+                        "        [-p] [number of procs/node]\n", argv[0]);
+                exit(1);
+        }
+    }
+    if (help) {
+        fprintf(stderr, "Usage: %s\n    Options:\n"
+                "        [-n] [number of nodes]\n"
+                "        [-d] [number of devices/node]\n"
+                "        [-p] [number of procs/node]\n", argv[0]);
+        exit(0);
+    }
+
+    pmix_asprintf(&tmp, "PMIX_MCA_pnet_sshot_num_nodes=%d", nnodes);
+    putenv(tmp);
+    pmix_asprintf(&tmp, "PMIX_MCA_pnet_sshot_devs_per_node=%d", ndevs);
+    putenv(tmp);
+    pmix_asprintf(&tmp, "PMIX_MCA_pnet_sshot_ppn=%d", ppn);
+    putenv(tmp);
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(NULL, NULL, 0))) {
+        pmix_output(0, "Server init failed: %s", PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "Server running");
+
+    DEBUG_CONSTRUCT_LOCK(&cd.lock);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_application("SIMPSCHED", NULL, 0,
+                                                             setup_cbfunc, &cd))) {
+        pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__, PMIx_Error_string(rc));
+        DEBUG_DESTRUCT_LOCK(&cd.lock);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&cd.lock);
+    DEBUG_DESTRUCT_LOCK(&cd.lock);
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support("SIMPSCHED", cd.info, cd.ninfo,
+                                                              local_cbfunc, &lock))) {
+        pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__, PMIx_Error_string(rc));
+        DEBUG_DESTRUCT_LOCK(&lock);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&lock);
+    DEBUG_DESTRUCT_LOCK(&lock);
+
+    /* check a few things */
+    PMIX_LOAD_PROCID(&proc, "SIMPSCHED", PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, "HPE_TRAFFIC_CLASS", NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "[%s:%d] Get of traffic class failed: %s", __FILE__, __LINE__, PMIx_Error_string(rc));
+    }
+    PMIX_VALUE_GET_NUMBER(rc, val, tclass, int);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "[%s:%d] Get of traffic class returned non-number", __FILE__, __LINE__);
+    }
+    pmix_output(0, "[%s:%d] Got traffic class %d", __FILE__, __LINE__, tclass);
+    PMIX_VALUE_RELEASE(val);
+
+    /* the test nodes are "nid000000" and "nid000001" */
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, "nid000000", PMIX_STRING);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val)) ||
+        NULL == val) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get fabric coordinate failed: %s",
+                    proc.nspace, proc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_DATA_ARRAY == val->type) {
+        geos = (pmix_geometry_t*)val->data.darray->array;
+        ngeos = val->data.darray->size;
+        /* print them out for diagnostics - someday we can figure
+         * out an automated way of testing the answer */
+        for (m=0; m < ngeos; m++) {
+            char **foo = NULL;
+            char *view;
+            pmix_output(0, "Device[%d]: %s Osname: %s", (int)m, geos[m].uuid, geos[m].osname);
+            for (n=0; n < geos[m].coordinates[0].dims; n++) {
+                asprintf(&tmp, "%d", geos[m].coordinates[0].coord[n]);
+                pmix_argv_append_nosize(&foo, tmp);
+                free(tmp);
+            }
+            tmp = pmix_argv_join(foo, ',');
+            pmix_argv_free(foo);
+            if (PMIX_COORD_LOGICAL_VIEW == geos[m].coordinates[0].view) {
+                view = "LOGICAL";
+            } else {
+                view = "PHYSICAL";
+            }
+            pmix_output(0, "\tCOORD VIEW %s: %s", view, tmp);
+            free(tmp);
+        }
+    } else {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get fabric coordinate returned wrong type: %s",
+                    proc.nspace, proc.rank, PMIx_Data_type_string(val->type));
+    }
+
+ done:
+    /* finalize us */
+    pmix_output(0, "Server finalizing");
+    if (PMIX_SUCCESS != (rc = PMIx_server_finalize())) {
+        fprintf(stderr, "Server finalize failed: %s\n", PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Server finalize successfully completed\n");
+    }
+    fflush(stderr);
+    return(rc);
+}


### PR DESCRIPTION
Cleanup checks for curl and jansson support. Ensure they properly get
included in the common/sse component and cleanup a few errors there.
Extend the pcompress framework to compress blocks of data instead of
just strings. Allow the pnet/sshot component to build when curl and
jansson support is available and the user specifically requests it to be
built by adding --with-slingshot. Extend the regex support to include
the "raw" option. Add PMIX_COMPRESSED_BYTE_OBJECT data type.

Signed-off-by: Ralph Castain <rhc@pmix.org>