### PR TITLE
WIP storage support

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -429,7 +429,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       netdb.h ucred.h zlib.h sys/auxv.h \
                       sys/sysctl.h termio.h termios.h pty.h \
                       libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h \
-                      sys/utsname.h])
+                      sys/utsname.h mntent.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],
                      [AC_INCLUDES_DEFAULT

--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Construct a dictionary for translating attributes to/from
@@ -100,6 +101,8 @@ def harvest_constants(options, path, constants):
                             datatype = "PMIX_UINT8"
                         elif tokens[3] == "(float)":
                             datatype = "PMIX_FLOAT"
+                        elif tokens[3] == "(double)":
+                            datatype = "PMIX_DOUBLE"
                         elif tokens[3] == "(pmix_byte_object_t)":
                             datatype = "PMIX_BYTE_OBJECT"
                         elif tokens[3] == "(hwloc_topology_t)":
@@ -142,6 +145,14 @@ def harvest_constants(options, path, constants):
                             datatype = "PMIX_ENDPOINT"
                         elif tokens[3] == "(pmix_device_type_t)":
                             datatype = "PMIX_DEVTYPE"
+                        elif tokens[3] == "(pmix_storage_medium_t)":
+                            datatype = "PMIX_STRG_MEDIUM"
+                        elif tokens[3] == "(pmix_storage_accessibility_t)":
+                            datatype = "PMIX_STRG_ACCESSIBILTY"
+                        elif tokens[3] == "(pmix_storage_persistence_t)":
+                            datatype = "PMIX_STRG_PERSISTENCE"
+                        elif tokens[3] == "(pmix_storage_access_type_t)":
+                            datatype = "PMIX_STRG_ACCESS"
                         elif tokens[3] == "(varies)":
                             datatype = "PMIX_INT"
                         else:
@@ -273,6 +284,7 @@ def main():
 
 #include "src/include/pmix_config.h"
 #include "src/include/pmix_globals.h"
+#include "include/pmix_common.h"
 
 pmix_regattr_input_t dictionary[] = {
 """)

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -930,16 +930,23 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_STORAGE_OBJECT_LIMIT           "pmix.strg.objlim"      // (uint64_t) overall limit on number of objects (e.g., inodes) for the storage system
 #define PMIX_STORAGE_OBJECTS_USED           "pmix.strg.objuse"      // (uint64_t) overall used number of objects (e.g., inodes) for the storage system
 
-#define PMIX_STORAGE_MINIMAL_XFER_SIZE      "pmix.strg.minxfer"     // (double) minimal transfer size (in bytes) for the storage system - this is the storage system’s atomic unit of transfer (e.g., block size)
+#define PMIX_STORAGE_MINIMAL_XFER_SIZE      "pmix.strg.minxfer"     // (double) minimal transfer size (in bytes) for the storage system - this is the storage
+                                                                    //      system’s atomic unit of transfer (e.g., block size)
 #define PMIX_STORAGE_SUGGESTED_XFER_SIZE    "pmix.strg.sxfer"       // (double) suggested transfer size (in bytes) for the storage system
 
-#define PMIX_STORAGE_BW_MAX                 "pmix.strg.bwmax"       // (double) maximum bandwidth (in bytes/sec) for storage system - provided as the theoretical maximum or the maximum observed bandwidth value
-#define PMIX_STORAGE_BW_CUR                 "pmix.strg.bwcur"       // (double) observed bandwidth (in bytes/sec) for storage system - provided as a recently observed bandwidth value
+#define PMIX_STORAGE_BW_MAX                 "pmix.strg.bwmax"       // (double) maximum bandwidth (in bytes/sec) for storage system - provided as the
+                                                                    //      theoretical maximum or the maximum observed bandwidth value
+#define PMIX_STORAGE_BW_CUR                 "pmix.strg.bwcur"       // (double) observed bandwidth (in bytes/sec) for storage system - provided as a
+                                                                    //      recently observed bandwidth value
 
-#define PMIX_STORAGE_IOPS_MAX               "pmix.strg.iopsmax"     // (double) maximum IOPS (in I/O operations per second) for storage system - provided as the theoretical maximum or the maximum observed IOPS value
-#define PMIX_STORAGE_IOPS_CUR               "pmix.strg.iopscur"     // (double) observed IOPS (in I/O operations per second) for storage system - provided as a recently observed IOPS value
+#define PMIX_STORAGE_IOPS_MAX               "pmix.strg.iopsmax"     // (double) maximum IOPS (in I/O operations per second) for storage system - provided
+                                                                    //      as the theoretical maximum or the maximum observed IOPS value
+#define PMIX_STORAGE_IOPS_CUR               "pmix.strg.iopscur"     // (double) observed IOPS (in I/O operations per second) for storage system - provided
+                                                                    //      as a recently observed IOPS value
 
-#define PMIX_STORAGE_ACCESS_TYPE            "pmix.strg.atype"       // (pmix_storage_access_type_t) qualifier describing the type of storage access to return information for (e.g., for qualifying PMIX_STORAGE_BW_CUR , PMIX_STORAGE_IOPS_CUR , or PMIX_STORAGE_SUGGESTED_XFER_SIZE attributes)
+#define PMIX_STORAGE_ACCESS_TYPE            "pmix.strg.atype"       // (pmix_storage_access_type_t) qualifier describing the type of storage access to
+                                                                    //      return information for (e.g., for qualifying PMIX_STORAGE_BW_CUR ,
+                                                                    //      PMIX_STORAGE_IOPS_CUR , or PMIX_STORAGE_SUGGESTED_XFER_SIZE attributes)
 
 /* Fabric-related Attributes */
 #define PMIX_FABRIC_COST_MATRIX             "pmix.fab.cm"          // (pointer) Pointer to a two-dimensional array of point-to-point relative
@@ -1355,6 +1362,10 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_NET_STATS                  63
 #define PMIX_NODE_STATS                 64
 #define PMIX_DATA_BUFFER                65
+#define PMIX_STRG_MEDIUM                66
+#define PMIX_STRG_ACCESSIBILITY         67
+#define PMIX_STRG_PERSISTENCE           68
+#define PMIX_STRG_ACCESS                69
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1451,6 +1462,45 @@ typedef enum {
     PMIX_GROUP_CONSTRUCT,
     PMIX_GROUP_DESTRUCT
 } pmix_group_operation_t;
+
+/* define a set of storage medium bit-mask values */
+typedef uint64_t pmix_storage_medium_t;
+#define PMIX_STORAGE_MEDIUM_UNKNOWN     0x0000000000000000      // The storage medium type is unknown
+#define PMIX_STORAGE_MEDIUM_TAPE        0x0000000000000001      // The storage system uses tape media.
+#define PMIX_STORAGE_MEDIUM_HDD         0x0000000000000002      // The storage system uses HDDs with traditional SAS, SATA interfaces.
+#define PMIX_STORAGE_MEDIUM_SSD         0x0000000000000004      // The storage system uses SSDs with traditional SAS, SATA interfaces.
+#define PMIX_STORAGE_MEDIUM_NVME        0x0000000000000008      // The storage system uses SSDs with NVMe interface
+#define PMIX_STORAGE_MEDIUM_PMEM        0x0000000000000010      // The storage system uses persistent memory
+#define PMIX_STORAGE_MEDIUM_RAM         0x0000000000000020      // The storage system is volatile (e.g., tmpfs).
+
+/* define a set of storage accessibility bit-mask values */
+typedef uint64_t pmix_storage_accessibility_t;
+#define PMIX_STORAGE_ACCESSIBILITY_NODE         0x0000000000000000      // The storage system resources are accessible within the same node.
+#define PMIX_STORAGE_ACCESSIBILITY_SESSION      0x0000000000000001      // The storage system resources are accessible within the same session.
+#define PMIX_STORAGE_ACCESSIBILITY_JOB          0x0000000000000002      // The storage system resources are accessible within the same job.
+#define PMIX_STORAGE_ACCESSIBILITY_RACK         0x0000000000000004      // The storage system resources are accessible within the same rack.
+#define PMIX_STORAGE_ACCESSIBILITY_CLUSTER      0x0000000000000008      // The storage system resources are accessible within the same cluster.
+#define PMIX_STORAGE_ACCESSIBILITY_REMOTE       0x0000000000000010      // The storage system resources are remote.
+
+/* define a set of storage persistence values */
+typedef uint16_t pmix_storage_persistence_t;
+#define PMIX_STORAGE_PERSISTENCE_TEMPORARY      0       // Data on the storage system is persisted only temporarily (i.e, it does not survive
+                                                        //      across sessions or node reboots).
+#define PMIX_STORAGE_PERSISTENCE_NODE           1       // Data on the storage system is persisted on the node.
+#define PMIX_STORAGE_PERSISTENCE_SESSION        2       // Data on the storage system is persisted for the duration of the session.
+#define PMIX_STORAGE_PERSISTENCE_JOB            3       // Data on the storage system is persisted for the duration of the job.
+#define PMIX_STORAGE_PERSISTENCE_SCRATCH        4       // Data on the storage system is persisted according to scratch storage policies
+                                                        //      (short-term storage, typically persisted for days to weeks).
+#define PMIX_STORAGE_PERSISTENCE_PROJECT        5       // Data on the storage system is persisted according to project storage policies
+                                                        //      (long-term storage, typically persisted for the duration of a project).
+#define PMIX_STORAGE_PERSISTENCE_ARCHIVE        6       //Data on the storage system is persisted according to archive storage policies
+                                                        //      (long-term storage, typically persisted indefinitely).
+
+/* define a set of storage access type bit-mask values */
+typedef uint16_t pmix_storage_access_type_t;
+#define PMIX_STORAGE_ACCESS_RD      0x0001  // Provide information on storage system read operations.
+#define PMIX_STORAGE_ACCESS_WR      0x0002  // Provide information on storage system write operations.
+#define PMIX_STORAGE_ACCESS_RDWR    0x0003  // Provide information on storage system read and write operations.
 
 
 /* define some "hooks" external libraries can use to
@@ -2363,6 +2413,10 @@ typedef struct pmix_value {
         pmix_disk_stats_t *dkstats;
         pmix_net_stats_t *netstats;
         pmix_node_stats_t *ndstats;
+        pmix_storage_medium_t storage_medium;
+        pmix_storage_accessibility_t storage_accessibility;
+        pmix_storage_persistence_t storage_persistence;
+        pmix_storage_access_type_t storage_access;
     } data;
 } pmix_value_t;
 /* allocate and initialize a specified number of value structs */
@@ -3411,55 +3465,59 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
                        PMIX_INT8 == (t) ||                          \
                        PMIX_UINT8 == (t) ||                         \
                        PMIX_POINTER == (t)) {                       \
-                (m)->array = pmix_calloc((n), sizeof(int8_t));           \
+                (m)->array = pmix_calloc((n), sizeof(int8_t));      \
                                                                     \
             } else if (PMIX_STRING == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(char*));            \
+                (m)->array = pmix_calloc((n), sizeof(char*));       \
                                                                     \
             } else if (PMIX_SIZE == (t)) {                          \
-                (m)->array = pmix_calloc((n), sizeof(size_t));           \
+                (m)->array = pmix_calloc((n), sizeof(size_t));      \
                                                                     \
             } else if (PMIX_PID == (t)) {                           \
-                (m)->array = pmix_calloc((n), sizeof(pid_t));            \
+                (m)->array = pmix_calloc((n), sizeof(pid_t));       \
                                                                     \
             } else if (PMIX_INT == (t) ||                           \
                        PMIX_UINT == (t) ||                          \
                        PMIX_STATUS == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(int));              \
+                (m)->array = pmix_calloc((n), sizeof(int));         \
                                                                     \
             } else if (PMIX_IOF_CHANNEL == (t) ||                   \
                        PMIX_DATA_TYPE == (t) ||                     \
                        PMIX_INT16 == (t) ||                         \
-                       PMIX_UINT16 == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(int16_t));          \
+                       PMIX_UINT16 == (t) ||                        \
+                       PMIX_STRG_PERSISTENCE == (t) ||              \
+                       PMIX_STRG_ACCESS == (t)) {                   \
+                (m)->array = pmix_calloc((n), sizeof(int16_t));     \
                                                                     \
             } else if (PMIX_PROC_RANK == (t) ||                     \
                        PMIX_INFO_DIRECTIVES == (t) ||               \
                        PMIX_INT32 == (t) ||                         \
                        PMIX_UINT32 == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(int32_t));          \
+                (m)->array = pmix_calloc((n), sizeof(int32_t));     \
                                                                     \
             } else if (PMIX_INT64 == (t) ||                         \
-                       PMIX_UINT64 == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(int64_t));          \
+                       PMIX_UINT64 == (t) ||                        \
+                       PMIX_STRG_MEDIUM == (t) ||                   \
+                       PMIX_STRG_ACCESSIBILITY == (t)) {            \
+                (m)->array = pmix_calloc((n), sizeof(int64_t));     \
                                                                     \
             } else if (PMIX_FLOAT == (t)) {                         \
-                (m)->array = pmix_calloc((n), sizeof(float));            \
+                (m)->array = pmix_calloc((n), sizeof(float));       \
                                                                     \
             } else if (PMIX_DOUBLE == (t)) {                        \
-                (m)->array = pmix_calloc((n), sizeof(double));           \
+                (m)->array = pmix_calloc((n), sizeof(double));      \
                                                                     \
             } else if (PMIX_TIMEVAL == (t)) {                       \
                 (m)->array = pmix_calloc((n), sizeof(struct timeval));   \
                                                                     \
             } else if (PMIX_TIME == (t)) {                          \
-                (m)->array = pmix_calloc((n), sizeof(time_t));           \
+                (m)->array = pmix_calloc((n), sizeof(time_t));      \
                                                                     \
             } else if (PMIX_REGATTR == (t)) {                       \
                 PMIX_REGATTR_CREATE((m)->array, (n));               \
                                                                     \
             } else if (PMIX_BOOL == (t)) {                          \
-                (m)->array = pmix_calloc((n), sizeof(bool));             \
+                (m)->array = pmix_calloc((n), sizeof(bool));        \
                                                                     \
             } else if (PMIX_COORD == (t)) {                         \
                 (m)->array = pmix_calloc((n), sizeof(pmix_coord_t));  \
@@ -3467,35 +3525,35 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
             } else if (PMIX_LINK_STATE == (t)) {                    \
                 (m)->array = pmix_calloc((n), sizeof(pmix_link_state_t));  \
                                                                     \
-            } else if (PMIX_ENDPOINT == (t)) {                         \
-                PMIX_ENDPOINT_CREATE((m)->array, n);                   \
+            } else if (PMIX_ENDPOINT == (t)) {                      \
+                PMIX_ENDPOINT_CREATE((m)->array, n);                \
                                                                     \
-            } else if (PMIX_PROC_NSPACE == (t)) {                         \
+            } else if (PMIX_PROC_NSPACE == (t)) {                   \
                 (m)->array = pmix_calloc((n), sizeof(pmix_nspace_t));     \
                                                                     \
-            } else if (PMIX_PROC_STATS == (t)) {                         \
-                PMIX_PROC_STATS_CREATE((m)->array, n);                   \
+            } else if (PMIX_PROC_STATS == (t)) {                    \
+                PMIX_PROC_STATS_CREATE((m)->array, n);              \
                                                                     \
-            } else if (PMIX_DISK_STATS == (t)) {                         \
-                PMIX_DISK_STATS_CREATE((m)->array, n);                   \
+            } else if (PMIX_DISK_STATS == (t)) {                    \
+                PMIX_DISK_STATS_CREATE((m)->array, n);              \
                                                                     \
-            } else if (PMIX_NET_STATS == (t)) {                         \
-                PMIX_NET_STATS_CREATE((m)->array, n);                   \
+            } else if (PMIX_NET_STATS == (t)) {                     \
+                PMIX_NET_STATS_CREATE((m)->array, n);               \
                                                                     \
-            } else if (PMIX_NODE_STATS == (t)) {                         \
-                PMIX_NODE_STATS_CREATE((m)->array, n);                   \
+            } else if (PMIX_NODE_STATS == (t)) {                    \
+                PMIX_NODE_STATS_CREATE((m)->array, n);              \
                                                                     \
-            } else if (PMIX_DEVICE_DIST == (t)) {                         \
-                PMIX_DEVICE_DIST_CREATE((m)->array, n);                   \
+            } else if (PMIX_DEVICE_DIST == (t)) {                   \
+                PMIX_DEVICE_DIST_CREATE((m)->array, n);             \
                                                                     \
-            } else if (PMIX_GEOMETRY == (t)) {                         \
-                PMIX_GEOMETRY_CREATE((m)->array, n);                   \
+            } else if (PMIX_GEOMETRY == (t)) {                      \
+                PMIX_GEOMETRY_CREATE((m)->array, n);                \
                                                                     \
-            } else if (PMIX_REGATTR == (t)) {                         \
-                PMIX_REGATTR_CREATE((m)->array, n);                   \
+            } else if (PMIX_REGATTR == (t)) {                       \
+                PMIX_REGATTR_CREATE((m)->array, n);                 \
                                                                     \
-            } else if (PMIX_PROC_CPUSET == (t)) {                         \
-                PMIX_CPUSET_CREATE((m)->array, n);                   \
+            } else if (PMIX_PROC_CPUSET == (t)) {                   \
+                PMIX_CPUSET_CREATE((m)->array, n);                  \
             } else {                                                \
                 (m)->array = NULL;                                  \
                 (m)->size = 0;                                      \

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -911,25 +911,24 @@ typedef uint32_t pmix_rank_t;
 
 
 /* Storage-Related Attributes */
-#define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"       // (char*) return comma-delimited list of identifiers for all available storage systems
-#define PMIX_STORAGE_CAPACITY_LIMIT         "pmix.strg.cap"        // (uint64_t) return overall capacity (in Megabytes[base2]) of specified storage system
-#define PMIX_STORAGE_CAPACITY_FREE          "pmix.strg.free"       // (uint64_t) return free capacity (in Megabytes[base2]) of specified storage system
-#define PMIX_STORAGE_CAPACITY_AVAIL         "pmix.strg.avail"      // (uint64_t) return capacity (in Megabytes[[base2]]) of specified storage
-                                                                   //            system that is available for use by the calling program
+#define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"        // (char*) return comma-delimited list of identifiers for all available storage systems
+#define PMIX_STORAGE_CAPACITY_LIMIT         "pmix.strg.caplim"      // (uint64_t) return overall capacity (in Megabytes[base2]) of specified storage system
+#define PMIX_STORAGE_CAPACITY_USED          "pmix.strg.capuse"      // (uint64_t) return used capacity (in Megabytes[base2]) of specified storage system
 
-#define PMIX_STORAGE_OBJECT_LIMIT           "pmix.strg.obj"        // (uint64_t) return overall limit on number of objects (e.g., inodes) of specified storage system
-#define PMIX_STORAGE_OBJECTS_FREE           "pmix.strg.objf"       // (uint64_t) return number of free objects (e.g., inodes) of specified storage system
-#define PMIX_STORAGE_OBJECTS_AVAIL          "pmix.strg.obja"       // (uint64_t) return number of objects (e.g., inodes) of specified storage system
-                                                                   //            that are available for use by the calling program
+#define PMIX_STORAGE_OBJECT_LIMIT           "pmix.strg.objlim"      // (uint64_t) return overall limit on number of objects (e.g., inodes) of specified storage system
+#define PMIX_STORAGE_OBJECTS_USED           "pmix.strg.objuse"      // (uint64_t) return number of used objects (e.g., inodes) of specified storage system
 
-#define PMIX_STORAGE_BW                     "pmix.strg.bw"         // (float) return overall bandwidth (in Megabytes[base2]/sec) of specified storage system
-#define PMIX_STORAGE_AVAIL_BW               "pmix.strg.availbw"    // (float) return overall bandwidth (in Megabytes[base2]/sec) of specified storage system
-                                                                   //         that is available for use by the calling program
+#define PMIX_STORAGE_XFER_SIZE              "pmix.strg.xfersz"      // (uint64_t) return optimal transfer size (in Kilobytes[base2]) of specified storage system
+
+#define PMIX_STORAGE_BW_LIMIT               "pmix.strg.bwlim"       // (float) return overall bandwidth limit (in Megabytes[base2]/sec) of specified storage system
+#define PMIX_STORAGE_BW                     "pmix.strg.bw"          // (float) return overall observed bandwidth (in Megabytes[base2]/sec) of specified storage system
 
 #define PMIX_STORAGE_ID                     "pmix.strg.id"         // (char*) identifier of the storage system being referenced
 #define PMIX_STORAGE_PATH                   "pmix.strg.path"       // (char*) Mount point corresponding to a specified storage ID
 #define PMIX_STORAGE_TYPE                   "pmix.strg.type"       // (char*) Qualifier indicating the type of storage being referenced by a query
                                                                    //         (e.g., lustre, gpfs, online, fabric-attached, ...)
+#define PMIX_STORAGE_HOST                   "pmix.strg.host"       // (char*) identifier of a particular storage system host
+#define PMIX_STORAGE_DEVICE                 "pmix.strg.dev"        // (char*) identifier of a particular storage system device
 
 /* Fabric-related Attributes */
 #define PMIX_FABRIC_COST_MATRIX             "pmix.fab.cm"          // (pointer) Pointer to a two-dimensional array of point-to-point relative

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -911,24 +911,33 @@ typedef uint32_t pmix_rank_t;
 
 
 /* Storage-Related Attributes */
-#define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"        // (char*) return comma-delimited list of identifiers for all available storage systems
-#define PMIX_STORAGE_CAPACITY_LIMIT         "pmix.strg.caplim"      // (uint64_t) return overall capacity (in Megabytes[base2]) of specified storage system
-#define PMIX_STORAGE_CAPACITY_USED          "pmix.strg.capuse"      // (uint64_t) return used capacity (in Megabytes[base2]) of specified storage system
+#define PMIX_STORAGE_ID                     "pmix.strg.id"          // (char*) identifier for a storage system
+#define PMIX_STORAGE_PATH                   "pmix.strg.path"        // (char*) mount point path for a file-based storage system
+#define PMIX_STORAGE_TYPE                   "pmix.strg.type"        // (char*) type of a storage system (e.g., "lustre", "gpfs", "ext4", "daos", ...)
+#define PMIX_STORAGE_VERSION                "pmix.strg.ver"         // (char*) version string for a storage system
 
-#define PMIX_STORAGE_OBJECT_LIMIT           "pmix.strg.objlim"      // (uint64_t) return overall limit on number of objects (e.g., inodes) of specified storage system
-#define PMIX_STORAGE_OBJECTS_USED           "pmix.strg.objuse"      // (uint64_t) return number of used objects (e.g., inodes) of specified storage system
+#define PMIX_STORAGE_MEDIUM                 "pmix.strg.medium"      // (pmix_storage_medium_t) types of storage mediums utilized by a storage system
+#define PMIX_STORAGE_ACCESSIBILITY          "pmix.strg.access"      // (pmix_storage_accessibility_t) accessibility level of a storage system
+#define PMIX_STORAGE_PERSISTENCE            "pmix.strg.persist"     // (pmix_storage_persistence_t) persistence level of a storage system
 
-#define PMIX_STORAGE_XFER_SIZE              "pmix.strg.xfersz"      // (uint64_t) return optimal transfer size (in Kilobytes[base2]) of specified storage system
+#define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"        // (char*) comma-delimited list of storage identifiers for available storage systems
 
-#define PMIX_STORAGE_BW_LIMIT               "pmix.strg.bwlim"       // (float) return overall bandwidth limit (in Megabytes[base2]/sec) of specified storage system
-#define PMIX_STORAGE_BW                     "pmix.strg.bw"          // (float) return overall observed bandwidth (in Megabytes[base2]/sec) of specified storage system
+#define PMIX_STORAGE_CAPACITY_LIMIT         "pmix.strg.caplim"      // (double) overall limit on capacity (in bytes) for the storage system
+#define PMIX_STORAGE_CAPACITY_USED          "pmix.strg.capuse"      // (double) overall used capacity (in bytes) for the storage system
 
-#define PMIX_STORAGE_ID                     "pmix.strg.id"         // (char*) identifier of the storage system being referenced
-#define PMIX_STORAGE_PATH                   "pmix.strg.path"       // (char*) Mount point corresponding to a specified storage ID
-#define PMIX_STORAGE_TYPE                   "pmix.strg.type"       // (char*) Qualifier indicating the type of storage being referenced by a query
-                                                                   //         (e.g., lustre, gpfs, online, fabric-attached, ...)
-#define PMIX_STORAGE_HOST                   "pmix.strg.host"       // (char*) identifier of a particular storage system host
-#define PMIX_STORAGE_DEVICE                 "pmix.strg.dev"        // (char*) identifier of a particular storage system device
+#define PMIX_STORAGE_OBJECT_LIMIT           "pmix.strg.objlim"      // (uint64_t) overall limit on number of objects (e.g., inodes) for the storage system
+#define PMIX_STORAGE_OBJECTS_USED           "pmix.strg.objuse"      // (uint64_t) overall used number of objects (e.g., inodes) for the storage system
+
+#define PMIX_STORAGE_MINIMAL_XFER_SIZE      "pmix.strg.minxfer"     // (double) minimal transfer size (in bytes) for the storage system - this is the storage system’s atomic unit of transfer (e.g., block size)
+#define PMIX_STORAGE_SUGGESTED_XFER_SIZE    "pmix.strg.sxfer"       // (double) suggested transfer size (in bytes) for the storage system
+
+#define PMIX_STORAGE_BW_MAX                 "pmix.strg.bwmax"       // (double) maximum bandwidth (in bytes/sec) for storage system - provided as the theoretical maximum or the maximum observed bandwidth value
+#define PMIX_STORAGE_BW_CUR                 "pmix.strg.bwcur"       // (double) observed bandwidth (in bytes/sec) for storage system - provided as a recently observed bandwidth value
+
+#define PMIX_STORAGE_IOPS_MAX               "pmix.strg.iopsmax"     // (double) maximum IOPS (in I/O operations per second) for storage system - provided as the theoretical maximum or the maximum observed IOPS value
+#define PMIX_STORAGE_IOPS_CUR               "pmix.strg.iopscur"     // (double) observed IOPS (in I/O operations per second) for storage system - provided as a recently observed IOPS value
+
+#define PMIX_STORAGE_ACCESS_TYPE            "pmix.strg.atype"       // (pmix_storage_access_type_t) qualifier describing the type of storage access to return information for (e.g., for qualifying PMIX_STORAGE_BW_CUR , PMIX_STORAGE_IOPS_CUR , or PMIX_STORAGE_SUGGESTED_XFER_SIZE attributes)
 
 /* Fabric-related Attributes */
 #define PMIX_FABRIC_COST_MATRIX             "pmix.fab.cm"          // (pointer) Pointer to a two-dimensional array of point-to-point relative

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -488,6 +488,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        event only when a process abnormally terminates.
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */
+#define PMIX_QUERY_RESULTS                  "pmix.qry.res"          // (pmix_data_array_t*) Collection of results for a query object, organized
+                                                                    //         by search key
 #define PMIX_QUERY_SUPPORTED_KEYS           "pmix.qry.keys"         // (char*) returns comma-delimited list of keys supported by the query
                                                                     //         function. NO QUALIFIERS
 #define PMIX_QUERY_NAMESPACES               "pmix.qry.ns"           // (char*) returns a comma-delimited list of active namespaces. NO QUALIFIERS

--- a/src/mca/pstrg/base/Makefile.am
+++ b/src/mca/pstrg/base/Makefile.am
@@ -16,4 +16,5 @@ headers += \
 libmca_pstrg_la_SOURCES += \
         base/pstrg_base_frame.c \
         base/pstrg_base_select.c \
-        base/pstrg_base_stubs.c
+        base/pstrg_base_stubs.c \
+        base/pstrg_base_fns.c

--- a/src/mca/pstrg/base/base.h
+++ b/src/mca/pstrg/base/base.h
@@ -63,5 +63,27 @@ PMIX_EXPORT pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t n
                                                 pmix_list_t *results,
                                                 pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
 
+PMIX_EXPORT extern pmix_hash_table_t fs_mount_to_id_hash;
+PMIX_EXPORT extern pmix_hash_table_t fs_id_to_mount_hash;
+
+typedef struct {
+    char *mnt_fsname;
+    char *mnt_dir;
+    char *mnt_type;
+} pmix_pstrg_mntent_t;
+
+//XXX individual modules allocate these, register them, and if successful-> add to per-mod list
+typedef struct {
+    char *id;
+    char *mount_dir;
+} pmix_pstrg_fs_info_t;
+
+PMIX_EXPORT pmix_status_t pmix_pstrg_get_fs_mounts(pmix_value_array_t **mounts);
+PMIX_EXPORT pmix_status_t pmix_pstrg_free_fs_mounts(pmix_value_array_t **mounts);
+PMIX_EXPORT pmix_status_t pmix_pstrg_register_fs(pmix_pstrg_fs_info_t fs_info);
+PMIX_EXPORT pmix_status_t pmix_pstrg_deregister_fs(pmix_pstrg_fs_info_t fs_info);
+PMIX_EXPORT char *pmix_pstrg_get_registered_fs_id_by_mount(char *mount_dir);
+PMIX_EXPORT char *pmix_pstrg_get_registered_fs_mount_by_id(char *id);
+
 END_C_DECLS
 #endif

--- a/src/mca/pstrg/base/base.h
+++ b/src/mca/pstrg/base/base.h
@@ -63,26 +63,38 @@ PMIX_EXPORT pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t n
                                                 pmix_list_t *results,
                                                 pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
 
-PMIX_EXPORT extern pmix_hash_table_t fs_mount_to_id_hash;
+/* tables to map from FS storage IDs to mount points, and vice versa */
 PMIX_EXPORT extern pmix_hash_table_t fs_id_to_mount_hash;
+PMIX_EXPORT extern pmix_hash_table_t fs_mount_to_id_hash;
 
+/* structure holding relevant FS mount entry state from getmntent calls */
 typedef struct {
     char *mnt_fsname;
     char *mnt_dir;
     char *mnt_type;
 } pmix_pstrg_mntent_t;
 
-//XXX individual modules allocate these, register them, and if successful-> add to per-mod list
+/* FS modules allocate FS info structs and register them with the base component */
+/* NOTE: registration of FSes is primarily so a storage system-specific module and
+ * the VFS module can agree on the ID of a particular storage system */
+/* NOTE: the first module to register a mount directory gets to set the associated
+ * FS ID -- other attempted registrations will fail */
 typedef struct {
     char *id;
     char *mount_dir;
 } pmix_pstrg_fs_info_t;
 
+/* get the list of currently mounted file systems and their state */
 PMIX_EXPORT pmix_status_t pmix_pstrg_get_fs_mounts(pmix_value_array_t **mounts);
+/* free the list of mounted file systems */
 PMIX_EXPORT pmix_status_t pmix_pstrg_free_fs_mounts(pmix_value_array_t **mounts);
+/* register information about a particular FS with the base component */
 PMIX_EXPORT pmix_status_t pmix_pstrg_register_fs(pmix_pstrg_fs_info_t fs_info);
+/* de-register information about a particular FS with the base component */
 PMIX_EXPORT pmix_status_t pmix_pstrg_deregister_fs(pmix_pstrg_fs_info_t fs_info);
+/* map a registered FS identifier to a FS mount directory */
 PMIX_EXPORT char *pmix_pstrg_get_registered_fs_id_by_mount(char *mount_dir);
+/* map a registered FS mount directory to a FS identifier */
 PMIX_EXPORT char *pmix_pstrg_get_registered_fs_mount_by_id(char *id);
 
 END_C_DECLS

--- a/src/mca/pstrg/base/pstrg_base_fns.c
+++ b/src/mca/pstrg/base/pstrg_base_fns.c
@@ -1,0 +1,157 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#ifdef HAVE_MNTENT_H
+#include <mntent.h>
+#endif
+
+#include "include/pmix_common.h"
+
+#include "src/mca/pstrg/pstrg.h"
+#include "src/mca/pstrg/base/base.h"
+
+pmix_hash_table_t fs_mount_to_id_hash;
+pmix_hash_table_t fs_id_to_mount_hash;
+
+pmix_status_t pmix_pstrg_get_fs_mounts(pmix_value_array_t **mounts)
+{
+#ifdef HAVE_MNTENT_H
+    FILE *mtab_fp;
+    struct mntent *ent;
+    pmix_pstrg_mntent_t tmp_pstrg_ent;
+    pmix_status_t rc;
+
+    mtab_fp = setmntent("/etc/mtab", "r");
+    if (!mtab_fp) {
+        rc = PMIX_ERROR;
+        goto exit;
+    }
+
+    *mounts = PMIX_NEW(pmix_value_array_t);
+    if (NULL == *mounts) {
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
+    }
+
+    rc = pmix_value_array_init(*mounts, sizeof(pmix_pstrg_mntent_t));
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(*mounts);
+        goto exit;
+    }
+
+    while (NULL != (ent = getmntent(mtab_fp))) {
+        /* iterate mount entries and add them to array to be returned */
+        tmp_pstrg_ent.mnt_fsname = strdup(ent->mnt_fsname);
+        tmp_pstrg_ent.mnt_dir = strdup(ent->mnt_dir);
+        tmp_pstrg_ent.mnt_type = strdup(ent->mnt_type);
+        rc = pmix_value_array_append_item(*mounts, &tmp_pstrg_ent);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(*mounts);
+            goto exit;
+        }
+    }
+
+exit:
+    if (mtab_fp)
+        endmntent(mtab_fp);
+    return rc;
+#else
+    return PMIX_ERR_NOT_SUPPORTED;
+#endif
+}
+
+pmix_status_t pmix_pstrg_free_fs_mounts(pmix_value_array_t **mounts)
+{
+    pmix_pstrg_mntent_t pstrg_ent;
+    size_t nmounts, n;
+
+    nmounts = pmix_value_array_get_size(*mounts);
+    for (n = 0; n < nmounts; n++) {
+        pstrg_ent = PMIX_VALUE_ARRAY_GET_ITEM(*mounts, pmix_pstrg_mntent_t, n);
+        free(pstrg_ent.mnt_fsname);
+        free(pstrg_ent.mnt_dir);
+        free(pstrg_ent.mnt_type);
+    }
+
+    PMIX_RELEASE(*mounts);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_pstrg_register_fs(pmix_pstrg_fs_info_t fs_info)
+{
+    pmix_status_t rc;
+
+    /* maintain mappings from FS id->mount and mount->id */
+    rc = pmix_hash_table_set_value_ptr(&fs_id_to_mount_hash,
+        fs_info.id, strlen(fs_info.id)+1, fs_info.mount_dir);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_hash_table_set_value_ptr(&fs_mount_to_id_hash,
+            fs_info.mount_dir, strlen(fs_info.mount_dir)+1, fs_info.id);
+        if (PMIX_SUCCESS != rc) {
+            pmix_hash_table_remove_value_ptr(&fs_id_to_mount_hash,
+                fs_info.id, strlen(fs_info.id)+1);
+        }
+    }
+
+    return rc;
+}
+
+pmix_status_t pmix_pstrg_deregister_fs(pmix_pstrg_fs_info_t fs_info)
+{
+    pmix_status_t rc;
+
+    /* try to remove from id->mnt and mnt->id tables */
+    rc = pmix_hash_table_remove_value_ptr(&fs_id_to_mount_hash,
+        fs_info.id, strlen(fs_info.id)+1);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_hash_table_remove_value_ptr(&fs_mount_to_id_hash,
+            fs_info.mount_dir, strlen(fs_info.mount_dir)+1);
+    }
+
+    return rc;
+}
+
+char *pmix_pstrg_get_registered_fs_id_by_mount(char *mount_dir)
+{
+    char *id;
+    pmix_status_t rc;
+
+    rc = pmix_hash_table_get_value_ptr(&fs_mount_to_id_hash,
+        mount_dir, strlen(mount_dir)+1, (void **)&id);
+    if (PMIX_SUCCESS == rc) {
+        return id;
+    }
+    else {
+        return NULL;
+    }
+}
+
+char *pmix_pstrg_get_registered_fs_mount_by_id(char *id)
+{
+    char *mount_dir;
+    pmix_status_t rc;
+
+    rc = pmix_hash_table_get_value_ptr(&fs_id_to_mount_hash,
+        id, strlen(id)+1, (void **)&mount_dir);
+    if (PMIX_SUCCESS == rc) {
+        return mount_dir;
+    }
+    else {
+        return NULL;
+    }
+}

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -59,6 +59,17 @@ static int pmix_pstrg_base_close(void)
     }
     PMIX_LIST_DESTRUCT(&pmix_pstrg_base.actives);
 
+    void *tmp_ptr = NULL;
+    size_t key_size;
+    void *key, *value;
+    for (; PMIX_SUCCESS == pmix_hash_table_get_next_key_ptr(
+            &fs_id_to_mount_hash, &key, &key_size, &value, tmp_ptr, &tmp_ptr);) {
+        printf("%s,%s\n", (char *)key, (char *)value);
+    }
+
+    PMIX_DESTRUCT(&fs_mount_to_id_hash);
+    PMIX_DESTRUCT(&fs_id_to_mount_hash);
+
     /* Close all remaining available components */
     return pmix_mca_base_framework_components_close(&pmix_pstrg_base_framework, NULL);
 }
@@ -76,6 +87,12 @@ static int pmix_pstrg_base_open(pmix_mca_base_open_flag_t flags)
 
     /* construct the list of modules */
     PMIX_CONSTRUCT(&pmix_pstrg_base.actives, pmix_list_t);
+
+    /* construct/initialize hash of file system mounts->ids */
+    PMIX_CONSTRUCT(&fs_mount_to_id_hash, pmix_hash_table_t);
+    pmix_hash_table_init(&fs_mount_to_id_hash, 256);
+    PMIX_CONSTRUCT(&fs_id_to_mount_hash, pmix_hash_table_t);
+    pmix_hash_table_init(&fs_id_to_mount_hash, 256);
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_pstrg_base_framework, flags);

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -59,14 +59,7 @@ static int pmix_pstrg_base_close(void)
     }
     PMIX_LIST_DESTRUCT(&pmix_pstrg_base.actives);
 
-    void *tmp_ptr = NULL;
-    size_t key_size;
-    void *key, *value;
-    for (; PMIX_SUCCESS == pmix_hash_table_get_next_key_ptr(
-            &fs_id_to_mount_hash, &key, &key_size, &value, tmp_ptr, &tmp_ptr);) {
-        printf("%s,%s\n", (char *)key, (char *)value);
-    }
-
+    /* destroy file system hash tables */
     PMIX_DESTRUCT(&fs_mount_to_id_hash);
     PMIX_DESTRUCT(&fs_id_to_mount_hash);
 
@@ -88,7 +81,7 @@ static int pmix_pstrg_base_open(pmix_mca_base_open_flag_t flags)
     /* construct the list of modules */
     PMIX_CONSTRUCT(&pmix_pstrg_base.actives, pmix_list_t);
 
-    /* construct/initialize hash of file system mounts->ids */
+    /* construct/initialize hash tables of file system mounts<->ids */
     PMIX_CONSTRUCT(&fs_mount_to_id_hash, pmix_hash_table_t);
     pmix_hash_table_init(&fs_mount_to_id_hash, 256);
     PMIX_CONSTRUCT(&fs_id_to_mount_hash, pmix_hash_table_t);

--- a/src/mca/pstrg/base/pstrg_base_stubs.c
+++ b/src/mca/pstrg/base/pstrg_base_stubs.c
@@ -93,6 +93,7 @@ pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t nqueries, pmi
             /* if they return success, then the values were
              * placed directly on the payload - nothing
              * to wait for here */
+            printf("PSTRG plugin %s returned %d\n", active->module->name, rc);
             if (PMIX_OPERATION_IN_PROGRESS == rc) {
                 myrollup->nrequests++;
             } else if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/src/mca/pstrg/base/pstrg_base_stubs.c
+++ b/src/mca/pstrg/base/pstrg_base_stubs.c
@@ -93,7 +93,6 @@ pmix_status_t pmix_pstrg_base_query(pmix_query_t queries[], size_t nqueries, pmi
             /* if they return success, then the values were
              * placed directly on the payload - nothing
              * to wait for here */
-            printf("PSTRG plugin %s returned %d\n", active->module->name, rc);
             if (PMIX_OPERATION_IN_PROGRESS == rc) {
                 myrollup->nrequests++;
             } else if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/src/mca/pstrg/lustre/configure.m4
+++ b/src/mca/pstrg/lustre/configure.m4
@@ -31,7 +31,7 @@ AC_DEFUN([MCA_pmix_pstrg_lustre_CONFIG],[
                       [pstrg_lustre_happy="no"])
 
 
-    AS_IF([test "$pstrg_lustre_happy" = "yes" || test "1" = "1"],
+    AS_IF([test "$pstrg_lustre_happy" = "yes"],
           [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [yes ($pmix_check_lustre_dir)])
            $1],
           [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [no])

--- a/src/mca/pstrg/lustre/pstrg_lustre.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre.c
@@ -45,6 +45,8 @@
 #include "src/mca/pstrg/base/base.h"
 #include "src/mca/pstrg/pstrg.h"
 
+#include <lustre/lustreapi.h>
+
 static pmix_status_t lustre_init(void);
 static void lustre_finalize(void);
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
@@ -80,27 +82,20 @@ static void lustre_finalize(void)
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
-    size_t n, m, k;
+
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre query");
+
+#if 0
+    size_t n, m, k, i, j;
     char **sid, **mountpt;
     bool takeus;
     uid_t uid = UINT32_MAX;
     gid_t gid = UINT32_MAX;
+    lustre_storage_t *q_sys;
+    char *q_str;
+    pmix_status_t q_ret;
 
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre query");
-
-    /* just put something here so that Travis will pass its tests
-     * because it treats warnings as errors, and wants to warn about
-     * unused variables */
-    sid = pmix_argv_split("foo,bar", ',');
-    pmix_argv_free(sid);
-    sid = NULL;
-    mountpt = pmix_argv_split("foo,bar", ',');
-    pmix_argv_free(mountpt);
-    mountpt = NULL;
-
-    /* now on to the real code */
-
-    for (n = 0; n < nqueries; n++) {
+    for (n=0; n < nqueries; n++) {
         /* did they specify a storage type for this query? */
         takeus = true;
         for (k = 0; k < queries[n].nqual; k++) {
@@ -109,7 +104,7 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 /* NOTE: I only included "lustre" as an accepted type, but we might
                  * want to consider other types as well - e.g., "parallel", "persistent",...) */
 
-                if (NULL == strcasestr("lustre", queries[n].qualifiers[k].value.data.string)) {
+                if (NULL == strcasestr(queries[n].qualifiers[k].value.data.string, "lustre")) {
                     /* they are not interested in us */
                     takeus = false;
                     ;
@@ -123,7 +118,7 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
 
         /* see if they want the list of storage systems - this doesn't take any
          * qualifiers */
-        for (m = 0; NULL != queries[n].keys[m]; m++) {
+        for (m=0; NULL != queries[n].keys[m]; m++) {
             if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
                 /* ADD HERE:
                  *
@@ -137,47 +132,78 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 continue;
             }
 
-            /* the remaining query keys all accept the storage ID and/or path qualifiers */
-            sid = NULL;
-            mountpt = NULL;
-            for (k = 0; k < queries[n].nqual; k++) {
-                if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
-                    /* there may be more than one (comma-delimited) storage ID, so
-                     * split them into a NULL-terminated argv-type array */
-                    sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
-                    /* there may be more than one (comma-delimited) mount pt, so
-                     * split them into a NULL-terminated argv-type array */
-                    mountpt = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
-                    uid = queries[n].qualifiers[k].value.data.uint32;
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
-                    gid = queries[n].qualifiers[k].value.data.uint32;
+            for (m=0; NULL != queries[n].keys[m]; m++) {
+                printf("%s:\n", queries[n].keys[m]);
+
+                /* the remaining query keys all accept the storage ID and/or path qualifiers */
+                sid = NULL;
+                mountpt = NULL;
+                for (k = 0; k < queries[n].nqual; k++) {
+                    if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
+                        /* there may be more than one (comma-delimited) storage ID, so
+                         * split them into a NULL-terminated argv-type array */
+                        sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
+                        /* there may be more than one (comma-delimited) mount pt, so
+                         * split them into a NULL-terminated argv-type array */
+                        mountpt = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
+                        uid = queries[n].qualifiers[k].value.data.uint32;
+                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
+                        gid = queries[n].qualifiers[k].value.data.uint32;
+                    }
                 }
-            }
 
-            if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
-                /* ADD HERE:
+                /* XXX: if no sid/mntpnt for queries below, do we return info on every storage system we know about? */
+
+                for (i = 0, j = 0;;) {
+                    if (sid && sid[i] != NULL) {
+                        /* storage id based query */
+                        k  = 0;
+                        while (availsys[k].name != NULL) {
+                            if (strcmp(availsys[k].name, sid[i]) == 0) {
+                                q_sys = &availsys[k];
+                                q_str = availsys[k].name;
+                                break;
+                            }
+                            k++;
+                        }
+                        i++;
+                    }
+                    else if (mountpt && mountpt[j] != NULL) {
+                        /* mount point based query */
+                        k = 0;
+                        while (availsys[k].name != NULL) {
+                            if (strcmp(availsys[k].mountpt, mountpt[j]) == 0) {
+                                q_sys = &availsys[k];
+                                q_str = availsys[k].mountpt;
+                                break;
+                            }
+                            k++;
+                        }
+                        j++;
+                    }
+                    else {
+                        /* no more storage systems to query */
+                        break;
+                    }
+                }
+
+            if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
+                /* don't worry about this one for now - once I see how to get the
+                 * storage list and mount pts, I will construct the response here
                  *
-                 * Get the capacity of the Lustre storage systems. If they ask for
-                 * a specific one(s), then get just those.
+                 * NOTE to self: could me a comma-delimited set of storage IDs, so
+                 * return the mount pt for each of them
                  */
+                char *strg_id = q_sys->name;
+                printf("\t%s: %s\n", q_str, strg_id);
 
                 /* I will package the data for return once I see what Lustre provides */
                 continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_FREE)) {
-                /* ADD HERE:
-                 *
-                 * Get the amount of free capacity of the Lustre storage systems. If they ask for
-                 * a specific one, then get just that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_AVAIL)) {
-                /* ADD HERE:
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
+                /* don't worry about this one for now - once I see how to get the
+                 * storage list and mount pts, I will construct the response here
                  *
                  * Get the capacity of the Lustre storage systems that are available to the
                  * caller's userid/grpid, as provided in the qualifiers.
@@ -191,36 +217,63 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                  * Let me know if you need further info to process the request - e.g.,
                  * we could provide the app's jobid or argv[0]. If they ask for
                  * a specific storage system, then get process that one.
+                 * NOTE to self: could me a comma-delimited set of paths, so
+                 * return the ID for each of them
                  */
+                char *mountpt = q_sys->mountpt;
+                printf("\t%s: %s\n", q_str, mountpt);
 
                 /* I will package the data for return once I see what Lustre provides */
                 continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECT_LIMIT)) {
-                /* ADD HERE:
-                 *
-                 * Get the limit on number of objects in the Lustre storage systems. If they ask for
-                 * a specific one(s), then get just those.
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
+                /* if given a uid/gid, answer this query using Lustre-specific code;
+                 * otherwise, fallthrough to base VFS query code
                  */
+                if (UINT32_MAX != uid || UINT32_MAX != gid) {
+                    /* ADD HERE:
+                     *
+                     * Get the total capacity of the Lustre storage system for the given
+                     * uid and gid. If they ask for a specific one(s), then get just those.
+                     */
+                    printf("\t%s: NOT SUPPORTED!\n", q_str);
 
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
+                    /*
+                     * Let me know if you need further info to process the request - e.g.,
+                     * we could provide the app's jobid or argv[0]. If they ask for
+                     * a specific storage system, then get process that one.
+                     */
 
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECTS_FREE)) {
-                /* ADD HERE:
-                 *
-                 * Get the number of free objects in the Lustre storage systems. If they ask for
-                 * a specific one(s), then get just those.
+                    /* I will package the data for return once I see what Lustre provides */
+                    continue;
+                }
+
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
+                /* if given a uid/gid, answer this query using Lustre-specific code;
+                 * otherwise, fallthrough to base VFS query code
                  */
+                if (UINT32_MAX != uid || UINT32_MAX != gid) {
+                    /* ADD HERE:
+                     *
+                     * Get the used capacity of the Lustre storage system for the given
+                     * uid and gid. If they ask for a specific one(s), then get just those.
+                     */
+                    printf("\t%s: NOT SUPPORTED!\n", q_str);
 
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
+                    /*
+                     * Let me know if you need further info to process the request - e.g.,
+                     * we could provide the app's jobid or argv[0]. If they ask for
+                     * a specific storage system, then get process that one.
+                     */
 
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_AVAIL)) {
+                    /* I will package the data for return once I see what Lustre provides */
+                    continue;
+                }
+
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
                 /* ADD HERE:
                  *
-                 * Get the number of objects in the Lustre storage systems that are available to the
-                 * caller's userid/grpid, as provided in the qualifiers.
+                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
+                 * a specific one, then get just that one.
                  */
                 if (UINT32_MAX == uid || UINT32_MAX == gid) {
                     /* they failed to provide the user's info - I will
@@ -231,16 +284,6 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                  * Let me know if you need further info to process the request - e.g.,
                  * we could provide the app's jobid or argv[0]. If they ask for
                  * a specific storage system, then get process that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
-                /* ADD HERE:
-                 *
-                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
-                 * a specific one, then get just that one.
                  */
 
                 /* I will package the data for return once I see what Lustre provides */
@@ -258,35 +301,22 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 }
 
                 /*
-                If you need further info, please let me know - e.g.,
+                 * Let me know if you need further info to process the request - e.g.,
                  * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get just that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * NOTE to self: could me a comma-delimited set of storage IDs, so
-                 * return the mount pt for each of them
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * NOTE to self: could me a comma-delimited set of paths, so
-                 * return the ID for each of them
+                 * a specific storage system, then get process that one.
                  */
 
                 /* I will package the data for return once I see what Lustre provides */
                 continue;
             }
+
+            /* as fallback, call into base code to run general VFS query */
+            printf("\t%s: ", q_str);
+            q_ret = pmix_pstrg_base_vfs_query(q_sys->mountpt, queries[n].keys[m],
+                results);
         }
     }
-    return PMIX_ERR_NOT_FOUND;
+#endif
+
+    return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/pstrg/lustre/pstrg_lustre.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre.c
@@ -14,48 +14,52 @@
 
 #include <string.h>
 #ifdef HAVE_UNISTD_H
-#    include <unistd.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_TYPES_H
-#    include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifdef HAVE_SYS_STAT_H
-#    include <sys/stat.h>
+#include <sys/stat.h>
 #endif
 #ifdef HAVE_FCNTL_H
-#    include <fcntl.h>
+#include <fcntl.h>
 #endif
 #include <time.h>
 
 #include "include/pmix_common.h"
 
-#include "src/class/pmix_list.h"
-#include "src/include/pmix_globals.h"
-#include "src/include/pmix_socket_errno.h"
 #include "src/mca/base/pmix_mca_base_var.h"
-#include "src/mca/preg/preg.h"
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
 #include "src/util/alfg.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/printf.h"
+#include "src/mca/preg/preg.h"
 
-#include "pstrg_lustre.h"
-#include "src/mca/pstrg/base/base.h"
 #include "src/mca/pstrg/pstrg.h"
+#include "src/mca/pstrg/base/base.h"
+#include "pstrg_lustre.h"
 
 #include <lustre/lustreapi.h>
 
 static pmix_status_t lustre_init(void);
 static void lustre_finalize(void);
-static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
+static pmix_status_t query(pmix_query_t queries[], size_t nqueries,
+                           pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
 
-pmix_pstrg_base_module_t pmix_pstrg_lustre_module = {.name = "lustre",
-                                                     .init = lustre_init,
-                                                     .finalize = lustre_finalize,
-                                                     .query = query};
+pmix_pstrg_base_module_t pmix_pstrg_lustre_module = {
+    .name = "lustre",
+    .init = lustre_init,
+    .finalize = lustre_finalize,
+    .query = query
+};
 
 typedef struct pmix_pstrg_lustre_tracker {
     pmix_list_item_t super;
@@ -85,12 +89,6 @@ static PMIX_CLASS_INSTANCE(pmix_pstrg_lustre_tracker_t,
 
 static pmix_status_t lustre_init(void)
 {
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre init");
-||||||| merged common ancestors
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
-                        "pstrg: lustre init");
-=======
     pmix_value_array_t *mounts;
     size_t nmounts, n;
     pmix_pstrg_mntent_t ent;
@@ -99,7 +97,6 @@ static pmix_status_t lustre_init(void)
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
                         "pstrg: lustre init");
->>>>>>> add first cut at functioning lustre module
 
     PMIX_CONSTRUCT(&registered_lustre_fs_list, pmix_list_t);
 
@@ -161,17 +158,10 @@ static pmix_status_t lustre_init(void)
 
 static void lustre_finalize(void)
 {
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre finalize");
-||||||| merged common ancestors
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
-                        "pstrg: lustre finalize");
-=======
     pmix_pstrg_lustre_tracker_t *tracker;
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
                         "pstrg: lustre finalize");
->>>>>>> add first cut at functioning lustre module
 
     /* ADD HERE:
      *
@@ -184,77 +174,24 @@ static void lustre_finalize(void)
     PMIX_LIST_DESTRUCT(&registered_lustre_fs_list);
 }
 
-static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
+static pmix_status_t query(pmix_query_t queries[], size_t nqueries,
+                           pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre query");
-
-#if 0
-    size_t n, m, k, i, j;
-    char **sid, **mountpt;
-    bool takeus;
-||||||| merged common ancestors
-    size_t n, m, k, i, j;
-    char **sid, **mountpt;
-    bool takeus;
-=======
     size_t n, m, k, i;
     char **sid, **mount; //XXX free?
     char *tmp_id, *tmp_mount;
->>>>>>> add first cut at functioning lustre module
     uid_t uid = UINT32_MAX;
     gid_t gid = UINT32_MAX;
     pmix_pstrg_lustre_tracker_t *tracker;
 
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-||||||| merged common ancestors
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
                         "pstrg: lustre query");
 
-#if 0
-=======
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
-                        "pstrg: lustre query");
-
->>>>>>> add first cut at functioning lustre module
     for (n=0; n < nqueries; n++) {
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-        /* did they specify a storage type for this query? */
-        takeus = true;
-        for (k = 0; k < queries[n].nqual; k++) {
-            if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_TYPE)) {
-||||||| merged common ancestors
-        /* did they specify a storage type for this query? */
-        takeus = true;
-        for (k=0; k < queries[n].nqual; k++) {
-            if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_TYPE)) {
-=======
 	sid = NULL;
 	mount = NULL;
->>>>>>> add first cut at functioning lustre module
 
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-                /* NOTE: I only included "lustre" as an accepted type, but we might
-                 * want to consider other types as well - e.g., "parallel", "persistent",...) */
-
-                if (NULL == strcasestr(queries[n].qualifiers[k].value.data.string, "lustre")) {
-                    /* they are not interested in us */
-                    takeus = false;
-                    ;
-                }
-                break;
-||||||| merged common ancestors
-                /* NOTE: I only included "lustre" as an accepted type, but we might
-                 * want to consider other types as well - e.g., "parallel", "persistent",...) */
-
-                if (NULL == strcasestr(queries[n].qualifiers[k].value.data.string, "lustre")) {
-                    /* they are not interested in us */
-                    takeus = false;;
-                }
-                break;
-=======
         for (k=0; k < queries[n].nqual; k++) {
             if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
                 /* we can answer generic queries for storage ids */
@@ -273,138 +210,14 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
             }
 	    else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
                 gid = queries[n].qualifiers[k].value.data.uint32;
->>>>>>> add first cut at functioning lustre module
             }
         }
 
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-        /* see if they want the list of storage systems - this doesn't take any
-         * qualifiers */
-||||||| merged common ancestors
-=======
         /* the remaining query keys all accept the storage ID or path qualifiers */
         ///XXX if there are multiple mounts and/or storage IDs, how do we account
         ///    for that properly in the returned results. Note that we do not allow
 
->>>>>>> add first cut at functioning lustre module
         for (m=0; NULL != queries[n].keys[m]; m++) {
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-            if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
-                /* ADD HERE:
-                 *
-                 * Obtain a list of all available Lustre storage systems. The IDs
-                 * we return should be those that we want the user to provide when
-                 * asking about a specific Lustre system. Please get the corresponding
-                 * mount pts for each identifier so I can track them for further queries.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            }
-
-            for (m=0; NULL != queries[n].keys[m]; m++) {
-                printf("%s:\n", queries[n].keys[m]);
-
-                /* the remaining query keys all accept the storage ID and/or path qualifiers */
-                sid = NULL;
-                mountpt = NULL;
-                for (k = 0; k < queries[n].nqual; k++) {
-                    if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
-                        /* there may be more than one (comma-delimited) storage ID, so
-                         * split them into a NULL-terminated argv-type array */
-                        sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
-                        /* there may be more than one (comma-delimited) mount pt, so
-                         * split them into a NULL-terminated argv-type array */
-                        mountpt = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
-                        uid = queries[n].qualifiers[k].value.data.uint32;
-                    } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
-                        gid = queries[n].qualifiers[k].value.data.uint32;
-                    }
-                }
-
-                /* XXX: if no sid/mntpnt for queries below, do we return info on every storage system we know about? */
-
-                for (i = 0, j = 0;;) {
-                    if (sid && sid[i] != NULL) {
-                        /* storage id based query */
-                        k  = 0;
-                        while (availsys[k].name != NULL) {
-                            if (strcmp(availsys[k].name, sid[i]) == 0) {
-                                q_sys = &availsys[k];
-                                q_str = availsys[k].name;
-                                break;
-                            }
-                            k++;
-                        }
-                        i++;
-                    }
-                    else if (mountpt && mountpt[j] != NULL) {
-                        /* mount point based query */
-                        k = 0;
-                        while (availsys[k].name != NULL) {
-                            if (strcmp(availsys[k].mountpt, mountpt[j]) == 0) {
-                                q_sys = &availsys[k];
-                                q_str = availsys[k].mountpt;
-                                break;
-                            }
-                            k++;
-                        }
-                        j++;
-                    }
-                    else {
-                        /* no more storage systems to query */
-                        break;
-||||||| merged common ancestors
-            printf("%s:\n", queries[n].keys[m]);
-
-            /* the remaining query keys all accept the storage ID and/or path qualifiers */
-            sid = NULL;
-            mountpt = NULL;
-            for (k=0; k < queries[n].nqual; k++) {
-                if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
-                    /* there may be more than one (comma-delimited) storage ID, so
-                     * split them into a NULL-terminated argv-type array */
-                    sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
-                    /* there may be more than one (comma-delimited) mount pt, so
-                     * split them into a NULL-terminated argv-type array */
-                    mountpt = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
-                    uid = queries[n].qualifiers[k].value.data.uint32;
-                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
-                    gid = queries[n].qualifiers[k].value.data.uint32;
-                }
-            }
-
-            /* XXX: if no sid/mntpnt for queries below, do we return info on every storage system we know about? */
-
-            for (i = 0, j = 0;;) {
-                if (sid && sid[i] != NULL) {
-                    /* storage id based query */
-                    k  = 0;
-                    while (availsys[k].name != NULL) {
-                        if (strcmp(availsys[k].name, sid[i]) == 0) {
-                            q_sys = &availsys[k];
-                            q_str = availsys[k].name;
-                            break;
-                        }
-                        k++;
-                    }
-                    i++;
-                }
-                else if (mountpt && mountpt[j] != NULL) {
-                    /* mount point based query */
-                    k = 0;
-                    while (availsys[k].name != NULL) {
-                        if (strcmp(availsys[k].mountpt, mountpt[j]) == 0) {
-                            q_sys = &availsys[k];
-                            q_str = availsys[k].mountpt;
-                            break;
-                        }
-                        k++;
-=======
             printf("%s:\n", queries[n].keys[m]);
 
             if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
@@ -413,248 +226,13 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                     PMIX_LIST_FOREACH(tracker, &registered_lustre_fs_list,
 				pmix_pstrg_lustre_tracker_t) {
                         printf("%s,", tracker->fs_info.id);
->>>>>>> add first cut at functioning lustre module
                     }
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-||||||| merged common ancestors
-                    j++;
-                }
-                else {
-                    /* no more storage systems to query */
-                    break;
-=======
                     printf("\n");
                 }
                 else {
                     /* no qualifiers supported for querying the storage list currently */
                     printf("ERR_NOT_SUPPORTED\n");
->>>>>>> add first cut at functioning lustre module
                 }
-<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
-
-            if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * NOTE to self: could me a comma-delimited set of storage IDs, so
-                 * return the mount pt for each of them
-                 */
-                char *strg_id = q_sys->name;
-                printf("\t%s: %s\n", q_str, strg_id);
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * Get the capacity of the Lustre storage systems that are available to the
-                 * caller's userid/grpid, as provided in the qualifiers.
-                 */
-                if (UINT32_MAX == uid || UINT32_MAX == gid) {
-                    /* they failed to provide the user's info - I will
-                     * take care of returning an appropriate error */
-                }
-
-                /*
-                 * Let me know if you need further info to process the request - e.g.,
-                 * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get process that one.
-                 * NOTE to self: could me a comma-delimited set of paths, so
-                 * return the ID for each of them
-                 */
-                char *mountpt = q_sys->mountpt;
-                printf("\t%s: %s\n", q_str, mountpt);
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
-                /* if given a uid/gid, answer this query using Lustre-specific code;
-                 * otherwise, fallthrough to base VFS query code
-                 */
-                if (UINT32_MAX != uid || UINT32_MAX != gid) {
-                    /* ADD HERE:
-                     *
-                     * Get the total capacity of the Lustre storage system for the given
-                     * uid and gid. If they ask for a specific one(s), then get just those.
-                     */
-                    printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                    /*
-                     * Let me know if you need further info to process the request - e.g.,
-                     * we could provide the app's jobid or argv[0]. If they ask for
-                     * a specific storage system, then get process that one.
-                     */
-
-                    /* I will package the data for return once I see what Lustre provides */
-                    continue;
-                }
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
-                /* if given a uid/gid, answer this query using Lustre-specific code;
-                 * otherwise, fallthrough to base VFS query code
-                 */
-                if (UINT32_MAX != uid || UINT32_MAX != gid) {
-                    /* ADD HERE:
-                     *
-                     * Get the used capacity of the Lustre storage system for the given
-                     * uid and gid. If they ask for a specific one(s), then get just those.
-                     */
-                    printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                    /*
-                     * Let me know if you need further info to process the request - e.g.,
-                     * we could provide the app's jobid or argv[0]. If they ask for
-                     * a specific storage system, then get process that one.
-                     */
-
-                    /* I will package the data for return once I see what Lustre provides */
-                    continue;
-                }
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
-                /* ADD HERE:
-                 *
-                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
-                 * a specific one, then get just that one.
-                 */
-                if (UINT32_MAX == uid || UINT32_MAX == gid) {
-                    /* they failed to provide the user's info - I will
-                     * take care of returning an appropriate error */
-                }
-
-                /*
-                 * Let me know if you need further info to process the request - e.g.,
-                 * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get process that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_AVAIL_BW)) {
-                /* ADD HERE:
-                 *
-                 * Get the bandwidth of the Lustre storage systems that is available to the
-                 * caller's userid/grpid.
-                 */
-                if (UINT32_MAX == uid || UINT32_MAX == gid) {
-                    /* they failed to provide the user's info - I will
-                     * take care of returning an appropriate error */
-                }
-
-                /*
-                 * Let me know if you need further info to process the request - e.g.,
-                 * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get process that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-||||||| merged common ancestors
-            }
-
-            if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * NOTE to self: could me a comma-delimited set of storage IDs, so
-                 * return the mount pt for each of them
-                 */
-                char *strg_id = q_sys->name;
-                printf("\t%s: %s\n", q_str, strg_id);
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
-                /* don't worry about this one for now - once I see how to get the
-                 * storage list and mount pts, I will construct the response here
-                 *
-                 * NOTE to self: could me a comma-delimited set of paths, so
-                 * return the ID for each of them
-                 */
-                char *mountpt = q_sys->mountpt;
-                printf("\t%s: %s\n", q_str, mountpt);
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
-                /* if given a uid/gid, answer this query using Lustre-specific code;
-                 * otherwise, fallthrough to base VFS query code
-                 */
-                if (UINT32_MAX != uid || UINT32_MAX != gid) {
-                    /* ADD HERE:
-                     *
-                     * Get the total capacity of the Lustre storage system for the given
-                     * uid and gid. If they ask for a specific one(s), then get just those.
-                     */
-                    printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                    /*
-                     * Let me know if you need further info to process the request - e.g.,
-                     * we could provide the app's jobid or argv[0]. If they ask for
-                     * a specific storage system, then get process that one.
-                     */
-
-                    /* I will package the data for return once I see what Lustre provides */
-                    continue;
-                }
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
-                /* if given a uid/gid, answer this query using Lustre-specific code;
-                 * otherwise, fallthrough to base VFS query code
-                 */
-                if (UINT32_MAX != uid || UINT32_MAX != gid) {
-                    /* ADD HERE:
-                     *
-                     * Get the used capacity of the Lustre storage system for the given
-                     * uid and gid. If they ask for a specific one(s), then get just those.
-                     */
-                    printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                    /*
-                     * Let me know if you need further info to process the request - e.g.,
-                     * we could provide the app's jobid or argv[0]. If they ask for
-                     * a specific storage system, then get process that one.
-                     */
-
-                    /* I will package the data for return once I see what Lustre provides */
-                    continue;
-                }
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
-                /* ADD HERE:
-                 *
-                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
-                 * a specific one, then get just that one.
-                 */
-                printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                /*
-                 * Let me know if you need further info to process the request - e.g.,
-                 * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get process that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-                continue;
-
-            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_AVAIL_BW)) {
-                /* ADD HERE:
-                 *
-                 * Get the bandwidth of the Lustre storage systems that is available to the
-                 * caller's userid/grpid.
-                 */
-                printf("\t%s: NOT SUPPORTED!\n", q_str);
-
-                /*
-                 * Let me know if you need further info to process the request - e.g.,
-                 * we could provide the app's jobid or argv[0]. If they ask for
-                 * a specific storage system, then get process that one.
-                 */
-
-                /* I will package the data for return once I see what Lustre provides */
-=======
->>>>>>> add first cut at functioning lustre module
                 continue;
             }
 	    else {

--- a/src/mca/pstrg/lustre/pstrg_lustre.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre.c
@@ -57,31 +57,137 @@ pmix_pstrg_base_module_t pmix_pstrg_lustre_module = {.name = "lustre",
                                                      .finalize = lustre_finalize,
                                                      .query = query};
 
+typedef struct pmix_pstrg_lustre_tracker {
+    pmix_list_item_t super;
+    pmix_pstrg_fs_info_t fs_info;
+    /* more Lustre FS state can go here */
+} pmix_pstrg_lustre_tracker_t;
+
+pmix_list_t registered_lustre_fs_list;
+
+static void tcon(pmix_pstrg_lustre_tracker_t *t)
+{
+    t->fs_info.id = NULL;
+    t->fs_info.mount_dir = NULL;
+}
+static void tdes(pmix_pstrg_lustre_tracker_t *t)
+{
+    if (NULL != t->fs_info.id) {
+        free(t->fs_info.id);
+    }
+    if (NULL != t->fs_info.mount_dir) {
+        free(t->fs_info.mount_dir);
+    }
+}
+static PMIX_CLASS_INSTANCE(pmix_pstrg_lustre_tracker_t,
+                           pmix_list_item_t,
+                           tcon, tdes);
+
 static pmix_status_t lustre_init(void)
 {
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre init");
+||||||| merged common ancestors
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre init");
+=======
+    pmix_value_array_t *mounts;
+    size_t nmounts, n;
+    pmix_pstrg_mntent_t ent;
+    pmix_pstrg_lustre_tracker_t *tracker;
+    pmix_status_t rc;
+
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre init");
+>>>>>>> add first cut at functioning lustre module
+
+    PMIX_CONSTRUCT(&registered_lustre_fs_list, pmix_list_t);
 
     /* ADD HERE:
      *
      * Discover/connect to any available Lustre systems. Return an error
      * if none are preset, or you are unable to connect to them
      */
+
+    ///XXX for now, just check the type of mount as specified in /etc/mtab
+    rc = pmix_pstrg_get_fs_mounts(&mounts);
+    if (PMIX_SUCCESS == rc) {
+        nmounts = pmix_value_array_get_size(mounts);
+
+	/* iterate returned mounts and register lustre ones we want to track */
+        for (n = 0; n < nmounts; n++) {
+            ent = PMIX_VALUE_ARRAY_GET_ITEM(mounts, pmix_pstrg_mntent_t, n);
+
+            /* skip non-lustre mounts */
+            if (strcmp(ent.mnt_type, "lustre") != 0) continue;
+
+            /* allocate a tracker so we can track Lustre mounts we register */
+            tracker = PMIX_NEW(pmix_pstrg_lustre_tracker_t);
+            if (NULL == tracker) {
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+
+            /* create a unique string ID for the file system. 
+             * currently the ID is just 'lustre-<fs_mount_dir>'
+             */
+            tracker->fs_info.id = malloc(strlen(ent.mnt_type) + strlen(ent.mnt_dir) + 2);
+            if (NULL == tracker->fs_info.id) {
+                PMIX_RELEASE(tracker);
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+            sprintf(tracker->fs_info.id, "%s-%s", ent.mnt_type, ent.mnt_dir);
+            tracker->fs_info.mount_dir = strdup(ent.mnt_dir);
+            if (NULL == tracker->fs_info.mount_dir) {
+                PMIX_RELEASE(tracker);
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+
+            rc = pmix_pstrg_register_fs(tracker->fs_info);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(tracker);
+                break;
+            }
+
+            pmix_list_append(&registered_lustre_fs_list, &tracker->super);
+	}
+        pmix_pstrg_free_fs_mounts(&mounts);
+    }
+
     return PMIX_SUCCESS;
 }
 
 static void lustre_finalize(void)
 {
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre finalize");
+||||||| merged common ancestors
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre finalize");
+=======
+    pmix_pstrg_lustre_tracker_t *tracker;
+
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre finalize");
+>>>>>>> add first cut at functioning lustre module
 
     /* ADD HERE:
      *
      * Disconnect from any Lustre systems to which you have connected
      */
+    ///XXX just free memory allocated above in lustre_init
+    PMIX_LIST_FOREACH(tracker, &registered_lustre_fs_list, pmix_pstrg_lustre_tracker_t) {
+        pmix_pstrg_deregister_fs(tracker->fs_info);
+    }
+    PMIX_LIST_DESTRUCT(&registered_lustre_fs_list);
 }
 
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre query");
 
@@ -89,18 +195,47 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
     size_t n, m, k, i, j;
     char **sid, **mountpt;
     bool takeus;
+||||||| merged common ancestors
+    size_t n, m, k, i, j;
+    char **sid, **mountpt;
+    bool takeus;
+=======
+    size_t n, m, k, i;
+    char **sid, **mount; //XXX free?
+    char *tmp_id, *tmp_mount;
+>>>>>>> add first cut at functioning lustre module
     uid_t uid = UINT32_MAX;
     gid_t gid = UINT32_MAX;
-    lustre_storage_t *q_sys;
-    char *q_str;
-    pmix_status_t q_ret;
+    pmix_pstrg_lustre_tracker_t *tracker;
 
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
+||||||| merged common ancestors
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre query");
+
+#if 0
+=======
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: lustre query");
+
+>>>>>>> add first cut at functioning lustre module
     for (n=0; n < nqueries; n++) {
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
         /* did they specify a storage type for this query? */
         takeus = true;
         for (k = 0; k < queries[n].nqual; k++) {
             if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_TYPE)) {
+||||||| merged common ancestors
+        /* did they specify a storage type for this query? */
+        takeus = true;
+        for (k=0; k < queries[n].nqual; k++) {
+            if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_TYPE)) {
+=======
+	sid = NULL;
+	mount = NULL;
+>>>>>>> add first cut at functioning lustre module
 
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
                 /* NOTE: I only included "lustre" as an accepted type, but we might
                  * want to consider other types as well - e.g., "parallel", "persistent",...) */
 
@@ -110,15 +245,50 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                     ;
                 }
                 break;
+||||||| merged common ancestors
+                /* NOTE: I only included "lustre" as an accepted type, but we might
+                 * want to consider other types as well - e.g., "parallel", "persistent",...) */
+
+                if (NULL == strcasestr(queries[n].qualifiers[k].value.data.string, "lustre")) {
+                    /* they are not interested in us */
+                    takeus = false;;
+                }
+                break;
+=======
+        for (k=0; k < queries[n].nqual; k++) {
+            if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
+                /* we can answer generic queries for storage ids */
+                /* there may be more than one (comma-delimited) storage id, so
+                 * split them into a NULL-terminated argv-type array */
+                sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+            }
+            else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
+                /* we can answer generic queries for storage paths */
+                /* there may be more than one (comma-delimited) mount pt, so
+                 * split them into a NULL-terminated argv-type array */
+                mount = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+            }
+            else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
+	        uid = queries[n].qualifiers[k].value.data.uint32;
+            }
+	    else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
+                gid = queries[n].qualifiers[k].value.data.uint32;
+>>>>>>> add first cut at functioning lustre module
             }
         }
-        if (!takeus) {
-            continue;
-        }
 
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
         /* see if they want the list of storage systems - this doesn't take any
          * qualifiers */
+||||||| merged common ancestors
+=======
+        /* the remaining query keys all accept the storage ID or path qualifiers */
+        ///XXX if there are multiple mounts and/or storage IDs, how do we account
+        ///    for that properly in the returned results. Note that we do not allow
+
+>>>>>>> add first cut at functioning lustre module
         for (m=0; NULL != queries[n].keys[m]; m++) {
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
             if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
                 /* ADD HERE:
                  *
@@ -186,8 +356,81 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                     else {
                         /* no more storage systems to query */
                         break;
-                    }
+||||||| merged common ancestors
+            printf("%s:\n", queries[n].keys[m]);
+
+            /* the remaining query keys all accept the storage ID and/or path qualifiers */
+            sid = NULL;
+            mountpt = NULL;
+            for (k=0; k < queries[n].nqual; k++) {
+                if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
+                    /* there may be more than one (comma-delimited) storage ID, so
+                     * split them into a NULL-terminated argv-type array */
+                    sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
+                    /* there may be more than one (comma-delimited) mount pt, so
+                     * split them into a NULL-terminated argv-type array */
+                    mountpt = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_USERID)) {
+                    uid = queries[n].qualifiers[k].value.data.uint32;
+                } else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_GRPID)) {
+                    gid = queries[n].qualifiers[k].value.data.uint32;
                 }
+            }
+
+            /* XXX: if no sid/mntpnt for queries below, do we return info on every storage system we know about? */
+
+            for (i = 0, j = 0;;) {
+                if (sid && sid[i] != NULL) {
+                    /* storage id based query */
+                    k  = 0;
+                    while (availsys[k].name != NULL) {
+                        if (strcmp(availsys[k].name, sid[i]) == 0) {
+                            q_sys = &availsys[k];
+                            q_str = availsys[k].name;
+                            break;
+                        }
+                        k++;
+                    }
+                    i++;
+                }
+                else if (mountpt && mountpt[j] != NULL) {
+                    /* mount point based query */
+                    k = 0;
+                    while (availsys[k].name != NULL) {
+                        if (strcmp(availsys[k].mountpt, mountpt[j]) == 0) {
+                            q_sys = &availsys[k];
+                            q_str = availsys[k].mountpt;
+                            break;
+                        }
+                        k++;
+=======
+            printf("%s:\n", queries[n].keys[m]);
+
+            if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
+                printf("\t%s: ", pmix_pstrg_lustre_module.name);
+                if (queries[n].nqual == 0) {
+                    PMIX_LIST_FOREACH(tracker, &registered_lustre_fs_list,
+				pmix_pstrg_lustre_tracker_t) {
+                        printf("%s,", tracker->fs_info.id);
+>>>>>>> add first cut at functioning lustre module
+                    }
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
+||||||| merged common ancestors
+                    j++;
+                }
+                else {
+                    /* no more storage systems to query */
+                    break;
+=======
+                    printf("\n");
+                }
+                else {
+                    /* no qualifiers supported for querying the storage list currently */
+                    printf("ERR_NOT_SUPPORTED\n");
+>>>>>>> add first cut at functioning lustre module
+                }
+<<<<<<< 19df213936a0c95fe2f3ce484790d73ea8babcab
 
             if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
                 /* don't worry about this one for now - once I see how to get the
@@ -307,16 +550,187 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                  */
 
                 /* I will package the data for return once I see what Lustre provides */
-                continue;
+||||||| merged common ancestors
             }
 
-            /* as fallback, call into base code to run general VFS query */
-            printf("\t%s: ", q_str);
-            q_ret = pmix_pstrg_base_vfs_query(q_sys->mountpt, queries[n].keys[m],
-                results);
+            if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
+                /* don't worry about this one for now - once I see how to get the
+                 * storage list and mount pts, I will construct the response here
+                 *
+                 * NOTE to self: could me a comma-delimited set of storage IDs, so
+                 * return the mount pt for each of them
+                 */
+                char *strg_id = q_sys->name;
+                printf("\t%s: %s\n", q_str, strg_id);
+
+                /* I will package the data for return once I see what Lustre provides */
+                continue;
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
+                /* don't worry about this one for now - once I see how to get the
+                 * storage list and mount pts, I will construct the response here
+                 *
+                 * NOTE to self: could me a comma-delimited set of paths, so
+                 * return the ID for each of them
+                 */
+                char *mountpt = q_sys->mountpt;
+                printf("\t%s: %s\n", q_str, mountpt);
+
+                /* I will package the data for return once I see what Lustre provides */
+                continue;
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
+                /* if given a uid/gid, answer this query using Lustre-specific code;
+                 * otherwise, fallthrough to base VFS query code
+                 */
+                if (UINT32_MAX != uid || UINT32_MAX != gid) {
+                    /* ADD HERE:
+                     *
+                     * Get the total capacity of the Lustre storage system for the given
+                     * uid and gid. If they ask for a specific one(s), then get just those.
+                     */
+                    printf("\t%s: NOT SUPPORTED!\n", q_str);
+
+                    /*
+                     * Let me know if you need further info to process the request - e.g.,
+                     * we could provide the app's jobid or argv[0]. If they ask for
+                     * a specific storage system, then get process that one.
+                     */
+
+                    /* I will package the data for return once I see what Lustre provides */
+                    continue;
+                }
+
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
+                /* if given a uid/gid, answer this query using Lustre-specific code;
+                 * otherwise, fallthrough to base VFS query code
+                 */
+                if (UINT32_MAX != uid || UINT32_MAX != gid) {
+                    /* ADD HERE:
+                     *
+                     * Get the used capacity of the Lustre storage system for the given
+                     * uid and gid. If they ask for a specific one(s), then get just those.
+                     */
+                    printf("\t%s: NOT SUPPORTED!\n", q_str);
+
+                    /*
+                     * Let me know if you need further info to process the request - e.g.,
+                     * we could provide the app's jobid or argv[0]. If they ask for
+                     * a specific storage system, then get process that one.
+                     */
+
+                    /* I will package the data for return once I see what Lustre provides */
+                    continue;
+                }
+
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
+                /* ADD HERE:
+                 *
+                 * Get the overall bandwidth of the Lustre storage systems. If they ask for
+                 * a specific one, then get just that one.
+                 */
+                printf("\t%s: NOT SUPPORTED!\n", q_str);
+
+                /*
+                 * Let me know if you need further info to process the request - e.g.,
+                 * we could provide the app's jobid or argv[0]. If they ask for
+                 * a specific storage system, then get process that one.
+                 */
+
+                /* I will package the data for return once I see what Lustre provides */
+                continue;
+
+            } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_AVAIL_BW)) {
+                /* ADD HERE:
+                 *
+                 * Get the bandwidth of the Lustre storage systems that is available to the
+                 * caller's userid/grpid.
+                 */
+                printf("\t%s: NOT SUPPORTED!\n", q_str);
+
+                /*
+                 * Let me know if you need further info to process the request - e.g.,
+                 * we could provide the app's jobid or argv[0]. If they ask for
+                 * a specific storage system, then get process that one.
+                 */
+
+                /* I will package the data for return once I see what Lustre provides */
+=======
+>>>>>>> add first cut at functioning lustre module
+                continue;
+            }
+	    else {
+               /* the following queries are all based on statvfs;
+                * other generic queries should probably be handled before this
+                */
+                char *marker;
+                if ((sid && !mount) || (mount && !sid)) {
+                    for (i = 0; (sid && sid[i] != NULL) ||
+                            (mount && mount[i] != NULL); i++) {
+                        if (sid) {
+                            marker = sid[i];
+                            tmp_id = sid[i];
+                            /* get mount to use for statfs */
+                            tmp_mount = pmix_pstrg_get_registered_fs_mount_by_id(sid[i]);
+                            if (!tmp_mount) {
+                                printf("\t%s: ERR_NOT_FOUND", marker);
+                            }
+                        }
+                        else
+                        {
+                            marker = mount[i];
+                            tmp_mount = mount[i];
+                            /* sanity check this mount has been registered before */
+                            tmp_id = pmix_pstrg_get_registered_fs_id_by_mount(mount[i]);
+                            if (!tmp_id) {
+                                printf("\t%s: ERR_NOT_FOUND", marker);
+                            }
+                        }
+
+			///XXX tmp_mount and tmp_id contain ID and mount for storage system being queried for this key
+
+			///XXX stubbed out query handlers for Lustre
+                        if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
+			   if (uid != UINT32_MAX || gid != UINT32_MAX) {
+				///XXX Lustre module will handle capacity/object queries when given specific uid/gid
+			   }
+			   else {
+				///XXX fall back to VFS module to handle generic queries
+			   }
+			}
+			else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
+			   if (uid != UINT32_MAX || gid != UINT32_MAX) {
+				///XXX Lustre module will handle capacity/object queries when given specific uid/gid
+			   }
+			   else {
+				///XXX fall back to VFS module to handle generic queries
+			   }
+			}
+			else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECT_LIMIT)) {
+			   if (UINT32_MAX != uid || UINT32_MAX != gid) {
+				///XXX Lustre module will handle capacity/object queries when given specific uid/gid
+			   }
+			   else {
+				///XXX fall back to VFS module to handle generic queries
+			   }
+			}
+			else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECTS_USED)) {
+			   if (UINT32_MAX != uid || UINT32_MAX != gid) {
+				///XXX Lustre module will handle capacity/object queries when given specific uid/gid
+			   }
+			   else {
+				///XXX fall back to VFS module to handle generic queries
+			   }
+			}
+			else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW_LIMIT)) {
+				///XXX if possible, implement BW attribute
+			}
+			else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_BW)) {
+				///XXX if possible, implement BW attribute
+			}
+		    }
+		}
+            }
         }
     }
-#endif
 
     return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/pstrg/vfs/pstrg_vfs.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs.c
@@ -111,8 +111,10 @@ static pmix_status_t vfs_init(void)
         for (n = 0; n < nmounts; n++) {
             ent = PMIX_VALUE_ARRAY_GET_ITEM(mounts, pmix_pstrg_mntent_t, n);
 
+#if 0
             /* XXX FILTER OUT ANY UNWANTED FILE SYSTEMS HERE */
             if (strcmp(ent.mnt_type, "ext4") != 0) continue;
+#endif
 
             /* allocate a tracker so we can track FSes we register */
             tracker = PMIX_NEW(pmix_pstrg_vfs_tracker_t);

--- a/src/mca/pstrg/vfs/pstrg_vfs.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs.c
@@ -169,7 +169,7 @@ static void vfs_finalize(void)
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
-    size_t n, m, k, i;
+    size_t n, m, k, i, p;
     char **sid, **mount; //XXX free?
     char *tmp_id, *tmp_mount;
     bool takeus;
@@ -177,6 +177,13 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
     struct statvfs stat_buf;
     int ret;
     pmix_status_t rc = PMIX_SUCCESS;
+    pmix_infolist_t *iptr;
+    pmix_info_t *infoptr;
+    pmix_kval_t *kv;
+    char **tmpres = NULL;
+    char *tmpstring;
+    pmix_list_t kyresults;
+    pmix_data_array_t *darray;
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
                         "pstrg: vfs query");
@@ -186,17 +193,29 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
         sid = NULL;
         mount = NULL;
 
+        PMIX_CONSTRUCT(&kyresults, pmix_list_t);
+
         for (k=0; k < queries[n].nqual; k++) {
             if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
                 /* we can answer generic queries for storage ids */
                 /* there may be more than one (comma-delimited) storage id, so
                  * split them into a NULL-terminated argv-type array */
+                if (NULL != sid) {
+                    /* cannot have more than one ID qualifier for a key */
+                    PMIX_LIST_DESTRUCT(&kyresults);
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
             }
             else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
                 /* we can answer generic queries for storage paths */
                 /* there may be more than one (comma-delimited) mount pt, so
                  * split them into a NULL-terminated argv-type array */
+                if (NULL != mount) {
+                    /* cannot have more than one path qualifier for a key */
+                    PMIX_LIST_DESTRUCT(&kyresults);
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 mount = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
             }
             else {
@@ -208,6 +227,7 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
         if (!takeus) {
             //XXX do we set an error? add an error to the response? just leave it blank?
             rc = PMIX_ERR_NOT_SUPPORTED;
+            PMIX_LIST_DESTRUCT(&kyresults);
             continue;
         }
 
@@ -220,12 +240,24 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
             printf("%s:\n", queries[n].keys[m]);
 
             if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
+                // RHC: where do you check for the qualifiers?
                 printf("\t%s: ", pmix_pstrg_vfs_module.name); 
                 if (queries[n].nqual == 0) {
                     PMIX_LIST_FOREACH(tracker, &registered_fs_list, pmix_pstrg_vfs_tracker_t) {
                         printf("%s,", tracker->fs_info.id);
+                        pmix_argv_append_nosize(&tmpres, tracker->fs_info.id);
                     }
                     printf("\n");
+                    if (0 < pmix_argv_count(tmpres)) {
+                        /* construct the result */
+                        iptr = PMIX_NEW(pmix_infolist_t);
+                        tmpstring = pmix_argv_join(tmpres, ',');
+                        pmix_argv_free(tmpres);
+                        PMIX_INFO_LOAD(&iptr->info, PMIX_QUERY_STORAGE_LIST, tmpstring, PMIX_STRING);
+                        free(tmpstring);
+                        /* add it to the results */
+                        pmix_list_append(&kyresults, &iptr->super);
+                    }
                 }
                 else {
                     /* no qualifiers supported for querying the storage list currently */
@@ -233,17 +265,31 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 }
                 continue;
             }
+            // RHC: I guess you are asking for the storage ID's corresponding to
+            // one or more mount paths? Perhaps some explanation of what you are
+            // trying to query would help here as I'm confused
             else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
-                if (mount && !sid) {
+                if (NULL != mount && NULL == sid) {
                     for (i = 0; mount[i] != NULL; i++) {
                         printf("\t%s: ", mount[i]);
                         tmp_id = pmix_pstrg_get_registered_fs_id_by_mount(mount[i]);
                         if (tmp_id) {
                             printf("%s\n", tmp_id);
+                            pmix_argv_append_nosize(&tmpres, mount[i]);
                         }
                         else {
                             printf("ERR_NOT_FOUND\n");
                         }
+                    }
+                    if (0 < pmix_argv_count(tmpres)) {
+                        /* construct the result */
+                        iptr = PMIX_NEW(pmix_infolist_t);
+                        tmpstring = pmix_argv_join(tmpres, ',');
+                        pmix_argv_free(tmpres);
+                        PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_ID, tmpstring, PMIX_STRING);
+                        free(tmpstring);
+                        /* add it to the results */
+                        pmix_list_append(&kyresults, &iptr->super);
                     }
                 }
                 else {
@@ -251,16 +297,30 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 }
             }
             else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
-                if (sid && !mount) {
+                if (NULL != sid && NULL == mount) {
                     for (i = 0; sid[i] != NULL; i++) {
                         printf("\t%s: ", sid[i]);
+                        // RHC: does this find more than one value? The attribute definition
+                        // implies "no", that it only is supposed to return one, but the loop
+                        // seems to aggregate all the values, so that is what I supported
                         tmp_mount = pmix_pstrg_get_registered_fs_mount_by_id(sid[i]);
                         if (tmp_mount) {
                             printf("%s\n", tmp_mount);
+                            pmix_argv_append_nosize(&tmpres, tmp_mount);
                         }
                         else {
                             printf("ERR_NOT_FOUND\n");
                         }
+                    }
+                    if (0 < pmix_argv_count(tmpres)) {
+                        /* construct the result */
+                        iptr = PMIX_NEW(pmix_infolist_t);
+                        tmpstring = pmix_argv_join(tmpres, ',');
+                        pmix_argv_free(tmpres);
+                        PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_PATH, tmpstring, PMIX_STRING);
+                        free(tmpstring);
+                        /* add it to the results */
+                        pmix_list_append(&kyresults, &iptr->super);
                     }
                 }
                 else {
@@ -303,23 +363,46 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                         }
 
                         if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
-                            uint64_t cap_limit = (stat_buf.f_blocks * stat_buf.f_frsize) /
-                                (1024 * 1024);
-                            printf("\t%s: %lu MB\n", marker, cap_limit);
+                            double cap_limit = (stat_buf.f_blocks * stat_buf.f_frsize);
+                            printf("\t%s: %.0lf bytes\n", marker, cap_limit);
+                            /* construct the result */
+                            iptr = PMIX_NEW(pmix_infolist_t);
+                            PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_CAPACITY_LIMIT, &cap_limit, PMIX_DOUBLE);
+                            /* add it to the results */
+                            pmix_list_append(&kyresults, &iptr->super);
                         } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
-                            uint64_t cap_used =
-                                ((stat_buf.f_blocks - stat_buf.f_bavail) * stat_buf.f_frsize) /
-                                (1024 * 1024);
-                            printf("\t%s: %lu MB\n", marker, cap_used);
+                            double cap_used =
+                                ((stat_buf.f_blocks - stat_buf.f_bavail) * stat_buf.f_frsize);
+                            printf("\t%s: %.0lf bytes\n", marker, cap_used);
+                            /* construct the result */
+                            iptr = PMIX_NEW(pmix_infolist_t);
+                            PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_CAPACITY_USED, &cap_used, PMIX_DOUBLE);
+                            /* add it to the results */
+                            pmix_list_append(&kyresults, &iptr->super);
                         } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECT_LIMIT)) {
                             uint64_t obj_limit = stat_buf.f_files;
-                            printf("\t%s: %lu\n", marker, obj_limit);
+                            printf("\t%s: %"PRIu64"\n", marker, obj_limit);
+                            /* construct the result */
+                            iptr = PMIX_NEW(pmix_infolist_t);
+                            PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_OBJECT_LIMIT, &obj_limit, PMIX_UINT64);
+                            /* add it to the results */
+                            pmix_list_append(&kyresults, &iptr->super);
                         } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECTS_USED)) {
                             uint64_t obj_used = stat_buf.f_files - stat_buf.f_favail;
-                            printf("\t%s: %lu\n", marker, obj_used);
+                            printf("\t%s: %"PRIu64"\n", marker, obj_used);
+                            /* construct the result */
+                            iptr = PMIX_NEW(pmix_infolist_t);
+                            PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_OBJECTS_USED, &obj_used, PMIX_UINT64);
+                            /* add it to the results */
+                            pmix_list_append(&kyresults, &iptr->super);
                         } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_MINIMAL_XFER_SIZE)) {
-                            uint64_t xfer_size = stat_buf.f_bsize / 1024;
-                            printf("\t%s: %lu KB\n", marker, xfer_size);
+                            double xfer_size = stat_buf.f_bsize;
+                            printf("\t%s: %.0lf bytes\n", marker, xfer_size);
+                            /* construct the result */
+                            iptr = PMIX_NEW(pmix_infolist_t);
+                            PMIX_INFO_LOAD(&iptr->info, PMIX_STORAGE_MINIMAL_XFER_SIZE, &xfer_size, PMIX_DOUBLE);
+                            /* add it to the results */
+                            pmix_list_append(&kyresults, &iptr->super);
                         } else {
                             printf("\t%s: ERR_NOT_SUPPORTED\n", marker);
                         }
@@ -328,9 +411,24 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                 else {
                     printf("\tERR_INVALID_ARGS\n");
                 }
-
             }
         }
+        if (0 < (p = pmix_list_get_size(&kyresults))) {
+            kv = PMIX_NEW(pmix_kval_t);
+            kv->key = strdup(PMIX_QUERY_RESULTS);
+            PMIX_VALUE_CREATE(kv->value, 1);
+            kv->value->type = PMIX_DATA_ARRAY;
+            PMIX_DATA_ARRAY_CREATE(darray, p, PMIX_INFO);
+            kv->value->data.darray = darray;
+            infoptr = (pmix_info_t*)darray->array;
+            p = 0;
+            PMIX_LIST_FOREACH(iptr, &kyresults, pmix_infolist_t) {
+                PMIX_INFO_XFER(&infoptr[p], &iptr->info);
+                ++p;
+            }
+            pmix_list_append(results, &kv->super);
+        }
+        PMIX_LIST_DESTRUCT(&kyresults);
     }
 
     return rc;

--- a/src/mca/pstrg/vfs/pstrg_vfs.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs.c
@@ -121,7 +121,7 @@ static pmix_status_t vfs_init(void)
                 break;
             }
 
-            /* create a unique string ID for the file system. 
+            /* create a unique string ID for the file system.
              * currently the ID is just '<mnt_type>-<fs_mount_dir>'
              */
             tracker->fs_info.id = malloc(strlen(ent.mnt_type) + strlen(ent.mnt_dir) + 2);
@@ -317,7 +317,7 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
                         } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECTS_USED)) {
                             uint64_t obj_used = stat_buf.f_files - stat_buf.f_favail;
                             printf("\t%s: %lu\n", marker, obj_used);
-                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_XFER_SIZE)) {
+                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_MINIMAL_XFER_SIZE)) {
                             uint64_t xfer_size = stat_buf.f_bsize / 1024;
                             printf("\t%s: %lu KB\n", marker, xfer_size);
                         } else {

--- a/src/mca/pstrg/vfs/pstrg_vfs.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright tracker->fs_info.id(c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
@@ -26,6 +26,12 @@
 #    include <fcntl.h>
 #endif
 #include <time.h>
+#ifdef HAVE_SYS_STATVFS_H
+#include <sys/statvfs.h>
+#endif
+#ifdef HAVE_MNTENT_H
+#include <mntent.h>
+#endif
 
 #include "include/pmix_common.h"
 
@@ -50,85 +56,282 @@ static void vfs_finalize(void);
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata);
 
-pmix_pstrg_base_module_t pmix_pstrg_vfs_module = {.name = "vfs",
-                                                  .init = vfs_init,
-                                                  .finalize = vfs_finalize,
-                                                  .query = query};
-
-#if 0
-
-typedef struct {
-    char *name;
-    char *mountpt;
-    uint64_t cap;
-    uint64_t free;
-    uint64_t avail;
-    uint64_t bw;
-    uint64_t availbw;
-} vfs_storage_t;
-
-static vfs_storage_t availsys[] = {
-    {.name = "vfs1", .mountpt = "/scratch1", .cap = 123456, .free = 5678,
-     .avail = 131, .bw = 100.0, .availbw = 13.2},
-
-    {.name = "vfs2", .mountpt = "/scratch2", .cap = 789, .free = 178,
-     .avail = 100, .bw = 10.0, .availbw = 2.2},
-
-    {.name = "vfs3", .mountpt = "/usr/tmp", .cap = 91, .free = 35,
-     .avail = 81, .bw = 5.0, .availbw = 42},
-    {.name = NULL}
+pmix_pstrg_base_module_t pmix_pstrg_vfs_module = {
+    .name = "vfs",
+    .init = vfs_init,
+    .finalize = vfs_finalize,
+    .query = query
 };
-#endif
+
+typedef struct pmix_pstrg_vfs_tracker {
+    pmix_list_item_t super;
+    pmix_pstrg_fs_info_t fs_info;
+    /* more FS state can go here */
+} pmix_pstrg_vfs_tracker_t;
+
+pmix_list_t registered_fs_list;
+
+static void tcon(pmix_pstrg_vfs_tracker_t *t)
+{
+    t->fs_info.id = NULL;
+    t->fs_info.mount_dir = NULL;
+}
+static void tdes(pmix_pstrg_vfs_tracker_t *t)
+{
+    if (NULL != t->fs_info.id) {
+        free(t->fs_info.id);
+    }
+    if (NULL != t->fs_info.mount_dir) {
+        free(t->fs_info.mount_dir);
+    }
+}
+static PMIX_CLASS_INSTANCE(pmix_pstrg_vfs_tracker_t,
+                           pmix_list_item_t,
+                           tcon, tdes);
+
 
 static pmix_status_t vfs_init(void)
 {
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: vfs init");
+    pmix_value_array_t *mounts;
+    size_t nmounts, n;
+    pmix_pstrg_mntent_t ent;
+    pmix_pstrg_vfs_tracker_t *tracker;
+    pmix_status_t rc;
 
-    /* ADD HERE:
-     *
-     * Discover/connect to any available Vfs systems. Return an error
-     * if none are preset, or you are unable to connect to them
-     */
-    return PMIX_SUCCESS;
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: vfs init");
+
+    PMIX_CONSTRUCT(&registered_fs_list, pmix_list_t);
+
+    rc = pmix_pstrg_get_fs_mounts(&mounts);
+    if (PMIX_SUCCESS == rc) {
+        nmounts = pmix_value_array_get_size(mounts);
+
+        /* iterate returned mounts and register ones we want to track */
+        for (n = 0; n < nmounts; n++) {
+            ent = PMIX_VALUE_ARRAY_GET_ITEM(mounts, pmix_pstrg_mntent_t, n);
+
+            /* XXX FILTER OUT ANY UNWANTED FILE SYSTEMS HERE */
+            if (strcmp(ent.mnt_type, "ext4") != 0) continue;
+
+            /* allocate a tracker so we can track FSes we register */
+            tracker = PMIX_NEW(pmix_pstrg_vfs_tracker_t);
+            if (NULL == tracker) {
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+
+            /* create a unique string ID for the file system. 
+             * currently the ID is just '<mnt_type>-<fs_mount_dir>'
+             */
+            tracker->fs_info.id = malloc(strlen(ent.mnt_type) + strlen(ent.mnt_dir) + 2);
+            if (NULL == tracker->fs_info.id) {
+                PMIX_RELEASE(tracker);
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+            sprintf(tracker->fs_info.id, "%s-%s", ent.mnt_type, ent.mnt_dir);
+            tracker->fs_info.mount_dir = strdup(ent.mnt_dir);
+            if (NULL == tracker->fs_info.mount_dir) {
+                PMIX_RELEASE(tracker);
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+
+            rc = pmix_pstrg_register_fs(tracker->fs_info);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(tracker);
+                break;
+            }
+
+            pmix_list_append(&registered_fs_list, &tracker->super);
+        }
+
+        pmix_pstrg_free_fs_mounts(&mounts);
+    }
+
+    return rc;
 }
 
 static void vfs_finalize(void)
 {
-    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: vfs finalize");
+    pmix_pstrg_vfs_tracker_t *tracker;
 
-    /* ADD HERE:
-     *
-     * Disconnect from any Vfs systems to which you have connected
-     */
+    pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
+                        "pstrg: vfs finalize");
+
+    PMIX_LIST_FOREACH(tracker, &registered_fs_list, pmix_pstrg_vfs_tracker_t) {
+        pmix_pstrg_deregister_fs(tracker->fs_info);
+    }
+    PMIX_LIST_DESTRUCT(&registered_fs_list);
 }
 
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
-#if 0
-    size_t n, m, k;
-    char **sid, **mountpt;
+    size_t n, m, k, i;
+    char **sid, **mount; //XXX free?
+    char *tmp_id, *tmp_mount;
     bool takeus;
-    uid_t uid = UINT32_MAX;
-    gid_t gid = UINT32_MAX;
+    pmix_pstrg_vfs_tracker_t *tracker;
+    struct statvfs stat_buf;
+    int ret;
+    pmix_status_t rc = PMIX_SUCCESS;
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output,
                         "pstrg: vfs query");
 
-    /* just put something here so that Travis will pass its tests
-     * because it treats warnings as errors, and wants to warn about
-     * unused variables */
-    sid = pmix_argv_split("foo,bar", ',');
-    pmix_argv_free(sid);
-    sid = NULL;
-    mountpt = pmix_argv_split("foo,bar", ',');
-    pmix_argv_free(mountpt);
-    mountpt = NULL;
-    if (availsys[0].cap != 123456) {
-        return PMIX_ERROR;
+    for (n=0; n < nqueries; n++) {
+        takeus=true;
+        sid = NULL;
+        mount = NULL;
+
+        for (k=0; k < queries[n].nqual; k++) {
+            if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_ID)) {
+                /* we can answer generic queries for storage ids */
+                /* there may be more than one (comma-delimited) storage id, so
+                 * split them into a NULL-terminated argv-type array */
+                sid = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+            }
+            else if (0 == strcmp(queries[n].qualifiers[k].key, PMIX_STORAGE_PATH)) {
+                /* we can answer generic queries for storage paths */
+                /* there may be more than one (comma-delimited) mount pt, so
+                 * split them into a NULL-terminated argv-type array */
+                mount = pmix_argv_split(queries[n].qualifiers[k].value.data.string, ',');
+            }
+            else {
+                /* we don't know how to handle any other qualifiers currently */
+                takeus = false;
+                break;
+            }
+        }
+        if (!takeus) {
+            //XXX do we set an error? add an error to the response? just leave it blank?
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            continue;
+        }
+
+        /* the remaining query keys all accept the storage ID or path qualifiers */
+        ///XXX if there are multiple mounts and/or storage IDs, how do we account
+        ///    for that properly in the returned results. Note that we do not allow
+        ///    mixing of STORAGE_ID and STORAGE_PATH qualifiers for simplicity
+
+        for (m=0; NULL != queries[n].keys[m]; m++) {
+            printf("%s:\n", queries[n].keys[m]);
+
+            if (0 == strcmp(queries[n].keys[m], PMIX_QUERY_STORAGE_LIST)) {
+                printf("\t%s: ", pmix_pstrg_vfs_module.name); 
+                if (queries[n].nqual == 0) {
+                    PMIX_LIST_FOREACH(tracker, &registered_fs_list, pmix_pstrg_vfs_tracker_t) {
+                        printf("%s,", tracker->fs_info.id);
+                    }
+                    printf("\n");
+                }
+                else {
+                    /* no qualifiers supported for querying the storage list currently */
+                    printf("ERR_NOT_SUPPORTED\n");
+                }
+                continue;
+            }
+            else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_ID)) {
+                if (mount && !sid) {
+                    for (i = 0; mount[i] != NULL; i++) {
+                        printf("\t%s: ", mount[i]);
+                        tmp_id = pmix_pstrg_get_registered_fs_id_by_mount(mount[i]);
+                        if (tmp_id) {
+                            printf("%s\n", tmp_id);
+                        }
+                        else {
+                            printf("ERR_NOT_FOUND\n");
+                        }
+                    }
+                }
+                else {
+                    printf("\tERR_INVALID_ARGS\n");
+                }
+            }
+            else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_PATH)) {
+                if (sid && !mount) {
+                    for (i = 0; sid[i] != NULL; i++) {
+                        printf("\t%s: ", sid[i]);
+                        tmp_mount = pmix_pstrg_get_registered_fs_mount_by_id(sid[i]);
+                        if (tmp_mount) {
+                            printf("%s\n", tmp_mount);
+                        }
+                        else {
+                            printf("ERR_NOT_FOUND\n");
+                        }
+                    }
+                }
+                else {
+                    printf("\tERR_INVALID_ARGS\n");
+                }
+            }
+            else {
+                /* the following queries are all based on statvfs;
+                 * other generic queries should probably be handled before this
+                 */
+                char *marker;
+                if ((sid && !mount) || (mount && !sid)) {
+                    for (i = 0; (sid && sid[i] != NULL) ||
+                            (mount && mount[i] != NULL); i++) {
+                        if (sid) {
+                            marker = sid[i];
+                            tmp_id = sid[i];
+                            /* get mount to use for statfs */
+                            tmp_mount = pmix_pstrg_get_registered_fs_mount_by_id(sid[i]);
+                            if (!tmp_mount) {
+                                printf("\t%s: ERR_NOT_FOUND", marker);
+                            }
+                        }
+                        else
+                        {
+                            marker = mount[i];
+                            tmp_mount = mount[i];
+                            /* sanity check this mount has been registered before */
+                            tmp_id = pmix_pstrg_get_registered_fs_id_by_mount(mount[i]);
+                            if (!tmp_id) {
+                                printf("\t%s: ERR_NOT_FOUND", marker);
+                            }
+                        }
+
+                        /* run statvfs on the mount point of the query */
+                        ret = statvfs(tmp_mount, &stat_buf);
+                        if (ret != 0) {
+                            printf("\t%s: ERR_NOT_FOUND\n", marker);
+                            continue;
+                        }
+
+                        if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_LIMIT)) {
+                            uint64_t cap_limit = (stat_buf.f_blocks * stat_buf.f_frsize) /
+                                (1024 * 1024);
+                            printf("\t%s: %lu MB\n", marker, cap_limit);
+                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_CAPACITY_USED)) {
+                            uint64_t cap_used =
+                                ((stat_buf.f_blocks - stat_buf.f_bavail) * stat_buf.f_frsize) /
+                                (1024 * 1024);
+                            printf("\t%s: %lu MB\n", marker, cap_used);
+                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECT_LIMIT)) {
+                            uint64_t obj_limit = stat_buf.f_files;
+                            printf("\t%s: %lu\n", marker, obj_limit);
+                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_OBJECTS_USED)) {
+                            uint64_t obj_used = stat_buf.f_files - stat_buf.f_favail;
+                            printf("\t%s: %lu\n", marker, obj_used);
+                        } else if (0 == strcmp(queries[n].keys[m], PMIX_STORAGE_XFER_SIZE)) {
+                            uint64_t xfer_size = stat_buf.f_bsize / 1024;
+                            printf("\t%s: %lu KB\n", marker, xfer_size);
+                        } else {
+                            printf("\t%s: ERR_NOT_SUPPORTED\n", marker);
+                        }
+                    }
+                }
+                else {
+                    printf("\tERR_INVALID_ARGS\n");
+                }
+
+            }
+        }
     }
 
-#endif
-
-    return PMIX_ERR_NOT_FOUND;
+    return rc;
 }


### PR DESCRIPTION
This contains query attribute definitions that are up-to-date with our proposal for the PMIx standard.

VFS module (i.e., the module that will answer generic queries for file systems) currently supports the following queries:
- PMIX_QUERY_STORAGE_LIST (no qualifiers)
- PMIX_STORAGE_ID (with PMIX_STORAGE_PATH qualifier)
- PMIX_STORAGE_PATH (with PMIX_STORAGE_ID qualifier)
- PMIX_STORAGE_CAPACITY_LIMIT (with PMIX_STORAGE_PATH/PMIX_STORAGE_ID qualifiers)
- PMIX_STORAGE_CAPACITY_USED (with PMIX_STORAGE_PATH/PMIX_STORAGE_ID qualifiers)
- PMIX_STORAGE_OBJECT_LIMIT (with PMIX_STORAGE_PATH/PMIX_STORAGE_ID qualifiers)
- PMIX_STORAGE_OBJECTS_USED (with PMIX_STORAGE_PATH/PMIX_STORAGE_ID qualifiers)
- PMIX_STORAGE_MINIMAL_XFER_SIZE (with PMIX_STORAGE_PATH/PMIX_STORAGE_ID qualifiers)

This PR includes a commit from Ralph for implementing query response, but I can't get the `pquery` utility to return anything but "NOT-SUPPORTED". In the meantime, I've made sure it prints out the query response I intended on stdout and that works as expected.

There is a stubbed out Lustre module, but it needs some work to properly find Lustre volumes and answer Lustre-specific query functionality 