### PR TITLE
Conditionally decode the nspace return value in Python

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -745,8 +745,11 @@ cdef class PMIxClient:
         pmix_free_apps(apps, napps)
         if 0 < ninfo:
             pmix_free_info(jinfo, ninfo)
-        pyns = nspace
-        return rc, pyns.decode('ascii')
+        if PMIX_SUCCESS != rc:
+            pyns = None
+        else:
+            pyns = nspace.decode('ascii')
+        return rc, pyns
 
     def connect(self, peers:list, pyinfo:list):
         cdef pmix_proc_t *procs


### PR DESCRIPTION
In the `spawn()` function in in the Python bindings it will currently try and unconditionally decode nspace return value from the base `PMIx_Spawn()` function. On failure the output of nspace seems to be undefined, so the output looks to be random data and the `decode()` function in Python will usually raise an exception that it can't decode the string. This patch fixes this behavior by conditionally decoding the output string only when the return status is `PMIX_SUCCESS`

Signed-off-by: Matthew Baker <bakermb@ornl.gov>