### PR TITLE
build: Allow autogen.pl to be run from a tarball

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -52,4 +52,6 @@ EXTRA_DIST = \
 	pmix_mca_priority_sort.pl \
 	mca_library_paths.txt \
     from-savannah/upstream-config.guess \
-    from-savannah/upstream-config.sub
+    from-savannah/upstream-config.sub \
+	ltmain_pgi_tp.diff \
+	ltmain_nag_pthread.diff


### PR DESCRIPTION
Add two files missing from dist tarballs which are needed for
autogen.pl to succeed when run in a dist tarball.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>