### PR TITLE
More fixes to dist / construct_dictionary

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,6 +98,4 @@ if WANT_INSTALL_HEADERS
 nobase_pmix_HEADERS += $(headers)
 endif
 
-MAINTAINERCLEANFILES = Makefile.in config.h config.h.in
-DISTCLEANFILES = Makefile
 CLEANFILES = core.* *~

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -52,10 +52,12 @@ headers += \
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
-nobase_nodist_pmix_HEADERS = \
-    pmix_config.h
+nobase_pmix_HEADERS = $(headers)
+nobase_nodist_pmix_HEADERS = $(nodist_headers)
 endif
 
+# Need to ensure that dictionary.h is built first -- before any other
+# targets.
 BUILT_SOURCES = dictionary.h
 
 dictionary.h: $(top_srcdir)/include/pmix_common.h.in


### PR DESCRIPTION
Tested with:

```
git clean -dfx ; \
./autogen.pl && \
./configure --prefix=$bogus --with-libevent=$libevent --with-hwloc=$hwloc |& tee config.out && \
make distcheck DISTCHECK_MAKE_FLAGS=-j32 AM_MAKEFLAGS=-j32 AM_DISTCHECK_CONFIGURE_FLAGS="--with-libevent=$libevent --with-hwloc=$hwloc"|& tee distcheck.out
```