### PR TITLE
Correctly enable new tool-server APIs

### DIFF
--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -52,6 +52,10 @@ def harvest_constants(options, path, constants):
                 continue
             if value.startswith("PMIX_HAVE_VISIB"):
                 continue
+            if value.startswith("PMIX_LAUNCHER_RNDZ_FILE"):
+                continue
+            if value.startswith("PMIX_LAUNCHER_RNDZ_URI"):
+                continue
             tokens = value.split()
             if len(tokens) >= 2:
                 if tokens[1][0] == '"':

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -117,19 +117,14 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_APP_WILDCARD  UINT32_MAX
 
 /****  PMIX ENVIRONMENTAL PARAMETERS  ****/
-/* There are a few environmental parameters used by PMIx for
- * various operations. While there is no "definition" of them
- * as values, we do record them here for informational purposes.
- *
- * PMIX_LAUNCHER_PAUSE_FOR_TOOL - if set to non-zero value, instructs
- * launchers (e.g., "prun") to stop prior to spawning the application until
- * a tool can connect with further instructions. This envar will be
- * set by the tool and is _not_ intended for the direct use of users.
- *
- * PMIX_LAUNCHER_RENDEZVOUS_FILE - if set, contains the full pathname
+/* URI of tool waiting for launcher to rendezvous back to it */
+#define PMIX_LAUNCHER_RNDZ_URI "PMIX_LAUNCHER_RNDZ_URI"
+
+/* PMIX_LAUNCHER_RNDZ_FILE - if set, contains the full pathname
  * of a file the launcher is to write that contains its connection info.
  * Works in addition to anything else the launcher may output.
  */
+#define PMIX_LAUNCHER_RNDZ_FILE "PMIX_LAUNCHER_RNDZ_FILE"
 
 /* define a set of "standard" PMIx attributes that can
  * be queried. Implementations (and users) are free to extend as
@@ -370,6 +365,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        access the published data
 #define PMIX_ACCESS_GRPIDS                  "pmix.agids"            // (pmix_data_array_t*) Array of effective GIDs that are allowed to
                                                                     //        access the published data
+#define PMIX_WAIT_FOR_CONNECTION            "pmix.wait.conn"        // (bool) wait until the specified connection has been made
+
 
 /* attributes used by host server to pass data to/from the server convenience library - the
  * data will then be parsed and provided to the local clients. Not generally accessible by users */
@@ -1463,6 +1460,8 @@ static inline void* pmix_calloc(size_t n, size_t m)
 #define PMIX_CHECK_PROCID(a, b) \
     (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
 
+#define PMIX_CHECK_RANK(a, b) \
+    ((a) == (b) || (PMIX_RANK_WILDCARD == (a) || PMIX_RANK_WILDCARD == (b)))
 
 /****    PMIX COORD    ****/
 /* define coordinate system views */

--- a/include/pmix_tool.h
+++ b/include/pmix_tool.h
@@ -140,7 +140,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc, pmix_p
  *
  * Returns PMIX_SUCCESS or a PMIx error constant
  */
-PMIX_EXPORT pmix_status_t PMIx_tool_disconnect(pmix_proc_t *server);
+PMIX_EXPORT pmix_status_t PMIx_tool_disconnect(const pmix_proc_t *server);
 
 
 /* Get an array containing the pmix_proc_t process identifiers of all
@@ -163,7 +163,8 @@ PMIX_EXPORT pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *
  *
  * Returns PMIX_SUCCESS or a PMIx error constant
  */
-PMIX_EXPORT pmix_status_t PMIx_tool_set_server(pmix_proc_t *server);
+PMIX_EXPORT pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
+                                               pmix_info_t info[], size_t ninfo);
 
 
 /* Define a callback function for delivering forwarded IO to a process

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -135,7 +135,6 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     bool forkexec = false;
     pmix_kval_t *kv;
     pmix_list_t ilist;
-    pmix_nspace_t nspace;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -228,11 +227,8 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
      * the specified application */
     if (forkexec) {
         rc = pmix_pfexec.spawn_job(job_info, ninfo,
-                                   apps, napps, nspace);
-        cb = (pmix_cb_t*)cbdata;
-        if (PMIX_OPERATION_SUCCEEDED == rc) {
-            cb->pname.nspace = strdup(nspace);
-        }
+                                   apps, napps,
+                                   cbfunc, cbdata);
         return rc;
     }
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -68,6 +68,10 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namelist_t,
                                 pmix_list_item_t,
                                 NULL, NULL);
 
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_proclist_t,
+                                pmix_list_item_t,
+                                NULL, NULL);
+
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_topo_obj_t,
                                 pmix_object_t,
                                 NULL, NULL);
