### PR TITLE
Test to get job info for other ranks + custom rank placement

### DIFF
--- a/test/test_v2/Makefile
+++ b/test/test_v2/Makefile
@@ -1,23 +1,28 @@
-#Fix below to be your local openpmix installation
-INSTALLDIR = /opt/cps/pmix-install
-INCLUDES = -I. -I$(INSTALLDIR)/include -I../../include -I../.. -I../../src/include
-vpath %.h .:$(INSTALLDIR)/include:../../include:../..:../../src/include
-LDIR = $(INSTALLDIR)/lib
+# Set the environment variable PMIX_INSTALLDIR to point to your local PMIx install directory
+PMIX_INSTALLDIR ?= $(HOME)/pmix-install
+
+INCLUDES = -I$(PMIX_INSTALLDIR)/include -I. -I../../include -I../.. -I../../src/include
+vpath %.h .:$(PMIX_INSTALLDIR)/include:../../include:../..:../../src/include
+LDIR = $(PMIX_INSTALLDIR)/lib
 
 CC = gcc
-CFLAGS = $(INCLUDES) -g -Wfatal-errors #-Wall -Wextra -Wpedantic -Wconversion -Wshadow
+CFLAGS = $(INCLUDES) -fno-omit-frame-pointer -g -Wfatal-errors #-Wall -Wextra -Wpedantic -Wconversion -Wshadow
+# Use CFLAGS below instead if you want to run with Sanitizer
+#CFLAGS = $(INCLUDES) -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak -fsanitize=undefined -g -Wfatal-errors -Wall
 LDFLAGS = -Wl,-rpath,$(LDIR)
-LIBS =-lpmix -lpthread -levent
+LIBS =-lpmix -lpthread -levent # -lefence # <-- can link against electric fence for memory checking
 
 # Executables
-EXE = pmix_test test_init_fin test_helloworld test_get_basic
+EXE = pmix_test test_init_fin test_helloworld test_get_basic test_get_peers
 
 # List of all .c source files.
 PCFILES = pmix_test.c test_common.c cli_stages.c test_server.c server_callbacks.c base64_enc_dec.c
-TC1FILES = test_init_fin.c test_common.c base64_enc_dec.c
-TC2FILES = test_helloworld.c test_common.c base64_enc_dec.c
-TC3FILES = test_get_basic.c test_common.c base64_enc_dec.c
-TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES)
+TCCOMMONFILES = test_common.c test_clientapp_funcs.c base64_enc_dec.c
+TC1FILES = test_init_fin.c $(TCCOMMONFILES)
+TC2FILES = test_helloworld.c $(TCCOMMONFILES)
+TC3FILES = test_get_basic.c $(TCCOMMONFILES)
+TC4FILES = test_get_peers.c $(TCCOMMONFILES)
+TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES) $(TC4FILES)
 CFILES = $(PCFILES) $(TCFILES)
 
 OBJ = $(CFILES:%.c=%.o)
@@ -25,21 +30,24 @@ POBJ = $(PCFILES:%.c=%.o)
 T1OBJ = $(TC1FILES:%.c=%.o)
 T2OBJ = $(TC2FILES:%.c=%.o)
 T3OBJ = $(TC3FILES:%.c=%.o)
+T4OBJ = $(TC4FILES:%.c=%.o)
 
-all: pmix_test test_init_fin test_helloworld test_get_basic
+all: pmix_test test_init_fin test_helloworld test_get_basic test_get_peers
 .PHONY: all
 
 clean:
 	rm -f $(EXE) $(OBJ) $(DEP)
 .PHONY: clean
 
