### PR TITLE
Require a hardware topology library at configure

### DIFF
--- a/.github/actions/mlnx/Dockerfile
+++ b/.github/actions/mlnx/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810
 RUN \
     yum install -y epel-release; \
     yum install -y perl perl-Data-Dumper \
-        automake libtool flex make bzip2 git which rpm-build libevent-devel pandoc
+        automake libtool flex make bzip2 git which rpm-build libevent-devel pandoc hwloc hwloc-devel
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/src/mca/ploc/base/help-ploc.txt
+++ b/src/mca/ploc/base/help-ploc.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -9,48 +10,13 @@
 #
 # This is a US/English help file
 #
-[reqd-not-found]
-The plog_base_order MCA parameter included a required logging
-channel that is not available:
+[no-actives]
+PMIx was not able to find any usable hardware topology
+components. This could be due to not finding a suitable
+supporting library such as HWLOC. PMIx requires access
+to topology information due to its increased role in
+providing information on critical areas such as device
+distances and fabric interfaces.
 
-  Channel:  %s
-
-Please update the parameter and try again.
-#
-[syslog:unrec-level]
-An unrecognized syslog level was given:
-
-  Level:  %s
-
-Please see "man syslog" for a list of defined levels. Input
-parameter strings and their corresponding syslog levels
-recognized by PMIx include:
-
-  Parameter       Level
-   err           LOG_ERR  (default)
-   alert         LOG_ALERT
-   crit          LOG_CRIT
-   emerg         LOG_EMERG
-   warn          LOG_WARNING
-   not           LOG_NOTICE
-   info          LOG_INFO
-   debug         LOG_DEBUG
-
-Please redefine the MCA parameter and try again.
-#
-[syslog:unrec-facility]
-An unsupported or unrecognized value was given for the
-syslog facility (i.e., the type of program calling syslog):
-
-  Value:  %s
-
-Please see "man syslog" for a list of defined facility values.
-PMIx currently supports only the following designations:
-
-   Parameter       Level
-    auth          LOG_AUTH
-    priv          LOG_AUTHPRIV
-    daemon        LOG_DAEMON
-    user          LOG_USER  (default)
-
-Please redefine the MCA parameter and try again.
+Please reconfigure PMIx with a hardware topology library
+of your choice.

--- a/src/mca/ploc/base/ploc_base_frame.c
+++ b/src/mca/ploc/base/ploc_base_frame.c
@@ -46,8 +46,8 @@
 
 /* Instantiate the global vars */
 pmix_ploc_globals_t pmix_ploc_globals = {{0}};
-pmix_ploc_API_module_t pmix_ploc
-    = {.setup_topology = pmix_ploc_base_setup_topology,
+pmix_ploc_API_module_t pmix_ploc = {
+       .setup_topology = pmix_ploc_base_setup_topology,
        .load_topology = pmix_ploc_base_load_topology,
        .generate_cpuset_string = pmix_ploc_base_generate_cpuset_string,
        .parse_cpuset_string = pmix_ploc_base_parse_cpuset_string,
@@ -66,7 +66,8 @@ pmix_ploc_API_module_t pmix_ploc
        .copy_topology = pmix_ploc_base_copy_topology,
        .print_topology = pmix_ploc_base_print_topology,
        .destruct_topology = pmix_ploc_base_destruct_topology,
-       .release_topology = pmix_ploc_base_release_topology};
+       .release_topology = pmix_ploc_base_release_topology
+};
 
 static pmix_status_t pmix_ploc_close(void)
 {

--- a/src/mca/ploc/base/ploc_base_select.c
+++ b/src/mca/ploc/base/ploc_base_select.c
@@ -27,6 +27,7 @@
 
 #include "src/mca/base/base.h"
 #include "src/mca/mca.h"
+#include "src/util/show_help.h"
 
 #include "src/mca/ploc/base/base.h"
 
@@ -118,6 +119,11 @@ int pmix_ploc_base_select(void)
         }
     }
 
+    /* there must be at least one active component */
+    if (0 == pmix_list_get_size(&pmix_ploc_globals.actives)) {
+        pmix_show_help("help-ploc.txt", "no-actives", true);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
     return PMIX_SUCCESS;
-    ;
 }

--- a/src/mca/ploc/hwloc/configure.m4
+++ b/src/mca/ploc/hwloc/configure.m4
@@ -56,7 +56,17 @@ AC_DEFUN([MCA_pmix_ploc_hwloc_CONFIG],[
 
     AS_IF([test $pmix_hwloc_support -eq 1],
           [AC_MSG_CHECKING([hwloc header])
-           AC_MSG_RESULT([$PMIX_HWLOC_HEADER])])
+           AC_MSG_RESULT([$PMIX_HWLOC_HEADER])],
+          [AC_MSG_WARN([PMIx requires access to topology])
+           AC_MSG_WARN([information due to its increased role])
+           AC_MSG_WARN([in providing information on critical])
+           AC_MSG_WARN([areas such as device distances and fabric])
+           AC_MSG_WARN([interfaces. At this time, only the HWLOC])
+           AC_MSG_WARN([library is supported - and an installation])
+           AC_MSG_WARN([of that library was not found.])
+           AC_MSG_WARN([Please reconfigure PMIx pointing to an HWLOC])
+           AC_MSG_WARN([installation.])
+           AC_MSG_ERROR([Cannot continue.])])
 
     AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER], [$PMIX_HWLOC_HEADER],
                    [Location of hwloc.h])

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -656,9 +656,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     pmix_client_globals.myserver->info = pmix_globals.mypeer->info;
 
     /* open the pmdl framework and select the active modules for this environment */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
+    rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
@@ -680,9 +679,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     }
 
     /* open the ploc framework */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_ploc_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
+    rc = pmix_mca_base_framework_open(&pmix_ploc_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }


### PR DESCRIPTION
While we are setup to support alternatives, for now we must
require HWLOC.

Signed-off-by: Ralph Castain <rhc@pmix.org>