### PR TITLE
Fix Python event notification

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -145,16 +145,6 @@ cdef void event_cache_cb(capsule, ret):
                    shifter[0].results, shifter[0].nresults,
                    shifter[0].event_handler, shifter[0].notification_cbdata)
 
-cdef void event_handler_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "event_handler")
-    shifter[0].event_handler(shifter[0].status, shifter[0].results, shifter[0].nresults,
-                             shifter[0].op_cbfunc, shifter[0].cbdata,
-                             shifter[0].notification_cbdata)
-    if 0 < shifter[0].nresults:
-        pmix_free_info(shifter[0].results, shifter[0].nresults)
-    return
-
 cdef void query_cb(capsule, ret):
     cdef pmix_pyshift_t *shifter
     shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "query")
@@ -1396,8 +1386,8 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
     elif PMIX_REGEX == value[0].type:
         return {'value': value[0].data.bo.bytes, 'val_type': PMIX_REGEX}
     else:
-        print("Unload_value: provided type is unknown")
-        return PMIX_ERR_TYPE_MISMATCH
+        print("Unload_value: provided type is unknown", value[0].type)
+        return {'value': None, 'val_type': PMIX_UNDEF}
 
 cdef void pmix_destruct_value(pmix_value_t *value):
     if value[0].type == PMIX_STRING:

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -1,13 +1,27 @@
 #!/usr/bin/env python3
 
 from pmix import *
+import time
+import threading
+
+termEvent = threading.Event()
 
 def default_evhandler(evhdlr:int, status:int,
                       source:dict, info:list, results:list):
     print("DEFAULT HANDLER")
     return PMIX_EVENT_ACTION_COMPLETE,None
 
+def model_evhandler(evhdlr:int, status:int,
+                    source:dict, info:list, results:list):
+    global termEvent
+
+    print("MODEL HANDLER")
+    termEvent.set()
+    return PMIX_EVENT_ACTION_COMPLETE,None
+
 def main():
+    global termEvent
+    
     foo = PMIxClient()
     print("Testing PMIx ", foo.get_version())
     info = [{'key':PMIX_PROGRAMMING_MODEL, 'value':'TEST', 'val_type':PMIX_STRING},
@@ -19,7 +33,11 @@ def main():
         exit(1)
     # register an event handler
     rc,myevhndlr = foo.register_event_handler(None, None, default_evhandler)
-    print("REGISTER", foo.error_string(rc))
+    print("REGISTER DEFAULT", foo.error_string(rc))
+    # register the model handler
+    rc,mymodelhndlr = foo.register_event_handler([PMIX_MODEL_DECLARED], None, model_evhandler)
+    print("REGISTER MODEL", foo.error_string(rc))
+
     # try putting something
     print("PUT")
     rc = foo.put(PMIX_GLOBAL, "mykey", {'value':1, 'val_type':PMIX_INT32})
@@ -45,6 +63,9 @@ def main():
     info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.fence(procs, info)
     print("Fence should be not supported:", foo.error_string(rc))
+    # wait for model event
+    while not termEvent.is_set():
+        time.sleep(0.001)
     # finalize
     info = []
     foo.finalize(info)


### PR DESCRIPTION
Use the Python "queue" class to shift the response from an event handler
to meet PMIx Standard requirements instead of a timer - greatly speeds
up the response.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 2d8bacc0657409bf2260fe74ebaafacf89c127a8)