-pmix_test: $(POBJ) 
+pmix_test: $(POBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 test_init_fin: $(T1OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 test_helloworld: $(T2OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 test_get_basic: $(T3OBJ)
+	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
+test_get_peers: $(T4OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 
 %.o : %.c

--- a/test/test_v2/base64_enc_dec.c
+++ b/test/test_v2/base64_enc_dec.c
@@ -27,7 +27,10 @@
 
 /* base64 encoding with illegal characters removed ('=' is replaced by ' ') */
 static inline unsigned char pmixt_base64_encsym (unsigned char value) {
-    assert (value < 64);
+    if (value >= 64) {
+        TEST_ERROR(("Unknown value passed to encoding function, exiting."));
+        exit(1);
+    }
 
     if (value < 26) {
     return 'A' + value;
@@ -60,8 +63,11 @@ static inline unsigned char pmixt_base64_decsym (unsigned char value) {
 
 static inline void pmixt_base64_encode_block (const unsigned char in[3], char out[4], int len) {
     out[0] = pmixt_base64_encsym (in[0] >> 2);
-    out[1] = pmixt_base64_encsym (((in[0] & 0x03) << 4) | ((in[1] & 0xf0) >> 4));
-    out[2] = 1 < len ? pmixt_base64_encsym(((in[1] & 0x0f) << 2) | ((in[2] & 0xc0) >> 6)) : ' ';
+    // len is the length of in[] - we need to make sure we don't reference uninitialized data, hence the conditionals
+    out[1] = 1 < len ? pmixt_base64_encsym(((in[0] & 0x03) << 4) | ((in[1] & 0xf0) >> 4)) : pmixt_base64_encsym((in[0] & 0x03) << 4);
+
+    out[2] = 1 < len ? pmixt_base64_encsym((in[1] & 0x0f) << 2) : ' ';
+    out[2] = 2 < len ? pmixt_base64_encsym(((in[1] & 0x0f) << 2) | ((in[2] & 0xc0) >> 6)) : out[2];
     out[3] = 2 < len ? pmixt_base64_encsym(in[2] & 0x3f) : ' ';
 }
 
@@ -79,7 +85,7 @@ static inline int pmixt_base64_decode_block (const char in[4], unsigned char out
     }
 
     out[1] = in_dec[1] << 4 | in_dec[2] >> 2;
-    if (64 == in_dec[3]) {     
+    if (64 == in_dec[3]) {
         return 2;
     }
 
@@ -103,14 +109,13 @@ char *pmixt_encode(const void *val, size_t vallen)
     }
 
     tmp[0] = (unsigned char)'\0';
-    TEST_VERBOSE(("vallen = %ld, outlen = %ld", vallen, outlen));
+    //TEST_VERBOSE(("vallen = %ld, outlen = %ld", vallen, outlen));
     return outdata;
 }
 
 ssize_t pmixt_decode (const char *data, void *decdata, size_t buffsz)
 {
     size_t input_len = strlen(data) / 4;
-    unsigned char *ret = decdata;
     int out_len;
     size_t i;
 
@@ -124,6 +129,6 @@ ssize_t pmixt_decode (const char *data, void *decdata, size_t buffsz)
             exit(1);
         }
     }
-    
+
     return out_len;
 }

--- a/test/test_v2/server_callbacks.c
+++ b/test/test_v2/server_callbacks.c
@@ -84,7 +84,7 @@ pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
         }
     }
     if (NULL == cli) {
-        TEST_ERROR(("cannot found rank %d", proc->rank));
+        TEST_ERROR(("cannot find rank %d", proc->rank));
         return PMIX_SUCCESS;
     }
     if( CLI_TERM <= cli->state ){

--- a/test/test_v2/test_clientapp_funcs.c
+++ b/test/test_v2/test_clientapp_funcs.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Triad National Security, LLC
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/* This file includes all functions called directly by client apps, along with
+ * their callees. */
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+
+#include "test_common.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
+
+extern int pmix_test_verbose;
+extern test_params params;
+
+extern FILE *pmixt_outfile;
+
+// presently a placeholder - to be developed into a client-only command parser,
+// separating the processing logic for client command line options from that for
+// other callers (test app or server), unlike how parse_cmd() presently works.
+void parse_cmd_client(int argc, char **argv, test_params *params, validation_params *v_params)
+{
+    ;
+}
+
+void pmixt_pre_init(int argc, char **argv, test_params *params, validation_params *v_params) {
+
+    ssize_t v_size = -1;
+
+    default_params(params, v_params);
+    parse_cmd(argc, argv, params, v_params);
+    TEST_OUTPUT(("v_params->pmix_rank: %d", v_params->pmix_rank));
+
+    /* set filename if available in params */
+    if ( NULL != params->prefix && -1 != params->ns_id ) {
+        PMIXT_SET_FILE(params->prefix, params->ns_id, v_params->pmix_rank);
+    }
+    else {
+        pmixt_outfile = stdout;
+    }
+}
+
+void pmixt_fix_rank_and_ns(pmix_proc_t *this_proc, test_params *params, validation_params *v_params) {
+    // first check for bugs
+    if (this_proc->rank != v_params->pmix_rank) {
+        TEST_ERROR(("Client ns: v_params %s; this_proc: %s, Rank returned in PMIx_Init: "
+                    "%d does not match validation rank: %d.", v_params->pmix_nspace,
+                    this_proc->nspace, this_proc->rank, v_params->pmix_rank));
+        pmixt_exit(1);
+    }
+    // Fix rank if running under RM
+    if( PMIX_RANK_UNDEF == v_params->pmix_rank ){
+        char *ranklist = getenv("SLURM_GTIDS");
+        char *rankno = getenv("SLURM_LOCALID");
+        // Fix rank if running under SLURM
+        if( NULL != ranklist && NULL != rankno ){
+            char **argv = pmix_argv_split(ranklist, ',');
+            int count = pmix_argv_count(argv);
+            int rankidx = strtoul(rankno, NULL, 10);
+            if( rankidx >= count ){
+                TEST_ERROR(("It feels like we are running under SLURM:\n\t"
+                            "SLURM_GTIDS=%s, SLURM_LOCALID=%s\nbut env vars are conflicting",
+                            ranklist, rankno));
+                pmixt_exit(1);
+            }
+            v_params->pmix_rank = strtoul(argv[rankidx], NULL, 10);
+            pmix_argv_free(argv);
+        }
+        else if ( NULL == getenv("PMIX_RANK") ) { /* we must not be running under SLURM */
+            // **Call separate function for your own resource manager here**
+            // It should likely be wrapped in condition that checks for existence of an RM env var
+            // Function name should be of form: fix_rank_and_nspace_rm_*
+            // and should check/fix both rank and nspace
+            // e.g: fix_rank_and_ns_rm_pbs(), fix_rank_and_ns_rm_torque(), etc.
+        }
+        else { /* unknown situation - PMIX_RANK is not null but SLURM env vars are */
+            TEST_ERROR(("It feels like we are running under SLURM:\n\t"
+                        "PMIX_RANK=%s\nbut SLURM env vars are null\n"
+                        "v_params.pmix_rank = %d, this_proc.rank = %d, pmix_local_peers = %s",
+                        getenv("PMIX_RANK"), v_params->pmix_rank, this_proc->rank,
+                        v_params->pmix_local_peers));
+            pmixt_exit(1);
+        }
+    }
+
+    // Fix namespace if running under RM
+    if( NULL == v_params->pmix_nspace ){
+        char *nspace = getenv("PMIX_NAMESPACE");
+        if( NULL != nspace ){
+            strcpy(v_params->pmix_nspace, nspace);
+            free(nspace);
+        }
+        else { /* If we aren't running under SLURM, you should have set nspace
+	          in your custom fix_rank_and_ns_rm_* function! */
+            TEST_ERROR(("nspace not set and no value for PMIX_NAMESPACE env variable. "
+                "Is the fix_rank_and_ns_rm_* function for this resource manager failing to set it?"));
+                pmixt_exit(1);
+        }
+    }
+}
+
+void pmixt_post_init(pmix_proc_t *this_proc, test_params *params, validation_params *val_params) {
+    pmixt_fix_rank_and_ns(this_proc, params, val_params);
+    TEST_VERBOSE((" Client/PMIX ns %s rank %d: PMIx_Init success", this_proc->nspace, this_proc->rank));
+}
+
+void pmixt_post_finalize(pmix_proc_t *this_proc, test_params *params, validation_params *v_params) {
+    free_params(params, v_params);
+    TEST_VERBOSE(("Client ns %s rank %d: PMIx_Finalize success", this_proc->nspace, this_proc->rank));
+    TEST_VERBOSE(("Before fclose (after file closed, no more output can be printed)"));
+    pmixt_exit(EXIT_SUCCESS);
+}
+
+/* This function is used to validate values returned from calls to PMIx_Get against
+   side channel validation data */
+void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key,
+                               pmix_value_t *value, const pmix_data_type_t expected_type,
+                               validation_params *val_params)
+{
+    pmix_status_t rc = PMIX_ERROR;
+    uint16_t local_rank = -1, node_rank = -1;
+    uint32_t local_size = -1, nodeid = -1;
+    char l_hostname[PMIX_MAX_KEYLEN];
+    bool rank_found = false;
+    int i, j;
+
+    if (!val_params->validate_params) {
+        TEST_VERBOSE(("All validation disabled, will not validate: %s", key));
+        return;
+    }
+
+    if (expected_type != value->type) {
+        TEST_ERROR_EXIT(("Type mismatch for key. Key: %s Type: %u Expected type: %u",
+                key, value->type, expected_type));
+    }
+    // if we're not validating our own process information, we are validating a peer's info,
+    // so we need to examine the nodes array to find the relevant validation info.
+    // For simplicity, we just do this for all cases in which we are validating node-local info.
+    if (PMIX_RANK_WILDCARD != myproc->rank) {
+        for (i = 0; i < val_params->pmix_num_nodes; i++) {
+            for (j = 0; j < nodes[i].pmix_local_size; j++) {
+                if (nodes[i].pmix_rank[j] == myproc->rank) {
+                    local_rank = j;
+                    // WARNING: if we test a multi-job case later, node_rank will not equal local_rank
+                    // and the assignment below will have to be changed
+                    node_rank = j;
+                    local_size = nodes[i].pmix_local_size;
+                    nodeid = nodes[i].pmix_nodeid;
+                    strcpy(l_hostname, nodes[i].pmix_hostname);
+                    rank_found = true;
+                    break;
+                }
+            }
+            if (rank_found) {
+                break;
+            }
+        }
+    }
+    switch (value->type) {
+        case PMIX_UINT16: {
+            uint16_t uint16data;
+            PMIX_VALUE_GET_NUMBER(rc, value, uint16data, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR_EXIT(("Failed to retrieve value correctly. Key: %s Type: %u",
+                key, value->type));
+            }
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_LOCAL_RANK, uint16data, local_rank);
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_NODE_RANK, uint16data, node_rank);
+            TEST_ERROR_EXIT(("Check input for case PMIX_UINT16: key: %s", key));
+        }
+        case PMIX_UINT32: {
+            uint32_t uint32data;
+            PMIX_VALUE_GET_NUMBER(rc, value, uint32data, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR_EXIT(("Failed to retrieve value correctly. Key: %s Type: %u",
+                key, value->type));
+            }
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_JOB_SIZE, uint32data, val_params->pmix_job_size);
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_UNIV_SIZE, uint32data, val_params->pmix_univ_size);
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_LOCAL_SIZE, uint32data, local_size);
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_NODEID, uint32data, nodeid);
+            TEST_ERROR_EXIT(("Check input for case PMIX_UINT32: key: %s", key));
+        }
+        case PMIX_PROC_RANK: {
+            pmix_rank_t rankdata;
+            PMIX_VALUE_GET_NUMBER(rc, value, rankdata, pmix_rank_t);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u",
+                key, value->type));
+                pmixt_exit(1);
+            }
+            PMIXT_TEST_NUM_KEY(myproc, key, PMIX_RANK, rankdata, val_params->pmix_rank);
+            TEST_ERROR_EXIT(("Check input for case PMIX_PROC_RANK: key: %s", key));
+        }
+        case PMIX_STRING: {
+            void *stringdata;
+            size_t lsize;
+            PMIX_VALUE_UNLOAD(rc, value, &stringdata, &lsize);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR_EXIT(("Failed to retrieve value correctly. Key: %s Type: %u",
+                key, value->type));
+            }
+            PMIXT_TEST_STR_KEY(myproc, key, PMIX_NSPACE, stringdata, val_params->pmix_nspace);
+            PMIXT_TEST_STR_KEY(myproc, key, PMIX_JOBID, stringdata, val_params->pmix_jobid);
+            PMIXT_TEST_STR_KEY(myproc, key, PMIX_LOCAL_PEERS, stringdata, val_params->pmix_local_peers);
+            PMIXT_TEST_STR_KEY(myproc, key, PMIX_HOSTNAME, stringdata, l_hostname);
+            TEST_ERROR_EXIT(("Check input for case PMIX_STRING: key: %s stringdata: %s",
+                key, stringdata));
+        }
+        default: {
+            TEST_ERROR_EXIT(("No test logic for type: %d, key: %s", value->type, key));
+        }
+    }
+}

