### PR TITLE
fabric: squash uninitialized var warning

### DIFF
--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -350,7 +350,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric,
     pmix_status_t rc;
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FABRIC_UPDATE_CMD;
-    pmix_info_t info;
+    pmix_info_t info = {0};
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 


### PR DESCRIPTION
using gcc 9.1.0 got this error on a system supporting libfabric:

client/pmix_client_fabric.c: In function ‘PMIx_Fabric_update_nb’:
../include/pmix_common.h:3277:8: warning: ‘*((void *)&info+520).type’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3277 |     if (PMIX_STRING == (m)->type) {
      |        ^
client/pmix_client_fabric.c:353:17: note: ‘*((void *)&info+520).type’ was declared here
  353 |     pmix_info_t info;
      |                 ^~~~
In file included from /usr/projects/artab/users/hpp/ompi/3rd-party/openpmix/include/pmix.h:53,
                 from client/pmix_client_fabric.c:19:
../include/pmix_common.h:3278:12: warning: ‘*((void *)&info+520).data.string’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3278 |         if (NULL != (m)->data.string) {
      |            ^
client/pmix_client_fabric.c:353:17: note: ‘*((void *)&info+520).data.string’ was declared here
  353 |     pmix_info_t info;
      |                 ^~~~
In file included from /usr/projects/artab/users/hpp/ompi/3rd-party/openpmix/include/pmix.h:53,
                 from client/pmix_client_fabric.c:19:
../include/pmix_common.h:1856:12: warning: ‘*((void *)&info+520).data.envar.value’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1856 |         if (NULL != (m)->value) {      \
      |            ^
client/pmix_client_fabric.c:353:17: note: ‘*((void *)&info+520).data.envar.value’ was declared here
  353 |     pmix_info_t info;

this commit squashes that warning

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>