### PR TITLE
Tool finalize crash due to ref count issue

### DIFF
--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -1953,6 +1953,7 @@ static void retry_set(int sd, short args, void *cbdata)
 
     /* switch the active server - we are in an event, so
      * it is safe to do so */
+    PMIX_RETAIN(peer);
     pmix_client_globals.myserver = peer;
     pmix_globals.connected = true;
 


### PR DESCRIPTION
 * Found while debugging PRRTE's indirect.c
   - PMIx_tool_init followed by a PMIx_Spawn
   - PMIx_tool_set_server switches to the IL
   - PMIx_tool_finalize will crash when destructing the
     `pmix_globals.iof_requests` array because of a 0 ref count
     on the `p->requestor` pointer.
 * Determined that this is because when switching servers
   we do not PMIX_RETAIN the peer pointer that becomes `myserver`
   so it gets destructed in pmix_tool.c when it cleans up the
   `pmix_server_globals.clients` list before calling `pmix_rte_finalize`.
   - By retaining the object, it is then cleaned up properly in finalize.