### PR TITLE
Fix Python binding build

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2073,7 +2073,7 @@ typedef struct pmix_proc_stats {
     pid_t pid;
     char *cmd;
     /* process stats */
-    char state[2];
+    char state;
     struct timeval time;
     float percent_cpu;
     int32_t priority;

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -1275,7 +1275,7 @@ pmix_status_t pmix_bfrops_base_copy_pstats(pmix_proc_stats_t **dest,
     if (NULL != src->cmd) {
         p->cmd = strdup(src->cmd);
     }
-    p->state[0] = src->state[0];
+    p->state = src->state;
     p->time = src->time;
     p->priority = src->priority;
     p->num_threads = src->num_threads;

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1646,7 +1646,7 @@ pmix_status_t pmix_bfrops_base_pack_pstats(pmix_pointer_array_t *regtypes,
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].state[0], 1, PMIX_BYTE, regtypes);
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].state, 1, PMIX_BYTE, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -2424,7 +2424,7 @@ pmix_status_t pmix_bfrops_base_print_pstats(char **output, char *prefix,
                   "%s\ttime: %ld.%06ld cpu: %5.2f  PSS: %8.2f  VMsize: %8.2f PeakVMSize: %8.2f RSS: %8.2f\n",
                   prefx, (long)src->sample_time.tv_sec, (long)src->sample_time.tv_usec,
                   prefx, src->node, PMIX_NAME_PRINT(&src->proc), src->pid, src->cmd,
-                  src->state[0], src->priority, src->num_threads, src->processor,
+                  src->state, src->priority, src->num_threads, src->processor,
                   prefx, (long)src->time.tv_sec, (long)src->time.tv_usec,
                   src->percent_cpu, src->pss, src->vsize, src->peak_vsize, src->rss);
     if (prefx != prefix) {

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -2037,7 +2037,7 @@ pmix_status_t pmix_bfrops_base_unpack_pstats(pmix_pointer_array_t *regtypes,
             return ret;
         }
         m=1;
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].state[0], &m, PMIX_BYTE, regtypes);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].state, &m, PMIX_BYTE, regtypes);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             return ret;

--- a/src/mca/pstat/linux/pstat_linux_module.c
+++ b/src/mca/pstat/linux/pstat_linux_module.c
@@ -231,7 +231,7 @@ static int query(pid_t pid,
         ptr = next_field(eptr, len);
 
         /* next is the process state - a single character */
-        stats->state[0] = *ptr;
+        stats->state = *ptr;
         /* move to next field */
         ptr = next_field(ptr, len);
 

--- a/src/mca/pstat/test/pstat_test.c
+++ b/src/mca/pstat/test/pstat_test.c
@@ -90,7 +90,7 @@ static int query(pid_t pid,
 
         stats->pid = pid;
         stats->cmd = strdup("UNKNOWN");
-        stats->state[0] = 'R';
+        stats->state = 'R';
         stats->priority = 2;
         stats->num_threads = 1;
 


### PR DESCRIPTION
Replace array of char in pmix_proc_stats_t with a single
character as that is all that is actually required.

Fixes https://github.com/openpmix/openpmix/issues/2079

Signed-off-by: Ralph Castain <rhc@pmix.org>