### PR TITLE
Complete revision of Python bindings

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -92,49 +92,9 @@ cdef void iofhdlr_cache(capsule, ret):
     cdef pmix_pyshift_t *shifter
     shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "iofhdlr_cache")
     pyiofhandler(shifter[0].idx, shifter[0].channel, &shifter[0].source,
-            shifter[0].payload, shifter[0].info, shifter[0].ndata)
+                 shifter[0].payload, shifter[0].info, shifter[0].ndata)
     if 0 < shifter[0].ndata:
         pmix_free_info(shifter[0].info, shifter[0].ndata)
-    return
-
-cdef void validationcredential_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "validationcredential")
-    shifter[0].validationcredential(shifter[0].status, shifter[0].info, shifter[0].ndata,
-            shifter[0].cbdata)
-    if 0 < shifter[0].ndata:
-        pmix_free_info(shifter[0].info, shifter[0].ndata)
-    return
-
-cdef void getcredential_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "getcredential")
-    shifter[0].getcredential(shifter[0].status, shifter[0].cred, shifter[0].info,
-                        shifter[0].ndata, shifter[0].cbdata)
-    if 0 < shifter[0].ndata:
-        pmix_free_info(shifter[0].info, shifter[0].ndata)
-    return
-
-cdef void allocate_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "allocate")
-    shifter[0].allocate(shifter[0].status, shifter[0].info, shifter[0].ndata,
-                        shifter[0].cbdata, shifter[0].release_fn,
-                        shifter[0].notification_cbdata)
-    if 0 < shifter[0].ndata:
-        pmix_free_info(shifter[0].info, shifter[0].ndata)
-    return
-
-cdef void toolconnected_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "toolconnected")
-    shifter[0].toolconnected(shifter[0].status, shifter[0].proc, shifter[0].cbdata)
-    return
-
-cdef void spawn_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "spawn")
-    shifter[0].spawn(shifter[0].status, shifter[0].nspace, shifter[0].cbdata)
     return
 
 cdef void event_cache_cb(capsule, ret):
@@ -144,38 +104,6 @@ cdef void event_cache_cb(capsule, ret):
                    shifter[0].info, shifter[0].ndata,
                    shifter[0].results, shifter[0].nresults,
                    shifter[0].event_handler, shifter[0].notification_cbdata)
-
-cdef void query_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "query")
-    shifter[0].query(ret, shifter[0].info, shifter[0].ndata, shifter[0].cbdata, NULL, NULL)
-    if 0 < shifter[0].ndata:
-        pmix_free_info(shifter[0].info, shifter[0].ndata)
-    return
-
-cdef void lookup_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "lookup")
-    shifter[0].lookup(ret, shifter[0].pdata, shifter[0].ndata, shifter[0].cbdata)
-    if 0 < shifter[0].ndata:
-        pmix_free_pdata(shifter[0].pdata, shifter[0].ndata)
-    return
-
-cdef void fence_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "fence")
-    shifter[0].modex(ret, shifter[0].bo.bytes, shifter[0].bo.size,
-                     shifter[0].cbdata, NULL, NULL)
-    return
-
-cdef void dmodex_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "dmodex")
-    shifter[0].modex(shifter[0].status, shifter[0].data, shifter[0].ndata,
-                     shifter[0].cbdata, NULL, NULL)
-    if 0 < shifter[0].ndata:
-        PyMem_Free(&(shifter[0].data))
-    return
 
 cdef void pmix_convert_locality(pmix_locality_t loc, pyloc:list):
     if PMIX_LOCALITY_NONLOCAL & loc:

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -36,7 +36,10 @@ def pyevhdlr(stop):
             break
         if not eventQueue.empty():
             capsule = eventQueue.get()
-            shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "event_handler")
+            try:
+                shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, NULL)
+            except:
+                continue
             op = shifter[0].op.decode('ascii')
             if "event_handler" == op:
                 shifter[0].event_handler(shifter[0].status, shifter[0].results, shifter[0].nresults,
@@ -44,10 +47,48 @@ def pyevhdlr(stop):
                                          shifter[0].notification_cbdata)
                 if 0 < shifter[0].nresults:
                     pmix_free_info(shifter[0].results, shifter[0].nresults)
