### PR TITLE
common/dstore: Fix inconsistent Makefile.am

### DIFF
--- a/src/mca/common/dstore/Makefile.am
+++ b/src/mca/common/dstore/Makefile.am
@@ -1,7 +1,9 @@
 #
 # Copyright (c) 2018      Mellanox Technologies.  All rights reserved.
-#
 # Copyright (c) 2018      Intel, Inc. All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
+#
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -10,8 +12,6 @@
 #
 
 # Header files
-
-AM_CPPFLAGS = $(LTDLINCL)
 
 headers = \
         dstore_common.h \
@@ -27,18 +27,19 @@ sources = \
 
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
-comp_inst = libmca_common_dstore.la
-comp_noinst = libmca_common_dstore_noinst.la
 
 if MCA_BUILD_pmix_common_dstore_DSO
-lib_LTLIBRARIES += $(comp_inst)
+lib_LTLIBRARIES += libmca_common_dstore.la
 else
-noinst_LTLIBRARIES += $(comp_noinst)
+noinst_LTLIBRARIES += libmca_common_dstore.la
 endif
 
 libmca_common_dstore_la_SOURCES = $(headers) $(sources)
-libmca_common_dstore_la_LDFLAGS = -version-info $(libmca_common_dstore_so_version)
-libmca_common_dstore_noinst_la_SOURCES = $(headers) $(sources)
+libmca_common_dstore_la_LDFLAGS =
+if MCA_BUILD_pmix_common_dstore_DSO
+libmca_common_dstore_la_LDFLAGS += -version-info $(libmca_common_dstore_so_version)
+endif
+libmca_common_dstore_la_LIBADD =
 
 # Conditionally install the header files
 
@@ -46,14 +47,3 @@ if WANT_INSTALL_HEADERS
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)
 endif
-
-all-local:
-	if test -z "$(lib_LTLIBRARIES)"; then \
-		rm -f "$(comp_inst)"; \
-		$(LN_S) "$(comp_noinst)" "$(comp_inst)"; \
-	fi
-
-clean-local:
-	if test -z "$(lib_LTLIBRARIES)"; then \
-		rm -f "$(comp_inst)"; \
-	fi


### PR DESCRIPTION
The Makefile.am for common/dstore was inconsistent in the
flags set for the static and dynamic build cases.  While
this was not causing any problems today, it could lead
to the problems seen with common/sse on the master branch.

This change is similar to 936bf79 on master, in that it
unifies on a single naming convention for the library produced
by common components.

At the same time, remove some unneeded flags, like the LTDLINC
CPPFLAGS, which are not used in this component.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>