### PR TITLE
Misc Python fixes

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -198,7 +198,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
                          pmix_info_t info[], size_t ninfo,
                          pmix_info_t *results, size_t nresults,
                          pmix_event_notification_cbfunc_fn_t cbfunc,
-                         void *cbdata):
+                         void *cbdata) with gil:
     cdef pmix_info_t *myresults
     cdef pmix_info_t **myresults_ptr
     cdef size_t nmyresults
@@ -3184,7 +3184,7 @@ cdef class PMIxTool(PMIxServer):
             rc = PMIx_tool_init(&self.myproc, NULL, 0)
         if PMIX_SUCCESS == rc:
             # convert the returned name
-            myname = {'nspace': str(self.myproc.nspace), 'rank': self.myproc.rank}
+            myname = {'nspace': (<bytes>self.myproc.nspace).decode('UTF-8'), 'rank': self.myproc.rank}
         return rc, myname
 
     # Finalize the tool library
@@ -3234,8 +3234,8 @@ cdef class PMIxTool(PMIxServer):
             rc = PMIx_tool_attach_to_server(&self.myproc, &srvr, NULL, 0)
         if PMIX_SUCCESS == rc:
             # convert the returned name
-            myname = {'nspace': str(self.myproc.nspace), 'rank': self.myproc.rank}
-            mysrvr = {'nspace': str(srvr.nspace), 'rank': srvr.rank}
+            myname = {'nspace': (<bytes>self.myproc.nspace).decode('UTF-8'), 'rank': self.myproc.rank}
+            mysrvr = {'nspace': (<bytes>srvr.nspace).decode('UTF-8'), 'rank': srvr.rank}
         return rc, myname, mysrvr
 
     def get_servers(self):


### PR DESCRIPTION
There are threeish different bugs being fixed here. One is string decoding, similar to several previous fixes.

One of the biggest changes is changing some instances of `PyMem_Malloc/PyMem_Free` with the system `malloc/free`. The reason for this is that in some code paths, such as called in `PMIx_Spawn()` will lead to PMIx internally calling the `realloc()` function. When the libc `realloc()` function sees a pointer from `PyMem_Malloc()` it crashes the program. So this change will use the system malloc when allocating data structures that will be given to PMIx rather than being given to Python. 

The last change is declare the `pyeventhandler()` cb function with the `with gil` clause. Without it the Python interpreter won't set up the Python thread state and won't be able to access the Python datatypes inside of the callback since it is called in a C context.