### PR TITLE
Ensure tools wait until all active events are processed

### DIFF
--- a/src/util/output.c
+++ b/src/util/output.c
@@ -197,7 +197,7 @@ bool pmix_output_init(void)
 
     /* Set some defaults */
 
-    if (0 > asprintf(&output_prefix, "output-pid%d-", getpid())) {
+    if (0 > asprintf(&output_prefix, "pmix-output-pid%d-", getpid())) {
         return false;
     }
     output_dir = strdup(pmix_tmp_directory());


### PR DESCRIPTION
Plus a minor cleanup in the pmix_output code.