### PR TITLE
Optimize check for nodes

### DIFF
--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -144,7 +144,7 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
 {
     size_t n, nds;
     pmix_status_t rc;
-    uint32_t nid = 0;
+    uint32_t nid = UINT32_MAX;
     char *hostname = NULL;
     bool found = false;
     pmix_nodeinfo_t *nd, *ndptr;
@@ -244,16 +244,16 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
 
     /* scan the list of nodes to find the matching entry */
     nd = NULL;
-    PMIX_LIST_FOREACH (ndptr, tgt, pmix_nodeinfo_t) {
-        if (NULL != hostname) {
-            if (pmix_gds_hash_check_nodename(ndptr, hostname)) {
+    if (UINT32_MAX!= nid) {
+        PMIX_LIST_FOREACH (ndptr, tgt, pmix_nodeinfo_t) {
+            if (UINT32_MAX != ndptr->nodeid &&
+                nid == ndptr->nodeid) {
                 nd = ndptr;
                 break;
             }
-        } else if (nid == ndptr->nodeid) {
-            nd = ndptr;
-            break;
         }
+    } else if (NULL != hostname) {
+        nd = pmix_gds_hash_check_nodename(tgt, hostname);
     }
     if (NULL == nd) {
         if (!found) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -150,7 +150,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
     pmix_status_t rc = PMIX_SUCCESS;
     size_t n, j, size, len;
     uint32_t flags = 0;
-    pmix_nodeinfo_t *nd, *ndptr;
+    pmix_nodeinfo_t *nd;
     pmix_apptrkr_t *apptr;
     bool found;
 
@@ -369,13 +369,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
         } else if (pmix_check_node_info(info[n].key)) {
             /* they are passing us the node-level info for just this
              * node - start by seeing if our node is on the list */
-            nd = NULL;
-            PMIX_LIST_FOREACH (ndptr, &trk->nodeinfo, pmix_nodeinfo_t) {
-                if (pmix_gds_hash_check_nodename(ndptr, pmix_globals.hostname)) {
-                    nd = ndptr;
-                    break;
-                }
-            }
+            nd = pmix_gds_hash_check_nodename(&trk->nodeinfo, pmix_globals.hostname);
             /* if not, then add it */
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
@@ -766,7 +760,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
     pmix_job_t *trk;
     pmix_hash_table_t *ht;
     char **nodelist = NULL;
-    pmix_nodeinfo_t *nd, *ndptr;
+    pmix_nodeinfo_t *nd;
     pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
@@ -890,15 +884,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 /* track the nodes in this nspace */
                 pmix_argv_append_nosize(&nodelist, kv.key);
                 /* check and see if we already have this node */
-                nd = NULL;
-                PMIX_LIST_FOREACH (ndptr, &trk->nodeinfo, pmix_nodeinfo_t) {
-                    if (pmix_gds_hash_check_nodename(ndptr, kv.key)) {
-                        /* we assume that the data is updating the current
-                         * values */
-                        nd = ndptr;
-                        break;
-                    }
-                }
+                nd = pmix_gds_hash_check_nodename(&trk->nodeinfo, kv.key);
                 if (NULL == nd) {
                     nd = PMIX_NEW(pmix_nodeinfo_t);
                     nd->hostname = strdup(kv.key);

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -102,7 +102,7 @@ extern bool pmix_gds_hash_check_hostname(char *h1, char *h2);
 
 extern bool pmix_gds_hash_check_node(pmix_nodeinfo_t *n1, pmix_nodeinfo_t *n2);
 
-extern bool pmix_gds_hash_check_nodename(pmix_nodeinfo_t *nptr, char *hostname);
+extern pmix_nodeinfo_t* pmix_gds_hash_check_nodename(pmix_list_t *nodes, char *hostname);
 
 extern pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                              uint32_t flags);

--- a/src/util/pif.c
+++ b/src/util/pif.c
@@ -675,36 +675,6 @@ int pmix_ifmatches(int kidx, char **nets)
     return PMIX_ERR_NOT_FOUND;
 }
 
-void pmix_ifgetaliases(char ***aliases)
-{
-    pmix_pif_t *intf;
-    char ipv4[INET_ADDRSTRLEN];
-    struct sockaddr_in *addr;
-    char ipv6[INET6_ADDRSTRLEN];
-    struct sockaddr_in6 *addr6;
-
-    /* set default answer */
-    *aliases = NULL;
-
-    for (intf = (pmix_pif_t *) pmix_list_get_first(&pmix_if_list);
-         intf != (pmix_pif_t *) pmix_list_get_end(&pmix_if_list);
-         intf = (pmix_pif_t *) pmix_list_get_next(intf)) {
-        addr = (struct sockaddr_in *) &intf->if_addr;
-        /* ignore purely loopback interfaces */
-        if ((intf->if_flags & IFF_LOOPBACK) != 0) {
-            continue;
-        }
-        if (addr->sin_family == AF_INET) {
-            inet_ntop(AF_INET, &(addr->sin_addr.s_addr), ipv4, INET_ADDRSTRLEN);
-            pmix_argv_append_nosize(aliases, ipv4);
-        } else {
-            addr6 = (struct sockaddr_in6 *) &intf->if_addr;
-            inet_ntop(AF_INET6, &(addr6->sin6_addr), ipv6, INET6_ADDRSTRLEN);
-            pmix_argv_append_nosize(aliases, ipv6);
-        }
-    }
-}
-
 #else /* HAVE_STRUCT_SOCKADDR_IN */
 
 /* if we don't have struct sockaddr_in, we don't have traditional
@@ -783,12 +753,6 @@ int pmix_iftupletoaddr(const char *inaddr, uint32_t *net, uint32_t *mask)
 int pmix_ifmatches(int idx, char **nets)
 {
     return PMIX_ERR_NOT_SUPPORTED;
-}
-
-void pmix_ifgetaliases(char ***aliases)
-{
-    /* set default answer */
-    *aliases = NULL;
 }
 
 #endif /* HAVE_STRUCT_SOCKADDR_IN */

--- a/src/util/pif.h
+++ b/src/util/pif.h
@@ -212,11 +212,6 @@ PMIX_EXPORT bool pmix_ifisloopback(int if_index);
  */
 PMIX_EXPORT int pmix_ifmatches(int kidx, char **nets);
 
-/*
- * Provide a list of strings that contain all known aliases for this node
- */
-PMIX_EXPORT void pmix_ifgetaliases(char ***aliases);
-
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
In most cases, we will receive consistent names for hosts. Thus,
whenever we are checking the input name of a host against our
array of known nodes, first just check the given name against
the known name of the nodes. If we don't find a match, then go
back thru the array and check the given name against all aliases.

This way, only those who use multiple names for their nodes will
pay the performance penalty.

Signed-off-by: Ralph Castain <rhc@pmix.org>