### PR TITLE
Do not forward cached IOF to self

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -142,6 +142,10 @@ static void process_cache(int sd, short args, void *cbdata)
         if (PMIX_CHECK_PROCID(&iof->source, &req->requestor->info->pname)) {
             continue;
         }
+        /* never forward to myself */
+        if (PMIX_CHECK_PROCID(&req->requestor->info->pname, &pmix_globals.myid)) {
+            continue;
+        }
         /* if the source does not match the request, then ignore it */
         found = false;
         for (n = 0; n < req->nprocs; n++) {
@@ -271,7 +275,7 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
             return PMIX_SUCCESS;
         }
         /* if there isn't a registration callback, then we can return "succeeded"
-         * as we atomically performend the request. threadshift to process any
+         * as we atomically performed the request. threadshift to process any
          * cached IO as we must return from this function before we do so */
         PMIX_THREADSHIFT(req, process_cache);
         return PMIX_OPERATION_SUCCEEDED;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -118,8 +118,10 @@ static void server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     pmix_iof_req_t *req;
     pmix_info_t *info = NULL;
 
-    pmix_output_verbose(2, pmix_client_globals.iof_output, "recvd IOF with %d bytes",
-                        (int) buf->bytes_used);
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "recvd IOF with %d bytes from %s",
+                        (int) buf->bytes_used,
+                        PMIX_PNAME_PRINT(&peer->info->pname));
 
     /* if the buffer is empty, they are simply closing the socket */
     if (0 == buf->bytes_used) {


### PR DESCRIPTION
Do not let a server forward cached IOF to itself
as it leads to duplicate output

Signed-off-by: Ralph Castain <rhc@pmix.org>