@@ -265,6 +269,7 @@ static void scon(pmix_shift_caddy_t *p)
     PMIX_CONSTRUCT_LOCK(&p->lock);
     p->codes = NULL;
     p->ncodes = 0;
+    p->peer = NULL;
     p->pname.nspace = NULL;
     p->pname.rank = PMIX_RANK_UNDEF;
     p->data = NULL;
@@ -288,6 +293,9 @@ static void scon(pmix_shift_caddy_t *p)
 static void scdes(pmix_shift_caddy_t *p)
 {
     PMIX_DESTRUCT_LOCK(&p->lock);
+    if (NULL != p->peer) {
+        PMIX_RELEASE(p->peer);
+    }
     if (NULL != p->pname.nspace) {
         free(p->pname.nspace);
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -257,6 +257,11 @@ typedef struct {
 } pmix_querylist_t;
 PMIX_CLASS_DECLARATION(pmix_querylist_t);
 
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t proc;
+} pmix_proclist_t;
+PMIX_CLASS_DECLARATION(pmix_proclist_t);
 
 /* object for tracking peers - each peer can have multiple
  * connections. This can occur if the initial app executes
@@ -388,6 +393,7 @@ PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
     pmix_status_t *codes;
     size_t ncodes;
     pmix_name_t pname;
+    pmix_peer_t *peer;
     const char *data;
     size_t ndata;
     const char *key;
@@ -467,6 +473,7 @@ PMIX_CLASS_DECLARATION(pmix_cb_t);
     pmix_event_evtimer_set(pmix_globals.evbase, &(r)->ev,   \
                                (c), (r));                   \
     _tv.tv_sec = (t);                                       \
+    _tv.tv_usec = ((t) - _tv.tv_sec) * 1000000.0;           \
     PMIX_POST_OBJECT((r));                                  \
     pmix_event_evtimer_add(&(r)->ev, &_tv);                 \
 } while (0)

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -247,7 +247,6 @@ PMIX_CLASS_INSTANCE(pmix_pfexec_child_t,
 
 static void fccon(pmix_pfexec_fork_caddy_t *p)
 {
-    PMIX_LOAD_NSPACE(p->nspace, NULL);
     p->jobinfo = NULL;
     p->njinfo = 0;
     p->apps = NULL;

--- a/src/mca/pfexec/pfexec.h
+++ b/src/mca/pfexec/pfexec.h
@@ -46,7 +46,7 @@ BEGIN_C_DECLS
  */
 typedef pmix_status_t (*pmix_pfexec_base_module_spawn_job_fn_t)(const pmix_info_t job_info[], size_t ninfo,
                                                                 const pmix_app_t apps[], size_t napps,
-                                                                pmix_nspace_t nspace);
+                                                                pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 
 /**
  * Kill the local process we started

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -91,8 +91,8 @@ static pmix_status_t setup_listeners(pmix_info_t *info, size_t ninfo, bool *need
             if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_AVAILABLE != rc) {
                 return rc;
             }
-            if (single) {
-                return PMIX_SUCCESS;
+            if (PMIX_SUCCESS == rc && single) {
+                break;
             }
         }
     }

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -127,6 +127,11 @@ typedef pmix_status_t (*pmix_ptl_connect_to_peer_fn_t)(struct pmix_peer_t *peer,
                                                        pmix_info_t info[], size_t ninfo);
 
 
+/* check for peer connection */
+typedef pmix_status_t (*pmix_ptl_check_peer_connection_fn_t)(const pmix_proc_t *proc,
+                                                             const pmix_info_t directives[], size_t ndirs,
+                                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+
 /* query available servers on the local node */
 typedef void (*pmix_ptl_query_servers_fn_t)(char *dirname, pmix_list_t *servers);
 
@@ -142,6 +147,7 @@ struct pmix_ptl_module_t {
     pmix_ptl_recv_fn_t                  recv;
     pmix_ptl_cancel_fn_t                cancel;
     pmix_ptl_connect_to_peer_fn_t       connect_to_peer;
+    pmix_ptl_check_peer_connection_fn_t check_connection;
     pmix_ptl_query_servers_fn_t         query_servers;
 };
 typedef struct pmix_ptl_module_t pmix_ptl_module_t;
@@ -171,6 +177,9 @@ typedef struct pmix_ptl_module_t pmix_ptl_module_t;
 
 #define PMIX_PTL_CANCEL(r, p, t)                        \
     (r) = (p)->nptr->compat.ptl->cancel((struct pmix_peer_t*)(p), t)
+
+#define PMIX_PTL_CHECK_CONNECTION(r, p, d, nd, cf, cd)         \
+    (r) = pmix_globals.mypeer->nptr->compat.ptl->check_connection((p), (d), (nd), (cf), (cd))
 
 PMIX_EXPORT extern pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t* peer,
                                                                pmix_info_t info[], size_t ninfo);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -76,17 +76,6 @@
 static pmix_event_t stdinsig;
 static pmix_iof_read_event_t stdinev;
 
-typedef struct {
-    pmix_list_item_t super;
-    pmix_proc_t server;
-    pmix_peer_t *peer;
-} pmix_myservers_t;
-static PMIX_CLASS_INSTANCE(pmix_myservers_t,
-                           pmix_list_item_t,
-                           NULL, NULL);
-
-static pmix_list_t myservers;
-
 static void _notify_complete(pmix_status_t status, void *cbdata)
 {
     pmix_event_chain_t *chain = (pmix_event_chain_t*)cbdata;
@@ -375,7 +364,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_buffer_t *req;
     pmix_cmd_t cmd = PMIX_REQ_CMD;
     pmix_iof_req_t *iofreq;
-    pmix_myservers_t *ps;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -394,7 +382,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_SUCCESS;
     }
-    PMIX_CONSTRUCT(&myservers, pmix_list_t);
 
     /* parse the input directives */
     gdsfound = false;
@@ -630,8 +617,16 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     } else {
         pmix_globals.mypeer->nptr->compat.type = PMIX_BFROP_BUFFER_NON_DESC;
     }
