### PR TITLE
Support autoconf 2.70

### DIFF
--- a/config/c_get_alignment.m4
+++ b/config/c_get_alignment.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -54,19 +55,12 @@ AC_DEFUN([PMIX_C_GET_ALIGNMENT],[
                                [ # cross compile - do a non-executable test.  Trick
                                  # taken from the Autoconf 2.59c.  Switch to using
                                  # AC_CHECK_ALIGNOF when we can require Autoconf 2.60.
-                                 _AC_COMPUTE_INT([(long int) offsetof (pmix__type_alignof_, y)],
-                                                 [AS_TR_SH([pmix_cv_c_align_$1])],
+                                 AC_CHECK_ALIGNOF([$1],
                                                  [AC_INCLUDES_DEFAULT
-#include <stdbool.h>
+                                                  #include <stdbool.h> ])
+                                 AS_TR_SH([pmix_cv_c_align_$1])
 
-#ifndef offsetof
-# define offsetof(type, member) ((char *) &((type *) 0)->member - (char *) 0)
-#endif
-typedef struct { char x; $1 y; } pmix__type_alignof_;
-],
-                                                 [AC_MSG_WARN([*** Problem running configure test!])
-                                                  AC_MSG_WARN([*** See config.log for details.])
-                                                  AC_MSG_ERROR([*** Cannot continue.])])])])
+])])
 
 AC_DEFINE_UNQUOTED([$2], [$AS_TR_SH([pmix_cv_c_align_$1])], [Alignment of type $1])
 eval "$2=$AS_TR_SH([pmix_cv_c_align_$1])"

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -196,7 +196,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     # Add any extra lib?
     AC_ARG_WITH([pmix-extra-lib],
-                AC_HELP_STRING([--with-pmix-extra-lib=LIB],
+                AS_HELP_STRING([--with-pmix-extra-lib=LIB],
                                [Link the output PMIx library to this extra lib (used in embedded mode)]))
     AC_MSG_CHECKING([for extra lib])
     AS_IF([test ! -z "$with_pmix_extra_lib"],
@@ -214,7 +214,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     # Add any extra libtool lib?
     AC_ARG_WITH([pmix-extra-ltlib],
-                AC_HELP_STRING([--with-pmix-extra-ltlib=LIB],
+                AS_HELP_STRING([--with-pmix-extra-ltlib=LIB],
                                [Link any embedded components/tools that require it to the provided libtool lib (used in embedded mode)]))
     AC_MSG_CHECKING([for extra ltlib])
     AS_IF([test ! -z "$with_pmix_extra_ltlib"],
@@ -235,7 +235,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     #
     AC_MSG_CHECKING([if want package/brand string])
     AC_ARG_WITH([pmix-package-string],
-         [AC_HELP_STRING([--with-pmix-package-string=STRING],
+         [AS_HELP_STRING([--with-pmix-package-string=STRING],
                          [Use a branding string throughout PMIx])])
     if test "$with_pmix_package_string" = "" || test "$with_pmix_package_string" = "no"; then
         with_package_string="PMIx $PMIX_CONFIGURE_USER@$PMIX_CONFIGURE_HOST Distribution"
@@ -632,9 +632,13 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     PMIX_VAR_SCOPE_PUSH([LDFLAGS_save])
     LDFLAGS_save=$LDFLAGS
     LDFLAGS="$LDFLAGS_save -Wl,-fini -Wl,finalize"
-    AC_TRY_LINK([void finalize (void) {}], [], [AC_MSG_RESULT([yes])
-            pmix_ld_have_fini=1], [AC_MSG_RESULT([no])
-            pmix_ld_have_fini=0])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+        void finalize (void) {}
+        ]])],
+        [AC_MSG_RESULT([yes])
+         pmix_ld_have_fini=1],
+        [AC_MSG_RESULT([no])
+         pmix_ld_have_fini=0])
     LDFLAGS=$LDFLAGS_save
     PMIX_VAR_SCOPE_POP
 
@@ -827,7 +831,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     AC_MSG_CHECKING([for default value of mca_base_component_show_load_errors])
     AC_ARG_ENABLE([show-load-errors-by-default],
-                  [AC_HELP_STRING([--enable-show-load-errors-by-default],
+                  [AS_HELP_STRING([--enable-show-load-errors-by-default],
                                   [Set the default value for the MCA parameter
                                    mca_base_component_show_load_errors (but can be
                                    overridden at run time by the usual
@@ -991,7 +995,7 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
     # do we want dlopen support ?
     AC_MSG_CHECKING([if want dlopen support])
     AC_ARG_ENABLE([dlopen],
-        [AC_HELP_STRING([--enable-dlopen],
+        [AS_HELP_STRING([--enable-dlopen],
                         [Whether build should attempt to use dlopen (or
                          similar) to dynamically load components.
                          (default: enabled)])])
@@ -1012,7 +1016,7 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
     # Embedded mode, or standalone?
     AC_MSG_CHECKING([if embedded mode is enabled])
     AC_ARG_ENABLE([embedded-mode],
-        [AC_HELP_STRING([--enable-embedded-mode],
+        [AS_HELP_STRING([--enable-embedded-mode],
                 [Using --enable-embedded-mode causes PMIx to skip a few configure checks and install nothing.  It should only be used when building PMIx within the scope of a larger package.])])
     AS_IF([test "$enable_embedded_mode" = "yes"],
           [pmix_mode=embedded
@@ -1029,7 +1033,7 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
 if test -e $PMIX_TOP_SRCDIR/.git; then
     PMIX_DEVEL=1
     # check for Flex
-    AC_PROG_LEX
+    AC_PROG_LEX(yywrap)
     if test "x$LEX" != xflex; then
         AC_MSG_WARN([PMIx requires Flex to build from non-tarball sources,])
         AC_MSG_WARN([but Flex was not found. Please install Flex into])
@@ -1047,7 +1051,7 @@ fi
 
 AC_MSG_CHECKING([if want developer-level compiler pickyness])
 AC_ARG_ENABLE(picky,
-    AC_HELP_STRING([--enable-picky],
+    AS_HELP_STRING([--enable-picky],
                    [enable developer-level compiler pickyness when building PMIx (default: disabled)]))
 if test "$enable_picky" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1069,7 +1073,7 @@ fi
 
 AC_MSG_CHECKING([if want developer-level debugging code])
 AC_ARG_ENABLE(debug,
-    AC_HELP_STRING([--enable-debug],
+    AS_HELP_STRING([--enable-debug],
                    [enable developer-level debugging code (not for general PMIx users!) (default: disabled)]))
 if test "$enable_debug" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1087,7 +1091,7 @@ AC_DEFINE_UNQUOTED(PMIX_ENABLE_DEBUG, $WANT_DEBUG,
                    [Whether we want developer-level debugging code or not])
 
 AC_ARG_ENABLE(debug-symbols,
-              AC_HELP_STRING([--disable-debug-symbols],
+              AS_HELP_STRING([--disable-debug-symbols],
                              [Disable adding compiler flags to enable debugging symbols if --enable-debug is specified.  For non-debugging builds, this flag has no effect.]))
 
 #
@@ -1095,7 +1099,7 @@ AC_ARG_ENABLE(debug-symbols,
 #
 AC_MSG_CHECKING([if want to install project-internal header files])
 AC_ARG_WITH(devel-headers,
-    AC_HELP_STRING([--with-devel-headers],
+    AS_HELP_STRING([--with-devel-headers],
                    [normal PMIx users/applications do not need this (pmix.h and friends are ALWAYS installed).  Developer headers are only necessary for authors doing deeper integration (default: disabled).]))
 if test "$with_devel_headers" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1109,7 +1113,7 @@ fi
 # Install tests and examples?
 AC_MSG_CHECKING([if tests and examples are to be installed])
 AC_ARG_WITH([tests-examples],
-    [AC_HELP_STRING([--with-tests-examples],
+    [AS_HELP_STRING([--with-tests-examples],
             [Whether or not to install the tests and example programs.])])
 AS_IF([test "$pmix_install_primary_headers" = "no"],
       [AS_IF([test -z "$with_tests_examples" || test "$with_tests_examples" = "no"],
@@ -1130,7 +1134,7 @@ AS_IF([test "$pmix_install_primary_headers" = "no"],
 # Support per-user config files?
 #
 AC_ARG_ENABLE([per-user-config-files],
-   [AC_HELP_STRING([--enable-per-user-config-files],
+   [AS_HELP_STRING([--enable-per-user-config-files],
       [Disable per-user configuration files, to save disk accesses during job start-up.  This is likely desirable for large jobs.  Note that this can also be acheived by environment variables at run-time.  (default: enabled)])])
 if test "$enable_per_user_config_files" = "no" ; then
   result=0
@@ -1146,7 +1150,7 @@ AC_DEFINE_UNQUOTED([PMIX_WANT_HOME_CONFIG_FILES], [$result],
 
 AC_MSG_CHECKING([if want pretty-print stacktrace])
 AC_ARG_ENABLE([pretty-print-stacktrace],
-              [AC_HELP_STRING([--enable-pretty-print-stacktrace],
+              [AS_HELP_STRING([--enable-pretty-print-stacktrace],
                               [Pretty print stacktrace on process signal (default: enabled)])])
 if test "$enable_pretty_print_stacktrace" = "no" ; then
     AC_MSG_RESULT([no])
@@ -1165,7 +1169,7 @@ AC_DEFINE_UNQUOTED([PMIX_WANT_PRETTY_PRINT_STACKTRACE],
 DSTORE_PTHREAD_LOCK="1"
 AC_MSG_CHECKING([if want dstore pthread-based locking])
 AC_ARG_ENABLE([dstore-pthlck],
-              [AC_HELP_STRING([--disable-dstore-pthlck],
+              [AS_HELP_STRING([--disable-dstore-pthlck],
                               [Disable pthread-based locking in dstor (default: enabled)])])
 if test "$enable_dstore_pthlck" = "no" ; then
     AC_MSG_RESULT([no])
@@ -1180,7 +1184,7 @@ fi
 #
 AC_MSG_CHECKING([if want ident string])
 AC_ARG_WITH([ident-string],
-            [AC_HELP_STRING([--with-ident-string=STRING],
+            [AS_HELP_STRING([--with-ident-string=STRING],
                             [Embed an ident string into PMIx object files])])
 if test "$with_ident_string" = "" || test "$with_ident_string" = "no"; then
     with_ident_string="%VERSION%"
@@ -1204,7 +1208,7 @@ AC_MSG_RESULT([$with_ident_string])
 #
 AC_MSG_CHECKING([if want developer-level timing support])
 AC_ARG_ENABLE(pmix-timing,
-              AC_HELP_STRING([--enable-pmix-timing],
+              AS_HELP_STRING([--enable-pmix-timing],
                              [enable PMIx developer-level timing code (default: disabled)]))
 if test "$enable_pmix_timing" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1224,7 +1228,7 @@ AM_CONDITIONAL([WANT_INSTALL_HEADERS], [test $WANT_INSTALL_HEADERS -eq 1])
 #
 AC_MSG_CHECKING([if want to disable binaries])
 AC_ARG_ENABLE(pmix-binaries,
-              AC_HELP_STRING([--enable-pmix-binaries],
+              AS_HELP_STRING([--enable-pmix-binaries],
                              [enable PMIx tools]))
 if test "$enable_pmix_binaries" = "no"; then
     AC_MSG_RESULT([no])
@@ -1241,7 +1245,7 @@ AM_CONDITIONAL([PMIX_INSTALL_BINARIES], [test $WANT_PMIX_BINARIES -eq 1])
 #
 AC_MSG_CHECKING([if want install Python bindings])
 AC_ARG_ENABLE(python-bindings,
-              AC_HELP_STRING([--enable-python-bindings],
+              AS_HELP_STRING([--enable-python-bindings],
                              [enable Python bindings (default: disabled)]))
 if test "$enable_python_bindings" != "yes"; then
     AC_MSG_RESULT([no])
@@ -1315,7 +1319,7 @@ AS_IF([test "$PYTHON" = ":" && test ! -f $srcdir/include/dictionary.h],
 # see if they want to disable non-RTLD_GLOBAL dlopen
 AC_MSG_CHECKING([if want to support dlopen of non-global namespaces])
 AC_ARG_ENABLE([nonglobal-dlopen],
-              AC_HELP_STRING([--enable-nonglobal-dlopen],
+              AS_HELP_STRING([--enable-nonglobal-dlopen],
                              [enable non-global dlopen (default: enabled)]))
 if test "$enable_nonglobal_dlopen" = "no"; then
     AC_MSG_RESULT([no])
@@ -1336,7 +1340,7 @@ AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" &&
 
 AC_MSG_CHECKING([if want pty support])
 AC_ARG_ENABLE(pty-support,
-    AC_HELP_STRING([--enable-pty-support],
+    AS_HELP_STRING([--enable-pty-support],
                    [Enable/disable PTY support for STDIO forwarding.  (default: enabled)]))
 if test "$enable_pty_support" = "no" ; then
     AC_MSG_RESULT([no])
@@ -1354,7 +1358,7 @@ AC_DEFINE_UNQUOTED([PMIX_ENABLE_PTY_SUPPORT], [$PMIX_ENABLE_PTY_SUPPORT],
 
 AC_MSG_CHECKING([if want build psec/dummy_handshake])
 AC_ARG_ENABLE(dummy-handshake,
-              AC_HELP_STRING([--enable-dummy-handshake],
+              AS_HELP_STRING([--enable-dummy-handshake],
                              [Enables psec dummy component intended to check the PTL handshake scenario (default: disabled)]))
 if test "$enable_dummy_handshake" != "yes"; then
     AC_MSG_RESULT([no])

--- a/config/pmix_check_attributes.m4
+++ b/config/pmix_check_attributes.m4
@@ -20,6 +20,7 @@
 #                         All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
 #########################
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -61,7 +62,7 @@ AC_DEFUN([_PMIX_CHECK_SPECIFIC_ATTRIBUTE], [
         #
         # Try to compile using the C compiler
         #
-        AC_TRY_COMPILE([$2],[],
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$2])],
                        [
                         #
                         # In case we did succeed: Fine, but was this due to the
@@ -111,29 +112,27 @@ AC_DEFUN([PMIX_CHECK_ATTRIBUTES], [
   AC_MSG_CHECKING(for __attribute__)
 
   AC_CACHE_VAL(pmix_cv___attribute__, [
-    AC_TRY_COMPILE(
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
       [#include <stdlib.h>
        /* Check for the longest available __attribute__ (since gcc-2.3) */
        struct foo {
            char a;
            int x[2] __attribute__ ((__packed__));
         };
-      ],
-      [],
+      ])],
       [pmix_cv___attribute__=1],
       [pmix_cv___attribute__=0],
     )
 
     if test "$pmix_cv___attribute__" = "1" ; then
-        AC_TRY_COMPILE(
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
           [#include <stdlib.h>
            /* Check for the longest available __attribute__ (since gcc-2.3) */
            struct foo {
                char a;
                int x[2] __attribute__ ((__packed__));
             };
-          ],
-          [],
+          ])],
           [pmix_cv___attribute__=1],
           [pmix_cv___attribute__=0],
         )

--- a/config/pmix_check_broken_qsort.m4
+++ b/config/pmix_check_broken_qsort.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -38,7 +39,7 @@ dnl the pmix_qsort instead.
 # --------------------------------------------------------
 AC_DEFUN([PMIX_CHECK_BROKEN_QSORT],[
   AC_ARG_WITH([broken-qsort],
-              [AC_HELP_STRING([--with-broken-qsort],
+              [AS_HELP_STRING([--with-broken-qsort],
                               [Build with FreeBSD qsort instead of native qsort (default: no)])])
   AC_MSG_CHECKING([for broken qsort])
 

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -2,6 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -24,7 +25,7 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
             CFLAGS_orig=$CFLAGS
             CFLAGS="$CFLAGS $1"
             AC_CACHE_VAL(pmix_cv_cc_[$2], [
-                   AC_TRY_COMPILE([], [$3],
+                   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [$3])],
                                    [
                                     pmix_cv_cc_[$2]=1
                                     _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])

--- a/config/pmix_check_compiler_version.m4
+++ b/config/pmix_check_compiler_version.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2019      Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -34,7 +35,7 @@ AC_DEFUN([PMIX_CHECK_COMPILER], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
-            AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <stdlib.h>
 #include "pmix_portable_platform.h"
@@ -48,11 +49,14 @@ int main (int argc, char * argv[])
     fclose(f);
     return 0;
 }
-            ], [
+            ])],
+            [
                 eval pmix_cv_compiler_$1=`cat conftestval`;
-            ], [
+            ],
+            [
                 eval pmix_cv_compiler_$1=0
-            ], [
+            ],
+            [
                 eval pmix_cv_compiler_$1=0
             ])
             CPPFLAGS=$CPPFLAGS_orig
@@ -67,7 +71,7 @@ AC_DEFUN([PMIX_CHECK_COMPILER_STRING], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
-            AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <stdlib.h>
 #include "pmix_portable_platform.h"
@@ -81,11 +85,14 @@ int main (int argc, char * argv[])
     fclose(f);
     return 0;
 }
-            ], [
+            ])],
+            [
                 eval pmix_cv_compiler_$1=`cat conftestval`;
-            ], [
+            ],
+            [
                 eval pmix_cv_compiler_$1=UNKNOWN
-            ], [
+            ],
+            [
                 eval pmix_cv_compiler_$1=UNKNOWN
             ])
             CPPFLAGS=$CPPFLAGS_orig
@@ -103,7 +110,7 @@ AC_DEFUN([PMIX_CHECK_COMPILER_STRINGIFY], [
     [
             CPPFLAGS_orig=$CPPFLAGS
             CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
-            AC_TRY_RUN([
+            AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <stdlib.h>
 #include "pmix_portable_platform.h"
@@ -117,7 +124,7 @@ int main (int argc, char * argv[])
     fclose(f);
     return 0;
 }
-            ], [
+            ])], [
                 eval pmix_cv_compiler_$1=`cat conftestval`;
             ], [
                 eval pmix_cv_compiler_$1=UNKNOWN

--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -17,6 +17,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,11 +33,11 @@ AC_DEFUN([PMIX_CHECK_CURL],[
 
     PMIX_VAR_SCOPE_PUSH(pmix_check_curl_save_CPPFLAGS pmix_check_curl_save_LDFLAGS pmix_check_curl_save_LIBS)
 	AC_ARG_WITH([curl],
-		    [AC_HELP_STRING([--with-curl(=DIR)],
+		    [AS_HELP_STRING([--with-curl(=DIR)],
 				    [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
 
     AC_ARG_WITH([curl-libdir],
-            [AC_HELP_STRING([--with-curl-libdir=DIR],
+            [AS_HELP_STRING([--with-curl-libdir=DIR],
                     [Search for Curl libraries in DIR])])
 
     pmix_check_curl_happy=no

--- a/config/pmix_check_icc.m4
+++ b/config/pmix_check_icc.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
 dnl Copyright (c) 2016-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -26,7 +27,7 @@ dnl On EM64T, icc-8.1 before version 8.1.027 segfaulted, since
 dnl va_start was miscompiled...
 dnl
 AC_MSG_CHECKING([whether icc-8.1 for EM64T works with variable arguments])
-AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,7 +50,9 @@ int main ()
   return 0;
 }
 
-],[pmix_ac_icc_varargs=`test -f conftestval`],[pmix_ac_icc_varargs=1],[pmix_ac_icc_varargs=1])
+])],
+[pmix_ac_icc_varargs=`test -f conftestval`],
+[pmix_ac_icc_varargs=1],[pmix_ac_icc_varargs=1])
 
 if test "$pmix_ac_icc_varargs" = "1"; then
     AC_MSG_WARN([*** Problem running configure test!])

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -17,6 +17,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,11 +33,11 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
 
     PMIX_VAR_SCOPE_PUSH(pmix_check_jansson_save_CPPFLAGS pmix_check_jansson_save_LDFLAGS pmix_check_jansson_save_LIBS)
 	AC_ARG_WITH([jansson],
-		    [AC_HELP_STRING([--with-jansson(=DIR)],
+		    [AS_HELP_STRING([--with-jansson(=DIR)],
 				    [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
 
     AC_ARG_WITH([jansson-libdir],
-            [AC_HELP_STRING([--with-jansson-libdir=DIR],
+            [AS_HELP_STRING([--with-jansson-libdir=DIR],
                     [Search for Jansson libraries in DIR])])
 
     pmix_check_jansson_happy=no

--- a/config/pmix_check_lustre.m4
+++ b/config/pmix_check_lustre.m4
@@ -17,6 +17,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -43,7 +44,7 @@ AC_DEFUN([PMIX_CHECK_LUSTRE],[
 
     # Get some configuration information
     AC_ARG_WITH([lustre],
-        [AC_HELP_STRING([--with-lustre(=DIR)],
+        [AS_HELP_STRING([--with-lustre(=DIR)],
              [Build Lustre support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     PMIX_CHECK_WITHDIR([lustre], [$with_lustre], [include/lustre/lustreapi.h])
 

--- a/config/pmix_check_ofi.m4
+++ b/config/pmix_check_ofi.m4
@@ -64,18 +64,18 @@ dnl
 AC_DEFUN([_PMIX_CHECK_OFI],[
     # Add --with options
     AC_ARG_WITH([libfabric],
-                [AC_HELP_STRING([--with-libfabric=DIR],
+                [AS_HELP_STRING([--with-libfabric=DIR],
                                 [Deprecated synonym for --with-ofi])])
     AC_ARG_WITH([libfabric-libdir],
-                [AC_HELP_STRING([--with-libfabric-libdir=DIR],
+                [AS_HELP_STRING([--with-libfabric-libdir=DIR],
                                 [Deprecated synonym for --with-ofi-libdir])])
 
     AC_ARG_WITH([ofi],
-                [AC_HELP_STRING([--with-ofi=DIR],
+                [AS_HELP_STRING([--with-ofi=DIR],
                                 [Specify location of OFI libfabric installation, adding DIR/include to the default search location for libfabric headers, and DIR/lib or DIR/lib64 to the default search location for libfabric libraries.  Error if libfabric support cannot be found.])])
 
     AC_ARG_WITH([ofi-libdir],
-                [AC_HELP_STRING([--with-ofi-libdir=DIR],
+                [AS_HELP_STRING([--with-ofi-libdir=DIR],
                                 [Search for OFI libfabric libraries in DIR])])
 
     if test "$with_ofi" = ""; then

--- a/config/pmix_check_package.m4
+++ b/config/pmix_check_package.m4
@@ -46,6 +46,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_HEADER], [
            test "$hdir_prefix" = "/usr" || \
            test "$hdir_prefix" = "/usr/local"],
            [ # try as is...
+            AC_MSG_NOTICE([looking for header without includes])
             AC_CHECK_HEADERS([$2], [pmix_check_package_header_happy="yes"], [])
             AS_IF([test "$pmix_check_package_header_happy" = "no"],
                   [# no go on the as is - reset the cache and try again
@@ -55,13 +56,13 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_HEADER], [
           [AS_IF([test "$hdir_prefix" != ""],
                  [$1_CPPFLAGS="$$1_CPPFLAGS -I$hdir_prefix"
                   CPPFLAGS="$CPPFLAGS -I$hdir_prefix"
-                  AC_VERBOSE([looking for header in $hdir_prefix])
+                  AC_MSG_NOTICE([looking for header in $hdir_prefix])
                   AC_CHECK_HEADERS([$2], [pmix_check_package_header_happy="yes"], [], [$6])
                   AS_IF([test "$pmix_check_package_header_happy" = "no"],
                         [unset pmix_Header
                          $1_CPPFLAGS="$$1_CPPFLAGS -I$hdir_prefix/include"
                          CPPFLAGS="$CPPFLAGS -I$hdir_prefix/include"
-                         AC_VERBOSE([looking for header in $hdir_prefix/include])
+                         AC_MSG_NOTICE([looking for header in $hdir_prefix/include])
                          AC_CHECK_HEADERS([$2], [pmix_check_package_header_happy="yes"], [], [$6])])])])
 
     AS_IF([test "$pmix_check_package_header_happy" = "yes"],
@@ -108,7 +109,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_LIB], [
             # first try standard locations as otherwise our
             # searches with libdir_prefix locations might come
             # back positive and unnecessarily add an LDFLAG
-            AC_VERBOSE([looking for library without search path])
+            AC_MSG_NOTICE([looking for library without search path])
             AC_SEARCH_LIBS([$3], [$2],
                            [pmix_check_package_lib_happy="yes"],
                            [pmix_check_package_lib_happy="no"], [$4])
@@ -125,7 +126,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_LIB], [
                        test "$libdir_prefix" != "/usr/local"],
                     [$1_LDFLAGS="$$1_LDFLAGS -L$libdir_prefix/lib64"
                      LDFLAGS="$LDFLAGS -L$libdir_prefix/lib64"
-                     AC_VERBOSE([looking for library in $libdir_prefix/lib64])
+                     AC_MSG_NOTICE([looking for library in $libdir_prefix/lib64])
                      AC_SEARCH_LIBS([$3], [$2],
                                [pmix_check_package_lib_happy="yes"],
                                [pmix_check_package_lib_happy="no"], [$4])
@@ -142,7 +143,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_LIB], [
                        test "$libdir_prefix" != "/usr/local"],
                     [$1_LDFLAGS="$$1_LDFLAGS -L$libdir_prefix/lib"
                      LDFLAGS="$LDFLAGS -L$libdir_prefix/lib"
-                     AC_VERBOSE([looking for library in $libdir_prefix/lib])
+                     AC_MSG_NOTICE([looking for library in $libdir_prefix/lib])
                      AC_SEARCH_LIBS([$3], [$2],
                                [pmix_check_package_lib_happy="yes"],
                                [pmix_check_package_lib_happy="no"], [$4])

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -36,11 +36,11 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
 
     if test -z "$pmix_check_psm2_happy" ; then
 	AC_ARG_WITH([psm2],
-		    [AC_HELP_STRING([--with-psm2(=DIR)],
+		    [AS_HELP_STRING([--with-psm2(=DIR)],
 				    [Build PSM2 support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
 	PMIX_CHECK_WITHDIR([psm2], [$with_psm2], [include/psm2.h])
 	AC_ARG_WITH([psm2-libdir],
-		    [AC_HELP_STRING([--with-psm2-libdir=DIR],
+		    [AS_HELP_STRING([--with-psm2-libdir=DIR],
 				    [Search for PSM2 libraries in DIR])])
 	PMIX_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
 

--- a/config/pmix_check_tm.m4
+++ b/config/pmix_check_tm.m4
@@ -16,6 +16,7 @@ dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -50,7 +51,7 @@ AC_DEFUN([PMIX_CHECK_TM],[
 	PMIX_VAR_SCOPE_PUSH([pmix_check_tm_found pmix_check_tm_dir pmix_check_tm_libdir pmix_check_tm_pbs_config pmix_check_tm_LDFLAGS_save pmix_check_tm_CPPFLAGS_save pmix_check_tm_LIBS_save])
 
 	AC_ARG_WITH([tm],
-                    [AC_HELP_STRING([--with-tm(=DIR)],
+                    [AS_HELP_STRING([--with-tm(=DIR)],
                                     [Build TM (Torque, PBSPro, and compatible) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
 	PMIX_CHECK_WITHDIR([tm], [$with_tm], [include/tm.h])
 

--- a/config/pmix_check_visibility.m4
+++ b/config/pmix_check_visibility.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009-2011 Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +29,7 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
     # Check if the compiler has support for visibility, like some
     # versions of gcc, icc Sun Studio cc.
     AC_ARG_ENABLE(visibility,
-        AC_HELP_STRING([--enable-visibility],
+        AS_HELP_STRING([--enable-visibility],
             [enable visibility feature of certain compilers/linkers (default: enabled)]))
 
     WANT_VISIBILITY=0

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -591,7 +592,7 @@ AC_DEFUN([PMIX_WITH_OPTION_MIN_MAX_VALUE], [
     max_value=[$2]
     AC_MSG_CHECKING([maximum length of ]m4_translit($1, [_], [ ]))
     AC_ARG_WITH([max-]m4_translit($1, [_], [-]),
-        AC_HELP_STRING([--with-max-]m4_translit($1, [_], [-])[=VALUE],
+        AS_HELP_STRING([--with-max-]m4_translit($1, [_], [-])[=VALUE],
                        [maximum length of ]m4_translit($1, [_], [ ])[s.  VALUE argument has to be specified (default: [$2]).]))
     if test ! -z "$with_max_[$1]" && test "$with_max_[$1]" != "no" ; then
         # Ensure it's a number (hopefully an integer!), and >0

--- a/config/pmix_load_platform.m4
+++ b/config/pmix_load_platform.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -24,11 +25,11 @@ dnl
 # --------------------
 AC_DEFUN([PMIX_LOAD_PLATFORM], [
     AC_ARG_WITH([pmix-platform-patches-dir],
-        [AC_HELP_STRING([--with-pmix-platform-patches-dir=DIR],
+        [AS_HELP_STRING([--with-pmix-platform-patches-dir=DIR],
                         [Location of the platform patches directory. If you use this option, you must also use --with-platform.])])
 
     AC_ARG_WITH([pmix-platform],
-        [AC_HELP_STRING([--with-pmix-platform=FILE],
+        [AS_HELP_STRING([--with-pmix-platform=FILE],
                         [Load options for build from FILE.  Options on the
                          command line not in FILE are used.  Options on the
                          command line and in FILE are replaced by what is

--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -12,6 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -50,11 +51,11 @@ AC_DEFUN([PMIX_MCA],[
     # --disable-mca-dso
     #
     AC_ARG_ENABLE([mca-no-build],
-        [AC_HELP_STRING([--enable-mca-no-build=LIST],
+        [AS_HELP_STRING([--enable-mca-no-build=LIST],
                         [Comma-separated list of <type>-<component> pairs
                          that will not be built.  Example: "--enable-mca-no-build=maffinity,btl-portals" will disable building all maffinity components and the "portals" btl components.])])
     AC_ARG_ENABLE(mca-dso,
-        AC_HELP_STRING([--enable-mca-dso=LIST],
+        AS_HELP_STRING([--enable-mca-dso=LIST],
                        [Comma-separated list of types and/or
                         type-component pairs that will be built as
                         run-time loadable components (as opposed to
@@ -62,7 +63,7 @@ AC_DEFUN([PMIX_MCA],[
                         platform.  The default is to build all components
                         as DSOs.]))
     AC_ARG_ENABLE(mca-static,
-        AC_HELP_STRING([--enable-mca-static=LIST],
+        AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or
                         type-component pairs that will be built statically
                         linked into the library.  The default (if DSOs are
@@ -70,7 +71,7 @@ AC_DEFUN([PMIX_MCA],[
                         Enabling a component as static disables it
                         building as a DSO.]))
     AC_ARG_ENABLE(mca-direct,
-        AC_HELP_STRING([--enable-mca-direct=LIST],
+        AS_HELP_STRING([--enable-mca-direct=LIST],
                        [Comma-separated list of type-component pairs that
                         will be hard coded as the one component to use for
                         a given component type, saving the (small)
@@ -448,7 +449,7 @@ EOF
         # exist, or b) the contents are different.  Do this to not
         # trigger recompilation of certain .c files just because the
         # timestamp changed on $outfile_real (similar to the way AC
-        # handles AC_CONFIG_HEADER files).
+        # handles AC_CONFIG_HEADERS files).
         diff $outfile $outfile_real > /dev/null 2>&1
         if test "$?" != "0"; then
             mv $outfile $outfile_real

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -21,6 +21,7 @@ dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -181,8 +182,11 @@ AC_DEFUN([PMIX_SETUP_CC],[
         # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
         # AC_MSG_ERROR([Aborting.])
         # From Open MPI 1.7 on we require a C99 compiant compiler
-        AC_PROG_CC_C99
-        # The result of AC_PROG_CC_C99 is stored in ac_cv_prog_cc_c99
+        # with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
+        m4_version_prereq([2.70],
+            [],
+            [AC_PROG_CC_C99])
+        # The C99 result of AC_PROG_CC is stored in ac_cv_prog_cc_c99
         if test "x$ac_cv_prog_cc_c99" = xno ; then
             AC_MSG_WARN([Open MPI requires a C99 (or newer) compiler. C11 is recommended.])
             AC_MSG_ERROR([Aborting.])
@@ -222,10 +226,6 @@ AC_DEFUN([PMIX_SETUP_CC],[
                        [Whether C compiler supports __thread])
 
     PMIX_C_COMPILER_VENDOR([pmix_c_vendor])
-
-    # Check for standard headers, needed here because needed before
-    # the types checks.
-    AC_HEADER_STDC
 
     # GNU C and autotools are inconsistent about whether this is
     # defined so let's make it true everywhere for now...  However, IBM
@@ -330,11 +330,12 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # see if the C compiler supports __builtin_expect
     AC_CACHE_CHECK([if $CC supports __builtin_expect],
         [pmix_cv_cc_supports___builtin_expect],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([,
           [void *ptr = (void*) 0;
-           if (__builtin_expect (ptr != (void*) 0, 1)) return 0;],
+           if (__builtin_expect (ptr != (void*) 0, 1)) return 0;
+          ]],
           [pmix_cv_cc_supports___builtin_expect="yes"],
-          [pmix_cv_cc_supports___builtin_expect="no"])])
+          [pmix_cv_cc_supports___builtin_expect="no"])])])
     if test "$pmix_cv_cc_supports___builtin_expect" = "yes" ; then
         have_cc_builtin_expect=1
     else
@@ -346,11 +347,11 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # see if the C compiler supports __builtin_prefetch
     AC_CACHE_CHECK([if $CC supports __builtin_prefetch],
         [pmix_cv_cc_supports___builtin_prefetch],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([
           [int ptr;
-           __builtin_prefetch(&ptr,0,0);],
+           __builtin_prefetch(&ptr,0,0);]],
           [pmix_cv_cc_supports___builtin_prefetch="yes"],
-          [pmix_cv_cc_supports___builtin_prefetch="no"])])
+          [pmix_cv_cc_supports___builtin_prefetch="no"])])])
     if test "$pmix_cv_cc_supports___builtin_prefetch" = "yes" ; then
         have_cc_builtin_prefetch=1
     else
@@ -362,11 +363,11 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # see if the C compiler supports __builtin_clz
     AC_CACHE_CHECK([if $CC supports __builtin_clz],
         [pmix_cv_cc_supports___builtin_clz],
-        [AC_TRY_LINK([],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([
             [int value = 0xffff; /* we know we have 16 bits set */
-             if ((8*sizeof(int)-16) != __builtin_clz(value)) return 0;],
+             if ((8*sizeof(int)-16) != __builtin_clz(value)) return 0;]],
             [pmix_cv_cc_supports___builtin_clz="yes"],
-            [pmix_cv_cc_supports___builtin_clz="no"])])
+            [pmix_cv_cc_supports___builtin_clz="no"])])])
     if test "$pmix_cv_cc_supports___builtin_clz" = "yes" ; then
         have_cc_builtin_clz=1
     else

--- a/config/pmix_setup_libev.m4
+++ b/config/pmix_setup_libev.m4
@@ -5,6 +5,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,12 +19,12 @@ AC_DEFUN([PMIX_LIBEV_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([pmix_libev_dir pmix_libev_libdir pmix_libev_standard_header_location pmix_libev_standard_lib_location pmix_check_libev_save_CPPFLAGS pmix_check_libev_save_LDFLAGS pmix_check_libev_save_LIBS])
 
     AC_ARG_WITH([libev],
-                [AC_HELP_STRING([--with-libev=DIR],
+                [AS_HELP_STRING([--with-libev=DIR],
                                 [Search for libev headers and libraries in DIR ])])
     PMIX_CHECK_WITHDIR([libev], [$with_libev], [include/event.h])
 
     AC_ARG_WITH([libev-libdir],
-                [AC_HELP_STRING([--with-libev-libdir=DIR],
+                [AS_HELP_STRING([--with-libev-libdir=DIR],
                                 [Search for libev libraries in DIR ])])
     PMIX_CHECK_WITHDIR([libev-libdir], [$with_livev_libdir], [libev.*])
 

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -8,6 +8,7 @@
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,15 +44,15 @@
 AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
 
     AC_ARG_WITH([libevent],
-                [AC_HELP_STRING([--with-libevent=DIR],
+                [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
 
     AC_ARG_WITH([libevent-libdir],
-                [AC_HELP_STRING([--with-libevent-libdir=DIR],
+                [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
 
     AC_ARG_WITH([libevent-header],
-                [AC_HELP_STRING([--with-libevent-header=HEADER],
+                [AS_HELP_STRING([--with-libevent-header=HEADER],
                                 [The value that should be included in C files to include event.h.  This option only has meaning if --enable-embedded-mode is enabled.])])
 
     pmix_libevent_support=0
@@ -87,15 +88,17 @@ AC_DEFUN([_PMIX_LIBEVENT_EMBEDDED_MODE], [
            PMIX_EVENT2_THREAD_HEADER="$with_libevent_header"])
 
     AC_MSG_CHECKING([if co-built libevent includes thread support])
-    AC_TRY_COMPILE([#include <event.h>
-#include <event2/thread.h>
-           ],[
-#if !(EVTHREAD_LOCK_API_VERSION >= 1)
-#error "No threads!"
-#endif
-    ],[AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])
-    AC_MSG_ERROR([No thread support in co-build libevent.  Aborting])])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+        [
+         #include <event.h>
+         #include <event2/thread.h>
+         #if !(EVTHREAD_LOCK_API_VERSION >= 1)
+         #error "No threads!"
+         #endif
+        ])],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])
+         AC_MSG_ERROR([No thread support in co-build libevent.  Aborting])])
 
     pmix_libevent_source=$1
     pmix_libevent_support=1

--- a/config/pmix_setup_man_pages.m4
+++ b/config/pmix_setup_man_pages.m4
@@ -3,6 +3,7 @@ dnl
 dnl Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -19,7 +20,7 @@ dnl
 
 AC_DEFUN([PMIX_SETUP_MAN_PAGES],[
     AC_ARG_ENABLE(man-pages,
-                  [AC_HELP_STRING([--disable-man-pages],
+                  [AS_HELP_STRING([--disable-man-pages],
                                   [Do not generate/install man pages (default: enabled)])])
 
     PANDOC=

--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -16,6 +16,7 @@ dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -75,25 +76,25 @@ AC_DEFUN([PMIX_WRAPPER_FLAGS_ADD], [
 #     doing so, and we'd like to force the issue.
 AC_DEFUN([PMIX_SETUP_WRAPPER_INIT],[
     AC_ARG_WITH([wrapper-cflags],
-                [AC_HELP_STRING([--with-wrapper-cflags],
+                [AS_HELP_STRING([--with-wrapper-cflags],
                                 [Extra flags to add to CFLAGS when using mpicc])])
     AS_IF([test "$with_wrapper_cflags" = "yes" || test "$with_wrapper_cflags" = "no"],
           [AC_MSG_ERROR([--with-wrapper-cflags must have an argument.])])
 
     AC_ARG_WITH([wrapper-cflags-prefix],
-                [AC_HELP_STRING([--with-wrapper-cflags-prefix],
+                [AS_HELP_STRING([--with-wrapper-cflags-prefix],
                                 [Extra flags (before user flags) to add to CFLAGS when using mpicc])])
     AS_IF([test "$with_wrapper_cflags_prefix" = "yes" || test "$with_wrapper_cflags_prefix" = "no"],
           [AC_MSG_ERROR([--with-wrapper-cflags-prefix must have an argument.])])
 
     AC_ARG_WITH([wrapper-ldflags],
-                [AC_HELP_STRING([--with-wrapper-ldflags],
+                [AS_HELP_STRING([--with-wrapper-ldflags],
                                 [Extra flags to add to LDFLAGS when using wrapper compilers])])
     AS_IF([test "$with_wrapper_ldflags" = "yes" || test "$with_wrapper_ldflags" = "no"],
           [AC_MSG_ERROR([--with-wrapper-ldflags must have an argument.])])
 
     AC_ARG_WITH([wrapper-libs],
-                [AC_HELP_STRING([--with-wrapper-libs],
+                [AS_HELP_STRING([--with-wrapper-libs],
                                 [Extra flags to add to LIBS when using wrapper compilers])])
     AS_IF([test "$with_wrapper_libs" = "yes" || test "$with_wrapper_libs" = "no"],
           [AC_MSG_ERROR([--with-wrapper-libs must have an argument.])])

--- a/config/pmix_try_assemble.m4
+++ b/config/pmix_try_assemble.m4
@@ -10,6 +10,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -38,13 +39,13 @@ else
 fi
 if AC_TRY_EVAL(pmix_assemble); then
   # save the warnings
-  cat conftest.out >&AC_FD_CC
+  cat conftest.out >&AS_MESSAGE_LOG_FD
   ifelse([$2],,:,[$2])
 else
   # save compiler output and failed program
-  cat conftest.out >&AC_FD_CC
-  echo "configure: failed program was:" >&AC_FD_CC
-  cat conftest.s >&AC_FD_CC
+  cat conftest.out >&AS_MESSAGE_LOG_FD
+  echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+  cat conftest.s >&AS_MESSAGE_LOG_FD
   ifelse([$3],,:,[$3])
 fi
 rm -rf conftest*

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,10 +43,8 @@ m4_include([config/autogen_found_items.m4])
 # call PMIX_GET_VERSION (etc.) before AC_INIT.  So use the shell
 # version.
 
-AC_INIT([pmix],
-        [m4_normalize(esyscmd([config/pmix_get_version.sh VERSION --tarball]))],
-        [https://github.com/pmix/pmix/issues], [pmix])
-AC_PREREQ(2.69)
+AC_INIT([pmix],[m4_normalize(esyscmd([config/pmix_get_version.sh VERSION --tarball]))],[https://github.com/pmix/pmix/issues],[pmix])
+AC_PREREQ([2.69])
 AC_CONFIG_AUX_DIR(./config)
 # Note that this directory must *exactly* match what was specified via
 # -I in ACLOCAL_AMFLAGS in the top-level Makefile.am.
@@ -105,6 +104,8 @@ AM_SILENT_RULES([yes])
 
 # set the language
 AC_LANG([C])
+# find NM
+AC_PATH_PROG([NM], [nm])
 
 # AC_USE_SYSTEM_EXTENSIONS will modify CFLAGS if nothing was in there
 # beforehand.  We don't want that.  So if there was nothing in
@@ -215,14 +216,14 @@ pmix_enable_static="$enable_static"
 AS_IF([test ! -z "$enable_static" && test "$enable_static" = "yes"],
       [CFLAGS="$CFLAGS -fPIC"])
 
-AM_ENABLE_SHARED
-AM_DISABLE_STATIC
+AC_ENABLE_SHARED([])
+AC_DISABLE_STATIC([])
 PMIX_SETUP_WRAPPER_INIT
 
 # This did not exist pre AM 1.11.x (where x is somewhere >0 and <3),
 # but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AM_PROG_LEX
+AC_PROG_LEX(yywrap)
 
 ############################################################################
 # Configuration options
@@ -331,7 +332,7 @@ AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
 ####################################################################
 
 AC_ARG_ENABLE(werror,
-    AC_HELP_STRING([--enable-werror],
+    AS_HELP_STRING([--enable-werror],
                    [Treat compiler warnings as errors]),
 [
     CFLAGS="$CFLAGS -Werror"

--- a/src/mca/pcompress/zlib/configure.m4
+++ b/src/mca/pcompress/zlib/configure.m4
@@ -3,6 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,11 +20,11 @@ AC_DEFUN([MCA_pmix_pcompress_zlib_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([pmix_zlib_dir pmix_zlib_libdir pmix_zlib_standard_lib_location pmix_zlib_standard_header_location pmix_check_zlib_save_CPPFLAGS pmix_check_zlib_save_LDFLAGS pmix_check_zlib_save_LIBS])
 
     AC_ARG_WITH([zlib],
-                [AC_HELP_STRING([--with-zlib=DIR],
+                [AS_HELP_STRING([--with-zlib=DIR],
                                 [Search for zlib headers and libraries in DIR ])])
 
     AC_ARG_WITH([zlib-libdir],
-                [AC_HELP_STRING([--with-zlib-libdir=DIR],
+                [AS_HELP_STRING([--with-zlib-libdir=DIR],
                                 [Search for zlib libraries in DIR ])])
 
     pmix_check_zlib_save_CPPFLAGS="$CPPFLAGS"

--- a/src/mca/pdl/plibltdl/configure.m4
+++ b/src/mca/pdl/plibltdl/configure.m4
@@ -3,6 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,10 +44,10 @@ AC_DEFUN([MCA_pmix_pdl_plibltdl_CONFIG],[
 
     # Add --with options
     AC_ARG_WITH([plibltdl],
-        [AC_HELP_STRING([--with-libltdl(=DIR)],
+        [AS_HELP_STRING([--with-libltdl(=DIR)],
              [Build libltdl support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     AC_ARG_WITH([libltdl-libdir],
-       [AC_HELP_STRING([--with-libltdl-libdir=DIR],
+       [AS_HELP_STRING([--with-libltdl-libdir=DIR],
              [Search for libltdl libraries in DIR])])
 
     # Sanity check the --with values

--- a/src/mca/ploc/hwloc/configure.m4
+++ b/src/mca/ploc/hwloc/configure.m4
@@ -5,6 +5,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,11 +37,11 @@ AC_DEFUN([MCA_pmix_ploc_hwloc_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([hwloc_build_mode])
 
     AC_ARG_WITH([hwloc],
-                [AC_HELP_STRING([--with-hwloc=DIR],
+                [AS_HELP_STRING([--with-hwloc=DIR],
                                 [Search for hwloc headers and libraries in DIR ])])
 
     AC_ARG_WITH([hwloc-libdir],
-                [AC_HELP_STRING([--with-hwloc-libdir=DIR],
+                [AS_HELP_STRING([--with-hwloc-libdir=DIR],
                                 [Search for hwloc libraries in DIR ])])
 
     pmix_hwloc_support=0

--- a/src/mca/pnet/simptest/configure.m4
+++ b/src/mca/pnet/simptest/configure.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,7 +15,7 @@
 AC_DEFUN([MCA_pmix_pnet_simptest_CONFIG], [
     AC_CONFIG_FILES([src/mca/pnet/simptest/Makefile])
 
-    AC_ARG_WITH([simptest], [AC_HELP_STRING([--with-simptest], [Include simptest fabric support])],
+    AC_ARG_WITH([simptest], [AS_HELP_STRING([--with-simptest], [Include simptest fabric support])],
                 [pmix_want_simptest=yes], [pmix_want_simptest=no])
 
     AS_IF([test "$pmix_want_simptest" = "yes"],

--- a/src/mca/pnet/sshot/configure.m4
+++ b/src/mca/pnet/sshot/configure.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,15 +15,15 @@
 AC_DEFUN([MCA_pmix_pnet_sshot_CONFIG], [
     AC_CONFIG_FILES([src/mca/pnet/sshot/Makefile])
 
-    AC_ARG_WITH([slingshot], [AC_HELP_STRING([--with-slingshot], [Include Slingshot fabric support])],
+    AC_ARG_WITH([slingshot], [AS_HELP_STRING([--with-slingshot], [Include Slingshot fabric support])],
                 [pmix_want_sshot=yes], [pmix_want_sshot=no])
 
-    AC_ARG_WITH([cxi], [AC_HELP_STRING([--with-cxi(=DIR)],
+    AC_ARG_WITH([cxi], [AS_HELP_STRING([--with-cxi(=DIR)],
                                        [Include CXI service library support, optionally adding DIR/include, DIR/include/cxi, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
                 [], [with_cxi=no])
 
     AC_ARG_WITH([cxi-libdir],
-                [AC_HELP_STRING([--with-cxi-libdir=DIR],
+                [AS_HELP_STRING([--with-cxi-libdir=DIR],
                                 [Search for CXI libraries in DIR])])
 
     AS_IF([test "$with_cxi" = "no"],

--- a/src/mca/psec/munge/configure.m4
+++ b/src/mca/psec/munge/configure.m4
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,11 +19,11 @@ AC_DEFUN([MCA_pmix_psec_munge_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([psec_munge_support psec_munge_dir psec_munge_libdir save_cpp save_ld])
 
     AC_ARG_WITH([munge],
-                [AC_HELP_STRING([--with-munge=DIR],
+                [AS_HELP_STRING([--with-munge=DIR],
                                 [Search for munge headers and libraries in DIR ])])
 
     AC_ARG_WITH([munge-libdir],
-                [AC_HELP_STRING([--with-munge-libdir=DIR],
+                [AS_HELP_STRING([--with-munge-libdir=DIR],
                                 [Search for munge libraries in DIR ])])
 
     psec_munge_support=0

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,7 +51,7 @@ PMIX_EXPORT extern int pmix_event_caching_window;
 PMIX_EXPORT extern bool pmix_suppress_missing_data_warning;
 
 /** version string of pmix */
-PMIX_EXPORT extern const char pmix_version_string[];
+extern const char pmix_version_string[];
 
 /**
  * Initialize the PMIX layer, including the MCA system.

--- a/src/util/show_help_lex.h
+++ b/src/util/show_help_lex.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +41,7 @@ PMIX_EXPORT int pmix_show_help_yylex(void);
 PMIX_EXPORT int pmix_show_help_init_buffer(FILE *file);
 PMIX_EXPORT int pmix_show_help_yylex_destroy(void);
 
-PMIX_EXPORT extern FILE *pmix_show_help_yyin;
+extern FILE *pmix_show_help_yyin;
 PMIX_EXPORT extern bool pmix_show_help_parse_done;
 PMIX_EXPORT extern char *pmix_show_help_yytext;
 PMIX_EXPORT extern int pmix_show_help_yynewlines;


### PR DESCRIPTION
AC_HELP_STRING --> AS_HELP_STRING
AC_VERBOSE --> AC_MSG_NOTICE
AC_FD_CC --> AS_MESSAGE_LOG_FD
AC_CONFIG_HEADER --> AC_CONFIG_HEADERS

Silence some of the warnings - more to go

Signed-off-by: Ralph Castain <rhc@pmix.org>