### PR TITLE
Validate CFLAGS individually.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -17,6 +17,8 @@
 #                         reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      IBM Corporation.  All rights reserved.
+#
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,6 +46,7 @@ EXTRA_DIST = \
 	pmix_functions.m4 \
 	pmix.m4 \
 	pmix_search_libs.m4 \
+	pmix_check_cflags.m4 \
 	pmix_setup_cc.m4 \
 	pmix_setup_libevent.m4 \
 	pmix_mca_priority_sort.pl \

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -1,0 +1,41 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
+dnl
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([_PMIX_CFLAGS_FAIL_SEARCH],[
+    AC_REQUIRE([AC_PROG_GREP])
+    if test -s conftest.err ; then
+        $GREP -iq $1 conftest.err
+        if test "$?" = "0" ; then
+            pmix_cv_cc_[$2]=0
+        fi
+    fi
+])
+
+AC_DEFUN([_PMIX_CHECK_SPECIFIC_CFLAGS], [
+AC_MSG_CHECKING(if $CC supports ([$1]))
+            CFLAGS_orig=$CFLAGS
+            CFLAGS="$CFLAGS $1"
+            AC_CACHE_VAL(pmix_cv_cc_[$2], [
+                   AC_TRY_COMPILE([], [$3],
+                                   [
+                                    pmix_cv_cc_[$2]=1
+                                    _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
+                                   ],
+                                    pmix_cv_cc_[$2]=1
+                                    _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
+                                 )])
+            if test "$pmix_cv_cc_[$2]" = "0" ; then
+                CFLAGS="$CFLAGS_orig"
+                AC_MSG_RESULT([no])
+            else
+                AC_MSG_RESULT([yes])
+            fi
+])


### PR DESCRIPTION
- Came across this when trying to debug other xlc compiler
  issues. The old configury logic would only set certain flags
  if the compiler vendor was labeled as 'gnu'. Ie - any non-gcc
  build would have far fewer CFLAGS compared to a gcc build.

  This change cropped up due to this commit:
  a2b2712d368c258782cbcf083742822ffe0dbc35
  which changed the way vendors are labeled. Before pretty much
  all vendors were labeled as gnu,
  Now, however, the vendor may be labeled as 'gnu'/'ibm'/
  'portland group'/ect. This change will validate and set CFLAGS
  for any compiler instead of assuming they are only valid for gcc.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>