### PR TITLE
Simple Wildcard fence (barrier, no data exchange) with timeout

### DIFF
--- a/test/test_v2/Makefile
+++ b/test/test_v2/Makefile
@@ -22,7 +22,8 @@ TC1FILES = test_init_fin.c $(TCCOMMONFILES)
 TC2FILES = test_helloworld.c $(TCCOMMONFILES)
 TC3FILES = test_get_basic.c $(TCCOMMONFILES)
 TC4FILES = test_get_peers.c $(TCCOMMONFILES)
-TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES) $(TC4FILES)
+TC5FILES = test_fence_wildcard.c $(TCCOMMONFILES)
+TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES) $(TC4FILES) $(TC5FILES)
 CFILES = $(PCFILES) $(TCFILES)
 
 OBJ = $(CFILES:%.c=%.o)
@@ -31,8 +32,9 @@ T1OBJ = $(TC1FILES:%.c=%.o)
 T2OBJ = $(TC2FILES:%.c=%.o)
 T3OBJ = $(TC3FILES:%.c=%.o)
 T4OBJ = $(TC4FILES:%.c=%.o)
+T5OBJ = $(TC5FILES:%.c=%.o)
 
-all: pmix_test test_init_fin test_helloworld test_get_basic test_get_peers
+all: pmix_test test_init_fin test_helloworld test_get_basic test_get_peers test_fence_wildcard
 .PHONY: all
 
 clean:
@@ -49,6 +51,8 @@ test_get_basic: $(T3OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 test_get_peers: $(T4OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
+test_fence_wildcard: $(T5OBJ)
+	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS) -lm
 
 %.o : %.c
 	$(CC) -c -o $@ $< $(CFLAGS)

--- a/test/test_v2/Makefile
+++ b/test/test_v2/Makefile
@@ -13,7 +13,7 @@ LDFLAGS = -Wl,-rpath,$(LDIR) #-Wl,--stack,10485760
 LIBS =-lpmix -lpthread -levent # -lefence # <-- can link against electric fence for memory checking
 
 # Executables
-EXE = pmix_test test_init_fin test_helloworld test_get_basic test_get_peers
+EXE = pmix_test test_init_fin test_helloworld test_get_basic test_get_peers test_fence_wildcard test_fence_wildcard_timeout
 
 # List of all .c source files.
 PCFILES = pmix_test.c test_common.c cli_stages.c test_server.c server_callbacks.c base64_enc_dec.c
@@ -23,7 +23,8 @@ TC2FILES = test_helloworld.c $(TCCOMMONFILES)
 TC3FILES = test_get_basic.c $(TCCOMMONFILES)
 TC4FILES = test_get_peers.c $(TCCOMMONFILES)
 TC5FILES = test_fence_wildcard.c $(TCCOMMONFILES)
-TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES) $(TC4FILES) $(TC5FILES)
+TC6FILES = test_fence_wildcard_timeout.c $(TCCOMMONFILES)
+TCFILES = $(TC1FILES) $(TC2FILES) $(TC3FILES) $(TC4FILES) $(TC5FILES) $(TC6FILES)
 CFILES = $(PCFILES) $(TCFILES)
 
 OBJ = $(CFILES:%.c=%.o)
@@ -33,8 +34,9 @@ T2OBJ = $(TC2FILES:%.c=%.o)
 T3OBJ = $(TC3FILES:%.c=%.o)
 T4OBJ = $(TC4FILES:%.c=%.o)
 T5OBJ = $(TC5FILES:%.c=%.o)
+T6OBJ = $(TC6FILES:%.c=%.o)
 
-all: pmix_test test_init_fin test_helloworld test_get_basic test_get_peers test_fence_wildcard
+all: pmix_test test_init_fin test_helloworld test_get_basic test_get_peers test_fence_wildcard test_fence_wildcard_timeout
 .PHONY: all
 
 clean:
@@ -52,6 +54,8 @@ test_get_basic: $(T3OBJ)
 test_get_peers: $(T4OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS)
 test_fence_wildcard: $(T5OBJ)
+	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS) -lm
+test_fence_wildcard_timeout: $(T6OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) -L$(LDIR) $(LDFLAGS) $(LIBS) -lm
 
 %.o : %.c

--- a/test/test_v2/test_clientapp_funcs.c
+++ b/test/test_v2/test_clientapp_funcs.c
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2020      Triad National Security, LLC
+ * Copyright (c) 2020-2021 Triad National Security, LLC
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -222,4 +222,30 @@ void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key,
             TEST_ERROR_EXIT(("No test logic for type: %d, key: %s", value->type, key));
         }
     }