--- a/test/test_v2/test_common.c
+++ b/test/test_v2/test_common.c
@@ -4,6 +4,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2020      Triad National Security, LLC
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,6 +14,9 @@
  *
  */
 
+/* Note: this file is for functions called by both client and server and their
+        callees. */
+
 #include <src/include/pmix_config.h>
 #include <pmix_common.h>
 
@@ -19,11 +24,12 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <assert.h>
 
 int pmix_test_verbose = 0;
 test_params params;
 
-FILE *file;
+FILE *pmixt_outfile;
 
 #define OUTPUT_MAX 1024
 char *pmix_test_output_prepare(const char *fmt, ... )
@@ -37,25 +43,125 @@ char *pmix_test_output_prepare(const char *fmt, ... )
     return output;
 }
 
-// presently a placeholder - to be developed into a client-only command parser,
-// separating the processing logic for client command line options from that for
-// other callers (test app or server), unlike how parse_cmd() presently works.
-void parse_cmd_client(int argc, char **argv, test_params *params, validation_params *v_params)
+void pmixt_exit(int exit_code) {
+    if( (stdout != pmixt_outfile) && (stderr != pmixt_outfile) ) {
+        fclose(pmixt_outfile);
+    }
+    exit(exit_code);
+}
+
+// initialize the global *nodes array
+void init_nodes(int num_nodes) {
+    int i;
+    nodes = malloc(num_nodes * sizeof(node_map));
+    for (i = 0; i < num_nodes; i++) {
+        nodes[i].pmix_rank = NULL;
+        nodes[i].pmix_hostname[0] = '\0';
+    }
+}
+
+// frees the global *nodes array
+void free_nodes(int num_nodes)
 {
-    ;
+    int i;
+    if (NULL == nodes) {
+        TEST_ERROR(("nodes pointer is NULL, cannot free; aborting"));
+        exit(1);
+    }
+    TEST_VERBOSE(("num_nodes = %d, nodes[0].pmix_rank[0] = %d", num_nodes, nodes[0].pmix_rank[0]));
+    for (i = 0; i < num_nodes; i++) {
+        if (NULL == nodes[i].pmix_rank) {
+            TEST_ERROR(("Encountered NULL pointer in free loop of nodes[%d].pmix_rank; aborting", i));
+            exit(1);
+        }
+        free(nodes[i].pmix_rank);
+    }
+    free(nodes);
+}
+
+// populates the global *nodes array for the default rank placement case
+void populate_nodes_default_placement(uint32_t num_nodes, int num_procs)
+{
+    int i, j, base_rank = 0, base_rank_next_node = 0;
+
+    for (i = 0; i < num_nodes; i++) {
+        base_rank_next_node += (num_procs % num_nodes) > (uint32_t)i ?
+                num_procs / num_nodes + 1 :
+                num_procs / num_nodes;
+        nodes[i].pmix_nodeid = i;
+        snprintf(nodes[i].pmix_hostname, PMIX_MAX_KEYLEN, "node%u", nodes[i].pmix_nodeid);
+        nodes[i].pmix_rank = malloc(sizeof(pmix_rank_t));
+        for (j = 0; j < base_rank_next_node - base_rank; j++) {
+            nodes[i].pmix_rank = (pmix_rank_t *) realloc(nodes[i].pmix_rank, (j+1) * sizeof(pmix_rank_t));
+            nodes[i].pmix_rank[j] = j + base_rank;
+        }
+        nodes[i].pmix_local_size = j;
+        base_rank = base_rank_next_node;
+        TEST_VERBOSE(("Default rank placement: num_nodes: %d num_procs: %d nodes[%d].pmix_local_size: %d",
+                      num_nodes, num_procs, i, nodes[i].pmix_local_size));
+    }
+}
+
+// populates the global *nodes array for the custom rank placement case (rank placement string as command line arg)
+void populate_nodes_custom_placement_string(char *placement_str, int num_nodes)
+{
+    /* example rank placement string:
+    // 0:0,2,4;1:1,3,5
+    // equates to: (node 0: ranks 0, 2, and 4; node 1: ranks 1, 3, and 5)
+    // no error checking in this function, we assume the string has correct syntax
+    // and all nodes/procs are properly accounted for */
+    char *tempstr, *pch, **buf;
+    char *saveptr = NULL;
+    size_t i, j, idx = 0;
+
+    buf = malloc(num_nodes * sizeof(char *));
+    tempstr = strdup(placement_str);
+    // first we separate the nodes from one another
+    pch = strtok_r(tempstr,";", &saveptr);
+    while (NULL != pch) {
+        buf[idx] = malloc(strlen(pch) + 1);
+        strcpy(buf[idx], pch);
+        pch = strtok_r(NULL, ";", &saveptr);
+        idx++;
+    }
+    // now we go back over populated buf array and separate the numbered nodes from the
+    // comma-delimited list of ranks; then we separate out each rank
+    for (i = 0; i < idx; i++) {
+        pch = strtok_r(buf[i], ":", &saveptr);
+        nodes[i].pmix_nodeid = strtol(pch, NULL, 0);
+        snprintf(nodes[i].pmix_hostname, PMIX_MAX_KEYLEN, "node%u", nodes[i].pmix_nodeid);
+        nodes[i].pmix_rank = malloc(sizeof(pmix_rank_t));
+        j = 0;
+        pch = strtok_r(NULL, ",", &saveptr);
+        while (NULL != pch) {
+            nodes[i].pmix_rank = (pmix_rank_t *) realloc(nodes[i].pmix_rank, (j+1) * sizeof(pmix_rank_t));
+            nodes[i].pmix_rank[j] = strtol(pch, NULL, 0);
+            pch = strtok_r(NULL, ",", &saveptr);
+            j++;
+        }
+        nodes[i].pmix_local_size = j;
+        TEST_VERBOSE(("num_nodes: %d idx: %d nodes[%d].pmix_local_size: %d hostname: %s",
+        num_nodes, idx, i, j, nodes[i].pmix_hostname));
+    }
+
+    free(tempstr);
+    for (i = 0; i < idx; i++) {
+        free(buf[i]);
+    }
+    free(buf);
 }
 
 void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_params)
 {
     int i;
     uint32_t job_size;
+    //bool custom_rank_placement = false;
 
-    /* set output to stderr by default */
-    file = stdout;
-    if( params->nspace != NULL ) {
-        params->nspace = NULL;
+    /* set output to stdout by default */
+    pmixt_outfile = stdout;
+    if( v_params->pmix_nspace[0] != '\0' ) {
+        v_params->pmix_nspace[0] = '\0';
     }
-
     /* parse user options */
     for (i=1; i < argc; i++) {
         if (0 == strcmp(argv[i], "--n") || 0 == strcmp(argv[i], "-n")) {
@@ -63,8 +169,9 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             if (NULL != argv[i]) {
                 params->np = strdup(argv[i]);
                 job_size = strtol(argv[i], NULL, 10);
-                params->nprocs = job_size;
-                PMIXT_VAL_PARAM_SETNUM(v_params, pmix_job_size, job_size);
+                //params->nprocs = job_size;
+                v_params->pmix_job_size = job_size;
+                v_params->pmix_univ_size = job_size;
                 if (-1 == params->ns_size) {
                     params->ns_size = job_size;
                 }
@@ -74,10 +181,11 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             fprintf(stderr, "usage: pmix_test [-h] [-e foo] [-b] [-nb]\n");
             fprintf(stderr, "\t-n       the job size (for checking purposes)\n");
             fprintf(stderr, "\t-s       number of servers to emulate\n");
-            fprintf(stderr, "\t-e foo   use foo as test client\n");
+            fprintf(stderr, "\t-e foo   use foo as test client executable\n");
             fprintf(stderr, "\t-v       verbose output\n");
             fprintf(stderr, "\t-t <>    set timeout\n");
             fprintf(stderr, "\t-o out   redirect clients logs to file out.<rank>\n");
+            fprintf(stderr, "\t-d str   assign ranks to servers, for example: 0:0,1:1:2,3,4\n");
             fprintf(stderr, "\t-c       fence[_nb] callback shall include all collected data\n");
             fprintf(stderr, "\t-nb      use non-blocking fence\n");
             exit(0);
@@ -89,9 +197,10 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
         } else if (0 == strcmp(argv[i], "--nservers") || 0 == strcmp(argv[i], "-s")){
             i++;
             if (NULL != argv[i]) {
-                params->nservers = atoi(argv[i]);
+                //params->nservers = atoi(argv[i]);
+                v_params->pmix_num_nodes = atoi(argv[i]);
             }
-            if (2 < params->nservers) {
+            if (2 < v_params->pmix_num_nodes) {
                 fprintf(stderr, "Only support up to 2 servers\n");
                 exit(1);
             }
@@ -111,25 +220,19 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             if (NULL != argv[i]) {
                 params->prefix = strdup(argv[i]);
             }
-        /*
-        } else if( 0 == strcmp(argv[i], "-s")) {
+        } else if( 0 == strcmp(argv[i], "--namespace")) {
             i++;
             if (NULL != argv[i]) {
-                params->nspace = strdup(argv[i]);
-
-        */
-        } else if (0 == strcmp(argv[i], "--rank") || 0 == strcmp(argv[i], "-r")) {
-            i++;
-            if (NULL != argv[i]) {
-                pmix_rank_t rank = strtol(argv[i], NULL, 10);
-                PMIXT_VAL_PARAM_SETNUM(v_params, pmix_rank, rank);
+                strcpy(v_params->pmix_nspace, argv[i]);
             }
+        /*
         } else if (0 == strcmp(argv[i], "--collect-corrupt")) {
             params->collect_bad = 1;
-        } else if (0 == strcmp(argv[i], "--collect") || 0 == strcmp(argv[i], "-c")) {
-            params->collect = 1;
         } else if (0 == strcmp(argv[i], "--non-blocking") || 0 == strcmp(argv[i], "-nb")) {
             params->nonblocking = 1;
+        } else if (0 == strcmp(argv[i], "--collect") || 0 == strcmp(argv[i], "-c")) {
+            params->collect = 1;
+        */
         } else if (0 == strcmp(argv[i], "--ns-size")) {
             i++;
             if (NULL != argv[i]) {
@@ -140,39 +243,60 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             if (NULL != argv[i]) {
                 params->ns_id = strtol(argv[i], NULL, 10);
             }
-        } else if (0 == strcmp(argv[i], "--base-rank")) {
-            i++;
-            if (NULL != argv[i]) {
-                params->base_rank = strtol(argv[i], NULL, 10);
-            }
-
         } else if (0 == strcmp(argv[i], "--validate-params")) {
             i++;
-            v_params->validate_params = 1;
+            v_params->validate_params = true;
             v_params_ascii_str = strdup(argv[i]);
-	    }
+        // set up custom rank placement
+	    } else if (0 == strcmp(argv[i], "--distribute-ranks") || 0 == strcmp(argv[i], "-d") ) {
+            i++;
+            if ((PMIX_MAX_KEYLEN - 1) < strlen(argv[i])) {
+                TEST_ERROR(("Rank distribution string exceeds max length of %d bytes", PMIX_MAX_KEYLEN-1));
+                exit(1);
+            }
+            v_params->custom_rank_placement = true;
+            strcpy(v_params->rank_placement_string, argv[i]);
+            TEST_VERBOSE(("rank_placement_string: %s", v_params->rank_placement_string));
+        }
         else {
-            fprintf(stderr, "unrecognized option: %s\n", argv[i]);
+            TEST_ERROR(("unrecognized option: %s", argv[i]));
             exit(1);
         }
     }
+
+    /* the block below allows us to immediately process things that depend on
+     * the contents of v_params.
+     * This will only be executed on clients; servers already have v_params
+     * populated from command line args. */
+    if (v_params->validate_params) {
+        ssize_t v_size;
+        v_size = pmixt_decode(v_params_ascii_str, v_params, sizeof(*v_params));
+        if (v_size != sizeof(*v_params)) {
+            assert(v_size == sizeof(*v_params));
+            exit(1);
+        }
+    }
+
+    TEST_VERBOSE(("v_params->pmix_num_nodes: %d being passed into init_nodes", v_params->pmix_num_nodes));
+    init_nodes(v_params->pmix_num_nodes);
+    if (v_params->custom_rank_placement){
+        char *local_rank_placement_string = NULL;
+        TEST_VERBOSE(("Before populate_nodes_custom_placement_string, string: %s", v_params->rank_placement_string));
+        local_rank_placement_string = strdup(v_params->rank_placement_string);
+        // populates global *nodes array
+        populate_nodes_custom_placement_string(local_rank_placement_string, v_params->pmix_univ_size);
+        free(local_rank_placement_string);
+    }
+    else {
+        // populates global *nodes array
+        populate_nodes_default_placement(v_params->pmix_num_nodes, v_params->pmix_univ_size);
+    }
+
     if (NULL == params->binary) {
         char *basename = NULL;
         basename = strrchr(argv[0], '/');
         if (basename) {
             *basename = '\0';
-            /* pmix_test and pmix_clients are the shell scripts that
-             * make sure that actual binary placed in "./.libs" directory
-             * is properly linked.
-             * after launch pmix_test you'll find the following process:
-             *      <pmix-root-dir>/test/.libs/lt-pmix_test
-             *
-             * To launch
-             *      <pmix-root-dir>/test/pmix_client
-             * instead of
-             *      <pmix-root-dir>/test/.libs/pmix_client
-             * we need to do a step back in directory tree.
-             */
             if (0 > asprintf(&params->binary, "%s/../pmix_client", argv[0])) {
                 exit(1);
             }
@@ -183,53 +307,41 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             }
         }
     }
-
+/*
     if( params->collect_bad ){
-        params->collect = params->rank % 2;
+        params->collect = v_params->pmix_rank % 2;
     }
+*/
 }
 
 void default_params(test_params *params, validation_params *v_params) {
     params->binary = NULL;
     params->np = NULL;
     params->prefix = NULL;
-    params->nspace = NULL;
-    params->nprocs = 1;
     params->timeout = TEST_DEFAULT_TIMEOUT;
     params->verbose = 0;
-    params->rank = PMIX_RANK_UNDEF;
-    params->collect_bad = 0;
-    params->collect = 0;
     params->nonblocking = 0;
     params->ns_size = -1;
     params->ns_id = -1;
-    params->base_rank = 0;
-    params->nservers = 1;
 
     v_params->version = PMIXT_VALIDATION_PARAMS_VER;
     v_params->validate_params = false;
-    v_params->check_pmix_rank = false;
+    v_params->custom_rank_placement = false;
     v_params->pmix_rank = PMIX_RANK_UNDEF;
-    v_params->check_pmix_nspace = false;
     v_params->pmix_nspace[0] = '\0';
-    v_params->check_pmix_job_size = false;
-    v_params->pmix_job_size = 0;
-    v_params->check_pmix_univ_size = false;
-    v_params->pmix_univ_size = 0;
-    v_params->check_pmix_jobid = false;
+    v_params->pmix_job_size = 1;
+    v_params->pmix_univ_size = 1;
     v_params->pmix_jobid[0] = '\0';
-    v_params->check_pmix_local_size = false;
-    v_params->pmix_local_size = 0;
-    v_params->check_pmix_local_rank = false;
+    v_params->pmix_local_size = 1;
     v_params->pmix_local_rank = 0;
-    v_params->check_pmix_nodeid = false;
     v_params->pmix_nodeid = 0;
-    v_params->check_pmix_local_peers = false;
     v_params->pmix_local_peers[0] = '\0';
-    v_params->check_pmix_hostname = false;
     v_params->pmix_hostname[0] = '\0';
+    v_params->pmix_num_nodes = 1;
+    v_params->pmix_node_rank = 0;
 }
 
+// also frees the global array *nodes
 void free_params(test_params *params, validation_params *vparams) {
     if (NULL != params->binary) {
         free(params->binary);
@@ -240,371 +352,13 @@ void free_params(test_params *params, validation_params *vparams) {
     if (NULL != params->prefix) {
         free(params->prefix);
     }
-    if (NULL != params->nspace) {
-        free(params->nspace);
-    }
+
     if (NULL != v_params_ascii_str) {
         free(v_params_ascii_str);
     }
-}
 
-void set_client_argv(test_params *params, char ***argv)
-{
-    pmix_argv_append_nosize(argv, params->binary);
-    pmix_argv_append_nosize(argv, "-n");
-    if (NULL == params->np) {
-        pmix_argv_append_nosize(argv, "1");
-    } else {
-        pmix_argv_append_nosize(argv, params->np);
-    }
-    if( params->verbose ){
-        pmix_argv_append_nosize(argv, "-v");
-    }
-    if (NULL != params->prefix) {
-        pmix_argv_append_nosize(argv, "-o");
-        pmix_argv_append_nosize(argv, params->prefix);
-    }
-    if (params->nonblocking) {
-        pmix_argv_append_nosize(argv, "-nb");
-    }
-    if (params->collect) {
-        pmix_argv_append_nosize(argv, "-c");
-    }
-    if (params->collect_bad) {
-        pmix_argv_append_nosize(argv, "--collect-corrupt");
-    }
-}
-
-void pmixt_pre_init(int argc, char **argv, test_params *params, validation_params *v_params) {
-
-    ssize_t v_size = -1;
-
-    default_params(params, v_params);
-    parse_cmd(argc, argv, params, v_params);
-    //parse_cmd_client(argc, argv, params, v_params);
-
-    if (v_params->validate_params) {
-        v_size = pmixt_decode(v_params_ascii_str, v_params, sizeof(*v_params));
-        if (v_size != sizeof(*v_params)) {
-            assert(v_size == sizeof(*v_params));
-            exit(1);
-        }
-    }
-    else {
-        // we're not doing any parameter validation - is this reasonable?
-        TEST_VERBOSE(("Parameter validation disabled\n"));
-    }
-
-    /* set filename if available in params */
-    if ( NULL != params->prefix && -1 != params->ns_id ) {
-	char *fname = malloc( strlen(params->prefix) + MAX_DIGIT_LEN + 2 );
-        sprintf(fname, "%s.%d.%d", params->prefix, params->ns_id, params->rank);
-        file = fopen(fname, "w");
-        free(fname);
-        if( NULL == file ){
-            fprintf(stderr, "Cannot open file %s for writing!", fname);
-            exit(1);
-        }
-    }
-    else {
-        file = stdout;
-    }
-}
-
-void pmixt_fix_rank_and_ns(pmix_proc_t *this_proc, test_params *params, validation_params *v_params) {
-    // Fix rank if running under RM
-    if( PMIX_RANK_UNDEF == v_params->pmix_rank ){
-        char *ranklist = getenv("SLURM_GTIDS");
-        char *rankno = getenv("SLURM_LOCALID");
-        // Fix rank if running under SLURM
-        if( NULL != ranklist && NULL != rankno ){
-            char **argv = pmix_argv_split(ranklist, ',');
-            int count = pmix_argv_count(argv);
-            int rankidx = strtoul(rankno, NULL, 10);
-            if( rankidx >= count ){
-                fprintf(stderr, "It feels like we are running under SLURM:\n\t"
-                        "SLURM_GTIDS=%s, SLURM_LOCALID=%s\nbut env vars are conflicting\n",
-                        ranklist, rankno);
-                if( (stdout != file) && (stderr != file) ) {
-                    fclose(file);
-                }
-                exit(1);
-            }
-            v_params->pmix_rank = strtoul(argv[rankidx], NULL, 10);
-            pmix_argv_free(argv);
-        }
-        else if ( NULL == getenv("PMIX_RANK") ) { /* we must not be running under SLURM */
-            // **Call separate function for your own resource manager here**
-            // It should likely be wrapped in condition that checks for existence of an RM env var
-            // Function name should be of form: fix_rank_and_nspace_rm_*
-            // and should check/fix both rank and nspace
-            // e.g: fix_rank_and_ns_rm_pbs(), fix_rank_and_ns_rm_torque(), etc.
-        }
-        else { /* unknown situation - PMIX_RANK is not null but SLURM env vars are */
-            fprintf(stderr, "It feels like we are running under SLURM:\n\t"
-                    "PMIX_RANK=%s\nbut SLURM env vars are null\n",
-                    getenv("PMIX_RANK"));
-            if( (stdout != file) && (stderr != file) ) {
-                  fclose(file);
-            }
-            exit(1);
-        }
-    }
-
-    // Fix namespace if running under RM
-    if( NULL == params->nspace ){
-        char *nspace = getenv("PMIX_NAMESPACE");
-        if( NULL != nspace ){
-            params->nspace = strdup(nspace);
-        }
-	else { /* If we aren't running under SLURM, you should have set nspace
-	          in your custom fix_rank_and_ns_rm_* function! */
-            fprintf(stderr, "nspace not set. Is the fix_rank_and_ns_rm_*"
-	            " function for this resource manager failing to set it?\n");
-            if( (stdout != file) && (stderr != file) ) {
-                fclose(file);
-            }
-            exit(1);
-        }
-    }
-
-    if (this_proc->rank != v_params->pmix_rank) {
-        TEST_ERROR(("Client ns %s Rank returned in PMIx_Init %d does not match rank from command line %d.",
-	    this_proc->nspace, this_proc->rank, v_params->pmix_rank));
-        if( (stdout != file) && (stderr != file) ) {
-            fclose(file);
-        }
-        exit(1);
-    }
-}
-
-void pmixt_post_init(pmix_proc_t *this_proc, test_params *params, validation_params *val_params) {
-    pmixt_fix_rank_and_ns(this_proc, params, val_params);
-    TEST_VERBOSE((" Client/PMIX ns %s rank %d: PMIx_Init success", this_proc->nspace, this_proc->rank));
-}
-
-void pmixt_post_finalize(pmix_proc_t *this_proc, test_params *params, validation_params *v_params) {
-    TEST_VERBOSE((" Client ns %s rank %d: PMIx_Finalize success", this_proc->nspace, this_proc->rank));
-    if( (stdout != file) && (stderr != file) ) {
-        fclose(file);
-    }
-    free_params(params, v_params);
-    exit(EXIT_SUCCESS);
-}
-
-/* This function is used to validate values returned from calls to Get against sidechannel validation data */
-void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key, pmix_value_t *value,
-                               const pmix_data_type_t expected_type, validation_params *val_params)
-{
-    pmix_status_t rc = PMIX_ERROR;
-    if (val_params->validate_params) {
-        if (expected_type != value->type) {
-            TEST_ERROR(("Type mismatch for key. Key: %s Type: %u Expected type: %u",
-                    key, value->type, expected_type));
-            exit(1);
-        }
-        switch (value->type) {
-            case PMIX_UINT16:
-                //empty statement to separate label and declaration
-                ;
-                uint16_t uint16data;
-                PMIX_VALUE_GET_NUMBER(rc, value, uint16data, uint16_t);
-                if (PMIX_SUCCESS != rc) {
-                    TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u",
-                    key, value->type));
-                    exit(1);
-                }
-                if (PMIXT_CHECK_KEY(key, PMIX_LOCAL_RANK) && val_params->check_pmix_local_rank) {
-                    if (val_params->pmix_local_rank != uint16data) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, uint16data, val_params->pmix_local_rank));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d: Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, uint16data));
-                } // other possibilities will be added here later
-                else {
-                   TEST_ERROR(("Check input for case PMIX_UINT16: key: %s check_pmix_local_rank %u",
-                       key, val_params->check_pmix_local_rank));
-                    exit(1);
-                }
-                break;
-            case PMIX_UINT32:
-                //empty statement to separate label and declaration
-                ;
-                uint32_t uint32data;
-                PMIX_VALUE_GET_NUMBER(rc, value, uint32data, uint32_t);
-                if (PMIX_SUCCESS != rc) {
-                    TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u",
-                    key, value->type));
-                    exit(1);
-                }
-                if (PMIXT_CHECK_KEY(key, PMIX_JOB_SIZE) && val_params->check_pmix_job_size) {
-                    if (val_params->pmix_job_size != uint32data) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, uint32data, val_params->pmix_job_size));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d: Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, uint32data));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_UNIV_SIZE) && val_params->check_pmix_univ_size) {
-                    if (val_params->pmix_univ_size != uint32data) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, uint32data, val_params->pmix_univ_size));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d: Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, uint32data));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_LOCAL_SIZE) && val_params->check_pmix_local_size) {
-                    if (val_params->pmix_local_size != uint32data) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, uint32data, val_params->pmix_local_size));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d: Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, uint32data));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_NODEID) && val_params->check_pmix_nodeid) {
-                    if (val_params->pmix_nodeid != uint32data) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, uint32data, val_params->pmix_nodeid));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d: Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, uint32data));
-                } // other possibilities will be added here later
-                else {
-                   TEST_ERROR(("Check input for case PMIX_UINT32: key: %s check_pmix_job_size: %u check_pmix_univ_size %u check_pmix_local_size %u",
-                        key, val_params->check_pmix_job_size, val_params->check_pmix_univ_size, val_params->check_pmix_local_size));
-                    exit(1);
-                }
-                break;
-            case PMIX_PROC_RANK:
-                //empty statement to separate label and declaration
-                ;
-                pmix_rank_t rankdata;
-                PMIX_VALUE_GET_NUMBER(rc, value, rankdata, pmix_rank_t);
-                if (PMIX_SUCCESS != rc) {
-                    TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u",
-                    key, value->type));
-                    exit(1);
-                }
-                if (PMIXT_CHECK_KEY(key, PMIX_RANK) && val_params->check_pmix_rank) {
-                    if (val_params->pmix_rank != rankdata) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %d Validation value: %d",
-                                     key, rankdata, val_params->pmix_rank));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d Data validated: Key: %s Value: %u",
-                        myproc->nspace, myproc->rank, key, rankdata));
-                } // other possibilities will be added here later
-                else {
-                    TEST_ERROR(("Check input for case PMIX_PROC_RANK: key: %s check_pmix_rank: %u",
-                        key, val_params->check_pmix_rank));
-                    exit(1);
-                }
-                break;
-            case PMIX_STRING:
-                //empty statement to separate label and declaration
-                ;
-                void *stringdata;
-                size_t lsize;
-                PMIX_VALUE_UNLOAD(rc, value, &stringdata, &lsize);
-                if (PMIX_SUCCESS != rc) {
-                    TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u",
-                    key, value->type));
-                    exit(1);
-                }
-                if (PMIXT_CHECK_KEY(key, PMIX_NSPACE) && val_params->check_pmix_nspace) {
-                    if (0 != strcmp(val_params->pmix_nspace, stringdata)) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %s Validation value: %s",
-                                     key, stringdata, val_params->pmix_nspace));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d Data validated: Key: %s Value: %s",
-                        myproc->nspace, myproc->rank, key, stringdata));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_JOBID) && val_params->check_pmix_jobid) {
-                    if (0 != strcmp(val_params->pmix_jobid, stringdata)) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %s Validation value: %s",
-                                     key, stringdata, val_params->pmix_jobid));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d Data validated: Key: %s Value: %s",
-                        myproc->nspace, myproc->rank, key, stringdata));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_LOCAL_PEERS) && val_params->check_pmix_local_peers) {
-                    if (0 != strcmp(val_params->pmix_local_peers, stringdata)) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %s Validation value: %s",
-                                     key, stringdata, val_params->pmix_local_peers));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d Data validated: Key: %s Value: %s",
-                        myproc->nspace, myproc->rank, key, stringdata));
-                }
-                else if (PMIXT_CHECK_KEY(key, PMIX_HOSTNAME) && val_params->check_pmix_hostname) {
-                    if (0 != strcmp(val_params->pmix_hostname, stringdata)) {
-                        TEST_ERROR(("Key %s failed validation. Get value: %s Validation value: %s",
-                                     key, stringdata, val_params->pmix_hostname));
-                        exit(1);
-                    }
-                    TEST_VERBOSE(("Namespace %s: Rank %d Data validated: Key: %s Value: %s",
-                        myproc->nspace, myproc->rank, key, stringdata));
-                } // other possibilities will be added here later
-                else {
-                    TEST_ERROR(("Check input for case PMIX_STRING: key: %s stringdata: %s",
-                        key, stringdata));
-                    exit(1);
-                }
-                free(stringdata);
-                break;
-            default:
-                TEST_ERROR(("No test logic for type: %d, key: %s", value->type, key));
-                exit(1);
-        }
-    }
-    else {
-        TEST_VERBOSE(("All validation disabled, will not validate: %s", key));
-    }
-}
-
-/* lifted from contrib/perf_tools/pmix.c, pmi_get_local_ranks() */
-// Not sure how to go about validating what we get here, which comes from PMIx_Get
-void pmixt_get_local_ranks(pmix_proc_t *this_proc, int **local_ranks, int *local_cnt) {
-    pmix_value_t value, *val = &value;
-    char *ptr;
-    int i, rc;
-    //pmix_proc_t job_proc = &this_proc;
-#if (PMIX_VERSION_MAJOR > 1 )
-    this_proc->rank = PMIX_RANK_WILDCARD;
-#endif
-
-    /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(this_proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get PMIX_LOCAL_SIZE failed: %d", this_proc->nspace, this_proc->rank, rc);
-        abort();
-    }
-    *local_cnt = val->data.uint32;
-    PMIX_VALUE_RELEASE(val);
-
-    *local_ranks = calloc(*local_cnt, sizeof(int));
-    /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(this_proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get PMIX_LOCAL_PEERS failed: %d", this_proc->nspace, this_proc->rank, rc);
-        abort();
-    }
-    ptr = val->data.string;
-    for(i=0; NULL != ptr && i < *local_cnt; i++ ){
-         char *loc_rank = strsep(&ptr, ",");
-         (*local_ranks)[i] = atoi(loc_rank);
-    }
-    if( i != *local_cnt || NULL != ptr ){
-        fprintf(stderr, "Client ns %s rank %d: number of local peers doesn't match",
-                this_proc->nspace, this_proc->rank);
-        abort();
-    }
+    free_nodes(vparams->pmix_num_nodes);
+    TEST_VERBOSE(("Completed free_params"));
 }
 
 static void fcon(fence_desc_t *p)
