### PR TITLE
build: Fix maintainer-clean issue

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -53,7 +53,3 @@ EXTRA_DIST = \
 	mca_library_paths.txt \
     from-savannah/upstream-config.guess \
     from-savannah/upstream-config.sub
-
-
-maintainer-clean-local:
-	rm -f pmix_get_version.sh


### PR DESCRIPTION
Fix place where maintainer-clean was removing files that were
under git control.  I think this was cruft from when get_version
was more complicated and shared code with a macro callable from
configure.  But now that it's a git-tracked file, don't clean
it.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>