### PR TITLE
Initialize val before get in case get isn't successful

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -569,6 +569,8 @@ cdef class PMIxClient:
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
 
+        val = None
+
         # pass it into the get API
         rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
         if PMIX_SUCCESS == rc:


### PR DESCRIPTION
I was trying out the Python interface to PMIx and noticed this bug. It looks like if the `PMIx_Get()` code path encounters an error, than `val` never gets set and Python crashes with a 'use before assignment' error when trying to return `val`. This PR add an assignment to `val` so that it is always initialized before the return