### PR TITLE
Some cleanups of the event notification and keepalive support

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -140,6 +140,7 @@ typedef struct pmix_event_chain_t {
     pmix_info_t *info;
     size_t ninfo;
     size_t nallocated;
+    pmix_status_t interim_status;
     pmix_info_t *results;
     size_t nresults;
     pmix_info_t *interim;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -91,13 +91,17 @@ static pmix_proc_t myparent;
 
 static void pdiedfn(int fd, short flags, void *arg)
 {
-    pmix_info_t info[3];
+    pmix_info_t info[2];
+    pmix_proc_t keepalive;
+
+    PMIX_LOAD_PROCID(&keepalive, "PMIX_KEEPALIVE_PIPE", PMIX_RANK_UNDEF);
 
     PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &myparent, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
 
     /* generate a job-terminated event */
-    PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL, info, 3,
+    PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
+                      PMIX_RANGE_PROC_LOCAL, info, 2,
                       NULL, NULL);
 }
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -81,13 +81,17 @@ static pmix_proc_t myparent;
 
 static void pdiedfn(int fd, short flags, void *arg)
 {
-    pmix_info_t info[3];
+    pmix_info_t info[2];
+    pmix_proc_t keepalive;
+
+    PMIX_LOAD_PROCID(&keepalive, "PMIX_KEEPALIVE_PIPE", PMIX_RANK_UNDEF);
 
     PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &myparent, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
 
     /* generate a job-terminated event */
-    PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL, info, 3,
+    PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
+                      PMIX_RANGE_PROC_LOCAL, info, 2,
                       NULL, NULL);
 }
 
@@ -221,8 +225,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         }
     }
 
-    pmix_output_verbose(
-        2, pmix_client_globals.event_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
         "[%s:%d] pmix:tool_notify_recv - processing event %s from source %s:%d, calling errhandler",
         pmix_globals.myid.nspace, pmix_globals.myid.rank, PMIx_Error_string(chain->status),
         chain->source.nspace, chain->source.rank);


### PR DESCRIPTION
Ensure that the event notification chain stops when it should by
tracking the interim status returned by each handler. When the keepalive
pipe goes away, generate an event with a known named affected proc
so that the host can catch it.

Signed-off-by: Ralph Castain <rhc@pmix.org>