### PR TITLE
Silence usock component warning message

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -556,6 +556,34 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     }
     ++pmix_globals.init_cntr;
 
+    /* backward compatibility fix - remove any directive to use
+     * the old usock component so we avoid a warning message */
+    if (NULL != (evar = getenv("PMIX_MCA_ptl"))) {
+        char **snip;
+        int argc;
+        if (0 == strcmp(evar, "usock")) {
+            /* we cannot support a usock-only environment */
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            fprintf(stderr, "-------------------------------------------------------------------\n");
+            fprintf(stderr, "PMIx no longer supports the \"usock\" transport for client-server\n");
+            fprintf(stderr, "communication. A directive was detected that only allows that mode.\n");
+            fprintf(stderr, "We cannot continue - please remove that constraint and try again.\n");
+            fprintf(stderr, "-------------------------------------------------------------------\n");
+            return PMIX_ERR_INIT;
+        }
+        /* anything else is okay - just clear the "usock" directive */
+        snip = pmix_argv_split(evar, ',');
+        for (n=0; NULL != snip[n]; n++) {
+            if (0 == strcmp(snip[n], "usock")) {
+                pmix_argv_delete(&argc, &snip, n, 1);
+                evar = pmix_argv_join(snip, ',');
+                pmix_setenv("PMIX_MCA_ptl", evar, true, &environ);
+                break;
+            }
+        }
+        pmix_argv_free(snip);
+    }
+
     /* setup the runtime - this init's the globals,
      * opens and initializes the required frameworks */
     if (PMIX_SUCCESS != (rc = pmix_rte_init(PMIX_PROC_CLIENT, info, ninfo,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -194,6 +194,35 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server init called");
 
+
+    /* backward compatibility fix - remove any directive to use
+     * the old usock component so we avoid a warning message */
+    if (NULL != (evar = getenv("PMIX_MCA_ptl"))) {
+        char **snip;
+        int argc;
+        if (0 == strcmp(evar, "usock")) {
+            /* we cannot support a usock-only environment */
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            fprintf(stderr, "-------------------------------------------------------------------\n");
+            fprintf(stderr, "PMIx no longer supports the \"usock\" transport for client-server\n");
+            fprintf(stderr, "communication. A directive was detected that only allows that mode.\n");
+            fprintf(stderr, "We cannot continue - please remove that constraint and try again.\n");
+            fprintf(stderr, "-------------------------------------------------------------------\n");
+            return PMIX_ERR_INIT;
+        }
+        /* anything else is okay - just clear the "usock" directive */
+        snip = pmix_argv_split(evar, ',');
+        for (n=0; NULL != snip[n]; n++) {
+            if (0 == strcmp(snip[n], "usock")) {
+                pmix_argv_delete(&argc, &snip, n, 1);
+                evar = pmix_argv_join(snip, ',');
+                pmix_setenv("PMIX_MCA_ptl", evar, true, &environ);
+                break;
+            }
+        }
+        pmix_argv_free(snip);
+    }
+
     PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_SERVER);
     /* setup the function pointers */
     if (NULL == module) {


### PR DESCRIPTION
Detect if someone has set an MCA param directing selection of ptl
components. If only usock is permitted, error out with an explanation
since we cannot support that option. Otherwise, silently remove the
restriction.

Signed-off-by: Ralph Castain <rhc@pmix.org>