### PR TITLE
Cleanup the test_v2 area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,5 +180,13 @@ test/sshot/server
 test/sshot/mytopo.json
 test/sshot/testcoord
 
+test/test_v2/pmix_test
+test/test_v2/test_fence_basic
+test/test_v2/test_fence_wildcard
+test/test_v2/test_get_basic
+test/test_v2/test_get_peers
+test/test_v2/test_helloworld
+test/test_v2/test_init_fin
+
 # coverity
 cov-int

--- a/config/pmix_check_os_flavors.m4
+++ b/config/pmix_check_os_flavors.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -63,6 +64,7 @@ AC_DEFUN([PMIX_CHECK_OS_FLAVORS],
     AC_DEFINE_UNQUOTED([PMIX_HAVE_APPLE],
                        [$pmix_have_apple],
                        [Whether or not we have apple])
+    AM_CONDITIONAL(PMIX_HAVE_APPLE, test "$pmix_have_apple" = "1")
 
     # check for sockaddr_in (a good sign we have TCP)
     AC_CHECK_HEADERS([netdb.h netinet/in.h netinet/tcp.h])

--- a/test/test_v2/Makefile.am
+++ b/test/test_v2/Makefile.am
@@ -16,6 +16,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2021      Triad National Security, LLC
 #                         All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -60,30 +61,36 @@ TC6FILES = test_fence_wildcard.c $(TCCOMMONFILES)
 # Note the use of -no-install in LDFLAGS to force rpath
 # into binaries and prevent libtool from creating the usual scripts.
 # This simplifies testing and debugging.
+if PMIX_HAVE_APPLE
+INSTALLFLAG=-no-fast-install
+else
+INSTALLFLAG=-no-install
+endif
+
 pmix_test_SOURCES = $(headers) $(PCFILES)
-pmix_test_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+pmix_test_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 pmix_test_LDADD = $(top_builddir)/src/libpmix.la
 
 test_init_fin_SOURCES = $(headers) $(TC1FILES)
-test_init_fin_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_init_fin_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_init_fin_LDADD = $(top_builddir)/src/libpmix.la
 
 test_helloworld_SOURCES = $(headers) $(TC2FILES)
-test_helloworld_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_helloworld_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_helloworld_LDADD = $(top_builddir)/src/libpmix.la
 
 test_get_basic_SOURCES = $(headers) $(TC3FILES)
-test_get_basic_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_get_basic_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_get_basic_LDADD = $(top_builddir)/src/libpmix.la
 
 test_get_peers_SOURCES = $(headers) $(TC4FILES)
-test_get_peers_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_get_peers_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_get_peers_LDADD = $(top_builddir)/src/libpmix.la
 
 test_fence_basic_SOURCES = $(headers) $(TC5FILES)
-test_fence_basic_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_fence_basic_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_fence_basic_LDADD = $(top_builddir)/src/libpmix.la
 
 test_fence_wildcard_SOURCES = $(headers) $(TC6FILES)
-test_fence_wildcard_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) -no-install
+test_fence_wildcard_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS) $(INSTALLFLAG)
 test_fence_wildcard_LDADD = $(top_builddir)/src/libpmix.la

--- a/test/test_v2/test_common.c
+++ b/test/test_v2/test_common.c
@@ -30,7 +30,8 @@
 int pmix_test_verbose = 0;
 test_params params;
 char **test_argv = NULL;
-
+node_map *nodes = NULL;
+char *v_params_ascii_str = NULL;
 FILE *pmixt_outfile;
 
 #define OUTPUT_MAX 1024
@@ -246,17 +247,8 @@ pmix_list_t key_replace;
 
 // cross-platform millisecond sleep function
 void sleep_ms(unsigned long milliseconds) {
-#ifdef WIN32
-    Sleep(milliseconds);
-#elif _POSIX_C_SOURCE >= 199309L
-    struct timespec ts;
-    ts.tv_sec = milliseconds / 1000;
-    ts.tv_nsec = (milliseconds % 1000) * 1000000;
-    nanosleep(&ts, NULL);
-#else
     if (1000 <= milliseconds) {
         sleep(milliseconds / 1000);
     }
     usleep((milliseconds % 1000) * 1000);
-#endif
 }

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -174,7 +174,7 @@ typedef struct {
     char pmix_hostname[PMIX_MAX_KEYLEN];
 } node_map;
 
-node_map *nodes;
+extern node_map *nodes;
 
 // order of these fields should be in order that we introduce them
 typedef struct {
@@ -197,7 +197,7 @@ typedef struct {
     // more as needed
 } validation_params;
 
-char *v_params_ascii_str;
+extern char *v_params_ascii_str;
 
 typedef struct {
     char *binary;


### PR DESCRIPTION
Avoid multiple definitions of a couple of variables declared
in test_common.h by making them "extern", instancing them
in test_common.c. Silence warnings on Mac due to use of
"-no-install" option in Makefile - it is "no-fast-install"
on the Mac. Although cute, we don't support Windows so let's
avoid the warnings from the "sleep" function.

Update ignores as well.

Fixes #2300 

Signed-off-by: Ralph Castain <rhc@pmix.org>