### PR TITLE
Add a few job error constants

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1245,6 +1245,10 @@ typedef int pmix_status_t;
 #define PMIX_ERR_JOB_NON_ZERO_TERM                  -187
 #define PMIX_ERR_JOB_ALLOC_FAILED                   -188
 #define PMIX_ERR_JOB_ABORTED_BY_SYS_EVENT           -189
+#define PMIX_ERR_JOB_EXE_NOT_FOUND                  -190
+#define PMIX_ERR_JOB_WDIR_NOT_FOUND                 -233
+#define PMIX_ERR_JOB_INSUFFICIENT_RESOURCES         -234
+#define PMIX_ERR_JOB_SYS_OP_FAILED                  -235
 
 /* job-related non-error events */
 #define PMIX_EVENT_JOB_START                        -191

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -318,6 +318,14 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
         return "JOB ABORTED BY SYSTEM EVENT";
     case PMIX_ERR_PROC_TERM_WO_SYNC:
         return "PROC TERMINATED WITHOUT SYNC";
+    case PMIX_ERR_JOB_EXE_NOT_FOUND:
+        return "EXECUTABLE NOT FOUND";
+    case PMIX_ERR_JOB_WDIR_NOT_FOUND:
+        return "WORKING DIRECTORY NOT FOUND";
+    case PMIX_ERR_JOB_INSUFFICIENT_RESOURCES:
+        return "INSUFFICIENT RESOURCES";
+    case PMIX_ERR_JOB_SYS_OP_FAILED:
+        return "SYSTEM OPERATION FAILED";
 
     case PMIX_EVENT_PROC_TERMINATED:
         return "PROC TERMINATED";


### PR DESCRIPTION
Better inform callers of "spawn" on what happened

Signed-off-by: Ralph Castain <rhc@pmix.org>