### PR TITLE
Initialize myproc structure before calling PMIx_tool_set_server

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -350,7 +350,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_cmd_t cmd;
     pmix_cb_t cb;
     pmix_value_t value;
-    pmix_proc_t myproc;
     pmix_lock_t reglock, releaselock;
     pmix_status_t code;
 
@@ -688,7 +687,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
             return rc;
         }
         /* restore our original primary server */
-        rc = PMIx_tool_set_server(&myproc, NULL, 0);
+        rc = PMIx_tool_set_server(&pmix_globals.myid, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }


### PR DESCRIPTION
The call to PMIx_tool_set_server near line 692 in src/server/pmix_server.c failed with return code -25, PMIX_ERR_UNREACH because the myproc structure passed in this call was uninitialized.

I initialized the myproc structure, which solves the problem.
 
Signed-off-by: David Wootton <dwootton@us.ibm.com>