+            elif "fence" == op:
+                shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "fence")
+                shifter[0].modex(shifter[0].status, shifter[0].bo.bytes, shifter[0].bo.size,
+                                 shifter[0].cbdata, NULL, NULL)
+            elif "directmodex" == op:
+                shifter[0].modex(shifter[0].status, shifter[0].data, shifter[0].ndata,
+                                 shifter[0].cbdata, NULL, NULL)
+                if 0 < shifter[0].ndata:
+                    PyMem_Free(&(shifter[0].data))
+            elif "lookup" == op:
+                shifter[0].lookup(shifter[0].status, shifter[0].pdata, shifter[0].ndata, shifter[0].cbdata)
+                if 0 < shifter[0].ndata:
+                    pmix_free_pdata(shifter[0].pdata, shifter[0].ndata)
+            elif "spawn" == op:
+                shifter[0].spawn(shifter[0].status, shifter[0].nspace, shifter[0].cbdata)
+            elif "query" == op:
+                shifter[0].query(shifter[0].status, shifter[0].info, shifter[0].ndata, shifter[0].cbdata, NULL, NULL)
+                if 0 < shifter[0].ndata:
+                    pmix_free_info(shifter[0].info, shifter[0].ndata)
+            elif "toolconnected" == op:
+                shifter[0].toolconnected(shifter[0].status, shifter[0].proc, shifter[0].cbdata)
+            elif "allocate" == op:
+                shifter[0].allocate(shifter[0].status, shifter[0].info, shifter[0].ndata,
+                                    shifter[0].cbdata, shifter[0].release_fn,
+                                    shifter[0].notification_cbdata)
+                if 0 < shifter[0].ndata:
+                    pmix_free_info(shifter[0].info, shifter[0].ndata)
+            elif "getcredential" == op:
+                shifter[0].getcredential(shifter[0].status, shifter[0].cred, shifter[0].info,
+                                         shifter[0].ndata, shifter[0].cbdata)
+                if 0 < shifter[0].ndata:
+                    pmix_free_info(shifter[0].info, shifter[0].ndata)
+            elif "validationcredential" == op:
+                shifter[0].validationcredential(shifter[0].status, shifter[0].info, shifter[0].ndata,
+                                                shifter[0].cbdata)
+                if 0 < shifter[0].ndata:
+                    pmix_free_info(shifter[0].info, shifter[0].ndata)
             else:
                 print("UNSUPPORTED OP", op)
         # don't beat on the cpu
         time.sleep(0.001)
+        return
 
 
 # create a progress thread for processing events
@@ -147,7 +188,7 @@ cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
         mycaddy.info                = info
         mycaddy.ndata               = ninfo
         cb = PyCapsule_New(mycaddy, "iofhdlr_cache", NULL)
