### PR TITLE
autogen.pl: ignore all excluded components

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -227,10 +227,18 @@ sub mca_process_framework {
                 verbose "--- Found pmix / $framework / $d component: src/mca/$framework/$d\n";
 
                 # Skip if specifically excluded
-                if (exists($exclude_list->{$framework}) &&
-                    $exclude_list->{$framework}[0] eq $d) {
-                    verbose "    => Excluded\n";
-                    next;
+                if (exists($exclude_list->{$framework})) {
+                    my $tst = 0;
+                    foreach my $ck (@{$exclude_list->{$framework}}) {
+                        if ($ck eq $d) {
+                            verbose "    => Excluded\n";
+                            $tst = 1;
+                            last;
+                        }
+                    }
+                    if ($tst) {
+                        next;
+                    }
                 }
 
                 # Skip if the framework is on the include list, but


### PR DESCRIPTION
If multiple components in a framework were excluded, then only the
first one in the list was being checked - which means that only the
first one in the list was actually being excluded. All others were
missed by the current code. This change actually searches the entire
list of excluded components to see if the one we found matches any
of the list members.

Port of https://github.com/open-mpi/ompi/pull/9040

Signed-off-by: Ralph Castain <rhc@pmix.org>