### PR TITLE
Various HWLOC support changes plus one OFI config fix

### DIFF
--- a/config/pmix_check_ofi.m4
+++ b/config/pmix_check_ofi.m4
@@ -112,7 +112,7 @@ AC_DEFUN([_PMIX_CHECK_OFI],[
            AS_IF([test ! -z "$with_ofi_libdir" && \
                          test "$with_ofi_libdir" != "yes"],
                  [pmix_ofi_libdir=$with_ofi_libdir],
-                 [if test ! -z "$with_ofi"; then
+                 [if test ! -z "$with_ofi" && test "$with_ofi" != "yes"; then
                      if test -d $with_ofi/lib; then
                          pmix_ofi_libdir=$with_ofi/lib
                      elif test -d $with_ofi/lib64; then

--- a/src/mca/ploc/hwloc/ploc_hwloc.c
+++ b/src/mca/ploc/hwloc/ploc_hwloc.c
@@ -180,8 +180,8 @@ pmix_status_t setup_topology(pmix_info_t *info, size_t ninfo)
     bool share = false;
 #if HWLOC_API_VERSION >= 0x20000
     pmix_status_t rc;
-#endif
     char *tmp;
+#endif
 
     /* see if they want us to share the topology with our clients */
     for (n=0; n < ninfo; n++) {
@@ -312,6 +312,14 @@ pmix_status_t setup_topology(pmix_info_t *info, size_t ninfo)
         return PMIX_SUCCESS;
     }
 
+    /* get the size of the topology shared memory segment */
+    if (0 != hwloc_shmem_topology_get_length(pmix_globals.topology.topology, &shmemsize, 0)) {
+        pmix_output_verbose(2, pmix_ploc_base_framework.framework_output,
+                            "%s hwloc topology shmem not available",
+                            PMIX_NAME_PRINT(&pmix_globals.myid));
+        return PMIX_SUCCESS;
+    }
+
     /* try and find a hole */
     if (PMIX_SUCCESS != (rc = find_hole(mca_ploc_hwloc_component.hole_kind,
                                         &shmemaddr, shmemsize))) {
@@ -378,8 +386,8 @@ pmix_status_t setup_topology(pmix_info_t *info, size_t ninfo)
     if (0 != (rc = hwloc_shmem_topology_write(pmix_globals.topology.topology, shmemfd, 0,
                                               (void*)shmemaddr, shmemsize, 0))) {
         pmix_output_verbose(2, pmix_ploc_base_framework.framework_output,
-                            "%s an error occurred while writing topology to %s",
-                            PMIX_NAME_PRINT(&pmix_globals.myid), shmemfile);
+                            "%s an error %d (%s) occurred while writing topology to %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid), rc, strerror(errno), shmemfile);
         unlink(shmemfile);
         free(shmemfile);
         shmemfile = NULL;
@@ -1818,7 +1826,8 @@ static int parse_map_line(const char *line,
     return PMIX_SUCCESS;
 }
 
-#define ALIGN2MB (2*1024*1024UL)
+#define ALIGN2MB  (2*1024*1024UL)
+#define ALIGN64MB (64*1024*1024UL)
 
 static int use_hole(unsigned long holebegin,
                     unsigned long holesize,
@@ -1833,7 +1842,6 @@ static int use_hole(unsigned long holebegin,
     }
 
     /* try to align the middle of the hole on 64MB for POWER's 64k-page PMD */
-    #define ALIGN64MB (64*1024*1024UL)
     aligned = (middle + ALIGN64MB) & ~(ALIGN64MB-1);
     if (aligned + size <= holebegin + holesize) {
         *addrp = aligned;

--- a/src/mca/ploc/hwloc/ploc_hwloc.c
+++ b/src/mca/ploc/hwloc/ploc_hwloc.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      Inria.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -180,6 +181,7 @@ pmix_status_t setup_topology(pmix_info_t *info, size_t ninfo)
 #if HWLOC_API_VERSION >= 0x20000
     pmix_status_t rc;
 #endif
+    char *tmp;
 
     /* see if they want us to share the topology with our clients */
     for (n=0; n < ninfo; n++) {
@@ -408,6 +410,12 @@ pmix_status_t setup_topology(pmix_info_t *info, size_t ninfo)
     PMIX_VALUE_LOAD(kv->value, &shmemsize, PMIX_SIZE);
     pmix_list_append(&pmix_server_globals.gdata, &kv->super);
 
+    /* and add them to the global cache of envars as well */
+    pmix_setenv("PMIX_HWLOC_SHMEM_FILE", shmemfile, true, &pmix_server_globals.genvars);
+    pmix_asprintf(&tmp, "%"PRIsize_t, shmemaddr);
+    pmix_setenv("PMIX_HWLOC_SHMEM_ADDR", tmp, true, &pmix_server_globals.genvars);
+    pmix_asprintf(&tmp, "%"PRIsize_t, shmemsize);
+    pmix_setenv("PMIX_HWLOC_SHMEM_SIZE", tmp, true, &pmix_server_globals.genvars);
 #endif
 
     return PMIX_SUCCESS;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1914,6 +1914,13 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
     /* communicate our version */
     pmix_setenv("PMIX_VERSION", PMIX_VERSION, true, env);
 
+    /* pass any global contributions */
+    if (NULL != pmix_server_globals.genvars) {
+        for (n=0; NULL != pmix_server_globals.genvars[n]; n++) {
+            pmix_argv_append_nosize(env, pmix_server_globals.genvars[n]);
+        }
+    }
+
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -184,6 +185,7 @@ typedef struct {
     pmix_list_t remote_pnd;                 // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing remote req's
     pmix_list_t local_reqs;                 // list of pmix_dmdx_local_t awaiting arrival of data from local neighbours
     pmix_list_t gdata;                      // cache of data given to me for passing to all clients
+    char **genvars;                         // argv array of envars given to me for passing to all clients
     pmix_list_t events;                     // list of pmix_regevents_info_t registered events
     pmix_list_t groups;                     // list of pmix_group_t group memberships
     pmix_list_t iof;                        // IO to be forwarded to clients

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -423,10 +424,11 @@ int main(int argc, char **argv)
 
 
     /* setup the server library and tell it to support tool connections */
-    ninfo = 2;
+    ninfo = 3;
     PMIX_INFO_CREATE(info, ninfo);
     PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&info[1], PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[2], PMIX_SERVER_SHARE_TOPOLOGY, NULL, PMIX_BOOL);
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, ninfo))) {
         fprintf(stderr, "Init failed with error %s\n", PMIx_Error_string(rc));
         return rc;


### PR DESCRIPTION
Provide an envar version of the HWLOC shmem rndvz info
Allow lower-level libs to attach to the HWLOC shmem region without requiring them to link against PMIx.

-----------------------

Fix bugs in OFI configure and HWLOC component
Protect against --with-ofi being "yes". Add missing function call to hwloc component to get shared memory size

-----------------------

Signed-off-by: Ralph Castain <rhc@pmix.org>