### PR TITLE
Enable re-init of clients

### DIFF
--- a/src/mca/plog/syslog/plog_syslog_component.c
+++ b/src/mca/plog/syslog/plog_syslog_component.c
@@ -62,6 +62,7 @@ static pmix_status_t syslog_register(void)
         PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_2,
         PMIX_MCA_BASE_VAR_SCOPE_READONLY, &mca_plog_syslog_component.console);
 
+    level = "info";
     (void) pmix_mca_base_component_var_register(&mca_plog_syslog_component.super.base, "level",
                                                 "Default syslog logging level (err, alert, crit, "
                                                 "emerg, warning, notice, info[default], or debug)",
@@ -89,6 +90,7 @@ static pmix_status_t syslog_register(void)
         rc = PMIX_ERR_NOT_SUPPORTED;
     }
 
+    facility = "user";
     (void) pmix_mca_base_component_var_register(
         &mca_plog_syslog_component.super.base, "facility",
         "Specify what type of program is logging the message "

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -166,8 +166,10 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
             }
         }
 
-        /* reduce the number of local procs */
-        if (0 < peer->nptr->nlocalprocs) {
+
+        /* if the peer simply died without finalizing,
+         * then reduce the number of local procs */
+        if (!peer->finalized && 0 < peer->nptr->nlocalprocs) {
             --peer->nptr->nlocalprocs;
         }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -313,7 +313,8 @@ static pmix_server_trkr_t *get_tracker(char *id, pmix_proc_t *procs, size_t npro
     size_t i, j;
     size_t matches;
 
-    pmix_output_verbose(5, pmix_server_globals.base_output, "get_tracker called with %d procs",
+    pmix_output_verbose(5, pmix_server_globals.fence_output,
+                        "get_tracker called with %d procs",
                         (int) nprocs);
 
     /* bozo check - should never happen outside of programmer error */
@@ -391,7 +392,8 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
     pmix_nspace_caddy_t *nm;
     pmix_nspace_t first;
 
-    pmix_output_verbose(5, pmix_server_globals.base_output, "new_tracker called with %d procs",
+    pmix_output_verbose(5, pmix_server_globals.fence_output,
+                        "new_tracker called with %d procs",
                         (int) nprocs);
 
     /* bozo check - should never happen outside of programmer error */
@@ -400,7 +402,8 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
         return NULL;
     }
 
-    pmix_output_verbose(5, pmix_server_globals.base_output, "adding new tracker %s with %d procs",
+    pmix_output_verbose(5, pmix_server_globals.fence_output,
+                        "adding new tracker %s with %d procs",
                         (NULL == id) ? "NO-ID" : id, (int) nprocs);
 
     /* this tracker is new - create it */
@@ -487,8 +490,8 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
         }
         if (0 == nptr->nlocalprocs) {
             /* the host has informed us that this nspace has no local procs */
-            pmix_output_verbose(5, pmix_server_globals.base_output,
-                                "new_tracker: unknown nspace %s", procs[i].nspace);
+            pmix_output_verbose(5, pmix_server_globals.fence_output,
+                                "new_tracker: nspace %s has no local procs", procs[i].nspace);
             trk->local = false;
             continue;
         }
@@ -533,7 +536,7 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
             /* nope, so no point in going further on this one - we'll
              * process it once all the procs are known */
             all_def = false;
-            pmix_output_verbose(5, pmix_server_globals.base_output,
+            pmix_output_verbose(5, pmix_server_globals.fence_output,
                                 "new_tracker: all clients not registered nspace %s",
                                 procs[i].nspace);
             continue;
@@ -542,7 +545,7 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
         found = false;
         PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
             if (procs[i].rank == info->pname.rank) {
-                pmix_output_verbose(5, pmix_server_globals.base_output,
+                pmix_output_verbose(5, pmix_server_globals.fence_output,
                                     "adding local proc %s.%d to tracker", info->pname.nspace,
                                     info->pname.rank);
                 found = true;
@@ -672,7 +675,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk, pmix_buffer_t *buf)
                                 > key_fmt_size[PMIX_MODEX_KEY_KEYMAP_FMT]
                             ? PMIX_MODEX_KEY_KEYMAP_FMT
                             : PMIX_MODEX_KEY_NATIVE_FMT;
-            pmix_output_verbose(5, pmix_server_globals.base_output, "key packing type %s",
+            pmix_output_verbose(5, pmix_server_globals.fence_output, "key packing type %s",
                                 kmap_type == PMIX_MODEX_KEY_KEYMAP_FMT ? "kmap" : "native");
         }
         PMIX_CONSTRUCT(&rank_blobs, pmix_list_t);


### PR DESCRIPTION
Only deprecate nlocalprocs if the client dies without
finalizing. Cleanup one spot where MCA params weren't
being reinitialized.

Fixes https://github.com/openpmix/openpmix/issues/2202

Signed-off-by: Ralph Castain <rhc@pmix.org>