### PR TITLE
Some cleanups for client finalize and IOF output

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -61,7 +61,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
 {
     pmix_server_trkr_t *trk, *tnxt;
     pmix_server_caddy_t *rinfo, *rnext;
-    pmix_rank_info_t *info, *pinfo;
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
@@ -83,7 +82,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     }
     CLOSE_THE_SOCKET(peer->sd);
 
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
          * we properly account for the loss of this client
          * from any local collectives in which it was
@@ -166,7 +166,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
             }
         }
 
-
         /* if the peer simply died without finalizing,
          * then reduce the number of local procs */
         if (!peer->finalized && 0 < peer->nptr->nlocalprocs) {
@@ -184,26 +183,19 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
             pmix_psensor.stop(peer, NULL);
         }
 
-        if (!peer->finalized && !PMIX_PEER_IS_TOOL(peer) && !pmix_globals.mypeer->finalized) {
+        if (!peer->finalized && !pmix_globals.mypeer->finalized) {
             /* if this peer already called finalize, then
              * we are just seeing their connection go away
              * when they terminate - so do not generate
              * an event. If not, then we do */
             PMIX_REPORT_EVENT(err, peer, PMIX_RANGE_PROC_LOCAL, _notify_complete);
         }
-        /* mark this rank as "dead" but do not remove it from ranks for this nspace if it is
-         * still there - we must check for multiple copies as there will be
-         * one for each "clone" of this peer */
-        PMIX_LIST_FOREACH_SAFE (info, pinfo, &(peer->nptr->ranks), pmix_rank_info_t) {
-            if (info == peer->info) {
-                peer->finalized = true;
-            }
-        }
 
         /* be sure to let the host know that the tool or client
          * is gone - otherwise, it won't know to cleanup the
          * resources it allocated to it */
-        if (NULL != pmix_host_server.client_finalized && !peer->finalized) {
+        if (NULL != pmix_host_server.client_finalized &&
+            !PMIX_PEER_IS_TOOL(peer) && !peer->finalized) {
             pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
             proc.rank = peer->info->pname.rank;
             /* now tell the host server */
@@ -618,7 +610,6 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(queue);
 
     if (NULL == queue->peer || NULL == queue->peer->info || NULL == queue->peer->nptr) {
-        pmix_output(0, "UNKNOWN PEER");
         /* we don't know this peer */
         if (NULL != queue->buf) {
             PMIX_RELEASE(queue->buf);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1413,10 +1413,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:tool finalize called");
 
-    /* flush anything that is still trying to be written out */
-    pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
-    pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
-
     /* if we are connected, then disconnect */
     if (pmix_globals.connected) {
         pmix_output_verbose(2, pmix_globals.debug_output,
@@ -1475,6 +1471,10 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
      * tear down the infrastructure, including removal
      * of any events objects may be holding */
     (void) pmix_progress_thread_pause(NULL);
+
+    /* flush anything that is still trying to be written out */
+    pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
+    pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
 
     PMIX_RELEASE(pmix_client_globals.myserver);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);


### PR DESCRIPTION
Don't close the send/recv socket for a client when it
finalizes - let the socket close upon client termination
and do the cleanup at that time. Be a little better
on setting the IOF output default for a server. Write
IOF output directly to stdout/stderr instead of pusing
into events to avoid potential loss of output upon
termination.

Signed-off-by: Ralph Castain <rhc@pmix.org>