+}
+
+double avg_fence_time(void) {
+	double avg_fence = 0.0;
+	int i, retval;
+    unsigned long usecs;
+    struct timeval local_start, local_end;
+
+    // Synchronize before timing
+    if (0 != PMIx_Fence(NULL, 0, NULL, 0)) {
+        TEST_ERROR_EXIT(("PMIx_Fence Problem: ret val = %d", retval));
+    }
+	/* Measure the average typical fence execution time */
+    gettimeofday(&local_start, NULL);
+	for(i = 0; i < 100; i++) {
+        if (0 != PMIx_Fence(NULL, 0, NULL, 0)) {
+            TEST_ERROR_EXIT(("PMIx_Fence Problem: ret val = %d", retval));
+        }
+	}
+    gettimeofday(&local_end, NULL);
+    usecs = (local_end.tv_sec * 1000000) + local_end.tv_usec
+        - ((local_start.tv_sec * 1000000) + local_start.tv_usec);
+    avg_fence = ((double)usecs)/1E8;
+
+    TEST_VERBOSE(("Simple PMIx_Fence, avg time: %lf", avg_fence));
+	return avg_fence;
 }

--- a/test/test_v2/test_common.c
+++ b/test/test_v2/test_common.c
@@ -184,8 +184,8 @@ void parse_cmd(int argc, char **argv, test_params *params, validation_params *v_
             fprintf(stderr, "\t-t <>    set timeout\n");
             fprintf(stderr, "\t-o out   redirect clients logs to file out.<rank>\n");
             fprintf(stderr, "\t-d str   assign ranks to servers, for example: 0:0,1:1:2,3,4\n");
-            fprintf(stderr, "\t-m num   fence time multiplier (similar to an error bar)\n");
-            fprintf(stderr, "\t-r num   fence timeout ratio (used to calculate sleep time before fence calls)\n");
+            fprintf(stderr, "\t-m num   fence time multiplier (similar to an error bar, default: 100)\n");
+            fprintf(stderr, "\t-r num   fence timeout ratio (used to calculate sleep time before fence calls, default: 100)\n");
             fprintf(stderr, "\t-c       fence[_nb] callback shall include all collected data\n");
             fprintf(stderr, "\t-nb      use non-blocking fence\n");
             exit(0);

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <sys/time.h>
+#include <math.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/class/pmix_list.h"
@@ -40,9 +41,9 @@
 
 #define PMIXT_VALIDATION_PARAMS_VER 1
 
-#define PMIXT_CHECK_EXPECT(rc, expected_rc, params, vparams) \
+#define PMIXT_CHECK_EXPECT(fn_call, expected_rc, params, vparams) \
 do {                                                   \
-   int pmix_rc = (rc);                               \
+   int pmix_rc = (fn_call);                               \
    if (expected_rc != pmix_rc) {                      \
        TEST_ERROR(("Client ns %s rank %d: PMIx call failed: %s", \
            vparams.pmix_nspace, vparams.pmix_rank,           \
@@ -118,6 +119,9 @@ extern FILE *pmixt_outfile;
 #define TEST_DEFAULT_TIMEOUT 10
 #define MAX_DIGIT_LEN 10
 #define TEST_REPLACE_DEFAULT "3:1"
+
+#define TEST_DEFAULT_FENCE_TIMEOUT_RATIO 20
+#define TEST_DEFAULT_FENCE_TIME_MULTIPLIER 100
 
 #define PMIXT_SET_FILE(prefix, ns_id, rank) { \
     char *fname = malloc( strlen(prefix) + MAX_DIGIT_LEN + 2 ); \
@@ -208,6 +212,8 @@ typedef struct {
     int nonblocking;
     int ns_size;
     int ns_id;
+    double fence_timeout_ratio;
+    double fence_time_multiplier;
 } test_params;
 
 extern test_params params;
@@ -233,6 +239,9 @@ void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key, pmix_v
 
 char *pmixt_encode(const void *val, size_t vallen);
 ssize_t pmixt_decode (const char *data, void *decdata, size_t buffsz);
+
+void sleep_ms(unsigned long milliseconds);
+double avg_fence_time(void);
 
 typedef struct {
     pmix_list_item_t super;

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -120,7 +120,7 @@ extern FILE *pmixt_outfile;
 #define MAX_DIGIT_LEN 10
 #define TEST_REPLACE_DEFAULT "3:1"
 
-#define TEST_DEFAULT_FENCE_TIMEOUT_RATIO 20
+#define TEST_DEFAULT_FENCE_TIMEOUT_RATIO 100
 #define TEST_DEFAULT_FENCE_TIME_MULTIPLIER 100
 
 #define PMIXT_SET_FILE(prefix, ns_id, rank) { \

--- a/test/test_v2/test_fence_wildcard.c
+++ b/test/test_v2/test_fence_wildcard.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* Test of basic fence with no data exchange (barrier) */
+
+#include "pmix.h"
+#include "test_common.h"
+
+int main(int argc, char *argv[]) {
+
+    pmix_value_t *val;
+    int rc, i;
+    size_t ninfo = 0, nprocs = 0;
+    test_params params;
+    validation_params v_params;
+    pmix_proc_t job_proc, this_proc;
+    pmix_proc_t *procs;
+    struct timeval start, end;
+    unsigned long usecs_elapsed, sleep_time_ms;
+    double secs_elapsed, fence_time, sleep_time, padded_fence_time;
+
+    pmixt_pre_init(argc, argv, &params, &v_params);
+    /* initialization */
+    PMIXT_CHECK(PMIx_Init(&this_proc, NULL, ninfo), params, v_params);
+
+    /* Handles everything that needs to happen after PMIx_Init() */
+    pmixt_post_init(&this_proc, &params, &v_params);
+
+    PMIX_PROC_CONSTRUCT(&job_proc);
+    strncpy(job_proc.nspace, this_proc.nspace, PMIX_MAX_NSLEN);
+    job_proc.rank = PMIX_RANK_WILDCARD;
+
+    // establishes baseline fence time before entering loop
+    fence_time = avg_fence_time();
+    // padded_fence_time is the time permitted just for the fence call
+    padded_fence_time = params.fence_time_multiplier * fence_time;
+    sleep_time = params.fence_timeout_ratio * padded_fence_time;
+    sleep_time_ms = (long)(sleep_time * 1000.0);
+
+    TEST_VERBOSE(("Rank %d fence timeout ratio: %lf fence time multiplier: %lf",
+        this_proc.rank, params.fence_timeout_ratio, params.fence_time_multiplier));
+
+    // Synchronize before timing
+    if (0 != PMIx_Fence(NULL, 0, NULL, 0)) {
+        TEST_ERROR_EXIT(("PMIx_Fence Problem: ret val = %d", rc));
+    }
+    if (0 == this_proc.rank){
+        sleep_ms(sleep_time_ms);
+    }
+    gettimeofday(&start, NULL);
+    rc = PMIx_Fence(&job_proc, 1, NULL, 0);
+    gettimeofday(&end, NULL);
+    if (0 != rc) {
+        TEST_ERROR_EXIT(("PMIx_Fence Problem: ret val = %d", rc));
+    }
+    usecs_elapsed =
+        ((end.tv_sec * 1000000 + end.tv_usec) - (start.tv_sec * 1000000 + start.tv_usec));
+    secs_elapsed = (double) usecs_elapsed / 1E6;
+    TEST_VERBOSE(("Rank %d fence time: %lf padded_fence_time: %lf sleep_time: %lf secs_elapsed: %lf",
+        this_proc.rank, fence_time, padded_fence_time, sleep_time, secs_elapsed));
+    // secs_elapsed for rank 0 must be less than padded_fence_time
+    if (0 == this_proc.rank) {
+        if (secs_elapsed > padded_fence_time) {
+        TEST_ERROR(("%s: PMIx_Fence timeout: Rank 0 elapsed fence time: %lf exceeded cutoff of: %lf",
+            this_proc.nspace, secs_elapsed, padded_fence_time));
+        pmixt_exit(PMIX_ERR_TIMEOUT);
+        }
+    }
+    else {
+        // secs_elapsed for other ranks must be within sleep_time +/- padded_fence_time
+        if (secs_elapsed < (sleep_time - padded_fence_time) ) {
+            TEST_ERROR(("%s: PMIx_Fence failed: Rank %d did not wait for Rank 0,"
+            " elapsed time: %lf",
+            this_proc.nspace, this_proc.rank, secs_elapsed));
+            pmixt_exit(PMIX_ERR_TIMEOUT);
+        }
+        else if (secs_elapsed > (sleep_time + padded_fence_time) ) {
+            TEST_ERROR(("%s: PMIx_Fence timeout: Rank %d elapsed fence time: %lf exceeded cutoff of: %lf",
+                this_proc.nspace, this_proc.rank, secs_elapsed, sleep_time + padded_fence_time));
+            pmixt_exit(PMIX_ERR_TIMEOUT);
+        }
+    }
+
+    PMIX_PROC_DESTRUCT(&job_proc);
+
+    /* finalize */
+    PMIXT_CHECK(PMIx_Finalize(NULL, 0), params, v_params);
+
+    /* Handles cleanup */
+    pmixt_post_finalize(&this_proc, &params, &v_params);
+}

--- a/test/test_v2/test_fence_wildcard_timeout.c
+++ b/test/test_v2/test_fence_wildcard_timeout.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* Test of basic Fence with no data exchange (barrier) that times out clients */
+
+#include "pmix.h"
+#include "test_common.h"
+
+int main(int argc, char *argv[]) {
+
+    int rc;
+    size_t ninfo = 0;
+    test_params params;
+    int timeout_duration;
+    validation_params v_params;
+    pmix_proc_t job_proc, this_proc;
+    pmix_info_t info;
+    struct timeval start, end;
+    unsigned long usecs_elapsed, sleep_time_ms;
+    double secs_elapsed, fence_time, sleep_time, padded_fence_time;
+
+    pmixt_pre_init(argc, argv, &params, &v_params);
+    /* initialization */
+    PMIXT_CHECK(PMIx_Init(&this_proc, NULL, ninfo), params, v_params);
+
+    /* Handles everything that needs to happen after PMIx_Init() */
+    pmixt_post_init(&this_proc, &params, &v_params);
+
+    PMIX_PROC_CONSTRUCT(&job_proc);
+    strncpy(job_proc.nspace, this_proc.nspace, PMIX_MAX_NSLEN);
+    job_proc.rank = PMIX_RANK_WILDCARD;
+
+    // establishes baseline fence time before entering loop
+    fence_time = avg_fence_time();
+
+    // padded_fence_time is the time permitted just for the fence call
+    padded_fence_time = params.fence_time_multiplier * fence_time;
+    sleep_time = params.fence_timeout_ratio * padded_fence_time;
+    sleep_time_ms = (unsigned long)(sleep_time * 1000.0);
+
+    TEST_VERBOSE(("Rank %d fence timeout ratio: %lf fence time multiplier: %lf",
+        this_proc.rank, params.fence_timeout_ratio, params.fence_time_multiplier));
+
+
+    timeout_duration = (int)ceil(sleep_time / 2.0);
+    if ((double)timeout_duration > sleep_time) {
+        TEST_ERROR_EXIT(("sleep_time: %lfs below minimum threshold: %ds.\n"
+            "    Try increasing input value for -r (fence time ratio)",
+            sleep_time, timeout_duration));
+    }
+    TEST_VERBOSE(("sleep_time: %lf s Timeout: %d s", sleep_time, timeout_duration));
+    PMIX_INFO_LOAD(&info, PMIX_TIMEOUT, &timeout_duration, PMIX_INT);
+    PMIX_INFO_REQUIRED(&info);
+    // Synchronize before timing
+    if (PMIX_SUCCESS != PMIx_Fence(NULL, 0, NULL, 0)) {
+        TEST_ERROR_EXIT(("PMIx_Fence Problem: ret val = %d", rc));
+    }
+
+    if (0 == this_proc.rank){
+        sleep_ms(sleep_time_ms);
+    }
+    gettimeofday(&start, NULL);
+    rc = PMIx_Fence(&job_proc, 1, &info, 1);
+    gettimeofday(&end, NULL);
+
+
+    usecs_elapsed =
+        ((end.tv_sec * 1000000 + end.tv_usec) - (start.tv_sec * 1000000 + start.tv_usec));
+    secs_elapsed = (double) usecs_elapsed / 1E6;
+    TEST_VERBOSE(("Rank %d fence time: %lf padded_fence_time: %lf sleep_time: %lf secs_elapsed: %lf",
+        this_proc.rank, fence_time, padded_fence_time, sleep_time, secs_elapsed));
+    // secs_elapsed for rank 0 must be less than padded_fence_time
+    if (0 == this_proc.rank) {
+        if (secs_elapsed > padded_fence_time) {
+        TEST_ERROR(("%s: PMIx_Fence unexpected delay Rank 0: elapsed fence time: %lf exceeded cutoff of: %lf",
+            this_proc.nspace, secs_elapsed, padded_fence_time));
+        pmixt_exit(PMIX_ERR_TIMEOUT);
+        }
+    }
+
+    if (PMIX_ERR_TIMEOUT == rc) {
+        if (0 == this_proc.rank) {
+            TEST_ERROR(("%s: PMIx_Fence unexpected timeout Rank 0: secs_elapsed: %lf timeout_duration: %d",
+                this_proc.nspace, secs_elapsed, timeout_duration));
+            pmixt_exit(PMIX_ERR_TIMEOUT);
+        }
+        if (secs_elapsed > (double)timeout_duration && secs_elapsed < sleep_time) {
+            TEST_OUTPUT(("Rank %d PMIx_Fence Timeout (expected behavior)", this_proc.rank));
+            fflush(stdout);
+        }
+        else {
+            TEST_ERROR_EXIT(("%s: PMIx_Fence unexpected timeout behavior, rank %d:"
+                " elapsed fence time: %lf timeout duration: %d",
+                this_proc.nspace, this_proc.rank, secs_elapsed, timeout_duration));
+        }
+    }
+    else if (PMIX_SUCCESS != rc) {
+        TEST_ERROR_EXIT(("Rank %d PMIx_Fence Problem: ret val = %d", this_proc.rank, rc));
+    }
+    else if (PMIX_SUCCESS == rc && 0 != this_proc.rank) {
+        TEST_ERROR_EXIT(("Rank %d PMIx_Fence did not timeout as expected", this_proc.rank, rc));
+    }
+
+    PMIX_PROC_DESTRUCT(&job_proc);
+
+    /* finalize */
+    PMIXT_CHECK(PMIx_Finalize(NULL, 0), params, v_params);
+
+    /* Handles cleanup */
+    pmixt_post_finalize(&this_proc, &params, &v_params);
+}

--- a/test/test_v2/test_init_fin.c
+++ b/test/test_v2/test_init_fin.c
@@ -21,11 +21,6 @@ int main(int argc, char *argv[]) {
     test_params params;
     validation_params v_params;
 
-/*
-    // for debugging frees down in clients
-    setenv("MALLOC_CHECK_", "3", 1);
-*/
-
     /* Handles all setup that's required prior to calling PMIx_Init() */
     pmixt_pre_init(argc, argv, &params, &v_params);
 

--- a/test/test_v2/test_server.c
+++ b/test/test_v2/test_server.c
@@ -108,6 +108,8 @@ static void release_cb(pmix_status_t status, void *cbdata)
 
 void set_client_argv(test_params *params, char ***argv)
 {
+    char num_str[MAX_DIGIT_LEN];
+
     pmix_argv_append_nosize(argv, params->binary);
 
     pmix_argv_append_nosize(argv, "-n");
@@ -127,14 +129,14 @@ void set_client_argv(test_params *params, char ***argv)
     if (params->nonblocking) {
         pmix_argv_append_nosize(argv, "-nb");
     }
-    /*
-    if (params->collect) {
-        pmix_argv_append_nosize(argv, "-c");
-    }
-    if (params->collect_bad) {
-        pmix_argv_append_nosize(argv, "--collect-corrupt");
-    }
-    */
+
+    pmix_argv_append_nosize(argv, "-r");
+    sprintf(num_str, "%lf", params->fence_timeout_ratio);
+    pmix_argv_append_nosize(argv, num_str);
+
+    pmix_argv_append_nosize(argv, "-m");
+    sprintf(num_str, "%lf", params->fence_time_multiplier);
+    pmix_argv_append_nosize(argv, num_str);
 }
 
 static void fill_seq_ranks_array(uint32_t nprocs, char **ranks)
@@ -695,6 +697,8 @@ int server_fence_contrib(char *data, size_t ndata,
     msg_hdr.dst_id = 0;
     msg_hdr.src_id = my_server_id;
     msg_hdr.size = ndata;
+    // this won't work if there is more than one fence active at the same time
+    // in the future, we will have to create a list instead of just one entry
     server->modex_cbfunc = cbfunc;
     server->cbdata = cbdata;
 


### PR DESCRIPTION
Added test case for a wildcard fence with clients that timeout. Normal execution implies that clients with a rank <> 0 timed out; if they don't timeout, the clients will exit with an error.

Note that for now a PMIx bug prevents us from timing out more than one client per PMIx_Fence call, so this test case does not work with more than two clients.

This PR also includes a commit that is from another presently open test suite PR. I know this could cause confusion but I'm trying to open these now before end of quarter. If I need to close and reopen it once the prior PR is accepted I can always do that.

In other words, if reviewing, please just focus on the latest commit and leave the fixes to the first commit to the prior PR.