### PR TITLE
Improve compression warning and fix "connect" timeout

### DIFF
--- a/src/mca/pcompress/base/help-pcompress.txt
+++ b/src/mca/pcompress/base/help-pcompress.txt
@@ -16,3 +16,7 @@ large data streams. This may result in longer-than-normal
 startup times and larger memory footprints. We will
 continue, but strongly recommend installing zlib or
 a comparable compression library for better user experience.
+
+You can suppress this warning by adding "pcompress_base_silence_warning=1"
+to your PMIx MCA default parameter file, or by adding
+"PMIX_MCA_pcompress_base_silence_warning=1" to your environment.

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -17,10 +17,11 @@
 
 #include "pmix_config.h"
 
+#include "src/include/pmix_globals.h"
 #include "src/util/show_help.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pcompress/base/base.h"
-
+#include "src/mca/ptl/ptl_types.h"
 #include "src/mca/pcompress/base/static-components.h"
 
 /*
@@ -34,7 +35,7 @@ static bool compress_block(uint8_t *inblock, size_t size,
     (void)size;
     (void)outbytes;
     (void)nbytes;
-    if (!pmix_compress_base.silent) {
+    if (!pmix_compress_base.silent && !PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         pmix_show_help("help-pcompress.txt", "unavailable", true);
         pmix_compress_base.silent = true;
     }
@@ -58,7 +59,7 @@ static bool compress_string(char *instring,
     (void)instring;
     (void)outbytes;
     (void)nbytes;
-    if (!pmix_compress_base.silent) {
+    if (!pmix_compress_base.silent && !PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         pmix_show_help("help-pcompress.txt", "unavailable", true);
         pmix_compress_base.silent = true;
     }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1854,20 +1854,18 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd,
 
 static void connect_timeout(int sd, short args, void *cbdata)
 {
-    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+    pmix_server_trkr_t *trk = (pmix_server_trkr_t*)cbdata;
 
     pmix_output_verbose(2, pmix_server_globals.connect_output,
                         "ALERT: connect timeout fired");
 
     /* execute the provided callback function with the error */
-    if (NULL != cd->trk->op_cbfunc) {
-        cd->trk->op_cbfunc(PMIX_ERR_TIMEOUT, cd->trk);
+    if (NULL != trk->op_cbfunc) {
+        trk->op_cbfunc(PMIX_ERR_TIMEOUT, trk);
         return;  // the cbfunc will have cleaned up the tracker
     }
-    cd->event_active = false;
-    /* remove it from the list */
-    pmix_list_remove_item(&cd->trk->local_cbs, &cd->super);
-    PMIX_RELEASE(cd);
+    trk->event_active = false;
+    PMIX_RELEASE(trk);
 }
 
 pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
@@ -2016,9 +2014,8 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     /* if a timeout was specified, set it */
     if (PMIX_SUCCESS == rc && 0 < tv.tv_sec) {
         PMIX_RETAIN(trk);
-        cd->trk = trk;
-        PMIX_THREADSHIFT_DELAY(cd, connect_timeout, tv.tv_sec);
-        cd->event_active = true;
+        PMIX_THREADSHIFT_DELAY(trk, connect_timeout, tv.tv_sec);
+        trk->event_active = true;
     }
 
   cleanup:


### PR DESCRIPTION
Update the compression warning so it tells the user how to
turn it off, and ensure it only comes from non-clients. Correct
the "connect" code to use the operation tracker for timeoue.

Signed-off-by: Ralph Castain <rhc@pmix.org>