### PR TITLE
Fix check for IBM xl compilers for v13.1 and later.

### DIFF
--- a/config/pmix_check_vendor.m4
+++ b/config/pmix_check_vendor.m4
@@ -172,7 +172,7 @@ AC_DEFUN([_PMIX_CHECK_COMPILER_VENDOR], [
 
     # IBM XL C/C++
     AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
-          [PMIX_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__)],
+          [PMIX_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)],
                [pmix_check_compiler_vendor_result="ibm"],
                [PMIX_IF_IFELSE([defined(_AIX) && !defined(__GNUC__)],
                     [pmix_check_compiler_vendor_result="ibm"])])])

--- a/config/pmix_check_vendor.m4
+++ b/config/pmix_check_vendor.m4
@@ -103,29 +103,6 @@ AC_DEFUN([_PMIX_CHECK_COMPILER_VENDOR], [
           [PMIX_IF_IFELSE([defined(__FUJITSU)],
                [pmix_check_compiler_vendor_result="fujitsu"])])
 
-    # GNU
-    AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
-          [PMIX_IFDEF_IFELSE([__GNUC__],
-               [pmix_check_compiler_vendor_result="gnu"
-
-               # We do not support gccfss as a compiler so die if
-               # someone tries to use said compiler.  gccfss (gcc
-               # for SPARC Systems) is a compiler that is no longer
-               # supported by Oracle and it has some major flaws
-               # that prevents it from actually compiling PMIX code.
-               # So if we detect it we automatically bail.
-
-               if ($CC --version | grep gccfss) >/dev/null 2>&1; then
-                   AC_MSG_RESULT([gccfss])
-                   AC_MSG_WARN([Detected gccfss being used to compile PMIx.])
-                   AC_MSG_WARN([Because of several issues PMIx does not support])
-                   AC_MSG_WARN([the gccfss compiler.  Please use a different compiler.])
-                   AC_MSG_WARN([If you didn't think you used gccfss you may want to])
-                   AC_MSG_WARN([check to see if the compiler you think you used is])
-                   AC_MSG_WARN([actually a link to gccfss.])
-                   AC_MSG_ERROR([Cannot continue])
-               fi])])
-
     # Borland Turbo C
     AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
           [PMIX_IFDEF_IFELSE([__TURBOC__],
@@ -246,6 +223,29 @@ AC_DEFUN([_PMIX_CHECK_COMPILER_VENDOR], [
     AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
           [PMIX_IFDEF_IFELSE([__WATCOMC__],
                [pmix_check_compiler_vendor_result="watcom"])])
+
+    # GNU
+    AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
+          [PMIX_IFDEF_IFELSE([__GNUC__],
+               [pmix_check_compiler_vendor_result="gnu"
+
+               # We do not support gccfss as a compiler so die if
+               # someone tries to use said compiler.  gccfss (gcc
+               # for SPARC Systems) is a compiler that is no longer
+               # supported by Oracle and it has some major flaws
+               # that prevents it from actually compiling PMIX code.
+               # So if we detect it we automatically bail.
+
+               if ($CC --version | grep gccfss) >/dev/null 2>&1; then
+                   AC_MSG_RESULT([gccfss])
+                   AC_MSG_WARN([Detected gccfss being used to compile PMIx.])
+                   AC_MSG_WARN([Because of several issues PMIx does not support])
+                   AC_MSG_WARN([the gccfss compiler.  Please use a different compiler.])
+                   AC_MSG_WARN([If you didn't think you used gccfss you may want to])
+                   AC_MSG_WARN([check to see if the compiler you think you used is])
+                   AC_MSG_WARN([actually a link to gccfss.])
+                   AC_MSG_ERROR([Cannot continue])
+               fi])])
 
     $1="$pmix_check_compiler_vendor_result"
     unset pmix_check_compiler_vendor_result

--- a/src/atomics/sys/powerpc/atomic.h
+++ b/src/atomics/sys/powerpc/atomic.h
@@ -108,7 +108,7 @@ void pmix_atomic_isync(void)
  *********************************************************************/
 #if PMIX_GCC_INLINE_ASSEMBLY
 
-#ifdef __xlC__
+#if defined(__xlC__) || defined(__ibmxl__) || defined(__IBMC__) || defined(__IBMCPP__)
 /* work-around bizzare xlc bug in which it sign-extends
    a pointer to a 32-bit signed integer */
 #define PMIX_ASM_ADDR(a) ((uintptr_t)a)

--- a/src/include/pmix_portable_platform.h
+++ b/src/include/pmix_portable_platform.h
@@ -171,7 +171,7 @@
        /* XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX */
 #    endif
 
-#elif defined(__xlC__)
+#elif defined(__xlC__) || defined(__ibmxl__) || defined(__IBMC__) || defined(__IBMCPP__)
 #    define PLATFORM_COMPILER_XLC  1
 #    define PLATFORM_COMPILER_FAMILYNAME XLC
 #    define PLATFORM_COMPILER_FAMILYID 5


### PR DESCRIPTION
By default newer xlc compilers only define __ibmxl__ now.

https://www.ibm.com/support/knowledgecenter/en/SSXVZZ_13.1.6/com.ibm.xlcpp1316.lelinux.doc/compiler_ref/xlmacros.html
Signed-off-by: Austen Lauria <awlauria@us.ibm.com>