### PR TITLE
Update the pnet/opa component to current architecture

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -23,6 +23,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -798,6 +799,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     PMIX_CHECK_CURL
 
+    PMIX_CHECK_OFI
 
     ##################################
     # Dstore Locking

--- a/config/pmix_check_ofi.m4
+++ b/config/pmix_check_ofi.m4
@@ -1,0 +1,179 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl PMIX_CHECK_OFI_VERSION_GE
+dnl
+dnl Check that the OFI API version number is >= a specific value.
+dnl
+dnl $1: version number to compare, in the form of "major,minor"
+dnl     (without quotes) -- i.e., a single token representing the
+dnl     arguments to FI_VERSION()
+dnl $2: action if OFI API version is >= $1
+dnl $3: action if OFI API version is < $1
+AC_DEFUN([PMIX_CHECK_OFI_VERSION_GE],[
+    PMIX_VAR_SCOPE_PUSH([pmix_ofi_ver_ge_save_CPPFLAGS pmix_ofi_ver_ge_happy])
+
+    AC_MSG_CHECKING([if OFI API version number is >= $1])
+    pmix_ofi_ver_ge_save_CPPFLAGS=$CPPFLAGS
+    CPPFLAGS=$pmix_ofi_CPPFLAGS
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fabric.h>]],
+[[
+#if !defined(FI_MAJOR_VERSION)
+#error "we cannot check the version -- sad panda"
+#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION($1))
+#error "version is too low -- nopes"
+#endif
+]])],
+                      [pmix_ofi_ver_ge_happy=1],
+                      [pmix_ofi_ver_ge_happy=0])
+
+    AS_IF([test $pmix_ofi_ver_ge_happy -eq 1],
+          [AC_MSG_RESULT([yes])
+           $2],
+          [AC_MSG_RESULT([no])
+           $3])
+
+    CPPFLAGS=$pmix_ofi_ver_ge_save_CPPFLAGS
+
+    PMIX_VAR_SCOPE_POP
+])dnl
+
+dnl
+dnl _PMIX_CHECK_OFI
+dnl --------------------------------------------------------
+dnl Do the real work of checking for OFI libfabric.
+dnl Upon return:
+dnl
+dnl - pmix_ofi_happy: will be "yes" or "no"
+dnl - pmix_ofi_{CPPFLAGS|LDFLAGS|LIBS} will be loaded (if relevant)
+dnl
+AC_DEFUN([_PMIX_CHECK_OFI],[
+    # Add --with options
+    AC_ARG_WITH([libfabric],
+                [AC_HELP_STRING([--with-libfabric=DIR],
+                                [Deprecated synonym for --with-ofi])])
+    AC_ARG_WITH([libfabric-libdir],
+                [AC_HELP_STRING([--with-libfabric-libdir=DIR],
+                                [Deprecated synonym for --with-ofi-libdir])])
+
+    AC_ARG_WITH([ofi],
+                [AC_HELP_STRING([--with-ofi=DIR],
+                                [Specify location of OFI libfabric installation, adding DIR/include to the default search location for libfabric headers, and DIR/lib or DIR/lib64 to the default search location for libfabric libraries.  Error if libfabric support cannot be found.])])
+
+    AC_ARG_WITH([ofi-libdir],
+                [AC_HELP_STRING([--with-ofi-libdir=DIR],
+                                [Search for OFI libfabric libraries in DIR])])
+
+    if test "$with_ofi" = ""; then
+         with_ofi=$with_libfabric
+    fi
+
+    if test "$with_ofi_libdir" = ""; then
+         with_ofi_libdir=$with_libfabric_libdir
+    fi
+
+    # Sanity check the --with values
+    PMIX_CHECK_WITHDIR([ofi], [$with_ofi],
+                       [include/rdma/fabric.h])
+    PMIX_CHECK_WITHDIR([ofi-libdir], [$with_ofi_libdir],
+                       [libfabric.*])
+
+    PMIX_VAR_SCOPE_PUSH([pmix_check_ofi_save_CPPFLAGS pmix_check_ofi_save_LDFLAGS pmix_check_ofi_save_LIBS pmix_check_fi_info_pci])
+    pmix_check_ofi_save_CPPFLAGS=$CPPFLAGS
+    pmix_check_ofi_save_LDFLAGS=$LDFLAGS
+    pmix_check_ofi_save_LIBS=$LIBS
+    pmix_check_fi_info_pci=0
+
+    pmix_ofi_happy=yes
+    AS_IF([test "$with_ofi" = "no"],
+          [pmix_ofi_happy=no])
+
+    AS_IF([test $pmix_ofi_happy = yes],
+          [AC_MSG_CHECKING([looking for OFI libfabric in])
+           AS_IF([test "$with_ofi" != "yes"],
+                 [pmix_ofi_dir=$with_ofi
+                  AC_MSG_RESULT([($pmix_ofi_dir)])],
+                 [AC_MSG_RESULT([(default search paths)])])
+           AS_IF([test ! -z "$with_ofi_libdir" && \
+                         test "$with_ofi_libdir" != "yes"],
+                 [pmix_ofi_libdir=$with_ofi_libdir])
+          ])
+
+    AS_IF([test $pmix_ofi_happy = yes],
+          [PMIX_CHECK_PACKAGE([pmix_ofi],
+                              [rdma/fabric.h],
+                              [fabric],
+                              [fi_getinfo],
+                              [],
+                              [$pmix_ofi_dir],
+                              [$pmix_ofi_libdir],
+                              [],
+                              [pmix_ofi_happy=no])])
+
+    CPPFLAGS="$CPPFLAGS $pmix_ofi_CPPFLAGS"
+
+    AS_IF([test $pmix_ofi_happy = yes],
+          [AC_CHECK_MEMBER([struct fi_info.nic],
+                           [pmix_check_fi_info_pci=1],
+                           [pmix_check_fi_info_pci=0],
+                           [[#include <rdma/fabric.h>]])])
+
+    AC_DEFINE_UNQUOTED([PMIX_OFI_PCI_DATA_AVAILABLE],
+                       [$pmix_check_fi_info_pci],
+                       [check if pci data is available in ofi])
+
+    CPPFLAGS=$pmix_check_ofi_save_CPPFLAGS
+    LDFLAGS=$pmix_check_ofi_save_LDFLAGS
+    LIBS=$pmix_check_ofi_save_LIBS
+
+    AC_SUBST([pmix_ofi_CPPFLAGS])
+    AC_SUBST([pmix_ofi_LDFLAGS])
+    AC_SUBST([pmix_ofi_LIBS])
+
+    AS_IF([test -z $pmix_ofi_dir],
+          [pmix_ofi_dir="Default"])
+
+    PMIX_VAR_SCOPE_POP
+
+    AS_IF([test $pmix_ofi_happy = no],
+          [AS_IF([test -n "$with_ofi" && test "$with_ofi" != "no"],
+                 [AC_MSG_WARN([OFI libfabric support requested (via --with-ofi or --with-libfabric), but not found.])
+                  AC_MSG_ERROR([Cannot continue.])])
+           ])
+])dnl
+
+
+dnl
+dnl PMIX_CHECK_OFI
+dnl --------------------------------------------------------
+dnl Check to see if OFI libfabric is available.
+dnl
+dnl This is a simple wrapper around _PMIX_CHECK_OFI that just
+dnl ensures to only run the checks once.  We do not use AC_REQUIRE
+dnl because that re-orders the texts and makes ordering in stdout
+dnl quite confusing / difficult to grok.
+dnl
+AC_DEFUN([PMIX_CHECK_OFI],[
+    # Check for OFI libfabric.  Note that $pmix_ofi_happy is used in
+    # other configure.m4's to know if OFI/libfabric configured
+    # successfully.  We only need to run the back-end checks once, but
+    # at least emit a "checking..." statement each subsequent time
+    # this macro is invoked so that configure's stdout has
+    # sensible/logical output.
+    AS_IF([test -z "$pmix_ofi_happy"],
+        [_PMIX_CHECK_OFI],
+        [AC_MSG_CHECKING([if OFI libfabric is available])
+         AC_MSG_RESULT([$pmix_ofi_happy])])
+])

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -17,6 +17,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,11 +37,11 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
     if test -z "$pmix_check_psm2_happy" ; then
 	AC_ARG_WITH([psm2],
 		    [AC_HELP_STRING([--with-psm2(=DIR)],
-				    [Build PSM2 (Intel PSM2) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+				    [Build PSM2 support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
 	PMIX_CHECK_WITHDIR([psm2], [$with_psm2], [include/psm2.h])
 	AC_ARG_WITH([psm2-libdir],
 		    [AC_HELP_STRING([--with-psm2-libdir=DIR],
-				    [Search for PSM (Intel PSM2) libraries in DIR])])
+				    [Search for PSM2 libraries in DIR])])
 	PMIX_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
 
 	pmix_check_psm2_save_CPPFLAGS="$CPPFLAGS"
@@ -89,6 +90,9 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
           [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "no"],
                  [AC_MSG_ERROR([PSM2 support requested but not found.  Aborting])])
            $3])
+
+    AS_IF([test -z $pmix_check_psm2_dir],
+          [pmix_check_psm2_dir="Default"])
 
     PMIX_VAR_SCOPE_POP
 ])

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,37 +71,6 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_base_active_module_t);
 
 typedef struct {
     pmix_list_item_t super;
-    char *nspace;
-    pmix_rank_t *ranks;
-    size_t np;
-} pmix_pnet_local_procs_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_local_procs_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    char *name;
-    pmix_list_t resources;
-}pmix_pnet_resource_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_resource_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    size_t index;
-    char *name;
-    pmix_list_t local_jobs;    // list of pmix_pnet_local_procs_t
-    pmix_list_t resources;     // list of pmix_pnet_resource_t
-} pmix_pnet_node_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_node_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    char *nspace;
-    pmix_pointer_array_t nodes;
-} pmix_pnet_job_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_job_t);
-
-typedef struct {
-    pmix_list_item_t super;
     char *name;
     size_t index;
     /* provide access to the component
@@ -115,13 +85,9 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pnet_fabric_t);
 
 /* framework globals */
 struct pmix_pnet_globals_t {
-    pmix_lock_t lock;
     pmix_list_t actives;
     pmix_list_t fabrics;
-    bool initialized;
     bool selected;
-    pmix_list_t jobs;
-    pmix_list_t nodes;
 };
 typedef struct pmix_pnet_globals_t pmix_pnet_globals_t;
 

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,12 +62,8 @@ pmix_pnet_API_module_t pmix_pnet = {
 
 static pmix_status_t pmix_pnet_close(void)
 {
-  pmix_pnet_base_active_module_t *active, *prev;
+    pmix_pnet_base_active_module_t *active, *prev;
 
-    if (!pmix_pnet_globals.initialized) {
-        return PMIX_SUCCESS;
-    }
-    pmix_pnet_globals.initialized = false;
     pmix_pnet_globals.selected = false;
 
     PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
@@ -76,26 +73,17 @@ static pmix_status_t pmix_pnet_close(void)
       }
       PMIX_RELEASE(active);
     }
-    PMIX_DESTRUCT(&pmix_pnet_globals.actives);
-    PMIX_DESTRUCT(&pmix_pnet_globals.fabrics);
+    PMIX_LIST_DESTRUCT(&pmix_pnet_globals.actives);
+    PMIX_LIST_DESTRUCT(&pmix_pnet_globals.fabrics);
 
-    PMIX_LIST_DESTRUCT(&pmix_pnet_globals.jobs);
-    PMIX_LIST_DESTRUCT(&pmix_pnet_globals.nodes);
-
-    PMIX_DESTRUCT_LOCK(&pmix_pnet_globals.lock);
     return pmix_mca_base_framework_components_close(&pmix_pnet_base_framework, NULL);
 }
 
 static pmix_status_t pmix_pnet_open(pmix_mca_base_open_flag_t flags)
 {
     /* initialize globals */
-    pmix_pnet_globals.initialized = true;
-    PMIX_CONSTRUCT_LOCK(&pmix_pnet_globals.lock);
-    pmix_pnet_globals.lock.active = false;
     PMIX_CONSTRUCT(&pmix_pnet_globals.actives, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_pnet_globals.fabrics, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_pnet_globals.jobs, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_pnet_globals.nodes, pmix_list_t);
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_pnet_base_framework, flags);
@@ -108,85 +96,6 @@ PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pnet, "PMIx Network Operations",
 PMIX_CLASS_INSTANCE(pmix_pnet_base_active_module_t,
                     pmix_list_item_t,
                     NULL, NULL);
