### PR TITLE
Add a wildcard nspace definition

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,9 +36,9 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
-AlignOperands:   Align
+AlignOperands: true
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
+AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortEnumsOnASingleLine: true
@@ -98,16 +98,16 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
   - BOOST_FOREACH
-  - OPAL_LIST_FOREACH
-  - OPAL_LIST_FOREACH_DECL
-  - OPAL_LIST_FOREACH_SAFE
-  - OPAL_LIST_FOREACH_REV
-  - OPAL_LIST_FOREACH_SAFE_REV
-  - OPAL_HASH_TABLE_FOREACH
-  - OPAL_HASH_TABLE_FOREACH_PTR
+  - PMIX_LIST_FOREACH
+  - PMIX_LIST_FOREACH_DECL
+  - PMIX_LIST_FOREACH_SAFE
+  - PMIX_LIST_FOREACH_REV
+  - PMIX_LIST_FOREACH_SAFE_REV
+  - PMIX_HASH_TABLE_FOREACH
+  - PMIX_HASH_TABLE_FOREACH_PTR
 IncludeBlocks:   Preserve
 IncludeCategories:
-  # Ensure config includes always come first (opal_config.h, ompi_config.h, etc)
+  # Ensure config includes always come first (pmix_config.h, etc)
   - Regex:           '^".*_config\.h"'
     Priority:        -1
   # In-tree includes come next (after main include)
@@ -138,8 +138,8 @@ ObjCBlockIndentWidth: 4
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 301
-PenaltyBreakBeforeFirstCallParameter: 300
+PenaltyBreakAssignment: 250
+PenaltyBreakBeforeFirstCallParameter: 301
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
@@ -184,5 +184,4 @@ WhitespaceSensitiveMacros:
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
 ...
-
 

--- a/contrib/clang-format-pmix.sh
+++ b/contrib/clang-format-pmix.sh
@@ -2,7 +2,7 @@
 
 echo "Running clang-format on code base..."
 
-files=($(git ls-tree -r master --name-only | grep -v 'contrib' | grep -e '.*\.[ch]$'))
+files=($(git ls-tree -r master --name-only | grep -v -E 'contrib/' | grep -e '.*\.[ch]$' ))
 
 for file in "${files[@]}" ; do
     if test "$1" = "-d" ; then
@@ -13,4 +13,3 @@ for file in "${files[@]}" ; do
 done
 
 echo "Done"
-

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -92,6 +92,9 @@ typedef char pmix_key_t[PMIX_MAX_KEYLEN+1];
 /* define a type for rank values */
 typedef uint32_t pmix_rank_t;
 
+/* point to a wildcared nspace that must be defined in the implementation */
+PMIX_EXPORT extern pmix_nspace_t pmix_nspace_wildcard;
+
 /* define a value for requests for job-level data
  * where the info itself isn't associated with any
  * specific rank, or when a request involves
@@ -1470,7 +1473,8 @@ static inline void* pmix_calloc(size_t n, size_t m)
 
 /* define a convenience macro for checking nspaces */
 #define PMIX_CHECK_NSPACE(a, b) \
-    (PMIX_NSPACE_INVALID((a)) || PMIX_NSPACE_INVALID((b)) || 0 == strncmp((a), (b), PMIX_MAX_NSLEN))
+    (!PMIX_NSPACE_INVALID((a)) && !PMIX_NSPACE_INVALID((b)) && \
+    (PMIX_NSPACE_WILDCARD((a)) || PMIX_NSPACE_WILDCARD((b)) || 0 == strncmp((a), (b), PMIX_MAX_NSLEN)))
 
 /* define a convenience macro for loading names */
 #define PMIX_LOAD_PROCID(a, b, c)               \
@@ -1491,6 +1495,9 @@ static inline void* pmix_calloc(size_t n, size_t m)
 
 #define PMIX_NSPACE_INVALID(a) \
     (NULL == (a) || 0 == strlen((a)))
+
+#define PMIX_NSPACE_WILDCARD(a) \
+    (0 == strncmp((a), pmix_nspace_wildcard, PMIX_MAX_NSLEN))
 
 #define PMIX_PROCID_INVALID(a)  \
     (PMIX_NSPACE_INVALID((a)->nspace) || PMIX_RANK_INVALID == (a)->rank)

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -55,6 +55,8 @@
 #include "src/util/argv.h"
 #include "src/util/os_path.h"
 
+pmix_nspace_t pmix_nspace_wildcard;
+
 static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd,
                             pmix_epilog_t *epi);
 static bool dirpath_is_empty(const char *path);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -132,6 +132,12 @@ int pmix_rte_init(uint32_t type,
 
     pmix_init_called = true;
 
+    /* init the wildcard nspace */
+    for (n=0; n < PMIX_MAX_NSLEN; n++) {
+        pmix_nspace_wildcard[n] = '*';
+    }
+    pmix_nspace_wildcard[PMIX_MAX_NSLEN-1] = '\0';
+
     /* initialize the output system */
     if (!pmix_output_init()) {
         return PMIX_ERROR;


### PR DESCRIPTION
We were using an empty pmix_nspace_t as "invalid" and "wildcard".
However, this can lead to confusion between nspace objects that
haven't yet been defined and those situations when we really
do want to check against all nspaces. So define a "wildcard" to
be a pmix_nspace_t that has nothing but '*' characters in it
(retaining the NULL to end the string).

Signed-off-by: Ralph Castain <rhc@pmix.org>