### PR TITLE
Transfer stdout/err formatting to PMIx

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -893,6 +893,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        debugger-related output into the application's results file.
                                                                     //        The original output stream(s) destination is restored upon
                                                                     //        termination of the tool.
+#define PMIX_IOF_LOCAL_OUTPUT               "pmix.iof.local"        // (bool) Write output streams to local stdout/err
 
 /* Attributes for controlling contents of application setup data */
 #define PMIX_SETUP_APP_ENVARS               "pmix.setup.env"        // (bool) harvest and include relevant envars

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -484,15 +484,13 @@ static void client_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         goto cleanup;
     }
     /* lookup the handler for this IOF package */
-    if (NULL
-            != (req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests,
-                                                                     refid))
-        && NULL != req->cbfunc) {
+    req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid);
+    if (NULL != req && NULL != req->cbfunc) {
         req->cbfunc(refid, channel, &source, &bo, info, ninfo);
     } else {
         /* otherwise, simply write it out to the specified std IO channel */
         if (NULL != bo.bytes && 0 < bo.size) {
-            pmix_iof_write_output(&source, channel, &bo, NULL);
+            pmix_iof_write_output(&source, channel, &bo);
         }
     }
 

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -59,7 +59,7 @@ BEGIN_C_DECLS
  * Maximum size of single msg
  */
 #define PMIX_IOF_BASE_MSG_MAX        4096
-#define PMIX_IOF_BASE_TAG_MAX        50
+#define PMIX_IOF_BASE_TAG_MAX        256
 #define PMIX_IOF_BASE_TAGGED_OUT_MAX 8192
 #define PMIX_IOF_MAX_INPUT_BUFFERS   50
 
@@ -108,14 +108,6 @@ typedef struct {
     size_t ndirs;
 } pmix_iof_read_event_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_read_event_t);
-
-/* define a struct to hold booleans controlling the
- * format/contents of the output */
-typedef struct {
-    bool xml;
-    time_t timestamp;
-    bool tag;
-} pmix_iof_flags_t;
 
 /* Write event macro's */
 
@@ -218,8 +210,7 @@ static inline bool pmix_iof_fd_always_ready(int fd)
 PMIX_EXPORT pmix_status_t pmix_iof_flush(void);
 
 PMIX_EXPORT pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t stream,
-                                                const pmix_byte_object_t *bo,
-                                                pmix_iof_flags_t *flags);
+                                                const pmix_byte_object_t *bo);
 PMIX_EXPORT void pmix_iof_static_dump_output(pmix_iof_sink_t *sink);
 PMIX_EXPORT void pmix_iof_write_handler(int fd, short event, void *cbdata);
 PMIX_EXPORT bool pmix_iof_stdin_check(int fd);
@@ -230,6 +221,7 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_byte_object_t *bo,
                                                const pmix_info_t *info, size_t ninfo,
                                                const pmix_iof_req_t *req);
+PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 
 END_C_DECLS
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -114,6 +114,9 @@ static void nscon(pmix_namespace_t *p)
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
     PMIX_CONSTRUCT(&p->setup_data, pmix_list_t);
+    memset(&p->iof_flags, 0, sizeof(p->iof_flags));
+    PMIX_CONSTRUCT(&p->sinks, pmix_list_t);
+
 }
 static void nsdes(pmix_namespace_t *p)
 {
@@ -131,6 +134,13 @@ static void nsdes(pmix_namespace_t *p)
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
     PMIX_LIST_DESTRUCT(&p->epilog.ignores);
     PMIX_LIST_DESTRUCT(&p->setup_data);
+    if (NULL != p->iof_flags.file) {
+        free(p->iof_flags.file);
+    }
+    if (NULL != p->iof_flags.directory) {
+        free(p->iof_flags.directory);
+    }
+    PMIX_LIST_DESTRUCT(&p->sinks);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namespace_t, pmix_list_item_t, nscon, nsdes);
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -190,6 +190,20 @@ typedef struct {
 } pmix_cleanup_dir_t;
 PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);
 
+/* define a struct to hold booleans controlling the
+ * format/contents of the output */
+typedef struct {
+    bool set;
+    bool xml;
+    bool timestamp;
+    bool tag;
+    char *file;
+    char *directory;
+    bool nocopy;
+    bool merge;
+    bool local_output;
+} pmix_iof_flags_t;
+
 /* objects used by servers for tracking active nspaces */
 typedef struct {
     pmix_list_item_t super;
@@ -217,6 +231,8 @@ typedef struct {
                             // from this nspace
     pmix_list_t setup_data; // list of pmix_kval_t containing info structs having blobs
                             // for setting up the local node for this nspace/application
+    pmix_iof_flags_t iof_flags;   // output formatting flags
+    pmix_list_t sinks;   // IOF write events for output to files or directories
 } pmix_namespace_t;
 PMIX_CLASS_DECLARATION(pmix_namespace_t);
 
@@ -577,6 +593,7 @@ typedef struct {
     pmix_topology_t topology;
     bool external_topology;
     bool external_progress;
+    pmix_iof_flags_t iof_flags;
 } pmix_globals_t;
 
 /* provide access to a function to cleanup epilogs */

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -467,6 +467,8 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
                 } else {
                     nptr->num_waiting = 1;
                 }
