### PR TITLE
Some cleanup of IOF output

### DIFF
--- a/.github/actions/mlnx/entrypoint.sh
+++ b/.github/actions/mlnx/entrypoint.sh
@@ -123,120 +123,6 @@ function check_result()
     test_id=$((test_id+1))
 }
 
-function pmix_run_tests()
-{
-    cd $build_dir/test
-
-    echo "1..14" >> $run_tap
-
-    test_ret=0
-
-    test_id=1
-    # 1 blocking fence with data exchange among all processes from two namespaces:
-    if [ "$pmix_ver" -ge 12 ]; then
-        test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]" -o $OUTDIR/out'
-        # All nspaces should started from 0 rank.                         ^ here is 0 rank for the second nspace
-        check_result "blocking fence w/ data all" "$test_exec"
-        test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:0]" -o $OUTDIR/out'
-        check_result "blocking fence w/ data all" "$test_exec"
-    else
-        # For old test version the rank counter for the second nspace may starts with not 0,
-        # this case supports old versions
-        test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:3]" -o $OUTDIR/out'
-        check_result "blocking fence w/ data all" "$test_exec"
-        test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:3]" -o $OUTDIR/out'
-        check_result "blocking fence w/ data all" "$test_exec"
-    fi
-    test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:]" -o $OUTDIR/out'
-    check_result "blocking fence w/ data all" "$test_exec"
-
-    # 1 non-blocking fence without data exchange among processes from the 1st namespace
-    test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[0:]" -o $OUTDIR/out'
-    check_result "non-blocking fence w/o data" "$test_exec"
-
-    # blocking fence without data exchange among processes from the 1st namespace
-    test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[b | 0:]" -o $OUTDIR/out'
-    check_result "blocking fence w/ data" "$test_exec"
-
-    # non-blocking fence with data exchange among processes from the 1st namespace. Ranks 0, 1 from ns 0 are sleeping for 2 sec before doing fence test.
-    test_exec='./pmix_test -n 4 --ns-dist 3:1 --fence "[d | 0:]" --noise "[0:0,1]" -o $OUTDIR/out'
-    check_result "non-blocking fence w/ data" "$test_exec"
-
-    # blocking fence with data exchange across processes from the same namespace.
-    test_exec='./pmix_test -n 4 --job-fence -c -o $OUTDIR/out'
-    check_result "blocking fence w/ data on the same nspace" "$test_exec"
-
-    # blocking fence with data exchange across processes from the same namespace.
-    test_exec='./pmix_test -n 4 --job-fence -o $OUTDIR/out'
-    check_result "blocking fence w/o data on the same nspace" "$test_exec"
-
-    # 3 fences: 1 - non-blocking without data exchange across processes from ns 0,
-    # 2 - non-blocking across processes 0 and 1 from ns 0 and process 3 from ns 1,
-    # 3 - blocking with data exchange across processes from their own namespace.
-    # Disabled as incorrect at the moment
-    # test_exec='./pmix_test -n 4 --job-fence -c --fence "[0:][d|0:0-1;1:]" --use-same-keys --ns-dist "3:1"'
-    # check_result "mix fence" $test_exec
-
-    # test publish/lookup/unpublish functionality.
-    test_exec='./pmix_test -n 2 --test-publish -o $OUTDIR/out'
-    check_result "publish" "$test_exec"
-
-    # test spawn functionality.
-    test_exec='./pmix_test -n 2 --test-spawn -o $OUTDIR/out'
-    check_result "spawn" "$test_exec"
-
-    # test connect/disconnect between processes from the same namespace.
-    test_exec='./pmix_test -n 2 --test-connect -o $OUTDIR/out'
-    check_result "connect" "$test_exec"
-
-    # resolve peers from different namespaces.
-    test_exec='./pmix_test -n 5 --test-resolve-peers --ns-dist "1:2:2" -o $OUTDIR/out'
-    check_result "resolve peers" "$test_exec"
-
-
-    if [ "$pmix_ver" -gt 11 ]; then
-        # resolve peers from different namespaces.
-        test_exec='./pmix_test -n 5 --test-replace 100:0,1,10,50,99 -o $OUTDIR/out'
-        check_result "key replacement" "$test_exec"
-
-        # resolve peers from different namespaces.
-        test_exec='./pmix_test -n 5 --test-internal 10 -o $OUTDIR/out'
-        check_result "local store" "$test_exec"
-    fi
-#    if [ "$pmix_ver" -ge 40 ]; then
-#        # test direct modex
-#        test_exec='./pmix_test -s 2 -n 2 --job-fence -o $OUTDIR/out'
-#        check_result "direct modex" "$test_exec"
-
-        # test full modex
-#        test_exec='./pmix_test -s 2 -n 2 --job-fence -c -o $OUTDIR/out'
-#        check_result "full modex" "$test_exec"
-#    fi
-
-    # run valgrind
-    if [ "$jenkins_test_vg" = "yes" ]; then
-        set +e
-        module load tools/valgrind
-        vg_opt="--tool=memcheck --leak-check=full --error-exitcode=0 --trace-children=yes  --trace-children-skip=*/sed,*/collect2,*/gcc,*/cat,*/rm,*/ls --track-origins=yes --xml=yes --xml-file=valgrind%p.xml --fair-sched=try --gen-suppressions=all"
-        valgrind $vg_opt  ./pmix_test -n 4 --timeout 60 --ns-dist 3:1 --fence "[db | 0:;1:3]"
-        valgrind $vg_opt  ./pmix_test -n 4 --timeout 60 --job-fence -c
-        valgrind $vg_opt  ./pmix_test -n 2 --timeout 60 --test-publish
-        valgrind $vg_opt  ./pmix_test -n 2 --timeout 60 --test-spawn
-        valgrind $vg_opt  ./pmix_test -n 2 --timeout 60 --test-connect
-        valgrind $vg_opt  ./pmix_test -n 5 --timeout 60 --test-resolve-peers --ns-dist "1:2:2"
-        valgrind $vg_opt  ./pmix_test -n 5 --test-replace 100:0,1,10,50,99
-        valgrind $vg_opt  ./pmix_test -n 5 --test-internal 10
-        module unload tools/valgrind
-        set -e
-    fi
-
-    if [ "$test_ret" = "0" ]; then
-        echo "Test OK"
-    else
-        echo "Test failed"
-    fi
-}
-
 trap "on_exit" INT TERM ILL KILL FPE SEGV ALRM
 
 on_start
