### PR TITLE
Correctly handle precedence for first/last overall events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ test/simple/simpcycle
 test/simple/simpfabric
 test/simple/get_put_example
 test/simple/simpvni
+test/simple/hybrid
 
 test/sshot/daemon
 test/sshot/generate

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,13 +33,15 @@
 
  BEGIN_C_DECLS
 
-#define PMIX_EVENT_ORDER_NONE       0x00
-#define PMIX_EVENT_ORDER_FIRST      0x01
-#define PMIX_EVENT_ORDER_LAST       0x02
-#define PMIX_EVENT_ORDER_BEFORE     0x04
-#define PMIX_EVENT_ORDER_AFTER      0x08
-#define PMIX_EVENT_ORDER_PREPEND    0x10
-#define PMIX_EVENT_ORDER_APPEND     0x20
+#define PMIX_EVENT_ORDER_NONE           0x00
+#define PMIX_EVENT_ORDER_FIRST          0x01
+#define PMIX_EVENT_ORDER_LAST           0x02
+#define PMIX_EVENT_ORDER_BEFORE         0x04
+#define PMIX_EVENT_ORDER_AFTER          0x08
+#define PMIX_EVENT_ORDER_PREPEND        0x10
+#define PMIX_EVENT_ORDER_APPEND         0x20
+#define PMIX_EVENT_ORDER_FIRST_OVERALL  0x40
+#define PMIX_EVENT_ORDER_LAST_OVERALL   0x80
 
 /* define an internal attribute for marking that the
  * server processed an event before passing it up

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -269,7 +270,6 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }
-
     return rc;
 }
 

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,7 +27,8 @@ headers = simptest.h
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
-                  simpcoord simpcycle doubleget simpfabric get_put_example simpvni
+                  simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
+                  hybrid
 
 simptest_SOURCES = \
         simptest.c
@@ -165,3 +167,10 @@ simpvni_SOURCES = \
 simpvni_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpvni_LDADD = \
     $(top_builddir)/src/libpmix.la
+
+hybrid_SOURCES = \
+        hybrid.c
+hybrid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+hybrid_LDADD = \
+    $(top_builddir)/src/libpmix.la
+

--- a/test/simple/hybrid.c
+++ b/test/simple/hybrid.c
@@ -1,0 +1,159 @@
+#include <stdio.h>
+
+#include <pmix.h>
+
+static volatile bool OMP_region_entered = false;
+static volatile bool MPI_region_entered = false;
+
+//<EG BEGIN ID="declare_model_cb">
+static void model_declared_cb(size_t evhdlr_registration_id,
+                              pmix_status_t status, const pmix_proc_t *source,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_info_t results[], size_t nresults,
+                              pmix_event_notification_cbfunc_fn_t cbfunc,
+                              void *cbdata) {
+  printf("Entered %s\n", __FUNCTION__);
+  int n;
+  for (n = 0; n < ninfo; n++) {
+    if (PMIX_CHECK_KEY(&info[n], PMIX_PROGRAMMING_MODEL) &&
+        strcmp(info[n].value.data.string, "MPI") == 0) {
+      /* ignore our own declaration */
+      break;
+    } else {
+      /* actions to perform when another model registers */
+    }
+  }
+  if (NULL != cbfunc) {
+    /* tell the event handler that we are only a partial step */
+    cbfunc(PMIX_EVENT_PARTIAL_ACTION_TAKEN, NULL, 0, NULL, NULL, cbdata);
+  }
+}
+//<EG END ID="declare_model_cb">
+
+//<EG BEGIN ID="omp_thread">
+static void parallel_region_OMP_cb(size_t evhdlr_registration_id,
+                                   pmix_status_t status,
+                                   const pmix_proc_t *source,
+                                   pmix_info_t info[], size_t ninfo,
+                                   pmix_info_t results[], size_t nresults,
+                                   pmix_event_notification_cbfunc_fn_t cbfunc,
+                                   void *cbdata) {
+  printf("Entered %s\n", __FUNCTION__);
+  /* do what we need OpenMP to do on entering a parallel region */
+  if (NULL != cbfunc) {
+    /* tell the event handler that we are only a partial step */
+    cbfunc(PMIX_EVENT_PARTIAL_ACTION_TAKEN, NULL, 0, NULL, NULL, cbdata);
+  }
+    OMP_region_entered = true;
+}
+//<EG END ID="omp_thread">
+
+//<EG BEGIN ID="mpi_thread">
+static void parallel_region_MPI_cb(size_t evhdlr_registration_id,
+                                   pmix_status_t status,
+                                   const pmix_proc_t *source,
+                                   pmix_info_t info[], size_t ninfo,
+                                   pmix_info_t results[], size_t nresults,
+                                   pmix_event_notification_cbfunc_fn_t cbfunc,
+                                   void *cbdata) {
+  printf("Entered %s\n", __FUNCTION__);
+  /* do what we need MPI to do on entering a parallel region */
+  if (NULL != cbfunc) {
+    /* do what we need MPI to do on entering a parallel region */
+    cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+  }
+    MPI_region_entered = true;
+}
+//<EG END ID="mpi_thread">
+
+static int openmp_handler() {
+  pmix_info_t *info;
+  int rc;
+
+  printf("Entered %s\n", __FUNCTION__);
+
+  //<EG BEGIN ID="omp_thread">
+  bool is_true = true;
+  pmix_status_t code = PMIX_OPENMP_PARALLEL_ENTERED;
+  PMIX_INFO_CREATE(info, 2);
+  PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "OpenMP-Master", PMIX_STRING);
+  PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_FIRST, &is_true, PMIX_BOOL);
+  rc = PMIx_Register_event_handler(&code, 1, info, 2, parallel_region_OMP_cb, NULL, NULL);
+  if (rc < 0)
+    fprintf(stderr, "%s: Failed to register event handler for OpenMP region entrance\n", __FUNCTION__);
+  PMIX_INFO_FREE(info, 2);
+  //<EG END ID="omp_thread">
+  printf("Registered OpenMP event handler for OpenMP parallel region entered\n");
+
+  return rc;
+}
+
+static int mpi_handler() {
+  pmix_info_t *info;
+  int rc;
+
+  printf("Entered %s\n", __FUNCTION__);
+
+  //<EG BEGIN ID="mpi_thread">
+  pmix_status_t code = PMIX_OPENMP_PARALLEL_ENTERED;
+  PMIX_INFO_CREATE(info, 2);
+  PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "MPI-Thread", PMIX_STRING);
+  PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_AFTER, "OpenMP-Master", PMIX_STRING);
+  rc = PMIx_Register_event_handler(&code, 1, info, 2, parallel_region_MPI_cb, NULL, NULL);
+  if (rc < 0)
+    fprintf(stderr, "%s: Failed to register event handler for OpenMP region entrance\n", __FUNCTION__);
+  PMIX_INFO_FREE(info, 2);
+  //<EG END ID="mpi_thread">
+  printf("Registered MPI event handler for OpenMP parallel region entered\n");
+
+  return rc;
+}
+
+int main() {
+  //<EG BEGIN ID="declare_model">
+  pmix_proc_t myproc;
+  pmix_info_t *info;
+
+  PMIX_INFO_CREATE(info, 4);
+  PMIX_INFO_LOAD(&info[0], PMIX_PROGRAMMING_MODEL, "MPI", PMIX_STRING);
+  PMIX_INFO_LOAD(&info[1], PMIX_MODEL_LIBRARY_NAME, "FooMPI", PMIX_STRING);
+  PMIX_INFO_LOAD(&info[2], PMIX_MODEL_LIBRARY_VERSION, "1.0.0", PMIX_STRING);
+  PMIX_INFO_LOAD(&info[3], PMIX_THREADING_MODEL, "pthread", PMIX_STRING);
+  pmix_status_t rc = PMIx_Init(&myproc, info, 4);
+  PMIX_INFO_FREE(info, 4);
+  //<EG END ID="declare_model">
+  printf("Registered MPI programming model\n");
+
+  printf("Registering event handler for model declaration\n");
+  //<EG BEGIN ID="declare_model_cb">
+  pmix_status_t code = PMIX_MODEL_DECLARED;
+  rc = PMIx_Register_event_handler(&code, 1, NULL, 0, model_declared_cb, NULL, NULL);
+  //<EG END ID="declare_model_cb">
+    if (rc < 0) {
+        fprintf(stderr, "Failed to register event handler for model declaration\n");
+        goto fin;
+    }
+  printf("Registered event handler for model declaration\n");
+
+  openmp_handler();
+  mpi_handler();
+
+  printf("Notifying OpenMP parallel region about to be entered\n");
+  //<EG BEGIN ID="notify_event">
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+  rc = PMIx_Notify_event(PMIX_OPENMP_PARALLEL_ENTERED, &myproc, PMIX_RANGE_PROC_LOCAL, info, 1, NULL, NULL);
+    if (rc < 0) {
+        fprintf(stderr, "Failed to notify OpenMP region entered\n");
+        goto fin;
+    }
+
+    while (!OMP_region_entered || !MPI_region_entered) {
+        sleep(1);
+    }
+    fprintf(stderr, "Test completed\n");
+
+fin:
+    PMIx_Finalize(NULL, 0);
+  //<EG END ID="notify_event">
+}


### PR DESCRIPTION
If someone specifies a first or last overall event and then registers an event relative to them, we need to correctly handle that both during registration and notification.

Signed-off-by: Ralph Castain <rhc@pmix.org>