+            } else {
+                pmix_iof_check_flags(&info[n], &nptr->iof_flags);
             }
         }
     }

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -432,11 +432,12 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
             }
             pmix_list_append(&trk->jobinfo, &kp2->super);
             /* check for job size */
-            if (PMIX_CHECK_KEY(&iptr[j], PMIX_JOB_SIZE) && !(PMIX_HASH_JOB_SIZE & *flags)) {
-                trk->nptr->nprocs = iptr[j].value.data.uint32;
-                *flags |= PMIX_HASH_JOB_SIZE;
-            }
-            if (PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_ON_EXEC)
+            if (PMIX_CHECK_KEY(&iptr[j], PMIX_JOB_SIZE)) {
+                if (!(PMIX_HASH_JOB_SIZE & *flags)) {
+                    trk->nptr->nprocs = iptr[j].value.data.uint32;
+                    *flags |= PMIX_HASH_JOB_SIZE;
+                }
+            } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_ON_EXEC)
                 || PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_INIT)
                 || PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_APP)) {
                 if (PMIX_RANK_WILDCARD == iptr[j].value.data.rank) {
@@ -444,6 +445,8 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
                 } else {
                     trk->nptr->num_waiting = 1;
                 }
+            } else {
+                pmix_iof_check_flags(&iptr[j], &trk->nptr->iof_flags);
             }
         }
     }

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -70,7 +70,6 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
     size_t n;
     pmix_status_t rc;
     pmix_byte_object_t bo;
-    pmix_iof_flags_t flags = {0};
 
     /* if there is no data, then we don't handle it */
     if (NULL == data || 0 == ndata) {
@@ -81,7 +80,7 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
     if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
-
+#if 0
     /* check to see if there are any relevant directives */
     for (n = 0; n < ndirs; n++) {
         if (0 == strncmp(directives[n].key, PMIX_LOG_TIMESTAMP, PMIX_MAX_KEYLEN)) {
@@ -92,7 +91,7 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
             flags.tag = PMIX_INFO_TRUE(&directives[n]);
         }
     }
-
+#endif
     /* check to see if there are any stdfd entries */
     rc = PMIX_ERR_TAKE_NEXT_OPTION;
     for (n = 0; n < ndata; n++) {
@@ -102,14 +101,14 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
         if (0 == strncmp(data[n].key, PMIX_LOG_STDERR, PMIX_MAX_KEYLEN)) {
             bo.bytes = data[n].value.data.string;
             bo.size = strlen(bo.bytes);
-            pmix_iof_write_output(source, PMIX_FWD_STDERR_CHANNEL, &bo, &flags);
+            pmix_iof_write_output(source, PMIX_FWD_STDERR_CHANNEL, &bo);
             /* flag that we did this one */
             PMIX_INFO_OP_COMPLETED(&data[n]);
             rc = PMIX_SUCCESS;
         } else if (0 == strncmp(data[n].key, PMIX_LOG_STDOUT, PMIX_MAX_KEYLEN)) {
             bo.bytes = data[n].value.data.string;
             bo.size = strlen(bo.bytes);
-            pmix_iof_write_output(source, PMIX_FWD_STDOUT_CHANNEL, &bo, &flags);
+            pmix_iof_write_output(source, PMIX_FWD_STDOUT_CHANNEL, &bo);
             /* flag that we did this one */
             PMIX_INFO_OP_COMPLETED(&data[n]);
             rc = PMIX_SUCCESS;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -219,6 +219,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
     /* setup the stdin forwarding target list */
     PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
+    memset(&pmix_globals.iof_flags, 0, sizeof(pmix_iof_flags_t));
 
     /* Setup client verbosities as all procs are allowed to
      * access client APIs */
@@ -325,6 +326,8 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                 pmix_globals.external_progress = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME_KEEP_FQDN)) {
                 keepfqdn = PMIX_INFO_TRUE(&info[n]);
+            } else {
+                pmix_iof_check_flags(&info[n], &pmix_globals.iof_flags);
             }
         }
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -163,15 +163,13 @@ static void server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         goto cleanup;
     }
     /* lookup the handler for this IOF package */
-    if (NULL
-            != (req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests,
-                                                                     refid))
-        && NULL != req->cbfunc) {
+    req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid);
+    if (NULL != req && NULL != req->cbfunc) {
         req->cbfunc(refid, channel, &source, &bo, info, ninfo);
     } else {
         /* otherwise, simply write it out to the specified std IO channel */
         if (NULL != bo.bytes && 0 < bo.size) {
-            pmix_iof_write_output(&source, channel, &bo, NULL);
+            pmix_iof_write_output(&source, channel, &bo);
         }
     }
 
@@ -1000,7 +998,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
     }
     nptr->nlocalprocs = cd->nlocalprocs;
 