@@ -255,10 +141,15 @@ configure_args=""
 
 cd $WORKSPACE
 if [ "$jenkins_test_build" = "yes" ]; then
+    echo "==========================  TEST BUILD  =========================="
     $autogen_script && touch .autogen_done
     echo ./configure --prefix=$pmix_dir $configure_args | bash -xeE
     make $make_opt install
+    cd test
+    echo "Running make check ..."
     make $make_opt check || (cat test/test-suite.log && exit 12)
+    echo "Make check complete"
+    echo "========================  TEST COMPLETE  ========================="
 fi
 
 cd $WORKSPACE
@@ -303,122 +194,4 @@ if [ "$jenkins_test_src_rpm" = "yes" ]; then
         # check distclean
         make $make_opt distclean
     fi
-fi
-
-cd $WORKSPACE
-if [ "$jenkins_test_check" = "yes" ]; then
-    run_tap=$WORKSPACE/run_test.tap
-    rm -rf $run_tap
-
-    export TMPDIR="/tmp"
-
-    if [ ! -d "$OUTDIR" ]; then
-        mkdir $OUTDIR
-    fi
-
-    # Run autogen only once
-    if [ "${autogen_done}" != "1" ]; then
-        $autogen_script && touch .autogen_done
-    fi
-
-    if [ $pmix_ver -le 20 ]; then
-        # Test pmix/messaging
-        echo "--------------------------- Building with messages ----------------------------------------"
-        mkdir ${build_dir}
-        cd ${build_dir}
-        echo ${WORKSPACE}/configure --prefix=${pmix_dir} $configure_args --disable-visibility --disable-dstore | bash -xeE
-        make $make_opt install
-        echo "--------------------------- Checking with messages ----------------------------------------"
-        echo "Checking without dstor:" >> $run_tap
-        pmix_run_tests
-        rm -Rf ${pmix_dir} ${build_dir}
-        rc=$test_ret
-
-        # Test pmix/dstore/flock
-        echo "--------------------------- Building with dstore/flock ----------------------------------------"
-        mkdir ${build_dir}
-        cd ${build_dir}
-        echo ${WORKSPACE}/configure --prefix=$pmix_dir $configure_args --disable-visibility --enable-dstore --disable-dstore-pthlck | bash -xeE
-        make $make_opt install
-        echo "--------------------------- Checking with dstore/flock ----------------------------------------"
-        echo "Checking with dstor/flock:" >> $run_tap
-        pmix_run_tests
-        rm -Rf ${pmix_dir} ${build_dir}
-        rc=$((test_ret+rc))
-
-        # Test pmix/dstore/pthread-lock
-        echo "--------------------------- Building with dstore/pthread-lock ----------------------------------------"
-        mkdir ${build_dir}
-        cd ${build_dir}
-        echo ${WORKSPACE}/configure --prefix=$pmix_dir $configure_args --disable-visibility --enable-dstore | bash -xeE
-        make $make_opt install
-        echo "--------------------------- Checking with dstore/pthread-lock ----------------------------------------"
-        echo "Checking with dstor:" >> $run_tap
-        pmix_run_tests
-        rm -Rf ${pmix_dir} ${build_dir}
-        rc=$((test_ret+rc))
-    else
-        has_gds_ds21=0
-        # Test pmix/dstore/pthread-lock
-        echo "--------------------------- Building with dstore/pthread-lock ----------------------------------------"
-        mkdir ${build_dir}
-        cd ${build_dir}
-        echo ${WORKSPACE}/configure --prefix=$pmix_dir $configure_args --disable-visibility | bash -xeE
-        make $make_opt install
-        echo "--------------------------- Checking with dstore/pthread-lock ----------------------------------------"
-        echo "----dstore/pthread-lock----" >> $run_tap
-
-        gds_list="hash ds12,hash"
-        # check the existence of ds21 component
-        has_gds_ds21=$($pmix_dir/bin/pmix_info --param gds ds21 | wc -l)
-        if [ "$has_gds_ds21" -gt 0 ]; then
-            gds_list="$gds_list ds21,hash"
-        fi
-
-        for gds in $gds_list; do
-            echo "Checking with $gds:" >> $run_tap
-            export PMIX_MCA_gds=$gds
-            pmix_run_tests
-        done
-        echo "Checking with auto gds:" >> $run_tap
-        export PMIX_MCA_gds=""
-        pmix_run_tests
-
-
-        rm -Rf ${pmix_dir} ${build_dir}
-        rc=$((test_ret+rc))
-
-        # Test pmix/dstore/flock
-        echo "--------------------------- Building with dstore/flock ----------------------------------------"
-        mkdir ${build_dir}
-        cd ${build_dir}
-        echo ${WORKSPACE}/configure --prefix=$pmix_dir $configure_args --disable-visibility --disable-dstore-pthlck | bash -xeE
-        make $make_opt install
-        echo "--------------------------- Checking with dstore/flock ----------------------------------------"
-        echo "----dstore/flock----" >> $run_tap
-
-        gds_list="hash ds12,hash"
-        # check the existence of ds21 component
-        # if [ "$has_gds_ds21" -gt 0 ]; then
-        #     gds_list="$gds_list ds21,hash"
-        # fi
-
-        for gds in $gds_list; do
-            echo "Checking with $gds:" >> $run_tap
-            export PMIX_MCA_gds=$gds
-            pmix_run_tests
-        done
-        echo "Checking with auto gds:" >> $run_tap
-        export PMIX_MCA_gds=""
-        pmix_run_tests
-
-        # rm -Rf ${pmix_dir} ${build_dir}
-        rc=$((test_ret+rc))
-    fi
-
-    unset TMPDIR
-    # rmdir $OUTDIR
-    cat $WORKSPACE/run_test.tap
-    exit $rc
-
 fi

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -58,15 +58,17 @@ BEGIN_C_DECLS
 /*
  * Maximum size of single msg
  */
