### PR TITLE
Add runtime warning that compression isn't active

### DIFF
--- a/src/mca/pcompress/base/Makefile.am
+++ b/src/mca/pcompress/base/Makefile.am
@@ -4,6 +4,7 @@
 #                         Corporation.  All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,3 +18,5 @@ headers += \
 libmca_pcompress_la_SOURCES += \
         base/pcompress_base_frame.c \
         base/pcompress_base_select.c
+
+dist_pmixdata_DATA = base/help-pcompress.txt

--- a/src/mca/pcompress/base/base.h
+++ b/src/mca/pcompress/base/base.h
@@ -4,6 +4,7 @@
  *                         Corporation.  All rights reserved.
  *
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,6 +56,7 @@ extern "C" {
 typedef struct {
     size_t compress_limit;
     bool selected;
+    bool silent;
 } pmix_compress_base_t;
 
 PMIX_EXPORT extern pmix_compress_base_t pmix_compress_base;

--- a/src/mca/pcompress/base/help-pcompress.txt
+++ b/src/mca/pcompress/base/help-pcompress.txt
@@ -1,0 +1,18 @@
+# -*- text -*-
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is a US/English help file
+#
+[unavailable]
+PMIx was unable to find a usable compression library
+on the system. We will therefore be unable to compress
+large data streams. This may result in longer-than-normal
+startup times and larger memory footprints. We will
+continue, but strongly recommend installing zlib or
+a comparable compression library for better user experience.

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -17,6 +17,7 @@
 
 #include "pmix_config.h"
 
+#include "src/util/show_help.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pcompress/base/base.h"
 
@@ -33,6 +34,10 @@ static bool compress_block(uint8_t *inblock, size_t size,
     (void)size;
     (void)outbytes;
     (void)nbytes;
+    if (!pmix_compress_base.silent) {
+        pmix_show_help("help-pcompress.txt", "unavailable", true);
+        pmix_compress_base.silent = true;
+    }
     return false;
 }
 
@@ -53,6 +58,10 @@ static bool compress_string(char *instring,
     (void)instring;
     (void)outbytes;
     (void)nbytes;
+    if (!pmix_compress_base.silent) {
+        pmix_show_help("help-pcompress.txt", "unavailable", true);
+        pmix_compress_base.silent = true;
+    }
     return false;
 }
 
@@ -81,9 +90,18 @@ static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
     pmix_compress_base.compress_limit = 4096;
     (void) pmix_mca_base_var_register("pmix", "compress", "base", "limit",
                                       "Threshold beyond which data will be compressed",
-                                      PMIX_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_3,
-                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY, &pmix_compress_base.compress_limit);
+                                      PMIX_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
+                                      PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_3,
+                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                      &pmix_compress_base.compress_limit);
 
+    pmix_compress_base.silent = false;
+    (void) pmix_mca_base_var_register("pmix", "compress", "base", "silence_warning",
+                                      "Do not warn if compression unavailable",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
+                                      PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_3,
+                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                      &pmix_compress_base.silent);
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
Only emit it once. Add param to silence even that warning.

Signed-off-by: Ralph Castain <rhc@pmix.org>