### PR TITLE
VERSION/NEWS: Prepare for v3.2.1rc1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,8 +24,16 @@ Master (not on release branches yet)
 ------------------------------------
 
 
-3.2.1 -- TBD
+3.2.2 -- TBD
 ----------------------
+
+
+3.2.1 -- 5 Nov 2020
+----------------------
+ - PR #1890:
+   - Fix Issue #1889: Fix symlinks in unit tests to include new timeout
+   - Fix Issue #1891: Remove pnet/opa component that should not be in v3.2
+ - PR #1904: Add more metadata to string generated from preg/compress
 
 
 3.2.0 -- 22 Oct 2020

--- a/VERSION
+++ b/VERSION
@@ -4,6 +4,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
 
 # This is the VERSION file for PMIx, describing the precise
 # version of PMIx in this distribution.  The various components of
@@ -23,7 +24,7 @@ release=1
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -44,7 +45,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Oct 22, 2020"
+date="Oct 30, 2020"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library


### PR DESCRIPTION
 * `.so` version already incremented in PR #1890 so no need to do so here