### PR TITLE
Enable singletons to connect to system servers

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -659,10 +659,9 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         /* if we didn't see a PMIx server (e.g., missing envar),
          * then allow us to run as a singleton */
         pid = getpid();
-        snprintf(pmix_globals.myid.nspace, PMIX_MAX_NSLEN, "singleton.%lu", (unsigned long)pid);
+        snprintf(pmix_globals.myid.nspace, PMIX_MAX_NSLEN, "singleton.%s.%lu",
+                 pmix_globals.hostname, (unsigned long)pid);
         pmix_globals.myid.rank = 0;
-        /* mark that we shouldn't connect to a server */
-        pmix_client_globals.singleton = true;
         if (NULL != proc) {
             PMIX_LOAD_PROCID(proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
         }
@@ -777,9 +776,11 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     }
     PMIX_INFO_DESTRUCT(&ginfo);
 
-    if (pmix_client_globals.singleton) {
-        pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
-        pmix_client_globals.myserver->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
+    /* attempt to connect to a server */
+    rc = pmix_ptl.connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
+    if (PMIX_SUCCESS != rc) {
+        /* mark that we couldn't connect to a server */
+        pmix_client_globals.singleton = true;
         /* initialize our data values */
         rc = pmix_tool_init_info();
         if (PMIX_SUCCESS != rc) {
@@ -788,15 +789,15 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
             return rc;
         }
         rc = PMIX_ERR_UNREACH;
-    } else {
-        /* connect to the server */
-        rc = pmix_ptl.connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
+    } else if (PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
+        /* we are a connected singleton */
+        rc = pmix_tool_init_info();
         if (PMIX_SUCCESS != rc) {
             pmix_init_result = rc;
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return rc;
         }
-
+    } else {
         /* send a request for our job info - we do this as a non-blocking
          * transaction because some systems cannot handle very large
          * blocking operations and error out if we try them. */

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -89,7 +89,7 @@ static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
 {
     (void)flags;
     pmix_compress_base.compress_limit = 4096;
-    (void) pmix_mca_base_var_register("pmix", "compress", "base", "limit",
+    (void) pmix_mca_base_var_register("pmix", "pcompress", "base", "limit",
                                       "Threshold beyond which data will be compressed",
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
                                       PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_3,
@@ -97,7 +97,7 @@ static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
                                       &pmix_compress_base.compress_limit);
 
     pmix_compress_base.silent = false;
-    (void) pmix_mca_base_var_register("pmix", "compress", "base", "silence_warning",
+    (void) pmix_mca_base_var_register("pmix", "pcompress", "base", "silence_warning",
                                       "Do not warn if compression unavailable",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                       PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_3,

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -41,6 +41,7 @@
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/ptl/ptl.h"
+#include "src/mca/ptl/base/ptl_base_handshake.h"
 
 
  BEGIN_C_DECLS
@@ -154,7 +155,7 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix,
                                                   int *sd, char **nspace,
                                                   pmix_rank_t *rank, char **uri,
                                                   pmix_peer_t *peer);
-PMIX_EXPORT uint8_t pmix_ptl_base_set_flag(size_t *sz);
+PMIX_EXPORT pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,
                                                         pmix_info_t *iptr, size_t niptr);
 PMIX_EXPORT void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace,
@@ -174,6 +175,7 @@ PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(char **orig_str, char *name);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
                                                         pmix_info_t *info, size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar);
+PMIX_EXPORT char *pmix_ptl_base_get_cmd_line(void);
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -59,7 +59,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     pmix_ptl_hdr_t hdr;
     pmix_peer_t *peer = NULL;
     pmix_status_t rc, reply;
-    char *msg = NULL, *mg, *p;
+    char *msg = NULL, *mg, *p, *blob=NULL;
     uint32_t u32;
     size_t cnt;
     pmix_namespace_t *nptr, *tmp;
@@ -121,14 +121,14 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     PMIX_PTL_GET_U8(pnd->flag);
 
     switch(pnd->flag) {
-        case 0:
+        case PMIX_SIMPLE_CLIENT:
             /* simple client process */
             PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_CLIENT);
             /* get their identifier */
             PMIX_PTL_GET_PROCID(pnd->proc);
             break;
 
-        case 1:
+        case PMIX_LEGACY_TOOL:
             /* legacy tool - may or may not have an identifier */
             PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_TOOL);
             /* get their uid/gid */
@@ -136,7 +136,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
             PMIX_PTL_GET_U32(pnd->gid);
             break;
 
-        case 2:
+        case PMIX_LEGACY_LAUNCHER:
             /* legacy launcher - may or may not have an identifier */
             PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_LAUNCHER);
             /* get their uid/gid */
@@ -144,8 +144,8 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
             PMIX_PTL_GET_U32(pnd->gid);
             break;
 
-        case 3:
-        case 6:
+        case PMIX_TOOL_NEEDS_ID:
+        case PMIX_LAUNCHER_NEEDS_ID:
             /* self-started tool/launcher process that needs an identifier */
             if (3 == pnd->flag) {
                 PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_TOOL);
@@ -159,8 +159,9 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
             pnd->need_id = true;
             break;
 
-        case 4:
-        case 7:
+        case PMIX_TOOL_GIVEN_ID:
+        case PMIX_LAUNCHER_GIVEN_ID:
+        case PMIX_SINGLETON_CLIENT:
             /* self-started tool/launcher process that was given an identifier by caller */
             if (4 == pnd->flag) {
                 PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_TOOL);
@@ -174,8 +175,8 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
             PMIX_PTL_GET_PROCID(pnd->proc);
             break;
 
-        case 5:
-        case 8:
+        case PMIX_TOOL_CLIENT:
+        case PMIX_LAUNCHER_CLIENT:
             /* tool/launcher that was started by a PMIx server - identifier specified by server */
             if (5 == pnd->flag) {
                 PMIX_SET_PROC_TYPE(&pnd->proc_type, PMIX_PROC_TOOL);
@@ -211,6 +212,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         pnd->bfrops = strdup("v20");
         pnd->buffer_type = pmix_bfrops_globals.default_type;  // we can't know any better
         pnd->gds = strdup("ds12,hash");
+        cnt = 0;
     } else {
         /* extract the name of the bfrops module they used */
         PMIX_PTL_GET_STRING(pnd->bfrops);
@@ -220,16 +222,24 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
 
         /* extract the name of the gds module they used */
         PMIX_PTL_GET_STRING(pnd->gds);
+
+        /* extract the blob */
+        if (0 < cnt) {
+            PMIX_PTL_GET_BLOB(blob, cnt);
+        }
     }
 
     /* see if this is a tool connection request */
-    if (0 != pnd->flag) {
+    if (PMIX_SIMPLE_CLIENT != pnd->flag) {
         /* nope, it's for a tool, so process it
          * separately - it is a 2-step procedure */
-        rc = process_tool_request(pnd, mg, cnt);
+        rc = process_tool_request(pnd, blob, cnt);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto error;
+        }
+        if (NULL != blob) {
+            free(blob);
         }
         return;
     }
@@ -492,7 +502,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
     /* if this tool wasn't initially registered as a client,
      * then add some required structures */
-    if (5 != pnd->flag && 8 != pnd->flag) {
+    if (PMIX_TOOL_CLIENT != pnd->flag && PMIX_LAUNCHER_CLIENT != pnd->flag) {
         PMIX_RETAIN(nptr);
         nptr->nspace = strdup(cd->proc.nspace);
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
@@ -658,7 +668,7 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     /* if this is a tool we launched, then the host may
      * have already registered it as a client - so check
      * to see if we already have a peer for it */
-    if (5 == pnd->flag || 8 == pnd->flag) {
+    if (PMIX_TOOL_CLIENT == pnd->flag || PMIX_LAUNCHER_CLIENT == pnd->flag) {
         /* registration only adds the nspace and a rank in that
          * nspace - it doesn't add the peer object to our array
          * of local clients. So let's start by searching for

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -41,6 +41,7 @@
 #include "src/include/pmix_socket_errno.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"
+#include "src/util/name_fns.h"
 #include "src/util/net.h"
 #include "src/util/os_path.h"
 #include "src/util/pif.h"
@@ -618,7 +619,8 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     reply = ntohl(u32);
 
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
         rc = pmix_ptl_base_client_handshake(peer, reply);
     } else {  // we are a tool
         rc = pmix_ptl_base_tool_handshake(peer, reply);
@@ -736,29 +738,19 @@ void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace,
     peer->send_ev_active = false;
 }
 
-uint8_t pmix_ptl_base_set_flag(size_t *sz)
+pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz)
 {
-    uint8_t flag;
+    pmix_rnd_flag_t flag;
     size_t sdsize = 0;
 
     /* Defined marker values:
      *
-     * 0 => simple client process
-     * 1 => legacy tool - may or may not have an identifier
-     * 2 => legacy launcher - may or may not have an identifier
-     * ------------------------------------------
-     * 3 => self-started tool process that needs an identifier
-     * 4 => self-started tool process that was given an identifier by caller
-     * 5 => tool that was started by a PMIx server - identifier specified by server
-     * 6 => self-started launcher that needs an identifier
-     * 7 => self-started launcher that was given an identifier by caller
-     * 8 => launcher that was started by a PMIx server - identifier specified by server
      */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
             /* if we are both launcher and client, then we need
              * to tell the server we are both */
-            flag = 8;
+            flag = PMIX_LAUNCHER_CLIENT;
             /* add space for our uid/gid for ACL purposes */
             sdsize += 2*sizeof(uint32_t);
             /* add space for our identifier */
@@ -769,37 +761,44 @@ uint8_t pmix_ptl_base_set_flag(size_t *sz)
             /* if they gave us an identifier, we need to pass it */
             if (0 < strlen(pmix_globals.myid.nspace) &&
                 PMIX_RANK_INVALID != pmix_globals.myid.rank) {
-                flag = 7;
+                flag = PMIX_LAUNCHER_GIVEN_ID;
                 sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
             } else {
-                flag = 6;
+                flag = PMIX_LAUNCHER_NEEDS_ID;
             }
         }
 
     } else if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
                !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-        /* we are a simple client */
-        flag = 0;
-        /* reserve space for our nspace and rank info */
-        sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-
+        if (PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
+            flag = PMIX_SINGLETON_CLIENT;
+            /* reserve space for our nspace and rank info */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            /* add space for our uid/gid for ACL purposes */
+            sdsize += 2*sizeof(uint32_t);
+        } else {
+            /* we are a simple client */
+            flag = PMIX_SIMPLE_CLIENT;
+            /* reserve space for our nspace and rank info */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+        }
     } else {  // must be a tool of some sort
         /* add space for our uid/gid for ACL purposes */
         sdsize += 2*sizeof(uint32_t);
         if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
             /* if we are both tool and client, then we need
              * to tell the server we are both */
-            flag = 5;
+            flag = PMIX_TOOL_CLIENT;
             /* add space for our identifier */
             sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
         } else if (0 < strlen(pmix_globals.myid.nspace) &&
             PMIX_RANK_INVALID != pmix_globals.myid.rank) {
             /* we were given an identifier by the caller, pass it */
             sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-            flag = 4;
+            flag = PMIX_TOOL_GIVEN_ID;
         } else {
             /* we are a self-started tool that needs an identifier */
-            flag = 3;
+            flag = PMIX_TOOL_NEEDS_ID;
         }
     }
 
@@ -829,6 +828,11 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
     hdr.pindex = -1;
     hdr.tag = UINT32_MAX;
 
+    /* add the name of our active sec module - we selected it
+     * in pmix_client.c prior to entering here */
+    sec = pmix_globals.mypeer->nptr->compat.psec->name;
+    sdsize += strlen(sec) + 1;
+
     /* a security module was assigned to us during rte_init based
      * on a list of available security modules provided by our
      * local PMIx server, if known. Now use that module to
@@ -841,32 +845,36 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
         PMIX_BYTE_OBJECT_DESTRUCT(&cred);
         return rc;
     }
+    sdsize += sizeof(uint32_t);  // need to pass the number of bytes
+    sdsize += cred.size;  // account for the payload itself
 
-    /* add the name of our active sec module - we selected it
-     * in pmix_client.c prior to entering here */
-    sec = pmix_globals.mypeer->nptr->compat.psec->name;
+    /* add our type flag */
+    sdsize += 1;
+
+    /* add our version string */
+    sdsize += strlen(PMIX_VERSION) + 1;
 
     /* add our active bfrops module name */
     bfrops = pmix_globals.mypeer->nptr->compat.bfrops->version;
+    sdsize += strlen(bfrops) + 1;
     /* and the type of buffer we are using */
     bftype = pmix_globals.mypeer->nptr->compat.type;
+    sdsize += sizeof(bftype);
 
     /* add our active gds module for working with the server */
     gds = (char*)peer->nptr->compat.gds->name;
+    sdsize += strlen(gds) + 1;
 
     /* if we were given info structs to pass to the server, pack them */
-    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
     if (NULL != iptr) {
+        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &niptr, 1, PMIX_SIZE);
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, iptr, niptr, PMIX_INFO);
+        sdsize += buf.bytes_used;
     }
 
