### PR TITLE
Cleanup the OFI detection m4

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -799,6 +799,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     PMIX_CHECK_CURL
 
+    ##################################
+    # OFI
+    ##################################
+    pmix_show_title "OFI"
+
     PMIX_CHECK_OFI
 
     ##################################

--- a/config/pmix_check_ofi.m4
+++ b/config/pmix_check_ofi.m4
@@ -103,21 +103,27 @@ AC_DEFUN([_PMIX_CHECK_OFI],[
           [pmix_ofi_happy=no])
 
     AS_IF([test $pmix_ofi_happy = yes],
-          [AC_MSG_CHECKING([looking for OFI libfabric in])
-           AS_IF([test "$with_ofi" != "yes"],
+          [AC_MSG_CHECKING([for OFI libfabric headers in])
+           AS_IF([test ! -z "$with_ofi" && test "$with_ofi" != "yes"],
                  [pmix_ofi_dir=$with_ofi
                   AC_MSG_RESULT([($pmix_ofi_dir)])],
                  [AC_MSG_RESULT([(default search paths)])])
+           AC_MSG_CHECKING([for OFI libfabric library in])
            AS_IF([test ! -z "$with_ofi_libdir" && \
                          test "$with_ofi_libdir" != "yes"],
                  [pmix_ofi_libdir=$with_ofi_libdir],
-                 [if test -d $with_ofi/lib; then
-                      pmix_ofi_libdir=$with_ofi/lib
-                  elif test -d $with_ofi/lib64; then
-                      pmix_ofi_libdir=$with_ofi/lib64
+                 [if test ! -z "$with_ofi"; then
+                     if test -d $with_ofi/lib; then
+                         pmix_ofi_libdir=$with_ofi/lib
+                     elif test -d $with_ofi/lib64; then
+                         pmix_ofi_libdir=$with_ofi/lib64
+                     else
+                         AC_MSG_RESULT([Could not find $with_ofi/lib or $with_ofi/lib64])
+                         AC_MSG_ERROR([Can not continue])
+                     fi
+                     AC_MSG_RESULT([($pmix_ofi_libdir)])
                   else
-                      AC_MSG_RESULT([Could not find $with_ofi/lib or $with_ofi/lib64])
-                      AC_MSG_ERROR([Can not continue])
+                     AC_MSG_RESULT([(default search paths)])
                   fi])
           ])
 

--- a/config/pmix_check_package.m4
+++ b/config/pmix_check_package.m4
@@ -15,6 +15,7 @@
 # Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,7 +46,6 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_HEADER], [
            test "$hdir_prefix" = "/usr" || \
            test "$hdir_prefix" = "/usr/local"],
            [ # try as is...
-            AC_VERBOSE([looking for header without includes])
             AC_CHECK_HEADERS([$2], [pmix_check_package_header_happy="yes"], [])
             AS_IF([test "$pmix_check_package_header_happy" = "no"],
                   [# no go on the as is - reset the cache and try again

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1478,6 +1478,9 @@ static inline void* pmix_calloc(size_t n, size_t m)
 #define PMIX_CHECK_RANK(a, b) \
     ((a) == (b) || (PMIX_RANK_WILDCARD == (a) || PMIX_RANK_WILDCARD == (b)))
 
+#define PMIX_NSPACE_INVALID(a) \
+    (0 < strlen((a)))
+
 /****    PMIX COORD    ****/
 /* define coordinate system views */
 typedef uint8_t pmix_coord_view_t;


### PR DESCRIPTION
If OFI isn't installed, don't abort unless the user specifically asked for it.

Signed-off-by: Ralph Castain <rhc@pmix.org>