@@ -647,207 +401,3 @@ pmix_list_t key_replace;
         }                                                       \
     }                                                           \
 } while (0)
-
-static int parse_token(char *str, int step, int store)
-{
-    char *pch;
-    int count = 0;
-    int remember = -1;
-    int i;
-    int rank;
-    participant_t *proc;
-
-    switch (step) {
-    case 0:
-        if (store) {
-            fdesc = PMIX_NEW(fence_desc_t);
-            participants = fdesc->participants;
-        }
-        pch = strchr(str, '|');
-        if (NULL != pch) {
-            while (pch != str) {
-                if ('d' == *str) {
-                    if (store && NULL != fdesc) {
-                        fdesc->data_exchange = 1;
-                    }
-                } else if ('b' == *str) {
-                    if (store && NULL != fdesc) {
-                        fdesc->blocking = 1;
-                    }
-                } else if (' ' != *str) {
-                    if (!store) {
-                        return 1;
-                    }
-                }
-                str++;
-            }
-            if (0 < parse_token(pch+1, 1, store)) {
-                if (!store) {
-                    return 1;
-                }
-            }
-        } else {
-            if (0 < parse_token(str, 1, store)) {
-                if (!store) {
-                    return 1;
-                }
-            }
-        }
-        if (store && NULL != fdesc) {
-            pmix_list_append(&test_fences, &fdesc->super);
-        }
-        break;
-    case 1:
-        if (store && NULL == participants) {
-            participants = PMIX_NEW(pmix_list_t);
-            noise_range = participants;
-        }
-        pch = strtok(str, ";");
-        while (NULL != pch) {
-            if (0 < parse_token(pch, 2, store)) {
-                if (!store) {
-                    return 1;
-                }
-            }
-            pch = strtok (NULL, ";");
-        }
-        break;
-    case 2:
-        pch = strchr(str, ':');
-        if (NULL != pch) {
-            *pch = '\0';
-            pch++;
-            while (' ' == *str) {
-                str++;
-            }
-            ns_id = (int)(strtol(str, NULL, 10));
-            CHECK_STRTOL_VAL(ns_id, str, store);
-            if (0 < parse_token(pch, 3, store)) {
-                if (!store) {
-                    return 1;
-                }
-            }
-        } else {
-            if (!store) {
-                return 1;
-            }
-        }
-        break;
-    case 3:
-        while (' ' == *str) {
-            str++;
-        }
-        if ('\0' == *str) {
-            /* all ranks from namespace participate */
-            if (store && NULL != participants) {
-                proc = PMIX_NEW(participant_t);
-                (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
-                proc->proc.rank = PMIX_RANK_WILDCARD;
-                pmix_list_append(participants, &proc->super);
-            }
-        }
-        while ('\0' != *str) {
-            if (',' == *str && 0 != count) {
-                *str = '\0';
-                if (-1 != remember) {
-                    rank = (int)(strtol(str-count, NULL, 10));
-                    CHECK_STRTOL_VAL(rank, str-count, store);
-                    for (i = remember; i < rank; i++) {
-                        if (store && NULL != participants) {
-                            proc = PMIX_NEW(participant_t);
-                            (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
-                            proc->proc.rank = i;
-                            pmix_list_append(participants, &proc->super);
-                        }
-                    }
-                    remember = -1;
-                }
-                rank = (int)(strtol(str-count, NULL, 10));
-                CHECK_STRTOL_VAL(rank, str-count, store);
-                if (store && NULL != participants) {
-                    proc = PMIX_NEW(participant_t);
-                    (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
-                    proc->proc.rank = rank;
-                    pmix_list_append(participants, &proc->super);
-                }
-                count = -1;
-            } else if ('-' == *str && 0 != count) {
-                *str = '\0';
-                remember = (int)(strtol(str-count, NULL, 10));
-                CHECK_STRTOL_VAL(remember, str-count, store);
-                count = -1;
-            }
-            str++;
-            count++;
-        }
-        if (0 != count) {
-            if (-1 != remember) {
-                rank = (int)(strtol(str-count, NULL, 10));
-                CHECK_STRTOL_VAL(rank, str-count, store);
-                for (i = remember; i < rank; i++) {
-                    if (store && NULL != participants) {
-                        proc = PMIX_NEW(participant_t);
-                        (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
-                        proc->proc.rank = i;
-                        pmix_list_append(participants, &proc->super);
-                    }
-                }
-                remember = -1;
-            }
-            rank = (int)(strtol(str-count, NULL, 10));
-            CHECK_STRTOL_VAL(rank, str-count, store);
-            if (store && NULL != participants) {
-                proc = PMIX_NEW(participant_t);
-                (void)snprintf(proc->proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ns_id);
-                proc->proc.rank = rank;
-                pmix_list_append(participants, &proc->super);
-            }
-        }
-        break;
-    default:
-        fprintf(stderr, "Incorrect parsing step.\n");
-        return 1;
-    }
-    return 0;
-}
-
-int parse_fence(char *fence_param, int store)
-{
-    int ret = 0;
-    char *tmp = strdup(fence_param);
-    char * pch, *ech;
-
-    pch = strchr(tmp, '[');
-    while (NULL != pch) {
-        pch++;
-        ech = strchr(pch, ']');
-        if (NULL != ech) {
-            *ech = '\0';
-            ech++;
-            ret += parse_token(pch, 0, store);
-            pch = strchr(ech, '[');
-        } else {
-            ret = 1;
-            break;
-        }
-    }
-    free(tmp);
-    return ret;
-}
-
-
-static int is_digit(const char *str)
-{
-    if (NULL == str)
-        return 0;
-
-    while (0 != *str) {
-        if (!isdigit(*str)) {
-        return 0;
-        }
-        else {
-            str++;
-        }
-    }
-    return 1;
-}

--- a/test/test_v2/test_get_basic.c
+++ b/test/test_v2/test_get_basic.c
@@ -22,19 +22,27 @@
 #include <unistd.h>
 */
 
-extern FILE *file;
+//extern FILE *pmixt_outfile;
 
 pmix_proc_t this_proc;
 
 int main(int argc, char *argv[]) {
 
     pmix_value_t *val;
+    int retval;
     size_t ninfo = 0;
     test_params params;
     validation_params v_params;
     pmix_proc_t job_proc;
+    bool check_self = true;
 
     pmixt_pre_init(argc, argv, &params, &v_params);
+    TEST_VERBOSE(("v_params values: pmix_nspace %s; pmix_job_size %d; pmix_univ_size %d",
+                  v_params.pmix_nspace, v_params.pmix_job_size, v_params.pmix_univ_size));
+    TEST_VERBOSE(("v_params values: pmix_rank %d; pmix_local_rank %d; pmix_nodeid %d; pmix_num_nodes %d",
+                  v_params.pmix_rank, v_params.pmix_local_rank, v_params.pmix_nodeid, v_params.pmix_num_nodes));
+    TEST_VERBOSE(("v_params values: pmix_local_peers: %s",
+                  v_params.pmix_local_peers));
     /* initialization */
     PMIXT_CHECK(PMIx_Init(&this_proc, NULL, ninfo), params, v_params);
 
@@ -42,33 +50,48 @@ int main(int argc, char *argv[]) {
     pmixt_post_init(&this_proc, &params, &v_params);
 
     job_proc = this_proc;
-    job_proc.rank = PMIX_RANK_WILDCARD; // Note that PMIX_RANK_WILDCARD == -2
+    job_proc.rank = PMIX_RANK_WILDCARD; // == UINT32_MAX-1
+
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), params, v_params);
     /* After using PMIx_Get to get a value, we need to compare it our validation parameters
        we've passed as an argument; this is the main purpose of pmixt_validate_predefined(). */
 
     pmixt_validate_predefined(&job_proc, PMIX_JOB_SIZE, val, PMIX_UINT32, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_JOB_SIZE check"));
 
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_UNIV_SIZE, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&job_proc, PMIX_UNIV_SIZE, val, PMIX_UINT32, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_UNIV_SIZE check"));
 
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_SIZE, NULL, 0, &val), params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_LOCAL_SIZE, val, PMIX_UINT32, &v_params);
+    pmixt_validate_predefined(&this_proc, PMIX_LOCAL_SIZE, val, PMIX_UINT32, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_LOCAL_SIZE check"));
 
     PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_LOCAL_RANK, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&this_proc, PMIX_LOCAL_RANK, val, PMIX_UINT16, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_LOCAL_RANK check"));
 
     PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_NODEID, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&this_proc, PMIX_NODEID, val, PMIX_UINT32, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_NODEID check"));
 
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_PEERS, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&job_proc, PMIX_LOCAL_PEERS, val, PMIX_STRING, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_LOCAL_PEERS check"));
 
     PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_HOSTNAME, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&this_proc, PMIX_HOSTNAME, val, PMIX_STRING, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_HOSTNAME check"));
 
     // Code hangs when PMIx_Get of PMIX_RANK is enabled
-    /*
+   /*
     job_proc.rank = PMIX_RANK_UNDEF;
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_RANK, NULL, 0, &val), params, v_params);
     pmixt_validate_predefined(&job_proc, PMIX_RANK, val, PMIX_PROC_RANK, &v_params);

--- a/test/test_v2/test_get_peers.c
+++ b/test/test_v2/test_get_peers.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* Test of rank position identification inside group */
+
+#include "pmix.h"
+#include "test_common.h"
+#include <stdio.h>
+#include <stdlib.h>
+/*
+#include <assert.h>
+#include <sys/time.h>
+#include <stdarg.h>
+#include <unistd.h>
+*/
+
+
+pmix_proc_t this_proc;
+
+int main(int argc, char *argv[]) {
+
+    pmix_value_t *val;
+    size_t ninfo = 0;
+    test_params params;
+    validation_params v_params;
+    pmix_proc_t job_proc, peer_proc;
+    int i;
+
+    pmixt_pre_init(argc, argv, &params, &v_params);
+    /* initialization */
+    PMIXT_CHECK(PMIx_Init(&this_proc, NULL, ninfo), params, v_params);
+
+    /* Handles everything that needs to happen after PMIx_Init() */
+    pmixt_post_init(&this_proc, &params, &v_params);
+
+    job_proc = this_proc;
+    job_proc.rank = PMIX_RANK_WILDCARD;
+
+    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), params, v_params);
+    pmixt_validate_predefined(&job_proc, PMIX_JOB_SIZE, val, PMIX_UINT32, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_JOB_SIZE check"));
+
+
+    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_PEERS, NULL, 0, &val), params, v_params);
+    pmixt_validate_predefined(&job_proc, PMIX_LOCAL_PEERS, val, PMIX_STRING, &v_params);
+    free(val);
+    TEST_VERBOSE(("after PMIX_LOCAL_PEERS check"));
+
+
+    // validation data must be populated for all peers, remote and local, by this point
+    peer_proc = this_proc;
+    for (i = 0; i < v_params.pmix_job_size; i++ ) {
+        peer_proc.rank = i;
+        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_LOCAL_RANK, NULL, 0, &val), params, v_params);
+        pmixt_validate_predefined(&peer_proc, PMIX_LOCAL_RANK, val, PMIX_UINT16, &v_params);
+        free(val);
+        TEST_VERBOSE(("after PMIX_LOCAL_RANK check for rank = %d", peer_proc.rank));
+
+        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_NODEID, NULL, 0, &val), params, v_params);
+        pmixt_validate_predefined(&peer_proc, PMIX_NODEID, val, PMIX_UINT32, &v_params);
+        free(val);
+        TEST_VERBOSE(("after PMIX_NODEID check for rank = %d", peer_proc.rank));
+
+        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_NODE_RANK, NULL, 0, &val), params, v_params);
+        pmixt_validate_predefined(&peer_proc, PMIX_NODE_RANK, val, PMIX_UINT16, &v_params);
+        free(val);
+        TEST_VERBOSE(("after PMIX_NODE_RANK check for rank = %d", peer_proc.rank));
+
+        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_HOSTNAME, NULL, 0, &val), params, v_params);
+        pmixt_validate_predefined(&peer_proc, PMIX_HOSTNAME, val, PMIX_STRING, &v_params);
+        free(val);
+        TEST_VERBOSE(("after PMIX_HOSTNAME check for rank = %d", peer_proc.rank));
+    }
+
+    /*
+    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_PEERS, NULL, 0, &val), params, v_params);
+    pmixt_validate_predefined(&job_proc, PMIX_LOCAL_PEERS, val, PMIX_STRING, &v_params);
+    */
+
+    /* finalize */
+    PMIXT_CHECK(PMIx_Finalize(NULL, 0), params, v_params);
+
+    /* Handles cleanup */
+    pmixt_post_finalize(&this_proc, &params, &v_params);
+}

