### PR TITLE
common/sse: Ensure library links against libcurl

### DIFF
--- a/src/mca/common/sse/Makefile.am
+++ b/src/mca/common/sse/Makefile.am
@@ -25,19 +25,19 @@ sources = \
 
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
-comp_inst = libmca_common_sse.la
-comp_noinst = libmca_common_sse_noinst.la
 
 if MCA_BUILD_pmix_common_sse_DSO
-lib_LTLIBRARIES += $(comp_inst)
+lib_LTLIBRARIES += libmca_common_sse.la
 else
-noinst_LTLIBRARIES += $(comp_noinst)
+noinst_LTLIBRARIES += libmca_common_sse.la
 endif
 
 libmca_common_sse_la_SOURCES = $(headers) $(sources)
-libmca_common_sse_la_LDFLAGS = -version-info $(libmca_common_sse_so_version) $(pmix_check_curl_LDFLAGS)
+libmca_common_sse_la_LDFLAGS = $(pmix_check_curl_LDFLAGS)
+if MCA_BUILD_pmix_common_sse_DSO
+libmca_common_sse_la_LDFLAGS += -version-info $(libmca_common_sse_so_version)
+endif
 libmca_common_sse_la_LIBADD = $(pmix_check_curl_LIBS)
-libmca_common_sse_noinst_la_SOURCES = $(headers) $(sources)
 
 # Conditionally install the header files
 
@@ -45,16 +45,5 @@ if WANT_INSTALL_HEADERS
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)
 endif
-
-all-local:
-	if test -z "$(lib_LTLIBRARIES)"; then \
-		rm -f "$(comp_inst)"; \
-		$(LN_S) "$(comp_noinst)" "$(comp_inst)"; \
-	fi
-
-clean-local:
-	if test -z "$(lib_LTLIBRARIES)"; then \
-		rm -f "$(comp_inst)"; \
-	fi
 
 MAINTAINERCLEANFILES = sse_lex.c


### PR DESCRIPTION
Unify on a single naming convention for the library produced for
the common/sse component, with libmca_common_sse.la.  Unlike
traditional components that are actual DSOs, common components
aren't dynamically loaded; they're dynamically linked by other
loaded components and are stand-alone shared libraries, so the
naming convention that is necessary for other components is
not necessary for common components.

This solves a bug with the common/sse component not being able
to find libcurl symbols when built as a static component.  The
*_LIBADD rule was only for the dynamic build mode and was missing
for the static build mode.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

Refs #2142 