+
+    /* set the ptl component */
+    pmix_globals.mypeer->nptr->compat.ptl = pmix_ptl_base_assign_module();
+    if (NULL == pmix_globals.mypeer->nptr->compat.ptl) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return rc;
+    }
     /* the server will be using the same */
-    pmix_client_globals.myserver->nptr->compat.type = pmix_globals.mypeer->nptr->compat.type;
+    pmix_client_globals.myserver->nptr->compat.ptl = pmix_globals.mypeer->nptr->compat.ptl;
 
     /* select a GDS module for our own internal use - the user may
      * have passed down a directive for this purpose. If they did, then
@@ -685,24 +680,26 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     if (do_not_connect) {
         /* ensure we mark that we are not connected */
         pmix_globals.connected = false;
-        /* it is an error if we were not given an nspace/rank */
+        /* if we were not given an nspace/rank, set something */
         if (!nspace_given || !rank_given) {
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            goto regattr;
+            /* self-assign a namespace and rank for ourselves. Use our hostname:pid
+             * for the nspace, and rank clearly is 0 */
+            snprintf(pmix_globals.myid.nspace, PMIX_MAX_NSLEN-1, "%s:%lu", pmix_globals.hostname, (unsigned long)pmix_globals.pid);
+            pmix_globals.myid.rank = 0;
+            nspace_given = false;
+            rank_given = false;
+            /* also setup the client myserver to point to ourselves */
+            pmix_client_globals.myserver->nptr->nspace = strdup(pmix_globals.myid.nspace);
+            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+            pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+            pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
+            pmix_client_globals.myserver->info->uid = pmix_globals.uid;
+            pmix_client_globals.myserver->info->gid = pmix_globals.gid;
         }
     } else {
         /* connect to the server */
         rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
-        if (PMIX_SUCCESS == rc) {
-            /* record that we connected to it */
-            ps = PMIX_NEW(pmix_myservers_t);
-            PMIX_RETAIN(pmix_client_globals.myserver);
-            ps->peer = pmix_client_globals.myserver;
-            PMIX_LOAD_PROCID(&ps->server,
-                             pmix_client_globals.myserver->info->pname.nspace,
-                             pmix_client_globals.myserver->info->pname.rank);
-            pmix_list_append(&myservers, &ps->super);
-        } else {
+        if (PMIX_SUCCESS != rc) {
             /* if connection wasn't optional, then error out */
             if (!connect_optional) {
                 PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -739,7 +736,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
     pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
     pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
-    /* if we are acting as a server, then start listening */
+    /* if we are acting as a server, then setup the global recv */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* setup the wildcard recv for inbound messages from clients */
         rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
@@ -848,7 +845,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
      * job info - we do this as a non-blocking
      * transaction because some systems cannot handle very large
      * blocking operations and error out if we try them. */
-    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
+    if (!do_not_connect && PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
          req = PMIX_NEW(pmix_buffer_t);
          PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
                           req, &cmd, 1, PMIX_COMMAND);
@@ -954,7 +951,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         }
     }
 
-  regattr:
     /* register the tool supported attrs */
     rc = pmix_register_tool_attrs();
     return rc;
@@ -1473,14 +1469,114 @@ pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
     return rc;
 }
 
+static void retry_attach(int sd, short args, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    pmix_event_base_t *evbase_save;
+    pmix_kval_t *kptr;
+    pmix_peer_t *peer;
+    size_t n;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    /* check for directives */
+    cb->checked = false;
+    for (n=0; n < cb->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&cb->info[n], PMIX_PRIMARY_SERVER)) {
+            cb->checked = PMIX_INFO_TRUE(&cb->info[n]);
+            break;
+        }
+    }
+
+    /* we are in an event, so the current event base can't
+     * move anywhere - save the current event base */
+    evbase_save = pmix_globals.evbase;
+
+    /* create a new progress thread so it can do some work for us */
+    pmix_globals.evbase = pmix_progress_thread_init("reconnect");
+    pmix_progress_thread_start("reconnect");
+
+    /* now ask the ptl to establish connection to the new server */
+    peer = PMIX_NEW(pmix_peer_t);
+    cb->status = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)peer, cb->info, cb->ninfo);
+
+    /* once that activity has all completed, stop the new progress thread */
+    pmix_progress_thread_stop("reconnect");
+    pmix_progress_thread_finalize("reconnect");
+    /* restore the original progress thread */
+    pmix_globals.evbase = evbase_save;
+
+    if (PMIX_SUCCESS == cb->status) {
+        /* return the name */
+        cb->pname.nspace = strdup(peer->info->pname.nspace);
+        cb->pname.rank = peer->info->pname.rank;
+
+        if (cb->checked) {
+            /* point our active server at this new one */
+            pmix_client_globals.myserver = peer;
+            /* update our active server's ID in the local key-value store */
+            if (NULL != peer->info &&
+                NULL != peer->info->pname.nspace) {
+                kptr = PMIX_NEW(pmix_kval_t);
+                kptr->key = strdup(PMIX_SERVER_NSPACE);
+                PMIX_VALUE_CREATE(kptr->value, 1);
+                kptr->value->type = PMIX_STRING;
+                kptr->value->data.string = strdup(peer->info->pname.nspace);
+                PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                                  &pmix_globals.myid,
+                                  PMIX_INTERNAL, kptr);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                }
+                PMIX_RELEASE(kptr); // maintain accounting
+                kptr = PMIX_NEW(pmix_kval_t);
+                kptr->key = strdup(PMIX_SERVER_RANK);
+                PMIX_VALUE_CREATE(kptr->value, 1);
+                kptr->value->type = PMIX_PROC_RANK;
+                kptr->value->data.rank = peer->info->pname.rank;
+                PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                                  &pmix_globals.myid,
+                                  PMIX_INTERNAL, kptr);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                }
+                PMIX_RELEASE(kptr); // maintain accounting
+            }
+        }
+
+        /* setup the communication events for the new server */
+        pmix_event_assign(&peer->recv_event,
+                          pmix_globals.evbase,
+                          peer->sd,
+                          EV_READ | EV_PERSIST,
+                          pmix_ptl_base_recv_handler, peer);
+        peer->recv_ev_active = true;
+        pmix_event_add(&peer->recv_event, 0);
+
+        /* setup send event */
+        pmix_event_assign(&peer->send_event,
+                          pmix_globals.evbase,
+                          peer->sd,
+                          EV_WRITE|EV_PERSIST,
+                          pmix_ptl_base_send_handler, peer);
+        peer->send_ev_active = false;
+
+        PMIX_POST_OBJECT(peer);
+    } else {
+        PMIX_RELEASE(peer);
+    }
+
+    PMIX_WAKEUP_THREAD(&cb->lock);
+    PMIX_POST_OBJECT(cb);
+    return;
+}
+
 pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc, pmix_proc_t *server,
                                          pmix_info_t info[], size_t ninfo)
 {
     pmix_status_t rc;
-    pmix_event_base_t *evbase_save;
-    pmix_kval_t *kptr;
-    pmix_myservers_t *ps;
-    pmix_peer_t *peer;
+    pmix_cb_t *cb;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -1495,56 +1591,13 @@ pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc, pmix_proc_t *serve
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* stop the existing progress thread */
-    (void)pmix_progress_thread_pause(NULL);
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->info = info;
+    cb->ninfo = ninfo;
+    PMIX_THREADSHIFT(cb, retry_attach);
 
-    /* save that event base */
-    evbase_save = pmix_globals.evbase;
-
-    /* create a new progress thread */
-    pmix_globals.evbase = pmix_progress_thread_init("reconnect");
-    pmix_progress_thread_start("reconnect");
-
-    /* now ask the ptl to establish connection to the new server */
-    peer = PMIX_NEW(pmix_peer_t);
-    rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)peer, info, ninfo);
-
-    /* once that activity has all completed, then stop the new progress thread */
-    pmix_progress_thread_stop("reconnect");
-    pmix_progress_thread_finalize("reconnect");
-
-    if (PMIX_SUCCESS == rc) {
-        /* track that we are connected to this new server */
-        ps = PMIX_NEW(pmix_myservers_t);
-        ps->peer = peer;
-        PMIX_LOAD_PROCID(&ps->server, peer->info->pname.nspace, peer->info->pname.rank);
-        pmix_list_append(&myservers, &ps->super);
-
-        /* point our active server at this new one */
-        pmix_client_globals.myserver = peer;
-    }
-
-    /* restore the original progress thread */
-    pmix_globals.evbase = evbase_save;
-    /* setup the communication events for the new server */
-    pmix_event_assign(&pmix_client_globals.myserver->recv_event,
-                      pmix_globals.evbase,
-                      pmix_client_globals.myserver->sd,
-                      EV_READ | EV_PERSIST,
-                      pmix_ptl_base_recv_handler, pmix_client_globals.myserver);
-    pmix_client_globals.myserver->recv_ev_active = true;
-    PMIX_POST_OBJECT(pmix_client_globals.myserver);
-    pmix_event_add(&pmix_client_globals.myserver->recv_event, 0);
-
-    /* setup send event */
-    pmix_event_assign(&pmix_client_globals.myserver->send_event,
-                      pmix_globals.evbase,
-                      pmix_client_globals.myserver->sd,
-                      EV_WRITE|EV_PERSIST,
-                      pmix_ptl_base_send_handler, pmix_client_globals.myserver);
-    pmix_client_globals.myserver->send_ev_active = false;
-    /* resume processing events */
-    pmix_progress_thread_resume(NULL);
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
 
     /* if they gave us an address, we pass back our name */
     if (NULL != myproc) {
@@ -1558,61 +1611,36 @@ pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc, pmix_proc_t *serve
 
     /* if they gave us an address, return the new server's ID */
     if (NULL != server) {
-        PMIX_LOAD_PROCID(server, pmix_client_globals.myserver->info->pname.nspace,
-                         pmix_client_globals.myserver->info->pname.rank);
-    }
-
-    /* update our active server's ID in the local key-value store */
-    if (NULL != pmix_client_globals.myserver &&
-        NULL != pmix_client_globals.myserver->info &&
-        NULL != pmix_client_globals.myserver->info->pname.nspace) {
-        kptr = PMIX_NEW(pmix_kval_t);
-        kptr->key = strdup(PMIX_SERVER_NSPACE);
-        PMIX_VALUE_CREATE(kptr->value, 1);
-        kptr->value->type = PMIX_STRING;
-        kptr->value->data.string = strdup(pmix_client_globals.myserver->info->pname.nspace);
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                          &pmix_globals.myid,
-                          PMIX_INTERNAL, kptr);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-        PMIX_RELEASE(kptr); // maintain accounting
-        kptr = PMIX_NEW(pmix_kval_t);
-        kptr->key = strdup(PMIX_SERVER_RANK);
-        PMIX_VALUE_CREATE(kptr->value, 1);
-        kptr->value->type = PMIX_PROC_RANK;
-        kptr->value->data.rank = pmix_client_globals.myserver->info->pname.rank;
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                          &pmix_globals.myid,
-                          PMIX_INTERNAL, kptr);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-        PMIX_RELEASE(kptr); // maintain accounting
+        PMIX_LOAD_PROCID(server, cb->pname.nspace, cb->pname.rank);
     }
 
     return PMIX_SUCCESS;
 }
 
