### PR TITLE
Fix some minor errors

### DIFF
--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Redistribution and use in source and binary forms, with or without
@@ -805,7 +806,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_deliver_inventory(pmix_info_t info[], size
                                                         pmix_info_t directives[], size_t ndirs,
                                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-\
+
 /******      ATTRIBUTE REGISTRATION      ******/
 /**
  * This function is used by the host environment to register with its

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -574,6 +574,9 @@ static pmix_status_t get_data(const char *key, const pmix_info_t info[], size_t 
         cb->key = strdup(key);
     }
     cb->proc = &lg->p;
+    cb->scope = lg->scope;
+    cb->info = (pmix_info_t*)info;
+    cb->ninfo = ninfo;
 
     PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
     if (PMIX_SUCCESS == rc) {
@@ -625,7 +628,7 @@ static pmix_status_t get_data(const char *key, const pmix_info_t info[], size_t 
             || !PMIX_CHECK_NSPACE(lg->p.nspace, pmix_globals.myid.nspace)) {
             /* flag that we want all of the job-level info */
             proc.rank = PMIX_RANK_WILDCARD;
-        } else if (NULL != cb->key) {
+        } else if (NULL != cb->key && !PMIX_CHECK_KEY(cb, PMIX_GROUP_CONTEXT_ID)) {
             /* this is a reserved key - we should have had this info, so
              * respond with the error - if they want us to check with the
              * server, they should ask us to refresh the cache */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -938,11 +938,15 @@ static void _register_nspace(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     pmix_namespace_t *nptr, *tmp;
     pmix_status_t rc;
-    size_t i;
+    size_t i, m, ninfo;
+    pmix_info_t *iptr;
     bool all_def;
     pmix_server_trkr_t *trk;
     pmix_namespace_t *ns;
     pmix_trkr_caddy_t *tcd;
+    pmix_gds_base_module_t *gds;
+    pmix_kval_t *kv;
+    pmix_proc_t proc;
 
     PMIX_ACQUIRE_OBJECT(caddy);
 
@@ -965,6 +969,31 @@ static void _register_nspace(int sd, short args, void *cbdata)
         }
         nptr->nspace = strdup(cd->proc.nspace);
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+    }
+    if (0 > cd->nlocalprocs) {
+        gds = nptr->compat.gds;
+        /* this is just an update */
+        for (i=0; i < cd->ninfo; i++) {
+            if (PMIX_CHECK_KEY(&cd->info[i], PMIX_PROC_DATA)) {
+                iptr = (pmix_info_t*)cd->info[i].value.data.darray->array;
+                ninfo = cd->info[i].value.data.darray->size;
+                /* the first position is the rank */
+                PMIX_LOAD_PROCID(&proc, cd->proc.nspace, iptr[0].value.data.rank);
+                /* get the peer object for this rank */
+                for (m=1; m < ninfo; m++) {
+                    PMIX_KVAL_NEW(kv, iptr[m].key);
+                    PMIX_VALUE_XFER(rc, kv->value, &iptr[m].value);
+                    gds->store(&proc, PMIX_REMOTE, kv);
+                    PMIX_RELEASE(kv); // maintain refcount
+                }
+            } else if (PMIX_CHECK_KEY(&cd->info[i], PMIX_GROUP_CONTEXT_ID)) {
+                PMIX_KVAL_NEW(kv, cd->info[i].key);
+                PMIX_VALUE_XFER(rc, kv->value, &cd->info[i].value);
+                gds->store(&proc, PMIX_GLOBAL, kv);
+                PMIX_RELEASE(kv); // maintain refcount
+            }
+        }
+        goto release;
     }
     nptr->nlocalprocs = cd->nlocalprocs;
 


### PR DESCRIPTION
Ensure we pass the desired scope on a PMIx_Get call.
Don't reinitialize nspace object on multiple calls to
PMIx_server_register_nspace
Allow the client to go up to the server when looking
for a newly assigned context ID

Signed-off-by: Ralph Castain <rhc@pmix.org>