### PR TITLE
Avoid use of MCA params for singleton and report-uri

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -179,7 +179,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_HOMOGENEOUS_SYSTEM             "pmix.homo"             // (bool) The nodes comprising the session are homogeneous - i.e., they
                                                                     //        each contain the same number of identical packages, fabric interfaces,
                                                                     //        GPU, and other devices
-
+#define PMIX_SINGLETON                      "pmix.singleton"        // (char*) String representation (nspace.rank) of proc ID for the singleton
+                                                                    //         the server was started to support
 
 /* tool-related attributes */
 #define PMIX_TOOL_NSPACE                    "pmix.tool.nspace"      // (char*) Name of the nspace to use for this tool

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -194,11 +194,6 @@ pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo)
                 free(pmix_ptl_base.uri);
             }
             pmix_ptl_base.uri = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_REPORT_URI)) {
-            if (NULL != pmix_ptl_base.report_uri) {
-                free(pmix_ptl_base.report_uri);
-            }
-            pmix_ptl_base.report_uri = strdup(info[n].value.data.string);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
             if (NULL != pmix_ptl_base.session_tmpdir) {
                 free(pmix_ptl_base.session_tmpdir);

--- a/src/mca/ptl/server/ptl_server.c
+++ b/src/mca/ptl/server/ptl_server.c
@@ -64,6 +64,21 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo)
             pmix_ptl_base.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
             pmix_ptl_base.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_REPORT_URI)) {
+            if (NULL != pmix_ptl_base.report_uri) {
+                free(pmix_ptl_base.report_uri);
+            }
+            pmix_ptl_base.report_uri = strdup(info[n].value.data.string);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
+            if (NULL != pmix_ptl_base.session_tmpdir) {
+                free(pmix_ptl_base.session_tmpdir);
+            }
+            pmix_ptl_base.session_tmpdir = strdup(info[n].value.data.string);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
+            if (NULL != pmix_ptl_base.system_tmpdir) {
+                free(pmix_ptl_base.system_tmpdir);
+            }
+            pmix_ptl_base.system_tmpdir = strdup(info[n].value.data.string);
         }
     }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -455,6 +455,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     pmix_status_t code;
     pmix_ptl_posted_recv_t *rcv;
     bool outputio;
+    char *singleton = NULL;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -528,6 +529,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
                 share_topo = true;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_IOF_LOCAL_OUTPUT)) {
                 outputio = PMIX_INFO_TRUE(&info[n]);
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SINGLETON)) {
+                singleton = info[n].value.data.string;
             }
         }
     }
@@ -681,8 +684,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
 
     /* if we were started to support a singleton, register it now
      * so we won't reject it when it connects to us */
-    if (NULL != (evar = getenv("PMIX_MCA_singleton"))) {
-        rc = register_singleton(evar);
+    if (NULL != singleton) {
+        rc = register_singleton(singleton);
         if (PMIX_SUCCESS != rc) {
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return rc;


### PR DESCRIPTION
This can cause problems because PMIx will pick them up
and forward them to all daemons and app procs, resulting
in confusion.

Signed-off-by: Ralph Castain <rhc@pmix.org>