-pmix_status_t PMIx_tool_disconnect(pmix_proc_t *server)
+static void disc(int sd, short args, void *cbdata)
 {
-    pmix_myservers_t *ps;
-    pmix_peer_t *peer = NULL;
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    pmix_peer_t *peer = NULL, *pr;
+    int n;
+
+    PMIX_ACQUIRE_OBJECT(cb);
 
     /* see if we have this server */
-    PMIX_LIST_FOREACH(ps, &myservers, pmix_myservers_t) {
-        if (PMIX_CHECK_PROCID(server, &ps->server)) {
-            peer = ps->peer;
-            pmix_list_remove_item(&myservers, &ps->super);
-            PMIX_RELEASE(ps);
+    for (n=0; n < pmix_server_globals.clients.size; n++) {
+        pr = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n);
+        if (NULL == pr) {
+            continue;
+        }
+        if (PMIX_CHECK_NSPACE(cb->proc->nspace, pr->info->pname.nspace) &&
+            PMIX_CHECK_RANK(cb->proc->rank, pr->info->pname.rank)) {
+            peer = pr;
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, n, NULL);
             break;
         }
     }
     if (NULL == peer) {
-        return PMIX_ERR_NOT_FOUND;
+        cb->status = PMIX_ERR_NOT_FOUND;
+        PMIX_WAKEUP_THREAD(&cb->lock);
     }
 
     /* if we are disconnecting from the active server, then we enter a
@@ -1620,89 +1648,225 @@ pmix_status_t PMIx_tool_disconnect(pmix_proc_t *server)
      * ourselves - effectively the same as when we init without connecting */
     if (peer == pmix_client_globals.myserver) {
         PMIX_RETAIN(pmix_globals.mypeer);
-        /* stop the existing progress thread */
-        (void)pmix_progress_thread_pause(NULL);
-        /* switch servers */
+        /* switch servers - we are in an event, so it is
+         * safe to do so */
         pmix_client_globals.myserver = pmix_globals.mypeer;
-        /* resume processing events */
-        pmix_progress_thread_resume(NULL);
     }
 
     /* now drop the connection */
     PMIX_RELEASE(peer);
-    return PMIX_SUCCESS;
+
+    cb->status = PMIX_SUCCESS;
+    PMIX_WAKEUP_THREAD(&cb->lock);
+
+    PMIX_POST_OBJECT(cb);
+    return;
 }
 
-pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *nservers)
+pmix_status_t PMIx_tool_disconnect(const pmix_proc_t *server)
 {
-    size_t n, ns;
-    pmix_myservers_t *ps;
-    pmix_proc_t *srvrs;
+    pmix_status_t rc;
+    pmix_cb_t *cb;
 
-    ns = pmix_list_get_size(&myservers);
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->proc = (pmix_proc_t*)server;
+    PMIX_THREADSHIFT(cb, disc);
+
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    cb->proc = NULL;
+    PMIX_RELEASE(cb);
+
+    return rc;
+}
+
+static void getsrvrs(int sd, short args, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    int n;
+    size_t ns;
+    pmix_list_t srvrs;
+    pmix_proclist_t *ps;
+    pmix_peer_t *pr;
+
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    /* get servers */
+    PMIX_CONSTRUCT(&srvrs, pmix_list_t);
+    /* put our current active server at the front */
+    if (pmix_globals.mypeer != pmix_client_globals.myserver) {
+        ps = PMIX_NEW(pmix_proclist_t);
+        PMIX_LOAD_PROCID(&ps->proc, pmix_client_globals.myserver->info->pname.nspace, pmix_client_globals.myserver->info->pname.rank);
+        pmix_list_append(&srvrs, &ps->super);
+    }
+
+    for (n=0; n < pmix_server_globals.clients.size; n++) {
+        pr = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n);
+        if (NULL == pr) {
+            continue;
+        }
+        /* if it is our current primary server, ignore it */
+        if (pr == pmix_client_globals.myserver) {
+            continue;
+        }
+        /* record it */
+        ps = PMIX_NEW(pmix_proclist_t);
+        PMIX_LOAD_PROCID(&ps->proc, pr->info->pname.nspace, pr->info->pname.rank);
+        pmix_list_append(&srvrs, &ps->super);
+    }
+
+    ns = pmix_list_get_size(&srvrs);
 
     if (0 == ns) {
         /* we aren't connected to anyone */
-        *nservers = 0;
-        *servers = NULL;
-        return PMIX_ERR_UNREACH;
+        cb->status = PMIX_ERR_UNREACH;
+        cb->nprocs = 0;
+        cb->procs = NULL;
+        PMIX_DESTRUCT(&srvrs);
+        PMIX_WAKEUP_THREAD(&cb->lock);
+        PMIX_POST_OBJECT(cb);
+        return;
     }
 
     /* allocate the array */
