### PR TITLE
finalize: set hostname in global to NULL

### DIFF
--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -141,6 +142,7 @@ void pmix_rte_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_globals.stdin_targets);
     if (NULL != pmix_globals.hostname) {
         free(pmix_globals.hostname);
+        pmix_globals.hostname = NULL;
     }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
 


### PR DESCRIPTION
otherwise applications that try to init/finalize pmix multiple times segfault
in second call to pmix_rte_finalize.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>