### PR TITLE
Silence some gcc11 warnings

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -130,7 +130,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const pmix_key_t key, pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
@@ -201,7 +201,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
  *     an error. The timeout parameter can help avoid "hangs" due to programming
  *     errors that prevent the target proc from ever exposing its data.
  */
-PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_value_t **val);
 
@@ -209,7 +209,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key
  * be executed once the specified data has been _PMIx_Put_
  * by the identified process and retrieved by the local server. The info
  * array is used as described above for the blocking form of this call. */
-PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t key,
+PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
                                       const pmix_info_t info[], size_t ninfo,
                                       pmix_value_cbfunc_t cbfunc, void *cbdata);
 
@@ -1141,7 +1141,7 @@ PMIX_EXPORT const char* PMIx_Get_version(void);
  * proc. This is data that has only internal scope - it will
  * never be "pushed" externally */
 PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                              const pmix_key_t key, pmix_value_t *val);
+                                              const char key[], pmix_value_t *val);
 
 
 /******    DATA BUFFER PACK/UNPACK SUPPORT    ******/

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3541,6 +3541,23 @@ static inline void pmix_strncpy(char *dest,
     *dest = '\0';
 }
 
+static inline size_t pmix_keylen(const char *src)
+{
+    size_t i;
+
+    if (NULL == src) {
+        return 0;
+    }
+    /* use an algorithm that also protects against
+     * non-NULL-terminated src strings */
+    for (i=0; i < PMIX_MAX_KEYLEN; ++i, ++src) {
+        if ('\0' == *src) {
+            break;
+        }
+    }
+    return i;
+}
+
 #include <pmix_extend.h>
 #include <pmix_deprecated.h>
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1205,7 +1205,7 @@ done:
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const pmix_key_t key, pmix_value_t *val)
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
@@ -1219,6 +1219,10 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const pmix_key_t key, pmi
         return PMIX_ERR_INIT;
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     /* create a callback object */
     cb = PMIX_NEW(pmix_cb_t);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -73,7 +73,7 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata);
 
 static pmix_status_t process_values(pmix_value_t **v, pmix_cb_t *cb);
 
-static pmix_status_t process_request(const pmix_proc_t *proc, const pmix_key_t key,
+static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
                                      const pmix_info_t info[], size_t ninfo, pmix_get_logic_t *lg,
                                      pmix_value_t **val)
 {
@@ -194,7 +194,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const pmix_key_t k
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
                                    const pmix_info_t info[], size_t ninfo, pmix_value_t **val)
 {
     pmix_cb_t *cb;
@@ -212,6 +212,10 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key
     pmix_output_verbose(2, pmix_client_globals.get_output, "pmix:client get for %s key %s",
                         (NULL == proc) ? "NULL" : PMIX_NAME_PRINT(proc),
                         (NULL == key) ? "NULL" : key);
+
+    if (NULL != key && PMIX_MAX_KEYLEN < pmix_keylen(key)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     lg = PMIX_NEW(pmix_get_logic_t);
     rc = process_request(proc, key, info, ninfo, lg, val);
@@ -293,6 +297,10 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t 
 
     if (NULL == cbfunc) {
         /* no way to return the result! */
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (NULL != key && PMIX_MAX_KEYLEN < pmix_keylen(key)) {
         return PMIX_ERR_BAD_PARAM;
     }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2218,7 +2218,7 @@ static void _store_internal(int sd, short args, void *cbdata)
     }
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const pmix_key_t key,
+PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const char key[],
                                               pmix_value_t *val)
 {
     pmix_shift_caddy_t *cd;
@@ -2230,6 +2230,10 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const pmi
         return PMIX_ERR_INIT;
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     /* setup to thread shift this request */
     cd = PMIX_NEW(pmix_shift_caddy_t);
@@ -2244,7 +2248,7 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const pmi
         PMIX_RELEASE(cd);
         return PMIX_ERR_NOMEM;
     }
-    cd->kv->key = strdup((char *) key);
+    cd->kv->key = strdup(key);
     cd->kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
     PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, cd->kv->value, val);
     if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
It's a subtle point, but gcc11's warnings of potential
string overflows are technically valid. If someone were
to pass a string longer than PMIX_MAX_KEYLEN to one of
the four functions that took a pmix_key_t argument, then
that argument would overflow and impact the surrounding
memory. So go back to the v3.0 function prototypes as
they are technically safer.

Signed-off-by: Ralph Castain <rhc@pmix.org>