### PR TITLE
Remove stale envar settings in hwloc support

### DIFF
--- a/src/mca/ploc/hwloc/ploc_hwloc.c
+++ b/src/mca/ploc/hwloc/ploc_hwloc.c
@@ -739,12 +739,6 @@ sharetopo:
     PMIX_VALUE_LOAD(kv->value, &shmemsize, PMIX_SIZE);
     pmix_list_append(&pmix_server_globals.gdata, &kv->super);
 
-    /* and add them to the global cache of envars as well */
-    pmix_setenv("PMIX_HWLOC_SHMEM_FILE", shmemfile, true, &pmix_server_globals.genvars);
-    pmix_asprintf(&tmp, "%" PRIsize_t, shmemaddr);
-    pmix_setenv("PMIX_HWLOC_SHMEM_ADDR", tmp, true, &pmix_server_globals.genvars);
-    pmix_asprintf(&tmp, "%" PRIsize_t, shmemsize);
-    pmix_setenv("PMIX_HWLOC_SHMEM_SIZE", tmp, true, &pmix_server_globals.genvars);
 #endif
 
     return PMIX_SUCCESS;


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>