### PR TITLE
Some mods/cleanup of debugger definitions and handling

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
      * directive is provided so that something like an MPI implementation
      * can do some initial setup in MPI_Init prior to pausing for the
      * debugger */
-    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_WAIT_FOR_NOTIFY, NULL, 0, &val))) {
+    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_STOP_IN_APP, NULL, 0, &val))) {
         /* register for debugger release */
         DEBUG_CONSTRUCT_LOCK(&mylock);
         PMIX_INFO_CREATE(info, 1);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -684,9 +684,16 @@ typedef uint32_t pmix_rank_t;
 
 
 /* debugger attributes */
-#define PMIX_DEBUG_STOP_ON_EXEC             "pmix.dbg.exec"         // (bool) job is being spawned under debugger - instruct it to pause on start
-#define PMIX_DEBUG_STOP_IN_INIT             "pmix.dbg.init"         // (bool) instruct job to stop during PMIx init
-#define PMIX_DEBUG_WAIT_FOR_NOTIFY          "pmix.dbg.notify"       // (bool) block at desired point until receiving debugger release notification
+#define PMIX_DEBUG_STOP_ON_EXEC             "pmix.dbg.exec"         // (pmix_rank_t) stop specified rank(s) on exec and notify ready-to-debug
+                                                                    //        Can be a pmix_data_array_t if an array of individual processes are
+                                                                    //        specified
+#define PMIX_DEBUG_STOP_IN_INIT             "pmix.dbg.init"         // (pmix_rank_t) stop specified rank(s) in PMIx_Init and notify ready-to-debug
+                                                                    //        Can be a pmix_data_array_t if an array of individual processes are
+                                                                    //        specified
+#define PMIX_DEBUG_STOP_IN_APP              "pmix.dbg.notify"       // (pmix_rank_t) direct specified ranks to stop at application-specific point and
+                                                                    //        notify ready-to-debug. Can be a pmix_data_array_t if an array of individual
+                                                                    //        processes are specified
+#define PMIX_BREAKPOINT                     "pmix.brkpnt"           // (char*) string ID of the breakpoint where the process(es) is(are) waiting
 #define PMIX_DEBUG_TARGET                   "pmix.dbg.tgt"          // (pmix_proc_t*) Identifier of proc(s) to be debugged
 #define PMIX_DEBUG_DAEMONS_PER_PROC         "pmix.dbg.dpproc"       // (uint16_t) Number of debugger daemons to be spawned per application
                                                                     //        process. The launcher is to pass the identifier of the namespace to
@@ -1164,7 +1171,7 @@ typedef int pmix_status_t;
 
 /* Debugger ops */
 #define PMIX_DEBUGGER_RELEASE                       -3      // replaced deprecated PMIX_ERR_DEBUGGER_RELEASE
-#define PMIX_DEBUG_WAITING_FOR_NOTIFY               -58
+#define PMIX_READY_FOR_DEBUG                        -58     // accompanied by PMIX_BREAKPOINT indicating where proc is waiting
 
 /* query errors */
 #define PMIX_QUERY_PARTIAL_SUCCESS                  -104

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -100,6 +100,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 #define PMIX_ERR_INVALID_NAMESPACE                  -44
 #define PMIX_ERR_SERVER_NOT_AVAIL                   -45
 #define PMIX_ERR_NOT_IMPLEMENTED                    -48
+#define PMIX_DEBUG_WAITING_FOR_NOTIFY               -58
 #define PMIX_ERR_LOST_CONNECTION_TO_SERVER          -101
 #define PMIX_ERR_LOST_PEER_CONNECTION               -102
 #define PMIX_ERR_LOST_CONNECTION_TO_CLIENT          -103

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -825,32 +825,37 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
     wildcard.rank = PMIX_RANK_WILDCARD;
     PMIX_INFO_LOAD(&ginfo, PMIX_OPTIONAL, NULL, PMIX_BOOL);
     if (PMIX_SUCCESS == PMIx_Get(&wildcard, PMIX_DEBUG_STOP_IN_INIT, &ginfo, 1, &val)) {
+        /* are we one of the procs to stop? */
+        if (PMIX_CHECK_RANK(val->data.rank, pmix_globals.myid.rank)) {
+            /* if the value was found, then we need to wait for debugger attach here */
+            /* register for the debugger release notification */
+            PMIX_CONSTRUCT_LOCK(&reglock);
+            PMIX_CONSTRUCT_LOCK(&releaselock);
+            PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
+            PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-DEBUGGER", PMIX_STRING);
+            pmix_output_verbose(2, pmix_client_globals.event_output,
+                                "[%s:%d] REGISTERING WAIT FOR DEBUGGER", pmix_globals.myid.nspace,
+                                pmix_globals.myid.rank);
+            code = PMIX_DEBUGGER_RELEASE;
+            PMIx_Register_event_handler(&code, 1, evinfo, 2, notification_fn, evhandler_reg_callbk,
+                                        (void *) &reglock);
+            /* wait for registration to complete */
+            PMIX_WAIT_THREAD(&reglock);
+            PMIX_DESTRUCT_LOCK(&reglock);
+            PMIX_INFO_DESTRUCT(&evinfo[0]);
+            PMIX_INFO_DESTRUCT(&evinfo[1]);
+            /* notify the host that we are waiting */
+            PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+            PMIX_INFO_LOAD(&evinfo[1], PMIX_BREAKPOINT, "pmix-init", PMIX_STRING);
+            PMIx_Notify_event(PMIX_READY_FOR_DEBUG, &pmix_globals.myid, PMIX_RANGE_RM,
+                              evinfo, 2, NULL, NULL);
+            PMIX_INFO_DESTRUCT(&evinfo[0]);
+            PMIX_INFO_DESTRUCT(&evinfo[1]);
+            /* wait for release to arrive */
+            PMIX_WAIT_THREAD(&releaselock);
+            PMIX_DESTRUCT_LOCK(&releaselock);
+        }
         PMIX_VALUE_FREE(val, 1); // cleanup memory
-        /* if the value was found, then we need to wait for debugger attach here */
-        /* register for the debugger release notification */
-        PMIX_CONSTRUCT_LOCK(&reglock);
-        PMIX_CONSTRUCT_LOCK(&releaselock);
-        PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
-        PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-DEBUGGER", PMIX_STRING);
-        pmix_output_verbose(2, pmix_client_globals.event_output,
-                            "[%s:%d] REGISTERING WAIT FOR DEBUGGER", pmix_globals.myid.nspace,
-                            pmix_globals.myid.rank);
-        code = PMIX_DEBUGGER_RELEASE;
-        PMIx_Register_event_handler(&code, 1, evinfo, 2, notification_fn, evhandler_reg_callbk,
-                                    (void *) &reglock);
-        /* wait for registration to complete */
-        PMIX_WAIT_THREAD(&reglock);
-        PMIX_DESTRUCT_LOCK(&reglock);
-        PMIX_INFO_DESTRUCT(&evinfo[0]);
-        PMIX_INFO_DESTRUCT(&evinfo[1]);
-        /* notify the host that we are waiting */
-        PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIx_Notify_event(PMIX_DEBUG_WAITING_FOR_NOTIFY, &pmix_globals.myid, PMIX_RANGE_RM,
-                          &evinfo[0], 1, NULL, NULL);
-        PMIX_INFO_DESTRUCT(&evinfo[0]);
-        /* wait for release to arrive */
-        PMIX_WAIT_THREAD(&releaselock);
-        PMIX_DESTRUCT_LOCK(&releaselock);
     }
     PMIX_INFO_DESTRUCT(&ginfo);
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1189,6 +1189,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                 /* mark that we sent it upstairs so we don't release
                  * the caddy until we return from the host RM */
                 holdcd = true;
+                pmix_output(0, "SERVER UPCALLING %s FOR SOURCE %s.%lu", PMIx_Error_string(cd->status), cd->source.nspace, cd->source.rank);
                 pmix_host_server.notify_event(cd->status, &cd->source, cd->range, cd->info,
                                               cd->ninfo, local_cbfunc, cd);
             }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -465,6 +465,14 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
                 flags |= PMIX_HASH_NUM_NODES;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_MAX_PROCS)) {
                 flags |= PMIX_HASH_MAX_PROCS;
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_ON_EXEC)
+                       || PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_IN_INIT)
+                       || PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_IN_APP)) {
+                if (PMIX_RANK_WILDCARD == info[n].value.data.rank) {
+                    nptr->num_waiting = nptr->nlocalprocs;
+                } else {
+                    nptr->num_waiting = 1;
+                }
             }
         }
     }

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -412,6 +412,15 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
                 trk->nptr->nprocs = iptr[j].value.data.uint32;
                 *flags |= PMIX_HASH_JOB_SIZE;
             }