-#define PMIX_IOF_BASE_MSG_MAX        4096
-#define PMIX_IOF_BASE_TAG_MAX        256
-#define PMIX_IOF_BASE_TAGGED_OUT_MAX 8192
+#define PMIX_IOF_BASE_MSG_MAX        8192
+#define PMIX_IOF_BASE_TAG_MAX        1024
+#define PMIX_IOF_BASE_TAGGED_OUT_MAX 16384
 #define PMIX_IOF_MAX_INPUT_BUFFERS   50
+#define PMIX_IOF_MAX_RETRIES         4
 
 typedef struct {
     pmix_list_item_t super;
     bool pending;
     bool always_writable;
+    int numtries;
     pmix_event_t ev;
     struct timeval tv;
     int fd;

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -379,14 +379,6 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
         return;
     }
 
-#if 0
-    /* if we opened the stdin IOF channel, be sure
-     * we close it */
-    if (NULL != orte_iof.close) {
-        orte_iof.close(&child->name, ORTE_IOF_STDIN);
-    }
-#endif
-
     /* remove the child from the list so waitpid callback won't
      * find it as this induces unmanageable race
      * conditions when we are deliberately killing the process
@@ -420,11 +412,6 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
     /* cleanup */
     PMIX_RELEASE(child);
     PMIX_WAKEUP_THREAD(scd->lock);
