### PR TITLE
configury: fix _PMIX_CHECK_PACKAGE_LIB() macro

### DIFF
--- a/config/pmix_check_package.m4
+++ b/config/pmix_check_package.m4
@@ -13,8 +13,8 @@
 # Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
-# Copyright (c) 2017      Research Organization for Information Science
-#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017-2021 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -81,9 +81,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_LIB], [
     # This is stolen from autoconf to peek under the covers to get the
     # cache variable for the library check.  one should not copy this
     # code into other places unless you want much pain and suffering
-    AS_LITERAL_IF([$2],
-                  [AS_VAR_PUSHDEF([pmix_Lib], [ac_cv_lib_$2_$3])],
-                  [AS_VAR_PUSHDEF([pmix_Lib], [ac_cv_lib_$2''_$3])])dnl
+    AS_VAR_PUSHDEF([pmix_Lib], [ac_cv_search_$3])
 
     # see comment above
     unset pmix_Lib


### PR DESCRIPTION
use the correct name for the cached variable
(so it can be properly un-cached)

This is a backport from open-mpi/ompi@7da50433f799c98de82e2963d2fb5ea5d21663fb

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>