### PR TITLE
Modified test_v2 status code return logic so timeouts can be propagated through to caller

### DIFF
--- a/test/test_v2/cli_stages.h
+++ b/test/test_v2/cli_stages.h
@@ -62,6 +62,7 @@ extern cli_info_t *cli_info;
 extern int cli_info_cnt;
 extern bool test_abort;
 extern bool test_complete;
+extern int test_timeout;
 
 int cli_rank(cli_info_t *cli);
 void cli_init(int nprocs);

--- a/test/test_v2/pmix_test.c
+++ b/test/test_v2/pmix_test.c
@@ -160,8 +160,23 @@ done:
     pmix_argv_free(client_argv);
     pmix_argv_free(client_env);
 
-    if (0 == test_fail) {
-        TEST_OUTPUT(("Test SUCCEEDED!"));
+    if (!test_fail && !test_timeout) {
+        if (0 == my_server_id) {
+            TEST_OUTPUT(("Test SUCCEEDED! All servers completed normally.", my_server_id));
+        }
     }
+    else if (!test_timeout) {
+        if (PMIX_ERR_TIMEOUT == test_fail){
+            TEST_OUTPUT(("Test TIMED OUT for server id: %d", my_server_id));
+        }
+        else {
+            TEST_OUTPUT(("Test FAILED for server id: %d, failure code = %d", my_server_id, test_fail));
+        }
+    }
+    else {
+        TEST_OUTPUT(("Test TIMED OUT for server id: %d", my_server_id));
+        return test_timeout;
+    }
+
     return test_fail;
 }


### PR DESCRIPTION
Needed for LANL-CI to proceed through timeouts without hard failure.