### PR TITLE
Setup clients to output forwarded IO

### DIFF
--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -257,7 +257,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         }
     }
 
-    /* if I am a tool and not connected, then just fork/exec
+    /* if we are not connected, then just fork/exec
      * the specified application */
     if (forkexec) {
         rc = pmix_pfexec.spawn_job(job_info, ninfo,


### PR DESCRIPTION
If a client spawns another job, then IO from that
job will automatically be forwarded to the parent.
Be prepare to properly output it

Signed-off-by: Ralph Castain <rhc@pmix.org>