### PR TITLE
Improved handling of C bytes to Python objects

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1274,10 +1274,7 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         pyns = str(value[0].data.proc[0].nspace)
         return {'value':{'nspace':pyns, 'rank':value[0].data.proc[0].rank}, 'val_type':PMIX_PROC}
     elif PMIX_BYTE_OBJECT == value[0].type:
-        mybytes = <char*> PyMem_Malloc(value[0].data.bo.size)
-        if not mybytes:
-            return PMIX_ERR_NOMEM
-        memcpy(mybytes, value[0].data.bo.bytes, value[0].data.bo.size)
+        mybytes = <bytes>value[0].data.bo.bytes[:value[0].data.bo.size]
         return {'value':{'bytes':mybytes, 'size':value[0].data.bo.size}, 'val_type':PMIX_BYTE_OBJECT}
     elif PMIX_PERSISTENCE == value[0].type:
         return {'value':value[0].data.persist, 'val_type':PMIX_PERSISTENCE}

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -341,7 +341,7 @@ cdef class PMIxClient:
             pmix_free_info(info, klen)
         if PMIX_SUCCESS == rc:
             # convert the returned name
-            myname = {'nspace': str(self.myproc.nspace), 'rank': self.myproc.rank}
+            myname = {'nspace': (<bytes>self.myproc.nspace).decode('UTF-8'), 'rank': self.myproc.rank}
         return rc, myname
 
     # Finalize the client library


### PR DESCRIPTION
When using the Python bindings I noticed some strange behavior with namespaces and `PMIX_BYTE_OBJECT` values. I made some bug fixes to the Python bindings that makes my use case work, and it also seems to fix some of the tests. The `PMIX_BYTE_OBJECT` use case is fixed by leveraging Cython's type casting ability to convert C `char[]`'s into Python `bytes` classes and the namespace bug is fixed by similarly casting `char[]` into `bytes` and then decoding those into a Python `string`. 
