### PR TITLE
Register ompi5 and ompi4 as aliases for ompi plugin

### DIFF
--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -388,6 +388,16 @@ static inline int pmix_next_poweroftwo(int value)
          PMIX_SUCCESS                                 \
          == pmix_hash_table_get_next_key_##type(ht, &key, (void **) &value, _nptr, &_nptr);)
 
+#define PMIX_HASH_TABLE_FOREACH_PTR(key, value, ht, body)                                       \
+    {                                                                                           \
+        size_t key_size_;                                                                       \
+        for (void *_nptr = NULL;                                                                \
+            PMIX_SUCCESS                                                                        \
+            == pmix_hash_table_get_next_key_ptr(ht, &key, &key_size_, (void **) &value, _nptr,  \
+                                                &_nptr);)                                       \
+            body                                                                                \
+    }
+
 END_C_DECLS
 
 #endif /* PMIX_HASH_TABLE_H */

--- a/src/mca/base/Makefile.am
+++ b/src/mca/base/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,7 +38,8 @@ headers = \
         pmix_mca_base_var_enum.h \
         pmix_mca_base_var_group.h \
         pmix_mca_base_vari.h \
-        pmix_mca_base_framework.h
+        pmix_mca_base_framework.h \
+        pmix_mca_base_alias.h
 
 # Library
 
@@ -58,7 +60,8 @@ libpmix_mca_base_la_SOURCES = \
         pmix_mca_base_var_group.c \
         pmix_mca_base_parse_paramfile.c \
         pmix_mca_base_components_register.c \
-        pmix_mca_base_framework.c
+        pmix_mca_base_framework.c \
+        pmix_mca_base_alias.c
 
 # Conditionally install the header files
 

