### PR TITLE
Update the v4 bfrops for the new types

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1736,7 +1736,7 @@ typedef struct pmix_byte_object {
 
 #define PMIX_BYTE_OBJECT_LOAD(b, d, s)      \
     do {                                    \
-        (b)->bytes = (d);                   \
+        (b)->bytes = (char*)(d);            \
         (d) = NULL;                         \
         (b)->size = (s);                    \
         (s) = 0;                            \

--- a/src/mca/bfrops/v4/Makefile.am
+++ b/src/mca/bfrops/v4/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -513,6 +514,22 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo,
                        pmix_bfrops_base_print_bo,
+                       &mca_bfrops_v4_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC_NSPACE",
+                       PMIX_PROC_NSPACE,
+                       pmix_bfrops_base_pack_nspace,
+                       pmix_bfrops_base_unpack_nspace,
+                       pmix_bfrops_base_copy_nspace,
+                       pmix_bfrops_base_print_nspace,
+                       &mca_bfrops_v4_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DATA_BUFFER",
+                       PMIX_DATA_BUFFER,
+                       pmix_bfrops_base_pack_dbuf,
+                       pmix_bfrops_base_unpack_dbuf,
+                       pmix_bfrops_base_copy_dbuf,
+                       pmix_bfrops_base_print_dbuf,
                        &mca_bfrops_v4_component.types);
 
     return PMIX_SUCCESS;

--- a/src/mca/bfrops/v4/bfrop_pmix4.h
+++ b/src/mca/bfrops/v4/bfrop_pmix4.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/bfrops/v4/bfrop_pmix4_component.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4_component.c
@@ -62,7 +62,7 @@ pmix_bfrops_base_component_t mca_bfrops_v4_component = {
         .pmix_mca_close_component = component_close,
         .pmix_mca_query_component = component_query,
     },
-    .priority = 50,
+    .priority = 55,
     .assign_module = assign_module
 };
 