-    PMIX_PROC_CREATE(srvrs, ns);
+    PMIX_PROC_CREATE(cb->procs, ns);
+    cb->nprocs = ns;
 
-    /* the return has to start with the current active server */
-    PMIX_LOAD_PROCID(&srvrs[0],
-                     pmix_client_globals.myserver->info->pname.nspace,
-                     pmix_client_globals.myserver->info->pname.rank);
-
-    /* now load the remainder, skipping the current active server */
-    n=1;
-    PMIX_LIST_FOREACH(ps, &myservers, pmix_myservers_t) {
-        if (ps->peer == pmix_client_globals.myserver) {
-            continue;
-        }
-        memcpy(&srvrs[n], &ps->server, sizeof(pmix_proc_t));
+    /* now load the array */
+    n=0;
+    PMIX_LIST_FOREACH(ps, &srvrs, pmix_proclist_t) {
+        memcpy(&cb->procs[n], &ps->proc, sizeof(pmix_proc_t));
         ++n;
-        if (ns == n) {
-            break;
-        }
     }
-    *nservers = ns;
-    *servers = srvrs;
+    cb->status = PMIX_SUCCESS;
+    PMIX_LIST_DESTRUCT(&srvrs);
 
-    return PMIX_SUCCESS;
+    PMIX_WAKEUP_THREAD(&cb->lock);
+    PMIX_POST_OBJECT(cb);
+    return;
+}
+pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *nservers)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    cb = PMIX_NEW(pmix_cb_t);
+
+    PMIX_THREADSHIFT(cb, getsrvrs);
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    *servers = cb->procs;
+    *nservers = cb->nprocs;
+
+    cb->procs = NULL;   // protect the array
+    cb->nprocs = 0;
+    PMIX_RELEASE(cb);
+
+    return rc;
 }
 
