### PR TITLE
Enable singleton "comm_spawn" operations

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -566,6 +566,16 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         if (NULL != info) {
             _check_for_notify(info, ninfo);
         }
+        /* if we were given connection info, then we should try
+         * to connect if are currently unconnected */
+        if (!pmix_globals.connected) {
+            rc = pmix_ptl.connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
+            if (PMIX_SUCCESS == rc) {
+                pmix_init_result = rc;
+                pmix_client_globals.singleton = false;
+            }
+        }
+
         return pmix_init_result;
     }
     ++pmix_globals.init_cntr;

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -173,6 +173,7 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_tool_handshake(pmix_peer_t *peer, pmix_s
 PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(char **orig_str, char *name);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
                                                         pmix_info_t *info, size_t ninfo);
+PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar);
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -342,9 +342,14 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     cred.bytes = pnd->cred;
     cred.size = pnd->len;
     PMIX_PSEC_VALIDATE_CONNECTION(reply, peer, NULL, 0, NULL, NULL, &cred);
+    if (PMIX_SUCCESS != reply) {
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "validation of client connection failed");
+        goto error;
+    }
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "client connection validated with status=%d", reply);
+                        "client connection validated");
 
     /* tell the client all is good */
     u32 = htonl(reply);
@@ -355,12 +360,10 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     /* If needed, perform the handshake. The macro will update reply */
     PMIX_PSEC_SERVER_HANDSHAKE_IFNEED(reply, peer, NULL, 0, NULL, NULL, &cred);
 
-    /* It is possible that connection validation failed
-     * We need to reply to the client first and cleanup after */
+    /* It is possible that connection validation failed */
     if (PMIX_SUCCESS != reply) {
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "validation of client connection failed");
-        /* send an error reply to the client */
         goto error;
     }
 

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -55,14 +55,14 @@
 static void timeout(int sd, short args, void *cbdata);
 static char *pmix_getline(FILE *fp);
 
-pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
+pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar)
 {
-    char *evar, *vrs;
     pmix_status_t rc;
+    char *vrs;
 
     vrs = getenv("PMIX_VERSION");
 
-    if (NULL != (evar = getenv("PMIX_SERVER_URI41"))) {
+    if (0 == strcmp(evar, "PMIX_SERVER_URI41")) {
         /* we are talking to a v4 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 4, 0);
@@ -72,11 +72,10 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
 
         /* must use the latest bfrops module */
         PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, NULL);
-        *ev = evar;
         return rc;
     }
 
-    if (NULL != (evar = getenv("PMIX_SERVER_URI4"))) {
+    if (0 == strcmp(evar, "PMIX_SERVER_URI4")) {
         /* we are talking to a v4 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 4, 0);
@@ -86,10 +85,10 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
 
         /* must use the V4 bfrops module */
         PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v4");
-        *ev = evar;
         return rc;
     }
-    if (NULL != (evar = getenv("PMIX_SERVER_URI3"))) {
+
+    if (0 == strcmp(evar, "PMIX_SERVER_URI3")) {
         /* we are talking to a v3 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 3, 0);
@@ -99,11 +98,10 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
 
         /* must use the v3 bfrops module */
         PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v3");
-        *ev = evar;
         return rc;
     }
 
-    if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
+    if (0 == strcmp(evar, "PMIX_SERVER_URI21")) {
         /* we are talking to a v2.1 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 2, 1);
@@ -113,11 +111,10 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
 
         /* must use the v21 bfrops module */
         PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v21");
-        *ev = evar;
         return rc;
     }
 
-    if (NULL != (evar = getenv("PMIX_SERVER_URI2"))) {
+    if (0 == strcmp(evar, "PMIX_SERVER_URI2")) {
         /* we are talking to a v2.0 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 2, 0);
@@ -127,6 +124,43 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
 
         /* must use the v20 bfrops module */
         PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v20");
+        return rc;
+    }
+
+    return PMIX_ERR_UNREACH;
+}
+
+pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
+{
+    char *evar;
+    pmix_status_t rc;
+
+    if (NULL != (evar = getenv("PMIX_SERVER_URI41"))) {
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI41");
+        *ev = evar;
+        return rc;
+    }
+
+    if (NULL != (evar = getenv("PMIX_SERVER_URI4"))) {
+        /* we are talking to a v4 server */
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI4");
+        *ev = evar;
+        return rc;
+    }
+    if (NULL != (evar = getenv("PMIX_SERVER_URI3"))) {
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI3");
+        *ev = evar;
+        return rc;
+    }
+
+    if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI21");
+        *ev = evar;
+        return rc;
+    }
+
+    if (NULL != (evar = getenv("PMIX_SERVER_URI2"))) {
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI2");
         *ev = evar;
         return rc;
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -240,6 +240,44 @@ done:
     }
 }
 
+static pmix_status_t register_singleton(char *name)
+{
+    char *tmp, *ptr;
+    pmix_namespace_t *nptr;
+    pmix_rank_t rank;
+    pmix_rank_info_t *rinfo;
+
+    tmp = strdup(name);
+    ptr = strrchr(tmp, '.');
+    *ptr = '\0';
+    ++ptr;
+    rank = strtoul(ptr, NULL, 10);
+
+    nptr = PMIX_NEW(pmix_namespace_t);
+    if (NULL == nptr) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
+    nptr->nspace = strdup(tmp);
+    nptr->nlocalprocs = 1;
+    nptr->nprocs = 1;
+    pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+    /* add this rank */
+    rinfo = PMIX_NEW(pmix_rank_info_t);
+    if (NULL == rinfo) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
+    rinfo->pname.nspace = strdup(tmp);
+    rinfo->pname.rank = rank;
+    rinfo->uid = geteuid();
+    rinfo->gid = getegid();
+    pmix_list_append(&nptr->ranks, &rinfo->super);
+    nptr->all_registered = true;
+    free(tmp);
+
+    return PMIX_SUCCESS;
+}
 
 // local functions for connection support
 pmix_status_t pmix_server_initialize(void)
@@ -567,6 +605,16 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     if (PMIX_SUCCESS != (rc = pmix_ploc_base_select())) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
+    }
+
+    /* if we were started to support a singleton, register it now
+     * so we won't reject it when it connects to us */
+    if (NULL != (evar = getenv("PMIX_MCA_singleton"))) {
+        rc = register_singleton(evar);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
     }
 
     /* setup the wildcard recv for inbound messages from clients */


### PR DESCRIPTION
Have the server "self-register" the singleton nspace/proc
so it doesn't reject the subsequent connection attempt.
Enable the client to connect to a specified server when
PMIx_Init is called again. Provide a mechanism by which
the PTL listener can output the connection info to a
provided pipe.

Signed-off-by: Ralph Castain <rhc@pmix.org>