### PR TITLE
Add missing datatype support in darray macros

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3357,23 +3357,32 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         if (0 < (n)) {                                              \
             if (PMIX_INFO == (t)) {                                 \
                 PMIX_INFO_CREATE((m)->array, (n));                  \
+                                                                    \
             } else if (PMIX_PROC == (t)) {                          \
                 PMIX_PROC_CREATE((m)->array, (n));                  \
+                                                                    \
             } else if (PMIX_PROC_INFO == (t)) {                     \
                 PMIX_PROC_INFO_CREATE((m)->array, (n));             \
+                                                                    \
             } else if (PMIX_ENVAR == (t)) {                         \
                 PMIX_ENVAR_CREATE((m)->array, (n));                 \
+                                                                    \
             } else if (PMIX_VALUE == (t)) {                         \
                 PMIX_VALUE_CREATE((m)->array, (n));                 \
+                                                                    \
             } else if (PMIX_PDATA == (t)) {                         \
                 PMIX_PDATA_CREATE((m)->array, (n));                 \
+                                                                    \
             } else if (PMIX_QUERY == (t)) {                         \
                 PMIX_QUERY_CREATE((m)->array, (n));                 \
+                                                                    \
             } else if (PMIX_APP == (t)) {                           \
                 PMIX_APP_CREATE((m)->array, (n));                   \
+                                                                    \
             } else if (PMIX_BYTE_OBJECT == (t) ||                   \
                        PMIX_COMPRESSED_STRING == (t)) {             \
                 PMIX_BYTE_OBJECT_CREATE((m)->array, (n));           \
+                                                                    \
             } else if (PMIX_ALLOC_DIRECTIVE == (t) ||               \
                        PMIX_PROC_STATE == (t) ||                    \
                        PMIX_PERSIST == (t) ||                       \
@@ -3384,45 +3393,93 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
                        PMIX_UINT8 == (t) ||                         \
                        PMIX_POINTER == (t)) {                       \
                 (m)->array = pmix_calloc((n), sizeof(int8_t));           \
+                                                                    \
             } else if (PMIX_STRING == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(char*));            \
+                                                                    \
             } else if (PMIX_SIZE == (t)) {                          \
                 (m)->array = pmix_calloc((n), sizeof(size_t));           \
+                                                                    \
             } else if (PMIX_PID == (t)) {                           \
                 (m)->array = pmix_calloc((n), sizeof(pid_t));            \
+                                                                    \
             } else if (PMIX_INT == (t) ||                           \
                        PMIX_UINT == (t) ||                          \
                        PMIX_STATUS == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(int));              \
+                                                                    \
             } else if (PMIX_IOF_CHANNEL == (t) ||                   \
                        PMIX_DATA_TYPE == (t) ||                     \
                        PMIX_INT16 == (t) ||                         \
                        PMIX_UINT16 == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(int16_t));          \
+                                                                    \
             } else if (PMIX_PROC_RANK == (t) ||                     \
                        PMIX_INFO_DIRECTIVES == (t) ||               \
                        PMIX_INT32 == (t) ||                         \
                        PMIX_UINT32 == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(int32_t));          \
+                                                                    \
             } else if (PMIX_INT64 == (t) ||                         \
                        PMIX_UINT64 == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(int64_t));          \
+                                                                    \
             } else if (PMIX_FLOAT == (t)) {                         \
                 (m)->array = pmix_calloc((n), sizeof(float));            \
+                                                                    \
             } else if (PMIX_DOUBLE == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(double));           \
+                                                                    \
             } else if (PMIX_TIMEVAL == (t)) {                       \
                 (m)->array = pmix_calloc((n), sizeof(struct timeval));   \
+                                                                    \
             } else if (PMIX_TIME == (t)) {                          \
                 (m)->array = pmix_calloc((n), sizeof(time_t));           \
+                                                                    \
             } else if (PMIX_REGATTR == (t)) {                       \
                 PMIX_REGATTR_CREATE((m)->array, (n));               \
+                                                                    \
             } else if (PMIX_BOOL == (t)) {                          \
                 (m)->array = pmix_calloc((n), sizeof(bool));             \
+                                                                    \
             } else if (PMIX_COORD == (t)) {                         \
-                (m)->array = pmix_calloc((n), sizeof(pmix_coord_t));     \
+                (m)->array = pmix_calloc((n), sizeof(pmix_coord_t));  \
+                                                                    \
             } else if (PMIX_LINK_STATE == (t)) {                    \
                 (m)->array = pmix_calloc((n), sizeof(pmix_link_state_t));  \
+                                                                    \
+            } else if (PMIX_ENDPOINT == (t)) {                         \
+                PMIX_ENDPOINT_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_PROC_NSPACE == (t)) {                         \
+                (m)->array = pmix_calloc((n), sizeof(pmix_nspace_t));     \
+                                                                    \
+            } else if (PMIX_PROC_STATS == (t)) {                         \
+                PMIX_PROC_STATS_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_DISK_STATS == (t)) {                         \
+                PMIX_DISK_STATS_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_NET_STATS == (t)) {                         \
+                PMIX_NET_STATS_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_NODE_STATS == (t)) {                         \
+                PMIX_NODE_STATS_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_DEVICE_DIST == (t)) {                         \
+                PMIX_DEVICE_DIST_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_GEOMETRY == (t)) {                         \
+                PMIX_GEOMETRY_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_REGATTR == (t)) {                         \
+                PMIX_REGATTR_CREATE((m)->array, n);                   \
+                                                                    \
+            } else if (PMIX_PROC_CPUSET == (t)) {                         \
+                PMIX_CPUSET_CREATE((m)->array, n);                   \
+            } else {                                                \
+                (m)->array = NULL;                                  \
+                (m)->size = 0;                                      \
             }                                                       \
         } else {                                                    \
             (m)->array = NULL;                                      \

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1313,6 +1313,7 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmi
     int32_t i, n, m;
     pmix_status_t ret;
     pmix_data_type_t t;
+    size_t sm;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d data arrays", *num_vals);
@@ -1342,13 +1343,14 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmi
             continue;
         }
         /* allocate storage for the array and unpack the array elements */
-        m = ptr[i].size;
+        sm = ptr[i].size;
         t = ptr[i].type;
 
-        PMIX_DATA_ARRAY_CONSTRUCT(&ptr[i], m, t);
+        PMIX_DATA_ARRAY_CONSTRUCT(&ptr[i], sm, t);
         if (NULL == ptr[i].array) {
             return PMIX_ERR_NOMEM;
         }
+        m = sm;
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].array, &m, t, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;


### PR DESCRIPTION
We were missing support for a number of datatypes in the
PMIX_DATA_ARRAY_CONSTRUCT macro and in the darray copy function.
They were present at one time - not sure what happened to them.

Fixes #2159 
Fixes #2160 

Signed-off-by: Ralph Castain <rhc@pmix.org>