### PR TITLE
Protect against bad nspace input

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1506,7 +1506,7 @@ static inline void* pmix_calloc(size_t n, size_t m)
     ((a) == (b) || (PMIX_RANK_WILDCARD == (a) || PMIX_RANK_WILDCARD == (b)))
 
 #define PMIX_NSPACE_INVALID(a) \
-    (NULL == (a) || 0 == strlen((a)))
+    (NULL == (a) || 0 == pmix_nslen((a)))
 
 #define PMIX_PROCID_INVALID(a)  \
     (PMIX_NSPACE_INVALID((a)->nspace) || PMIX_RANK_INVALID == (a)->rank)
@@ -1975,11 +1975,11 @@ typedef struct pmix_proc {
     do {                                                                    \
         size_t _len;                                                        \
         memset((t), 0, PMIX_MAX_NSLEN+1);                                   \
-        _len = strlen((c));                                                 \
-        if ((_len + strlen((n))) < PMIX_MAX_NSLEN) {                        \
-            pmix_strncpy((char*)(t), (c), PMIX_MAX_NSLEN);                         \
+        _len = pmix_nslen((c));                                             \
+        if ((_len + pmix_nslen((n))) < PMIX_MAX_NSLEN) {                    \
+            pmix_strncpy((char*)(t), (c), PMIX_MAX_NSLEN);                  \
             (t)[_len] = ':';                                                \
-            pmix_strncpy((char*)&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);         \
+            pmix_strncpy((char*)&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);  \
         }                                                                   \
     } while(0)
 
@@ -3543,14 +3543,33 @@ static inline void pmix_strncpy(char *dest,
 
 static inline size_t pmix_keylen(const char *src)
 {
-    size_t i;
+    size_t i, maxlen;
 
     if (NULL == src) {
         return 0;
     }
+    maxlen = PMIX_MAX_KEYLEN + 1;
     /* use an algorithm that also protects against
      * non-NULL-terminated src strings */
-    for (i=0; i < PMIX_MAX_KEYLEN; ++i, ++src) {
+    for (i=0; i < maxlen; ++i, ++src) {
+        if ('\0' == *src) {
+            break;
+        }
+    }
+    return i;
+}
+
+static inline size_t pmix_nslen(const char *src)
+{
+    size_t i, maxlen;
+
+    if (NULL == src) {
+        return 0;
+    }
+    maxlen = PMIX_MAX_NSLEN + 1;
+    /* use an algorithm that also protects against
+     * non-NULL-terminated src strings */
+    for (i=0; i < maxlen; ++i, ++src) {
         if ('\0' == *src) {
             break;
         }

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1442,7 +1442,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
         ninfo = 2;
     }
 
-    if (NULL == nspace || 0 == strlen(nspace)) {
+    if (NULL == nspace || 0 == pmix_nslen(nspace)) {
         rc = PMIX_ERR_NOT_FOUND;
         np = 0;
         /* cycle across all known nspaces and aggregate the results */
@@ -1593,7 +1593,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     /* get the list of nodes for this nspace */
     proc.rank = PMIX_RANK_WILDCARD;
 
-    if (NULL == nspace || 0 == strlen(nspace)) {
+    if (NULL == nspace || 0 == pmix_nslen(nspace)) {
         rc = PMIX_ERR_NOT_FOUND;
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {


### PR DESCRIPTION
Non-terminated strings can cause strlen to run wild,
so create a safe way of computing it for pmix_nspace_t.

Signed-off-by: Ralph Castain <rhc@pmix.org>