### PR TITLE
psec: include missing psec.h

### DIFF
--- a/src/mca/psec/munge/psec_munge.h
+++ b/src/mca/psec/munge/psec_munge.h
@@ -15,6 +15,7 @@
 BEGIN_C_DECLS
 
 #include "src/include/pmix_config.h"
+#include "src/mca/psec/psec.h"
 
 /* the component must be visible data for the linker to find it */
 PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_munge_component;


### PR DESCRIPTION
Fixes compile error:

	In file included from psec_munge_component.c:33:
	psec_munge.h:20:20: error: unknown type name
	âpmix_psec_base_component_tâ
	   20 | PMIX_EXPORT extern pmix_psec_base_component_t
	mca_psec_munge_component;
	      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~