### PR TITLE
Protect the socket/bind call and avoid unnecessary key waits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,7 +23,7 @@ multiple release branches.
 Master (not on release branches yet)
 ------------------------------------
 
-4.0.0 -- TBD
+4.0.0 -- 30 Dec 2020
 ----------------------
 **** NOTE: This release implements the complete PMIx v4.0 Standard
 **** and therefore includes a number of new APIs and features. These

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -317,6 +317,7 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     int myport;
     pmix_kval_t *urikv;
     pid_t mypid;
+    pmix_socklen_t socklen;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tool setup_listener");
@@ -480,7 +481,12 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         goto sockerror;
     }
 
-    if (bind(lt->socket, (struct sockaddr*)&pmix_ptl_base.connection, sizeof(struct sockaddr_storage)) < 0) {
+#if PMIX_HAVE_APPLE
+    socklen = sizeof(struct sockaddr);
+#else
+    socklen = sizeof(struct sockaddr_storage);
+#endif
+    if (bind(lt->socket, (struct sockaddr*)&pmix_ptl_base.connection, socklen) < 0) {
         printf("%s:%d bind() failed for socket %d size %u: %s\n",
                __FILE__, __LINE__, lt->socket, (unsigned)sizeof(struct sockaddr_storage), strerror(errno));
         goto sockerror;

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -414,9 +414,14 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
             }
         }
 
-        /* ask for a non-existent key */
-        proc.rank = i+params.base_rank;
-        j = 2;
+      cleanout:
+        TEST_VERBOSE(("%s:%d: rank %d is OK", my_nspace, my_rank, i+params.base_rank));
+    }
+
+    /* ask for a non-existent key */
+    if (0 == my_rank) {
+        proc.rank = 1+params.base_rank;
+        j = 1;
         PMIX_INFO_LOAD(&info, PMIX_TIMEOUT, &j, PMIX_INT);
         PMIX_INFO_REQUIRED(&info);
         if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, "foobar", &info, 1, &val))) {
@@ -436,10 +441,8 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
             TEST_ERROR(("%s:%d [ERROR]: PMIx_Get did not return NULL value", my_nspace, my_rank));
             exit(PMIX_ERROR);
         }
-
-      cleanout:
-        TEST_VERBOSE(("%s:%d: rank %d is OK", my_nspace, my_rank, i+params.base_rank));
     }
+
     free(peers);
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
When performing a get operation that goes up to the server, check to see
if the key exists in some other scope and return the correct error if it
does. Check for that error and don't "wait" for the data to appear as it
will never do so if it is already posted to a scope outside the range of
the caller.

Protect the socket/bind call when running on Mac.

Update test_job_fence so only one proc tries one time to find a
nonexistent key - helps reduce the runtime of the test

Signed-off-by: Ralph Castain <rhc@pmix.org>