### PR TITLE
atomics: Fix broken make dist

### DIFF
--- a/src/atomics/sys/Makefile.include
+++ b/src/atomics/sys/Makefile.include
@@ -29,5 +29,5 @@
 
 headers += \
 	atomics/sys/atomic.h \
-	atomics/sys/atomic_stdc.h
+	atomics/sys/atomic_stdc.h \
 	atomics/sys/atomic_gcc_builtin.h


### PR DESCRIPTION
A missing \ resulted in the gcc_builtins atomic file not ending
up in the tarball.  Ooops.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>