### PR TITLE
Allow servers to receive IOF

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -255,6 +255,8 @@ static void iofreqcon(pmix_iof_req_t *p)
     p->nprocs = 0;
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
+    p->regcbfunc = NULL;
+    p->cbdata = NULL;
 }
 static void iofreqdes(pmix_iof_req_t *p)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -301,6 +301,7 @@ PMIX_CLASS_DECLARATION(pmix_peer_t);
 /* tracker for IOF requests */
 typedef struct {
     pmix_object_t super;
+    pmix_event_t ev;
     pmix_peer_t *requestor;
     size_t local_id;
     size_t remote_id;
@@ -308,6 +309,8 @@ typedef struct {
     size_t nprocs;
     pmix_iof_channel_t channels;
     pmix_iof_cbfunc_t cbfunc;
+    pmix_hdlr_reg_cbfunc_t regcbfunc;
+    void *cbdata;
 } pmix_iof_req_t;
 PMIX_CLASS_DECLARATION(pmix_iof_req_t);
 


### PR DESCRIPTION
Sometimes the server needs to receive IO forwarded by someone
else or even itself. Allow a server to register for IO, and
enable processes to send messages to themselves.

Signed-off-by: Ralph Castain <rhc@pmix.org>