### PR TITLE
v3.1: Fix configury so PMIx is compiled with -O3 by default.

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1016,15 +1016,11 @@ else
     AC_MSG_RESULT([no])
     WANT_DEBUG=0
 fi
-#################### Early development override ####################
-if test "$WANT_DEBUG" = "0" && test -z "$enable_debug" && test "$PMIX_DEVEL" = "1"; then
-    WANT_DEBUG=1
-    echo "--> developer override: enable debugging code by default"
-fi
-#################### Early development override ####################
+
 if test "$WANT_DEBUG" = "0"; then
     CFLAGS="-DNDEBUG $CFLAGS"
 fi
+
 AC_DEFINE_UNQUOTED(PMIX_ENABLE_DEBUG, $WANT_DEBUG,
                    [Whether we want developer-level debugging code or not])
 


### PR DESCRIPTION
Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit fcb79a6)