### PR TITLE
Protect against duplicate envar harvesting

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -486,6 +486,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        event whenever a process either normally or abnormally terminates.
 #define PMIX_NOTIFY_PROC_ABNORMAL_TERMINATION   "pmix.noteabproc"   // (bool) Requests that the launcher generate the PMIX_EVENT_PROC_TERMINATED
                                                                     //        event only when a process abnormally terminates.
+#define PMIX_ENVARS_HARVESTED               "pmix.evar.hvstd"       // (bool) Envars have been harvested by the spawn requestor
+
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */
 #define PMIX_QUERY_SUPPORTED_KEYS           "pmix.qry.keys"         // (char*) returns comma-delimited list of keys supported by the query

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -144,7 +144,8 @@ static pmix_status_t harvest_envars(pmix_namespace_t *nptr, const pmix_info_t in
     size_t n;
     char *file, *tmp, *evar;
 
-    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output, "pmdl:ompi:harvest envars");
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi:harvest envars");
 
     if (!checkus(info, ninfo)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
@@ -154,7 +155,7 @@ static pmix_status_t harvest_envars(pmix_namespace_t *nptr, const pmix_info_t in
     if (NULL != *priors) {
         char **t2 = *priors;
         for (n = 0; NULL != t2[n]; n++) {
-            if (0 == strncmp(t2[n], "ompi", 4)) {
+            if (0 == strncmp(t2[n], "ompi", strlen("ompi"))) {
                 return PMIX_ERR_TAKE_NEXT_OPTION;
             }
         }
@@ -162,6 +163,17 @@ static pmix_status_t harvest_envars(pmix_namespace_t *nptr, const pmix_info_t in
     /* flag that we worked on this */
     pmix_argv_append_nosize(priors, "ompi");
 
+    /* are we to harvest envars? */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ENVARS)) {
+            goto harvest;
+        }
+    }
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi:harvest envars: NO");
+    return PMIX_ERR_TAKE_NEXT_OPTION;
+
+harvest:
     if (NULL != nptr) {
         /* see if we already have this nspace */
         ns = NULL;

--- a/src/mca/pmdl/oshmem/pmdl_oshmem.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem.c
@@ -137,13 +137,38 @@ static pmix_status_t harvest_envars(pmix_namespace_t *nptr, const pmix_info_t in
 {
     pmdl_nspace_t *ns, *ns2;
     pmix_status_t rc;
+    size_t n;
 
-    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output, "pmdl:oshmem:harvest envars");
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:oshmem:harvest envars");
 
     if (!checkus(info, ninfo)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
+    /* don't do OSHMEM again if already done */
+    if (NULL != *priors) {
+        char **t2 = *priors;
+        for (n = 0; NULL != t2[n]; n++) {
+            if (0 == strncmp(t2[n], "oshmem", strlen("oshmem"))) {
+                return PMIX_ERR_TAKE_NEXT_OPTION;
+            }
+        }
+    }
+    /* flag that we worked on this */
+    pmix_argv_append_nosize(priors, "oshmem");
+
+    /* are we to harvest envars? */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ENVARS)) {
+            goto harvest;
+        }
+    }
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:oshmem:harvest envars: NO");
+    return PMIX_ERR_TAKE_NEXT_OPTION;
+
+harvest:
     if (NULL != nptr) {
         /* see if we already have this nspace */
         ns = NULL;

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -395,8 +395,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
             while (PMIX_SUCCESS == rc) {
                 pmix_list_append(&ns->envars, &ev->super);
                 /* if this is the transport key, save it */
-                if (0
-                    == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports",
+                if (0 == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports",
                                PMIX_MAX_KEYLEN)) {
                     /* add it to the job-level info */
                     PMIX_LOAD_PROCID(&proc, ns->nspace, PMIX_RANK_WILDCARD);


### PR DESCRIPTION
In the DVM use-case, we want prun to pickup the envars
as that is where the user is acting. We then need to tell
PRRTE _not_ to pick them up as that would overwrite the
user's settings.

Signed-off-by: Ralph Castain <rhc@pmix.org>