### PR TITLE
Properly read/output stdout/err from a fork/exec'd child

### DIFF
--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -649,6 +649,13 @@ static pmix_status_t register_nspace(char *nspace, pmix_pfexec_fork_caddy_t *fcd
         return rc;
     }
 
+    /* mark us as the parent */
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_PARENT_ID, &pmix_globals.myid, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_INFO_LIST_RELEASE(jinfo);
+        return rc;
+    }
+
     /* node size */
     PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_NODE_SIZE, &nprocs, PMIX_UINT32);
     if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
If a tool calls "spawn" while not connected, we will fork/exec
the specified app as a child of the PMIx library. In this case,
the library takes responsibility for reading, forwarding, and/or
outputting any stdout/err from that child.

Signed-off-by: Ralph Castain <rhc@pmix.org>