### PR TITLE
Add oversubscribed attribute

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -274,6 +274,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CPUSET_BITMAP                  "pmix.bitmap"           // (pmix_cpuset_t*) Bitmap applied to process at launch
 #define PMIX_CREDENTIAL                     "pmix.cred"             // (char*) security credential assigned to proc
 #define PMIX_SPAWNED                        "pmix.spawned"          // (bool) true if this proc resulted from a call to PMIx_Spawn
+#define PMIX_NODE_OVERSUBSCRIBED            "pmix.ndosub"           // (bool) true if number of procs from this job on this node
+                                                                    //        exceeds the number of slots allocated to it
+
 
 /* scratch directory locations for use by applications */
 #define PMIX_TMPDIR                         "pmix.tmpdir"           // (char*) top-level tmp dir assigned to session

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -599,6 +599,7 @@ static inline bool pmix_check_node_info(const char *key)
                     PMIX_LOCAL_SIZE,
                     PMIX_NODE_SIZE,
                     PMIX_LOCALLDR,
+                    PMIX_NODE_OVERSUBSCRIBED,
                     NULL};
     size_t n;
 


### PR DESCRIPTION
Enable RM to indicate that the node is oversubscribed

Signed-off-by: Ralph Castain <rhc@pmix.org>