### PR TITLE
Add missing storage constants

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1358,6 +1358,10 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_NET_STATS                  63
 #define PMIX_NODE_STATS                 64
 #define PMIX_DATA_BUFFER                65
+#define PMIX_STOR_MEDIUM                66
+#define PMIX_STOR_ACCESS                67
+#define PMIX_STOR_PERSIST               68
+#define PMIX_STOR_ACCESS_TYPE           69
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1455,6 +1455,57 @@ typedef enum {
     PMIX_GROUP_DESTRUCT
 } pmix_group_operation_t;
 
+/* define storage medium values
+ * The pmix_storage_medium_t is a uint64_t type that defines
+ * a set of bit-mask flags for specifying different types of
+ * storage mediums. These can be bitwise OR'd together to
+ * accommodate storage systems that mix storage medium types. */
+typedef uint64_t pmix_storage_medium_t;
+#define PMIX_STORAGE_MEDIUM_UNKNOWN     0x0000000000000001
+#define PMIX_STORAGE_MEDIUM_TAPE        0x0000000000000002
+#define PMIX_STORAGE_MEDIUM_HDD         0x0000000000000004
+#define PMIX_STORAGE_MEDIUM_SSD         0x0000000000000008
+#define PMIX_STORAGE_MEDIUM_NVME        0x0000000000000010
+#define PMIX_STORAGE_MEDIUM_PMEM        0x0000000000000020
+#define PMIX_STORAGE_MEDIUM_RAM         0x0000000000000040
+
+/* define storage accessibility values
+ * The pmix_storage_accessibility_t is a uint64_t type that
+ * defines a set of bit-mask flags for specifying different
+ * levels of storage accessibility (i.e,. from where a storage
+ * system may be accessed). These can be bitwise OR'd together
+ * to accommodate storage systems that are accessibile in
+ * multiple ways. */
+typedef uint64_t pmix_storage_accessibility_t;
+#define PMIX_STORAGE_ACCESSIBILITY_NODE     0x0000000000000001
+#define PMIX_STORAGE_ACCESSIBILITY_SESSION  0x0000000000000002
+#define PMIX_STORAGE_ACCESSIBILITY_JOB      0x0000000000000004
+#define PMIX_STORAGE_ACCESSIBILITY_RACK     0x0000000000000008
+#define PMIX_STORAGE_ACCESSIBILITY_CLUSTER  0x0000000000000010
+#define PMIX_STORAGE_ACCESSIBILITY_REMOTE   0x0000000000000020
+
+/* define storage persistence values
+ * The pmix_storage_persistence_t is a uint64_t type that defines
+ * a set of bit-mask flags for specifying different levels of
+ * persistence for a particular storage system. */
+typedef uint64_t pmix_storage_persistence_t;
+#define PMIX_STORAGE_PERSISTENCE_TEMPORARY  0x0000000000000001
+#define PMIX_STORAGE_PERSISTENCE_NODE       0x0000000000000002
+#define PMIX_STORAGE_PERSISTENCE_SESSION    0x0000000000000004
+#define PMIX_STORAGE_PERSISTENCE_JOB        0x0000000000000008
+#define PMIX_STORAGE_PERSISTENCE_SCRATCH    0x0000000000000010
+#define PMIX_STORAGE_PERSISTENCE_PROJECT    0x0000000000000020
+#define PMIX_STORAGE_PERSISTENCE_ARCHIVE    0x0000000000000040
+
+/* define storage access values
+ * The pmix_storage_access_type_t is a uint16_t type that defines
+ * a set of bit-mask flags for specifying different storage system
+ * access types. */
+typedef uint16_t pmix_storage_access_type_t;
+#define PMIX_STORAGE_ACCESS_RD      0x0001
+#define PMIX_STORAGE_ACCESS_WR      0x0002
+#define PMIX_STORAGE_ACCESS_RDWR    0x0003
+
 
 /* define some "hooks" external libraries can use to
  * intercept memory allocation/release operations */

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -505,6 +505,18 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_ndstats(pmix_pointer_array_t *re
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_dbuf(pmix_pointer_array_t *regtypes,
                                                      pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_smed(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
+                                                     int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_sacc(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
+                                                     int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_spers(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
+                                                      int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_satyp(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
+                                                      int32_t num_vals, pmix_data_type_t type);
 
 /*
  * "Standard" unpack functions
@@ -700,6 +712,18 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_ndstats(pmix_pointer_array_t *
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes,
                                                        pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_smed(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
+                                                       int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_sacc(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
+                                                       int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_spers(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
+                                                        int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_satyp(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
+                                                        int32_t *num_vals, pmix_data_type_t type);
 
 /**** DEPRECATED ****/
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_pointer_array_t *regtypes,
@@ -940,6 +964,18 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_ndstats(char **output, char *pr
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_dbuf(char **output, char *prefix,
                                                       pmix_data_buffer_t *src,
                                                       pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_smed(char **output, char *prefix,
+                                                      pmix_storage_medium_t *src,
+                                                      pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_sacc(char **output, char *prefix,
+                                                      pmix_storage_accessibility_t *src,
+                                                      pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_spers(char **output, char *prefix,
+                                                       pmix_storage_persistence_t *src,
+                                                       pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *prefix,
+                                                       pmix_storage_access_type_t *src,
+                                                       pmix_data_type_t type);
 
 /*
  * Common helper functions

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -126,6 +126,7 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src, pmix_data_type_t
     case PMIX_UINT16:
     case PMIX_IOF_CHANNEL:
     case PMIX_LOCTYPE:
+    case PMIX_STOR_ACCESS_TYPE:
         datasize = 2;
         break;
 
@@ -137,6 +138,9 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src, pmix_data_type_t
     case PMIX_INT64:
     case PMIX_UINT64:
     case PMIX_DEVTYPE:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
         datasize = 8;
         break;
 

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -120,12 +120,16 @@ void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data, pmix_data_ty
             memcpy(&(v->data.uint8), data, 1);
             break;
         case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
             memcpy(&(v->data.uint16), data, 2);
             break;
         case PMIX_UINT32:
             memcpy(&(v->data.uint32), data, 4);
             break;
         case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
             memcpy(&(v->data.uint64), data, 8);
             break;
         case PMIX_FLOAT:
@@ -408,6 +412,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
             *sz = 1;
             break;
         case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
             memcpy(*data, &(kv->data.uint16), 2);
             *sz = 2;
             break;
@@ -416,6 +421,9 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
             *sz = 4;
             break;
         case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
             memcpy(*data, &(kv->data.uint64), 8);
             *sz = 8;
             break;
@@ -720,6 +728,7 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p, pmix_value_t *p1)
         }
         break;
     case PMIX_UINT16:
+    case PMIX_STOR_ACCESS_TYPE:
         if (p->data.uint16 == p1->data.uint16) {
             rc = PMIX_EQUAL;
         }
@@ -730,6 +739,9 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p, pmix_value_t *p1)
         }
         break;
     case PMIX_UINT64:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
         if (p->data.uint64 == p1->data.uint64) {
             rc = PMIX_EQUAL;
         }
@@ -872,6 +884,7 @@ pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p, const pmix_value_t *s
         p->data.uint8 = src->data.uint8;
         break;
     case PMIX_UINT16:
+    case PMIX_STOR_ACCESS_TYPE:
         /* to avoid alignment issues */
         memcpy(&p->data.uint16, &src->data.uint16, 2);
         break;
@@ -880,7 +893,10 @@ pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p, const pmix_value_t *s
         memcpy(&p->data.uint32, &src->data.uint32, 4);
         break;
     case PMIX_UINT64:
-        /* to avoid alignment issues */
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
+       /* to avoid alignment issues */
         memcpy(&p->data.uint64, &src->data.uint64, 8);
         break;
     case PMIX_FLOAT:

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1880,3 +1880,67 @@ pmix_status_t pmix_bfrops_base_pack_dbuf(pmix_pointer_array_t *regtypes, pmix_bu
     }
     return PMIX_SUCCESS;
 }
+
+pmix_status_t pmix_bfrops_base_pack_smed(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                         const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (NULL == regtypes) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (PMIX_STOR_MEDIUM != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_pack_sacc(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                         const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (NULL == regtypes) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (PMIX_STOR_ACCESS != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_pack_spers(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                          const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (NULL == regtypes) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (PMIX_STOR_PERSIST != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_pack_satyp(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                          const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (NULL == regtypes) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (PMIX_STOR_ACCESS_TYPE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
+    return ret;
+}

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1116,6 +1116,18 @@ int pmix_bfrops_base_print_value(char **output, char *prefix, pmix_value_t *src,
     case PMIX_ENDPOINT:
         rc = pmix_bfrops_base_print_endpoint(output, prefx, src->data.endpoint, PMIX_ENDPOINT);
         break;
+    case PMIX_STOR_MEDIUM:
+        rc = pmix_bfrops_base_print_smed(output, prefx, &src->data.uint64, PMIX_STOR_MEDIUM);
+        break;
+    case PMIX_STOR_ACCESS:
+        rc = pmix_bfrops_base_print_sacc(output, prefx, &src->data.uint64, PMIX_STOR_ACCESS);
+        break;
+    case PMIX_STOR_PERSIST:
+        rc = pmix_bfrops_base_print_spers(output, prefx, &src->data.uint64, PMIX_STOR_PERSIST);
+        break;
+    case PMIX_STOR_ACCESS_TYPE:
+        rc = pmix_bfrops_base_print_satyp(output, prefx, &src->data.uint16, PMIX_STOR_ACCESS_TYPE);
+        break;
     default:
         rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;
@@ -2514,4 +2526,216 @@ pmix_status_t pmix_bfrops_base_print_dbuf(char **output, char *prefix, pmix_data
     }
 
     return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_bfrops_base_print_smed(char **output, char *prefix,
+                                          pmix_storage_medium_t *src,
+                                          pmix_data_type_t type)
+{
+    char *prefx, **tmp = NULL, *str;
+    int ret;
+
+    if (PMIX_STOR_MEDIUM != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (PMIX_STORAGE_MEDIUM_UNKNOWN & *src) {
+        str = strdup("UNKNOWN");
+    } else {
+        if (PMIX_STORAGE_MEDIUM_TAPE & *src) {
+            pmix_argv_append_nosize(&tmp, "TAPE");
+        }
+        if (PMIX_STORAGE_MEDIUM_HDD & *src) {
+            pmix_argv_append_nosize(&tmp, "HDD");
+        }
+        if (PMIX_STORAGE_MEDIUM_SSD & *src) {
+            pmix_argv_append_nosize(&tmp, "SSD");
+        }
+        if (PMIX_STORAGE_MEDIUM_NVME & *src) {
+            pmix_argv_append_nosize(&tmp, "NVME");
+        }
+        if (PMIX_STORAGE_MEDIUM_PMEM & *src) {
+            pmix_argv_append_nosize(&tmp, "PMEM");
+        }
+        if (PMIX_STORAGE_MEDIUM_RAM & *src) {
+            pmix_argv_append_nosize(&tmp, "RAM");
+        }
+        str = pmix_argv_join(tmp, ':');
+        pmix_argv_free(tmp);
+    }
+
+    ret = asprintf(output, "%sData type: PMIX_STOR_MEDIUM\tValue: %s", prefx, str);
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    free(str);
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_sacc(char **output, char *prefix,
+                                          pmix_storage_accessibility_t *src,
+                                          pmix_data_type_t type)
+{
+    char *prefx, **tmp = NULL, *str;
+    int ret;
+
+    if (PMIX_STOR_ACCESS != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (PMIX_STORAGE_ACCESSIBILITY_NODE & *src) {
+        pmix_argv_append_nosize(&tmp, "NODE");
+    }
+    if (PMIX_STORAGE_ACCESSIBILITY_SESSION & *src) {
+        pmix_argv_append_nosize(&tmp, "SESSION");
+    }
+    if (PMIX_STORAGE_ACCESSIBILITY_JOB & *src) {
+        pmix_argv_append_nosize(&tmp, "JOB");
+    }
+    if (PMIX_STORAGE_ACCESSIBILITY_RACK & *src) {
+        pmix_argv_append_nosize(&tmp, "RACK");
+    }
+    if (PMIX_STORAGE_ACCESSIBILITY_CLUSTER & *src) {
+        pmix_argv_append_nosize(&tmp, "CLUSTER");
+    }
+    if (PMIX_STORAGE_ACCESSIBILITY_REMOTE & *src) {
+        pmix_argv_append_nosize(&tmp, "REMOTE");
+    }
+    str = pmix_argv_join(tmp, ':');
+    pmix_argv_free(tmp);
+
+    ret = asprintf(output, "%sData type: PMIX_STOR_ACCESS\tValue: %s", prefx, str);
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    free(str);
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_spers(char **output, char *prefix,
+                                           pmix_storage_persistence_t *src,
+                                           pmix_data_type_t type)
+{
+    char *prefx, **tmp = NULL, *str;
+    int ret;
+
+    if (PMIX_STOR_PERSIST != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (PMIX_STORAGE_PERSISTENCE_TEMPORARY & *src) {
+        pmix_argv_append_nosize(&tmp, "TEMPORARY");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_NODE & *src) {
+        pmix_argv_append_nosize(&tmp, "NODE");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_SESSION & *src) {
+        pmix_argv_append_nosize(&tmp, "SESSION");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_JOB & *src) {
+        pmix_argv_append_nosize(&tmp, "JOB");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_SCRATCH & *src) {
+        pmix_argv_append_nosize(&tmp, "SCRATCH");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_PROJECT & *src) {
+        pmix_argv_append_nosize(&tmp, "PROJECT");
+    }
+    if (PMIX_STORAGE_PERSISTENCE_ARCHIVE & *src) {
+        pmix_argv_append_nosize(&tmp, "ARCHIVE");
+    }
+
+    str = pmix_argv_join(tmp, ':');
+    pmix_argv_free(tmp);
+
+    ret = asprintf(output, "%sData type: PMIX_STOR_PERSIST\tValue: %s", prefx, str);
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    free(str);
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *prefix,
+                                           pmix_storage_access_type_t *src,
+                                           pmix_data_type_t type)
+{
+    char *prefx, **tmp = NULL, *str;
+    int ret;
+
+    if (PMIX_STOR_ACCESS_TYPE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (PMIX_STORAGE_ACCESS_RD & *src) {
+        pmix_argv_append_nosize(&tmp, "READ");
+    }
+    if (PMIX_STORAGE_ACCESS_WR & *src) {
+        pmix_argv_append_nosize(&tmp, "WRITE");
+    }
+    str = pmix_argv_join(tmp, ':');
+    pmix_argv_free(tmp);
+
+    ret = asprintf(output, "%sData type: PMIX_STOR_ACCESS_TYPE\tValue: %s", prefx, str);
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    free(str);
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
 }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -2387,3 +2387,71 @@ pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes, pmix_
     }
     return PMIX_SUCCESS;
 }
+
+pmix_status_t pmix_bfrops_base_unpack_smed(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                           void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d storage medium", *num_vals);
+
+    if (PMIX_STOR_MEDIUM != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
+
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_unpack_sacc(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                           void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d storage access", *num_vals);
+
+    if (PMIX_STOR_ACCESS != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
+
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_unpack_spers(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                            void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d storage persistence", *num_vals);
+
+    if (PMIX_STOR_PERSIST != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
+
+    return ret;
+}
+
+pmix_status_t pmix_bfrops_base_unpack_satyp(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                            void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d storage access type", *num_vals);
+
+    if (PMIX_STOR_ACCESS_TYPE != type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT16, regtypes);
+
+    return ret;
+}

--- a/src/mca/bfrops/v41/bfrop_pmix41.c
+++ b/src/mca/bfrops/v41/bfrop_pmix41.c
@@ -342,6 +342,22 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_dbuf, pmix_bfrops_base_copy_dbuf,
                        pmix_bfrops_base_print_dbuf, &mca_bfrops_v41_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_STOR_MEDIUM", PMIX_STOR_MEDIUM, pmix_bfrops_base_pack_smed,
+                       pmix_bfrops_base_unpack_smed, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_smed, &mca_bfrops_v41_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_STOR_ACCESS", PMIX_STOR_ACCESS, pmix_bfrops_base_pack_sacc,
+                       pmix_bfrops_base_unpack_sacc, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_sacc, &mca_bfrops_v41_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_STOR_PERSIST", PMIX_STOR_PERSIST, pmix_bfrops_base_pack_spers,
+                       pmix_bfrops_base_unpack_spers, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_spers, &mca_bfrops_v41_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_STOR_ACCESS_TYPE", PMIX_STOR_ACCESS_TYPE, pmix_bfrops_base_pack_satyp,
+                       pmix_bfrops_base_unpack_satyp, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_satyp, &mca_bfrops_v41_component.types);
+
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
Define and assign values to the PMIx storage types per the Standard.

Signed-off-by: Ralph Castain <rhc@pmix.org>