-    /* set the number of bytes to be read beyond the header - must
-     * NULL terminate the strings! */
-    hdr.nbytes = sdsize + strlen(PMIX_VERSION) + 1 + strlen(sec) + 1 \
-                + strlen(bfrops) + 1 + sizeof(bftype) \
-                + strlen(gds) + 1 + sizeof(uint32_t) + cred.size \
-                + buf.bytes_used;
+    /* set the number of bytes to be read beyond the header */
+    hdr.nbytes = sdsize;
 
     /* create a space for our message */
     sdsize = sizeof(hdr) + hdr.nbytes;
@@ -898,7 +906,7 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
     PMIX_PTL_PUT_U8(peer->proc_type.flag);
 
     switch(peer->proc_type.flag) {
-        case 0:
+        case PMIX_SIMPLE_CLIENT:
             /* simple client process */
             PMIX_PTL_PUT_PROCID(pmix_globals.myid);
             break;
@@ -906,8 +914,8 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
         /* we cannot have cases 1 or 2 because those are only
          * for legacy processes */
 
-        case 3:
-        case 6:
+        case PMIX_TOOL_NEEDS_ID:
+        case PMIX_LAUNCHER_NEEDS_ID:
             /* self-started tool/launcher process that needs an identifier */
             euid = geteuid();
             PMIX_PTL_PUT_U32(euid);
@@ -915,9 +923,10 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
             PMIX_PTL_PUT_U32(egid);
             break;
 
-        case 4:
-        case 7:
-            /* self-started tool/launcher process that was given an identifier by caller */
+        case PMIX_TOOL_GIVEN_ID:
+        case PMIX_LAUNCHER_GIVEN_ID:
+        case PMIX_SINGLETON_CLIENT:
+            /* self-started tool/launcher/singleton process that was given an identifier by caller */
             euid = geteuid();
             PMIX_PTL_PUT_U32(euid);
             egid = getegid();
@@ -926,8 +935,8 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
             PMIX_PTL_PUT_PROCID(pmix_globals.myid);
             break;
 
-        case 5:
-        case 8:
+        case PMIX_TOOL_CLIENT:
+        case PMIX_LAUNCHER_CLIENT:
             /* tool/launcher that was started by a PMIx server - identifier specified by server */
             euid = geteuid();
             PMIX_PTL_PUT_U32(euid);
@@ -957,8 +966,10 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer,
     PMIX_PTL_PUT_STRING(gds);
 
     /* provide the info struct bytes */
-    PMIX_PTL_PUT_BLOB(buf.base_ptr, buf.bytes_used);
-    PMIX_DESTRUCT(&buf);
+    if (NULL != iptr) {
+        PMIX_PTL_PUT_BLOB(buf.base_ptr, buf.bytes_used);
+        PMIX_DESTRUCT(&buf);
+    }
 
     *msgout = msg;
     *sz = sdsize;
@@ -1051,7 +1062,7 @@ pmix_status_t pmix_ptl_base_tool_handshake(pmix_peer_t *peer, pmix_status_t rp)
     }
 
     /* if we need an identifier, it comes next */
