### PR TITLE
Fix typo

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1745,7 +1745,7 @@ pmix_status_t pmix_bfrops_base_unpack_geometry(pmix_pointer_array_t *regtypes,
             ptr[i].coordinates = (pmix_coord_t *) calloc(ptr[i].ncoords, sizeof(pmix_coord_t));
             /* unpack them */
             m = ptr[i].ncoords;
-            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].coordinates, &m, PMIX_COORD, regtypes);
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coordinates, &m, PMIX_COORD, regtypes);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 return ret;


### PR DESCRIPTION
Pass the array and not the address of the array when
unpacking the coordinates in a pmix_geometry_t

Fixes #2162 

Signed-off-by: Ralph Castain <rhc@pmix.org>