### PR TITLE
Do not include curl and jansson support unless requested

### DIFF
--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -34,7 +34,8 @@ AC_DEFUN([PMIX_CHECK_CURL],[
     PMIX_VAR_SCOPE_PUSH(pmix_check_curl_save_CPPFLAGS pmix_check_curl_save_LDFLAGS pmix_check_curl_save_LIBS)
 	AC_ARG_WITH([curl],
 		    [AS_HELP_STRING([--with-curl(=DIR)],
-				    [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+				    [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
+            [], [with_curl=no])
 
     AC_ARG_WITH([curl-libdir],
             [AS_HELP_STRING([--with-curl-libdir=DIR],

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -34,7 +34,8 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
     PMIX_VAR_SCOPE_PUSH(pmix_check_jansson_save_CPPFLAGS pmix_check_jansson_save_LDFLAGS pmix_check_jansson_save_LIBS)
 	AC_ARG_WITH([jansson],
 		    [AS_HELP_STRING([--with-jansson(=DIR)],
-				    [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+				    [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
+            [], [with_jansson=no])
 
     AC_ARG_WITH([jansson-libdir],
             [AS_HELP_STRING([--with-jansson-libdir=DIR],


### PR DESCRIPTION
Even if the libs are in standard locations, do not install
this support unless asked to do so. It is mainly targeting
future components.

Signed-off-by: Ralph Castain <rhc@pmix.org>