-pmix_status_t PMIx_tool_set_server(pmix_proc_t *server)
+static void retry_set(int sd, short args, void *cbdata)
 {
-    pmix_myservers_t *ps;
-    pmix_peer_t *peer = NULL;
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    int n;
+    pmix_peer_t *peer = NULL, *pr;
+
+    PMIX_ACQUIRE_OBJECT(cb);
 
     /* see if we have this server */
-    PMIX_LIST_FOREACH(ps, &myservers, pmix_myservers_t) {
-        if (PMIX_CHECK_PROCID(server, &ps->server)) {
-            peer = ps->peer;
+    for (n=0; n < pmix_server_globals.clients.size; n++) {
+        pr = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n);
+        if (NULL == pr) {
+            continue;
+        }
+        if (PMIX_CHECK_NSPACE(cb->proc->nspace, pr->info->pname.nspace) &&
+            PMIX_CHECK_RANK(cb->proc->rank, pr->info->pname.rank)) {
+            peer = pr;
             break;
         }
     }
     if (NULL == peer) {
-        return PMIX_ERR_NOT_FOUND;
+        /* do they want us to wait? */
+        if (cb->checked) {
+            /* have we timed out? */
+            --cb->status;
+            if (cb->status < 0) {
+                cb->status = PMIX_ERR_NOT_FOUND;
+                PMIX_WAKEUP_THREAD(&cb->lock);
+                return;
+            }
+            PMIX_THREADSHIFT_DELAY(cb, retry_set, 0.25);
+        } else {
+            /* no - so just return failure */
+            cb->status = PMIX_ERR_UNREACH;
+            PMIX_WAKEUP_THREAD(&cb->lock);
+        }
+        PMIX_POST_OBJECT(cb);
+        return;
     }
 
     /* if this is the current active server, then ignore the request */
     if (peer == pmix_client_globals.myserver) {
-        return PMIX_SUCCESS;
+        cb->status = PMIX_SUCCESS;
+        PMIX_WAKEUP_THREAD(&cb->lock);
+        PMIX_POST_OBJECT(cb);
+        return;
     }
 
-    /* stop the existing progress thread */
-    (void)pmix_progress_thread_pause(NULL);
-
-    /* switch the active server */
+    /* switch the active server - we are in an event, so
+     * it is safe to do so */
     pmix_client_globals.myserver = peer;
 
-    /* resume processing events */
-    pmix_progress_thread_resume(NULL);
+    cb->status = PMIX_SUCCESS;
+    PMIX_WAKEUP_THREAD(&cb->lock);
+    PMIX_POST_OBJECT(cb);
+    return;
+}
 
-   return PMIX_SUCCESS;
+pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
+                                   pmix_info_t info[], size_t ninfo)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+    size_t n;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* threadshift this so we can access global structures */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->proc = (pmix_proc_t*)server;
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+            cb->status = 4 * info[n].value.data.integer;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_WAIT_FOR_CONNECTION)) {
+            cb->checked = PMIX_INFO_TRUE(&info[n]);
+        }
+    }
+    PMIX_THREADSHIFT(cb, retry_set);
+
+    /* wait for completion */
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    PMIX_RELEASE(cb);
+
+    return rc;
 }


### PR DESCRIPTION
Threadshift APIs to access global structures. Handle the rendezvous URI
correctly when tool spawns a launcher. Track the v4 Standard by removing
PMIX_LAUNCHER_WAIT_FOR_TOOL as being redundant - if the URI is given,
then the launcher needs to connect back to the tool.

Signed-off-by: Ralph Castain <rhc@pmix.org>