### PR TITLE
Revert change to PMIx_Abort

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1061,8 +1061,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
-                                     pmix_proc_t procs[], size_t nprocs)
+PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[], pmix_proc_t procs[], size_t nprocs)
 {
     pmix_buffer_t *bfr;
     pmix_cmd_t cmd = PMIX_ABORT_CMD;
@@ -1077,10 +1076,10 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send - just abort */
+    /* if we aren't connected, don't attempt to send */
     if (!pmix_globals.connected) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
-        goto myabort;
+        return PMIX_ERR_UNREACH;
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
@@ -1094,7 +1093,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
         return rc;
     }
     /* pack the status flag */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &status, 1, PMIX_STATUS);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &flag, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
@@ -1135,10 +1134,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
     /* wait for the release */
     PMIX_WAIT_THREAD(&reglock);
     PMIX_DESTRUCT_LOCK(&reglock);
-
-myabort:
-    /* Now Exit */
-    _exit(status);
+    return PMIX_SUCCESS;
 }
 
 static void _putfn(int sd, short args, void *cbdata)

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -174,7 +174,6 @@ static mylock_t globallock;
 static bool model = false;
 static bool xversion = false;
 static pmix_event_base_t *simptest_evbase = NULL;
-static bool abort_has_been_called = false;
 
 static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myxfer_t *x);
 static void errhandler(size_t evhdlr_registration_id, pmix_status_t status,
@@ -522,11 +521,10 @@ int main(int argc, char **argv)
 
     /* see if anyone exited with non-zero status unless the test
      * was expected to do so */
-    if (NULL == strstr(executable, "simpdie") ||
-        (abort_has_been_called && 248 == exit_code)) {
+    if (NULL == strstr(executable, "simpdie")) {
         n = 0;
         PMIX_LIST_FOREACH (child, &children, wait_tracker_t) {
-            if (0 != child->exit_code && !abort_has_been_called) {
+            if (0 != child->exit_code) {
                 fprintf(stderr, "Child %d [%d] exited with status %d - test FAILED\n", n,
                         child->pid, child->exit_code);
             }
@@ -769,11 +767,23 @@ static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
     return PMIX_OPERATION_SUCCEEDED;
 }
 
+static void abcbfunc(pmix_status_t status, void *cbdata)
+{
+    myxfer_t *x = (myxfer_t *) cbdata;
+
+    /* be sure to release the caller */
+    if (NULL != x->cbfunc) {
+        x->cbfunc(status, x->cbdata);
+    }
+    PMIX_RELEASE(x);
+}
+
 static pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object, int status,
                               const char msg[], pmix_proc_t procs[], size_t nprocs,
                               pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    wait_tracker_t *t2;
+    pmix_status_t rc;
+    myxfer_t *x;
 
     if (NULL != procs) {
         pmix_output(0, "SERVER: ABORT on %s:%d", procs[0].nspace, procs[0].rank);
@@ -781,11 +791,29 @@ static pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object, int 
         pmix_output(0, "SERVER: ABORT OF ALL PROCS IN NSPACE %s", proc->nspace);
     }
 
-    /* mark that the client called abort so we know it will simply exit */
-    abort_has_been_called = true;
+    /* instead of aborting the specified procs, notify them
+     * (if they have registered their errhandler) */
 
-    PMIX_LIST_FOREACH (t2, &children, wait_tracker_t) {
-        kill(t2->pid, SIGKILL);
+    /* use the myxfer_t object to ensure we release
+     * the caller when notification has been queued */
+    x = PMIX_NEW(myxfer_t);
+    (void) strncpy(x->caller.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    x->caller.rank = proc->rank;
+
+    PMIX_INFO_CREATE(x->info, 2);
+    (void) strncpy(x->info[0].key, "DARTH", PMIX_MAX_KEYLEN);
+    x->info[0].value.type = PMIX_INT8;
+    x->info[0].value.data.int8 = 12;
+    (void) strncpy(x->info[1].key, "VADER", PMIX_MAX_KEYLEN);
+    x->info[1].value.type = PMIX_DOUBLE;
+    x->info[1].value.data.dval = 12.34;
+    x->cbfunc = cbfunc;
+    x->cbdata = cbdata;
+
+    if (PMIX_SUCCESS
+        != (rc = PMIx_Notify_event(status, &x->caller, PMIX_RANGE_NAMESPACE, x->info, 2, abcbfunc,
+                                   x))) {
+        pmix_output(0, "SERVER: FAILED NOTIFY ERROR %d", (int) rc);
     }
 
     return PMIX_SUCCESS;
@@ -1191,14 +1219,8 @@ static void wait_signal_callback(int fd, short event, void *arg)
                         t2->exit_code = WTERMSIG(status) + 128;
                     }
                 }
-                if (0 == exit_code) {
-                    if (abort_has_been_called) {
-                        if (137 != t2->exit_code) {
-                            exit_code = t2->exit_code;
-                        }
-                    } else if (0 != t2->exit_code) {
-                        exit_code = t2->exit_code;
-                    }
+                if (0 != t2->exit_code && 0 == exit_code) {
+                    exit_code = t2->exit_code;
                 }
                 --wakeup;
                 break;


### PR DESCRIPTION
Do not call "exit" from within the function - just return an "unreachable" error if the PMIx server is no longer available. Retain the changes to the "simptest" program.

Signed-off-by: Ralph Castain <rhc@pmix.org>