+            if (PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_ON_EXEC)
+                || PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_INIT)
+                || PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_APP)) {
+                if (PMIX_RANK_WILDCARD == iptr[j].value.data.rank) {
+                    trk->nptr->num_waiting = trk->nptr->nlocalprocs;
+                } else {
+                    trk->nptr->num_waiting = 1;
+                }
+            }
         }
     }
     return PMIX_SUCCESS;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -285,15 +285,12 @@ static void debugger_aggregator(size_t evhdlr_registration_id, pmix_status_t sta
     }
 
     /* track the number of waiting-for-notify alerts we get */
-    nptr->num_waiting++;
+    nptr->num_waiting--;
 
-    /* if one local proc called us, then we assume all must - this
-     * is probably not a fully accurate assumption, but the best
-     * we can do at the moment */
-    if (nptr->num_waiting == nptr->nlocalprocs) {
+    if (nptr->num_waiting <= 0) {
         PMIX_LOAD_PROCID(&proc, source->nspace, PMIX_RANK_LOCAL_PEERS);
         /* pass an event to our host */
-        rc = pmix_prm.notify(status, &proc, PMIX_RANGE_RM, NULL, 0, NULL, NULL);
+        rc = pmix_prm.notify(status, &proc, PMIX_RANGE_RM, info, ninfo, NULL, NULL);
         if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
             PMIX_ERROR_LOG(rc);
         }

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -48,8 +48,8 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
 
     case PMIX_DEBUGGER_RELEASE:
         return "DEBUGGER-RELEASE";
-    case PMIX_DEBUG_WAITING_FOR_NOTIFY:
-        return "DEBUG-WAITING-FOR-NOTIFY";
+    case PMIX_READY_FOR_DEBUG:
+        return "READY-FOR-DEBUG";
 
     case PMIX_ERR_PROC_RESTART:
         return "PROC_RESTART";


### PR DESCRIPTION
The host/debugger needs a way to communicate which ranks are to
be debugged - eg., which are to be stopped on exec. We had been
assuming that it would be all of them as that is the typical
case, but that isn't a restriction. Modify the debugger attrs
to pass a rank (or an array of ranks) instead of just "bool".
Allow the app to indicate where they are stopped, should they
choose to do so. Replace `WAIT_FOR_NOTIFY` with `READY_FOR_DEBUG`
as release by notification is probably the least-used use-case.

Signed-off-by: Ralph Castain <rhc@pmix.org>