### PR TITLE
Ensure the server waits for all IOF and message events to complete

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1401,8 +1401,7 @@ void pmix_iof_static_dump_output(pmix_iof_sink_t *sink)
     if (!pmix_list_is_empty(&wev->outputs)) {
         dump = false;
         /* make one last attempt to write this out */
-        while (NULL
-               != (output = (pmix_iof_write_output_t *) pmix_list_remove_first(&wev->outputs))) {
+        while (NULL != (output = (pmix_iof_write_output_t *) pmix_list_remove_first(&wev->outputs))) {
             if (!dump && 0 < output->numbytes) {
                 num_written = write(wev->fd, output->data, output->numbytes);
                 if (num_written < output->numbytes) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -845,11 +845,19 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     return PMIX_SUCCESS;
 }
 
+static void checkev(int fd, short args, void *cbdata)
+{
+    pmix_lock_t *lock = (pmix_lock_t*)cbdata;
+    PMIX_WAKEUP_THREAD(lock);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 {
     int i;
     pmix_peer_t *peer;
     pmix_namespace_t *ns;
+    pmix_lock_t lock;
+    pmix_event_t ev;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -865,6 +873,14 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     pmix_globals.init_cntr = 0;
 
     pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server finalize called");
+
+    /* wait here until all active events have been processed */
+    PMIX_CONSTRUCT_LOCK(&lock);
+    pmix_event_assign(&ev, pmix_globals.evbase, -1, EV_WRITE, checkev, &lock);
+    PMIX_POST_OBJECT(&lock);
+    pmix_event_active(&ev, EV_WRITE, 1);
+    PMIX_WAIT_THREAD(&lock);
+    PMIX_DESTRUCT_LOCK(&lock);
 
     /* stop the progress thread, but leave the event base
      * still constructed. This will allow us to safely
@@ -2500,8 +2516,10 @@ static void _iofdeliver(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
-                        "PMIX:SERVER delivering IOF from %s on channel %0x",
-                        PMIX_NAME_PRINT(cd->procs), cd->channels);
+                        "PMIX:SERVER delivering IOF from %s on channel %s with %d bytes",
+                        PMIX_NAME_PRINT(cd->procs),
+                        PMIx_IOF_channel_string(cd->channels),
+                        (int)cd->bo->size);
 
     /* output it locally if requested */
     rc = pmix_iof_write_output(cd->procs, cd->channels, cd->bo);
@@ -2527,7 +2545,9 @@ static void _iofdeliver(int sd, short args, void *cbdata)
 
     /* if nobody has registered for this yet, then cache it */
     if (!found) {
-        pmix_output_verbose(2, pmix_server_globals.iof_output, "PMIx:SERVER caching IOF");
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER caching IOF %d",
+                            (int)cd->bo->size);
         if (pmix_server_globals.max_iof_cache == pmix_list_get_size(&pmix_server_globals.iof)) {
             /* remove the oldest cached message */
             iof = (pmix_iof_cache_t *) pmix_list_remove_first(&pmix_server_globals.iof);
@@ -2540,8 +2560,10 @@ static void _iofdeliver(int sd, short args, void *cbdata)
         iof->channel = cd->channels;
         /* copy the data */
         PMIX_BYTE_OBJECT_CREATE(iof->bo, 1);
-        iof->bo->bytes = (char *) malloc(cd->bo->size);
-        memcpy(iof->bo->bytes, cd->bo->bytes, cd->bo->size);
+        if (0 < cd->bo->size) {
+            iof->bo->bytes = (char *) malloc(cd->bo->size);
+            memcpy(iof->bo->bytes, cd->bo->bytes, cd->bo->size);
+        }
         iof->bo->size = cd->bo->size;
         if (0 < cd->ninfo) {
             PMIX_INFO_CREATE(iof->info, cd->ninfo);


### PR DESCRIPTION
Append an event on the end of the event library in server finalize
and wait for that event to be executed before exiting.

Signed-off-by: Ralph Castain <rhc@pmix.org>