-    if (3 == peer->proc_type.flag || 6 == peer->proc_type.flag) {
+    if (PMIX_TOOL_NEEDS_ID == peer->proc_type.flag || PMIX_LAUNCHER_NEEDS_ID == peer->proc_type.flag) {
         PMIX_PTL_RECV_NSPACE(peer->sd, pmix_globals.myid.nspace);
         PMIX_PTL_RECV_U32(peer->sd, pmix_globals.myid.rank);
     }

--- a/src/mca/ptl/base/ptl_base_handshake.h
+++ b/src/mca/ptl/base/ptl_base_handshake.h
@@ -31,6 +31,33 @@
 
 BEGIN_C_DECLS
 
+/* define flag values that indicate the type of process attempting
+ * to connect to a server:
+ * 0 => simple client process
+ * 1 => legacy tool - may or may not have an identifier
+ * 2 => legacy launcher - may or may not have an identifier
+ * ------------------------------------------
+ * 3 => self-started tool process that needs an identifier
+ * 4 => self-started tool process that was given an identifier by caller
+ * 5 => tool that was started by a PMIx server - identifier specified by server
+ * 6 => self-started launcher that needs an identifier
+ * 7 => self-started launcher that was given an identifier by caller
+ * 8 => launcher that was started by a PMIx server - identifier specified by server
+ * 9 => singleton client - treated like a tool that has an identifier
+ */
+typedef uint8_t pmix_rnd_flag_t;
+#define PMIX_SIMPLE_CLIENT      0
+#define PMIX_LEGACY_TOOL        1
+#define PMIX_LEGACY_LAUNCHER    2
+#define PMIX_TOOL_NEEDS_ID      3
+#define PMIX_TOOL_GIVEN_ID      4
+#define PMIX_TOOL_CLIENT        5
+#define PMIX_LAUNCHER_NEEDS_ID  6
+#define PMIX_LAUNCHER_GIVEN_ID  7
+#define PMIX_LAUNCHER_CLIENT    8
+#define PMIX_SINGLETON_CLIENT   9
+
+
 /* The following macros are used in the ptl_base_connection_hdlr.c
  * file to parse the handshake message and extract its fields */
 

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -55,6 +55,7 @@
 #include "src/class/pmix_list.h"
 #include "src/util/output.h"
 #include "src/mca/bfrops/bfrops_types.h"
+#include "src/mca/ptl/base/ptl_base_handshake.h"
 
 BEGIN_C_DECLS
 
@@ -91,6 +92,8 @@ typedef struct {
 #define PMIX_PROC_CLIENT            0x00000001      // simple client process
 #define PMIX_PROC_SERVER            0x00000002      // simple server process
 #define PMIX_PROC_TOOL              0x00000004      // simple tool
+#define PMIX_PROC_SINGLETON_ACT     0x00000008      // self-started client process
+#define PMIX_PROC_SINGLETON         (PMIX_PROC_CLIENT | PMIX_PROC_SINGLETON_ACT)
 #define PMIX_PROC_LAUNCHER_ACT      0x10000000      // process acting as launcher
 #define PMIX_PROC_LAUNCHER          (PMIX_PROC_TOOL | PMIX_PROC_SERVER | PMIX_PROC_LAUNCHER_ACT)
 #define PMIX_PROC_CLIENT_LAUNCHER   (PMIX_PROC_LAUNCHER | PMIX_PROC_CLIENT)
@@ -108,6 +111,7 @@ typedef struct {
 
 /* define some convenience macros for testing proc type */
 #define PMIX_PEER_IS_CLIENT(p)              (PMIX_PROC_CLIENT & (p)->proc_type.type)
+#define PMIX_PEER_IS_SINGLETON(p)           (PMIX_PROC_SINGLETON_ACT & (p)->proc_type.type)
 #define PMIX_PEER_IS_SERVER(p)              (PMIX_PROC_SERVER & (p)->proc_type.type)
 #define PMIX_PEER_IS_TOOL(p)                (PMIX_PROC_TOOL & (p)->proc_type.type)
 #define PMIX_PEER_IS_LAUNCHER(p)            (PMIX_PROC_LAUNCHER_ACT & (p)->proc_type.type)
@@ -301,7 +305,7 @@ typedef struct {
     pmix_listener_protocol_t protocol;
     int sd;
     bool need_id;
-    uint8_t flag;
+    pmix_rnd_flag_t flag;
     pmix_proc_t proc;
     pmix_info_t *info;
     size_t ninfo;

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -169,11 +169,11 @@ pmix_cmd_line_init_t cmd_line_opts[] = {
  * Once we have dealt with the returned data, we must
  * call the release_fn so that the PMIx library can
  * cleanup */
-static void cbfunc(pmix_status_t status,
-                   pmix_info_t *info, size_t ninfo,
-                   void *cbdata,
-                   pmix_release_cbfunc_t release_fn,
-                   void *release_cbdata)
+static void querycbfunc(pmix_status_t status,
+                        pmix_info_t *info, size_t ninfo,
+                        void *cbdata,
+                        pmix_release_cbfunc_t release_fn,
+                        void *release_cbdata)
 {
     myquery_data_t *mq = (myquery_data_t*)cbdata;
     size_t n;
@@ -354,7 +354,7 @@ main(int argc, char *argv[])
     myquery_data.ninfo = 0;
     /* execute the query */
     fprintf(stderr, "pps: querying nspaces\n");
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&myquery_data))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, querycbfunc, (void*)&myquery_data))) {
         fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
         goto done;
     }


### PR DESCRIPTION
Allow a singleton to act like a tool if a system server
is available. The singleton must pass authorization tests
as if it were a tool, including being approved by the
system server's host. This greatly simplifies singleton
comm_spawn and other dynamic operations in appropriate
environments (e.g., under PRRTE).

Signed-off-by: Ralph Castain <rhc@pmix.org>