-
-#if 0
-    /* ensure the child's session directory is cleaned up */
-    orte_session_dir_finalize(&child->name);
-#endif
 
     return;
 }
@@ -494,17 +481,6 @@ static pmix_status_t setup_prefork(pmix_pfexec_child_t *child)
         return PMIX_ERR_SYS_OTHER;
     }
 
-#if 0
-    /* connect stdin endpoint */
-    if (opts->connect_stdin) {
-        /* and connect the pty to stdin */
-        ret = orte_iof.pull(name, ORTE_IOF_STDIN, opts->p_stdin[1]);
-        if(ORTE_SUCCESS != ret) {
-            ORTE_ERROR_LOG(ret);
-            return ret;
-        }
-    }
-#endif
     /* connect read ends to IOF */
     PMIX_IOF_READ_EVENT(&child->stdoutev, targets, 0, directives, 0, opts->p_stdout[0],
                         pmix_iof_read_local_handler, false);

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -245,8 +245,6 @@ static void stop_progress_engine(pmix_progress_tracker_t *trk)
     /* break the event loop - this will cause the loop to exit upon
        completion of any current event */
     pmix_event_base_loopexit(trk->ev_base);
-
-    pmix_thread_join(&trk->engine, NULL);
 }
 
 static int start_progress_engine(pmix_progress_tracker_t *trk)

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2497,13 +2497,15 @@ static void _iofdeliver(int sd, short args, void *cbdata)
     size_t n;
     pmix_status_t rc;
 
+    PMIX_ACQUIRE_OBJECT(cd);
+
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "PMIX:SERVER delivering IOF from %s on channel %0x",
                         PMIX_NAME_PRINT(cd->procs), cd->channels);
 
     /* output it locally if requested */
     rc = pmix_iof_write_output(cd->procs, cd->channels, cd->bo);
-    if (PMIX_SUCCESS != rc) {
+    if (0 > rc) {
         goto done;
     }
 
@@ -2611,6 +2613,9 @@ pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source, pmix_iof_channe
 static void cirelease(void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
     if (NULL != cd->info) {
         PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
@@ -2623,6 +2628,8 @@ static void clct(int sd, short args, void *cbdata)
     pmix_list_t inventory;
     pmix_data_array_t darray;
     pmix_status_t rc;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     PMIX_CONSTRUCT(&inventory, pmix_list_t);
 
@@ -2685,6 +2692,8 @@ static void dlinv(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
     pmix_status_t rc;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     rc = pmix_pnet.deliver_inventory(cd->info, cd->ninfo, cd->directives, cd->ndirs);
     if (PMIX_SUCCESS != rc) {
@@ -2776,6 +2785,9 @@ typedef struct {
 static void release_info(pmix_status_t status, void *cbdata)
 {
     mydata_t *cd = (mydata_t *) cbdata;
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
     PMIX_INFO_FREE(cd->info, cd->ninfo);
     free(cd);
 }
@@ -2789,6 +2801,8 @@ static void psetdef(int sd, short args, void *cbdata)
     pmix_data_array_t *darray;
     pmix_proc_t *ptr;
     pmix_pset_t *ps;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     mydat = (mydata_t *) malloc(sizeof(mydata_t));
     mydat->ninfo = 3;
@@ -2855,6 +2869,8 @@ static void psetdel(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     mydata_t *mydat;
     pmix_pset_t *ps;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     mydat = (mydata_t *) malloc(sizeof(mydata_t));
     mydat->ninfo = 2;
@@ -3065,7 +3081,6 @@ static void spawn_cbfunc(pmix_status_t status, char *nspace, void *cbdata)
         cd->pname.nspace = strdup(nspace);
     }
     cd->cd = (pmix_server_caddy_t *) cbdata;
-    ;
 
     PMIX_THREADSHIFT(cd, _spcb);
 }


### PR DESCRIPTION
No longer directly output stdout/stderr - add them to the event
list for output. This helps us deal with the case where the std
file descriptors are getting blocked/metered. Add a counter to
track the number of times we attempt to output to a given sink
and abort if we exceed that count - helps avoid deadlock where
we simply cannot get the output to go. Also, don't try to "join"
the progress thread when we stop it as this can hang if we are
in an event we cannot get out of.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 5b1be8dbd1b60aea4983801d65b112116b8b2389)