### PR TITLE
v4: Fix Python binding build for VPATH

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
-Copyright (c) 2008      IBM Corporation.  All rights reserved.
+Copyright (c) 2008-2021 IBM Corporation.  All rights reserved.
 Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
@@ -173,6 +173,12 @@ INSTALLATION OPTIONS
   Load configure options for the build from FILE.  Options on the
   command line that are not in FILE are also used.  Options on the
   command line and in FILE are replaced by what is in FILE.
+
+--enable-python-bindings
+  Build the Python bindings for PMIx. Note the following packages
+  are required to be installed.
+    yum install Cython python3 python3-devel
+    pip3 install Cython
 
 Once OpenPMIx has been built and installed, it is safe to run "make
 clean" and/or remove the entire build tree.

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2021      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,9 +29,11 @@ EXTRA_DIST = $(helpers)
 if WANT_PYTHON_BINDINGS
 
 install-exec-local: $(helpers)
-	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include"
-	$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --include-dirs="$(top_builddir)/include" --library-dirs="$(DESTDIR)$(libdir)" --user
-	$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --prefix="$(DESTDIR)$(prefix)"
+	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include" --include-dir="$(top_srcdir)/include"
+	PMIX_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+		$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --library-dirs="$(DESTDIR)$(libdir)" --user
+	PMIX_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+		$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --prefix="$(DESTDIR)$(prefix)"
 
 uninstall-hook:
 	rm -f $(pythondir)/pmix*.so

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -19,8 +19,12 @@ def harvest_constants(options, src, constants, definitions):
     try:
         inputfile = open(path, "r")
     except:
-        print("File", path, "could not be opened")
-        return
+        path = os.path.join(options.includedir, src)
+        try:
+            inputfile = open(path, "r")
+        except:
+            print("File", path, "could not be opened")
+            return -1
     # read the file - these files aren't too large
     # so ingest the whole thing at one gulp
     lines = inputfile.readlines()
@@ -408,7 +412,7 @@ def harvest_constants(options, src, constants, definitions):
                         definitions.write(" ")
                     definitions.write(api[n] + "\n")
             definitions.write("\n")
-    return
+    return 0
 
 def main():
     global takeconst, takeapis, takedtypes
@@ -427,6 +431,8 @@ def main():
     execGroup = OptionGroup(parser, "Execution Options")
     execGroup.add_option("--src", dest="src",
                          help="The directory where the PMIx header files will be found")
+    execGroup.add_option("--include-dir", dest="includedir",
+                         help="The directory where the generated PMIx header files will be found")
     execGroup.add_option("--constants",
                          action="store_true", dest="constants", default=False,
                          help="Translate constants")
@@ -463,6 +469,12 @@ def main():
             print("SOURCE directory",options.src,"does not exist")
             sys.exit(1)
 
+    if options.includedir:
+        # see if the include directory directory exists
+        if not os.path.exists(options.includedir):
+            print("Include directory",options.includedir,"does not exist")
+            sys.exit(1)
+
     if options.dryrun:
         constants = sys.stdout
         definitions = sys.stdout
@@ -497,7 +509,8 @@ def main():
     # scan across the header files in the src directory
     # looking for constants and typedefs
     # add some space
-    harvest_constants(options, "pmix_common.h", constants, definitions)
+    if harvest_constants(options, "pmix_common.h", constants, definitions) != 0:
+        sys.exit(1)
     definitions.write("\n\n")
     constants.write("\n\n")
     harvest_constants(options, "pmix.h", constants, definitions)

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -2,14 +2,36 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
 from sys import platform, maxsize, version_info
-import os
-from Cython.Compiler.Main import default_options
+import os, sys
+from Cython.Compiler.Main import default_options, CompilationOptions
 default_options['emit_linenums'] = True
 from subprocess import check_output, CalledProcessError
 
+def get_include():
+    dirs = []
+    try:
+        dirs.append(os.environ['PMIX_TOP_BUILDDIR'] + "/include")
+        dirs.append(os.environ['PMIX_TOP_SRCDIR'] + "/include")
+    except:
+        return dirs
+    return dirs
+    
 def getVersion():
     dir = os.path.dirname(__file__)
+
     vers_path = os.path.join(dir, '../../include', 'pmix_version.h')
+    if not os.path.exists(vers_path):
+        include_dirs = get_include()
+        vers_path = None
+        for dir in include_dirs:
+            tmp_path = os.path.join(dir, 'pmix_version.h')
+            if os.path.exists(tmp_path):
+                vers_path = tmp_path
+                break
+        if vers_path is None:
+            print("Error: pmix_version.h does not exist at path: ",vers_path)
+            sys.exit(1)
+
     with open(vers_path) as verFile:
         lines = verFile.readlines()
         for l in lines:
@@ -44,6 +66,9 @@ setup(
             'Programming Language :: Python :: 3.6'],
     keywords = 'PMI PMIx HPC MPI SHMEM',
     platforms = 'any',
-    ext_modules = cythonize([Extension("pmix", ["pmix.pyx"], libraries=["pmix"])],
-                            compiler_directives={'language_level': 3})
+    ext_modules = cythonize([Extension("pmix",
+                                       [os.environ['PMIX_TOP_SRCDIR']+"/bindings/python/pmix.pyx"],
+                                       libraries=["pmix"]) ],
+                            compiler_directives={'language_level': 3}),
+    include_dirs = get_include()
 )

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2009-2018 IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2009-2021 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
@@ -1256,15 +1256,14 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
     else
         AC_MSG_RESULT([no])
         # Cython doesn't have any include or lib files - it is just a binary
-        AC_CHECK_PROG(pmix_cython_rpm, cython, ["found"], ["not found"])
-        if test "$pmix_cython_rpm" = "found"; then
+        AC_CHECK_PROG(pmix_cython_rpm, cython, [cython])
+        if test "$pmix_cython_rpm" != ""; then
             AC_MSG_CHECKING([Cython version])
             cyvers=`cython --version 2>&1`
             cython_version=${cyvers#"Cython version "}
             AC_MSG_RESULT([$cython_version])
             PMIX_SUMMARY_ADD([[Bindings]],[[Cython]], [pmix_cython], [yes ($cython_version)])
         else
-            AC_MSG_RESULT([no])
             AC_MSG_WARN([Python bindings were enabled, but the Cython])
             AC_MSG_WARN([package was not found. PMIx Python bindings])
             AC_MSG_WARN([require that the Cython package be installed])


### PR DESCRIPTION
 * We need to include both the autogenerated include directory
  (in the VPATH) and the static include directory (in src/include)
  when building the python bindings.
 * Fixes #2003