-    /* see if we have everyone */
+    /* see if we already have everyone */
     if (nptr->nlocalprocs == pmix_list_get_size(&nptr->ranks)) {
         nptr->all_registered = true;
     }
@@ -1689,7 +1687,7 @@ static void _register_client(int sd, short args, void *cbdata)
     info->gid = cd->gid;
     info->server_object = cd->server_object;
     pmix_list_append(&nptr->ranks, &info->super);
-    /* see if we have everyone - not that nlocalprocs is set to
+    /* see if we have everyone - note that nlocalprocs is set to
      * a default value to ensure we don't execute this
      * test until the host calls "register_nspace" */
     if (SIZE_MAX != nptr->nlocalprocs && nptr->nlocalprocs == pmix_list_get_size(&nptr->ranks)) {
@@ -2475,24 +2473,31 @@ static void _iofdeliver(int sd, short args, void *cbdata)
     pmix_iof_cache_t *iof;
     int i;
     size_t n;
+    pmix_status_t rc;
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "PMIX:SERVER delivering IOF from %s on channel %0x",
                         PMIX_NAME_PRINT(cd->procs), cd->channels);
 
+    /* output it locally if requested */
+    rc = pmix_iof_write_output(cd->procs, cd->channels, cd->bo);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
     /* cycle across our list of IOF requests and see who wants
      * this channel from this source */
     for (i = 0; i < pmix_globals.iof_requests.size; i++) {
-        if (NULL
-            == (req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests,
-                                                                     i))) {
+        req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+        if (NULL == req) {
             continue;
         }
-        if (PMIX_OPERATION_SUCCEEDED
-            == pmix_iof_process_iof(cd->channels, cd->procs, cd->bo, cd->info, cd->ninfo, req)) {
+        rc = pmix_iof_process_iof(cd->channels, cd->procs, cd->bo, cd->info, cd->ninfo, req);
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
             /* flag that we do have at least one registrant for this info,
              * so there is no need to cache it */
             found = true;
+            rc = PMIX_SUCCESS;
         }
     }
 
@@ -2522,10 +2527,12 @@ static void _iofdeliver(int sd, short args, void *cbdata)
             }
         }
         pmix_list_append(&pmix_server_globals.iof, &iof->super);
+        rc = PMIX_SUCCESS;
     }
 
+done:
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);
+        cd->opcbfunc(rc, cd->cbdata);
     }
 
     /* release the caddy */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -219,7 +219,6 @@ typedef struct {
     // verbosity for basic server functions
     int base_output;
     int base_verbose;
-
 } pmix_server_globals_t;
 
 #define PMIX_GDS_CADDY(c, p, t)              \

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -309,15 +309,13 @@ static void tool_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_b
         goto cleanup;
     }
     /* lookup the handler for this IOF package */
-    if (NULL
-            != (req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests,
-                                                                     refid))
-        && NULL != req->cbfunc) {
+    req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, refid);
+    if (NULL != req && NULL != req->cbfunc) {
         req->cbfunc(refid, channel, &source, &bo, info, ninfo);
     } else {
         /* otherwise, simply write it out to the specified std IO channel */
         if (NULL != bo.bytes && 0 < bo.size) {
-            pmix_iof_write_output(&source, channel, &bo, NULL);
+            pmix_iof_write_output(&source, channel, &bo);
         }
     }
 
@@ -477,7 +475,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_TOOL);
     if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_TOOL_DO_NOT_CONNECT, PMIX_MAX_KEYLEN)) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_DO_NOT_CONNECT)) {
                 do_not_connect = PMIX_INFO_TRUE(&info[n]);
             } else if (0 == strncmp(info[n].key, PMIX_TOOL_NSPACE, PMIX_MAX_KEYLEN)) {
                 if (NULL != nspace) {
@@ -488,21 +486,21 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
                 }
                 nspace = strdup(info[n].value.data.string);
                 nspace_given = true;
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_RANK, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_RANK)) {
                 rank = info[n].value.data.rank;
                 rank_given = true;
-            } else if (0 == strncmp(info[n].key, PMIX_FWD_STDIN, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_FWD_STDIN)) {
                 /* they want us to forward our stdin to someone */
                 fwd_stdin = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_LAUNCHER, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_LAUNCHER)) {
                 if (PMIX_INFO_TRUE(&info[n])) {
                     PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_LAUNCHER);
                 }
-            } else if (0 == strncmp(info[n].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
-            } else if (0 == strncmp(info[n].key, PMIX_SYSTEM_TMPDIR, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
                 pmix_server_globals.system_tmpdir = strdup(info[n].value.data.string);
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_CONNECT_OPTIONAL, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_CONNECT_OPTIONAL)) {
                 connect_optional = PMIX_INFO_TRUE(&info[n]);
             }
         }


### PR DESCRIPTION
Transfer the PRRTE output formatting code to the PMIx library
so that tools can also provide a similar capability. This
includes the ability to output XML format, timestamps,
and tagged output as well as the ability to specify a
file format and/or directory where the output is to be
written.

Please see the OpenPMIx wiki page for explanation of
this feature and how to use it.

Signed-off-by: Ralph Castain <rhc@pmix.org>