--- a/test/test_v2/test_helloworld.c
+++ b/test/test_v2/test_helloworld.c
@@ -42,8 +42,8 @@ int main(int argc, char *argv[]) {
            this_proc.nspace, this_proc.rank, v_params.pmix_rank));
         exit(1);
     }
-    TEST_VERBOSE(("nspace validated: %s, rank validated: %d", v_params.pmix_nspace, 
-                   v_params.pmix_rank));  
+    TEST_VERBOSE(("nspace validated: %s, rank validated: %d", v_params.pmix_nspace,
+                   v_params.pmix_rank));
 
     PMIXT_CHECK(PMIx_Finalize(NULL, 0), params, v_params);
 

--- a/test/test_v2/test_init_fin.c
+++ b/test/test_v2/test_init_fin.c
@@ -13,14 +13,6 @@
 
 #include "pmix.h"
 #include "test_common.h"
-#include <assert.h>
-#include <sys/time.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <unistd.h>
-
-extern FILE *file;
 
 int main(int argc, char *argv[]) {
 
@@ -43,4 +35,5 @@ int main(int argc, char *argv[]) {
 
     /* Handles cleanup */
     pmixt_post_finalize(&this_proc, &params, &v_params);
+
 }

--- a/test/test_v2/test_server.h
+++ b/test/test_v2/test_server.h
@@ -65,15 +65,15 @@ extern pmix_list_t *server_list;
 extern server_info_t *my_server_info;
 extern pmix_list_t *server_nspace;
 
-int server_init(test_params *params, validation_params *val_params);
-int server_finalize(test_params *params, int local_fail);
+int server_init(test_params *params, validation_params *v_params);
+int server_finalize(validation_params *v_params, int local_fail);
 int server_barrier(void);
 int server_fence_contrib(char *data, size_t ndata,
                          pmix_modex_cbfunc_t cbfunc, void *cbdata);
 int server_dmdx_get(const char *nspace, int rank,
                     pmix_modex_cbfunc_t cbfunc, void *cbdata);
-int server_launch_clients(int local_size, int univ_size, int base_rank,
-                   test_params *params, validation_params *v_params, char *** client_env, char ***base_argv);
+int server_launch_clients(test_params *params,
+            validation_params *v_params, char ***client_env, char ***base_argv);
 
 
 #endif // TEST_SERVER_C


### PR DESCRIPTION
This PR is the implementation of https://github.com/openpmix/pmix-tests/issues/66.

It includes a new client test to get job information for all ranks, plus the ability to place ranks on servers (nodes) in a user-specified configuration.

Also included is a commit with bug fixes to prior tests.