### PR TITLE
Extend data buffer support a little bit

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1422,6 +1422,9 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unload(pmix_data_buffer_t *buffer,
  * payload - the load function cannot convert to network byte order
  * any data contained in the provided payload.
  *
+ * @note The "payload" object will be empty upon completion of
+ * this operation.
+ *
  * @param buffer A pointer to the buffer into which the payload is to
  * be loaded.
  *
@@ -1444,6 +1447,45 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unload(pmix_data_buffer_t *buffer,
  */
 PMIX_EXPORT pmix_status_t PMIx_Data_load(pmix_data_buffer_t *buffer,
                                          pmix_byte_object_t *payload);
+
+/**
+* Embed a data payload into a buffer.
+*
+* The embed function is identical in operation to PMIx_Data_load
+* except that it does NOT "clear" the payload upon completion.
+*
+* @note The buffer must be allocated in advance - failing to do so
+* will cause the function to return an error code.
+*
+* @note The caller is responsible for pre-packing the provided
+* payload - the load function cannot convert to network byte order
+* any data contained in the provided payload.
+*
+* @note The "payload" object is unaltered by this operation.
+*
+* @param buffer A pointer to the buffer into which the payload is to
+* be loaded.
+*
+* @param payload A pointer to the pmix_byte_object_t .containing the
+* desired payload
+*
+* @retval PMIX_SUCCESS The request was successfully completed
+*
+* @retval PMIX_ERROR(s) An appropriate error code indicating the
+* problem will be returned. This should be handled appropriately by
+* the caller.
+*
+* @code
+* pmix_data_buffer_t *buffer;
+* pmix_byte_object_t payload;
+*
+* PMIX_DATA_BUFFER_CREATE(buffer);
+* status_code = PMIx_Data_embed(buffer, &payload);
+* @endcode
+*/
+PMIX_EXPORT pmix_status_t PMIx_Data_embed(pmix_data_buffer_t *buffer,
+                                          const pmix_byte_object_t *payload);
+
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -333,7 +333,7 @@ typedef uint32_t pmix_rank_t;
 
 
 /* topology info */
-#define PMIX_TOPOLOGY2                      "pmix.topo2"            // (pmix_topology_t) pointer to a PMIx topology object
+#define PMIX_TOPOLOGY2                      "pmix.topo2"            // (pmix_topology_t*) pointer to a PMIx topology object
 #define PMIX_LOCALITY_STRING                "pmix.locstr"           // (char*) string describing a proc's location
 
 
@@ -1324,11 +1324,10 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_LOCTYPE                    58
 #define PMIX_COMPRESSED_BYTE_OBJECT     59
 #define PMIX_PROC_NSPACE                60
-#define PMIX_PROC_NAME                  61
-#define PMIX_PROC_STATS                 62
-#define PMIX_DISK_STATS                 63
-#define PMIX_NET_STATS                  64
-#define PMIX_NODE_STATS                 65
+#define PMIX_PROC_STATS                 61
+#define PMIX_DISK_STATS                 62
+#define PMIX_NET_STATS                  63
+#define PMIX_NODE_STATS                 64
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1764,7 +1763,7 @@ typedef struct pmix_byte_object {
 
 #define PMIX_BYTE_OBJECT_LOAD(b, d, s)      \
     do {                                    \
-        (b)->bytes = (d);                   \
+        (b)->bytes = (char*)(d);            \
         (d) = NULL;                         \
         (b)->size = (s);                    \
         (s) = 0;                            \
@@ -2401,6 +2400,9 @@ typedef struct pmix_value {
             (r) = pmix_value_xfer((v), (s));                    \
         }                                                       \
     } while(0)
+
+#define PMIX_VALUE_XFER_DIRECT(r, v, s)     \
+    (r) = pmix_value_xfer((v), (s))
 
 #define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
     do {                                                \


### PR DESCRIPTION
Add an API for embedding a byte object into a buffer.
Add a macro for transferring pmix_value_t data without
allocating a new pmix_value_t

Signed-off-by: Ralph Castain <rhc@pmix.org>