### PR TITLE
[v3.2] Fix dependency issue with hwloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,9 +266,9 @@ AC_MSG_RESULT([$LIBS])
 # Dependencies that themselves have a pkg-config file available.
 #
 PC_REQUIRES=""
-AS_IF([test "$pmix_hwloc_source" != "embedded"],
+AS_IF([test "$pmix_hwloc_support_will_build" = "yes" && test "$pmix_hwloc_source" != "embedded"],
       [PC_REQUIRES="$PC_REQUIRES hwloc"])
-AS_IF([test $pmix_libevent_support -eq 1],
+AS_IF([test $pmix_libevent_support -eq 1 && test "$pmix_libevent_source" != "embedded"],
       [PC_REQUIRES="$PC_REQUIRES libevent"])
 AS_IF([test "$pmix_zlib_support" = "1"],
       [PC_REQUIRES="$PC_REQUIRES zlib"])

--- a/configure.ac
+++ b/configure.ac
@@ -266,7 +266,7 @@ AC_MSG_RESULT([$LIBS])
 # Dependencies that themselves have a pkg-config file available.
 #
 PC_REQUIRES=""
-AS_IF([test "$pmix_hwloc_support_will_build" = "yes"],
+AS_IF([test "$pmix_hwloc_source" != "embedded"],
       [PC_REQUIRES="$PC_REQUIRES hwloc"])
 AS_IF([test $pmix_libevent_support -eq 1],
       [PC_REQUIRES="$PC_REQUIRES libevent"])


### PR DESCRIPTION
Take hwloc as a dependency ONLY when hwloc is
NOT in embedded mode.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>