### PR TITLE
Fix fence timeout

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3274,7 +3274,6 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     PMIX_LIST_FOREACH_SAFE(cd, nxt, &tracker->local_cbs, pmix_server_caddy_t) {
         reply = PMIX_NEW(pmix_buffer_t);
         if (NULL == reply) {
-            rc = PMIX_ERR_NOMEM;
             break;
         }
         /* setup the reply, starting with the returned status */
@@ -3286,8 +3285,8 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         pmix_output_verbose(2, pmix_server_globals.base_output,
                             "server:modex_cbfunc reply being sent to %s:%u",
                             cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
-        PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
-        if (PMIX_SUCCESS != rc) {
+        PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
+        if (PMIX_SUCCESS != ret) {
             PMIX_RELEASE(reply);
         }
         /* remove this entry */

--- a/test/test_v2/server_callbacks.c
+++ b/test/test_v2/server_callbacks.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,8 +125,17 @@ pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
                char *data, size_t ndata,
                pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
+    size_t n;
+
     TEST_VERBOSE(("Getting data for %s:%d",
                   procs[0].nspace, procs[0].rank));
+
+    /* see if we are asked to do something we don't support */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+    }
 
     if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
         if (NULL != cbfunc) {


### PR DESCRIPTION
The PMIx library can only test timeout for local completion - we
cannot continue the timer once we pass the operation to the host
as we would have conflicting timers running. Correctly have the
tracker (and not the individual proc entry's) event carry the
timeout. Fix reuse of a status variable to ensure that all
participants receive the "timeout" status code.

Fixes #2096 

Signed-off-by: Ralph Castain <rhc@pmix.org>