### PR TITLE
Disable IPv6 by default

### DIFF
--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,7 +90,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_2,
                                      PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
                                      &pmix_ptl_base.if_include);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_include", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_include",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "if_exclude",
                                      "Comma-delimited list of devices and/or CIDR notation of TCP networks to NOT use "
@@ -99,7 +101,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_2,
                                      PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
                                      &pmix_ptl_base.if_exclude);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_exclude", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_exclude",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     /* if_include and if_exclude need to be mutually exclusive */
     if (NULL != pmix_ptl_base.if_include &&
@@ -116,7 +119,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.ipv4_port);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "ipv4_port", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "ipv4_port",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "ipv6_port",
                                      "IPv6 port to be used",
@@ -124,7 +128,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.ipv6_port);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "ipv6_port", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "ipv6_port",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "disable_ipv4_family",
                                      "Disable the IPv4 interfaces",
@@ -132,15 +137,18 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.disable_ipv4_family);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "disable_ipv4_family", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "disable_ipv4_family",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
+    pmix_ptl_base.disable_ipv6_family = true;
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "disable_ipv6_family",
-                                     "Disable the IPv6 interfaces",
+                                     "Disable the IPv6 interfaces (default:disabled)",
                                      PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.disable_ipv6_family);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "disable_ipv6_family", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "disable_ipv6_family",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "connection_wait_time",
                                      "Number of seconds to wait for the server connection file to appear",
@@ -148,7 +156,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.wait_to_connect);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "connection_wait_time", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "connection_wait_time",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "max_retries",
                                      "Number of times to look for the connection file before quitting",
@@ -156,7 +165,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.max_retries);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "max_retries", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "max_retries",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "handshake_wait_time",
                                      "Number of seconds to wait for the server reply to the handshake request",
@@ -164,7 +174,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.handshake_wait_time);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_wait_time", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_wait_time",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "handshake_max_retries",
                                      "Number of times to retry the handshake request before giving up",
@@ -172,7 +183,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_4,
                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                      &pmix_ptl_base.handshake_max_retries);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_max_retries", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_max_retries",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     idx = pmix_mca_base_var_register("pmix", "ptl", "base", "report_uri",
                                      "Output URI [- => stdout, + => stderr, or filename]",
@@ -180,7 +192,8 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                      PMIX_INFO_LVL_2,
                                      PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
                                      &pmix_ptl_base.report_uri);
-    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "report_uri", PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void)pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "report_uri",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
 
     return PMIX_SUCCESS;

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -317,7 +318,6 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     int myport;
     pmix_kval_t *urikv;
     pid_t mypid;
-    pmix_socklen_t socklen;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tool setup_listener");
@@ -445,11 +445,13 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     /* set the port */
     if (AF_INET == pmix_ptl_base.connection.ss_family) {
         ((struct sockaddr_in*) &pmix_ptl_base.connection)->sin_port = htons(pmix_ptl_base.ipv4_port);
+        addrlen = sizeof(struct sockaddr_in);
         if (0 != pmix_ptl_base.ipv4_port) {
             flags = 1;
         }
     } else if (AF_INET6 == pmix_ptl_base.connection.ss_family) {
-        ((struct sockaddr_in6*) &pmix_ptl_base.connection)->sin6_port = htons(pmix_ptl_base.ipv6_port);
+       ((struct sockaddr_in6*) &pmix_ptl_base.connection)->sin6_port = htons(pmix_ptl_base.ipv6_port);
+        addrlen = sizeof(struct sockaddr_in6);
         if (0 != pmix_ptl_base.ipv6_port) {
             flags = 1;
         }
@@ -459,7 +461,6 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     lt->protocol = PMIX_PROTOCOL_V2;
     lt->cbfunc = pmix_ptl_base_connection_handler;
 
-    addrlen = sizeof(struct sockaddr_storage);
     /* create a listen socket for incoming connection attempts */
     lt->socket = socket(pmix_ptl_base.connection.ss_family, SOCK_STREAM, 0);
     if (lt->socket < 0) {
@@ -481,14 +482,9 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         goto sockerror;
     }
 
-#if PMIX_HAVE_APPLE
-    socklen = sizeof(struct sockaddr);
-#else
-    socklen = sizeof(struct sockaddr_storage);
-#endif
-    if (bind(lt->socket, (struct sockaddr*)&pmix_ptl_base.connection, socklen) < 0) {
-        printf("%s:%d bind() failed for socket %d size %u: %s\n",
-               __FILE__, __LINE__, lt->socket, (unsigned)sizeof(struct sockaddr_storage), strerror(errno));
+    if (bind(lt->socket, (struct sockaddr*)&pmix_ptl_base.connection, addrlen) < 0) {
+        printf("[%u] %s:%d bind() failed for socket %d storage size %u: %s\n",
+               (unsigned)getpid(), __FILE__, __LINE__, lt->socket, (unsigned)addrlen, strerror(errno));
         goto sockerror;
     }
 


### PR DESCRIPTION
We are getting errors from the "bind" function on ARM machines due to IPv6 interfaces. We don't normally see those, and typically we disable them by default - but PMIx didn't set that default for some reason. Correct that here.

If someone cares about IPv6 support, they will need/want to further debug this behavior

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 7427abfa4f8c704de5514490abfdf2f7eb823701)