### PR TITLE
Ensure we always copy the source field in pmix_topology_t

### DIFF
--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -308,13 +308,13 @@ pmix_status_t pmix_hwloc_copy_topology(pmix_topology_t *dest, pmix_topology_t *s
     if (NULL == src->source || 0 != strncasecmp(src->source, "hwloc", 5)) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
+    dest->source = strdup("hwloc");
 
 #if PMIX_HAVE_HWLOC_TOPOLOGY_DUP
     /* use the hwloc dup function */
     if (0 != hwloc_topology_dup((hwloc_topology_t *) &dest->topology, src->topology)) {
         return PMIX_ERROR;
     }
-    dest->source = strdup("hwloc");
 
     return PMIX_SUCCESS;
 #else


### PR DESCRIPTION
Even for ancient versions of hwloc

Signed-off-by: Ralph Castain <rhc@pmix.org>