### PR TITLE
Clean up PTL refactoring

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -127,6 +127,7 @@ PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
 PMIX_EXPORT pmix_status_t pmix_base_write_rndz_file(char *filename, char *uri, bool *created);
 
 /* base support functions */
+PMIX_EXPORT pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **evar);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env);
 PMIX_EXPORT void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -412,14 +412,6 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     }
     CLOSE_THE_SOCKET(pnd->sd);
     PMIX_RELEASE(pnd);
-
-    /* send an error reply to the client */
-    u32 = htonl(rc);
-    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(int)))) {
-        PMIX_ERROR_LOG(rc);
-        CLOSE_THE_SOCKET(pnd->sd);
-    }
-    PMIX_RELEASE(pnd);
     return;
 }
 

--- a/src/mca/ptl/client/ptl_client.c
+++ b/src/mca/ptl/client/ptl_client.c
@@ -75,7 +75,7 @@ pmix_ptl_module_t pmix_ptl_client_module = {
 static pmix_status_t connect_to_peer(struct pmix_peer_t *pr,
                                      pmix_info_t *info, size_t ninfo)
 {
-    char *evar, *vrs, *suri = NULL;
+    char *evar, *suri = NULL;
     char *nspace=NULL;
     pmix_rank_t rank = PMIX_RANK_WILDCARD;
     char **server_nspace = NULL, *rendfile = NULL;
@@ -85,66 +85,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *pr,
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tcp: connecting to server");
 
-    vrs = getenv("PMIX_VERSION");
-
-    if (NULL != (evar = getenv("PMIX_SERVER_URI4"))) {
-        /* we are talking to a v4 server */
-        PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
-        PMIX_SET_PEER_VERSION(peer, vrs, 4, 0);
-
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "V4 SERVER DETECTED");
-
-        /* must use the latest bfrops module */
-        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, NULL);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-
-    } else if (NULL != (evar = getenv("PMIX_SERVER_URI3"))) {
-        /* we are talking to a v3 server */
-        PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
-        PMIX_SET_PEER_VERSION(peer, vrs, 3, 0);
-
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "V3 SERVER DETECTED");
-
-        /* must use the v3 bfrops module */
-        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v3");
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-
-    } else if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
-        /* we are talking to a v2.1 server */
-        PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
-        PMIX_SET_PEER_VERSION(peer, vrs, 2, 1);
-
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "V21 SERVER DETECTED");
-
-        /* must use the v21 bfrops module */
-        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v21");
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-
-    } else if (NULL != (evar = getenv("PMIX_SERVER_URI2"))) {
-        /* we are talking to a v2.0 server */
-        PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
-        PMIX_SET_PEER_VERSION(peer, vrs, 2, 0);
-
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "V20 SERVER DETECTED");
-
-        /* must use the v20 bfrops module */
-        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v20");
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-
-    } else {
-        return PMIX_ERR_UNREACH;
+    rc = pmix_ptl_base_check_server_uris(peer, &evar);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
     }
 
     /* the URI consists of the following elements:

--- a/src/mca/ptl/client/ptl_client_component.c
+++ b/src/mca/ptl/client/ptl_client_component.c
@@ -65,7 +65,8 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     /* if I am not a client, then look elsewhere */
-    if (!PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
+    if (!PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+        PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         *module = NULL;
         *priority = 0;
         return PMIX_ERR_TAKE_NEXT_OPTION;


### PR DESCRIPTION
Completely separate tools from clients, pushing the detection of server
URI envars into the ptl/base as that code is common to the two cases.
Ensure that tool_attach_to_server sets up the necessary infrastructure
prior to attempting to connect to the new server.

Signed-off-by: Ralph Castain <rhc@pmix.org>