-        threading.Timer(2, iofhdlr_cache, [cb, rc]).start()
+        threading.Timer(0.001, iofhdlr_cache, [cb, rc]).start()
     return
 
 cdef void pyeventhandler(size_t evhdlr_registration_id,
@@ -2167,6 +2208,7 @@ cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
         blist = []
         ilist = []
         barray = None
+
         if NULL == procs:
             myprocs.append({'nspace': myname.nspace, 'rank': PMIX_RANK_WILDCARD})
         else:
@@ -2192,16 +2234,20 @@ cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
     # threadshift so we can generate the callback safely
     data  = strdup(ret_data)
     ndata = len(ret_data)
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("fence")
+        mycaddy.status = PMIX_SUCCESS
         mycaddy.bo.bytes = data
         mycaddy.bo.size = ndata
         mycaddy.modex = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "fence", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, fence_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int directmodex(const pmix_proc_t *proc,
@@ -2230,18 +2276,21 @@ cdef int directmodex(const pmix_proc_t *proc,
     cdef size_t ndata
     data  = strdup(ret_data)
     ndata = len(ret_data)
+    global eventQueue
 
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("directmodex")
-        mycaddy.status = rc
+        mycaddy.status = PMIX_SUCCESS
         mycaddy.data = data
         mycaddy.ndata = ndata
         mycaddy.modex = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "directmodex", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, dmodex_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int publish(const pmix_proc_t *proc,
@@ -2307,10 +2356,10 @@ cdef int lookup(const pmix_proc_t *proc, char **keys,
             pd = <pmix_pdata_t*> PyMem_Malloc(ndata * sizeof(pmix_pdata_t))
             if not pdata:
                 return PMIX_ERR_NOMEM
-            rc = pmix_load_pdata(myprocs[0], pd, pdata)
-            if PMIX_SUCCESS != rc:
+            prc = pmix_load_pdata(myprocs[0], pd, pdata)
+            if PMIX_SUCCESS != prc:
                 pmix_free_pdata(pd, ndata)
-                return rc
+                return prc
         else:
             pd = NULL
     else:
@@ -2322,16 +2371,20 @@ cdef int lookup(const pmix_proc_t *proc, char **keys,
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("lookup")
+        mycaddy.status = PMIX_SUCCESS
         mycaddy.pdata = pd
         mycaddy.ndata = ndata
         mycaddy.lookup = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "lookup", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, lookup_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int unpublish(const pmix_proc_t *proc, char **keys,
@@ -2397,6 +2450,7 @@ cdef int spawn(const pmix_proc_t *proc,
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("spawn")
@@ -2404,9 +2458,11 @@ cdef int spawn(const pmix_proc_t *proc,
         mycaddy.nspace = ns
         mycaddy.spawn  = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "spawn", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, spawn_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int connect(const pmix_proc_t procs[], size_t nprocs,
@@ -2587,16 +2643,16 @@ cdef int query(pmix_proc_t *source,
     # pmix_info_t structs
     cdef pmix_info_t *info;
     cdef size_t ninfo
-    if results is not None:
+    if results is not None and 0 < len(results):
         ninfo = len(results)
         if 0 < nqueries:
             info = <pmix_info_t*> PyMem_Malloc(ninfo * sizeof(pmix_info_t))
             if not info:
                 return PMIX_ERR_NOMEM
-            rc = pmix_load_info(info, results)
-            if PMIX_SUCCESS != rc:
+            prc = pmix_load_info(info, results)
+            if PMIX_SUCCESS != prc:
                 pmix_free_info(info, ninfo)
-                return rc
+                return prc
         else:
             info = NULL
     else:
@@ -2608,16 +2664,20 @@ cdef int query(pmix_proc_t *source,
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("query")
+        mycaddy.status = rc
         mycaddy.info = info
         mycaddy.ndata = nqueries
         mycaddy.query = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "query", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, query_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef void toolconnected(pmix_info_t *info, size_t ninfo,
@@ -2648,6 +2708,7 @@ cdef void toolconnected(pmix_info_t *info, size_t ninfo,
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("toolconnected")
@@ -2655,9 +2716,10 @@ cdef void toolconnected(pmix_info_t *info, size_t ninfo,
         mycaddy.proc = proc
         mycaddy.toolconnected = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "toolconnected", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, toolconnected_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
     return
 
 cdef void log(const pmix_proc_t *client,
@@ -2726,26 +2788,32 @@ cdef int allocate(const pmix_proc_t *client,
     cdef size_t ninfo = 0
     info              = NULL
     info_ptr          = &info
-    rc = pmix_alloc_info(info_ptr, &ninfo, refarginfo)
+    prc = pmix_alloc_info(info_ptr, &ninfo, refarginfo)
+    if PMIX_SUCCESS != prc:
+        print("Error transferring info to C:", prc)
+        return prc
     # we cannot execute a callback function here as
     # that would cause PMIx to lockup. Likewise, the
     # Python function we called can't do it as it
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("allocate")
-        mycaddy.status = rc
+        mycaddy.status = PMIX_SUCCESS
         mycaddy.info = info
         mycaddy.ndata = ninfo
         mycaddy.allocate = cbfunc
         mycaddy.cbdata = cbdata
         mycaddy.release_fn = NULL
         mycaddy.notification_cbdata = NULL
-        cb = PyCapsule_New(mycaddy, "allocate", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, allocate_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int jobcontrol(const pmix_proc_t *requestor,
@@ -2867,6 +2935,7 @@ cdef int getcredential(const pmix_proc_t *proc,
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("getcredential")
@@ -2876,9 +2945,11 @@ cdef int getcredential(const pmix_proc_t *proc,
         mycaddy.cred = bo
         mycaddy.getcredential = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "getcredential", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, getcredential_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int validatecredential(const pmix_proc_t *proc,
@@ -2906,6 +2977,7 @@ cdef int validatecredential(const pmix_proc_t *proc,
             pmix_unload_info(directives, ndirs, mydirs)
             args['directives'] = mydirs
         status, pyinfo = pmixservermodule['validatecredential'](args)
+        rc = status
     else:
         rc = PMIX_ERR_NOT_SUPPORTED
     # we cannot execute a callback function here as
@@ -2917,14 +2989,17 @@ cdef int validatecredential(const pmix_proc_t *proc,
     cdef size_t ninfo = 0
     info              = NULL
     info_ptr          = &info
-    rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
-
+    prc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+    if PMIX_SUCCESS != prc:
+        print("Error converting info to C:", prc)
+        return prc
     # we cannot execute a callback function here as
     # that would cause PMIx to lockup. Likewise, the
     # Python function we called can't do it as it
     # would require them to call a C-function. So
     # if they succeeded in processing this request,
     # threadshift so we can generate the callback safely
+    global eventQueue
     if PMIX_SUCCESS == rc or PMIX_OPERATION_SUCCEEDED == rc:
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("validationcredential")
@@ -2933,9 +3008,11 @@ cdef int validatecredential(const pmix_proc_t *proc,
         mycaddy.ndata = ninfo
         mycaddy.validationcredential = cbfunc
         mycaddy.cbdata = cbdata
-        cb = PyCapsule_New(mycaddy, "validationcredential", NULL)
-        rc = PMIX_SUCCESS
-        threading.Timer(0.5, validationcredential_cb, [cb, rc]).start()
+        cb = PyCapsule_New(mycaddy, NULL, NULL)
+        # push the results into the queue to return them
+        # to the PMIx library
+        eventQueue.put(cb)
+        return PMIX_SUCCESS
     return rc
 
 cdef int iofpull(const pmix_proc_t procs[], size_t nprocs,
@@ -3086,9 +3163,7 @@ cdef class PMIxTool(PMIxServer):
         global progressThread
 
         # start the event handler progress thread
-        print("TOOL STARTING THREAD")
         progressThread.start()
-        print("TOOL THREAD STARTED")
 
         # init myname
         myname = {'nspace':'UNASSIGNED', 'rank':PMIX_RANK_UNDEF}
@@ -3115,7 +3190,7 @@ cdef class PMIxTool(PMIxServer):
 
         # stop progress thread
         stop_progress = True
-        progressThread.join()
+        progressThread.join(timeout=1)
         # finalize
         rc = PMIx_tool_finalize()
         return rc

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -39,6 +39,8 @@ def pyevhdlr(stop):
             try:
                 shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, NULL)
             except:
+                # don't beat on the cpu
+                time.sleep(0.001)
                 continue
             op = shifter[0].op.decode('ascii')
             if "event_handler" == op:
@@ -88,7 +90,7 @@ def pyevhdlr(stop):
                 print("UNSUPPORTED OP", op)
         # don't beat on the cpu
         time.sleep(0.001)
-        return
+    return
 
 
 # create a progress thread for processing events

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -111,6 +111,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_RANK_INVALID   UINT32_MAX-3
 /* define a boundary for valid ranks */
 #define PMIX_RANK_VALID         UINT32_MAX-50
+/* define a macro for testing for valid ranks */
+#define PMIX_RANK_IS_VALID(r)   \
+    ((r) < PMIX_RANK_VALID)
 
 /* define a value to indicate that data applies
  * to all apps in a job */

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -106,6 +106,40 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("rank %d: Universe size check: PASSED", myproc.rank));
 
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {
+        TEST_ERROR(("rank %d: PMIx_Get hostname failed: %s", myproc.rank, PMIx_Error_string(rc)));
+        FREE_TEST_PARAMS(params);
+        exit(rc);
+    }
+    if (NULL == val) {
+        TEST_ERROR(("rank %d: PMIx_Get hostname returned NULL value", myproc.rank));
+        FREE_TEST_PARAMS(params);
+        exit(1);
+    }
+    if (val->type != PMIX_STRING) {
+        TEST_ERROR(("rank %d: Hostname type mismatch: %s",
+                    myproc.rank, PMIx_Data_type_string(val->type)));
+        FREE_TEST_PARAMS(params);
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NODEID, NULL, 0, &val))) {
+        TEST_ERROR(("rank %d: PMIx_Get nodeid failed: %s", myproc.rank, PMIx_Error_string(rc)));
+        FREE_TEST_PARAMS(params);
+        exit(rc);
+    }
+    if (NULL == val) {
+        TEST_ERROR(("rank %d: PMIx_Get nodeid returned NULL value", myproc.rank));
+        FREE_TEST_PARAMS(params);
+        exit(1);
+    }
+    if (val->type != PMIX_UINT32) {
+        TEST_ERROR(("rank %d: NodeID type mismatch: %s",
+                    myproc.rank, PMIx_Data_type_string(val->type)));
+        FREE_TEST_PARAMS(params);
+        exit(1);
+    }
+
     if( NULL != params.nspace && 0 != strcmp(myproc.nspace, params.nspace) ) {
         TEST_ERROR(("rank %d: Bad nspace!", myproc.rank));
         FREE_TEST_PARAMS(params);

--- a/test/python/sched.py
+++ b/test/python/sched.py
@@ -48,14 +48,14 @@ def main():
     print("Version: ", vers)
 
     # Register a fabric
-    rc = foo.fabric_register(None)
-    print("Fabric registered: ", rc)
+    rc,fab = foo.fabric_register(None)
+    print("Fabric registered: ", foo.error_string(rc))
 
     # setup the application
     (rc, regex) = foo.generate_regex(["test000","test001","test002"])
-    print("Node regex, rc: ", regex, rc)
+    print("Node regex, rc: ", regex, foo.error_string(rc))
     (rc, ppn) = foo.generate_ppn(["0,1,2", "3,4,5", "6,7"])
-    print("PPN, rc: ", ppn, rc)
+    print("PPN, rc: ", ppn, foo.error_string(rc))
     darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_FABRIC_ID,
                             'value':'SIMPSCHED.net', 'val_type':PMIX_STRING},
                            {'key':PMIX_ALLOC_FABRIC_SEC_KEY, 'value':'T',
@@ -71,7 +71,7 @@ def main():
     print("SETUPAPP: ", appinfo)
 
     rc = foo.setup_local_support("SIMPSCHED", appinfo)
-    print("SETUPLOCAL: ", rc)
+    print("SETUPLOCAL: ", foo.error_string(rc))
 
     # get our environment as a base
     env = os.environ.copy()
@@ -83,18 +83,18 @@ def main():
              {'key':PMIX_JOB_SIZE, 'value':1, 'val_type':PMIX_UINT32}]
     print("REGISTERING NSPACE")
     rc = foo.register_nspace("testnspace", 1, kvals)
-    print("RegNspace ", rc)
+    print("RegNspace ", foo.error_string(rc))
 
     # register a client
     uid = os.getuid()
     gid = os.getgid()
     print("REGISTERING CLIENT")
     rc = foo.register_client({'nspace':"testnspace", 'rank':0}, uid, gid)
-    print("RegClient ", rc)
+    print("RegClient ", foo.error_string(rc))
 
     # setup the fork
     rc = foo.setup_fork({'nspace':"testnspace", 'rank':0}, env)
-    print("SetupFrk", rc)
+    print("SetupFrk", foo.error_string(rc))
 
     # setup the client argv
     args = ["./client.py"]

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -75,16 +75,16 @@ def main():
              {'key':PMIX_JOB_SIZE, 'value':1, 'val_type':PMIX_UINT32}]
     print("REGISTERING NSPACE")
     rc = foo.register_nspace("testnspace", 1, kvals)
-    print("RegNspace ", rc)
+    print("RegNspace ", foo.error_string(rc))
 
     # register a client
     uid = os.getuid()
     gid = os.getgid()
     rc = foo.register_client({'nspace':"testnspace", 'rank':0}, uid, gid)
-    print("RegClient ", rc)
+    print("RegClient ", foo.error_string(rc))
     # setup the fork
     rc = foo.setup_fork({'nspace':"testnspace", 'rank':0}, env)
-    print("SetupFrk", rc)
+    print("SetupFrk", foo.error_string(rc))
 
     # setup the client argv
     args = ["./client.py"]


### PR DESCRIPTION
Use the queue class to threadshift all server-level responses instead of
doing a timer delay

-----------------------

Let hash search for node/app info on specified proc
If the process has been specified in a PMIx_Get and its node or app
information is requested, then search the proc-level data to get it.

Fixes #1965

-----------------------

Ensure Python progress thread doesn't return early

-----------------------

Signed-off-by: Ralph Castain <rhc@pmix.org>