### PR TITLE
Reject ambiguous connection options

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -107,15 +107,22 @@ typedef struct pmix_ptl_base_t pmix_ptl_base_t;
 
 PMIX_EXPORT extern pmix_ptl_base_t pmix_ptl_base;
 
+typedef struct {
+    pmix_list_item_t super;
+    int sd;
+    char *nspace;
+    pmix_rank_t rank;
+    char *uri;
+    char *version;
+} pmix_connection_t;
+PMIX_CLASS_DECLARATION(pmix_connection_t);
+
 /* API stubs */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *peer,
                                                         pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
-                                                       char **uri,
-                                                       char **nspace,
-                                                       pmix_rank_t *rank,
-                                                       pmix_peer_t *peer);
+                                                       pmix_list_t *connections);
 
 PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_connection(char *uri,
                                                          struct sockaddr_storage *connection,
@@ -152,9 +159,7 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri(const char *evar, char **nspac
                                                   pmix_rank_t *rank, char **suri);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix,
                                                   pmix_info_t info[], size_t ninfo,
-                                                  int *sd, char **nspace,
-                                                  pmix_rank_t *rank, char **uri,
-                                                  pmix_peer_t *peer);
+                                                  pmix_list_t *connections);
 PMIX_EXPORT pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,
                                                         pmix_info_t *iptr, size_t niptr);

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -111,3 +112,11 @@ The connection was rejected.
 [no-listeners]
 No sockets were able to be opened on the available protocols
 (IPv4 and/or IPv6). Please check your network and retry.
+#
+[too-many-conns]
+PMIx has found multiple possible servers to which it could
+connect. Further guidance is required to ensure the connection
+is made to a desirable server. Guidance can be in the form
+of the namespace or PID of a specific server, a directive to
+connect to a system server, a specific URI to use, or the name
+of a rendezvous file.

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -287,18 +287,19 @@ pmix_status_t pmix_ptl_base_parse_uri(const char *evar, char **nspace,
 }
 
 pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
-                                           char **uri,
-                                           char **nspace,
-                                           pmix_rank_t *rank,
-                                           pmix_peer_t *peer)
+                                           pmix_list_t *connections)
 {
     FILE *fp;
-    char *srvr, *p;
+    char *srvr, *p = NULL;
     pmix_lock_t lock;
     pmix_event_t ev;
     struct timeval tv;
     int retries;
     pmix_status_t rc;
+    pmix_connection_t *cn;
+    char *nspace = NULL;
+    pmix_rank_t rank;
+    char *uri = NULL;
 
      /* if we cannot open the file, then the server must not
      * be configured to support tool connections, or this
@@ -377,31 +378,39 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
         return PMIX_ERR_UNREACH;
     }
 
-    peer->protocol = PMIX_PROTOCOL_V2;
     /* see if this file contains the server's version */
     p = pmix_getline(fp);
-    PMIX_SET_PEER_VERSION(peer, p, 2, 0);
-    if (NULL != p) {
-        free(p);
-    }
     fclose(fp);
 
     /* parse the URI */
-    rc = pmix_ptl_base_parse_uri(srvr, nspace, rank, uri);
+    rc = pmix_ptl_base_parse_uri(srvr, &nspace, &rank, &uri);
     free(srvr);
-
+    if (PMIX_SUCCESS == rc) {
+        cn = PMIX_NEW(pmix_connection_t);
+        cn->nspace = nspace;
+        cn->rank = rank;
+        cn->uri = uri;
+        cn->version = p;
+        pmix_list_append(connections, &cn->super);
+    } else {
+        if (NULL != nspace) {
+            free(nspace);
+        }
+        if (NULL != uri) {
+            free(uri);
+        }
+        if (NULL != p) {
+            free(p);
+        }
+    }
     return rc;
 }
 
 pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix,
                                       pmix_info_t info[], size_t ninfo,
-                                      int *sd, char **nspace,
-                                      pmix_rank_t *rank, char **uri,
-                                      pmix_peer_t *peer)
+                                      pmix_list_t *connections)
 {
-    char *suri, *nsp, *newdir;
-    pmix_rank_t rk;
-    pmix_status_t rc;
+    char *newdir;
     struct stat buf;
     DIR *cur_dirp;
     struct dirent *dir_entry;
@@ -428,13 +437,9 @@ pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix,
         }
         /* if it is a directory, down search */
         if (S_ISDIR(buf.st_mode)) {
-            rc = pmix_ptl_base_df_search(newdir, prefix, info, ninfo,
-                                         sd, nspace, rank, uri, peer);
+            pmix_ptl_base_df_search(newdir, prefix, info, ninfo,
+                                    connections);
             free(newdir);
-            if (PMIX_SUCCESS == rc) {
-                closedir(cur_dirp);
-                return rc;
-            }
             continue;
         }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -444,28 +449,15 @@ pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix,
             /* try to read this file */
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "pmix:tool: reading file %s", newdir);
-            rc = pmix_ptl_base_parse_uri_file(newdir, &suri, &nsp, &rk, peer);
-            if (PMIX_SUCCESS == rc) {
-                /* go ahead and try to connect */
-                pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                    "pmix:tool: attempting to connect to %s", suri);
-                rc = pmix_ptl_base_make_connection(peer, suri, info, ninfo);
-                if (PMIX_SUCCESS == rc) {
-                    (*nspace) = nsp;
-                    *rank = rk;
-                    closedir(cur_dirp);
-                    *uri = suri;
-                    free(newdir);
-                    return PMIX_SUCCESS;
-                }
-                free(suri);
-                free(nsp);
-            }
+            pmix_ptl_base_parse_uri_file(newdir, connections);
         }
         free(newdir);
     }
     closedir(cur_dirp);
-    return PMIX_ERR_NOT_FOUND;
+    if (0 == pmix_list_get_size(connections)) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_ptl_base_setup_connection(char *uri,

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -507,3 +507,27 @@ static void qdes(pmix_ptl_queue_t *p)
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_queue_t,
                                 pmix_object_t,
                                 qcon, qdes);
+
+static void ccon(pmix_connection_t *p)
+{
+    p->sd = -1;
+    p->nspace = NULL;
+    p->rank = PMIX_RANK_INVALID;
+    p->uri = NULL;
+    p->version = NULL;
+}
+static void dcon(pmix_connection_t *p)
+{
+    if (NULL != p->nspace) {
+        free(p->nspace);
+    }
+    if (NULL != p->uri) {
+        free(p->uri);
+    }
+    if (NULL != p->version) {
+        free(p->version);
+    }
+}
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_connection_t,
+                                pmix_list_item_t,
+                                ccon, dcon);

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -540,7 +540,7 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         goto sockerror;
     }
 
-    rc = asprintf(&lt->uri, "%s.%d;%s%s:%d", pmix_globals.myid.nspace, pmix_globals.myid.rank, prefix, myconnhost, myport);
+    rc = asprintf(&lt->uri, "%s.%u;%s%s:%d", pmix_globals.myid.nspace, pmix_globals.myid.rank, prefix, myconnhost, myport);
     if (0 > rc || NULL == lt->uri) {
         goto sockerror;
     }


### PR DESCRIPTION
If a tool finds multiple servers that it could connect to, then it
shall return an error indicating that the user must provide more
information so a specific server can be selected. Otherwise, it can
be a somewhat random selection. Multiple connection files are permitted,
but we check to see if all point to the same server. If not, then
report the ambiguity and ask for clarification.

Fixes https://github.com/openpmix/prrte/issues/864

Signed-off-by: Ralph Castain <rhc@pmix.org>