--- a/src/mca/base/pmix_mca_base_alias.c
+++ b/src/mca/base/pmix_mca_base_alias.c
@@ -1,0 +1,191 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+#include <string.h>
+
+#include "include/pmix_common.h"
+#include "src/class/pmix_hash_table.h"
+#include "src/mca/base/pmix_mca_base_alias.h"
+
+static void pmix_mca_base_alias_init(pmix_mca_base_alias_t *alias)
+{
+    PMIX_CONSTRUCT(&alias->component_aliases, pmix_list_t);
+}
+
+static void pmix_mca_base_alias_fini(pmix_mca_base_alias_t *alias)
+{
+    PMIX_LIST_DESTRUCT(&alias->component_aliases);
+}
+
+PMIX_CLASS_INSTANCE(pmix_mca_base_alias_t, pmix_object_t, pmix_mca_base_alias_init,
+                    pmix_mca_base_alias_fini);
+
+static void pmix_mca_base_alias_item_init(pmix_mca_base_alias_item_t *alias_item)
+{
+    alias_item->component_alias = NULL;
+}
+
+static void pmix_mca_base_alias_item_fini(pmix_mca_base_alias_item_t *alias_item)
+{
+    free(alias_item->component_alias);
+}
+
+PMIX_CLASS_INSTANCE(pmix_mca_base_alias_item_t, pmix_list_item_t, pmix_mca_base_alias_item_init,
+                    pmix_mca_base_alias_item_fini);
+
+/*
+ * local variables
+ */
+static pmix_hash_table_t *alias_hash_table;
+
+void pmix_mca_base_alias_cleanup(void)
+{
+    if (!alias_hash_table) {
+        return;
+    }
+
+    void *key;
+    pmix_object_t *value;
+    PMIX_HASH_TABLE_FOREACH_PTR(key, value, alias_hash_table, { PMIX_RELEASE(value); });
+
+    PMIX_RELEASE(alias_hash_table);
+    alias_hash_table = NULL;
+}
+
+static int pmix_mca_base_alias_setup(void)
+{
+    if (NULL != alias_hash_table) {
+        return PMIX_SUCCESS;
+    }
+
+    alias_hash_table = PMIX_NEW(pmix_hash_table_t);
+    if (NULL == alias_hash_table) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    int ret = pmix_hash_table_init(alias_hash_table, 32);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_RELEASE(alias_hash_table);
+        alias_hash_table = NULL;
+        return ret;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static char *pmix_mca_base_alias_generate_name(const char *project, const char *framework,
+                                               const char *component_name)
+{
+    size_t project_length = project ? strlen(project) : 0;
+    size_t framework_length = framework ? strlen(framework) : 0;
+    size_t component_name_length = strlen(component_name);
+    size_t length = project_length + framework_length + component_name_length + 2;
+    char *tmp = calloc(1, length + 1);
+    if (NULL == tmp) {
+        return tmp;
+    }
+
+    if (project_length) {
+        strncat(tmp, project, length);
+        // NOTE: We use strcat() here (and not strncat()) because
+        // we're appending a constant string with a fixed/hard-coded
+        // length.  It's the exact equivalent of strncat(tmp, "_", 1),
+        // but strncat() would actually be more overhead.  Indeed, GCC
+        // 10 emits a warning if we use strncatd() with a compile-time
+        // constant string as the source and a hard-coded length that
+        // is equivalent to the length of that compile-time constant
+        // string.  So avoid the warning and use strcat().
+        strcat(tmp, "_");
+        length -= project_length + 1;
+    }
+
+    if (framework_length) {
+        strncat(tmp, framework, length);
+        // Use strcat() here instead of strncat(); see the comment
+        // above for an explanation.
+        strcat(tmp, "_");
+        length -= framework_length + 1;
+    }
+
+    strncat(tmp, component_name, length);
+
+    return tmp;
+}
+
+static pmix_mca_base_alias_t *pmix_mca_base_alias_lookup_internal(const char *name)
+{
+    pmix_mca_base_alias_t *alias = NULL;
+    if (NULL == alias_hash_table) {
+        return NULL;
+    }
+
+    (void) pmix_hash_table_get_value_ptr(alias_hash_table, name, strlen(name), (void **) &alias);
+    return alias;
+}
+
+int pmix_mca_base_alias_register(const char *project, const char *framework,
+                                 const char *component_name, const char *component_alias,
+                                 uint32_t alias_flags)
+{
+    if (NULL == component_name) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    int ret = pmix_mca_base_alias_setup();
+    if (PMIX_SUCCESS != ret) {
+        return ret;
+    }
+
+    char *name = pmix_mca_base_alias_generate_name(project, framework, component_name);
+    assert(NULL != name);
+
+    pmix_mca_base_alias_t *alias = pmix_mca_base_alias_lookup_internal(name);
+    if (NULL == alias) {
+        alias = PMIX_NEW(pmix_mca_base_alias_t);
+        if (NULL == alias) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+
+        pmix_hash_table_set_value_ptr(alias_hash_table, name, strlen(name), alias);
+        free(name);
+        name = NULL;
+    }
+
+    pmix_mca_base_alias_item_t *alias_item = PMIX_NEW(pmix_mca_base_alias_item_t);
+    if (NULL == alias_item) {
+        if (NULL != name)
+            free(name);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    alias_item->component_alias = strdup(component_alias);
+    alias_item->alias_flags = alias_flags;
+
+    pmix_list_append(&alias->component_aliases, &alias_item->super);
+
+    return PMIX_SUCCESS;
+}
+
+const pmix_mca_base_alias_t *pmix_mca_base_alias_lookup(const char *project, const char *framework,
+                                                        const char *component_name)
+{
+    if (NULL == component_name) {
+        return NULL;
+    }
+
+    char *name = pmix_mca_base_alias_generate_name(project, framework, component_name);
+    assert(NULL != name);
+    const pmix_mca_base_alias_t *alias = pmix_mca_base_alias_lookup_internal(name);
+    free(name);
+
+    return alias;
+}

--- a/src/mca/base/pmix_mca_base_alias.h
+++ b/src/mca/base/pmix_mca_base_alias.h
@@ -1,0 +1,87 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_MCA_BASE_ALIAS_H
+#define PMIX_MCA_BASE_ALIAS_H
+
+#include "pmix_config.h"
+#include "src/class/pmix_list.h"
+
+BEGIN_C_DECLS
+
+enum pmix_mca_base_alias_flags_t {
+    PMIX_MCA_BASE_ALIAS_FLAG_NONE = 0,
+    /** The aliased name has been deprecated. */
+    PMIX_MCA_BASE_ALIAS_FLAG_DEPRECATED = 1,
+};
+
+typedef enum pmix_mca_base_alias_flags_t pmix_mca_base_alias_flags_t;
+
+struct pmix_mca_base_alias_item_t {
+    pmix_list_item_t super;
+    /** Name aias. */
+    char *component_alias;
+    /** Alias flags. */
+    uint32_t alias_flags;
+};
+
+typedef struct pmix_mca_base_alias_item_t pmix_mca_base_alias_item_t;
+
+PMIX_CLASS_DECLARATION(pmix_mca_base_alias_item_t);
+
+struct pmix_mca_base_alias_t {
+    pmix_object_t super;
+    /** List of name aliases. */
+    pmix_list_t component_aliases;
+};
+
+typedef struct pmix_mca_base_alias_t pmix_mca_base_alias_t;
+
+PMIX_CLASS_DECLARATION(pmix_mca_base_alias_t);
+
+/**
+ * @brief Create a alias for a component name.
+ *
+ * @param[in] project         Project name (may be NULL)
+ * @param[in] framework       Framework name (may be NULL)
+ * @param[in] component_name  Name of component to alias (may not be NULL)
+ * @param[in] component_alias Aliased name (may not be NULL)
+ * @param[in] alias_flags     Flags (see mca_base_alias_flags_t)
+ *
+ * This function aliases one component name to another. When aliased
+ * any variable registered with this project, framework, and
+ * component_name will have synonyms created. For example, if
+ * pmix_btl_vader is aliased to sm then registers a variable
+ * named btl_vader_flags then a synonym will be created with the
+ * name btl_sm_flags. If an alias is registered early enough
+ * (during framework registration for example) then the alias can
+ * also be used for component selection. In the previous example
+ * --mca btl vader and --mca btl sm would select the same
+ * component if the synonym is registered in the btl framework
+ * registration function.
+ */
+PMIX_EXPORT int pmix_mca_base_alias_register(const char *project, const char *framework,
+                                             const char *component_name,
+                                             const char *component_alias, uint32_t alias_flags);
+
+/**
+ * @brief Check for aliases for a component.
+ *
+ * @param[in] project        Project name (may be NULL)
+ * @param[in] frameworek     Framework name (may be NULL)
+ * @param[in] component_name Component name (may not be NULL)
+ */
+PMIX_EXPORT const pmix_mca_base_alias_t *
+pmix_mca_base_alias_lookup(const char *project, const char *framework, const char *component_name);
+
+PMIX_EXPORT void pmix_mca_base_alias_cleanup(void);
+
+#endif /* PMIX_MCA_BASE_ALIAS_H */


### PR DESCRIPTION
We unified the "ompix" plugins to be simply "ompi" as they
wound up being duplicative. However, as they were previously
included in at least one release and people might have set
MCA params accordingly, alias the two prior plugin names
to the new one. Port the MCA aliasing code to support it

Signed-off-by: Ralph Castain <rhc@pmix.org>