### PR TITLE
atomics: Fix broken make dist

### DIFF
--- a/src/atomics/sys/Makefile.include
+++ b/src/atomics/sys/Makefile.include
@@ -29,5 +29,5 @@
 
 headers += \
 	atomics/sys/atomic.h \
-	atomics/sys/atomic_stdc.h
+	atomics/sys/atomic_stdc.h \
 	atomics/sys/atomic_gcc_builtin.h


### PR DESCRIPTION
A missing \ resulted in the gcc_builtins atomic file not ending
up in the tarball.  Ooops.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 4f400a89b071c26064f530570c8227a943c9432b)