### PR TITLE
Track changes to IOF attributes and implementation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,9 @@ multiple release branches.
 
 4.1.0 -- TBD
 ----------------------
+ - PR #2248: Continue updates to support MPICH integration
+     - Extend IOF outputting format to cover Hydra options.
+ - PR #2246: Cleanup some IOF attributes
  - PR #2235: Cherry-pick updates from master branch
      - Default tools to outputting their IOF
      - Initalize val before get in case get isn't successful

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -876,6 +876,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_XML_OUTPUT                 "pmix.iof.xml"          // (bool) Format output in XML
 #define PMIX_IOF_OUTPUT_TO_FILE             "pmix.iof.file"         // (char*) direct application output into files of form
                                                                     //         "<filename>.rank" with both stdout and stderr redirected into it
+#define PMIX_IOF_FILE_PATTERN               "pmix.iof.fpt"          // (bool) Specified output file is to be treated as a pattern and not
+                                                                    //        automatically annotated by nspace, rank, or other parameters
 #define PMIX_IOF_OUTPUT_TO_DIRECTORY        "pmix.iof.dir"          // (char*) direct application output into files of form
                                                                     //         "<directory>/<jobid>/rank.<rank>/stdout[err]"
 #define PMIX_IOF_FILE_ONLY                  "pmix.iof.fonly"        // (bool) output only into designated files - do not also output

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -452,15 +452,6 @@ typedef uint32_t pmix_rank_t;
                                                                     //        job - i.e., not part of the "comm_world" of the job
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
-#define PMIX_TAG_OUTPUT                     "pmix.tagout"           // (bool) tag application output with the ID of the source
-#define PMIX_TIMESTAMP_OUTPUT               "pmix.tsout"            // (bool) timestamp output from applications
-#define PMIX_MERGE_STDERR_STDOUT            "pmix.mergeerrout"      // (bool) merge stdout and stderr streams from application procs
-#define PMIX_OUTPUT_TO_FILE                 "pmix.outfile"          // (char*) direct application output into files of form
-                                                                    //         "<filename>.rank" with both stdout and stderr redirected into it
-#define PMIX_OUTPUT_TO_DIRECTORY            "pmix.outdir"           // (char*) direct application output into files of form
-                                                                    //         "<directory>/<jobid>/rank.<rank>/stdout[err]"
-#define PMIX_OUTPUT_NOCOPY                  "pmix.nocopy"           // (bool) output only into designated files - do not also output
-                                                                    //        a copy to stdout/stderr
 #define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc
 #define PMIX_CPUS_PER_PROC                  "pmix.cpuperproc"       // (uint32_t) #cpus to assign to each rank
 #define PMIX_NO_PROCS_ON_HEAD               "pmix.nolocal"          // (bool) do not place procs on the head node
@@ -878,9 +869,17 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_PUSH_STDIN                 "pmix.iof.stdin"        // (bool) Used by a tool to request that the PMIx library collect
                                                                     //        the tool's stdin and forward it to the procs specified in
                                                                     //        the PMIx_IOF_push call
-#define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the channel it comes from
+#define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the [nspace,rank] and channel it comes from
+#define PMIX_IOF_RANK_OUTPUT                "pmix.iof.rank"         // (bool) Tag output with the rank it came from
 #define PMIX_IOF_TIMESTAMP_OUTPUT           "pmix.iof.ts"           // (bool) Timestamp output
+#define PMIX_IOF_MERGE_STDERR_STDOUT        "pmix.iof.mrg"          // (bool) merge stdout and stderr streams from application procs
 #define PMIX_IOF_XML_OUTPUT                 "pmix.iof.xml"          // (bool) Format output in XML
+#define PMIX_IOF_OUTPUT_TO_FILE             "pmix.iof.file"         // (char*) direct application output into files of form
+                                                                    //         "<filename>.rank" with both stdout and stderr redirected into it
+#define PMIX_IOF_OUTPUT_TO_DIRECTORY        "pmix.iof.dir"          // (char*) direct application output into files of form
+                                                                    //         "<directory>/<jobid>/rank.<rank>/stdout[err]"
+#define PMIX_IOF_FILE_ONLY                  "pmix.iof.fonly"        // (bool) output only into designated files - do not also output
+                                                                    //        a copy to stdout/stderr
 #define PMIX_IOF_COPY                       "pmix.iof.cpy"          // (bool) Requests that the host environment deliver a copy of the
                                                                     //        specified output stream(s) to the tool, letting the stream(s)
                                                                     //        continue to also be delivered to the default location. This

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -166,6 +166,15 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
                                                                     //        the event and believes termination of the application is not required
 #define PMIX_EVENT_WANT_TERMINATION         "pmix.evterm"           // (bool) ***** DEPRECATED ***** indicates that the handler has determined that the
                                                                     //        application should be terminated
+#define PMIX_TAG_OUTPUT                     "pmix.tagout"           // (bool) ***** DEPRECATED ***** tag application output with the ID of the source
+#define PMIX_TIMESTAMP_OUTPUT               "pmix.tsout"            // (bool) ***** DEPRECATED ***** timestamp output from applications
+#define PMIX_MERGE_STDERR_STDOUT            "pmix.mergeerrout"      // (bool) ***** DEPRECATED ***** merge stdout and stderr streams from application procs
+#define PMIX_OUTPUT_TO_FILE                 "pmix.outfile"          // (char*) ***** DEPRECATED ***** direct application output into files of form
+                                                                    //         "<filename>.rank" with both stdout and stderr redirected into it
+#define PMIX_OUTPUT_TO_DIRECTORY            "pmix.outdir"           // (char*) ***** DEPRECATED ***** direct application output into files of form
+                                                                    //         "<directory>/<jobid>/rank.<rank>/stdout[err]"
+#define PMIX_OUTPUT_NOCOPY                  "pmix.nocopy"           // (bool) ***** DEPRECATED ***** output only into designated files - do not also output
+                                                                    //        a copy to stdout/stderr
 
 /* attributes for GDS */
 #define PMIX_GDS_MODULE                     "pmix.gds.mod"          // (char*) ***** DEPRECATED ***** comma-delimited string of desired modules

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -203,6 +203,7 @@ typedef struct {
     bool nocopy;
     bool merge;
     bool local_output;
+    bool pattern;
 } pmix_iof_flags_t;
 
 /* objects used by servers for tracking active nspaces */

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -197,6 +197,7 @@ typedef struct {
     bool xml;
     bool timestamp;
     bool tag;
+    bool rank;
     char *file;
     char *directory;
     bool nocopy;


### PR DESCRIPTION
Cleanup some IOF attributes

Deprecate some early ones in favor of collecting all the IOF-related
attributes under the "PMIX_IOF_" prefix. Add one to tag output solely
with the rank of the source.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit f9e15e6)

Continue updates to support MPICH integration

Extend IOF outputting format to cover Hydra options.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit cb50b26)