### PR TITLE
Set the default for enable-mca-dso

### DIFF
--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -62,7 +62,8 @@ AC_DEFUN([PMIX_MCA],[
                         type-component pairs that will be built as
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
-                        platform.]))
+                        platform.]),
+                        [], [enable_mca_dso=pcompress-zlib,ploc-hwloc,pnet-opa,pnet-sshot,prm])
     AC_ARG_ENABLE(mca-static,
         AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or


### PR DESCRIPTION
Some components should always be built as dso's to allow
for situations where the libs aren't present on the backend.
Default to supporting that situation, allowing a user to
override it if they want everything static.

Signed-off-by: Ralph Castain <rhc@pmix.org>