### PR TITLE
configury: fix getdate.sh woes

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = \
 	c_get_alignment.m4 \
 	pmix_get_version.sh \
 	distscript.sh \
+	getdate.sh \
 	md2nroff.pl \
 	pmix_check_attributes.m4 \
 	pmix_check_broken_qsort.m4 \

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -96,7 +96,7 @@ EOF
 
 PMIX_CONFIGURE_USER="${USER:-`whoami`}"
 PMIX_CONFIGURE_HOST="${HOSTNAME:-`(hostname || uname -n) 2> /dev/null | sed 1q`}"
-PMIX_CONFIGURE_DATE="`$srcdir/config/getdate.sh`"
+PMIX_CONFIGURE_DATE="`$top_srcdir/config/getdate.sh`"
 
 
 AC_SUBST([SOURCE_DATE_EPOCH])

--- a/configure.ac
+++ b/configure.ac
@@ -76,9 +76,9 @@ AC_SUBST(PMIX_TOP_BUILDDIR)
 top_buildir=`pwd`
 cd "$srcdir"
 PMIX_TOP_SRCDIR="`pwd`"
+top_srcdir=$PMIX_TOP_SRCDIR
 AC_SUBST(PMIX_TOP_SRCDIR)
 cd "$PMIX_TOP_BUILDDIR"
-top_srcdir=`pwd`
 
 AC_MSG_NOTICE([builddir: $PMIX_TOP_BUILDDIR])
 AC_MSG_NOTICE([srcdir: $PMIX_TOP_SRCDIR])


### PR DESCRIPTION
- Ensure getdate.sh is included in the dist tarball
- Ensure $top_srcdir is set properly
- Use $top_srcdir to find getdate.sh, not $srcdir

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Thanks to @tonycurtis for the heads up.  Refs https://github.com/open-mpi/ompi/issues/8182. 