@@ -71,7 +71,7 @@ pmix_status_t component_open(void)
 {
     /* setup the types array */
     PMIX_CONSTRUCT(&mca_bfrops_v4_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v4_component.types, 42, INT_MAX, 16);
+    pmix_pointer_array_init(&mca_bfrops_v4_component.types, 50, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/bfrops/v401/Makefile.am
+++ b/src/mca/bfrops/v401/Makefile.am
@@ -1,0 +1,54 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = bfrop_pmix401.h
+sources = \
+        bfrop_pmix401_component.c \
+        bfrop_pmix401.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_bfrops_v401_DSO
+lib =
+lib_sources =
+component = mca_bfrops_v401.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_bfrops_v401.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_bfrops_v401_la_SOURCES = $(component_sources)
+mca_bfrops_v401_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_bfrops_v401_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_bfrops_v401_la_SOURCES = $(lib_sources)
+libmca_bfrops_v401_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v401/bfrop_pmix401.c
+++ b/src/mca/bfrops/v401/bfrop_pmix401.c
@@ -27,7 +27,7 @@
 #include "src/include/pmix_config.h"
 
 #include "src/mca/bfrops/base/base.h"
-#include "bfrop_pmix4.h"
+#include "bfrop_pmix401.h"
 
 #include "src/mca/psquash/psquash.h"
 #include "src/mca/psquash/base/base.h"
@@ -35,14 +35,14 @@
 
 static pmix_status_t init(void);
 static void finalize(void);
-static pmix_status_t pmix4_pack(pmix_buffer_t *buffer,
+static pmix_status_t pmix401_pack(pmix_buffer_t *buffer,
                                 const void *src, int num_vals,
                                 pmix_data_type_t type);
-static pmix_status_t pmix4_unpack(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t pmix401_unpack(pmix_buffer_t *buffer, void *dest,
                                   int32_t *num_vals, pmix_data_type_t type);
-static pmix_status_t pmix4_copy(void **dest, void *src,
+static pmix_status_t pmix401_copy(void **dest, void *src,
                                 pmix_data_type_t type);
-static pmix_status_t pmix4_print(char **output, char *prefix,
+static pmix_status_t pmix401_print(char **output, char *prefix,
                                  void *src, pmix_data_type_t type);
 static pmix_status_t register_type(const char *name,
                                    pmix_data_type_t type,
@@ -53,38 +53,38 @@ static pmix_status_t register_type(const char *name,
 static const char* data_type_string(pmix_data_type_t type);
 
 static pmix_status_t
-pmix4_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
                                    pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
 static pmix_status_t
-pmix4_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
                            pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type);
 static pmix_status_t
-pmix4_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
                              pmix_buffer_t *buffer, const void *src,
                              int32_t num_vals, pmix_data_type_t type);
 static pmix_status_t
-pmix4_bfrops_base_unpack_general_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_general_int(pmix_pointer_array_t *regtypes,
                                      pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
 static pmix_status_t
-pmix4_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
                              pmix_buffer_t *buffer, void *dest,
                              int32_t *num_vals, pmix_data_type_t type);
 static pmix_status_t
-pmix4_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
                                pmix_buffer_t *buffer, void *dest,
                                int32_t *num_vals, pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix4_module = {
-    .version = "v4",
+pmix_bfrops_module_t pmix_bfrops_pmix401_module = {
+    .version = "v401",
     .init = init,
     .finalize = finalize,
-    .pack = pmix4_pack,
-    .unpack = pmix4_unpack,
-    .copy = pmix4_copy,
-    .print = pmix4_print,
+    .pack = pmix401_pack,
+    .unpack = pmix401_unpack,
+    .copy = pmix401_copy,
+    .print = pmix401_print,
     .copy_payload = pmix_bfrops_base_copy_payload,
     .value_xfer = pmix_bfrops_base_value_xfer,
     .value_load = pmix_bfrops_base_value_load,
@@ -102,43 +102,43 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_bool,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_bool,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE,
                        pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_byte,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING,
                        pmix_bfrops_base_pack_string,
                        pmix_bfrops_base_unpack_string,
                        pmix_bfrops_base_copy_string,
                        pmix_bfrops_base_print_string,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE,
-                       pmix4_bfrops_base_pack_sizet,
-                       pmix4_bfrops_base_unpack_sizet,
+                       pmix401_bfrops_base_pack_sizet,
+                       pmix401_bfrops_base_unpack_sizet,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_size,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID,
                        pmix_bfrops_base_pack_pid,
                        pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_pid,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT,
-                       pmix4_bfrops_base_pack_int,
-                       pmix4_bfrops_base_unpack_int,
+                       pmix401_bfrops_base_pack_int,
+                       pmix401_bfrops_base_unpack_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8,
@@ -146,154 +146,154 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int8,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int16,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int32,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int64,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT,
-                       pmix4_bfrops_base_pack_int,
-                       pmix4_bfrops_base_unpack_int,
+                       pmix401_bfrops_base_pack_int,
+                       pmix401_bfrops_base_unpack_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8,
                        pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint8,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint16,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint32,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64,
-                       pmix4_bfrops_base_pack_general_int,
-                       pmix4_bfrops_base_unpack_general_int,
+                       pmix401_bfrops_base_pack_general_int,
+                       pmix401_bfrops_base_unpack_general_int,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint64,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT,
                        pmix_bfrops_base_pack_float,
                        pmix_bfrops_base_unpack_float,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_float,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE,
                        pmix_bfrops_base_pack_double,
                        pmix_bfrops_base_unpack_double,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_double,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL,
                        pmix_bfrops_base_pack_timeval,
                        pmix_bfrops_base_unpack_timeval,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_timeval,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME,
                        pmix_bfrops_base_pack_time,
                        pmix_bfrops_base_unpack_time,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_time,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS,
                        pmix_bfrops_base_pack_status,
                        pmix_bfrops_base_unpack_status,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_status,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE,
                        pmix_bfrops_base_pack_value,
                        pmix_bfrops_base_unpack_value,
                        pmix_bfrops_base_copy_value,
                        pmix_bfrops_base_print_value,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC,
                        pmix_bfrops_base_pack_proc,
                        pmix_bfrops_base_unpack_proc,
                        pmix_bfrops_base_copy_proc,
                        pmix_bfrops_base_print_proc,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP,
                        pmix_bfrops_base_pack_app,
                        pmix_bfrops_base_unpack_app,
                        pmix_bfrops_base_copy_app,
                        pmix_bfrops_base_print_app,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO,
                        pmix_bfrops_base_pack_info,
                        pmix_bfrops_base_unpack_info,
                        pmix_bfrops_base_copy_info,
                        pmix_bfrops_base_print_info,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA,
                        pmix_bfrops_base_pack_pdata,
                        pmix_bfrops_base_unpack_pdata,
                        pmix_bfrops_base_copy_pdata,
                        pmix_bfrops_base_print_pdata,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER,
                        pmix_bfrops_base_pack_buf,
                        pmix_bfrops_base_unpack_buf,
                        pmix_bfrops_base_copy_buf,
                        pmix_bfrops_base_print_buf,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT,
                        pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo,
                        pmix_bfrops_base_print_bo,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL,
                        pmix_bfrops_base_pack_kval,
                        pmix_bfrops_base_unpack_kval,
                        pmix_bfrops_base_copy_kval,
                        pmix_bfrops_base_print_kval,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST,
@@ -301,84 +301,84 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_persist,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_persist,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER,
                        pmix_bfrops_base_pack_ptr,
                        pmix_bfrops_base_unpack_ptr,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_ptr,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE,
                        pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_std_copy,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE,
                        pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_ptr,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND,
                        pmix_bfrops_base_pack_cmd,
                        pmix_bfrops_base_unpack_cmd,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_cmd,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix_bfrops_base_pack_info_directives,
                        pmix_bfrops_base_unpack_info_directives,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_info_directives,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE,
                        pmix_bfrops_base_pack_datatype,
                        pmix_bfrops_base_unpack_datatype,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_datatype,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE,
                        pmix_bfrops_base_pack_pstate,
                        pmix_bfrops_base_unpack_pstate,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_pstate,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO,
                        pmix_bfrops_base_pack_pinfo,
                        pmix_bfrops_base_unpack_pinfo,
                        pmix_bfrops_base_copy_pinfo,
                        pmix_bfrops_base_print_pinfo,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY,
                        pmix_bfrops_base_pack_darray,
                        pmix_bfrops_base_unpack_darray,
                        pmix_bfrops_base_copy_darray,
                        pmix_bfrops_base_print_darray,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK,
                        pmix_bfrops_base_pack_rank,
                        pmix_bfrops_base_unpack_rank,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_rank,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY,
                        pmix_bfrops_base_pack_query,
                        pmix_bfrops_base_unpack_query,
                        pmix_bfrops_base_copy_query,
                        pmix_bfrops_base_print_query,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING",
                        PMIX_COMPRESSED_STRING,
@@ -386,7 +386,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo,
                        pmix_bfrops_base_print_bo,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE",
                        PMIX_ALLOC_DIRECTIVE,
@@ -394,7 +394,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_alloc_directive,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_alloc_directive,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL",
                        PMIX_IOF_CHANNEL,
@@ -402,7 +402,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_iof_channel,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_iof_channel,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENVAR",
                        PMIX_ENVAR,
@@ -410,7 +410,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_envar,
                        pmix_bfrops_base_copy_envar,
                        pmix_bfrops_base_print_envar,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COORD",
                        PMIX_COORD,
@@ -418,7 +418,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_coord,
                        pmix_bfrops_base_copy_coord,
                        pmix_bfrops_base_print_coord,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGATTR",
                        PMIX_REGATTR,
@@ -426,7 +426,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_regattr,
                        pmix_bfrops_base_copy_regattr,
                        pmix_bfrops_base_print_regattr,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGEX",
                        PMIX_REGEX,
@@ -434,7 +434,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_regex,
                        pmix_bfrops_base_copy_regex,
                        pmix_bfrops_base_print_regex,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_JOB_STATE",
                        PMIX_JOB_STATE,
@@ -442,7 +442,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_jobstate,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_jobstate,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LINK_STATE",
                        PMIX_LINK_STATE,
@@ -450,7 +450,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_linkstate,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_linkstate,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_CPUSET",
                        PMIX_PROC_CPUSET,
@@ -458,7 +458,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_cpuset,
                        pmix_bfrops_base_copy_cpuset,
                        pmix_bfrops_base_print_cpuset,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_GEOMETRY",
                        PMIX_GEOMETRY,
@@ -466,7 +466,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_geometry,
                        pmix_bfrops_base_copy_geometry,
                        pmix_bfrops_base_print_geometry,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVICE_DIST",
                        PMIX_DEVICE_DIST,
@@ -474,7 +474,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_devdist,
                        pmix_bfrops_base_copy_devdist,
                        pmix_bfrops_base_print_devdist,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENDPOINT",
                        PMIX_ENDPOINT,
@@ -482,7 +482,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_endpoint,
                        pmix_bfrops_base_copy_endpoint,
                        pmix_bfrops_base_print_endpoint,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TOPO",
                        PMIX_TOPO,
@@ -490,7 +490,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_topology,
                        pmix_bfrops_base_copy_topology,
                        pmix_bfrops_base_print_topology,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVTYPE",
                        PMIX_DEVTYPE,
@@ -498,7 +498,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_devtype,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_devtype,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LOCTYPE",
                        PMIX_LOCTYPE,
@@ -506,7 +506,7 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_locality,
                        pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_locality,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_BYTE_OBJECT",
     				   PMIX_COMPRESSED_BYTE_OBJECT,
@@ -514,7 +514,23 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo,
                        pmix_bfrops_base_print_bo,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC_NSPACE",
+                       PMIX_PROC_NSPACE,
+                       pmix_bfrops_base_pack_nspace,
+                       pmix_bfrops_base_unpack_nspace,
+                       pmix_bfrops_base_copy_nspace,
+                       pmix_bfrops_base_print_nspace,
+                       &mca_bfrops_v401_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DATA_BUFFER",
+                       PMIX_DATA_BUFFER,
+                       pmix_bfrops_base_pack_dbuf,
+                       pmix_bfrops_base_unpack_dbuf,
+                       pmix_bfrops_base_copy_dbuf,
+                       pmix_bfrops_base_print_dbuf,
+                       &mca_bfrops_v401_component.types);
 
     return PMIX_SUCCESS;
 }
@@ -524,42 +540,42 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n=0; n < mca_bfrops_v4_component.types.size; n++) {
-        if (NULL != (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v4_component.types, n))) {
+    for (n=0; n < mca_bfrops_v401_component.types.size; n++) {
+        if (NULL != (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v401_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v4_component.types, n, NULL);
+            pmix_pointer_array_set_item(&mca_bfrops_v401_component.types, n, NULL);
         }
     }
 }
 
-static pmix_status_t pmix4_pack(pmix_buffer_t *buffer,
+static pmix_status_t pmix401_pack(pmix_buffer_t *buffer,
                                 const void *src, int num_vals,
                                 pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v4_component.types,
+    return pmix_bfrops_base_pack(&mca_bfrops_v401_component.types,
                                  buffer, src, num_vals, type);
 }
 
-static pmix_status_t pmix4_unpack(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t pmix401_unpack(pmix_buffer_t *buffer, void *dest,
                                   int32_t *num_vals, pmix_data_type_t type)
 {
      /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v4_component.types,
+    return pmix_bfrops_base_unpack(&mca_bfrops_v401_component.types,
                                    buffer, dest, num_vals, type);
 }
 
-static pmix_status_t pmix4_copy(void **dest, void *src,
+static pmix_status_t pmix401_copy(void **dest, void *src,
                                 pmix_data_type_t type)
 {
-    return pmix_bfrops_base_copy(&mca_bfrops_v4_component.types,
+    return pmix_bfrops_base_copy(&mca_bfrops_v401_component.types,
                                  dest, src, type);
 }
 
-static pmix_status_t pmix4_print(char **output, char *prefix,
+static pmix_status_t pmix401_print(char **output, char *prefix,
                                  void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_print(&mca_bfrops_v4_component.types,
+    return pmix_bfrops_base_print(&mca_bfrops_v401_component.types,
                                   output, prefix, src, type);
 }
 
@@ -572,20 +588,20 @@ static pmix_status_t register_type(const char *name, pmix_data_type_t type,
     PMIX_REGISTER_TYPE(name, type,
                        pack, unpack,
                        copy, print,
-                       &mca_bfrops_v4_component.types);
+                       &mca_bfrops_v401_component.types);
     return PMIX_SUCCESS;
 }
 
 static const char* data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v4_component.types, type);
+    return pmix_bfrops_base_data_type_string(&mca_bfrops_v401_component.types, type);
 }
 
 /*
  * INT16, INT32, INT64
  */
 static pmix_status_t
-pmix4_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
                                    pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type)
 {
@@ -635,7 +651,7 @@ pmix4_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
  * INT
  */
 static pmix_status_t
-pmix4_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
                            pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type)
 {
@@ -658,7 +674,7 @@ pmix4_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
  * SIZE_T
  */
 static pmix_status_t
-pmix4_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
                              pmix_buffer_t *buffer, const void *src,
                              int32_t num_vals, pmix_data_type_t type)
 {
@@ -680,7 +696,7 @@ pmix4_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
  * INT16, INT32, INT64
  */
 static pmix_status_t
-pmix4_bfrops_base_unpack_general_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_general_int(pmix_pointer_array_t *regtypes,
                                      pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type)
 {
@@ -738,7 +754,7 @@ pmix4_bfrops_base_unpack_general_int(pmix_pointer_array_t *regtypes,
  * INT
  */
 static pmix_status_t
-pmix4_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
                              pmix_buffer_t *buffer, void *dest,
                              int32_t *num_vals, pmix_data_type_t type)
 {
@@ -768,7 +784,7 @@ pmix4_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
  * SIZE_T
  */
 static pmix_status_t
-pmix4_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
+pmix401_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
                                pmix_buffer_t *buffer, void *dest,
                                int32_t *num_vals, pmix_data_type_t type)
 {

--- a/src/mca/bfrops/v401/bfrop_pmix401.h
+++ b/src/mca/bfrops/v401/bfrop_pmix401.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_BFROPS_PMIX401_H
+#define PMIX_BFROPS_PMIX401_H
+
+#include "src/mca/bfrops/bfrops.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+ PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v401_component;
+
+extern pmix_bfrops_module_t pmix_bfrops_pmix401_module;
+
+END_C_DECLS
+
+#endif /* PMIX_BFROPS_PMIX401_H */

--- a/src/mca/bfrops/v401/bfrop_pmix401_component.c
+++ b/src/mca/bfrops/v401/bfrop_pmix401_component.c
@@ -35,9 +35,9 @@
 #include "src/util/error.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/mca/bfrops/base/base.h"
-#include "bfrop_pmix4.h"
+#include "bfrop_pmix401.h"
 
-extern pmix_bfrops_module_t pmix_bfrops_pmix4_module;
+extern pmix_bfrops_module_t pmix_bfrops_pmix401_module;
 
 static pmix_status_t component_open(void);
 static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
@@ -48,12 +48,12 @@ static pmix_bfrops_module_t* assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v4_component = {
+pmix_bfrops_base_component_t mca_bfrops_v401_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
         /* Component name and version */
-        .pmix_mca_component_name = "v4",
+        .pmix_mca_component_name = "v401",
         PMIX_MCA_BASE_MAKE_VERSION(component, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
                                    PMIX_RELEASE_VERSION),
 
@@ -62,7 +62,7 @@ pmix_bfrops_base_component_t mca_bfrops_v4_component = {
         .pmix_mca_close_component = component_close,
         .pmix_mca_query_component = component_query,
     },
-    .priority = 50,
+    .priority = 55,
     .assign_module = assign_module
 };
 
@@ -70,8 +70,8 @@ pmix_bfrops_base_component_t mca_bfrops_v4_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v4_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v4_component.types, 42, INT_MAX, 16);
+    PMIX_CONSTRUCT(&mca_bfrops_v401_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&mca_bfrops_v401_component.types, 50, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -80,21 +80,21 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v4_component.priority;
-    *module = (pmix_mca_base_module_t *)&pmix_bfrops_pmix4_module;
+    *priority = mca_bfrops_v401_component.priority;
+    *module = (pmix_mca_base_module_t *)&pmix_bfrops_pmix401_module;
     return PMIX_SUCCESS;
 }
 
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v4_component.types);
+    PMIX_DESTRUCT(&mca_bfrops_v401_component.types);
     return PMIX_SUCCESS;
 }
 
 static pmix_bfrops_module_t* assign_module(void)
 {
     pmix_output_verbose(10, pmix_bfrops_base_framework.framework_output,
-                        "bfrops:pmix4 assigning module");
-    return &pmix_bfrops_pmix4_module;
+                        "bfrops:pmix401 assigning module");
+    return &pmix_bfrops_pmix401_module;
 }

--- a/src/mca/pcompress/base/help-pcompress.txt
+++ b/src/mca/pcompress/base/help-pcompress.txt
@@ -16,3 +16,6 @@ large data streams. This may result in longer-than-normal
 startup times and larger memory footprints. We will
 continue, but strongly recommend installing zlib or
 a comparable compression library for better user experience.
+
+You can set the MCA parameter "compress_base_silence_warning=1"
+to silence this warning in the future.

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -20,7 +20,8 @@
 #include "src/util/show_help.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pcompress/base/base.h"
-
+#include "src/mca/ptl/ptl_types.h"
+#include "src/include/pmix_globals.h"
 #include "src/mca/pcompress/base/static-components.h"
 
 /*
@@ -34,7 +35,7 @@ static bool compress_block(uint8_t *inblock, size_t size,
     (void)size;
     (void)outbytes;
     (void)nbytes;
-    if (!pmix_compress_base.silent) {
+    if (!PMIX_PROC_IS_CLIENT(&pmix_globals.mypeer->proc_type) && !pmix_compress_base.silent) {
         pmix_show_help("help-pcompress.txt", "unavailable", true);
         pmix_compress_base.silent = true;
     }
@@ -58,7 +59,7 @@ static bool compress_string(char *instring,
     (void)instring;
     (void)outbytes;
     (void)nbytes;
-    if (!pmix_compress_base.silent) {
+    if (!PMIX_PROC_IS_CLIENT(&pmix_globals.mypeer->proc_type) && !pmix_compress_base.silent) {
         pmix_show_help("help-pcompress.txt", "unavailable", true);
         pmix_compress_base.silent = true;
     }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -62,16 +62,16 @@ pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar)
 
     vrs = getenv("PMIX_VERSION");
 
-    if (0 == strcmp(evar, "PMIX_SERVER_URI41")) {
+    if (0 == strcmp(evar, "PMIX_SERVER_URI401")) {
         /* we are talking to a v4 server */
         PMIX_SET_PEER_TYPE(peer, PMIX_PROC_SERVER);
         PMIX_SET_PEER_VERSION(peer, vrs, 4, 0);
 
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "V41 SERVER DETECTED");
+                            "V401 SERVER DETECTED");
 
         /* must use the latest bfrops module */
-        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, NULL);
+        PMIX_BFROPS_SET_MODULE(rc, pmix_globals.mypeer, peer, "v401");
         return rc;
     }
 
@@ -135,8 +135,8 @@ pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **ev)
     char *evar;
     pmix_status_t rc;
 
-    if (NULL != (evar = getenv("PMIX_SERVER_URI41"))) {
-        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI41");
+    if (NULL != (evar = getenv("PMIX_SERVER_URI401"))) {
+        rc = pmix_ptl_base_set_peer(peer, "PMIX_SERVER_URI401");
         *ev = evar;
         return rc;
     }

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -471,7 +471,7 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    lt->varname = strdup("PMIX_SERVER_URI4:PMIX_SERVER_URI3:PMIX_SERVER_URI2:PMIX_SERVER_URI21");
+    lt->varname = strdup("PMIX_SERVER_URI401:PMIX_SERVER_URI4:PMIX_SERVER_URI3:PMIX_SERVER_URI2:PMIX_SERVER_URI21");
     lt->protocol = PMIX_PROTOCOL_V2;
     lt->cbfunc = pmix_ptl_base_connection_handler;
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -109,7 +109,6 @@ int pmix_rte_init(uint32_t type,
     char *error = NULL, *evar;
     size_t n, m;
     char hostname[PMIX_MAXHOSTNAMELEN] = {0};
-    char *gds = NULL;
     pmix_info_t *iptr;
     size_t minfo;
     bool keepfqdn = false;
@@ -302,8 +301,6 @@ int pmix_rte_init(uint32_t type,
                 if (PMIX_SUCCESS != ret) {
                     goto return_error;
                 }
-            } else if (PMIX_CHECK_KEY(&info[n], PMIX_GDS_MODULE)) {
-                gds = info[n].value.data.string;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_INFO_ARRAY)) {
                 /* contains info about our node */
                 iptr = (pmix_info_t*)info[n].value.data.darray->array;


### PR DESCRIPTION
Also restrict compression warning to non-clients

Signed-off-by: Ralph Castain <rhc@pmix.org>