### PR TITLE
Fix IOF dereg

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -243,17 +243,11 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
     /* if I am my own active server, then just register
      * the request */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         pmix_client_globals.myserver == pmix_globals.mypeer) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         req = PMIX_NEW(pmix_iof_req_t);
         if (NULL == req) {
             return PMIX_ERR_NOMEM;
@@ -279,6 +273,14 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         PMIX_THREADSHIFT(req, process_cache);
         return PMIX_OPERATION_SUCCEEDED;
     }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        PMIX_ERROR_LOG(PMIX_ERR_UNREACH);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* send this request to the server */
     cd = PMIX_NEW(pmix_shift_caddy_t);


### PR DESCRIPTION
Pass the correct cbdata to the server response function. Create
a separate response function just to keep things clearer. Init
server to point at itself as its own server.

Fixes https://github.com/openpmix/prrte/issues/744

Signed-off-by: Ralph Castain <rhc@pmix.org>