### PR TITLE
Cleanup the device distance computation

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1054,7 +1054,7 @@ typedef uint32_t pmix_rank_t;
 
 
 /* Distance Attributes */
-#define PMIX_DEVICE_DISTANCES               "pmix.dev.dist"        // (pmix_data_array_t*) Return an array of pmix_device_dist_t containing the
+#define PMIX_DEVICE_DISTANCES               "pmix.dev.dist"        // (pmix_data_array_t*) Return an array of pmix_device_distance_t containing the
                                                                    //         minimum and maximum distances of the given process location to all
                                                                    //         devices of the specified type on the local node.
 #define PMIX_DEVICE_TYPE                    "pmix.dev.type"        // (pmix_device_type_t) Bitmask specifying the type(s) of device(s) whose

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -136,7 +136,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_IOF_DEREG_CMD                29
 #define PMIX_FABRIC_REGISTER_CMD          30
 #define PMIX_FABRIC_UPDATE_CMD            31
-#define PMIX_FABRIC_COMPUTE_DISTANCES_CMD 32
+#define PMIX_COMPUTE_DEVICE_DISTANCES_CMD 32
 
 /* provide a "pretty-print" function for cmds */
 const char *pmix_command_string(pmix_cmd_t cmd);
@@ -593,6 +593,7 @@ typedef struct {
     size_t output_limit;
     pmix_list_t nspaces;
     pmix_topology_t topology;
+    pmix_cpuset_t cpuset;
     bool external_topology;
     bool external_progress;
     pmix_iof_flags_t iof_flags;

--- a/src/mca/ploc/base/ploc_base_frame.c
+++ b/src/mca/ploc/base/ploc_base_frame.c
@@ -95,6 +95,10 @@ static pmix_status_t pmix_ploc_close(void)
 
 static pmix_status_t pmix_ploc_open(pmix_mca_base_open_flag_t flags)
 {
+    if (pmix_ploc_globals.initialized) {
+        return PMIX_SUCCESS;
+    }
+
     /* initialize globals */
     pmix_ploc_globals.initialized = true;
     PMIX_CONSTRUCT_LOCK(&pmix_ploc_globals.lock);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -86,6 +86,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {.init_cntr = 0,
                                            .commits_pending = false,
                                            .pushstdin = false,
                                            .topology = {NULL, NULL},
+                                           .cpuset = {NULL, NULL},
                                            .external_topology = false,
                                            .external_progress = false};
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -678,17 +678,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
         return rc;
     }
 
-    /* open the ploc framework */
-    rc = pmix_mca_base_framework_open(&pmix_ploc_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    if (PMIX_SUCCESS != (rc = pmix_ploc_base_select())) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-
     /* if we were started to support a singleton, register it now
      * so we won't reject it when it connects to us */
     if (NULL != (evar = getenv("PMIX_MCA_singleton"))) {
@@ -4232,6 +4221,53 @@ complete:
     }
 }
 
+static void dist_cbfunc(pmix_status_t status, pmix_device_distance_t *dist, size_t ndist, void *cbdata,
+                        pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t rc;
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:fabric callback with status %d",
+                        status);
+
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
+    }
+    /* pack the returned data */
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &ndist, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
+    }
+    if (0 < ndist) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, dist, ndist, PMIX_DEVICE_DIST);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+
+complete:
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+    }
+    PMIX_RELEASE(cd);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
 /* the switchyard is the primary message handling function. It's purpose
  * is to take incoming commands (packed into a buffer), unpack them,
  * and then call the corresponding host server's function to execute
@@ -4576,6 +4612,14 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
     if (PMIX_FABRIC_UPDATE_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         if (PMIX_SUCCESS != (rc = pmix_server_fabric_update(cd, buf, fabric_cbfunc))) {
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+
+    if (PMIX_COMPUTE_DEVICE_DISTANCES_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_device_dists(cd, buf, dist_cbfunc))) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -56,6 +56,7 @@
 #include "src/common/pmix_attributes.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/gds/base/base.h"
+#include "src/mca/ploc/ploc.h"
 #include "src/mca/plog/plog.h"
 #include "src/mca/pnet/pnet.h"
 #include "src/mca/prm/prm.h"
@@ -4633,6 +4634,106 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
     return PMIX_SUCCESS;
 
 exit:
+    return rc;
+}
+
+pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
+                                       pmix_buffer_t *buf,
+                                       pmix_device_dist_cbfunc_t cbfunc)
+{
+    pmix_topology_t topo = {NULL, NULL};
+    pmix_cpuset_t cpuset = {NULL, NULL};
+    pmix_status_t rc;
+    pmix_device_distance_t *distances;
+    size_t ndist;
+    int cnt;
+    pmix_cb_t cb;
+    pmix_kval_t *kv;
+    pmix_proc_t proc;
+
+    /* unpack the topology they want us to use */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &topo, &cnt, PMIX_TOPO);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* unpack the cpuset */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &cpuset, &cnt, PMIX_PROC_CPUSET);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    /* unpack any directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    if (0 < cd->ninfo) {
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        cnt = cd->ninfo;
+        PMIX_BFROPS_UNPACK(rc, cd->peer, buf, cd->info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+
+    /* if the provided topo is NULL, use my own */
+    if (NULL == topo.topology) {
+        if (NULL == pmix_globals.topology.topology) {
+            /* try to get it */
+            rc = pmix_ploc.load_topology(&pmix_globals.topology);
+            if (PMIX_SUCCESS != rc) {
+                /* nothing we can do */
+                goto cleanup;
+            }
+        }
+        topo.topology = pmix_globals.topology.topology;
+    }
+
+    /* if the cpuset is NULL, see if we know the binding of the requesting process */
+    if (NULL == cpuset.bitmap) {
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.key = strdup(PMIX_CPUSET);
+        PMIX_LOAD_PROCID(&proc, cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
+        cb.proc = &proc;
+        cb.scope = PMIX_LOCAL;
+        cb.copy = true;
+        PMIX_GDS_FETCH_KV(rc, cd->peer, &cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DESTRUCT(&cb);
+            goto cleanup;
+        }
+        kv = (pmix_kval_t*)pmix_list_get_first(&cb.kvs);
+        rc = pmix_ploc.parse_cpuset_string(kv->value->data.string, cpuset.bitmap);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DESTRUCT(&cb);
+            goto cleanup;
+        }
+        PMIX_DESTRUCT(&cb);
+    }
+    /* compute the distances */
+    rc = pmix_ploc.compute_distances(&topo, &cpuset, cd->info, cd->ninfo, &distances, &ndist);
+    if (PMIX_SUCCESS == rc) {
+        /* send the reply */
+        cbfunc(rc, distances, ndist, cd, NULL, NULL);
+        PMIX_DEVICE_DIST_FREE(distances, ndist);
+    }
+
+cleanup:
+    if (NULL != topo.topology &&
+        topo.topology != pmix_globals.topology.topology) {
+        pmix_ploc.destruct_topology(&topo);
+    }
+    if (NULL != cpuset.bitmap) {
+        pmix_ploc.destruct_cpuset(&cpuset);
+    }
     return rc;
 }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -353,6 +353,10 @@ PMIX_EXPORT pmix_status_t pmix_server_fabric_get_device_index(pmix_server_caddy_
                                                               pmix_buffer_t *buf,
                                                               pmix_info_cbfunc_t cbfunc);
 
+PMIX_EXPORT pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
+                                                   pmix_buffer_t *buf,
+                                                   pmix_device_dist_cbfunc_t cbfunc);
+
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;
 


### PR DESCRIPTION
Establish the relative roles of the client and server
in performing the calculation. Passing of NULL topology
indicates use of local topology. Passing of NULL cpuset
indicates use of local cpuset for proc.

Signed-off-by: Ralph Castain <rhc@pmix.org>