### PR TITLE
Ignore PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER status in PMIx_IOF_deregister callback

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
@@ -58,7 +58,13 @@ static void msgcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer
     m = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &m, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
-        status = rc;
+        /* Ignore short buffer/premature connection disconnect */
+        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+            status = PMIX_SUCCESS;
+        }
+        else {
+            status = rc;
+        }
     }
     if (NULL != cd->iofreq) {
         pmix_output_verbose(2, pmix_client_globals.iof_output,


### PR DESCRIPTION
The processing callback called as part of PMIx_IOF_deregister processing intermittently returns PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER as completion status.

This seems to be caused by PMIx_IOF_deregister being called as PMIx processes are shutting down, resulting in partial or invalid buffers passed to the callback. When PMIX_BFROPS_UNPACK tries to unpack the buffer, this status is the result.

This change forces the returned status to PMIX_SUCCESS in this case.

There is a second problem that occurs when I run the PRRTE attach testcase, where the PMIx_IOF_deregister callback is intermittently returning an invalid status. The status is an apparently random number that is not a valid error status.

I think that there is a path thru the buffer unpack code where an error occurs but an uninitialized return code is incorrectly returned. I tried running the attach example with valgrind and that did not find anything.

This fixes issue #2121
Signed-off-by: David Wootton <dwootton@us.ibm.com>