### PR TITLE
Sometimes we just need any version of Python

### DIFF
--- a/.github/actions/mlnx/Dockerfile
+++ b/.github/actions/mlnx/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810
 RUN \
     yum install -y epel-release; \
     yum install -y perl perl-Data-Dumper \
-        automake libtool flex make bzip2 git which rpm-build libevent-devel pandoc python3
+        automake libtool flex make bzip2 git which rpm-build libevent-devel pandoc
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1233,14 +1233,6 @@ AM_CONDITIONAL([WANT_PYTHON_BINDINGS], [test $WANT_PYTHON_BINDINGS -eq 1])
 
 AM_PATH_PYTHON([3.4], [pmix_python_good=yes], [pmix_python_good=no])
 
-# If we didn't find a good python and we don't have dictionary.h, then
-# give up.  I.e., we require developers (i.e., those building from git
-# clones) to have Python >=v3.4.
-AS_IF([test "$PYTHON" = ":" && test ! -f $srcdir/include/dictionary.h],
-      [AC_MSG_WARN([Could not find a modern enough Python])
-       AC_MSG_WARN([Developer builds (e.g., git clones) of OpenPMIx must have Python >=v3.4 available])
-       AC_MSG_ERROR([Cannot continue])])
-
 if test "$WANT_PYTHON_BINDINGS" = "1"; then
     if test "$pmix_python_good" = "no"; then
         AC_MSG_WARN([Python bindings were enabled, but no suitable])
@@ -1283,6 +1275,21 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
     pmix_pythondir=`eval echo $pythondir`
     AC_SUBST([PMIX_PYTHON_EGG_PATH], [$pmix_pythondir], [Path to installed Python egg])
 fi
+
+# If we didn't find a good Python and we don't have dictionary.h, then
+# see if we can find an older Python (because construct_dictionary.py
+# can use an older Python).
+AS_IF([test "$PYTHON" = ":" && test ! -f $srcdir/include/dictionary.h],
+      [PYTHON=
+       AM_PATH_PYTHON
+       # If we still can't find Python (and we don't have
+       # dictionary.h), then give up.
+       AS_IF([test "$PYTHON" = ":"],
+             [AC_MSG_WARN([Could not find a modern enough Python])
+              AC_MSG_WARN([Developer builds (e.g., git clones) of OpenPMIx must have Python available])
+              AC_MSG_ERROR([Cannot continue])
+             ])
+       ])
 
 # see if they want to disable non-RTLD_GLOBAL dlopen
 AC_MSG_CHECKING([if want to support dlopen of non-global namespaces])


### PR DESCRIPTION
We just need Python in some cases (e.g., developer git clones where we
don't have directory.h).  If you have Python, it's probably modern
enough.  So roll back the Mellanox CI that updates to Python 3, and
let's make sure that even older Python works fine.
    
To be clear: if you're building the Python bindings, you still need
Python >= v3.4 -- that requirement has not changed.  This commit is
more about when you're *not* building the Python bindings.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>