### PR TITLE
ptl: help on too-many-conns: mention conn handle files

### DIFF
--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -120,3 +120,6 @@ is made to a desirable server. Guidance can be in the form
 of the namespace or PID of a specific server, a directive to
 connect to a system server, a specific URI to use, or the name
 of a rendezvous file.
+
+Some connection handles have been read from files named pmix.*
+in subdirectories of $TMPDIR; delete them if they are stale.


### PR DESCRIPTION
Otherwise, it can be mysterious why prun/pterm report this error,
when the user certainly has only one DVM running.

I haven't checked if saying `$TMPDIR` is accurate; perhaps it should say just `/tmp`.

Presumably garbage is left only in case of unclean shutdown (segfault, etc), but it happens.

```
$ prte  --report-pid $PWD/dvm.pid &
$ prun -n 2 hostname
--------------------------------------------------------------------------
PMIx has found multiple possible servers to which it could
connect. Further guidance is required to ensure the connection
is made to a desirable server. Guidance can be in the form
of the namespace or PID of a specific server, a directive to
connect to a system server, a specific URI to use, or the name
of a rendezvous file.
--------------------------------------------------------------------------
```

```
$ find /tmp/ -name 'pmix*' 2>/dev/null
/tmp/prte.batch4.16380/dvm.58675/pmix.batch4.tool.prte-batch4-58675@0
/tmp/prte.batch4.16380/dvm.58675/pmix.batch4.tool.58675
...

$ find /tmp -name 'pmix*' -delete 2>/dev/null
```
Then the error is gone.