### PR TITLE
Fix some minor errors

### DIFF
--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Redistribution and use in source and binary forms, with or without
@@ -805,7 +806,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_deliver_inventory(pmix_info_t info[], size
                                                         pmix_info_t directives[], size_t ndirs,
                                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-\
+
 /******      ATTRIBUTE REGISTRATION      ******/
 /**
  * This function is used by the host environment to register with its

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -801,6 +801,8 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                                         "pmix:client old server - fetching data");
                     proc.rank = PMIX_RANK_WILDCARD;
                     goto request;
+                } else if (PMIX_CHECK_KEY(cb, PMIX_GROUP_CONTEXT_ID)) {
+                    goto request;
                 }
                 /* we should have had this info, so respond with the error - if
                  * they want us to check with the server, they should ask us to


### PR DESCRIPTION
Ensure we pass the desired scope on a PMIx_Get call.
Don't reinitialize nspace object on multiple calls to
PMIx_server_register_nspace
Allow the client to go up to the server when looking
for a newly assigned context ID

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 705ece510a2551bcca53ae2ef3a7721789daac78)