-
-static void lpcon(pmix_pnet_local_procs_t *p)
-{
-    p->nspace = NULL;
-    p->ranks = NULL;
-    p->np = 0;
-}
-static void lpdes(pmix_pnet_local_procs_t *p)
-{
-    if (NULL != p->nspace) {
-        free(p->nspace);
-    }
-    if (NULL != p->ranks) {
-        free(p->ranks);
-    }
-}
-PMIX_CLASS_INSTANCE(pmix_pnet_local_procs_t,
-                    pmix_list_item_t,
-                    lpcon, lpdes);
-
-static void ndcon(pmix_pnet_node_t *p)
-{
-    p->name = NULL;
-    PMIX_CONSTRUCT(&p->local_jobs, pmix_list_t);
-    PMIX_CONSTRUCT(&p->resources, pmix_list_t);
-}
-static void nddes(pmix_pnet_node_t *p)
-{
-    if (NULL != p->name) {
-        free(p->name);
-    }
-    PMIX_LIST_DESTRUCT(&p->local_jobs);
-    PMIX_LIST_DESTRUCT(&p->resources);
-}
-PMIX_CLASS_INSTANCE(pmix_pnet_node_t,
-                    pmix_list_item_t,
-                    ndcon, nddes);
-
-static void jcon(pmix_pnet_job_t *p)
-{
-    p->nspace = NULL;
-    PMIX_CONSTRUCT(&p->nodes, pmix_pointer_array_t);
-    pmix_pointer_array_init(&p->nodes, 1, INT_MAX, 1);
-}
-static void jdes(pmix_pnet_job_t *p)
-{
-    int n;
-    pmix_pnet_node_t *nd;
-
-    if (NULL != p->nspace) {
-        free(p->nspace);
-    }
-    for (n=0; n < p->nodes.size; n++) {
-        if (NULL != (nd = (pmix_pnet_node_t*)pmix_pointer_array_get_item(&p->nodes, n))) {
-            pmix_pointer_array_set_item(&p->nodes, n, NULL);
-            PMIX_RELEASE(nd);
-        }
-    }
-    PMIX_DESTRUCT(&p->nodes);
-}
-PMIX_CLASS_INSTANCE(pmix_pnet_job_t,
-                    pmix_list_item_t,
-                    jcon, jdes);
-
-static void rcon(pmix_pnet_resource_t *p)
-{
-    p->name = NULL;
-    PMIX_CONSTRUCT(&p->resources, pmix_list_t);
-}
-static void rdes(pmix_pnet_resource_t *p)
-{
-    if (NULL != p->name) {
-        free(p->name);
-    }
-    PMIX_LIST_DESTRUCT(&p->resources);
-}
-PMIX_CLASS_INSTANCE(pmix_pnet_resource_t,
-                    pmix_list_item_t,
-                    rcon, rdes);
 
 static void ftcon(pmix_pnet_fabric_t *p)
 {

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -27,88 +27,33 @@
 AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
     AC_CONFIG_FILES([src/mca/pnet/opa/Makefile])
 
-    PMIX_CHECK_PSM2([pnet_opa],
-                    [pnet_opa_happy="yes"],
-                    [pnet_opa_happy="no"])
+    PMIX_CHECK_PSM2([pnet_psm2],
+                    [pnet_psm2_happy="yes"],
+                    [pnet_psm2_happy="no"])
 
-    AC_ARG_WITH([opamgt],
-        [AC_HELP_STRING([--with-opamgt(=DIR)],
-        [Build OmniPath Fabric Management support (optionally adding DIR/include, DIR/include/opamgt, DIR/lib, and DIR/lib64 to the search path for headers and libraries])], [], [with_opamgt=no])
+    pnet_opa_CFLAGS=
+    pnet_opa_CPPFLAGS=
+    pnet_opa_LDFLAGS=
+    pnet_opa_LIBS=
 
-    AC_ARG_WITH([opamgt-libdir],
-                [AC_HELP_STRING([--with-opamgt-libdir=DIR],
-                                [Search for OmniPath Fabric Management libraries in DIR])])
-
-    pmix_check_opamgt_save_CPPFLAGS="$CPPFLAGS"
-    pmix_check_opamgt_save_LDFLAGS="$LDFLAGS"
-    pmix_check_opamgt_save_LIBS="$LIBS"
-
-    pmix_check_opamgt_libdir=
-    pmix_check_opamgt_dir=
-
-    AC_MSG_CHECKING([if opamgt requested])
-    AS_IF([test "$with_opamgt" = "no"],
-          [AC_MSG_RESULT([no])
-           pmix_check_opamgt_happy=no],
-          [AC_MSG_RESULT([yes])
-           PMIX_CHECK_WITHDIR([opamgt-libdir], [$with_opamgt_libdir], [libopamgt.*])
-           AS_IF([test ! -z "$with_opamgt" && test "$with_opamgt" != "yes"],
-                 [pmix_check_opamgt_dir="$with_opamgt"
-                  AS_IF([test ! -d "$pmix_check_opamgt_dir" || test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
-                         [$pmix_check_opamgt_dir=$pmix_check_opamgt_dir/include
-                          AS_IF([test ! -d "$pmix_check_opamgt_dir" || test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
-                                [$pmix_check_opamgt_dir=$pmix_check_opamgt_dir/opamgt
-                                 AS_IF([test ! -d "$pmix_check_opamgt_dir" || test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
-                                       [AC_MSG_WARN([OmniPath Fabric Management support requested, but])
-                                        AC_MSG_WARN([required header file opamgt.h not found. Locations tested:])
-                                        AC_MSG_WARN([    $with_opamgt])
-                                        AC_MSG_WARN([    $with_opamgt/include])
-                                        AC_MSG_WARN([    $with_opamgt/include/opamgt])
-                                        AC_MSG_ERROR([Cannot continue])])])])],
-                 [pmix_check_opamgt_dir="/usr/include/opamgt"])
-
-           AS_IF([test ! -z "$with_opamgt_libdir" && test "$with_opamgt_libdir" != "yes"],
-                 [pmix_check_opamgt_libdir="$with_opamgt_libdir"])
-
-           # no easy way to check this, so let's ensure that the
-           # full opamgt install was done, including the iba support
-           AS_IF([test ! -d "$pmix_check_opamgt_dir/iba" || test ! -f "$pmix_check_opamgt_dir/iba/vpi.h"],
-                 [pmix_check_opamgt_happy="no"],
-                 [PMIX_CHECK_PACKAGE([pnet_opamgt],
-                                     [opamgt.h],
-                                     [opamgt],
-                                     [omgt_query_sa],
-                                     [],
-                                     [$pmix_check_opamgt_dir],
-                                     [$pmix_check_opamgt_libdir],
-                                     [pmix_check_opamgt_happy="yes"
-                                      pnet_opa_CFLAGS="$pnet_opa_CFLAGS $pnet_opamgt_CFLAGS"
-                                      pnet_opa_CPPFLAGS="$pnet_opa_CPPFLAGS $pnet_opamgt_CPPFLAGS"
-                                      pnet_opa_LDFLAGS="$pnet_opa_LDFLAGS $pnet_opamgt_LDFLAGS"
-                                      pnet_opa_LIBS="$pnet_opa_LIBS $pnet_opamgt_LIBS"],
-                                     [pmix_check_opamgt_happy="no"])])
-           ])
-
-    AS_IF([test "$pmix_check_opamgt_happy" = "yes"],
-          [pmix_want_opamgt=1],
-          [pmix_want_opamgt=0])
-    AC_DEFINE_UNQUOTED([PMIX_WANT_OPAMGT], [$pmix_want_opamgt],
-                       [Whether or not to include OmniPath Fabric Manager support])
-
-    CPPFLAGS="$pmix_check_opamgt_save_CPPFLAGS"
-    LDFLAGS="$pmix_check_opamgt_save_LDFLAGS"
-    LIBS="$pmix_check_opamgt_save_LIBS"
-
-    AS_IF([test "$pnet_opa_happy" = "yes"],
-          [PMIX_SUMMARY_ADD([[Transports]],[[OmniPath]], [pnet_opa], [yes ($pmix_check_psm2_dir)])
-           AS_IF([test "$pmix_check_opamgt_happy" = "yes"],
-                 [PMIX_SUMMARY_ADD([[Transports]],[[OmniPath Mgmt]], [pnet_opa_mgmt], [yes ($pmix_check_opamgt_dir)])],
-                 [PMIX_SUMMARY_ADD([[Transports]],[[OmniPath Mgmt]], [pnet_opa_mgmt], [no])])
-           $1],
-          [PMIX_SUMMARY_ADD([[Transports]],[[OmniPath]], [pnet_opa], [no])
+    AS_IF([test "$pnet_psm2_happy" = "yes"],
+          [PMIX_SUMMARY_ADD([[Transports]],[[PSM2]], [pnet_opa], [yes ($pmix_check_psm2_dir)])
+           pnet_opa_CFLAGS="$pnet_opa_CFLAGS $pnet_psm2_CFLAGS"
+           pnet_opa_CPPFLAGS="$pnet_opa_CPPFLAGS $pnet_psm2_CPPFLAGS"
+           pnet_opa_LDFLAGS="$pnet_opa_LDFLAGS $pnet_psm2_LDFLAGS"
+           pnet_opa_LIBS="$pnet_opa_LIBS $pnet_psm2_LIBS"],
+          [PMIX_SUMMARY_ADD([[Transports]],[[PSM2]], [pnet_opa], [no])
            $2])
 
-    # substitute in the things needed to build psm2
+    AS_IF([test "$pmix_ofi_happy" = "yes"],
+          [PMIX_SUMMARY_ADD([[Transports]],[[OFI]], [pnet_opa], [yes ($pmix_ofi_dir)])
+           pnet_opa_CPPFLAGS="$pnet_opa_CPPFLAGS $pmix_ofi_CPPFLAGS"
+           pnet_opa_LDFLAGS="$pnet_opa_LDFLAGS $pmix_ofi_LDFLAGS"
+           pnet_opa_LIBS="$pnet_opa_LIBS $pmix_ofi_LIBS"],
+          [PMIX_SUMMARY_ADD([[Transports]],[[OFI]], [pnet_opa], [no])
+           $2])
+
+    # substitute in the things needed to build opa
     AC_SUBST([pnet_opa_CFLAGS])
     AC_SUBST([pnet_opa_CPPFLAGS])
     AC_SUBST([pnet_opa_LDFLAGS])

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -27,11 +27,6 @@
 #endif
 #include <time.h>
 
-#if PMIX_WANT_OPAMGT
-#include <opamgt/opamgt.h>
-#include <opamgt/opamgt_sa.h>
-#endif
-
 #include "include/pmix_common.h"
 
 #include "src/mca/base/pmix_mca_base_var.h"


### PR DESCRIPTION
Pass the envars to the backend and let the plugin apply them. This provides a generic method that doesn't rely on PRRTE to apply the envars itself.

Cleanup the pnet base
Don't use memory to track all that stuff - let the components decide if they need it

Signed-off-by: Ralph Castain <rhc@pmix.org>