### PR TITLE
Enable ultra-picky compiler options

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1060,6 +1060,9 @@ if test "$WANT_PICKY_COMPILER" = "0" && test -z "$enable_picky" && test "$PMIX_D
 fi
 #################### Early development override ####################
 
+AC_DEFINE_UNQUOTED(PMIX_PICKY_COMPILERS, $WANT_PICKY_COMPILER,
+                   [Whether or not we are using picky compiler settings])
+
 #
 # Developer debugging
 #

--- a/config/pmix_check_vendor.m4
+++ b/config/pmix_check_vendor.m4
@@ -15,6 +15,7 @@ dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -96,7 +97,7 @@ AC_DEFUN([_PMIX_CHECK_COMPILER_VENDOR], [
     # Portland Group
     AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],
           [PMIX_IFDEF_IFELSE([__PGI],
-               [pmix_check_compiler_vendor_result="portland group"])])
+               [pmix_check_compiler_vendor_result="pgi"])])
 
     # Fujitsu
     AS_IF([test "$pmix_check_compiler_vendor_result" = "unknown"],

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -285,21 +285,6 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # gcc-impersonating compilers won't accept them.
     PMIX_CFLAGS_BEFORE_PICKY="$CFLAGS"
 
-    if test $WANT_PICKY_COMPILER -eq 1 && test "$pmix_c_vendor" != "pgi"; then
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wundef, Wundef)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-long-long, Wno_long_long, int main() { long long x; })
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wsign-compare, Wsign_compare)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wmissing-prototypes, Wmissing_prototypes)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wstrict-prototypes, Wstrict_prototypes)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wcomment, Wcomment)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wshadow, Wshadow)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror-implicit-function-declaration, Werror_implicit_function_declaration)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-long-double, Wno_long_double, int main() { long double x; })
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-fno-strict-aliasing, fno_strict_aliasing, int main () { int x; })
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-pedantic, pedantic)
-        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wall, Wall)
-    fi
-
     # Note: Some versions of clang (at least >= 3.5 -- perhaps
     # older versions, too?) and xlc with -g (v16.1, perhaps older)
     # will *warn* about -finline-functions, but still allow it.
@@ -429,4 +414,26 @@ AC_DEFUN([_PMIX_PROG_CC],[
     PMIX_WHICH([$pmix_cc_argv0], [PMIX_CC_ABSOLUTE])
     AC_SUBST(PMIX_CC_ABSOLUTE)
     PMIX_VAR_SCOPE_POP
+])
+
+AC_DEFUN([PMIX_SETUP_PICKY_COMPILERS],[
+    if test $WANT_PICKY_COMPILER -eq 1 && test "$pmix_c_vendor" != "pgi"; then
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wundef, Wundef)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-long-long, Wno_long_long, int main() { long long x; })
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wsign-compare, Wsign_compare)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wmissing-prototypes, Wmissing_prototypes)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wstrict-prototypes, Wstrict_prototypes)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wcomment, Wcomment)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wshadow, Wshadow)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror-implicit-function-declaration, Werror_implicit_function_declaration)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-long-double, Wno_long_double, int main() { long double x; })
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-fno-strict-aliasing, fno_strict_aliasing, int main () { int x; })
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-pedantic, pedantic)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wall, Wall)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wextra, Wextra)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror, Werror)
+#        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=address, fsanitize=address)
+#        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=undefined, fsanitize=undefined)
+    fi
+
 ])

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -285,7 +285,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # gcc-impersonating compilers won't accept them.
     PMIX_CFLAGS_BEFORE_PICKY="$CFLAGS"
 
-    if test $WANT_PICKY_COMPILER -eq 1; then
+    if test $WANT_PICKY_COMPILER -eq 1 && test "$pmix_c_vendor" != "pgi"; then
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Wundef, Wundef)
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-long-long, Wno_long_long, int main() { long long x; })
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Wsign-compare, Wsign_compare)

--- a/configure.ac
+++ b/configure.ac
@@ -270,9 +270,10 @@ AS_IF([test ! -z "$PMIX_CFLAGS_cache"], [CFLAGS="$CFLAGS $PMIX_CFLAGS_cache"])
 
 # Delay setting pickyness until here so we
 # don't break configure code tests
-#if test "$WANT_PICKY_COMPILER" = "1"; then
-#    CFLAGS="$CFLAGS -Wall -Wextra -Werror"
-#fi
+if test "$WANT_PICKY_COMPILER" = "1" && test "$pmix_c_vendor" != "pgi"; then
+        CFLAGS="$CFLAGS -Wall -Wextra -Werror"
+# -fsanitize=address -fsanitize=undefined"
+fi
 
 # Cleanup duplicate flags
 PMIX_FLAGS_UNIQ(CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -268,12 +268,8 @@ AS_IF([test -z "$CC_FOR_BUILD"],[
 # restore any user-provided Werror flags
 AS_IF([test ! -z "$PMIX_CFLAGS_cache"], [CFLAGS="$CFLAGS $PMIX_CFLAGS_cache"])
 
-# Delay setting pickyness until here so we
-# don't break configure code tests
-if test "$WANT_PICKY_COMPILER" = "1" && test "$pmix_c_vendor" != "pgi"; then
-        CFLAGS="$CFLAGS -Wall -Wextra -Werror"
-# -fsanitize=address -fsanitize=undefined"
-fi
+# setup "picky" compiler options if enabled
+PMIX_SETUP_PICKY_COMPILERS
 
 # Cleanup duplicate flags
 PMIX_FLAGS_UNIQ(CFLAGS)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,6 +22,8 @@
 headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup
 if !WANT_HIDDEN

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3452,6 +3452,13 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
     }
 }
 
+#define PMIX_DATA_ARRAY_INIT(m, t)      \
+    do {                                \
+        (m)->array = NULL;              \
+        (m)->type = (t);                \
+        (m)->size = 0;                  \
+    } while(0)
+
 #define PMIX_DATA_ARRAY_CONSTRUCT(m, n, t)                          \
     do {                                                            \
         (m)->type = (t);                                            \

--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -23,6 +23,7 @@
 #include "src/include/pmix_config.h"
 #include "src/class/pmix_list.h"
 #include "include/pmix_common.h"
+#include "src/include/pmix_globals.h"
 
 /*
  *  List classes
@@ -61,6 +62,7 @@ static void pmix_list_item_destruct(pmix_list_item_t *item)
     assert(0 == item->pmix_list_item_refcount);
     assert(NULL == item->pmix_list_item_belong_to);
 #endif /* PMIX_ENABLE_DEBUG */
+    PMIX_HIDE_UNUSED_PARAMS(item);
 }
 
 /*

--- a/src/class/pmix_pointer_array.h
+++ b/src/class/pmix_pointer_array.h
@@ -62,6 +62,19 @@ struct pmix_pointer_array_t {
     /** pointer to array of pointers */
     void **addr;
 };
+
+#define PMIX_POINTER_ARRAY_STATIC_INIT              \
+{                                                   \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .lowest_free = 0,                               \
+    .number_free = 0,                               \
+    .size = 0,                                      \
+    .max_size = 0,                                  \
+    .block_size = 0,                                \
+    .free_bits = NULL,                              \
+    .addr = NULL                                    \
+}
+
 /**
  * Convenience typedef
  */

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -151,6 +151,8 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
                         "%s pmix:client_notify_recv - processing event",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
+    PMIX_HIDE_UNUSED_PARAMS(peer, hdr, cbdata);
+
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */
     if (PMIX_BUFFER_IS_EMPTY(buf)) {
@@ -244,7 +246,30 @@ error:
     pmix_invoke_local_event_hdlr(chain);
 }
 
-pmix_client_globals_t pmix_client_globals = {0};
+pmix_client_globals_t pmix_client_globals = {
+    .myserver = NULL,
+    .singleton = false,
+    .pending_requests = PMIX_LIST_STATIC_INIT,
+    .peers = PMIX_POINTER_ARRAY_STATIC_INIT,
+    .get_output = -1,
+    .get_verbose = 0,
+    .connect_output = -1,
+    .connect_verbose = 0,
+    .fence_output = -1,
+    .fence_verbose = 0,
+    .pub_output = -1,
+    .pub_verbose = 0,
+    .spawn_output = -1,
+    .spawn_verbose = 0,
+    .event_output = -1,
+    .event_verbose = 0,
+    .iof_output = -1,
+    .iof_verbose = 0,
+    .base_output = -1,
+    .base_verbose = 0,
+    .iof_stdout = PMIX_IOF_SINK_STATIC_INIT,
+    .iof_stderr = PMIX_IOF_SINK_STATIC_INIT
+};
 
 /* callback for wait completion */
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
@@ -253,6 +278,9 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_lock_t *lock = (pmix_lock_t *) cbdata;
 
     pmix_output_verbose(2, pmix_client_globals.base_output, "pmix:client wait_cbfunc received");
+    if (NULL == pr || NULL == hdr || NULL == buf || NULL == cbdata) {
+        ;
+    }
     PMIX_WAKEUP_THREAD(lock);
 }
 
@@ -263,6 +291,9 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
     char *nspace;
     int32_t cnt = 1;
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+
+
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */
@@ -305,6 +336,9 @@ static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, voi
 {
     pmix_lock_t *lock = (pmix_lock_t *) cbdata;
 
+
+    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref);
+
     lock->status = status;
     PMIX_WAKEUP_THREAD(lock);
 }
@@ -320,6 +354,9 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
 
     pmix_output_verbose(2, pmix_client_globals.base_output, "[%s:%d] DEBUGGER RELEASE RECVD",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
+
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
     if (NULL != info) {
         lock = NULL;
         for (n = 0; n < ninfo; n++) {
@@ -360,6 +397,8 @@ static void release_info(pmix_status_t status, void *cbdata)
     mydata_t *cd = (mydata_t *) cbdata;
     PMIX_INFO_FREE(cd->info, cd->ninfo);
     free(cd);
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
 }
 
 static void _check_for_notify(pmix_info_t info[], size_t ninfo)
@@ -437,6 +476,8 @@ static void client_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
 
     pmix_output_verbose(2, pmix_client_globals.iof_output, "recvd IOF with %d bytes",
                         (int) buf->bytes_used);
+
+    PMIX_HIDE_UNUSED_PARAMS(hdr, cbdata);
 
     /* if the buffer is empty, they are simply closing the socket */
     if (0 == buf->bytes_used) {
@@ -921,6 +962,9 @@ static void fin_timeout(int sd, short args, void *cbdata)
     tev = (pmix_client_timeout_t *) cbdata;
 
     pmix_output_verbose(2, pmix_client_globals.base_output, "pmix:client finwait timeout fired");
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     if (tev->active) {
         tev->active = false;
         PMIX_WAKEUP_THREAD(&tev->lock);
@@ -934,6 +978,9 @@ static void finwait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buf
     tev = (pmix_client_timeout_t *) cbdata;
 
     pmix_output_verbose(2, pmix_client_globals.base_output, "pmix:client finwait_cbfunc received");
+
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr, buf);
+
     if (tev->active) {
         tev->active = false;
         PMIX_WAKEUP_THREAD(&tev->lock);
@@ -1151,6 +1198,9 @@ static void _putfn(int sd, short args, void *cbdata)
     /* need to acquire the cb object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cb);
 
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+
     /* no need to push info that starts with "pmix" as that is
      * info we would have been provided at startup */
     if (0 == strncmp(cb->key, "pmix", 4)) {
@@ -1253,6 +1303,8 @@ static void _commitfn(int sd, short args, void *cbdata)
 
     /* need to acquire the cb object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cb);
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     msgout = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -333,6 +333,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     if (NULL == buf) {
         ret = PMIX_ERR_BAD_PARAM;

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -86,6 +86,8 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
     pmix_status_t rc;
     int cnt;
 
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
+
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:fabric recv from server with %d bytes",
                         (int) buf->bytes_used);
 
@@ -431,6 +433,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric, pmix_
                                                     void *cbdata)
 {
     pmix_status_t rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -246,6 +246,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_status_t rc;
 
     pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence_nb callback recvd");
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     if (NULL == cb) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -273,6 +273,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
 static void gcbfn(int sd, short args, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     cb->cbfunc.valuefn(cb->status, cb->value, cb->cbdata);
     PMIX_RELEASE(cb);
@@ -439,6 +440,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buff
     pmix_get_logic_t *lg;
 
     PMIX_ACQUIRE_OBJECT(cb);
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     pmix_output_verbose(2, pmix_client_globals.get_output, "pmix: get_nb callback recvd");
 

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -409,6 +409,7 @@ done:
 static void chaincbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     if (NULL != cb) {
         PMIX_RELEASE(cb);
@@ -432,6 +433,8 @@ static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
     size_t n;
     pmix_status_t rc = PMIX_GROUP_INVITE_DECLINED;
     size_t contextid = SIZE_MAX;
+
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, results, nresults);
 
     /* find the object we asked to be returned with event */
     for (n = 0; n < ninfo; n++) {
@@ -740,6 +743,8 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
+    PMIX_HIDE_UNUSED_PARAMS(results, nresults);
+
     /* create a callback object as we need to pass it to the
      * recv routine so we know which lock to release when
      * the return message is recvd */
@@ -772,6 +777,8 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     pmix_data_range_t range;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    PMIX_HIDE_UNUSED_PARAMS(grp, cbfunc);
 
     pmix_output_verbose(2, pmix_client_globals.connect_output, "[%s:%d] pmix: join nb called",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
@@ -986,6 +993,8 @@ static void grp_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_
     int32_t cnt;
     size_t ctxid, ninfo = 0;
     pmix_info_t info, *iptr = NULL;
+
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     pmix_output_verbose(2, pmix_client_globals.connect_output,
                         "pmix:client recv callback activated with %d bytes",

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -485,6 +485,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     if (NULL == buf) {
         ret = PMIX_ERR_BAD_PARAM;
@@ -535,6 +536,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     /* set the defaults */
     pdata = NULL;

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -381,6 +381,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     /* init */
     memset(nspace, 0, PMIX_MAX_NSLEN + 1);

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -27,6 +27,7 @@
 static void _loadtp(int sd, short args, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     cb->pstatus = pmix_hwloc_load_topology(cb->topo);
     PMIX_WAKEUP_THREAD(&cb->lock);
@@ -191,6 +192,7 @@ pmix_status_t PMIx_Compute_distances(pmix_topology_t *topo, pmix_cpuset_t *cpuse
 static void dcbfunc(int sd, short args, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (NULL != cb->cbfunc.distfn) {
         cb->cbfunc.distfn(cb->status, cb->dist, cb->nvals, cb->cbdata, icbrelfn, cb);
@@ -205,6 +207,8 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_status_t rc;
     int cnt;
+
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:compute_dist recv from server with %d bytes", (int) buf->bytes_used);

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -608,13 +608,14 @@ static void relcbfunc(void *cbdata)
     }
     PMIX_RELEASE(cd);
 }
-static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                         void *cbdata)
+static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                         pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     pmix_status_t rc;
     pmix_shift_caddy_t *results;
     int cnt;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:attrs:query cback from server");
 
@@ -668,6 +669,7 @@ PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata)
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_QUERY_CMD;
     pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -45,13 +45,14 @@ static void relcbfunc(void *cbdata)
     }
     PMIX_RELEASE(cd);
 }
-static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                         void *cbdata)
+static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                         pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     pmix_status_t rc;
     pmix_shift_caddy_t *results;
     int cnt;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:job_ctrl cback from server with %d bytes", (int) buf->bytes_used);

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -42,12 +42,13 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
-static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                       void *cbdata)
+static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                       pmix_buffer_t *buf, void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
     int32_t m;
     pmix_status_t rc, status;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     /* unpack the return status */
     m = 1;

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -47,8 +47,8 @@ static void relcbfunc(void *cbdata)
     }
     PMIX_RELEASE(cd);
 }
-static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                         void *cbdata)
+static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                         pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     pmix_status_t rc;
@@ -56,6 +56,7 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buf
     int cnt;
     size_t n;
     pmix_kval_t *kv;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:query cback from server");
 
@@ -262,6 +263,7 @@ static void localquery(int sd, short args, void *cbdata)
     pmix_kval_t *kv, *kvnxt;
     pmix_proc_t proc;
     bool rank_given = false;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* setup the list of local results */
     PMIX_CONSTRUCT(&results, pmix_list_t);

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -34,8 +34,8 @@
 #include "src/include/pmix_globals.h"
 #include "src/server/pmix_server_ops.h"
 
-static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                      void *cbdata)
+static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                      pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     pmix_status_t rc, status = PMIX_ERR_UNPACK_FAILURE;
@@ -43,6 +43,7 @@ static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_byte_object_t cred;
     pmix_info_t *info = NULL;
     size_t ninfo = 0;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:security cback from server with %d bytes", (int) buf->bytes_used);
@@ -108,10 +109,11 @@ complete:
     PMIX_RELEASE(cd);
 }
 
-static void mycdcb(pmix_status_t status, pmix_byte_object_t *credential, pmix_info_t info[],
-                   size_t ninfo, void *cbdata)
+static void mycdcb(pmix_status_t status, pmix_byte_object_t *credential,
+                   pmix_info_t info[], size_t ninfo, void *cbdata)
 {
     pmix_query_caddy_t *cb = (pmix_query_caddy_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
 
     PMIX_ACQUIRE_OBJECT(cb);
     cb->status = status;
@@ -254,14 +256,15 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_
     return rc;
 }
 
-static void valid_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                         void *cbdata)
+static void valid_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                         pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     pmix_status_t rc, status = PMIX_ERR_UNPACK_FAILURE;
     int cnt;
     pmix_info_t *info = NULL;
     size_t ninfo = 0;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:security cback from server with %d bytes", (int) buf->bytes_used);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -331,6 +331,8 @@ static void cycle_events(int sd, short args, void *cbdata)
                         PMIX_NAME_PRINT(&pmix_globals.myid),
                         PMIx_Error_string(chain->interim_status));
 
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     /* aggregate the results per RFC0018 - first search the
      * prior chained results to see if any keys have been NULL'd
      * as this indicates that info struct should be removed */

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -83,7 +83,9 @@ static void check_cached_events(pmix_rshift_caddy_t *cd);
 
 /* catch the event registration response message from the
  * server and process it */
-static void regevents_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
+static void regevents_cbfunc(struct pmix_peer_t *peer,
+                             pmix_ptl_hdr_t *hdr,
+                             pmix_buffer_t *buf,
                              void *cbdata)
 {
     pmix_rshift_caddy_t *rb = (pmix_rshift_caddy_t *) cbdata;
@@ -93,6 +95,8 @@ static void regevents_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix
     size_t index = rb->index;
 
     pmix_output_verbose(2, pmix_client_globals.event_output, "pmix: regevents callback recvd");
+
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     /* unpack the status code */
     cnt = 1;
@@ -472,6 +476,8 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "[%s]: register event_hdlr with %d infos",
@@ -960,6 +966,8 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* if I am not the server, and I am connected, then I need
      * to notify the server to remove my registration */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -712,3 +712,13 @@ pmix_event_t *pmix_event_new(pmix_event_base_t *b, int fd, short fg, event_callb
 
     return ev;
 }
+
+#if PMIX_PICKY_COMPILERS
+void pmix_hide_unused_params(int x, ...)
+{
+    va_list ap;
+
+    va_start(ap, x);
+    va_end(ap);
+}
+#endif

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -676,6 +676,19 @@ static inline bool pmix_check_session_info(const char *key)
     return false;
 }
 
+#if PMIX_PICKY_COMPILERS
+#define PMIX_HIDE_UNUSED_PARAMS(...)                \
+    do {                                            \
+        int __x = 3;                                \
+        pmix_hide_unused_params(__x, __VA_ARGS__);  \
+    } while(0)
+
+PMIX_EXPORT void pmix_hide_unused_params(int x, ...);
+
+#else
+#define PMIX_HIDE_UNUSED_PARAMS(...)
+#endif
+
 END_C_DECLS
 
 #endif /* PMIX_GLOBALS_H */

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -49,6 +49,7 @@
 
 #include "include/pmix_common.h"
 #include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
 #include "src/mca/mca.h"
@@ -104,6 +105,7 @@ int pmix_mca_base_component_find(const char *directory, pmix_mca_base_framework_
     pmix_mca_base_component_list_item_t *cli;
     bool include_mode = true;
     int ret;
+    PMIX_HIDE_UNUSED_PARAMS(open_dso_components);
 
     pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_COMPONENT, framework->framework_output,
                         "mca: base: component_find: searching %s for %s components", directory,

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -38,6 +38,7 @@
 #include "include/pmix_common.h"
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
 #include "src/mca/mca.h"
@@ -201,6 +202,7 @@ static int file_exists(const char *filename, const char *ext)
 
 int pmix_mca_base_component_repository_add(const char *path)
 {
+    PMIX_HIDE_UNUSED_PARAMS(path);
 #if PMIX_HAVE_PDL_SUPPORT
     char *path_to_use = NULL, *dir, *ctx;
     const char sep[] = {PMIX_ENV_SEP, '\0'};
@@ -293,6 +295,7 @@ int pmix_mca_base_component_repository_get_components(pmix_mca_base_framework_t 
                                          strlen(framework->framework_name),
                                          (void **) framework_components);
 #else
+    PMIX_HIDE_UNUSED_PARAMS(framework);
     return PMIX_ERR_NOT_FOUND;
 #endif
 }
@@ -350,6 +353,8 @@ void pmix_mca_base_component_repository_release(const pmix_mca_base_component_t 
     if (NULL != ri && !(--ri->ri_refcnt)) {
         pmix_mca_base_component_repository_release_internal(ri);
     }
+#else
+    PMIX_HIDE_UNUSED_PARAMS(component);
 #endif
 }
 
@@ -365,6 +370,7 @@ int pmix_mca_base_component_repository_retain_component(const char *type, const 
 
     return PMIX_ERR_NOT_FOUND;
 #else
+    PMIX_HIDE_UNUSED_PARAMS(type, name);
     return PMIX_ERR_NOT_SUPPORTED;
 #endif
 }
@@ -559,6 +565,7 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
 #else
 
     /* no dlopen support */
+    PMIX_HIDE_UNUSED_PARAMS(framework, ri);
     return PMIX_ERR_NOT_SUPPORTED;
 #endif
 }

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -222,9 +222,8 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src, pmix_data_type_t
  */
 pmix_status_t pmix_bfrops_base_copy_string(char **dest, char *src, pmix_data_type_t type)
 {
-    if (PMIX_STRING != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (NULL == src) { /* got zero-length string/NULL pointer - store NULL */
         *dest = NULL;
     } else {
@@ -240,9 +239,8 @@ pmix_status_t pmix_bfrops_base_copy_value(pmix_value_t **dest, pmix_value_t *src
 {
     pmix_value_t *p;
 
-    if (PMIX_VALUE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     *dest = (pmix_value_t *) malloc(sizeof(pmix_value_t));
     if (NULL == *dest) {
@@ -259,9 +257,8 @@ pmix_status_t pmix_bfrops_base_copy_value(pmix_value_t **dest, pmix_value_t *src
 pmix_status_t pmix_bfrops_base_copy_info(pmix_info_t **dest, pmix_info_t *src,
                                          pmix_data_type_t type)
 {
-    if (PMIX_VALUE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_t *) malloc(sizeof(pmix_info_t));
     pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     (*dest)->flags = src->flags;
@@ -271,9 +268,8 @@ pmix_status_t pmix_bfrops_base_copy_info(pmix_info_t **dest, pmix_info_t *src,
 pmix_status_t pmix_bfrops_base_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
                                         pmix_data_type_t type)
 {
-    if (PMIX_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = PMIX_NEW(pmix_buffer_t);
     pmix_bfrops_base_copy_payload(*dest, src);
     return PMIX_SUCCESS;
@@ -283,9 +279,8 @@ pmix_status_t pmix_bfrops_base_copy_app(pmix_app_t **dest, pmix_app_t *src, pmix
 {
     size_t j;
 
-    if (PMIX_APP != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_app_t *) malloc(sizeof(pmix_app_t));
     (*dest)->cmd = strdup(src->cmd);
     (*dest)->argv = pmix_argv_copy(src->argv);
@@ -308,9 +303,8 @@ pmix_status_t pmix_bfrops_base_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
 {
     pmix_kval_t *p;
 
-    if (PMIX_KVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     *dest = PMIX_NEW(pmix_kval_t);
     if (NULL == *dest) {
@@ -327,9 +321,8 @@ pmix_status_t pmix_bfrops_base_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
 pmix_status_t pmix_bfrops_base_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
                                          pmix_data_type_t type)
 {
-    if (PMIX_PROC != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -342,9 +335,8 @@ pmix_status_t pmix_bfrops_base_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
 pmix_status_t pmix_bfrop_base_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
                                            pmix_data_type_t type)
 {
-    if (PMIX_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_persistence_t *) malloc(sizeof(pmix_persistence_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -356,9 +348,8 @@ pmix_status_t pmix_bfrop_base_copy_persist(pmix_persistence_t **dest, pmix_persi
 pmix_status_t pmix_bfrops_base_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
                                        pmix_data_type_t type)
 {
-    if (PMIX_BYTE_OBJECT != type && PMIX_COMPRESSED_BYTE_OBJECT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_byte_object_t *) malloc(sizeof(pmix_byte_object_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -372,9 +363,8 @@ pmix_status_t pmix_bfrops_base_copy_bo(pmix_byte_object_t **dest, pmix_byte_obje
 pmix_status_t pmix_bfrops_base_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
                                           pmix_data_type_t type)
 {
-    if (PMIX_PDATA != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_pdata_t *) malloc(sizeof(pmix_pdata_t));
     pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
@@ -387,9 +377,8 @@ pmix_status_t pmix_bfrops_base_copy_pinfo(pmix_proc_info_t **dest, pmix_proc_inf
 {
     pmix_proc_info_t *p;
 
-    if (PMIX_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_PROC_INFO_CREATE(p, 1);
     if (NULL == p) {
         return PMIX_ERR_NOMEM;
@@ -454,9 +443,7 @@ pmix_status_t pmix_bfrops_base_copy_darray(pmix_data_array_t **dest, pmix_data_a
     pmix_net_stats_t *ntdest, *ntsrc;
     pmix_node_stats_t *nddest, *ndsrc;
 
-    if (PMIX_DATA_ARRAY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     p = (pmix_data_array_t *) calloc(1, sizeof(pmix_data_array_t));
     if (NULL == p) {
@@ -1074,9 +1061,8 @@ pmix_status_t pmix_bfrops_base_copy_query(pmix_query_t **dest, pmix_query_t *src
 {
     pmix_status_t rc;
 
-    if (PMIX_QUERY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_query_t *) malloc(sizeof(pmix_query_t));
     if (NULL != src->keys) {
         (*dest)->keys = pmix_argv_copy(src->keys);
@@ -1096,9 +1082,8 @@ pmix_status_t pmix_bfrops_base_copy_query(pmix_query_t **dest, pmix_query_t *src
 pmix_status_t pmix_bfrops_base_copy_envar(pmix_envar_t **dest, pmix_envar_t *src,
                                           pmix_data_type_t type)
 {
-    if (PMIX_ENVAR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_ENVAR_CREATE(*dest, 1);
     if (NULL == (*dest)) {
         return PMIX_ERR_NOMEM;
@@ -1119,9 +1104,8 @@ pmix_status_t pmix_bfrops_base_copy_coord(pmix_coord_t **dest, pmix_coord_t *src
     pmix_coord_t *d;
     pmix_status_t rc;
 
-    if (PMIX_COORD != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     d = (pmix_coord_t *) malloc(sizeof(pmix_coord_t));
     if (NULL == d) {
         return PMIX_ERR_NOMEM;
@@ -1140,9 +1124,8 @@ pmix_status_t pmix_bfrops_base_copy_coord(pmix_coord_t **dest, pmix_coord_t *src
 pmix_status_t pmix_bfrops_base_copy_regattr(pmix_regattr_t **dest, pmix_regattr_t *src,
                                             pmix_data_type_t type)
 {
-    if (PMIX_REGATTR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_REGATTR_CREATE(*dest, 1);
     if (NULL == (*dest)) {
         return PMIX_ERR_NOMEM;
@@ -1160,9 +1143,7 @@ pmix_status_t pmix_bfrops_base_copy_regex(char **dest, char *src, pmix_data_type
 {
     size_t len;
 
-    if (PMIX_REGEX != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     return pmix_preg.copy(dest, &len, src);
 }
@@ -1173,9 +1154,8 @@ pmix_status_t pmix_bfrops_base_copy_cpuset(pmix_cpuset_t **dest, pmix_cpuset_t *
     pmix_cpuset_t *dst;
     pmix_status_t rc;
 
-    if (PMIX_PROC_CPUSET != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_CPUSET_CREATE(dst, 1);
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1197,9 +1177,8 @@ pmix_status_t pmix_bfrops_base_copy_geometry(pmix_geometry_t **dest, pmix_geomet
     pmix_status_t rc;
     size_t n;
 
-    if (PMIX_GEOMETRY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_GEOMETRY_CREATE(dst, 1);
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1233,9 +1212,8 @@ pmix_status_t pmix_bfrops_base_copy_devdist(pmix_device_distance_t **dest,
 {
     pmix_device_distance_t *dst;
 
-    if (PMIX_DEVICE_DIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_DEVICE_DIST_CREATE(dst, 1);
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1260,9 +1238,8 @@ pmix_status_t pmix_bfrops_base_copy_endpoint(pmix_endpoint_t **dest, pmix_endpoi
 {
     pmix_endpoint_t *dst;
 
-    if (PMIX_ENDPOINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_ENDPOINT_CREATE(dst, 1);
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1290,9 +1267,8 @@ pmix_status_t pmix_bfrops_base_copy_topology(pmix_topology_t **dest, pmix_topolo
     pmix_topology_t *dst;
     pmix_status_t rc;
 
-    if (PMIX_TOPO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_TOPOLOGY_CREATE(dst, 1);
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1312,9 +1288,8 @@ pmix_status_t pmix_bfrops_base_copy_nspace(pmix_nspace_t **dest, pmix_nspace_t *
 {
     pmix_nspace_t *dst;
 
-    if (PMIX_PROC_NSPACE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     dst = (pmix_nspace_t *) malloc(sizeof(pmix_nspace_t));
     if (NULL == dst) {
         return PMIX_ERR_NOMEM;
@@ -1353,6 +1328,8 @@ pmix_status_t pmix_bfrops_base_copy_pstats(pmix_proc_stats_t **dest, pmix_proc_s
 {
     pmix_proc_stats_t *p;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     PMIX_PROC_STATS_CREATE(p, 1);
     if (NULL == p) {
@@ -1386,6 +1363,8 @@ pmix_status_t pmix_bfrops_base_copy_dkstats(pmix_disk_stats_t **dest, pmix_disk_
 {
     pmix_disk_stats_t *p;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     PMIX_DISK_STATS_CREATE(p, 1);
     if (NULL == p) {
@@ -1413,6 +1392,8 @@ pmix_status_t pmix_bfrops_base_copy_netstats(pmix_net_stats_t **dest, pmix_net_s
                                              pmix_data_type_t type)
 {
     pmix_net_stats_t *p;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* create the new object */
     PMIX_NET_STATS_CREATE(p, 1);
@@ -1466,6 +1447,8 @@ pmix_status_t pmix_bfrops_base_copy_ndstats(pmix_node_stats_t **dest, pmix_node_
 {
     pmix_node_stats_t *p;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     PMIX_NODE_STATS_CREATE(p, 1);
     if (NULL == p) {
@@ -1481,6 +1464,8 @@ pmix_status_t pmix_bfrops_base_copy_dbuf(pmix_data_buffer_t **dest, pmix_data_bu
 {
     pmix_data_buffer_t *p;
     pmix_status_t rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* create the new object */
     PMIX_DATA_BUFFER_CREATE(p);

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -1189,7 +1189,7 @@ PMIX_EXPORT pmix_status_t pmix_info_list_convert(void *ptr, pmix_data_array_t *p
     if (NULL == par || NULL == ptr) {
         return PMIX_ERR_BAD_PARAM;
     }
-    PMIX_DATA_ARRAY_CONSTRUCT(par, 0, PMIX_INFO);
+    PMIX_DATA_ARRAY_INIT(par, PMIX_INFO);
 
     n = pmix_list_get_size(p);
     if (0 == n) {

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -96,12 +96,8 @@ pmix_status_t pmix_bfrops_base_pack_bool(pmix_pointer_array_t *regtypes, pmix_bu
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_bool * %d\n", num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BOOL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = (uint8_t *) pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -131,9 +127,8 @@ pmix_status_t pmix_bfrops_base_pack_int(pmix_pointer_array_t *regtypes, pmix_buf
 {
     pmix_status_t ret;
 
-    if (PMIX_INT != type && PMIX_UINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them */
     if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
@@ -153,9 +148,8 @@ pmix_status_t pmix_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes, pmix_b
 {
     int ret;
 
-    if (PMIX_SIZE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them. */
     if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
@@ -174,9 +168,8 @@ pmix_status_t pmix_bfrops_base_pack_pid(pmix_pointer_array_t *regtypes, pmix_buf
 {
     int ret;
 
-    if (PMIX_PID != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them. */
     if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_PID_T))) {
@@ -199,12 +192,8 @@ pmix_status_t pmix_bfrops_base_pack_byte(pmix_pointer_array_t *regtypes, pmix_bu
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_byte * %d\n", num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BYTE != type && PMIX_UINT8 != type && PMIX_INT8 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -233,12 +222,8 @@ pmix_status_t pmix_bfrops_base_pack_int16(pmix_pointer_array_t *regtypes, pmix_b
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_int16 * %d\n", num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT16 != type && PMIX_UINT16 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -268,12 +253,8 @@ pmix_status_t pmix_bfrops_base_pack_int32(pmix_pointer_array_t *regtypes, pmix_b
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_int32 * %d\n", num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT32 != type && PMIX_UINT32 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -303,12 +284,8 @@ pmix_status_t pmix_bfrops_base_pack_int64(pmix_pointer_array_t *regtypes, pmix_b
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_int64 * %d\n", num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT64 != type && PMIX_UINT64 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -336,12 +313,8 @@ pmix_status_t pmix_bfrops_base_pack_string(pmix_pointer_array_t *regtypes, pmix_
     int32_t i, len;
     char **ssrc = (char **) src;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STRING != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) { /* got zero-length string/NULL pointer - store NULL */
             len = 0;
@@ -373,12 +346,8 @@ pmix_status_t pmix_bfrops_base_pack_float(pmix_pointer_array_t *regtypes, pmix_b
     float *ssrc = (float *) src;
     char *convert;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_FLOAT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         ret = asprintf(&convert, "%f", ssrc[i]);
         if (0 > ret) {
@@ -403,12 +372,8 @@ pmix_status_t pmix_bfrops_base_pack_double(pmix_pointer_array_t *regtypes, pmix_
     double *ssrc = (double *) src;
     char *convert;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DOUBLE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         ret = asprintf(&convert, "%f", ssrc[i]);
         if (0 > ret) {
@@ -434,12 +399,8 @@ pmix_status_t pmix_bfrops_base_pack_timeval(pmix_pointer_array_t *regtypes, pmix
     int32_t i;
     struct timeval *ssrc = (struct timeval *) src;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_TIMEVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t) ssrc[i].tv_sec;
         tmp[1] = (int64_t) ssrc[i].tv_usec;
@@ -460,12 +421,8 @@ pmix_status_t pmix_bfrops_base_pack_time(pmix_pointer_array_t *regtypes, pmix_bu
     time_t *ssrc = (time_t *) src;
     uint64_t ui64;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_TIME != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* time_t is a system-dependent size, so cast it
      * to uint64_t as a generic safe size
      */
@@ -488,12 +445,8 @@ pmix_status_t pmix_bfrops_base_pack_status(pmix_pointer_array_t *regtypes, pmix_
     pmix_status_t *ssrc = (pmix_status_t *) src;
     int32_t status;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STATUS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         status = (int32_t) ssrc[i];
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &status, 1, PMIX_INT32, regtypes);
@@ -512,12 +465,8 @@ pmix_status_t pmix_bfrops_base_pack_buf(pmix_pointer_array_t *regtypes, pmix_buf
     int32_t i;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_buffer_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -550,12 +499,8 @@ pmix_status_t pmix_bfrops_base_pack_bo(pmix_pointer_array_t *regtypes, pmix_buff
     int i;
     pmix_byte_object_t *bo;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BYTE_OBJECT != type && PMIX_COMPRESSED_BYTE_OBJECT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     bo = (pmix_byte_object_t *) src;
     for (i = 0; i < num_vals; i++) {
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &bo[i].size, 1, PMIX_SIZE, regtypes);
@@ -579,12 +524,8 @@ pmix_status_t pmix_bfrops_base_pack_proc(pmix_pointer_array_t *regtypes, pmix_bu
     int32_t i;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     proc = (pmix_proc_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -609,12 +550,8 @@ pmix_status_t pmix_bfrops_base_pack_value(pmix_pointer_array_t *regtypes, pmix_b
     int32_t i;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_VALUE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_value_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -638,12 +575,8 @@ pmix_status_t pmix_bfrops_base_pack_info(pmix_pointer_array_t *regtypes, pmix_bu
     int ret;
     char *foo;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     info = (pmix_info_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -679,12 +612,8 @@ pmix_status_t pmix_bfrops_base_pack_pdata(pmix_pointer_array_t *regtypes, pmix_b
     int ret;
     char *foo;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PDATA != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     pdata = (pmix_pdata_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -722,12 +651,8 @@ pmix_status_t pmix_bfrops_base_pack_app(pmix_pointer_array_t *regtypes, pmix_buf
     int32_t i, j, nvals;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_APP != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     app = (pmix_app_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -798,12 +723,8 @@ pmix_status_t pmix_bfrops_base_pack_kval(pmix_pointer_array_t *regtypes, pmix_bu
     int32_t i;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_KVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_kval_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -826,12 +747,8 @@ pmix_status_t pmix_bfrops_base_pack_persist(pmix_pointer_array_t *regtypes, pmix
                                             pmix_data_type_t type)
 {
     pmix_status_t ret;
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_BYTE, regtypes);
     return ret;
 }
@@ -841,12 +758,8 @@ pmix_status_t pmix_bfrops_base_pack_datatype(pmix_pointer_array_t *regtypes, pmi
                                              pmix_data_type_t type)
 {
     pmix_status_t ret;
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DATA_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
     return ret;
 }
@@ -857,12 +770,8 @@ pmix_status_t pmix_bfrops_base_pack_ptr(pmix_pointer_array_t *regtypes, pmix_buf
     pmix_status_t ret;
     uint8_t foo = 1;
 
-    if (NULL == regtypes || NULL != src || 0 == num_vals) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_POINTER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(src, num_vals, type);
+
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just pack a sentinel */
     PMIX_BFROPS_PACK_TYPE(ret, buffer, &foo, 1, PMIX_UINT8, regtypes);
@@ -874,12 +783,8 @@ pmix_status_t pmix_bfrops_base_pack_scope(pmix_pointer_array_t *regtypes, pmix_b
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_SCOPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -889,12 +794,8 @@ pmix_status_t pmix_bfrops_base_pack_range(pmix_pointer_array_t *regtypes, pmix_b
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DATA_RANGE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -904,12 +805,8 @@ pmix_status_t pmix_bfrops_base_pack_cmd(pmix_pointer_array_t *regtypes, pmix_buf
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_COMMAND != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -920,12 +817,8 @@ pmix_status_t pmix_bfrops_base_pack_info_directives(pmix_pointer_array_t *regtyp
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INFO_DIRECTIVES != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT32, regtypes);
     return ret;
 }
@@ -935,12 +828,8 @@ pmix_status_t pmix_bfrops_base_pack_pstate(pmix_pointer_array_t *regtypes, pmix_
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -952,12 +841,8 @@ pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_pointer_array_t *regtypes, pmix_b
     pmix_status_t ret;
     int32_t i;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; i++) {
         /* pack the proc identifier */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].proc, 1, PMIX_PROC, regtypes);
@@ -993,12 +878,8 @@ pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes, pmix_
     pmix_status_t ret;
     int32_t i;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DATA_ARRAY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; i++) {
         /* pack the actual type in the array */
         if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, p[i].type))) {
@@ -1031,12 +912,8 @@ pmix_status_t pmix_bfrops_base_pack_rank(pmix_pointer_array_t *regtypes, pmix_bu
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_RANK != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT32, regtypes);
     return ret;
 }
@@ -1049,12 +926,8 @@ pmix_status_t pmix_bfrops_base_pack_query(pmix_pointer_array_t *regtypes, pmix_b
     int32_t i;
     int32_t nkeys;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_QUERY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; i++) {
         /* pack the number of keys */
         nkeys = pmix_argv_count(pq[i].keys);
@@ -1137,12 +1010,8 @@ pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_pointer_array_t *regtyp
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_ALLOC_DIRECTIVE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -1153,12 +1022,8 @@ pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_IOF_CHANNEL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
     return ret;
 }
@@ -1170,12 +1035,8 @@ pmix_status_t pmix_bfrops_base_pack_envar(pmix_pointer_array_t *regtypes, pmix_b
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_ENVAR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the name */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].envar, 1, PMIX_STRING, regtypes);
@@ -1203,12 +1064,8 @@ pmix_status_t pmix_bfrops_base_pack_coord(pmix_pointer_array_t *regtypes, pmix_b
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_COORD != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the view */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].view, 1, PMIX_UINT8, regtypes);
@@ -1238,12 +1095,8 @@ pmix_status_t pmix_bfrops_base_pack_regattr(pmix_pointer_array_t *regtypes, pmix
     pmix_status_t ret;
     char *foo;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_REGATTR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the name */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].name, 1, PMIX_STRING, regtypes);
@@ -1285,12 +1138,8 @@ pmix_status_t pmix_bfrops_base_pack_regex(pmix_pointer_array_t *regtypes, pmix_b
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_REGEX != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     for (i = 0; i < num_vals; ++i) {
         ret = pmix_preg.pack(buffer, ptr[i]);
         if (PMIX_SUCCESS != ret) {
@@ -1306,12 +1155,8 @@ pmix_status_t pmix_bfrops_base_pack_jobstate(pmix_pointer_array_t *regtypes, pmi
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_JOB_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -1322,12 +1167,8 @@ pmix_status_t pmix_bfrops_base_pack_linkstate(pmix_pointer_array_t *regtypes, pm
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_LINK_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
     return ret;
 }
@@ -1339,12 +1180,7 @@ pmix_status_t pmix_bfrops_base_pack_cpuset(pmix_pointer_array_t *regtypes, pmix_
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_CPUSET != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         ret = pmix_hwloc_pack_cpuset(buffer, &ptr[i], regtypes);
@@ -1363,12 +1199,7 @@ pmix_status_t pmix_bfrops_base_pack_geometry(pmix_pointer_array_t *regtypes, pmi
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_GEOMETRY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].fabric, 1, PMIX_SIZE, regtypes);
@@ -1404,12 +1235,7 @@ pmix_status_t pmix_bfrops_base_pack_devdist(pmix_pointer_array_t *regtypes, pmix
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DEVICE_DIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].uuid, 1, PMIX_STRING, regtypes);
@@ -1444,12 +1270,7 @@ pmix_status_t pmix_bfrops_base_pack_endpoint(pmix_pointer_array_t *regtypes, pmi
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_ENDPOINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].uuid, 1, PMIX_STRING, regtypes);
@@ -1483,12 +1304,7 @@ pmix_status_t pmix_bfrops_base_pack_topology(pmix_pointer_array_t *regtypes, pmi
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_TOPO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         /* call the framework to pack it */
@@ -1506,12 +1322,7 @@ pmix_status_t pmix_bfrops_base_pack_devtype(pmix_pointer_array_t *regtypes, pmix
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DEVTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
     return ret;
@@ -1523,12 +1334,7 @@ pmix_status_t pmix_bfrops_base_pack_locality(pmix_pointer_array_t *regtypes, pmi
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_LOCTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
     return ret;
@@ -1542,12 +1348,7 @@ pmix_status_t pmix_bfrops_base_pack_nspace(pmix_pointer_array_t *regtypes, pmix_
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_NSPACE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         p = (char *) ptr[i];
@@ -1567,12 +1368,7 @@ pmix_status_t pmix_bfrops_base_pack_pstats(pmix_pointer_array_t *regtypes, pmix_
     int ret;
     char *cptr;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         cptr = ptr[i].node;
@@ -1643,12 +1439,7 @@ pmix_status_t pmix_bfrops_base_pack_dkstats(pmix_pointer_array_t *regtypes, pmix
     int ret;
     char *cptr;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DISK_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         cptr = ptr[i].disk;
@@ -1714,12 +1505,7 @@ pmix_status_t pmix_bfrops_base_pack_netstats(pmix_pointer_array_t *regtypes, pmi
     int ret;
     char *cptr;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_NET_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         cptr = ptr[i].net_interface;
@@ -1764,12 +1550,7 @@ pmix_status_t pmix_bfrops_base_pack_ndstats(pmix_pointer_array_t *regtypes, pmix
     int ret;
     char *cptr;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_NODE_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         cptr = ptr[i].node;
@@ -1858,12 +1639,7 @@ pmix_status_t pmix_bfrops_base_pack_dbuf(pmix_pointer_array_t *regtypes, pmix_bu
     int32_t i;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DATA_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].bytes_used, 1, PMIX_SIZE, regtypes);
@@ -1886,12 +1662,7 @@ pmix_status_t pmix_bfrops_base_pack_smed(pmix_pointer_array_t *regtypes, pmix_bu
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STOR_MEDIUM != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
     return ret;
@@ -1902,12 +1673,7 @@ pmix_status_t pmix_bfrops_base_pack_sacc(pmix_pointer_array_t *regtypes, pmix_bu
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STOR_ACCESS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
     return ret;
@@ -1918,12 +1684,7 @@ pmix_status_t pmix_bfrops_base_pack_spers(pmix_pointer_array_t *regtypes, pmix_b
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STOR_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT64, regtypes);
     return ret;
@@ -1934,12 +1695,7 @@ pmix_status_t pmix_bfrops_base_pack_satyp(pmix_pointer_array_t *regtypes, pmix_b
 {
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_STOR_ACCESS_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
     return ret;

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -107,9 +107,8 @@ int pmix_bfrops_base_print_byte(char **output, char *prefix, uint8_t *src, pmix_
     char *prefx;
     int ret;
 
-    if (PMIX_BYTE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -149,9 +148,8 @@ int pmix_bfrops_base_print_string(char **output, char *prefix, char *src, pmix_d
     char *prefx;
     int ret;
 
-    if (PMIX_STRING != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -191,9 +189,8 @@ int pmix_bfrops_base_print_size(char **output, char *prefix, size_t *src, pmix_d
     char *prefx;
     int ret;
 
-    if (PMIX_SIZE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -233,9 +230,8 @@ int pmix_bfrops_base_print_pid(char **output, char *prefix, pid_t *src, pmix_dat
     char *prefx;
     int ret;
 
-    if (PMIX_PID != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -274,9 +270,8 @@ int pmix_bfrops_base_print_int(char **output, char *prefix, int *src, pmix_data_
     char *prefx;
     int ret;
 
-    if (PMIX_INT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -316,9 +311,8 @@ int pmix_bfrops_base_print_uint(char **output, char *prefix, uint *src, pmix_dat
     char *prefx;
     int ret;
 
-    if (PMIX_UINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -358,9 +352,8 @@ int pmix_bfrops_base_print_uint8(char **output, char *prefix, uint8_t *src, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_UINT8 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -400,9 +393,8 @@ int pmix_bfrops_base_print_uint16(char **output, char *prefix, uint16_t *src, pm
     char *prefx;
     int ret;
 
-    if (PMIX_UINT16 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -442,9 +434,8 @@ int pmix_bfrops_base_print_uint32(char **output, char *prefix, uint32_t *src, pm
     char *prefx;
     int ret;
 
-    if (PMIX_UINT32 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -484,9 +475,8 @@ int pmix_bfrops_base_print_int8(char **output, char *prefix, int8_t *src, pmix_d
     char *prefx;
     int ret;
 
-    if (PMIX_INT8 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -526,9 +516,8 @@ int pmix_bfrops_base_print_int16(char **output, char *prefix, int16_t *src, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_INT16 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -568,9 +557,8 @@ int pmix_bfrops_base_print_int32(char **output, char *prefix, int32_t *src, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_INT32 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -609,9 +597,8 @@ int pmix_bfrops_base_print_uint64(char **output, char *prefix, uint64_t *src, pm
     char *prefx;
     int ret;
 
-    if (PMIX_UINT64 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -651,9 +638,8 @@ int pmix_bfrops_base_print_int64(char **output, char *prefix, int64_t *src, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_INT64 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -693,9 +679,8 @@ int pmix_bfrops_base_print_float(char **output, char *prefix, float *src, pmix_d
     char *prefx;
     int ret;
 
-    if (PMIX_FLOAT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -735,9 +720,8 @@ int pmix_bfrops_base_print_double(char **output, char *prefix, double *src, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_DOUBLE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -778,9 +762,8 @@ int pmix_bfrops_base_print_time(char **output, char *prefix, time_t *src, pmix_d
     char *t;
     int ret;
 
-    if (PMIX_TIME != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -824,9 +807,8 @@ int pmix_bfrops_base_print_timeval(char **output, char *prefix, struct timeval *
     char *prefx;
     int ret;
 
-    if (PMIX_TIMEVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -868,9 +850,8 @@ int pmix_bfrops_base_print_status(char **output, char *prefix, pmix_status_t *sr
     char *prefx;
     int ret;
 
-    if (PMIX_STATUS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -918,9 +899,8 @@ int pmix_bfrops_base_print_value(char **output, char *prefix, pmix_value_t *src,
     pmix_regattr_t *r;
     char *tp;
 
-    if (PMIX_VALUE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1148,9 +1128,8 @@ int pmix_bfrops_base_print_info(char **output, char *prefix, pmix_info_t *src,
     char *tmp = NULL, *tmp2 = NULL;
     int ret;
 
-    if (PMIX_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     pmix_bfrops_base_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
     pmix_bfrops_base_print_info_directives(&tmp2, NULL, &src->flags, PMIX_INFO_DIRECTIVES);
     ret = asprintf(output, "%sKEY: %s\n%s\t%s\n%s\t%s", prefix, src->key, prefix, tmp2, prefix,
@@ -1170,9 +1149,8 @@ int pmix_bfrops_base_print_pdata(char **output, char *prefix, pmix_pdata_t *src,
     char *tmp1, *tmp2;
     int ret;
 
-    if (PMIX_PDATA != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     pmix_bfrops_base_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix_bfrops_base_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
     ret = asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
@@ -1193,17 +1171,15 @@ int pmix_bfrops_base_print_pdata(char **output, char *prefix, pmix_pdata_t *src,
 int pmix_bfrops_base_print_buf(char **output, char *prefix, pmix_buffer_t *src,
                                pmix_data_type_t type)
 {
-    if (NULL == output || NULL == prefix || NULL == src || PMIX_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
 int pmix_bfrops_base_print_app(char **output, char *prefix, pmix_app_t *src, pmix_data_type_t type)
 {
-    if (NULL == output || NULL == prefix || NULL == src || PMIX_APP != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -1213,9 +1189,8 @@ int pmix_bfrops_base_print_proc(char **output, char *prefix, pmix_proc_t *src,
     char *prefx;
     int rc;
 
-    if (PMIX_PROC != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1250,9 +1225,8 @@ int pmix_bfrops_base_print_proc(char **output, char *prefix, pmix_proc_t *src,
 int pmix_bfrops_base_print_kval(char **output, char *prefix, pmix_kval_t *src,
                                 pmix_data_type_t type)
 {
-    if (NULL == output || NULL == prefix || NULL == src || PMIX_KVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -1261,9 +1235,8 @@ int pmix_bfrops_base_print_persist(char **output, char *prefix, pmix_persistence
 {
     char *prefx;
 
-    if (PMIX_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1299,9 +1272,8 @@ pmix_status_t pmix_bfrops_base_print_scope(char **output, char *prefix, pmix_sco
 {
     char *prefx;
 
-    if (PMIX_SCOPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1327,9 +1299,8 @@ pmix_status_t pmix_bfrops_base_print_range(char **output, char *prefix, pmix_dat
 {
     char *prefx;
 
-    if (PMIX_DATA_RANGE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1354,9 +1325,8 @@ pmix_status_t pmix_bfrops_base_print_cmd(char **output, char *prefix, pmix_cmd_t
 {
     char *prefx;
 
-    if (PMIX_COMMAND != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1383,9 +1353,8 @@ pmix_status_t pmix_bfrops_base_print_info_directives(char **output, char *prefix
 {
     char *prefx;
 
-    if (PMIX_INFO_DIRECTIVES != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1412,9 +1381,8 @@ pmix_status_t pmix_bfrops_base_print_datatype(char **output, char *prefix, pmix_
     char *prefx;
     int ret;
 
-    if (PMIX_DATA_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1456,9 +1424,8 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix, pmix_byte_object_t *s
     char *prefx;
     int ret;
 
-    if (PMIX_BYTE_OBJECT != type && PMIX_COMPRESSED_BYTE_OBJECT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1503,9 +1470,8 @@ int pmix_bfrops_base_print_ptr(char **output, char *prefix, void *src, pmix_data
     char *prefx;
     int ret;
 
-    if (PMIX_POINTER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1533,9 +1499,8 @@ pmix_status_t pmix_bfrops_base_print_pstate(char **output, char *prefix, pmix_pr
     char *prefx;
     int ret;
 
-    if (PMIX_PROC_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1565,9 +1530,8 @@ pmix_status_t pmix_bfrops_base_print_pinfo(char **output, char *prefix, pmix_pro
     pmix_status_t rc = PMIX_SUCCESS;
     char *p2, *tmp;
 
-    if (PMIX_PROC_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1611,9 +1575,8 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix, pmix_da
     char *prefx;
     int ret;
 
-    if (PMIX_DATA_ARRAY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1644,9 +1607,8 @@ pmix_status_t pmix_bfrops_base_print_query(char **output, char *prefix, pmix_que
     char *tmp, *t2, *t3;
     size_t n;
 
-    if (PMIX_QUERY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1717,9 +1679,8 @@ pmix_status_t pmix_bfrops_base_print_rank(char **output, char *prefix, pmix_rank
     char *prefx;
     int rc;
 
-    if (PMIX_PROC_RANK != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1759,9 +1720,8 @@ pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix
     char *prefx;
     int ret;
 
-    if (PMIX_ALLOC_DIRECTIVE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1790,9 +1750,8 @@ pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
     char *prefx;
     int ret;
 
-    if (PMIX_IOF_CHANNEL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1821,9 +1780,8 @@ pmix_status_t pmix_bfrops_base_print_envar(char **output, char *prefix, pmix_env
     char *prefx;
     int ret;
 
-    if (PMIX_ENVAR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1855,9 +1813,8 @@ pmix_status_t pmix_bfrops_base_print_coord(char **output, char *prefix, pmix_coo
     int ret;
     char *tp;
 
-    if (PMIX_COORD != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1895,9 +1852,8 @@ pmix_status_t pmix_bfrops_base_print_regattr(char **output, char *prefix, pmix_r
     char *prefx;
     int ret;
 
-    if (PMIX_REGATTR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1928,9 +1884,8 @@ pmix_status_t pmix_bfrops_base_print_regex(char **output, char *prefix, char *sr
     char *prefx;
     int ret;
 
-    if (PMIX_REGEX != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1959,9 +1914,8 @@ pmix_status_t pmix_bfrops_base_print_jobstate(char **output, char *prefix, pmix_
     char *prefx;
     int ret;
 
-    if (PMIX_JOB_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1990,9 +1944,8 @@ pmix_status_t pmix_bfrops_base_print_linkstate(char **output, char *prefix, pmix
     char *prefx;
     int ret;
 
-    if (PMIX_LINK_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -2021,9 +1974,7 @@ pmix_status_t pmix_bfrops_base_print_cpuset(char **output, char *prefix, pmix_cp
     char *prefx, *string;
     int ret;
 
-    if (PMIX_PROC_CPUSET != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     string = pmix_hwloc_print_cpuset(src);
     if (NULL == string) {
@@ -2060,9 +2011,7 @@ pmix_status_t pmix_bfrops_base_print_geometry(char **output, char *prefix, pmix_
     int ret;
     size_t n;
 
-    if (PMIX_GEOMETRY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2125,9 +2074,8 @@ pmix_status_t pmix_bfrops_base_print_devdist(char **output, char *prefix,
     char *prefx;
     int ret;
 
-    if (PMIX_DEVICE_DIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -2159,9 +2107,8 @@ pmix_status_t pmix_bfrops_base_print_endpoint(char **output, char *prefix, pmix_
     char *prefx;
     int ret;
 
-    if (PMIX_ENDPOINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -2192,9 +2139,7 @@ pmix_status_t pmix_bfrops_base_print_topology(char **output, char *prefix, pmix_
     char *prefx, *string;
     int ret;
 
-    if (PMIX_TOPO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     string = pmix_hwloc_print_topology(src);
     if (NULL == string) {
@@ -2230,9 +2175,7 @@ pmix_status_t pmix_bfrops_base_print_devtype(char **output, char *prefix, pmix_d
     char *prefx;
     int ret;
 
-    if (PMIX_DEVTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2262,9 +2205,7 @@ pmix_status_t pmix_bfrops_base_print_locality(char **output, char *prefix, pmix_
     char *prefx, **tmp = NULL, *str;
     int ret;
 
-    if (PMIX_LOCTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2327,9 +2268,7 @@ pmix_status_t pmix_bfrops_base_print_nspace(char **output, char *prefix, pmix_ns
     char *prefx;
     int ret;
 
-    if (PMIX_PROC_NSPACE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2356,6 +2295,8 @@ pmix_status_t pmix_bfrops_base_print_pstats(char **output, char *prefix, pmix_pr
                                             pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2392,6 +2333,8 @@ pmix_status_t pmix_bfrops_base_print_dkstats(char **output, char *prefix, pmix_d
                                              pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2433,6 +2376,8 @@ pmix_status_t pmix_bfrops_base_print_netstats(char **output, char *prefix, pmix_
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         pmix_asprintf(&prefx, " ");
@@ -2469,6 +2414,8 @@ pmix_status_t pmix_bfrops_base_print_ndstats(char **output, char *prefix, pmix_n
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         pmix_asprintf(&prefx, " ");
@@ -2504,6 +2451,8 @@ pmix_status_t pmix_bfrops_base_print_dbuf(char **output, char *prefix, pmix_data
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         pmix_asprintf(&prefx, " ");
@@ -2535,9 +2484,7 @@ pmix_status_t pmix_bfrops_base_print_smed(char **output, char *prefix,
     char *prefx, **tmp = NULL, *str;
     int ret;
 
-    if (PMIX_STOR_MEDIUM != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2593,9 +2540,7 @@ pmix_status_t pmix_bfrops_base_print_sacc(char **output, char *prefix,
     char *prefx, **tmp = NULL, *str;
     int ret;
 
-    if (PMIX_STOR_ACCESS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2647,9 +2592,7 @@ pmix_status_t pmix_bfrops_base_print_spers(char **output, char *prefix,
     char *prefx, **tmp = NULL, *str;
     int ret;
 
-    if (PMIX_STOR_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -2705,9 +2648,7 @@ pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *prefix,
     char *prefx, **tmp = NULL, *str;
     int ret;
 
-    if (PMIX_STOR_ACCESS_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -160,12 +160,7 @@ pmix_status_t pmix_bfrops_base_unpack_bool(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_bool * %d\n", (int) *num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BOOL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
@@ -199,9 +194,7 @@ pmix_status_t pmix_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes, pmix_b
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_INT != type && PMIX_UINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
@@ -232,6 +225,8 @@ pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes, pmix
         return PMIX_ERR_BAD_PARAM;
     }
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         PMIX_ERROR_LOG(ret);
         return ret;
@@ -260,9 +255,7 @@ pmix_status_t pmix_bfrops_base_unpack_pid(pmix_pointer_array_t *regtypes, pmix_b
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_PID != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
@@ -291,12 +284,7 @@ pmix_status_t pmix_bfrops_base_unpack_byte(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_byte * %d\n", (int) *num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_BYTE != type && PMIX_UINT8 != type && PMIX_INT8 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
@@ -321,12 +309,7 @@ pmix_status_t pmix_bfrops_base_unpack_int16(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_int16 * %d\n", (int) *num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT16 != type && PMIX_UINT16 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
@@ -353,12 +336,7 @@ pmix_status_t pmix_bfrops_base_unpack_int32(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_int32 * %d\n", (int) *num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT32 != type && PMIX_UINT32 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
@@ -382,9 +360,8 @@ pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
-    if (PMIX_DATA_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT16, regtypes);
     return ret;
 }
@@ -398,12 +375,7 @@ pmix_status_t pmix_bfrops_base_unpack_int64(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_int64 * %d\n", (int) *num_vals);
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_INT64 != type && PMIX_UINT64 != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
@@ -428,9 +400,7 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_pointer_array_t *regtypes, pmi
     int32_t i, len, n = 1;
     char **sdest = (char **) dest;
 
-    if (PMIX_STRING != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < (*num_vals); ++i) {
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &len, &n, PMIX_INT32, regtypes);
@@ -465,9 +435,7 @@ pmix_status_t pmix_bfrops_base_unpack_float(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_float * %d\n", (int) *num_vals);
 
-    if (PMIX_FLOAT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
@@ -497,9 +465,7 @@ pmix_status_t pmix_bfrops_base_unpack_double(pmix_pointer_array_t *regtypes, pmi
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_double * %d\n", (int) *num_vals);
 
-    if (PMIX_DOUBLE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
@@ -529,9 +495,7 @@ pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_pointer_array_t *regtypes, pm
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_timeval * %d\n", (int) *num_vals);
 
-    if (PMIX_TIMEVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
@@ -562,9 +526,7 @@ pmix_status_t pmix_bfrops_base_unpack_time(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_time * %d\n", (int) *num_vals);
 
-    if (PMIX_TIME != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
@@ -587,9 +549,7 @@ pmix_status_t pmix_bfrops_base_unpack_status(pmix_pointer_array_t *regtypes, pmi
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_status * %d\n", (int) *num_vals);
 
-    if (PMIX_STATUS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* unpack the data */
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT32, regtypes);
@@ -609,126 +569,126 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
 
     m = 1;
     switch (val->type) {
-    case PMIX_UNDEF:
-        break;
-    case PMIX_PROC:
-        /* this field is now a pointer, so we must allocate storage for it */
-        PMIX_PROC_CREATE(val->data.proc, m);
-        if (NULL == val->data.proc) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.proc, &m, PMIX_PROC, regtypes);
-        break;
-    case PMIX_PROC_INFO:
-        /* this is now a pointer, so allocate storage for it */
-        PMIX_PROC_INFO_CREATE(val->data.pinfo, 1);
-        if (NULL == val->data.pinfo) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.pinfo, &m, PMIX_PROC_INFO, regtypes);
-        break;
-    case PMIX_DATA_ARRAY:
-        /* this is now a pointer, so allocate storage for it */
-        val->data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
-        if (NULL == val->data.darray) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.darray, &m, PMIX_DATA_ARRAY, regtypes);
-        break;
-    case PMIX_REGATTR:
-        val->data.ptr = (pmix_regattr_t *) calloc(1, sizeof(pmix_regattr_t));
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ptr, &m, PMIX_REGATTR, regtypes);
-        return ret;
-    case PMIX_COORD:
-        val->data.coord = (pmix_coord_t *) calloc(1, sizeof(pmix_coord_t));
-        if (NULL == val->data.coord) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.coord, &m, PMIX_COORD, regtypes);
-        return ret;
-    case PMIX_TOPO:
-        PMIX_TOPOLOGY_CREATE(val->data.topo, 1);
-        if (NULL == val->data.topo) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.topo, &m, PMIX_TOPO, regtypes);
-        return ret;
-    case PMIX_PROC_CPUSET:
-        PMIX_CPUSET_CREATE(val->data.cpuset, 1);
-        if (NULL == val->data.cpuset) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.cpuset, &m, PMIX_PROC_CPUSET, regtypes);
-        return ret;
-    case PMIX_GEOMETRY:
-        PMIX_GEOMETRY_CREATE(val->data.geometry, 1);
-        if (NULL == val->data.geometry) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.geometry, &m, PMIX_GEOMETRY, regtypes);
-        return ret;
-    case PMIX_DEVICE_DIST:
-        PMIX_DEVICE_DIST_CREATE(val->data.devdist, 1);
-        if (NULL == val->data.devdist) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.devdist, &m, PMIX_DEVICE_DIST, regtypes);
-        return ret;
-    case PMIX_ENDPOINT:
-        PMIX_ENDPOINT_CREATE(val->data.endpoint, 1);
-        if (NULL == val->data.endpoint) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.endpoint, &m, PMIX_ENDPOINT, regtypes);
-        return ret;
-    case PMIX_PROC_NSPACE:
-        PMIX_PROC_CREATE(val->data.proc, 1);
-        if (NULL == val->data.proc) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data.proc->nspace, &m, PMIX_PROC_NSPACE,
-                                regtypes);
-        return ret;
-    case PMIX_PROC_STATS:
-        PMIX_PROC_STATS_CREATE(val->data.pstats, 1);
-        if (NULL == val->data.pstats) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.pstats, &m, PMIX_PROC_STATS, regtypes);
-        return ret;
-    case PMIX_DISK_STATS:
-        PMIX_DISK_STATS_CREATE(val->data.dkstats, 1);
-        if (NULL == val->data.dkstats) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.dkstats, &m, PMIX_DISK_STATS, regtypes);
-        return ret;
-    case PMIX_NET_STATS:
-        PMIX_NET_STATS_CREATE(val->data.netstats, 1);
-        if (NULL == val->data.netstats) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.netstats, &m, PMIX_NET_STATS, regtypes);
-        return ret;
-    case PMIX_NODE_STATS:
-        PMIX_NODE_STATS_CREATE(val->data.ndstats, 1);
-        if (NULL == val->data.ndstats) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ndstats, &m, PMIX_NODE_STATS, regtypes);
-        return ret;
-    case PMIX_DATA_BUFFER:
-        PMIX_DATA_BUFFER_CREATE(val->data.ptr);
-        if (NULL == val->data.ptr) {
-            return PMIX_ERR_NOMEM;
-        }
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ptr, &m, PMIX_DATA_BUFFER, regtypes);
-        return ret;
-    default:
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data, &m, val->type, regtypes);
-        if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
-            pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int) val->type);
-        }
+        case PMIX_UNDEF:
+            break;
+        case PMIX_PROC:
+            /* this field is now a pointer, so we must allocate storage for it */
+            PMIX_PROC_CREATE(val->data.proc, m);
+            if (NULL == val->data.proc) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.proc, &m, PMIX_PROC, regtypes);
+            break;
+        case PMIX_PROC_INFO:
+            /* this is now a pointer, so allocate storage for it */
+            PMIX_PROC_INFO_CREATE(val->data.pinfo, 1);
+            if (NULL == val->data.pinfo) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.pinfo, &m, PMIX_PROC_INFO, regtypes);
+            break;
+        case PMIX_DATA_ARRAY:
+            /* this is now a pointer, so allocate storage for it */
+            val->data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
+            if (NULL == val->data.darray) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.darray, &m, PMIX_DATA_ARRAY, regtypes);
+            break;
+        case PMIX_REGATTR:
+            val->data.ptr = (pmix_regattr_t *) calloc(1, sizeof(pmix_regattr_t));
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ptr, &m, PMIX_REGATTR, regtypes);
+            return ret;
+        case PMIX_COORD:
+            val->data.coord = (pmix_coord_t *) calloc(1, sizeof(pmix_coord_t));
+            if (NULL == val->data.coord) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.coord, &m, PMIX_COORD, regtypes);
+            return ret;
+        case PMIX_TOPO:
+            PMIX_TOPOLOGY_CREATE(val->data.topo, 1);
+            if (NULL == val->data.topo) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.topo, &m, PMIX_TOPO, regtypes);
+            return ret;
+        case PMIX_PROC_CPUSET:
+            PMIX_CPUSET_CREATE(val->data.cpuset, 1);
+            if (NULL == val->data.cpuset) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.cpuset, &m, PMIX_PROC_CPUSET, regtypes);
+            return ret;
+        case PMIX_GEOMETRY:
+            PMIX_GEOMETRY_CREATE(val->data.geometry, 1);
+            if (NULL == val->data.geometry) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.geometry, &m, PMIX_GEOMETRY, regtypes);
+            return ret;
+        case PMIX_DEVICE_DIST:
+            PMIX_DEVICE_DIST_CREATE(val->data.devdist, 1);
+            if (NULL == val->data.devdist) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.devdist, &m, PMIX_DEVICE_DIST, regtypes);
+            return ret;
+        case PMIX_ENDPOINT:
+            PMIX_ENDPOINT_CREATE(val->data.endpoint, 1);
+            if (NULL == val->data.endpoint) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.endpoint, &m, PMIX_ENDPOINT, regtypes);
+            return ret;
+        case PMIX_PROC_NSPACE:
+            PMIX_PROC_CREATE(val->data.proc, 1);
+            if (NULL == val->data.proc) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data.proc->nspace, &m, PMIX_PROC_NSPACE,
+                                    regtypes);
+            return ret;
+        case PMIX_PROC_STATS:
+            PMIX_PROC_STATS_CREATE(val->data.pstats, 1);
+            if (NULL == val->data.pstats) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.pstats, &m, PMIX_PROC_STATS, regtypes);
+            return ret;
+        case PMIX_DISK_STATS:
+            PMIX_DISK_STATS_CREATE(val->data.dkstats, 1);
+            if (NULL == val->data.dkstats) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.dkstats, &m, PMIX_DISK_STATS, regtypes);
+            return ret;
+        case PMIX_NET_STATS:
+            PMIX_NET_STATS_CREATE(val->data.netstats, 1);
+            if (NULL == val->data.netstats) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.netstats, &m, PMIX_NET_STATS, regtypes);
+            return ret;
+        case PMIX_NODE_STATS:
+            PMIX_NODE_STATS_CREATE(val->data.ndstats, 1);
+            if (NULL == val->data.ndstats) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ndstats, &m, PMIX_NODE_STATS, regtypes);
+            return ret;
+        case PMIX_DATA_BUFFER:
+            PMIX_DATA_BUFFER_CREATE(val->data.ptr);
+            if (NULL == val->data.ptr) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ptr, &m, PMIX_DATA_BUFFER, regtypes);
+            return ret;
+        default:
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data, &m, val->type, regtypes);
+            if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
+                pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int) val->type);
+            }
     }
 
     return ret;
@@ -744,9 +704,7 @@ pmix_status_t pmix_bfrops_base_unpack_value(pmix_pointer_array_t *regtypes, pmix
     ptr = (pmix_value_t *) dest;
     n = *num_vals;
 
-    if (PMIX_VALUE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         /* unpack the type */
@@ -774,9 +732,7 @@ pmix_status_t pmix_bfrops_base_unpack_info(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d info", *num_vals);
 
-    if (PMIX_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_info_t *) dest;
     n = *num_vals;
@@ -831,9 +787,7 @@ pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d pdata", *num_vals);
 
-    if (PMIX_PDATA != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_pdata_t *) dest;
     n = *num_vals;
@@ -890,9 +844,7 @@ pmix_status_t pmix_bfrops_base_unpack_buf(pmix_pointer_array_t *regtypes, pmix_b
     ptr = (pmix_buffer_t *) dest;
     n = *num_vals;
 
-    if (PMIX_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         PMIX_CONSTRUCT(&ptr[i], pmix_buffer_t);
@@ -940,9 +892,7 @@ pmix_status_t pmix_bfrops_base_unpack_proc(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d procs", *num_vals);
 
-    if (PMIX_PROC != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_proc_t *) dest;
     n = *num_vals;
@@ -986,9 +936,7 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes, pmix_b
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d apps", *num_vals);
 
-    if (PMIX_APP != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_app_t *) dest;
     n = *num_vals;
@@ -1088,9 +1036,7 @@ pmix_status_t pmix_bfrops_base_unpack_kval(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d kvals", *num_vals);
 
-    if (PMIX_KVAL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_kval_t *) dest;
     n = *num_vals;
@@ -1120,9 +1066,7 @@ pmix_status_t pmix_bfrops_base_unpack_persist(pmix_pointer_array_t *regtypes, pm
 {
     pmix_status_t ret;
 
-    if (PMIX_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_BYTE, regtypes);
     return ret;
@@ -1138,9 +1082,7 @@ pmix_status_t pmix_bfrops_base_unpack_bo(pmix_pointer_array_t *regtypes, pmix_bu
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d byte_object", *num_vals);
 
-    if (PMIX_BYTE_OBJECT != type && PMIX_COMPRESSED_BYTE_OBJECT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_byte_object_t *) dest;
     n = *num_vals;
@@ -1172,15 +1114,7 @@ pmix_status_t pmix_bfrops_base_unpack_ptr(pmix_pointer_array_t *regtypes, pmix_b
     int32_t cnt = 1;
     pmix_status_t ret;
 
-    if (NULL == dest) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (NULL == num_vals) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_POINTER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(dest, num_vals, type);
 
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just unpack the sentinel */
@@ -1193,9 +1127,7 @@ pmix_status_t pmix_bfrops_base_unpack_scope(pmix_pointer_array_t *regtypes, pmix
 {
     pmix_status_t ret;
 
-    if (PMIX_SCOPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1206,9 +1138,7 @@ pmix_status_t pmix_bfrops_base_unpack_range(pmix_pointer_array_t *regtypes, pmix
 {
     pmix_status_t ret;
 
-    if (PMIX_DATA_RANGE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1219,9 +1149,7 @@ pmix_status_t pmix_bfrops_base_unpack_cmd(pmix_pointer_array_t *regtypes, pmix_b
 {
     pmix_status_t ret;
 
-    if (PMIX_COMMAND != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1233,9 +1161,7 @@ pmix_status_t pmix_bfrops_base_unpack_info_directives(pmix_pointer_array_t *regt
 {
     pmix_status_t ret;
 
-    if (PMIX_INFO_DIRECTIVES != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT32, regtypes);
     return ret;
@@ -1246,9 +1172,7 @@ pmix_status_t pmix_bfrops_base_unpack_pstate(pmix_pointer_array_t *regtypes, pmi
 {
     pmix_status_t ret;
 
-    if (PMIX_PROC_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1264,9 +1188,7 @@ pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d pinfo", *num_vals);
 
-    if (PMIX_PROC_INFO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_proc_info_t *) dest;
     n = *num_vals;
@@ -1319,9 +1241,7 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmi
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d data arrays", *num_vals);
 
-    if (PMIX_DATA_ARRAY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_data_array_t *) dest;
     n = *num_vals;
@@ -1365,9 +1285,7 @@ pmix_status_t pmix_bfrops_base_unpack_rank(pmix_pointer_array_t *regtypes, pmix_
 {
     pmix_status_t ret;
 
-    if (PMIX_PROC_RANK != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT32, regtypes);
     return ret;
@@ -1384,9 +1302,7 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d queries", *num_vals);
 
-    if (PMIX_QUERY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_query_t *) dest;
     n = *num_vals;
@@ -1436,9 +1352,7 @@ pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_pointer_array_t *regt
 {
     pmix_status_t ret;
 
-    if (PMIX_ALLOC_DIRECTIVE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1450,9 +1364,7 @@ pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes
 {
     pmix_status_t ret;
 
-    if (PMIX_IOF_CHANNEL != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT16, regtypes);
     return ret;
@@ -1468,9 +1380,7 @@ pmix_status_t pmix_bfrops_base_unpack_envar(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d envars", *num_vals);
 
-    if (PMIX_ENVAR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_envar_t *) dest;
     n = *num_vals;
@@ -1509,9 +1419,7 @@ pmix_status_t pmix_bfrops_base_unpack_coord(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d coordinates", *num_vals);
 
-    if (PMIX_COORD != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_coord_t *) dest;
     n = *num_vals;
@@ -1554,9 +1462,7 @@ pmix_status_t pmix_bfrops_base_unpack_regattr(pmix_pointer_array_t *regtypes, pm
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d regattrs", *num_vals);
 
-    if (PMIX_REGATTR != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_regattr_t *) dest;
     n = *num_vals;
@@ -1622,9 +1528,7 @@ pmix_status_t pmix_bfrops_base_unpack_regex(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d regex", *num_vals);
 
-    if (PMIX_REGEX != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     ptr = (char **) dest;
     n = *num_vals;
@@ -1645,9 +1549,7 @@ pmix_status_t pmix_bfrops_base_unpack_jobstate(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
-    if (PMIX_JOB_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1659,9 +1561,7 @@ pmix_status_t pmix_bfrops_base_unpack_linkstate(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
-    if (PMIX_LINK_STATE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
     return ret;
@@ -1677,9 +1577,7 @@ pmix_status_t pmix_bfrops_base_unpack_cpuset(pmix_pointer_array_t *regtypes, pmi
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d cpuset", *num_vals);
 
-    if (PMIX_PROC_CPUSET != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_cpuset_t *) dest;
     n = *num_vals;
@@ -1705,9 +1603,7 @@ pmix_status_t pmix_bfrops_base_unpack_geometry(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d geometry", *num_vals);
 
-    if (PMIX_GEOMETRY != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_geometry_t *) dest;
     n = *num_vals;
@@ -1766,9 +1662,7 @@ pmix_status_t pmix_bfrops_base_unpack_devdist(pmix_pointer_array_t *regtypes, pm
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d device distances", *num_vals);
 
-    if (PMIX_DEVICE_DIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_device_distance_t *) dest;
     n = *num_vals;
@@ -1821,9 +1715,7 @@ pmix_status_t pmix_bfrops_base_unpack_endpoint(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d endpts", *num_vals);
 
-    if (PMIX_ENDPOINT != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_endpoint_t *) dest;
     n = *num_vals;
@@ -1873,9 +1765,7 @@ pmix_status_t pmix_bfrops_base_unpack_topology(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d topology", *num_vals);
 
-    if (PMIX_TOPO != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_topology_t *) dest;
     n = *num_vals;
@@ -1898,9 +1788,7 @@ pmix_status_t pmix_bfrops_base_unpack_devtype(pmix_pointer_array_t *regtypes, pm
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d device types", *num_vals);
 
-    if (PMIX_DEVTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
 
@@ -1916,9 +1804,7 @@ pmix_status_t pmix_bfrops_base_unpack_locality(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d locality", *num_vals);
 
-    if (PMIX_LOCTYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT16, regtypes);
 
@@ -1936,9 +1822,7 @@ pmix_status_t pmix_bfrops_base_unpack_nspace(pmix_pointer_array_t *regtypes, pmi
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d nspace", *num_vals);
 
-    if (PMIX_PROC_NSPACE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_nspace_t *) dest;
     n = *num_vals;
@@ -1966,12 +1850,7 @@ pmix_status_t pmix_bfrops_base_unpack_pstats(pmix_pointer_array_t *regtypes, pmi
     ptr = (pmix_proc_stats_t *) dest;
     n = *num_vals;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_PROC_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         m = 1;
@@ -2070,12 +1949,8 @@ pmix_status_t pmix_bfrops_base_unpack_dkstats(pmix_pointer_array_t *regtypes, pm
     pmix_status_t ret;
     pmix_disk_stats_t *ptr = (pmix_disk_stats_t *) dest;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DISK_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* unpack them */
     n = *num_vals;
     for (i = 0; i < n; i++) {
@@ -2170,12 +2045,7 @@ pmix_status_t pmix_bfrops_base_unpack_netstats(pmix_pointer_array_t *regtypes,
     int32_t i, m, n;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_NET_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     n = *num_vals;
     for (i = 0; i < n; i++) {
@@ -2232,12 +2102,7 @@ pmix_status_t pmix_bfrops_base_unpack_ndstats(pmix_pointer_array_t *regtypes, pm
     int32_t i, m, n;
     int ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_NODE_STATS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     n = *num_vals;
     for (i = 0; i < n; i++) {
@@ -2362,12 +2227,7 @@ pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes, pmix_
     int32_t i, m, n;
     pmix_status_t ret;
 
-    if (NULL == regtypes) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    if (PMIX_DATA_BUFFER != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     n = *num_vals;
     for (i = 0; i < n; ++i) {
@@ -2397,9 +2257,7 @@ pmix_status_t pmix_bfrops_base_unpack_smed(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d storage medium", *num_vals);
 
-    if (PMIX_STOR_MEDIUM != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
 
@@ -2414,9 +2272,7 @@ pmix_status_t pmix_bfrops_base_unpack_sacc(pmix_pointer_array_t *regtypes, pmix_
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d storage access", *num_vals);
 
-    if (PMIX_STOR_ACCESS != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
 
@@ -2431,9 +2287,7 @@ pmix_status_t pmix_bfrops_base_unpack_spers(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d storage persistence", *num_vals);
 
-    if (PMIX_STOR_PERSIST != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT64, regtypes);
 
@@ -2448,9 +2302,7 @@ pmix_status_t pmix_bfrops_base_unpack_satyp(pmix_pointer_array_t *regtypes, pmix
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d storage access type", *num_vals);
 
-    if (PMIX_STOR_ACCESS_TYPE != type) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT16, regtypes);
 

--- a/src/mca/bfrops/bfrops.h
+++ b/src/mca/bfrops/bfrops.h
@@ -339,14 +339,6 @@ typedef pmix_status_t (*pmix_bfrop_value_unload_fn_t)(pmix_value_t *kv, void **d
  */
 typedef pmix_value_cmp_t (*pmix_bfrop_value_cmp_fn_t)(pmix_value_t *p1, pmix_value_t *p2);
 
-/* define a component-level API for registering a new
- * datatype, providing all the required functions */
-typedef pmix_status_t (*pmix_bfrop_base_register_fn_t)(const char *name, pmix_data_type_t type,
-                                                       pmix_bfrop_pack_fn_t pack,
-                                                       pmix_bfrop_unpack_fn_t unpack,
-                                                       pmix_bfrop_copy_fn_t copy,
-                                                       pmix_bfrop_print_fn_t print);
-
 /* return the string name of a provided data type */
 typedef const char *(*pmix_bfrop_data_type_string_fn_t)(pmix_data_type_t type);
 
@@ -366,7 +358,6 @@ typedef struct {
     pmix_bfrop_value_load_fn_t value_load;
     pmix_bfrop_value_unload_fn_t value_unload;
     pmix_bfrop_value_cmp_fn_t value_cmp;
-    pmix_bfrop_base_register_fn_t register_type;
     pmix_bfrop_data_type_string_fn_t data_type_string;
 } pmix_bfrops_module_t;
 

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -33,25 +33,23 @@
 
 static pmix_status_t init(void);
 static void finalize(void);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix12_module = {.version = "v12",
-                                                  .init = init,
-                                                  .finalize = finalize,
-                                                  .pack = pmix12_bfrop_pack,
-                                                  .unpack = pmix12_bfrop_unpack,
-                                                  .copy = pmix12_bfrop_copy,
-                                                  .print = pmix12_bfrop_print,
-                                                  .copy_payload = pmix12_bfrop_copy_payload,
-                                                  .value_xfer = pmix12_bfrop_value_xfer,
-                                                  .value_load = pmix12_bfrop_value_load,
-                                                  .value_unload = pmix12_bfrop_value_unload,
-                                                  .value_cmp = pmix12_bfrop_value_cmp,
-                                                  .register_type = register_type,
-                                                  .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix12_module = {
+    .version = "v12",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix12_bfrop_pack,
+    .unpack = pmix12_bfrop_unpack,
+    .copy = pmix12_bfrop_copy,
+    .print = pmix12_bfrop_print,
+    .copy_payload = pmix12_bfrop_copy_payload,
+    .value_xfer = pmix12_bfrop_value_xfer,
+    .value_load = pmix12_bfrop_value_load,
+    .value_unload = pmix12_bfrop_value_unload,
+    .value_cmp = pmix12_bfrop_value_cmp,
+    .data_type_string = data_type_string
+};
 
 static pmix_status_t init(void)
 {
@@ -247,14 +245,6 @@ static void finalize(void)
             pmix_pointer_array_set_item(&mca_bfrops_v12_component.types, n, NULL);
         }
     }
-}
-
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v12_component.types);
-    return PMIX_SUCCESS;
 }
 
 static const char *data_type_string(pmix_data_type_t type)

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -90,58 +90,58 @@ pmix_status_t pmix12_bfrop_std_copy(void **dest, void *src, pmix_data_type_t typ
     uint8_t *val = NULL;
 
     switch (type) {
-    case PMIX_BOOL:
-        datasize = sizeof(bool);
-        break;
+        case PMIX_BOOL:
+            datasize = sizeof(bool);
+            break;
 
-    case PMIX_INT:
-    case PMIX_UINT:
-        datasize = sizeof(int);
-        break;
+        case PMIX_INT:
+        case PMIX_UINT:
+            datasize = sizeof(int);
+            break;
 
-    case PMIX_SIZE:
-        datasize = sizeof(size_t);
-        break;
+        case PMIX_SIZE:
+            datasize = sizeof(size_t);
+            break;
 
-    case PMIX_PID:
-        datasize = sizeof(pid_t);
-        break;
+        case PMIX_PID:
+            datasize = sizeof(pid_t);
+            break;
 
-    case PMIX_BYTE:
-    case PMIX_INT8:
-    case PMIX_UINT8:
-        datasize = 1;
-        break;
+        case PMIX_BYTE:
+        case PMIX_INT8:
+        case PMIX_UINT8:
+            datasize = 1;
+            break;
 
-    case PMIX_INT16:
-    case PMIX_UINT16:
-        datasize = 2;
-        break;
+        case PMIX_INT16:
+        case PMIX_UINT16:
+            datasize = 2;
+            break;
 
-    case PMIX_INT32:
-    case PMIX_UINT32:
-        datasize = 4;
-        break;
+        case PMIX_INT32:
+        case PMIX_UINT32:
+            datasize = 4;
+            break;
 
-    case PMIX_INT64:
-    case PMIX_UINT64:
-        datasize = 8;
-        break;
+        case PMIX_INT64:
+        case PMIX_UINT64:
+            datasize = 8;
+            break;
 
-    case PMIX_FLOAT:
-        datasize = sizeof(float);
-        break;
+        case PMIX_FLOAT:
+            datasize = sizeof(float);
+            break;
 
-    case PMIX_TIMEVAL:
-        datasize = sizeof(struct timeval);
-        break;
+        case PMIX_TIMEVAL:
+            datasize = sizeof(struct timeval);
+            break;
 
-    case PMIX_TIME:
-        datasize = sizeof(time_t);
-        break;
+        case PMIX_TIME:
+            datasize = sizeof(time_t);
+            break;
 
-    default:
-        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+        default:
+            return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }
 
     val = (uint8_t *) malloc(datasize);
@@ -162,6 +162,8 @@ pmix_status_t pmix12_bfrop_std_copy(void **dest, void *src, pmix_data_type_t typ
  */
 pmix_status_t pmix12_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (NULL == src) { /* got zero-length string/NULL pointer - store NULL */
         *dest = NULL;
     } else {
@@ -322,6 +324,9 @@ pmix_status_t pmix12_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src, pm
 {
     pmix_value_t *p;
 
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     *dest = (pmix_value_t *) malloc(sizeof(pmix_value_t));
     if (NULL == *dest) {
@@ -337,6 +342,8 @@ pmix_status_t pmix12_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src, pm
 
 pmix_status_t pmix12_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_t *) malloc(sizeof(pmix_info_t));
     pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     return pmix_value_xfer(&(*dest)->value, &src->value);
@@ -344,6 +351,8 @@ pmix_status_t pmix12_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src, pmix_
 
 pmix_status_t pmix12_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = PMIX_NEW(pmix_buffer_t);
     pmix_bfrops_base_copy_payload(*dest, src);
     return PMIX_SUCCESS;
@@ -353,7 +362,9 @@ pmix_status_t pmix12_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src, pmix_dat
 {
     size_t j;
 
-    *dest = (pmix_app_t *) malloc(sizeof(pmix_app_t));
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   *dest = (pmix_app_t *) malloc(sizeof(pmix_app_t));
     (*dest)->cmd = strdup(src->cmd);
     (*dest)->argv = pmix_argv_copy(src->argv);
     (*dest)->env = pmix_argv_copy(src->env);
@@ -370,6 +381,8 @@ pmix_status_t pmix12_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src, pmix_dat
 pmix_status_t pmix12_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src, pmix_data_type_t type)
 {
     pmix_kval_t *p;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* create the new object */
     *dest = PMIX_NEW(pmix_kval_t);
@@ -389,6 +402,8 @@ pmix_status_t pmix12_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_array_
 {
     pmix_info_t *d1, *s1;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_array_t *) malloc(sizeof(pmix_info_array_t));
     (*dest)->size = src->size;
     (*dest)->array = (pmix_info_t *) malloc(src->size * sizeof(pmix_info_t));
@@ -400,6 +415,8 @@ pmix_status_t pmix12_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_array_
 
 pmix_status_t pmix12_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -412,6 +429,8 @@ pmix_status_t pmix12_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src, pmix_
 pmix_status_t pmix12_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_modex_data_t *) malloc(sizeof(pmix_modex_data_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -432,6 +451,8 @@ pmix_status_t pmix12_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_
 pmix_status_t pmix12_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
                                         pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_persistence_t *) malloc(sizeof(pmix_persistence_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -443,6 +464,8 @@ pmix_status_t pmix12_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persiste
 pmix_status_t pmix12_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
                                    pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_byte_object_t *) malloc(sizeof(pmix_byte_object_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -455,6 +478,8 @@ pmix_status_t pmix12_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t
 
 pmix_status_t pmix12_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_pdata_t *) malloc(sizeof(pmix_pdata_t));
     pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
@@ -465,16 +490,22 @@ pmix_status_t pmix12_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src, pm
 pmix_status_t pmix12_bfrop_copy_darray(pmix_pdata_t **dest, pmix_data_array_t *src,
                                        pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(dest, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_copy_proc_info(pmix_pdata_t **dest, pmix_proc_info_t *src,
                                           pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(dest, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_copy_query(pmix_pdata_t **dest, pmix_query_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(dest, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -75,22 +75,22 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_pointer_array_t *regtypes, pmix_buff
 
     /* some v1 types are simply declared differently */
     switch (type) {
-    case PMIX_COMMAND:
-        v1type = PMIX_UINT32;
-        break;
-    case PMIX_SCOPE:
-    case PMIX_DATA_RANGE:
-        v1type = PMIX_UINT;
-        break;
-    case PMIX_PROC_RANK:
-    case PMIX_PERSIST:
-        v1type = PMIX_INT;
-        break;
-    case PMIX_INFO_ARRAY:
-        v1type = 22;
-        break;
-    default:
-        v1type = type;
+        case PMIX_COMMAND:
+            v1type = PMIX_UINT32;
+            break;
+        case PMIX_SCOPE:
+        case PMIX_DATA_RANGE:
+            v1type = PMIX_UINT;
+            break;
+        case PMIX_PROC_RANK:
+        case PMIX_PERSIST:
+            v1type = PMIX_INT;
+            break;
+        case PMIX_INFO_ARRAY:
+            v1type = 22;
+            break;
+        default:
+            v1type = type;
     }
 
     /* Pack the declared data type */
@@ -107,9 +107,8 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_pointer_array_t *regtypes, pmix_buff
 
     /* Lookup the pack function for this type and call it */
 
-    if (NULL
-        == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, v1type))) {
+    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, v1type);
+    if (NULL == info) {
         return PMIX_ERR_PACK_FAILURE;
     }
 
@@ -129,6 +128,9 @@ pmix_status_t pmix12_bfrop_pack_bool(pmix_pointer_array_t *regtypes, pmix_buffer
     bool *s = (bool *) src;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix12_bfrop_pack_bool * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = (uint8_t *) pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -158,6 +160,8 @@ pmix_status_t pmix12_bfrop_pack_int(pmix_pointer_array_t *regtypes, pmix_buffer_
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them */
     if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
@@ -176,6 +180,8 @@ pmix_status_t pmix12_bfrop_pack_sizet(pmix_pointer_array_t *regtypes, pmix_buffe
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them. */
     if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
@@ -192,6 +198,8 @@ pmix_status_t pmix12_bfrop_pack_pid(pmix_pointer_array_t *regtypes, pmix_buffer_
                                     const void *src, int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* System types need to always be described so we can properly
        unpack them. */
@@ -214,6 +222,9 @@ pmix_status_t pmix12_bfrop_pack_byte(pmix_pointer_array_t *regtypes, pmix_buffer
     char *dst;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix12_bfrop_pack_byte * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -240,6 +251,9 @@ pmix_status_t pmix12_bfrop_pack_int16(pmix_pointer_array_t *regtypes, pmix_buffe
     char *dst;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix12_bfrop_pack_int16 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -267,6 +281,9 @@ pmix_status_t pmix12_bfrop_pack_int32(pmix_pointer_array_t *regtypes, pmix_buffe
     char *dst;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix12_bfrop_pack_int32 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -301,6 +318,9 @@ pmix_status_t pmix12_bfrop_pack_int64(pmix_pointer_array_t *regtypes, pmix_buffe
     size_t bytes_packed = num_vals * sizeof(tmp);
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix12_bfrop_pack_int64 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -327,6 +347,8 @@ pmix_status_t pmix12_bfrop_pack_string(pmix_pointer_array_t *regtypes, pmix_buff
     int ret = PMIX_SUCCESS;
     int32_t i, len;
     char **ssrc = (char **) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) { /* got zero-length string/NULL pointer - store NULL */
@@ -360,6 +382,8 @@ pmix_status_t pmix12_bfrop_pack_float(pmix_pointer_array_t *regtypes, pmix_buffe
     float *ssrc = (float *) src;
     char *convert;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     for (i = 0; i < num_vals; ++i) {
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
@@ -383,6 +407,8 @@ pmix_status_t pmix12_bfrop_pack_double(pmix_pointer_array_t *regtypes, pmix_buff
     int32_t i;
     double *ssrc = (double *) src;
     char *convert;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     for (i = 0; i < num_vals; ++i) {
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
@@ -408,6 +434,8 @@ pmix_status_t pmix12_bfrop_pack_timeval(pmix_pointer_array_t *regtypes, pmix_buf
     int32_t i;
     struct timeval *ssrc = (struct timeval *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t) ssrc[i].tv_sec;
         tmp[1] = (int64_t) ssrc[i].tv_usec;
@@ -427,6 +455,8 @@ pmix_status_t pmix12_bfrop_pack_time(pmix_pointer_array_t *regtypes, pmix_buffer
     int32_t i;
     time_t *ssrc = (time_t *) src;
     uint64_t ui64;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* time_t is a system-dependent size, so cast it
      * to uint64_t as a generic safe size
@@ -610,6 +640,8 @@ pmix_status_t pmix12_bfrop_pack_value(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     int v1type;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     ptr = (pmix_value_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -639,6 +671,8 @@ pmix_status_t pmix12_bfrop_pack_info(pmix_pointer_array_t *regtypes, pmix_buffer
     int v1type;
 
     info = (pmix_info_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     for (i = 0; i < num_vals; ++i) {
         /* pack key */
@@ -670,6 +704,8 @@ pmix_status_t pmix12_bfrop_pack_pdata(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     char *foo;
     int v1type;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     pdata = (pmix_pdata_t *) src;
 
@@ -707,6 +743,8 @@ pmix_status_t pmix12_bfrop_pack_buf(pmix_pointer_array_t *regtypes, pmix_buffer_
     int32_t i;
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     ptr = (pmix_buffer_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -735,6 +773,8 @@ pmix_status_t pmix12_bfrop_pack_proc(pmix_pointer_array_t *regtypes, pmix_buffer
     int32_t i;
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     proc = (pmix_proc_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -758,6 +798,8 @@ pmix_status_t pmix12_bfrop_pack_app(pmix_pointer_array_t *regtypes, pmix_buffer_
     int32_t i, j, nvals;
     pmix_status_t ret;
     int argc;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     app = (pmix_app_t *) src;
 
@@ -819,6 +861,8 @@ pmix_status_t pmix12_bfrop_pack_kval(pmix_pointer_array_t *regtypes, pmix_buffer
     int32_t i;
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     ptr = (pmix_kval_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -844,6 +888,8 @@ pmix_status_t pmix12_bfrop_pack_array(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_info_array_t *ptr;
     int32_t i;
     pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     ptr = (pmix_info_array_t *) src;
 
@@ -873,6 +919,8 @@ pmix_status_t pmix12_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmix_buffe
     int32_t i;
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     ptr = (pmix_modex_data_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
@@ -894,6 +942,8 @@ pmix_status_t pmix12_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmix_buffe
 pmix_status_t pmix12_bfrop_pack_persist(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);
 }
 
@@ -903,6 +953,8 @@ pmix_status_t pmix12_bfrop_pack_bo(pmix_pointer_array_t *regtypes, pmix_buffer_t
     pmix_status_t ret;
     int i;
     pmix_byte_object_t *bo;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     bo = (pmix_byte_object_t *) src;
     for (i = 0; i < num_vals; i++) {
@@ -925,6 +977,8 @@ pmix_status_t pmix12_bfrop_pack_ptr(pmix_pointer_array_t *regtypes, pmix_buffer_
                                     const void *src, int32_t num_vals, pmix_data_type_t type)
 {
     /* v1.x has no concept of packing a pointer, so just return */
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -935,6 +989,8 @@ pmix_status_t pmix12_bfrop_pack_scope(pmix_pointer_array_t *regtypes, pmix_buffe
     unsigned int *v1scope;
     pmix_status_t ret;
     int i;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* v1.2 packed scope as PMIX_UINT, so we have to convert */
     v1scope = (unsigned int *) malloc(num_vals * sizeof(unsigned int));
@@ -952,6 +1008,8 @@ pmix_status_t pmix12_bfrop_pack_scope(pmix_pointer_array_t *regtypes, pmix_buffe
 pmix_status_t pmix12_bfrop_pack_status(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                        const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* v1.2 declares pmix_status_t as an enum, which translates to int and
      * matches that of v2 */
     return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);
@@ -964,6 +1022,8 @@ pmix_status_t pmix12_bfrop_pack_range(pmix_pointer_array_t *regtypes, pmix_buffe
     unsigned int *v1range;
     pmix_status_t ret;
     int i;
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* v1.2 packed data range as PMIX_UINT, so we have to convert */
     v1range = (unsigned int *) malloc(num_vals * sizeof(unsigned int));
@@ -986,6 +1046,8 @@ pmix_status_t pmix12_bfrop_pack_cmd(pmix_pointer_array_t *regtypes, pmix_buffer_
     pmix_status_t ret;
     int i;
 
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* v1.2 commands were enum (i.e., int), while they are uint8_t in v2 */
     v1cmd = (int *) malloc(num_vals * sizeof(int));
     if (NULL == v1cmd) {
@@ -1003,6 +1065,8 @@ pmix_status_t pmix12_bfrop_pack_info_directives(pmix_pointer_array_t *regtypes,
                                                 pmix_buffer_t *buffer, const void *src,
                                                 int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     /* v1.x has no concept of an info directive, so just return */
     return PMIX_SUCCESS;
 }
@@ -1010,6 +1074,8 @@ pmix_status_t pmix12_bfrop_pack_info_directives(pmix_pointer_array_t *regtypes,
 pmix_status_t pmix12_bfrop_pack_proc_state(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                            const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     /* v1.x has no concept of proc state, so just return */
     return PMIX_SUCCESS;
 }
@@ -1017,24 +1083,32 @@ pmix_status_t pmix12_bfrop_pack_proc_state(pmix_pointer_array_t *regtypes, pmix_
 pmix_status_t pmix12_bfrop_pack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                        const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_pack_proc_info(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                           const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_pack_query(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, src, num_vals, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_pack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                      const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* v1 rank is just an int, not a separate data type - it is defined
      * to be an unint32 in v2 */
     return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);

--- a/src/mca/bfrops/v12/print.c
+++ b/src/mca/bfrops/v12/print.c
@@ -46,9 +46,8 @@ pmix_status_t pmix12_bfrop_print(char **output, char *prefix, void *src, pmix_da
 
     /* Lookup the print function for this type and call it */
 
-    if (NULL
-        == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, type))) {
+    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, type);
+    if (NULL == info) {
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }
 
@@ -61,6 +60,8 @@ pmix_status_t pmix12_bfrop_print(char **output, char *prefix, void *src, pmix_da
 pmix_status_t pmix12_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -98,6 +99,8 @@ pmix_status_t pmix12_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -132,6 +135,8 @@ pmix_status_t pmix12_bfrop_print_string(char **output, char *prefix, char *src,
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -168,7 +173,9 @@ pmix_status_t pmix12_bfrop_print_size(char **output, char *prefix, size_t *src,
 {
     char *prefx;
 
-    /* deal with NULL prefix */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
@@ -201,6 +208,8 @@ pmix_status_t pmix12_bfrop_print_size(char **output, char *prefix, size_t *src,
 pmix_status_t pmix12_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -235,6 +244,8 @@ pmix_status_t pmix12_bfrop_print_int(char **output, char *prefix, int *src, pmix
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -268,6 +279,8 @@ pmix_status_t pmix12_bfrop_print_int(char **output, char *prefix, int *src, pmix
 pmix_status_t pmix12_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -304,6 +317,8 @@ pmix_status_t pmix12_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -339,7 +354,9 @@ pmix_status_t pmix12_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
 {
     char *prefx;
 
-    /* deal with NULL prefix */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
@@ -373,6 +390,8 @@ pmix_status_t pmix12_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -409,6 +428,8 @@ pmix_status_t pmix12_bfrop_print_int8(char **output, char *prefix, int8_t *src,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -443,6 +464,8 @@ pmix_status_t pmix12_bfrop_print_int16(char **output, char *prefix, int16_t *src
                                        pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -479,6 +502,8 @@ pmix_status_t pmix12_bfrop_print_int32(char **output, char *prefix, int32_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -512,6 +537,8 @@ pmix_status_t pmix12_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -548,6 +575,8 @@ pmix_status_t pmix12_bfrop_print_int64(char **output, char *prefix, int64_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -583,6 +612,8 @@ pmix_status_t pmix12_bfrop_print_float(char **output, char *prefix, float *src,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -617,6 +648,8 @@ pmix_status_t pmix12_bfrop_print_double(char **output, char *prefix, double *src
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -654,7 +687,9 @@ pmix_status_t pmix12_bfrop_print_time(char **output, char *prefix, time_t *src,
     char *prefx;
     char *t;
 
-    /* deal with NULL prefix */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
@@ -691,6 +726,8 @@ pmix_status_t pmix12_bfrop_print_timeval(char **output, char *prefix, struct tim
                                          pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -733,6 +770,8 @@ pmix_status_t pmix12_bfrop_print_value(char **output, char *prefix, pmix_value_t
 {
     char *prefx;
     int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -843,6 +882,8 @@ pmix_status_t pmix12_bfrop_print_info(char **output, char *prefix, pmix_info_t *
     char *tmp;
     int rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     pmix12_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
     rc = asprintf(output, "%sKEY: %s %s", prefix, src->key,
                   (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
@@ -860,6 +901,8 @@ pmix_status_t pmix12_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 {
     char *tmp1, *tmp2;
     int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     pmix12_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix12_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
@@ -880,12 +923,16 @@ pmix_status_t pmix12_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 pmix_status_t pmix12_bfrop_print_buf(char **output, char *prefix, pmix_buffer_t *src,
                                      pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix12_bfrop_print_app(char **output, char *prefix, pmix_app_t *src,
                                      pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -893,6 +940,8 @@ pmix_status_t pmix12_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
                                       pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -912,6 +961,8 @@ pmix_status_t pmix12_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 pmix_status_t pmix12_bfrop_print_kval(char **output, char *prefix, pmix_kval_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -921,6 +972,8 @@ pmix_status_t pmix12_bfrop_print_array(char **output, char *prefix, pmix_info_ar
     size_t j;
     char *tmp, *tmp2, *tmp3, *pfx;
     pmix_info_t *s1;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
@@ -949,6 +1002,8 @@ pmix_status_t pmix12_bfrop_print_array(char **output, char *prefix, pmix_info_ar
 pmix_status_t pmix12_bfrop_print_modex(char **output, char *prefix, pmix_modex_data_t *src,
                                        pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -956,6 +1011,8 @@ pmix_status_t pmix12_bfrop_print_persist(char **output, char *prefix, pmix_persi
                                          pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -992,6 +1049,8 @@ pmix_status_t pmix12_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1025,63 +1084,85 @@ pmix_status_t pmix12_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 pmix_status_t pmix12_bfrop_print_scope(char **output, char *prefix, pmix_scope_t *src,
                                        pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_status(char **output, char *prefix, pmix_status_t *src,
                                         pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_ptr(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_cmd(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_info_directives(char **output, char *prefix, void *src,
                                                  pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_datatype(char **output, char *prefix, pmix_data_type_t *src,
                                           pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_proc_state(char **output, char *prefix, pmix_data_type_t *src,
                                             pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_darray(char **output, char *prefix, pmix_data_array_t *src,
                                         pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_proc_info(char **output, char *prefix, pmix_proc_info_t *src,
                                            pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_query(char **output, char *prefix, pmix_query_t *src,
                                        pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_print_rank(char **output, char *prefix, pmix_rank_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -136,20 +136,20 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_pointer_array_t *regtypes, pmix_bu
 
     /* some v1 types are simply declared differently */
     switch (type) {
-    case PMIX_COMMAND:
-        v1type = PMIX_UINT32;
-        break;
-    case PMIX_SCOPE:
-    case PMIX_DATA_RANGE:
-        v1type = PMIX_UINT;
-        break;
-    case PMIX_PROC_RANK:
-    case PMIX_PERSIST:
-    case PMIX_STATUS:
-        v1type = PMIX_INT;
-        break;
-    default:
-        v1type = type;
+        case PMIX_COMMAND:
+            v1type = PMIX_UINT32;
+            break;
+        case PMIX_SCOPE:
+        case PMIX_DATA_RANGE:
+            v1type = PMIX_UINT;
+            break;
+        case PMIX_PROC_RANK:
+        case PMIX_PERSIST:
+        case PMIX_STATUS:
+            v1type = PMIX_INT;
+            break;
+        default:
+            v1type = type;
     }
 
     /** Unpack the declared data type */
@@ -185,6 +185,9 @@ pmix_status_t pmix12_bfrop_unpack_bool(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_bool * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -217,6 +220,8 @@ pmix_status_t pmix12_bfrop_unpack_int(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
@@ -245,6 +250,8 @@ pmix_status_t pmix12_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes, pmix_buf
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
@@ -272,6 +279,8 @@ pmix_status_t pmix12_bfrop_unpack_pid(pmix_pointer_array_t *regtypes, pmix_buffe
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
@@ -302,6 +311,9 @@ pmix_status_t pmix12_bfrop_unpack_byte(pmix_pointer_array_t *regtypes, pmix_buff
 {
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_byte * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -324,7 +336,10 @@ pmix_status_t pmix12_bfrop_unpack_int16(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_int16 * %d\n", (int) *num_vals);
-    /* check to see if there's enough data in buffer */
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+   /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
     }
@@ -348,6 +363,9 @@ pmix_status_t pmix12_bfrop_unpack_int32(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_int32 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -378,6 +396,9 @@ pmix_status_t pmix12_bfrop_unpack_int64(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_int64 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -400,6 +421,8 @@ pmix_status_t pmix12_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
     pmix_status_t ret;
     int32_t i, len, n = 1;
     char **sdest = (char **) dest;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < (*num_vals); ++i) {
         if (PMIX_SUCCESS
@@ -433,6 +456,9 @@ pmix_status_t pmix12_bfrop_unpack_float(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_float * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(float))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -468,6 +494,9 @@ pmix_status_t pmix12_bfrop_unpack_double(pmix_pointer_array_t *regtypes, pmix_bu
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_double * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(double))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -503,6 +532,9 @@ pmix_status_t pmix12_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes, pmix_b
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_timeval * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(struct timeval))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -536,6 +568,9 @@ pmix_status_t pmix12_bfrop_unpack_time(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack_time * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * (sizeof(uint64_t)))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -728,6 +763,8 @@ pmix_status_t pmix12_bfrop_unpack_value(pmix_pointer_array_t *regtypes, pmix_buf
     pmix_status_t ret;
     int v1type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_value_t *) dest;
     n = *num_vals;
 
@@ -761,6 +798,8 @@ pmix_status_t pmix12_bfrop_unpack_info(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d info", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_info_t *) dest;
     n = *num_vals;
@@ -816,6 +855,8 @@ pmix_status_t pmix12_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d pdata", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_pdata_t *) dest;
     n = *num_vals;
@@ -873,6 +914,8 @@ pmix_status_t pmix12_bfrop_unpack_buf(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     size_t nbytes;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_buffer_t *) dest;
     n = *num_vals;
 
@@ -912,6 +955,8 @@ pmix_status_t pmix12_bfrop_unpack_proc(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d procs", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_proc_t *) dest;
     n = *num_vals;
@@ -964,6 +1009,8 @@ pmix_status_t pmix12_bfrop_unpack_app(pmix_pointer_array_t *regtypes, pmix_buffe
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d apps", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_app_t *) dest;
     n = *num_vals;
@@ -1056,6 +1103,8 @@ pmix_status_t pmix12_bfrop_unpack_kval(pmix_pointer_array_t *regtypes, pmix_buff
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d kvals", *num_vals);
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_kval_t *) dest;
     n = *num_vals;
 
@@ -1090,6 +1139,8 @@ pmix_status_t pmix12_bfrop_unpack_array(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d info arrays", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_info_array_t *) dest;
     n = *num_vals;
@@ -1127,6 +1178,8 @@ pmix_status_t pmix12_bfrop_unpack_modex(pmix_pointer_array_t *regtypes, pmix_buf
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d modex", *num_vals);
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_modex_data_t *) dest;
     n = *num_vals;
 
@@ -1154,6 +1207,8 @@ pmix_status_t pmix12_bfrop_unpack_modex(pmix_pointer_array_t *regtypes, pmix_buf
 pmix_status_t pmix12_bfrop_unpack_persist(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                           void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix12_bfrop_unpack_int(regtypes, buffer, dest, num_vals, PMIX_INT);
 }
 
@@ -1166,6 +1221,8 @@ pmix_status_t pmix12_bfrop_unpack_bo(pmix_pointer_array_t *regtypes, pmix_buffer
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: %d byte_object", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     ptr = (pmix_byte_object_t *) dest;
     n = *num_vals;
@@ -1194,30 +1251,35 @@ pmix_status_t pmix12_bfrop_unpack_bo(pmix_pointer_array_t *regtypes, pmix_buffer
 pmix_status_t pmix12_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_scope(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_status(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                          void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_range(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
@@ -1225,35 +1287,41 @@ pmix_status_t pmix12_bfrop_unpack_info_directives(pmix_pointer_array_t *regtypes
                                                   pmix_buffer_t *buffer, void *dest,
                                                   int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_proc_state(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                              void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                          void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_proc_info(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                             void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_query(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 pmix_status_t pmix12_bfrop_unpack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                        void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, buffer, dest, num_vals, type);
     return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -36,25 +36,23 @@
 
 static pmix_status_t init(void);
 static void finalize(void);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix20_module = {.version = "v20",
-                                                  .init = init,
-                                                  .finalize = finalize,
-                                                  .pack = pmix20_bfrop_pack,
-                                                  .unpack = pmix20_bfrop_unpack,
-                                                  .copy = pmix20_bfrop_copy,
-                                                  .print = pmix20_bfrop_print,
-                                                  .copy_payload = pmix20_bfrop_copy_payload,
-                                                  .value_xfer = pmix20_bfrop_value_xfer,
-                                                  .value_load = pmix20_bfrop_value_load,
-                                                  .value_unload = pmix20_bfrop_value_unload,
-                                                  .value_cmp = pmix20_bfrop_value_cmp,
-                                                  .register_type = register_type,
-                                                  .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix20_module = {
+    .version = "v20",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix20_bfrop_pack,
+    .unpack = pmix20_bfrop_unpack,
+    .copy = pmix20_bfrop_copy,
+    .print = pmix20_bfrop_print,
+    .copy_payload = pmix20_bfrop_copy_payload,
+    .value_xfer = pmix20_bfrop_value_xfer,
+    .value_load = pmix20_bfrop_value_load,
+    .value_unload = pmix20_bfrop_value_unload,
+    .value_cmp = pmix20_bfrop_value_cmp,
+    .data_type_string = data_type_string
+};
 
 static pmix_status_t init(void)
 {
@@ -187,7 +185,7 @@ static pmix_status_t init(void)
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix20_bfrop_pack_scope, pmix20_bfrop_unpack_scope,
-                       pmix20_bfrop_std_copy, pmix20_bfrop_std_copy,
+                       pmix20_bfrop_std_copy, pmix20_bfrop_print_scope,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix20_bfrop_pack_range,
@@ -259,21 +257,12 @@ static void finalize(void)
     }
 }
 
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v20_component.types);
-    return PMIX_SUCCESS;
-}
-
 static const char *data_type_string(pmix_data_type_t type)
 {
     pmix_bfrop_type_info_t *info;
 
-    if (NULL
-        == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+    info = (pmix_bfrop_type_info_t *)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type);
+    if (NULL == info) {
         return NULL;
     }
     return info->odti_name;
@@ -287,14 +276,14 @@ pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type)
      * a PMIx v20 compatible client. The data type was redefined
      * in v21, and so we have to do some conversions here */
     switch (v21type) {
-    case PMIX_COMMAND:
-        /* the peer unfortunately didn't separate these out,
-         * but instead set them to PMIX_UINT32 */
-        v20type = PMIX_UINT32;
-        break;
+        case PMIX_COMMAND:
+            /* the peer unfortunately didn't separate these out,
+             * but instead set them to PMIX_UINT32 */
+            v20type = PMIX_UINT32;
+            break;
 
-    default:
-        v20type = v21type;
+        default:
+            v20type = v21type;
     }
     return v20type;
 }

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -258,6 +258,8 @@ pmix_value_cmp_t pmix20_bfrop_value_cmp(pmix_value_t *p, pmix_value_t *p1)
  */
 pmix_status_t pmix20_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (NULL == src) { /* got zero-length string/NULL pointer - store NULL */
         *dest = NULL;
     } else {
@@ -910,7 +912,9 @@ pmix_status_t pmix20_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src, pm
 {
     pmix_value_t *p;
 
-    /* create the new object */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* create the new object */
     *dest = (pmix_value_t *) malloc(sizeof(pmix_value_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -925,6 +929,8 @@ pmix_status_t pmix20_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src, pm
 
 pmix_status_t pmix20_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_t *) malloc(sizeof(pmix_info_t));
     pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     (*dest)->flags = src->flags;
@@ -933,6 +939,8 @@ pmix_status_t pmix20_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src, pmix_
 
 pmix_status_t pmix20_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = PMIX_NEW(pmix_buffer_t);
     pmix20_bfrop_copy_payload(*dest, src);
     return PMIX_SUCCESS;
@@ -941,6 +949,8 @@ pmix_status_t pmix20_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src, pm
 pmix_status_t pmix20_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src, pmix_data_type_t type)
 {
     size_t j;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     *dest = (pmix_app_t *) malloc(sizeof(pmix_app_t));
     (*dest)->cmd = strdup(src->cmd);
@@ -963,6 +973,8 @@ pmix_status_t pmix20_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src, pmix_
 {
     pmix_kval_t *p;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* create the new object */
     *dest = PMIX_NEW(pmix_kval_t);
     if (NULL == *dest) {
@@ -978,6 +990,8 @@ pmix_status_t pmix20_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src, pmix_
 
 pmix_status_t pmix20_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -990,6 +1004,8 @@ pmix_status_t pmix20_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src, pmix_
 pmix_status_t pmix20_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_modex_data_t *) malloc(sizeof(pmix_modex_data_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -1010,6 +1026,8 @@ pmix_status_t pmix20_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_
 pmix_status_t pmix20_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
                                         pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_persistence_t *) malloc(sizeof(pmix_persistence_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -1021,6 +1039,8 @@ pmix_status_t pmix20_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persiste
 pmix_status_t pmix20_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
                                    pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_byte_object_t *) malloc(sizeof(pmix_byte_object_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -1033,6 +1053,8 @@ pmix_status_t pmix20_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t
 
 pmix_status_t pmix20_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_pdata_t *) malloc(sizeof(pmix_pdata_t));
     pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
@@ -1043,6 +1065,8 @@ pmix_status_t pmix20_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src, pm
 pmix_status_t pmix20_bfrop_copy_pinfo(pmix_proc_info_t **dest, pmix_proc_info_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_proc_info_t *) malloc(sizeof(pmix_proc_info_t));
     pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
@@ -1078,6 +1102,8 @@ pmix_status_t pmix20_bfrop_copy_darray(pmix_data_array_t **dest, pmix_data_array
     pmix_modex_data_t *pm, *sm;
     pmix_proc_info_t *pi, *si;
     pmix_query_t *pq, *sq;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     p = (pmix_data_array_t *) calloc(1, sizeof(pmix_data_array_t));
     if (NULL == p) {
@@ -1511,6 +1537,8 @@ pmix_status_t pmix20_bfrop_copy_query(pmix_query_t **dest, pmix_query_t *src, pm
 {
     pmix_status_t rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_query_t *) malloc(sizeof(pmix_query_t));
     if (NULL != src->keys) {
         (*dest)->keys = pmix_argv_copy(src->keys);
@@ -1531,6 +1559,8 @@ pmix_status_t pmix20_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_array_
                                       pmix_data_type_t type)
 {
     pmix_info_t *d1, *s1;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     *dest = (pmix_info_array_t *) malloc(sizeof(pmix_info_array_t));
     (*dest)->size = src->size;

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -115,6 +115,9 @@ pmix_status_t pmix20_bfrop_pack_bool(pmix_pointer_array_t *regtypes, pmix_buffer
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_pack_bool * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = (uint8_t *) pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -144,6 +147,8 @@ pmix_status_t pmix20_bfrop_pack_int(pmix_pointer_array_t *regtypes, pmix_buffer_
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them */
     if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
@@ -162,6 +167,8 @@ pmix_status_t pmix20_bfrop_pack_sizet(pmix_pointer_array_t *regtypes, pmix_buffe
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* System types need to always be described so we can properly
        unpack them. */
     if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
@@ -178,6 +185,8 @@ pmix_status_t pmix20_bfrop_pack_pid(pmix_pointer_array_t *regtypes, pmix_buffer_
                                     const void *src, int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* System types need to always be described so we can properly
        unpack them. */
@@ -201,6 +210,9 @@ pmix_status_t pmix20_bfrop_pack_byte(pmix_pointer_array_t *regtypes, pmix_buffer
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_pack_byte * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -228,6 +240,9 @@ pmix_status_t pmix20_bfrop_pack_int16(pmix_pointer_array_t *regtypes, pmix_buffe
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_pack_int16 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -256,6 +271,9 @@ pmix_status_t pmix20_bfrop_pack_int32(pmix_pointer_array_t *regtypes, pmix_buffe
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_pack_int32 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -277,6 +295,8 @@ pmix_status_t pmix20_bfrop_pack_datatype(pmix_pointer_array_t *regtypes, pmix_bu
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_INT16, regtypes);
     return ret;
 }
@@ -294,6 +314,9 @@ pmix_status_t pmix20_bfrop_pack_int64(pmix_pointer_array_t *regtypes, pmix_buffe
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_pack_int64 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -320,6 +343,8 @@ pmix_status_t pmix20_bfrop_pack_string(pmix_pointer_array_t *regtypes, pmix_buff
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i, len;
     char **ssrc = (char **) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) { /* got zero-length string/NULL pointer - store NULL */
@@ -353,6 +378,8 @@ pmix_status_t pmix20_bfrop_pack_float(pmix_pointer_array_t *regtypes, pmix_buffe
     float *ssrc = (float *) src;
     char *convert;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
@@ -376,6 +403,8 @@ pmix_status_t pmix20_bfrop_pack_double(pmix_pointer_array_t *regtypes, pmix_buff
     int32_t i;
     double *ssrc = (double *) src;
     char *convert;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
@@ -401,6 +430,8 @@ pmix_status_t pmix20_bfrop_pack_timeval(pmix_pointer_array_t *regtypes, pmix_buf
     int32_t i;
     struct timeval *ssrc = (struct timeval *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t) ssrc[i].tv_sec;
         tmp[1] = (int64_t) ssrc[i].tv_usec;
@@ -420,6 +451,8 @@ pmix_status_t pmix20_bfrop_pack_time(pmix_pointer_array_t *regtypes, pmix_buffer
     int32_t i;
     time_t *ssrc = (time_t *) src;
     uint64_t ui64;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* time_t is a system-dependent size, so cast it
      * to uint64_t as a generic safe size
@@ -443,6 +476,8 @@ pmix_status_t pmix20_bfrop_pack_status(pmix_pointer_array_t *regtypes, pmix_buff
     int32_t i;
     pmix_status_t *ssrc = (pmix_status_t *) src;
     int32_t status;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         status = (int32_t) ssrc[i];
@@ -682,6 +717,8 @@ pmix_status_t pmix20_bfrop_pack_value(pmix_pointer_array_t *regtypes, pmix_buffe
 
     ptr = (pmix_value_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the type */
         if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, ptr[i].type))) {
@@ -705,6 +742,8 @@ pmix_status_t pmix20_bfrop_pack_info(pmix_pointer_array_t *regtypes, pmix_buffer
     char *foo;
 
     info = (pmix_info_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         /* pack key */
@@ -742,6 +781,8 @@ pmix_status_t pmix20_bfrop_pack_pdata(pmix_pointer_array_t *regtypes, pmix_buffe
 
     pdata = (pmix_pdata_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the proc */
         if (PMIX_SUCCESS
@@ -776,6 +817,8 @@ pmix_status_t pmix20_bfrop_pack_buf(pmix_pointer_array_t *regtypes, pmix_buffer_
 
     ptr = (pmix_buffer_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the number of bytes */
         if (PMIX_SUCCESS
@@ -804,6 +847,8 @@ pmix_status_t pmix20_bfrop_pack_proc(pmix_pointer_array_t *regtypes, pmix_buffer
 
     proc = (pmix_proc_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         char *ptr = proc[i].nspace;
         if (PMIX_SUCCESS
@@ -826,6 +871,8 @@ pmix_status_t pmix20_bfrop_pack_app(pmix_pointer_array_t *regtypes, pmix_buffer_
     pmix_status_t ret;
 
     app = (pmix_app_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         if (PMIX_SUCCESS
@@ -894,6 +941,8 @@ pmix_status_t pmix20_bfrop_pack_kval(pmix_pointer_array_t *regtypes, pmix_buffer
 
     ptr = (pmix_kval_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         /* pack the key */
         st = ptr[i].key;
@@ -920,6 +969,8 @@ pmix_status_t pmix20_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmix_buffe
 
     ptr = (pmix_modex_data_t *) src;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; ++i) {
         if (PMIX_SUCCESS
             != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
@@ -939,30 +990,40 @@ pmix_status_t pmix20_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmix_buffe
 pmix_status_t pmix20_bfrop_pack_persist(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_pack_scope(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_pack_range(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       const void *src, int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_pack_cmd(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                     const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_pack_infodirs(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                          const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_int32(regtypes, buffer, src, num_vals, PMIX_UINT32);
 }
 
@@ -972,6 +1033,8 @@ pmix_status_t pmix20_bfrop_pack_bo(pmix_pointer_array_t *regtypes, pmix_buffer_t
     pmix_status_t ret;
     int i;
     pmix_byte_object_t *bo;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     bo = (pmix_byte_object_t *) src;
     for (i = 0; i < num_vals; i++) {
@@ -994,6 +1057,9 @@ pmix_status_t pmix20_bfrop_pack_ptr(pmix_pointer_array_t *regtypes, pmix_buffer_
                                     const void *src, int32_t num_vals, pmix_data_type_t type)
 {
     uint8_t foo = 1;
+
+    PMIX_HIDE_UNUSED_PARAMS(src, num_vals, type);
+
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just pack a sentinel */
     return pmix20_bfrop_pack_byte(regtypes, buffer, &foo, 1, PMIX_UINT8);
@@ -1002,6 +1068,8 @@ pmix_status_t pmix20_bfrop_pack_ptr(pmix_pointer_array_t *regtypes, pmix_buffer_
 pmix_status_t pmix20_bfrop_pack_pstate(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                        const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
@@ -1011,6 +1079,8 @@ pmix_status_t pmix20_bfrop_pack_pinfo(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_proc_info_t *pinfo = (pmix_proc_info_t *) src;
     pmix_status_t ret;
     int32_t i;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; i++) {
         /* pack the proc identifier */
@@ -1050,6 +1120,8 @@ pmix_status_t pmix20_bfrop_pack_darray(pmix_pointer_array_t *regtypes, pmix_buff
     pmix_status_t ret;
     int32_t i;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < num_vals; i++) {
         /* pack the actual type in the array */
         if (PMIX_SUCCESS
@@ -1079,6 +1151,8 @@ pmix_status_t pmix20_bfrop_pack_darray(pmix_pointer_array_t *regtypes, pmix_buff
 pmix_status_t pmix20_bfrop_pack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                      const void *src, int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_int32(regtypes, buffer, src, num_vals, PMIX_UINT32);
 }
 
@@ -1089,6 +1163,8 @@ pmix_status_t pmix20_bfrop_pack_query(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     int32_t i;
     int32_t nkeys;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; i++) {
         /* pack the number of keys */
@@ -1126,6 +1202,8 @@ pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_pointer_array_t *regtypes,
                                                 pmix_buffer_t *buffer, const void *src,
                                                 int32_t num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
@@ -1138,6 +1216,8 @@ pmix_status_t pmix20_bfrop_pack_array(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
 
     ptr = (pmix_info_array_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -64,6 +64,8 @@ pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pm
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -100,6 +102,8 @@ pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -134,6 +138,8 @@ pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src,
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -170,6 +176,8 @@ pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -204,6 +212,8 @@ pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -236,6 +246,8 @@ pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -270,6 +282,8 @@ pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix
 pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -306,6 +320,8 @@ pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -340,6 +356,8 @@ pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -376,6 +394,8 @@ pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -410,6 +430,8 @@ pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix, int8_t *src,
                                       pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -446,6 +468,8 @@ pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix, int16_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -481,6 +505,8 @@ pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -514,6 +540,8 @@ pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -550,6 +578,8 @@ pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix, int64_t *src
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -584,6 +614,8 @@ pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix, float *src,
                                        pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -620,7 +652,9 @@ pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix, double *src
 {
     char *prefx;
 
-    /* deal with NULL prefix */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
@@ -655,6 +689,8 @@ pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix, time_t *src,
 {
     char *prefx;
     char *t;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -694,6 +730,8 @@ pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix, struct tim
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -729,6 +767,8 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix, pmix_status
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -771,6 +811,8 @@ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t
 {
     char *prefx;
     int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -931,6 +973,8 @@ pmix_status_t pmix20_bfrop_print_info(char **output, char *prefix, pmix_info_t *
     char *tmp;
     int rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     pmix20_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
     rc = asprintf(output, "%sKEY: %s DIRECTIVES: %0x %s", prefix, src->key, src->flags,
                   (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
@@ -948,6 +992,8 @@ pmix_status_t pmix20_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 {
     char *tmp1, *tmp2;
     int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     pmix20_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix20_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
@@ -968,12 +1014,16 @@ pmix_status_t pmix20_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 pmix_status_t pmix20_bfrop_print_buf(char **output, char *prefix, pmix_buffer_t *src,
                                      pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix20_bfrop_print_app(char **output, char *prefix, pmix_app_t *src,
                                      pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -982,6 +1032,8 @@ pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 {
     char *prefx;
     int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1017,12 +1069,16 @@ pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 pmix_status_t pmix20_bfrop_print_kval(char **output, char *prefix, pmix_kval_t *src,
                                       pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix20_bfrop_print_modex(char **output, char *prefix, pmix_modex_data_t *src,
                                        pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 
@@ -1030,6 +1086,8 @@ pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix, pmix_persi
                                          pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1066,6 +1124,8 @@ pmix_status_t pmix20_bfrop_print_scope(char **output, char *prefix, pmix_scope_t
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1090,6 +1150,8 @@ pmix_status_t pmix20_bfrop_print_range(char **output, char *prefix, pmix_data_ra
                                        pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1116,6 +1178,8 @@ pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix, pmix_cmd_t *sr
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1141,6 +1205,8 @@ pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix, pmix_info
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1165,6 +1231,8 @@ pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
                                     pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1200,6 +1268,8 @@ pmix_status_t pmix20_bfrop_print_ptr(char **output, char *prefix, void *src, pmi
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1223,6 +1293,8 @@ pmix_status_t pmix20_bfrop_print_pstate(char **output, char *prefix, pmix_proc_s
                                         pmix_data_type_t type)
 {
     char *prefx;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1251,7 +1323,9 @@ pmix_status_t pmix20_bfrop_print_pinfo(char **output, char *prefix, pmix_proc_in
     pmix_status_t rc = PMIX_SUCCESS;
     char *p2, *tmp;
 
-    /* deal with NULL prefix */
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
@@ -1293,6 +1367,8 @@ pmix_status_t pmix20_bfrop_print_darray(char **output, char *prefix, pmix_data_a
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1320,6 +1396,8 @@ pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix, pmix_query_t
     pmix_status_t rc = PMIX_SUCCESS;
     char *tmp, *t2, *t3;
     size_t n;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
@@ -1391,6 +1469,8 @@ pmix_status_t pmix20_bfrop_print_rank(char **output, char *prefix, pmix_rank_t *
     char *prefx;
     int rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1428,6 +1508,8 @@ pmix_status_t pmix20_bfrop_print_alloc_directive(char **output, char *prefix,
 {
     char *prefx;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* deal with NULL prefix */
     if (NULL == prefix) {
         if (0 > asprintf(&prefx, " ")) {
@@ -1456,7 +1538,9 @@ pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix, pmix_info_ar
     char *tmp, *tmp2, *tmp3, *pfx;
     pmix_info_t *s1;
 
-    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+   if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
     }
     if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -166,6 +166,9 @@ pmix_status_t pmix20_bfrop_unpack_bool(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_bool * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -198,6 +201,8 @@ pmix_status_t pmix20_bfrop_unpack_int(pmix_pointer_array_t *regtypes, pmix_buffe
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
@@ -226,6 +231,8 @@ pmix_status_t pmix20_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes, pmix_buf
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
@@ -253,6 +260,8 @@ pmix_status_t pmix20_bfrop_unpack_pid(pmix_pointer_array_t *regtypes, pmix_buffe
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
@@ -283,6 +292,9 @@ pmix_status_t pmix20_bfrop_unpack_byte(pmix_pointer_array_t *regtypes, pmix_buff
 {
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_byte * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, *num_vals)) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -305,6 +317,9 @@ pmix_status_t pmix20_bfrop_unpack_int16(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_int16 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -329,6 +344,9 @@ pmix_status_t pmix20_bfrop_unpack_int32(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_int32 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -350,6 +368,8 @@ pmix_status_t pmix20_bfrop_unpack_datatype(pmix_pointer_array_t *regtypes, pmix_
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT16, regtypes);
     return ret;
 }
@@ -362,6 +382,9 @@ pmix_status_t pmix20_bfrop_unpack_int64(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_int64 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -384,6 +407,8 @@ pmix_status_t pmix20_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
     pmix_status_t ret;
     int32_t i, len, n = 1;
     char **sdest = (char **) dest;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < (*num_vals); ++i) {
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &len, &n, PMIX_INT32, regtypes);
@@ -417,6 +442,9 @@ pmix_status_t pmix20_bfrop_unpack_float(pmix_pointer_array_t *regtypes, pmix_buf
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_float * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(float))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -449,6 +477,9 @@ pmix_status_t pmix20_bfrop_unpack_double(pmix_pointer_array_t *regtypes, pmix_bu
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_double * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(double))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -481,6 +512,9 @@ pmix_status_t pmix20_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes, pmix_b
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_timeval * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(struct timeval))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -514,6 +548,9 @@ pmix_status_t pmix20_bfrop_unpack_time(pmix_pointer_array_t *regtypes, pmix_buff
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_time * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n = 1;
@@ -534,6 +571,9 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_pointer_array_t *regtypes, pmix_bu
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_status * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals) * (sizeof(pmix_status_t)))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -824,6 +864,8 @@ pmix_status_t pmix20_bfrop_unpack_value(pmix_pointer_array_t *regtypes, pmix_buf
     ptr = (pmix_value_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         /* unpack the type */
         if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &ptr[i].type))) {
@@ -850,6 +892,8 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_pointer_array_t *regtypes, pmix_buff
 
     ptr = (pmix_info_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         memset(ptr[i].key, 0, sizeof(ptr[i].key));
@@ -914,6 +958,8 @@ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes, pmix_buf
     ptr = (pmix_pdata_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         PMIX_PDATA_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
@@ -964,6 +1010,8 @@ pmix_status_t pmix20_bfrop_unpack_buf(pmix_pointer_array_t *regtypes, pmix_buffe
     ptr = (pmix_buffer_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         /* unpack the number of bytes */
         m = 1;
@@ -1003,6 +1051,8 @@ pmix_status_t pmix20_bfrop_unpack_proc(pmix_pointer_array_t *regtypes, pmix_buff
 
     ptr = (pmix_proc_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
@@ -1048,6 +1098,8 @@ pmix_status_t pmix20_bfrop_unpack_app(pmix_pointer_array_t *regtypes, pmix_buffe
 
     ptr = (pmix_app_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         /* initialize the fields */
@@ -1146,6 +1198,8 @@ pmix_status_t pmix20_bfrop_unpack_kval(pmix_pointer_array_t *regtypes, pmix_buff
     ptr = (pmix_kval_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         PMIX_CONSTRUCT(&ptr[i], pmix_kval_t);
         /* unpack the key */
@@ -1181,6 +1235,8 @@ pmix_status_t pmix20_bfrop_unpack_modex(pmix_pointer_array_t *regtypes, pmix_buf
     ptr = (pmix_modex_data_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
         /* unpack the number of bytes */
@@ -1205,30 +1261,40 @@ pmix_status_t pmix20_bfrop_unpack_modex(pmix_pointer_array_t *regtypes, pmix_buf
 pmix_status_t pmix20_bfrop_unpack_persist(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                           void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_unpack_scope(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_unpack_range(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                         void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                       void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                            void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, PMIX_UINT32);
 }
 
@@ -1244,6 +1310,8 @@ pmix_status_t pmix20_bfrop_unpack_bo(pmix_pointer_array_t *regtypes, pmix_buffer
 
     ptr = (pmix_byte_object_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         memset(&ptr[i], 0, sizeof(pmix_byte_object_t));
@@ -1272,6 +1340,8 @@ pmix_status_t pmix20_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes, pmix_buffe
     uint8_t foo = 1;
     int32_t cnt = 1;
 
+    PMIX_HIDE_UNUSED_PARAMS(dest, num_vals, type);
+
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just unpack the sentinel */
     return pmix20_bfrop_unpack_byte(regtypes, buffer, &foo, &cnt, PMIX_UINT8);
@@ -1280,6 +1350,8 @@ pmix_status_t pmix20_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes, pmix_buffe
 pmix_status_t pmix20_bfrop_unpack_pstate(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                          void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
@@ -1295,6 +1367,8 @@ pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_pointer_array_t *regtypes, pmix_buf
 
     ptr = (pmix_proc_info_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         PMIX_PROC_INFO_CONSTRUCT(&ptr[i]);
@@ -1348,6 +1422,8 @@ pmix_status_t pmix20_bfrop_unpack_darray(pmix_pointer_array_t *regtypes, pmix_bu
 
     ptr = (pmix_data_array_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         memset(&ptr[i], 0, sizeof(pmix_data_array_t));
@@ -1446,6 +1522,7 @@ pmix_status_t pmix20_bfrop_unpack_darray(pmix_pointer_array_t *regtypes, pmix_bu
             break;
         case PMIX_QUERY:
             nbytes = sizeof(pmix_query_t);
+            break;
         default:
             return PMIX_ERR_NOT_SUPPORTED;
         }
@@ -1464,6 +1541,8 @@ pmix_status_t pmix20_bfrop_unpack_darray(pmix_pointer_array_t *regtypes, pmix_bu
 pmix_status_t pmix20_bfrop_unpack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                        void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, PMIX_UINT32);
 }
 
@@ -1480,6 +1559,8 @@ pmix_status_t pmix20_bfrop_unpack_query(pmix_pointer_array_t *regtypes, pmix_buf
 
     ptr = (pmix_query_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         PMIX_QUERY_CONSTRUCT(&ptr[i]);
@@ -1526,6 +1607,8 @@ pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_pointer_array_t *regtypes
                                                   pmix_buffer_t *buffer, void *dest,
                                                   int32_t *num_vals, pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
@@ -1542,6 +1625,8 @@ pmix_status_t pmix20_bfrop_unpack_array(pmix_pointer_array_t *regtypes, pmix_buf
 
     ptr = (pmix_info_array_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -38,25 +38,23 @@ static pmix_status_t pmix21_unpack(pmix_buffer_t *buffer, void *dest, int32_t *n
                                    pmix_data_type_t type);
 static pmix_status_t pmix21_copy(void **dest, void *src, pmix_data_type_t type);
 static pmix_status_t pmix21_print(char **output, char *prefix, void *src, pmix_data_type_t type);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix21_module = {.version = "v21",
-                                                  .init = init,
-                                                  .finalize = finalize,
-                                                  .pack = pmix21_pack,
-                                                  .unpack = pmix21_unpack,
-                                                  .copy = pmix21_copy,
-                                                  .print = pmix21_print,
-                                                  .copy_payload = pmix_bfrops_base_copy_payload,
-                                                  .value_xfer = pmix_bfrops_base_value_xfer,
-                                                  .value_load = pmix_bfrops_base_value_load,
-                                                  .value_unload = pmix_bfrops_base_value_unload,
-                                                  .value_cmp = pmix_bfrops_base_value_cmp,
-                                                  .register_type = register_type,
-                                                  .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix21_module = {
+    .version = "v21",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix21_pack,
+    .unpack = pmix21_unpack,
+    .copy = pmix21_copy,
+    .print = pmix21_print,
+    .copy_payload = pmix_bfrops_base_copy_payload,
+    .value_xfer = pmix_bfrops_base_value_xfer,
+    .value_load = pmix_bfrops_base_value_load,
+    .value_unload = pmix_bfrops_base_value_unload,
+    .value_cmp = pmix_bfrops_base_value_cmp,
+    .data_type_string = data_type_string
+};
 
 /* DEPRECATED data type values */
 #define PMIX_MODEX      29
@@ -223,7 +221,7 @@ static pmix_status_t init(void)
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_std_copy, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_scope, &mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
@@ -319,14 +317,6 @@ static pmix_status_t pmix21_print(char **output, char *prefix, void *src, pmix_d
     return pmix_bfrops_base_print(&mca_bfrops_v21_component.types, output, prefix, src, type);
 }
 
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v21_component.types);
-    return PMIX_SUCCESS;
-}
-
 static const char *data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v21_component.types, type);
@@ -342,6 +332,8 @@ static pmix_status_t pmix21_bfrop_pack_array(pmix_pointer_array_t *regtypes, pmi
     pmix_status_t ret;
 
     ptr = (pmix_info_array_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
@@ -371,6 +363,8 @@ static pmix_status_t pmix21_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmi
     pmix_status_t ret;
 
     ptr = (pmix_modex_data_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         if (PMIX_SUCCESS
@@ -404,6 +398,8 @@ static pmix_status_t pmix21_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
 
     ptr = (pmix_info_array_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
@@ -440,6 +436,8 @@ static pmix_status_t pmix21_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack: %d modex", *num_vals);
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     ptr = (pmix_modex_data_t *) dest;
     n = *num_vals;
 
@@ -473,6 +471,8 @@ static pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest, pmix_info
 {
     pmix_info_t *d1, *s1;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_array_t *) malloc(sizeof(pmix_info_array_t));
     (*dest)->size = src->size;
     (*dest)->array = (pmix_info_t *) malloc(src->size * sizeof(pmix_info_t));
@@ -485,6 +485,8 @@ static pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest, pmix_info
 static pmix_status_t pmix21_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                                              pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_modex_data_t *) malloc(sizeof(pmix_modex_data_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -511,6 +513,8 @@ static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix, pmix_
     size_t j;
     char *tmp, *tmp2, *tmp3, *pfx;
     pmix_info_t *s1;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
@@ -539,6 +543,8 @@ static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix, pmix_
 static pmix_status_t pmix21_bfrop_print_modex(char **output, char *prefix, pmix_modex_data_t *src,
                                               pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -38,25 +38,23 @@ static pmix_status_t pmix3_unpack(pmix_buffer_t *buffer, void *dest, int32_t *nu
                                   pmix_data_type_t type);
 static pmix_status_t pmix3_copy(void **dest, void *src, pmix_data_type_t type);
 static pmix_status_t pmix3_print(char **output, char *prefix, void *src, pmix_data_type_t type);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix3_module = {.version = "v3",
-                                                 .init = init,
-                                                 .finalize = finalize,
-                                                 .pack = pmix3_pack,
-                                                 .unpack = pmix3_unpack,
-                                                 .copy = pmix3_copy,
-                                                 .print = pmix3_print,
-                                                 .copy_payload = pmix_bfrops_base_copy_payload,
-                                                 .value_xfer = pmix_bfrops_base_value_xfer,
-                                                 .value_load = pmix_bfrops_base_value_load,
-                                                 .value_unload = pmix_bfrops_base_value_unload,
-                                                 .value_cmp = pmix_bfrops_base_value_cmp,
-                                                 .register_type = register_type,
-                                                 .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix3_module = {
+    .version = "v3",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix3_pack,
+    .unpack = pmix3_unpack,
+    .copy = pmix3_copy,
+    .print = pmix3_print,
+    .copy_payload = pmix_bfrops_base_copy_payload,
+    .value_xfer = pmix_bfrops_base_value_xfer,
+    .value_load = pmix_bfrops_base_value_load,
+    .value_unload = pmix_bfrops_base_value_unload,
+    .value_cmp = pmix_bfrops_base_value_cmp,
+    .data_type_string = data_type_string
+};
 
 /* DEPRECATED data type values */
 #define PMIX_MODEX      29
@@ -221,7 +219,7 @@ static pmix_status_t init(void)
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_std_copy, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_scope, &mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
@@ -325,14 +323,6 @@ static pmix_status_t pmix3_print(char **output, char *prefix, void *src, pmix_da
     return pmix_bfrops_base_print(&mca_bfrops_v3_component.types, output, prefix, src, type);
 }
 
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v3_component.types);
-    return PMIX_SUCCESS;
-}
-
 static const char *data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v3_component.types, type);
@@ -348,6 +338,8 @@ static pmix_status_t pmix3_bfrop_pack_array(pmix_pointer_array_t *regtypes, pmix
     pmix_status_t ret;
 
     ptr = (pmix_info_array_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
@@ -377,6 +369,8 @@ static pmix_status_t pmix3_bfrop_pack_modex(pmix_pointer_array_t *regtypes, pmix
     pmix_status_t ret;
 
     ptr = (pmix_modex_data_t *) src;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
         if (PMIX_SUCCESS
@@ -409,6 +403,8 @@ static pmix_status_t pmix3_bfrop_unpack_array(pmix_pointer_array_t *regtypes, pm
 
     ptr = (pmix_info_array_t *) dest;
     n = *num_vals;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < n; ++i) {
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
@@ -447,6 +443,8 @@ static pmix_status_t pmix3_bfrop_unpack_modex(pmix_pointer_array_t *regtypes, pm
     ptr = (pmix_modex_data_t *) dest;
     n = *num_vals;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     for (i = 0; i < n; ++i) {
         memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
         /* unpack the number of bytes */
@@ -477,6 +475,8 @@ static pmix_status_t pmix3_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_
 {
     pmix_info_t *d1, *s1;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_info_array_t *) malloc(sizeof(pmix_info_array_t));
     (*dest)->size = src->size;
     (*dest)->array = (pmix_info_t *) malloc(src->size * sizeof(pmix_info_t));
@@ -489,6 +489,8 @@ static pmix_status_t pmix3_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_
 static pmix_status_t pmix3_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                                             pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     *dest = (pmix_modex_data_t *) malloc(sizeof(pmix_modex_data_t));
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -515,6 +517,8 @@ static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix, pmix_i
     size_t j;
     char *tmp, *tmp2, *tmp3, *pfx;
     pmix_info_t *s1;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
@@ -543,6 +547,8 @@ static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix, pmix_i
 static pmix_status_t pmix3_bfrop_print_modex(char **output, char *prefix, pmix_modex_data_t *src,
                                              pmix_data_type_t type)
 {
+    PMIX_HIDE_UNUSED_PARAMS(output, prefix, src, type);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -41,9 +41,6 @@ static pmix_status_t pmix4_unpack(pmix_buffer_t *buffer, void *dest, int32_t *nu
                                   pmix_data_type_t type);
 static pmix_status_t pmix4_copy(void **dest, void *src, pmix_data_type_t type);
 static pmix_status_t pmix4_print(char **output, char *prefix, void *src, pmix_data_type_t type);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
 static pmix_status_t pmix4_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
@@ -65,20 +62,21 @@ static pmix_status_t pmix4_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtyp
                                                     pmix_buffer_t *buffer, void *dest,
                                                     int32_t *num_vals, pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix4_module = {.version = "v4",
-                                                 .init = init,
-                                                 .finalize = finalize,
-                                                 .pack = pmix4_pack,
-                                                 .unpack = pmix4_unpack,
-                                                 .copy = pmix4_copy,
-                                                 .print = pmix4_print,
-                                                 .copy_payload = pmix_bfrops_base_copy_payload,
-                                                 .value_xfer = pmix_bfrops_base_value_xfer,
-                                                 .value_load = pmix_bfrops_base_value_load,
-                                                 .value_unload = pmix_bfrops_base_value_unload,
-                                                 .value_cmp = pmix_bfrops_base_value_cmp,
-                                                 .register_type = register_type,
-                                                 .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix4_module = {
+    .version = "v4",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix4_pack,
+    .unpack = pmix4_unpack,
+    .copy = pmix4_copy,
+    .print = pmix4_print,
+    .copy_payload = pmix_bfrops_base_copy_payload,
+    .value_xfer = pmix_bfrops_base_value_xfer,
+    .value_load = pmix_bfrops_base_value_load,
+    .value_unload = pmix_bfrops_base_value_unload,
+    .value_cmp = pmix_bfrops_base_value_cmp,
+    .data_type_string = data_type_string
+};
 
 static pmix_status_t init(void)
 {
@@ -208,7 +206,7 @@ static pmix_status_t init(void)
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_std_copy, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_scope, &mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
@@ -359,14 +357,6 @@ static pmix_status_t pmix4_print(char **output, char *prefix, void *src, pmix_da
     return pmix_bfrops_base_print(&mca_bfrops_v4_component.types, output, prefix, src, type);
 }
 
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v4_component.types);
-    return PMIX_SUCCESS;
-}
-
 static const char *data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v4_component.types, type);
@@ -386,6 +376,8 @@ static pmix_status_t pmix4_bfrops_base_pack_general_int(pmix_pointer_array_t *re
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_integer * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes);
 
     PMIX_SQUASH_TYPE_SIZEOF(rc, type, val_size);
     if (PMIX_SUCCESS != rc) {
@@ -429,6 +421,8 @@ static pmix_status_t pmix4_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (false == pmix_psquash.int_type_is_encoded) {
         /* System types need to always be described so we can properly
            unpack them */
@@ -450,6 +444,8 @@ static pmix_status_t pmix4_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes
                                                   int32_t num_vals, pmix_data_type_t type)
 {
     int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (false == pmix_psquash.int_type_is_encoded) {
         /* System types need to always be described so we can properly
@@ -477,6 +473,8 @@ static pmix_status_t pmix4_bfrops_base_unpack_general_int(pmix_pointer_array_t *
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_unpack_integer * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (buffer->pack_ptr == buffer->unpack_ptr) {
@@ -531,6 +529,8 @@ static pmix_status_t pmix4_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (false == pmix_psquash.int_type_is_encoded) {
         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
             return ret;
@@ -559,6 +559,8 @@ static pmix_status_t pmix4_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtyp
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (false == pmix_psquash.int_type_is_encoded) {
         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {

--- a/src/mca/bfrops/v41/bfrop_pmix41.c
+++ b/src/mca/bfrops/v41/bfrop_pmix41.c
@@ -41,9 +41,6 @@ static pmix_status_t pmix41_unpack(pmix_buffer_t *buffer, void *dest, int32_t *n
                                    pmix_data_type_t type);
 static pmix_status_t pmix41_copy(void **dest, void *src, pmix_data_type_t type);
 static pmix_status_t pmix41_print(char **output, char *prefix, void *src, pmix_data_type_t type);
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print);
 static const char *data_type_string(pmix_data_type_t type);
 
 static pmix_status_t pmix41_bfrops_base_pack_general_int(pmix_pointer_array_t *regtypes,
@@ -66,20 +63,21 @@ static pmix_status_t pmix41_bfrops_base_unpack_sizet(pmix_pointer_array_t *regty
                                                      pmix_buffer_t *buffer, void *dest,
                                                      int32_t *num_vals, pmix_data_type_t type);
 
-pmix_bfrops_module_t pmix_bfrops_pmix41_module = {.version = "v41",
-                                                  .init = init,
-                                                  .finalize = finalize,
-                                                  .pack = pmix41_pack,
-                                                  .unpack = pmix41_unpack,
-                                                  .copy = pmix41_copy,
-                                                  .print = pmix41_print,
-                                                  .copy_payload = pmix_bfrops_base_copy_payload,
-                                                  .value_xfer = pmix_bfrops_base_value_xfer,
-                                                  .value_load = pmix_bfrops_base_value_load,
-                                                  .value_unload = pmix_bfrops_base_value_unload,
-                                                  .value_cmp = pmix_bfrops_base_value_cmp,
-                                                  .register_type = register_type,
-                                                  .data_type_string = data_type_string};
+pmix_bfrops_module_t pmix_bfrops_pmix41_module = {
+    .version = "v41",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix41_pack,
+    .unpack = pmix41_unpack,
+    .copy = pmix41_copy,
+    .print = pmix41_print,
+    .copy_payload = pmix_bfrops_base_copy_payload,
+    .value_xfer = pmix_bfrops_base_value_xfer,
+    .value_load = pmix_bfrops_base_value_load,
+    .value_unload = pmix_bfrops_base_value_unload,
+    .value_cmp = pmix_bfrops_base_value_cmp,
+    .data_type_string = data_type_string
+};
 
 static pmix_status_t init(void)
 {
@@ -209,7 +207,7 @@ static pmix_status_t init(void)
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_std_copy, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_scope, &mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
@@ -400,14 +398,6 @@ static pmix_status_t pmix41_print(char **output, char *prefix, void *src, pmix_d
     return pmix_bfrops_base_print(&mca_bfrops_v41_component.types, output, prefix, src, type);
 }
 
-static pmix_status_t register_type(const char *name, pmix_data_type_t type,
-                                   pmix_bfrop_pack_fn_t pack, pmix_bfrop_unpack_fn_t unpack,
-                                   pmix_bfrop_copy_fn_t copy, pmix_bfrop_print_fn_t print)
-{
-    PMIX_REGISTER_TYPE(name, type, pack, unpack, copy, print, &mca_bfrops_v41_component.types);
-    return PMIX_SUCCESS;
-}
-
 static const char *data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v41_component.types, type);
@@ -427,6 +417,8 @@ static pmix_status_t pmix41_bfrops_base_pack_general_int(pmix_pointer_array_t *r
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_integer * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes);
 
     PMIX_SQUASH_TYPE_SIZEOF(rc, type, val_size);
     if (PMIX_SUCCESS != rc) {
@@ -470,6 +462,8 @@ static pmix_status_t pmix41_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
 {
     pmix_status_t ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (false == pmix_psquash.int_type_is_encoded) {
         /* System types need to always be described so we can properly
            unpack them */
@@ -491,6 +485,8 @@ static pmix_status_t pmix41_bfrops_base_pack_sizet(pmix_pointer_array_t *regtype
                                                    int32_t num_vals, pmix_data_type_t type)
 {
     int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (false == pmix_psquash.int_type_is_encoded) {
         /* System types need to always be described so we can properly
@@ -518,6 +514,8 @@ static pmix_status_t pmix41_bfrops_base_unpack_general_int(pmix_pointer_array_t 
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_unpack_integer * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     /* check to see if there's enough data in buffer */
     if (buffer->pack_ptr == buffer->unpack_ptr) {
@@ -572,6 +570,8 @@ static pmix_status_t pmix41_bfrops_base_unpack_int(pmix_pointer_array_t *regtype
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
     if (false == pmix_psquash.int_type_is_encoded) {
         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
             return ret;
@@ -600,6 +600,8 @@ static pmix_status_t pmix41_bfrops_base_unpack_sizet(pmix_pointer_array_t *regty
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (false == pmix_psquash.int_type_is_encoded) {
         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {

--- a/src/mca/gds/base/gds_base_frame.c
+++ b/src/mca/gds/base/gds_base_frame.c
@@ -47,7 +47,12 @@
 #include "src/mca/gds/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_gds_globals_t pmix_gds_globals = {{{0}}};
+pmix_gds_globals_t pmix_gds_globals = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .selected = false,
+    .all_mods = NULL
+};
 int pmix_gds_base_output = -1;
 
 static pmix_status_t pmix_gds_close(void)

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -493,6 +493,9 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
                         PMIX_NAME_PRINT(&pmix_globals.myid), (NULL == key) ? "NULL" : key,
                         PMIX_NAME_PRINT(proc), PMIx_Scope_string(scope));
 
+
+    PMIX_HIDE_UNUSED_PARAMS(copy);
+
     /* see if we have a tracker for this nspace - we will
      * if we already cached the job info for it. If we
      * didn't then we'll have no idea how to answer any

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -101,6 +101,9 @@ pmix_gds_base_module_t pmix_hash_module = {.name = "hash",
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 {
+
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
     return PMIX_SUCCESS;
 }
 
@@ -1236,6 +1239,8 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx, pmix_proc_t *pro
                         "[%s:%d] gds:hash:store_modex for nspace %s", pmix_globals.myid.nspace,
                         pmix_globals.myid.rank, proc->nspace);
 
+    PMIX_HIDE_UNUSED_PARAMS(ctx);
+
     /* find the hash table for this nspace */
     trk = pmix_gds_hash_get_tracker(proc->nspace, true);
     if (NULL == trk) {
@@ -1284,6 +1289,9 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx, pmix_proc_t *pro
 
 static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
 {
+
+    PMIX_HIDE_UNUSED_PARAMS(proc, env);
+
     /* we don't need to add anything */
     return PMIX_SUCCESS;
 }
@@ -1291,6 +1299,9 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
 static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs, pmix_info_t info[],
                                 size_t ninfo)
 {
+
+    PMIX_HIDE_UNUSED_PARAMS(nspace, nlocalprocs, info, ninfo);
+
     /* we don't need to do anything here */
     return PMIX_SUCCESS;
 }
@@ -1298,6 +1309,7 @@ static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs, pmix_i
 static pmix_status_t nspace_del(const char *nspace)
 {
     pmix_job_t *t;
+
 
     /* find the hash table for this nspace */
     PMIX_LIST_FOREACH (t, &mca_gds_hash_component.myjobs, pmix_job_t) {

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -57,12 +57,17 @@ pmix_gds_hash_component_t mca_gds_hash_component = {
             .pmix_mca_open_component = component_open,
             .pmix_mca_close_component = component_close,
             .pmix_mca_query_component = component_query,
+            .reserved = {0}
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
-        }
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
+        },
+        .priority = 10
     },
+    .mysessions = PMIX_LIST_STATIC_INIT,
+    .myjobs = PMIX_LIST_STATIC_INIT
 };
 
 static int component_open(void)

--- a/src/mca/mca.h
+++ b/src/mca/mca.h
@@ -258,6 +258,25 @@ struct pmix_mca_base_component_2_1_0_t {
         breaking older components. */
     char reserved[32];
 };
+#define PMIX_BASE_COMPONENT_STATIC_INIT         \
+{                                               \
+    .pmix_mca_major_version = 0,                \
+    .pmix_mca_minor_version = 0,                \
+    .pmix_mca_release_version = 0,              \
+    .pmix_mca_project_name = {0},               \
+    .pmix_mca_type_major_version = 0,           \
+    .pmix_mca_type_minor_version = 0,           \
+    .pmix_mca_type_release_version = 0,         \
+    .pmix_mca_component_name = {0},             \
+    .pmix_mca_component_major_version = 0,      \
+    .pmix_mca_component_minor_version = 0,      \
+    .pmix_mca_component_release_version = 0,    \
+    .pmix_mca_open_component = NULL,            \
+    .pmix_mca_close_component = NULL,           \
+    .pmix_mca_query_component = NULL,           \
+    .pmix_mca_register_component_params = NULL, \
+    .reserved = {0}                             \
+}
 /** Unversioned convenience typedef; use this name in
     frameworks/components to stay forward source-compatible */
 typedef struct pmix_mca_base_component_2_1_0_t pmix_mca_base_component_t;
@@ -284,6 +303,12 @@ struct pmix_mca_base_component_data_2_0_0_t {
         breaking older components. */
     char reserved[32];
 };
+#define PMIX_BASE_DATA_STATIC_INIT      \
+{                                       \
+    .param_field = 0,                   \
+    .reserved = {0}                     \
+}
+
 /** Unversioned convenience typedef; use this name in
     frameworks/components to stay forward source-compatible */
 typedef struct pmix_mca_base_component_data_2_0_0_t pmix_mca_base_component_data_t;

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -73,9 +73,19 @@ pmix_compress_base_module_t pmix_compress = {.compress = compress_block,
                                              .decompress = decompress_block,
                                              .compress_string = compress_string,
                                              .decompress_string = decompress_string};
-pmix_compress_base_t pmix_compress_base = {0};
+pmix_compress_base_t pmix_compress_base = {
+    .compress_limit = 0,
+    .selected = false,
+    .silent = false
+};
 
-pmix_compress_base_component_t pmix_compress_base_selected_component = {{0}};
+pmix_compress_base_component_t pmix_compress_base_selected_component = {
+    .base_version = PMIX_BASE_COMPONENT_STATIC_INIT,
+    .base_data = PMIX_BASE_DATA_STATIC_INIT,
+    .verbose = 0,
+    .output_handle = 0,
+    .priority = 0
+};
 
 static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
 {

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
@@ -63,7 +63,8 @@ pmix_pdl_pdlopen_component_t mca_pdl_pdlopen_component = {
 
         .base_data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         },
 
         /* The pdl framework members */

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -448,8 +448,6 @@ static pmix_status_t setup_prefork(pmix_pfexec_child_t *child)
 {
     int ret = -1;
     pmix_pfexec_base_io_conf_t *opts = &child->opts;
-    pmix_proc_t *targets = NULL;
-    pmix_info_t *directives = NULL;
 
     fflush(stdout);
 
@@ -482,13 +480,13 @@ static pmix_status_t setup_prefork(pmix_pfexec_child_t *child)
     }
 
     /* connect read ends to IOF */
-    PMIX_IOF_READ_EVENT(&child->stdoutev, targets, 0, directives, 0, opts->p_stdout[0],
-                        pmix_iof_read_local_handler, false);
+    PMIX_IOF_READ_EVENT_LOCAL(&child->stdoutev, opts->p_stdout[0],
+                              pmix_iof_read_local_handler, false);
     PMIX_LOAD_PROCID(&child->stdoutev->name, child->proc.nspace, child->proc.rank);
     child->stdoutev->childproc = (void *) child;
     child->stdoutev->channel = PMIX_FWD_STDOUT_CHANNEL;
-    PMIX_IOF_READ_EVENT(&child->stderrev, targets, 0, directives, 0, opts->p_stderr[0],
-                        pmix_iof_read_local_handler, false);
+    PMIX_IOF_READ_EVENT_LOCAL(&child->stderrev, opts->p_stderr[0],
+                              pmix_iof_read_local_handler, false);
     PMIX_LOAD_PROCID(&child->stderrev->name, child->proc.nspace, child->proc.rank);
     child->stderrev->childproc = (void *) child;
     child->stderrev->channel = PMIX_FWD_STDERR_CHANNEL;

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -55,12 +55,23 @@
 /*
  * Instantiate globals
  */
-pmix_pfexec_base_module_t pmix_pfexec = {0};
+pmix_pfexec_base_module_t pmix_pfexec = {
+    .spawn_job = NULL,
+    .kill_proc = NULL,
+    .signal_proc = NULL
+};
 
 /*
  * Framework global variables
  */
-pmix_pfexec_globals_t pmix_pfexec_globals = {0};
+pmix_pfexec_globals_t pmix_pfexec_globals = {
+    .handler = NULL,
+    .active = false,
+    .children = PMIX_LIST_STATIC_INIT,
+    .timeout_before_sigkill = 0,
+    .nextid = 0,
+    .selected = false
+};
 
 static int pmix_pfexec_base_close(void)
 {

--- a/src/mca/pgpu/amd/pgpu_amd.c
+++ b/src/mca/pgpu/amd/pgpu_amd.c
@@ -222,6 +222,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {
     /* search the topology for AMD GPUs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
 
     return PMIX_SUCCESS;
 }
@@ -230,6 +231,7 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/amd/pgpu_amd_component.c
+++ b/src/mca/pgpu/amd/pgpu_amd_component.c
@@ -65,7 +65,8 @@ pmix_pgpu_amd_component_t mca_pgpu_amd_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pgpu/intel/pgpu_intel.c
+++ b/src/mca/pgpu/intel/pgpu_intel.c
@@ -222,6 +222,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {
     /* search the topology for intel GPUs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
 
     return PMIX_SUCCESS;
 }
@@ -230,6 +231,7 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/intel/pgpu_intel_component.c
+++ b/src/mca/pgpu/intel/pgpu_intel_component.c
@@ -65,7 +65,8 @@ pmix_pgpu_intel_component_t mca_pgpu_intel_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pgpu/nvd/pgpu_nvd.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd.c
@@ -222,6 +222,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {
     /* search the topology for nvd GPUs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
 
     return PMIX_SUCCESS;
 }
@@ -230,6 +231,7 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/nvd/pgpu_nvd_component.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd_component.c
@@ -65,7 +65,8 @@ pmix_pgpu_nvd_component_t mca_pgpu_nvd_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pif/base/pif_base_components.c
+++ b/src/mca/pif/base/pif_base_components.c
@@ -22,7 +22,7 @@
 #include "src/util/output.h"
 
 /* instantiate the global list of interfaces */
-pmix_list_t pmix_if_list = {{0}};
+pmix_list_t pmix_if_list = PMIX_LIST_STATIC_INIT;
 bool pmix_if_do_not_resolve = false;
 bool pmix_if_retain_loopback = false;
 

--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -77,7 +77,8 @@ pmix_pif_base_component_t mca_pif_bsdx_ipv4_component = {
     },
     .data = {
         /* This component is checkpointable */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -80,7 +80,8 @@ pmix_pif_base_component_t mca_pif_bsdx_ipv6_component = {
     },
     .data = {
         /* This component is checkpointable */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -72,7 +72,8 @@ pmix_pif_base_component_t mca_pif_linux_ipv6_component = {
     },
     .data = {
         /* This component is checkpointable */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -77,7 +77,8 @@ pmix_pif_base_component_t mca_pif_posix_ipv4_component = {
     },
     .data = {
         /* This component is checkpointable */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
+++ b/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
@@ -90,7 +90,8 @@ pmix_pif_base_component_t mca_pif_solaris_ipv6_component = {
     },
     .data = {
         /* This component is checkpointable */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
@@ -23,7 +23,25 @@
 #include "src/mca/pinstalldirs/base/static-components.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 
-pmix_pinstall_dirs_t pmix_pinstall_dirs = {0};
+pmix_pinstall_dirs_t pmix_pinstall_dirs = {
+    .prefix = NULL,
+    .exec_prefix = NULL,
+    .bindir = NULL,
+    .sbindir = NULL,
+    .libexecdir = NULL,
+    .datarootdir = NULL,
+    .datadir = NULL,
+    .sysconfdir = NULL,
+    .sharedstatedir = NULL,
+    .localstatedir = NULL,
+    .libdir = NULL,
+    .includedir = NULL,
+    .infodir = NULL,
+    .mandir = NULL,
+    .pmixdatadir = NULL,
+    .pmixlibdir = NULL,
+    .pmixincludedir = NULL
+};
 
 #define CONDITIONAL_COPY(target, origin, field)             \
     do {                                                    \

--- a/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
+++ b/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
@@ -18,17 +18,38 @@
 const pmix_pinstalldirs_base_component_t mca_pinstalldirs_config_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
-    {PMIX_PINSTALLDIRS_BASE_VERSION_1_0_0,
+    .component = {
+        PMIX_PINSTALLDIRS_BASE_VERSION_1_0_0,
 
-     /* Component name and version */
-     "config", PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION, PMIX_RELEASE_VERSION,
+        /* Component name and version */
+        "config", PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION, PMIX_RELEASE_VERSION,
 
-     /* Component open and close functions */
-     NULL, NULL},
-    {/* This component is Checkpointable */
-     PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT},
+        /* Component open and close functions */
+        NULL, NULL
+    },
+    .component_data = {
+        /* This component is Checkpointable */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
+    },
 
-    {PMIX_INSTALL_PREFIX, PMIX_EXEC_PREFIX, PMIX_BINDIR, PMIX_SBINDIR, PMIX_LIBEXECDIR,
-     PMIX_DATAROOTDIR, PMIX_DATADIR, PMIX_SYSCONFDIR, PMIX_SHAREDSTATEDIR, PMIX_LOCALSTATEDIR,
-     PMIX_LIBDIR, PMIX_INCLUDEDIR, PMIX_INFODIR, PMIX_MANDIR, PMIX_PKGDATADIR, PMIX_PKGLIBDIR,
-     PMIX_PKGINCLUDEDIR}};
+    .install_dirs_data = {
+        .prefix = PMIX_INSTALL_PREFIX,
+        .exec_prefix = PMIX_EXEC_PREFIX,
+        .bindir = PMIX_BINDIR,
+        .sbindir = PMIX_SBINDIR,
+        .libexecdir = PMIX_LIBEXECDIR,
+        .datarootdir = PMIX_DATAROOTDIR,
+        .datadir = PMIX_DATADIR,
+        .sysconfdir = PMIX_SYSCONFDIR,
+        .sharedstatedir = PMIX_SHAREDSTATEDIR,
+        .localstatedir = PMIX_LOCALSTATEDIR,
+        .libdir = PMIX_LIBDIR,
+        .includedir = PMIX_INCLUDEDIR,
+        .infodir = PMIX_INFODIR,
+        .mandir = PMIX_MANDIR,
+        .pmixdatadir = PMIX_PKGDATADIR,
+        .pmixlibdir = PMIX_PKGLIBDIR,
+        .pmixincludedir = PMIX_PKGINCLUDEDIR
+    }
+};

--- a/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
+++ b/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
@@ -24,7 +24,7 @@ static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo);
 pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
-    {
+    .component = {
         PMIX_PINSTALLDIRS_BASE_VERSION_1_0_0,
 
         /* Component name and version */
@@ -33,12 +33,30 @@ pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
         PMIX_MINOR_VERSION,
         PMIX_RELEASE_VERSION,
     },
-    {/* This component is checkpointable */
-     PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT},
+    .component_data = {/* This component is checkpointable */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
+    },
 
     /* Next the pmix_pinstall_dirs_t install_dirs_data information */
-    {
-        NULL,
+    .install_dirs_data = {
+        .prefix = NULL,
+        .exec_prefix = NULL,
+        .bindir = NULL,
+        .sbindir = NULL,
+        .libexecdir = NULL,
+        .datarootdir = NULL,
+        .datadir = NULL,
+        .sysconfdir = NULL,
+        .sharedstatedir = NULL,
+        .localstatedir = NULL,
+        .libdir = NULL,
+        .includedir = NULL,
+        .infodir = NULL,
+        .mandir = NULL,
+        .pmixdatadir = NULL,
+        .pmixlibdir = NULL,
+        .pmixincludedir = NULL
     },
     .init = pinstalldirs_env_init};
 

--- a/src/mca/plog/base/plog_base_frame.c
+++ b/src/mca/plog/base/plog_base_frame.c
@@ -33,7 +33,13 @@
 #include "src/mca/plog/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_plog_globals_t pmix_plog_globals = {{0}};
+pmix_plog_globals_t pmix_plog_globals = {
+    .lock = PMIX_LOCK_STATIC_INIT,
+    .actives = PMIX_POINTER_ARRAY_STATIC_INIT,
+    .initialized = false,
+    .selected = false,
+    .channels = NULL
+};
 pmix_plog_API_module_t pmix_plog = {.log = pmix_plog_base_log};
 
 static char *order = NULL;

--- a/src/mca/plog/default/plog_default_component.c
+++ b/src/mca/plog/default/plog_default_component.c
@@ -33,7 +33,8 @@ pmix_plog_base_component_t mca_plog_default_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -80,6 +80,10 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
     if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
+
+
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, cbfunc, cbdata);
+    
 #if 0
     /* check to see if there are any relevant directives */
     for (n = 0; n < ndirs; n++) {

--- a/src/mca/plog/stdfd/plog_stdfd_component.c
+++ b/src/mca/plog/stdfd/plog_stdfd_component.c
@@ -33,7 +33,8 @@ pmix_plog_base_component_t mca_plog_stdfd_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/plog/syslog/plog_syslog.c
+++ b/src/mca/plog/syslog/plog_syslog.c
@@ -94,6 +94,8 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
+
     /* check directives */
     if (NULL != directives) {
         for (n = 0; n < ndirs; n++) {

--- a/src/mca/plog/syslog/plog_syslog_component.c
+++ b/src/mca/plog/syslog/plog_syslog_component.c
@@ -41,7 +41,8 @@ pmix_plog_syslog_component_t mca_plog_syslog_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         },
     },
     .console = false,

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -46,17 +46,28 @@
 #include "src/mca/pmdl/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_pmdl_globals_t pmix_pmdl_globals = {{0}};
-pmix_pmdl_API_module_t pmix_pmdl = {.harvest_envars = pmix_pmdl_base_harvest_envars,
-                                    .setup_nspace = pmix_pmdl_base_setup_nspace,
-                                    .setup_nspace_kv = pmix_pmdl_base_setup_nspace_kv,
-                                    .register_nspace = pmix_pmdl_base_register_nspace,
-                                    .setup_client = pmix_pmdl_base_setup_client,
-                                    .setup_fork = pmix_pmdl_base_setup_fork,
-                                    .deregister_nspace = pmix_pmdl_base_deregister_nspace};
+pmix_pmdl_globals_t pmix_pmdl_globals = {
+    .lock = PMIX_LOCK_STATIC_INIT,
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .selected = false
+};
+
+pmix_pmdl_API_module_t pmix_pmdl = {
+    .harvest_envars = pmix_pmdl_base_harvest_envars,
+    .setup_nspace = pmix_pmdl_base_setup_nspace,
+    .setup_nspace_kv = pmix_pmdl_base_setup_nspace_kv,
+    .register_nspace = pmix_pmdl_base_register_nspace,
+    .setup_client = pmix_pmdl_base_setup_client,
+    .setup_fork = pmix_pmdl_base_setup_fork,
+    .deregister_nspace = pmix_pmdl_base_deregister_nspace};
 
 static int pmix_pmdl_register(pmix_mca_base_register_flag_t flags)
 {
+    if (PMIX_MCA_BASE_REGISTER_STATIC_ONLY == flags) {
+        return PMIX_SUCCESS;
+    }
+
     /* Note that we break abstraction rules here by listing a
      specific PMDL here in the base.  This is necessary, however,
      due to extraordinary circumstances:

--- a/src/mca/pmdl/mpich/pmdl_mpich_component.c
+++ b/src/mca/pmdl/mpich/pmdl_mpich_component.c
@@ -54,7 +54,8 @@ pmix_pmdl_mpich_component_t mca_pmdl_mpich_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -54,7 +54,8 @@ pmix_pmdl_ompi_component_t mca_pmdl_ompi_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
@@ -54,7 +54,8 @@ pmix_pmdl_oshmem_component_t mca_pmdl_oshmem_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -45,8 +45,9 @@
 #include "src/mca/pnet/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_pnet_globals_t pmix_pnet_globals = {.actives = PMIX_LIST_STATIC_INIT,
-                                         .fabrics = PMIX_LIST_STATIC_INIT
+pmix_pnet_globals_t pmix_pnet_globals = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .fabrics = PMIX_LIST_STATIC_INIT
 };
 pmix_pnet_API_module_t pmix_pnet = {
     .allocate = pmix_pnet_base_allocate,

--- a/src/mca/pnet/nvd/pnet_nvd.c
+++ b/src/mca/pnet/nvd/pnet_nvd.c
@@ -221,6 +221,8 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
+    PMIX_HIDE_UNUSED_PARAMS(directives,ndirs, inventory);
+
     /* search the topology for Mellanox/NVIDIA NICs */
     hwloc_obj_t device;
 
@@ -247,6 +249,8 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/nvd/pnet_nvd_component.c
+++ b/src/mca/pnet/nvd/pnet_nvd_component.c
@@ -65,7 +65,8 @@ pmix_pnet_nvd_component_t mca_pnet_nvd_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -373,6 +373,8 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {
     /* search the topology for OPA NICs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
+
 
     return PMIX_SUCCESS;
 }
@@ -381,6 +383,8 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
+
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -65,7 +65,8 @@ pmix_pnet_opa_component_t mca_pnet_opa_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/pnet/usnic/pnet_usnic.c
+++ b/src/mca/pnet/usnic/pnet_usnic.c
@@ -221,6 +221,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {
     /* search the topology for usnic NICs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
 
     return PMIX_SUCCESS;
 }
@@ -229,6 +230,7 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
                                        pmix_info_t directives[], size_t ndirs)
 {
     /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, info, ninfo);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/usnic/pnet_usnic_component.c
+++ b/src/mca/pnet/usnic/pnet_usnic_component.c
@@ -66,7 +66,8 @@ pmix_pnet_usnic_component_t mca_pnet_usnic_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
     .include = NULL,

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -46,14 +46,21 @@
 #include "src/mca/preg/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_preg_globals_t pmix_preg_globals = {{{0}}};
-pmix_preg_module_t pmix_preg = {.generate_node_regex = pmix_preg_base_generate_node_regex,
-                                .generate_ppn = pmix_preg_base_generate_ppn,
-                                .parse_nodes = pmix_preg_base_parse_nodes,
-                                .parse_procs = pmix_preg_base_parse_procs,
-                                .copy = pmix_preg_base_copy,
-                                .pack = pmix_preg_base_pack,
-                                .unpack = pmix_preg_base_unpack};
+pmix_preg_globals_t pmix_preg_globals = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .selected = false
+};
+
+pmix_preg_module_t pmix_preg = {
+    .generate_node_regex = pmix_preg_base_generate_node_regex,
+    .generate_ppn = pmix_preg_base_generate_ppn,
+    .parse_nodes = pmix_preg_base_parse_nodes,
+    .parse_procs = pmix_preg_base_parse_procs,
+    .copy = pmix_preg_base_copy,
+    .pack = pmix_preg_base_pack,
+    .unpack = pmix_preg_base_unpack
+};
 
 static pmix_status_t pmix_preg_close(void)
 {

--- a/src/mca/prm/base/prm_base_frame.c
+++ b/src/mca/prm/base/prm_base_frame.c
@@ -45,8 +45,16 @@
 #include "src/mca/prm/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_prm_globals_t pmix_prm_globals = {{0}};
-pmix_prm_API_module_t pmix_prm = {.notify = pmix_prm_base_notify};
+pmix_prm_globals_t pmix_prm_globals = {
+    .lock = PMIX_LOCK_STATIC_INIT,
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .selected = false
+};
+
+pmix_prm_API_module_t pmix_prm = {
+    .notify = pmix_prm_base_notify
+};
 
 static pmix_status_t pmix_prm_close(void)
 {

--- a/src/mca/prm/default/prm_default_component.c
+++ b/src/mca/prm/default/prm_default_component.c
@@ -43,7 +43,8 @@ pmix_prm_base_component_t mca_prm_default_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
     }
 };
 

--- a/src/mca/prm/slurm/prm_slurm_component.c
+++ b/src/mca/prm/slurm/prm_slurm_component.c
@@ -34,7 +34,8 @@ pmix_prm_base_component_t mca_prm_slurm_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
 };
 

--- a/src/mca/psec/base/psec_base_frame.c
+++ b/src/mca/psec/base/psec_base_frame.c
@@ -45,7 +45,11 @@
 #include "src/mca/psec/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_psec_globals_t pmix_psec_globals = {{{0}}};
+pmix_psec_globals_t pmix_psec_globals = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .selected = false
+};
 
 static pmix_status_t pmix_psec_close(void)
 {

--- a/src/mca/psec/native/psec_native_component.c
+++ b/src/mca/psec/native/psec_native_component.c
@@ -60,7 +60,8 @@ pmix_psec_base_component_t mca_psec_native_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
     .assign_module = assign_module
 };

--- a/src/mca/psec/none/psec_none.c
+++ b/src/mca/psec/none/psec_none.c
@@ -60,6 +60,8 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer, const pmix_info_t dir
                                  size_t ndirs, pmix_info_t **info, size_t *ninfo,
                                  pmix_byte_object_t *cred)
 {
+    PMIX_HIDE_UNUSED_PARAMS(peer, directives, ndirs, info, ninfo);
+
     /* ensure initialization */
     PMIX_BYTE_OBJECT_CONSTRUCT(cred);
 
@@ -75,6 +77,8 @@ static pmix_status_t validate_cred(struct pmix_peer_t *peer, const pmix_info_t d
     bool takeus;
 
     pmix_output_verbose(2, pmix_globals.debug_output, "psec: none always reports valid");
+
+    PMIX_HIDE_UNUSED_PARAMS(peer, cred);
 
     /* if we are responding to a local request to validate a credential,
      * then see if they specified a mechanism */

--- a/src/mca/psec/none/psec_none_component.c
+++ b/src/mca/psec/none/psec_none_component.c
@@ -61,7 +61,8 @@ pmix_psec_base_component_t mca_psec_none_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
     .assign_module = assign_module
 };

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -39,8 +39,16 @@
 /*
  * Global variables
  */
-pmix_psensor_base_module_t pmix_psensor = {pmix_psensor_base_start, pmix_psensor_base_stop};
-pmix_psensor_base_t pmix_psensor_base = {{{0}}};
+pmix_psensor_base_module_t pmix_psensor = {
+    .start = pmix_psensor_base_start,
+    .stop = pmix_psensor_base_stop
+};
+
+pmix_psensor_base_t pmix_psensor_base = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .evbase = NULL,
+    .selected = false
+};
 
 static bool use_separate_thread = false;
 

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -154,6 +154,8 @@ static void add_tracker(int sd, short flags, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(fd);
 
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
+
     /* add the tracker to our list */
     pmix_list_append(&mca_psensor_file_component.trackers, &ft->super);
 
@@ -171,6 +173,8 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
 {
     file_tracker_t *ft;
     size_t n;
+
+    PMIX_HIDE_UNUSED_PARAMS(error);
 
     PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking file monitoring for requestor %s:%d",
@@ -226,6 +230,8 @@ static void del_tracker(int sd, short flags, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
+
     /* remove the tracker from our list */
     PMIX_LIST_FOREACH_SAFE (ft, ftnext, &mca_psensor_file_component.trackers, file_tracker_t) {
         if (ft->requestor != cd->requestor) {
@@ -262,6 +268,8 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     file_tracker_t *ft = (file_tracker_t *) cbdata;
 
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     PMIX_RELEASE(ft);
 }
 
@@ -273,6 +281,8 @@ static void file_sample(int sd, short args, void *cbdata)
     pmix_proc_t source;
 
     PMIX_ACQUIRE_OBJECT(ft);
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sampling file %s", pmix_globals.myid.nspace,

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -146,6 +146,7 @@ static void add_tracker(int sd, short flags, void *cbdata)
     pmix_heartbeat_trkr_t *ft = (pmix_heartbeat_trkr_t *) cbdata;
 
     PMIX_ACQUIRE_OBJECT(ft);
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* add the tracker to our list */
     pmix_list_append(&mca_psensor_heartbeat_component.trackers, &ft->super);
@@ -222,6 +223,7 @@ static void del_tracker(int sd, short flags, void *cbdata)
     pmix_heartbeat_trkr_t *ft, *ftnext;
 
     PMIX_ACQUIRE_OBJECT(cd);
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* remove the tracker from our list */
     PMIX_LIST_FOREACH_SAFE (ft, ftnext, &mca_psensor_heartbeat_component.trackers,
@@ -259,6 +261,7 @@ static pmix_status_t heartbeat_stop(pmix_peer_t *requestor, char *id)
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_heartbeat_trkr_t *ft = (pmix_heartbeat_trkr_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     PMIX_RELEASE(ft); // maintain accounting
 }
@@ -274,6 +277,8 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
     pmix_proc_t source;
 
     PMIX_ACQUIRE_OBJECT(ft);
+    PMIX_HIDE_UNUSED_PARAMS(fd, dummy);
+
 
     PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sensor:check_heartbeat for proc %s:%d", pmix_globals.myid.nspace,
@@ -318,6 +323,7 @@ static void add_beat(int sd, short args, void *cbdata)
     pmix_heartbeat_trkr_t *ft;
 
     PMIX_ACQUIRE_OBJECT(b);
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* find this peer in our trackers */
     PMIX_LIST_FOREACH (ft, &mca_psensor_heartbeat_component.trackers, pmix_heartbeat_trkr_t) {
@@ -337,6 +343,8 @@ void pmix_psensor_heartbeat_recv_beats(struct pmix_peer_t *peer, pmix_ptl_hdr_t 
                                        pmix_buffer_t *buf, void *cbdata)
 {
     pmix_psensor_beat_t *b;
+
+    PMIX_HIDE_UNUSED_PARAMS(hdr, buf, cbdata);
 
     b = PMIX_NEW(pmix_psensor_beat_t);
     PMIX_RETAIN(peer);

--- a/src/mca/psquash/base/psquash_base_frame.c
+++ b/src/mca/psquash/base/psquash_base_frame.c
@@ -45,8 +45,17 @@
 
 #include "src/mca/psquash/base/static-components.h"
 
-pmix_psquash_base_module_t pmix_psquash = {0};
-pmix_psquash_globals_t pmix_psquash_globals = {0};
+pmix_psquash_base_module_t pmix_psquash = {
+    .init = NULL,
+    .finalize = NULL,
+    .get_max_size = NULL,
+    .encode_int = NULL,
+    .decode_int = NULL
+};
+pmix_psquash_globals_t pmix_psquash_globals = {
+    .initialized = false,
+    .selected = false
+};
 
 static pmix_status_t pmix_psquash_close(void)
 {

--- a/src/mca/psquash/flex128/psquash_flex128_component.c
+++ b/src/mca/psquash/flex128/psquash_flex128_component.c
@@ -43,7 +43,8 @@ pmix_psquash_base_component_t mca_psquash_flex128_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     }
 };
 

--- a/src/mca/psquash/native/psquash_native_component.c
+++ b/src/mca/psquash/native/psquash_native_component.c
@@ -46,7 +46,8 @@ pmix_psquash_base_component_t mca_psquash_native_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     }
 };
 

--- a/src/mca/pstat/base/pstat_base_open.c
+++ b/src/mca/pstat/base/pstat_base_open.c
@@ -24,6 +24,7 @@
 #include "pmix_config.h"
 
 #include "include/pmix_common.h"
+#include "src/include/pmix_globals.h"
 #include "src/mca/base/base.h"
 #include "src/mca/mca.h"
 #include "src/mca/pstat/base/base.h"
@@ -47,9 +48,11 @@ static int pmix_pstat_base_unsupported_finalize(void);
  * Globals
  */
 pmix_pstat_base_component_t *pmix_pstat_base_component = NULL;
-pmix_pstat_base_module_t pmix_pstat = {pmix_pstat_base_unsupported_init,
-                                       pmix_pstat_base_unsupported_query,
-                                       pmix_pstat_base_unsupported_finalize};
+pmix_pstat_base_module_t pmix_pstat = {
+    pmix_pstat_base_unsupported_init,
+    pmix_pstat_base_unsupported_query,
+    pmix_pstat_base_unsupported_finalize
+};
 
 /* Use default register/open/close functions */
 static int pmix_pstat_base_close(void)
@@ -79,6 +82,8 @@ static int pmix_pstat_base_unsupported_init(void)
 static int pmix_pstat_base_unsupported_query(pid_t pid, pmix_proc_stats_t *stats,
                                              pmix_node_stats_t *nstats)
 {
+    PMIX_HIDE_UNUSED_PARAMS(pid, stats, nstats);
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 

--- a/src/mca/pstat/linux/pstat_linux_component.c
+++ b/src/mca/pstat/linux/pstat_linux_component.c
@@ -69,10 +69,7 @@ const pmix_pstat_base_component_t mca_pstat_linux_component = {
 
         .pmix_mca_query_component = pstat_linux_component_query,
     },
-    .base_data = {
-        /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
-    },
+    .base_data = PMIX_BASE_DATA_STATIC_INIT
 };
 
 static int pstat_linux_component_query(pmix_mca_base_module_t **module, int *priority)

--- a/src/mca/pstat/test/pstat_test_component.c
+++ b/src/mca/pstat/test/pstat_test_component.c
@@ -76,7 +76,8 @@ const pmix_pstat_base_component_t mca_pstat_test_component = {
     /* Next the MCA v1.0.0 component meta data */
     .base_data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     }
 };
 

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -39,8 +39,16 @@
 /*
  * Global variables
  */
-pmix_pstrg_API_module_t pmix_pstrg = {pmix_pstrg_base_query};
-pmix_pstrg_base_t pmix_pstrg_base = {{{0}}};
+pmix_pstrg_API_module_t pmix_pstrg = {
+    .query = pmix_pstrg_base_query
+};
+
+pmix_pstrg_base_t pmix_pstrg_base = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .evbase = NULL,
+    .selected = false,
+    .init = false
+};
 
 static int pmix_pstrg_base_close(void)
 {

--- a/src/mca/pstrg/lustre/pstrg_lustre.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre.c
@@ -87,7 +87,8 @@ static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t 
     gid_t gid = UINT32_MAX;
 
     pmix_output_verbose(2, pmix_pstrg_base_framework.framework_output, "pstrg: lustre query");
-
+    PMIX_HIDE_UNUSED_PARAMS(results, cbfunc, cbdata);
+    
     /* just put something here so that Travis will pass its tests
      * because it treats warnings as errors, and wants to warn about
      * unused variables */

--- a/src/mca/pstrg/lustre/pstrg_lustre_component.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre_component.c
@@ -63,7 +63,8 @@ pmix_pstrg_lustre_component_t mca_pstrg_lustre_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
 };

--- a/src/mca/pstrg/vfs/pstrg_vfs.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs.c
@@ -105,6 +105,8 @@ static void vfs_finalize(void)
 static pmix_status_t query(pmix_query_t queries[], size_t nqueries, pmix_list_t *results,
                            pmix_pstrg_query_cbfunc_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(queries, nqueries, results, cbfunc, cbdata) ;
+    
 #if 0
     size_t n, m, k;
     char **sid, **mountpt;

--- a/src/mca/pstrg/vfs/pstrg_vfs_component.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs_component.c
@@ -63,7 +63,8 @@ pmix_pstrg_vfs_component_t mca_pstrg_vfs_component = {
         },
         .data = {
             /* The component is checkpoint ready */
-            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+            .reserved = {0}
         }
     },
 };

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -65,7 +65,7 @@ struct pmix_ptl_base_t {
     int stop_thread[2];
     bool listen_thread_active;
     pmix_listener_t listener;
-    struct sockaddr_storage connection;
+    struct sockaddr_storage *connection;
     uint32_t current_tag;
     size_t max_msg_size;
     char *session_tmpdir;

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -70,6 +70,9 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
 
+    // must use sd, args to avoid -Werror
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
                         "ptl:base:connection_handler: new connection: %d", pnd->sd);
 
@@ -463,6 +466,9 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(cd);
+    // must use sd, args to avoid -Werror
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     /* shortcuts */
     peer = (pmix_peer_t *) pnd->peer;
     nptr = peer->nptr;

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -221,6 +221,8 @@ pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo)
 
 pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env)
 {
+    PMIX_HIDE_UNUSED_PARAMS(proc);
+
     pmix_setenv("PMIX_SERVER_TMPDIR", pmix_ptl_base.session_tmpdir, true, env);
     pmix_setenv("PMIX_SYSTEM_TMPDIR", pmix_ptl_base.system_tmpdir, true, env);
 
@@ -954,6 +956,7 @@ pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct timeval *save,
 
 void pmix_ptl_base_setup_socket(pmix_peer_t *peer)
 {
+    PMIX_HIDE_UNUSED_PARAMS(peer);
 #if defined(TCP_NODELAY)
     int optval;
     optval = 1;
@@ -1347,6 +1350,8 @@ void pmix_ptl_base_query_servers(int sd, short args, void *cbdata)
     pmix_infolist_t *iptr;
     pmix_status_t rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     PMIX_CONSTRUCT(&servers, pmix_list_t);
 
     query_servers(NULL, &servers);
@@ -1373,6 +1378,8 @@ void pmix_ptl_base_query_servers(int sd, short args, void *cbdata)
 static void timeout(int sd, short args, void *cbdata)
 {
     pmix_lock_t *lock = (pmix_lock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     PMIX_WAKEUP_THREAD(lock);
 }
 

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -64,9 +64,62 @@
 #define PMIX_MAX_MSG_SIZE 16
 
 /* Instantiate the global vars */
-pmix_ptl_base_t pmix_ptl_base = {0};
+pmix_ptl_base_t pmix_ptl_base = {
+    .initialized = false,
+    .selected = false,
+    .posted_recvs = PMIX_LIST_STATIC_INIT,
+    .unexpected_msgs = PMIX_LIST_STATIC_INIT,
+    .stop_thread = {0, 0},
+    .listen_thread_active = false,
+    .listener = PMIX_LISTENER_STATIC_INIT,
+    .connection = NULL,
+    .current_tag = 0,
+    .max_msg_size = 0,
+    .session_tmpdir = NULL,
+    .system_tmpdir = NULL,
+    .report_uri = NULL,
+    .uri = NULL,
+    .urifile = NULL,
+    .system_filename = NULL,
+    .session_filename = NULL,
+    .nspace_filename = NULL,
+    .pid_filename = NULL,
+    .rendezvous_filename = NULL,
+    .created_rendezvous_file = false,
+    .created_session_tmpdir = false,
+    .created_system_tmpdir = false,
+    .created_system_filename = false,
+    .created_session_filename = false,
+    .created_nspace_filename = false,
+    .created_pid_filename = false,
+    .created_urifile = false,
+    .remote_connections = false,
+    .system_tool = false,
+    .session_tool = false,
+    .tool_support = false,
+    .if_include = NULL,
+    .if_exclude = NULL,
+    .ipv4_port = 0,
+    .disable_ipv4_family = false,
+    .ipv6_port = 0,
+    .disable_ipv6_family = true,
+    .max_retries = 0,
+    .wait_to_connect = 0,
+    .handshake_wait_time = 0,
+    .handshake_max_retries = 0
+};
 int pmix_ptl_base_output = -1;
-pmix_ptl_module_t pmix_ptl = {0};
+pmix_ptl_module_t pmix_ptl = {
+    .name = NULL,
+    .init = NULL,
+    .finalize = NULL,
+    .recv = NULL,
+    .cancel = NULL,
+    .connect_to_peer = NULL,
+    .query_servers = NULL,
+    .setup_listener = NULL,
+    .setup_fork = NULL
+};
 
 static size_t max_msg_size = PMIX_MAX_MSG_SIZE;
 
@@ -202,7 +255,9 @@ static pmix_status_t pmix_ptl_close(void)
             pmix_client_globals.myserver->sd = -1;
         }
     }
-
+    if (NULL != pmix_ptl_base.connection) {
+        free(pmix_ptl_base.connection);
+    }
     /* the component will cleanup when closed */
     PMIX_LIST_DESTRUCT(&pmix_ptl_base.posted_recvs);
     PMIX_LIST_DESTRUCT(&pmix_ptl_base.unexpected_msgs);
@@ -308,6 +363,11 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     pmix_ptl_base.listen_thread_active = false;
     PMIX_CONSTRUCT(&pmix_ptl_base.listener, pmix_listener_t);
     pmix_ptl_base.current_tag = PMIX_PTL_TAG_DYNAMIC;
+    pmix_ptl_base.connection = (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
+    if (NULL == pmix_ptl_base.connection) {
+        return PMIX_ERR_NOMEM;
+    }
+    memset(pmix_ptl_base.connection, 0, sizeof(struct sockaddr_storage));
 
     /* check for environ-based directives
      * on system tmpdir to use */

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -436,7 +436,7 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
 
     /* save the connection */
     if (PMIX_SUCCESS
-        != pmix_ifindextoaddr(saveindex, (struct sockaddr *) &pmix_ptl_base.connection,
+        != pmix_ifindextoaddr(saveindex, (struct sockaddr *) pmix_ptl_base.connection,
                               sizeof(struct sockaddr))) {
         pmix_output(0, "ptl:base: problems getting address for kernel index %i\n",
                     pmix_ifindextokindex(saveindex));
@@ -444,15 +444,15 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     }
 
     /* set the port */
-    if (AF_INET == pmix_ptl_base.connection.ss_family) {
-        ((struct sockaddr_in *) &pmix_ptl_base.connection)->sin_port = htons(
+    if (AF_INET == pmix_ptl_base.connection->ss_family) {
+        ((struct sockaddr_in *) pmix_ptl_base.connection)->sin_port = htons(
             pmix_ptl_base.ipv4_port);
         addrlen = sizeof(struct sockaddr_in);
         if (0 != pmix_ptl_base.ipv4_port) {
             flags = 1;
         }
-    } else if (AF_INET6 == pmix_ptl_base.connection.ss_family) {
-        ((struct sockaddr_in6 *) &pmix_ptl_base.connection)->sin6_port = htons(
+    } else if (AF_INET6 == pmix_ptl_base.connection->ss_family) {
+        ((struct sockaddr_in6 *) pmix_ptl_base.connection)->sin6_port = htons(
             pmix_ptl_base.ipv6_port);
         addrlen = sizeof(struct sockaddr_in6);
         if (0 != pmix_ptl_base.ipv6_port) {
@@ -471,7 +471,7 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
     lt->cbfunc = pmix_ptl_base_connection_handler;
 
     /* create a listen socket for incoming connection attempts */
-    lt->socket = socket(pmix_ptl_base.connection.ss_family, SOCK_STREAM, 0);
+    lt->socket = socket(pmix_ptl_base.connection->ss_family, SOCK_STREAM, 0);
     if (lt->socket < 0) {
         printf("%s:%d socket() failed\n", __FILE__, __LINE__);
         goto sockerror;
@@ -493,14 +493,14 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         goto sockerror;
     }
 
-    if (bind(lt->socket, (struct sockaddr *) &pmix_ptl_base.connection, addrlen) < 0) {
+    if (bind(lt->socket, (struct sockaddr *) pmix_ptl_base.connection, addrlen) < 0) {
         printf("[%u] %s:%d bind() failed for socket %d storage size %u: %s\n", (unsigned) getpid(),
                __FILE__, __LINE__, lt->socket, (unsigned) addrlen, strerror(errno));
         goto sockerror;
     }
 
     /* resolve assigned port */
-    if (getsockname(lt->socket, (struct sockaddr *) &pmix_ptl_base.connection, &addrlen) < 0) {
+    if (getsockname(lt->socket, (struct sockaddr *) pmix_ptl_base.connection, &addrlen) < 0) {
         pmix_output(0, "ptl:tool:create_listen: getsockname(): %s (%d)",
                     strerror(pmix_socket_errno), pmix_socket_errno);
         goto sockerror;
@@ -523,15 +523,15 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
         goto sockerror;
     }
 
-    if (AF_INET == pmix_ptl_base.connection.ss_family) {
+    if (AF_INET == pmix_ptl_base.connection->ss_family) {
         prefix = "tcp4://";
-        myport = ntohs(((struct sockaddr_in *) &pmix_ptl_base.connection)->sin_port);
-        inet_ntop(AF_INET, &((struct sockaddr_in *) &pmix_ptl_base.connection)->sin_addr,
+        myport = ntohs(((struct sockaddr_in *) pmix_ptl_base.connection)->sin_port);
+        inet_ntop(AF_INET, &((struct sockaddr_in *) pmix_ptl_base.connection)->sin_addr,
                   myconnhost, PMIX_MAXHOSTNAMELEN - 1);
-    } else if (AF_INET6 == pmix_ptl_base.connection.ss_family) {
+    } else if (AF_INET6 == pmix_ptl_base.connection->ss_family) {
         prefix = "tcp6://";
-        myport = ntohs(((struct sockaddr_in6 *) &pmix_ptl_base.connection)->sin6_port);
-        inet_ntop(AF_INET6, &((struct sockaddr_in6 *) &pmix_ptl_base.connection)->sin6_addr,
+        myport = ntohs(((struct sockaddr_in6 *) pmix_ptl_base.connection)->sin6_port);
+        inet_ntop(AF_INET6, &((struct sockaddr_in6 *) pmix_ptl_base.connection)->sin6_addr,
                   myconnhost, PMIX_MAXHOSTNAMELEN - 1);
     } else {
         goto sockerror;

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -331,6 +331,20 @@ typedef struct pmix_listener_t {
 } pmix_listener_t;
 PMIX_CLASS_DECLARATION(pmix_listener_t);
 
+#define PMIX_LISTENER_STATIC_INIT           \
+{                                           \
+    .super = PMIX_LIST_ITEM_STATIC_INIT,    \
+    .protocol = PMIX_PROTOCOL_UNDEF,        \
+    .socket = 0,                            \
+    .varname = NULL,                        \
+    .uri = NULL,                            \
+    .owner = 0,                             \
+    .owner_given = false,                   \
+    .group = 0,                             \
+    .mode = 0,                              \
+    .cbfunc = NULL                          \
+}
+
 /* provide a backdoor to the framework output for debugging */
 PMIX_EXPORT extern int pmix_ptl_base_output;
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -92,6 +92,8 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {.init_cntr = 0,
 static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel, int room_num, void *occupant)
 {
     pmix_notify_caddy_t *cache = (pmix_notify_caddy_t *) occupant;
+    PMIX_HIDE_UNUSED_PARAMS(hotel, room_num);
+
     PMIX_RELEASE(cache);
 }
 

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -208,9 +208,10 @@ void pmix_event_base_loopexit(pmix_event_base_t *ev_base)
  * If this event is fired, just restart it so that this event base
  * continues to have something to block on.
  */
-static void dummy_timeout_cb(int fd, short args, void *cbdata)
+static void dummy_timeout_cb(int sd, short args, void *cbdata)
 {
     pmix_progress_tracker_t *trk = (pmix_progress_tracker_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_event_add(&trk->block, &long_timeout);
 }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -922,7 +922,7 @@ cleanup:
 }
 
 /* process the returned data from the host RM server */
-static void _process_dmdx_reply(int fd, short args, void *cbdata)
+static void _process_dmdx_reply(int sd, short args, void *cbdata)
 {
     pmix_dmdx_reply_caddy_t *caddy = (pmix_dmdx_reply_caddy_t *) cbdata;
     pmix_server_caddy_t *cd;
@@ -940,6 +940,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
     pmix_cb_t cb;
 
     PMIX_ACQUIRE_OBJECT(caddy);
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.get_output, "[%s:%d] process dmdx reply from %s:%u",
                         __FILE__, __LINE__, caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
@@ -1127,6 +1128,7 @@ static void dmdx_cbfunc(pmix_status_t status, const char *data, size_t ndata, vo
 static void get_timeout(int sd, short args, void *cbdata)
 {
     pmix_dmdx_request_t *req = (pmix_dmdx_request_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.get_output, "ALERT: get timeout fired");
     /* execute the provided callback function with the error */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -83,7 +83,36 @@ static void bufdes(rank_blob_t *p)
 }
 static PMIX_CLASS_INSTANCE(rank_blob_t, pmix_list_item_t, NULL, bufdes);
 
-pmix_server_module_t pmix_host_server = {0};
+pmix_server_module_t pmix_host_server = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .listener = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .get_credential = NULL,
+    .validate_credential = NULL,
+    .iof_pull = NULL,
+    .push_stdin = NULL,
+    .group = NULL,
+    .fabric = NULL,
+    .client_connected2 = NULL
+};
 
 pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
                                 void *cbdata)
@@ -571,6 +600,7 @@ static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t npro
 static void fence_timeout(int sd, short args, void *cbdata)
 {
     pmix_server_trkr_t *trk = (pmix_server_trkr_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.fence_output, "ALERT: fence timeout fired");
 
@@ -1831,6 +1861,7 @@ cleanup:
 static void connect_timeout(int sd, short args, void *cbdata)
 {
     pmix_server_trkr_t *trk = (pmix_server_trkr_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.connect_output, "ALERT: connect timeout fired");
 
@@ -2027,6 +2058,8 @@ static void _check_cached_events(int sd, short args, void *cbdata)
     pmix_buffer_t *relay;
     pmix_status_t ret = PMIX_SUCCESS;
     pmix_cmd_t cmd = PMIX_NOTIFY_CMD;
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* check if any matching notifications have been cached */
     rngtrk.procs = NULL;
@@ -3796,6 +3829,7 @@ static void grp_timeout(int sd, short args, void *cbdata)
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
     pmix_buffer_t *reply;
     pmix_status_t ret, rc = PMIX_ERR_TIMEOUT;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.fence_output, "ALERT: grp construct timeout fired");
 
@@ -3826,7 +3860,7 @@ error:
     PMIX_RELEASE(cd);
 }
 
-static void _grpcbfunc(int sd, short argc, void *cbdata)
+static void _grpcbfunc(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *scd = (pmix_shift_caddy_t *) cbdata;
     pmix_server_trkr_t *trk = scd->tracker;
@@ -3841,6 +3875,7 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
     bool found;
 
     PMIX_ACQUIRE_OBJECT(scd);
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (NULL == trk) {
         /* give them a release if they want it - this should
@@ -4479,6 +4514,7 @@ error:
 static void _fabric_response(int sd, short args, void *cbdata)
 {
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     qcd->cbfunc(PMIX_SUCCESS, qcd->info, qcd->ninfo, qcd->cbdata, NULL, NULL);
     PMIX_RELEASE(qcd);

--- a/src/threads/threads.h
+++ b/src/threads/threads.h
@@ -71,6 +71,14 @@ typedef struct {
     volatile bool active;
 } pmix_lock_t;
 
+#define PMIX_LOCK_STATIC_INIT               \
+    {                                       \
+        .status = PMIX_SUCCESS,             \
+        .mutex = PMIX_MUTEX_STATIC_INIT,    \
+        .cond = PMIX_CONDITION_STATIC_INIT, \
+        .active = false                     \
+    }
+
 #define PMIX_CONSTRUCT_LOCK(l)                     \
     do {                                           \
         PMIX_CONSTRUCT(&(l)->mutex, pmix_mutex_t); \

--- a/src/tool/pmix_tool_ops.c
+++ b/src/tool/pmix_tool_ops.c
@@ -107,13 +107,14 @@ pmix_status_t pmix_tool_relay_op(pmix_cmd_t cmd, pmix_peer_t *peer, pmix_buffer_
     return PMIX_SUCCESS;
 }
 
-static void tool_switchyard(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                            void *cbdata)
+static void tool_switchyard(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
+                            pmix_buffer_t *buf, void *cbdata)
 {
     pmix_shift_caddy_t *s = (pmix_shift_caddy_t *) cbdata;
     pmix_buffer_t *relay;
     pmix_status_t rc;
     uint32_t tag = (uint32_t) s->ncodes;
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     /* the tag for the original sender was stored in ncodes, and
      * the server would have packed the buffer using my

--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -108,6 +108,8 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             pmix_info_t results[], size_t nresults,
                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status,
+                            source, info, ninfo, results, nresults);
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -154,58 +156,75 @@ typedef struct {
     bool hostfns;
 } pmix_pattrs_globals_t;
 
-pmix_pattrs_globals_t pmix_pattrs_globals = {0};
+pmix_pattrs_globals_t pmix_pattrs_globals = {
+    .help = false,
+    .verbose = false,
+    .pid = 0,
+    .nspace = NULL,
+    .uri = NULL,
+    .sysfirst = false,
+    .system = false,
+    .client = NULL,
+    .server = NULL,
+    .tool = NULL,
+    .host = NULL,
+    .clientfns = false,
+    .serverfns = false,
+    .toolfns = false,
+    .hostfns = false
+};
 
 pmix_cmd_line_init_t cmd_line_opts[] = {
     {NULL, 'h', NULL, "help", 0, &pmix_pattrs_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
-     "This help message"},
+     "This help message", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 'v', NULL, "verbose", 0, &pmix_pattrs_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
-     "Be Verbose"},
+     "Be Verbose", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 'p', NULL, "pid", 1, &pmix_pattrs_globals.pid, PMIX_CMD_LINE_TYPE_INT,
-     "Specify server pid to connect to"},
+     "Specify server pid to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 'n', NULL, "nspace", 1, &pmix_pattrs_globals.nspace, PMIX_CMD_LINE_TYPE_STRING,
-     "Specify server nspace to connect to"},
+     "Specify server nspace to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "uri", 1, &pmix_pattrs_globals.uri, PMIX_CMD_LINE_TYPE_STRING,
-     "Specify URI of server to connect to"},
+     "Specify URI of server to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "system-server-first", 0, &pmix_pattrs_globals.sysfirst,
-     PMIX_CMD_LINE_TYPE_BOOL, "Look for the system server first"},
+     PMIX_CMD_LINE_TYPE_BOOL, "Look for the system server first", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "system-server", 0, &pmix_pattrs_globals.system, PMIX_CMD_LINE_TYPE_BOOL,
-     "Specifically connect to the system server"},
+     "Specifically connect to the system server", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 'c', NULL, "client", 1, &pmix_pattrs_globals.client, PMIX_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of client function whose attributes are to be printed (function or "
-     "all)"},
+     "all)", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 's', NULL, "server", 1, &pmix_pattrs_globals.server, PMIX_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of server function whose attributes are to be printed (function or "
-     "all)"},
+     "all)", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 't', NULL, "tool", 1, &pmix_pattrs_globals.tool, PMIX_CMD_LINE_TYPE_STRING,
-     "Comma-delimited list of tool function whose attributes are to be printed (function or all)"},
+     "Comma-delimited list of tool function whose attributes are to be printed (function or all)", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, 'h', NULL, "host", 1, &pmix_pattrs_globals.host, PMIX_CMD_LINE_TYPE_STRING,
-     "Comma-delimited list of host function whose attributes are to be printed (function or all)"},
+     "Comma-delimited list of host function whose attributes are to be printed (function or all)", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "client-fns", 0, &pmix_pattrs_globals.clientfns, PMIX_CMD_LINE_TYPE_BOOL,
-     "List the functions supported in this client library"},
+     "List the functions supported in this client library", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "server-fns", 0, &pmix_pattrs_globals.serverfns, PMIX_CMD_LINE_TYPE_BOOL,
-     "List the functions supported in this server library"},
+     "List the functions supported in this server library", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "tool-fns", 0, &pmix_pattrs_globals.toolfns, PMIX_CMD_LINE_TYPE_BOOL,
-     "List the functions supported in this tool library"},
+     "List the functions supported in this tool library", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     {NULL, '\0', NULL, "host-fns", 0, &pmix_pattrs_globals.hostfns, PMIX_CMD_LINE_TYPE_BOOL,
-     "List the functions supported by this host environment"},
+     "List the functions supported by this host environment", PMIX_CMD_LINE_OTYPE_GENERAL},
 
     /* End of list */
-    {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL}};
+    {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL, PMIX_CMD_LINE_OTYPE_GENERAL}
+};
 
 int main(int argc, char **argv)
 {

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -58,6 +58,9 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             pmix_info_t results[], size_t nresults,
                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status,
+                            source, info, ninfo, results, nresults);
+
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -74,6 +77,7 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
 {
     mylock_t *lock = (mylock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref);
 
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
@@ -94,28 +98,34 @@ typedef struct {
     int range;
 } pmix_pevent_globals_t;
 
-pmix_pevent_globals_t pmix_pevent_globals = {0};
+pmix_pevent_globals_t pmix_pevent_globals = {
+    .help = false,
+    .verbose = false,
+    .pid = 0,
+    .code = 0,
+    .range = 0
+};
 
 pmix_cmd_line_init_t cmd_line_opts[] = {{NULL, 'h', NULL, "help", 0, &pmix_pevent_globals.help,
-                                         PMIX_CMD_LINE_TYPE_BOOL, "This help message"},
+                                         PMIX_CMD_LINE_TYPE_BOOL, "This help message", PMIX_CMD_LINE_OTYPE_GENERAL},
 
                                         {NULL, 'v', NULL, "verbose", 0,
                                          &pmix_pevent_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
-                                         "Be Verbose"},
+                                         "Be Verbose", PMIX_CMD_LINE_OTYPE_GENERAL},
 
                                         {NULL, 'p', NULL, "pid", 1, &pmix_pevent_globals.pid,
-                                         PMIX_CMD_LINE_TYPE_INT, "Specify launcher pid"},
+                                         PMIX_CMD_LINE_TYPE_INT, "Specify launcher pid", PMIX_CMD_LINE_OTYPE_GENERAL},
 
                                         {NULL, 'e', NULL, "event", 0, &pmix_pevent_globals.code,
                                          PMIX_CMD_LINE_TYPE_INT,
-                                         "Status code (integer value) of event to be sent"},
+                                         "Status code (integer value) of event to be sent", PMIX_CMD_LINE_OTYPE_GENERAL},
 
                                         {NULL, 'r', NULL, "range", 0, &pmix_pevent_globals.range,
-                                         PMIX_CMD_LINE_TYPE_INT, "Range of event to be sent"},
+                                         PMIX_CMD_LINE_TYPE_INT, "Range of event to be sent", PMIX_CMD_LINE_OTYPE_GENERAL},
 
                                         /* End of list */
                                         {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL,
-                                         NULL}};
+                                         NULL, PMIX_CMD_LINE_OTYPE_GENERAL}};
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -56,6 +56,9 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             pmix_info_t results[], size_t nresults,
                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo,
+                            results, nresults);
+
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -72,6 +75,7 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
 {
     mylock_t *lock = (mylock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref);
 
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
@@ -92,26 +96,33 @@ typedef struct {
     int timeout;
 } pmix_plookup_globals_t;
 
-pmix_plookup_globals_t pmix_plookup_globals = {0};
+pmix_plookup_globals_t pmix_plookup_globals = {
+    .help = false,
+    .verbose = false,
+    .pid = 0,
+    .wait = false,
+    .timeout = 0
+};
 
 pmix_cmd_line_init_t cmd_line_opts[]
     = {{NULL, 'h', NULL, "help", 0, &pmix_plookup_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
-        "This help message"},
+        "This help message", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'v', NULL, "verbose", 0, &pmix_plookup_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
-        "Be Verbose"},
+        "Be Verbose", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'p', NULL, "pid", 1, &pmix_plookup_globals.pid, PMIX_CMD_LINE_TYPE_INT,
-        "Specify launcher pid"},
+        "Specify launcher pid", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'w', NULL, "wait", 0, &pmix_plookup_globals.wait, PMIX_CMD_LINE_TYPE_BOOL,
-        "Wait for data to be available"},
+        "Wait for data to be available", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 't', NULL, "timeout", 0, &pmix_plookup_globals.timeout, PMIX_CMD_LINE_TYPE_INT,
-        "Max number of seconds to wait for data to become available"},
+        "Max number of seconds to wait for data to become available", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        /* End of list */
-       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL}};
+       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL, PMIX_CMD_LINE_OTYPE_GENERAL}
+    };
 
 int main(int argc, char **argv)
 {

--- a/src/tools/pmix_info/pmix_info.c
+++ b/src/tools/pmix_info/pmix_info.c
@@ -61,8 +61,8 @@
  */
 
 pmix_cmd_line_t *pmix_info_cmd_line = NULL;
-pmix_pointer_array_t pmix_component_map = {{0}};
-pmix_pointer_array_t mca_types = {{0}};
+pmix_pointer_array_t pmix_component_map = PMIX_POINTER_ARRAY_STATIC_INIT;
+pmix_pointer_array_t mca_types = PMIX_POINTER_ARRAY_STATIC_INIT;
 
 const char *pmix_info_type_base = "base";
 

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -116,26 +116,33 @@ typedef struct {
     pid_t pid;
 } pmix_ps_globals_t;
 
-pmix_ps_globals_t pmix_ps_globals = {0};
+pmix_ps_globals_t pmix_ps_globals = {
+    .help = false,
+    .parseable = false,
+    .nodes = false,
+    .nspace = NULL,
+    .pid = 0
+};
 
 pmix_cmd_line_init_t cmd_line_opts[]
     = {{NULL, 'h', NULL, "help", 0, &pmix_ps_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
-        "This help message"},
+        "This help message", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, '\0', NULL, "parseable", 0, &pmix_ps_globals.parseable, PMIX_CMD_LINE_TYPE_BOOL,
-        "Provide parseable output"},
+        "Provide parseable output", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, '\0', NULL, "nspace", 0, &pmix_ps_globals.nspace, PMIX_CMD_LINE_TYPE_STRING,
-        "Nspace of job whose status is being requested"},
+        "Nspace of job whose status is being requested", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'p', NULL, "pid", 1, &pmix_ps_globals.pid, PMIX_CMD_LINE_TYPE_INT,
-        "Specify pid of launcher to be contacted (default is to system server"},
+        "Specify pid of launcher to be contacted (default is to system server", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'n', NULL, "nodes", 0, &pmix_ps_globals.nodes, PMIX_CMD_LINE_TYPE_BOOL,
-        "Display Node Information"},
+        "Display Node Information", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        /* End of list */
-       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL}};
+       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL, PMIX_CMD_LINE_OTYPE_GENERAL}
+    };
 
 /* this is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
@@ -154,6 +161,7 @@ static void querycbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
 {
     myquery_data_t *mq = (myquery_data_t *) cbdata;
     size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     /* save the returned info - the PMIx library "owns" it
      * and will release it and perform other cleanup actions
@@ -185,6 +193,9 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             pmix_info_t results[], size_t nresults,
                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo,
+                            results, nresults);
+
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -110,6 +110,9 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             pmix_info_t results[], size_t nresults,
                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status,
+                            source, info, ninfo, results, nresults);
+
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -156,32 +159,49 @@ typedef struct {
     bool hostfns;
 } pmix_pquery_globals_t;
 
-pmix_pquery_globals_t pmix_pquery_globals = {0};
+pmix_pquery_globals_t pmix_pquery_globals = {
+    .help = false,
+    .verbose = false,
+    .pid = 0,
+    .nspace = NULL,
+    .uri = NULL,
+    .sysfirst = false,
+    .system = false,
+    .client = NULL,
+    .server = NULL,
+    .tool = NULL,
+    .host = NULL,
+    .clientfns = false,
+    .serverfns = false,
+    .toolfns = false,
+    .hostfns = false
+};
 
 pmix_cmd_line_init_t cmd_line_opts[]
     = {{NULL, 'h', NULL, "help", 0, &pmix_pquery_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
-        "This help message"},
+        "This help message", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'v', NULL, "verbose", 0, &pmix_pquery_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
-        "Be Verbose"},
+        "Be Verbose", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'p', NULL, "pid", 1, &pmix_pquery_globals.pid, PMIX_CMD_LINE_TYPE_INT,
-        "Specify server pid to connect to"},
+        "Specify server pid to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, 'n', NULL, "nspace", 1, &pmix_pquery_globals.nspace, PMIX_CMD_LINE_TYPE_STRING,
-        "Specify server nspace to connect to"},
+        "Specify server nspace to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, '\0', NULL, "uri", 1, &pmix_pquery_globals.uri, PMIX_CMD_LINE_TYPE_STRING,
-        "Specify URI of server to connect to"},
+        "Specify URI of server to connect to", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, '\0', NULL, "system-server-first", 0, &pmix_pquery_globals.sysfirst,
-        PMIX_CMD_LINE_TYPE_BOOL, "Look for the system server first"},
+        PMIX_CMD_LINE_TYPE_BOOL, "Look for the system server first", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        {NULL, '\0', NULL, "system-server", 0, &pmix_pquery_globals.system, PMIX_CMD_LINE_TYPE_BOOL,
-        "Specifically connect to the system server"},
+        "Specifically connect to the system server", PMIX_CMD_LINE_OTYPE_GENERAL},
 
        /* End of list */
-       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL}};
+       {NULL, '\0', NULL, NULL, 0, NULL, PMIX_CMD_LINE_TYPE_NULL, NULL, PMIX_CMD_LINE_OTYPE_GENERAL}
+    };
 
 int main(int argc, char **argv)
 {
@@ -190,7 +210,12 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_cmd_line_t cmd_line;
     size_t n, m, k, nqueries, ninfo, ndarray;
-    myquery_data_t mq = {{0}};
+    myquery_data_t mq = {
+        .lock = PMIX_LOCK_STATIC_INIT,
+        .status = 0,
+        .info = NULL,
+        .ninfo = 0
+    };
     int count;
     char **qkeys = NULL;
     const char *attr;

--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -976,7 +976,7 @@ static int make_opt(pmix_cmd_line_t *cmd, pmix_cmd_line_init_t *e)
         (void) pmix_mca_base_var_env_name(e->ocl_mca_param_name, &option->clo_mca_param_env_var);
     }
 
-    option->clo_otype = e->ocl_otype;
+    option->clo_otype = PMIX_CMD_LINE_OTYPE_GENERAL;
 
     /* Append the item, serializing thread access */
 

--- a/src/util/keyval/Makefile.am
+++ b/src/util/keyval/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,6 +20,9 @@
 
 
 AM_LFLAGS = -Ppmix_util_keyval_yy
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
+
 LEX_OUTPUT_ROOT = lex.pmix_util_keyval_yy
 
 noinst_LTLIBRARIES = libpmixutilkeyval.la

--- a/src/util/path.c
+++ b/src/util/path.c
@@ -70,6 +70,7 @@
 #    define MOUNTED_FILE "/etc/mtab"
 #endif
 
+#include "src/include/pmix_globals.h"
 #include "src/include/pmix_stdint.h"
 #include "src/util/argv.h"
 #include "src/util/os_path.h"
@@ -415,6 +416,7 @@ char *pmix_find_absolute_path(char *app_name)
 
 static char *pmix_check_mtab(char *dev_path)
 {
+    PMIX_HIDE_UNUSED_PARAMS(dev_path);
 
 #ifdef HAVE_MNTENT_H
     FILE *mtab = NULL;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,8 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
         test_replace.h test_internal.h test_server.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 noinst_SCRIPTS = pmix_client_otheruser.sh \
 	run_tests00.pl \

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -1,11 +1,14 @@
 #
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 noinst_SCRIPTS = \
 	run_server.sh.in \

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -21,6 +21,8 @@
 #
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 headers = simptest.h
 

--- a/test/sshot/Makefile.am
+++ b/test/sshot/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,8 @@
 #
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix $(pmix_check_jansson_CPPFLAGS)
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 if HAVE_JANSSON
 noinst_PROGRAMS = generate server daemon testcoord

--- a/test/test_v2/Makefile.am
+++ b/test/test_v2/Makefile.am
@@ -27,6 +27,8 @@
 headers = cli_stages.h server_callbacks.h test_common.h test_server.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 # Can be added in for purposes of debugging on platforms building with gcc (gcc-specific flags)
 #AM_CFLAGS = -fno-omit-frame-pointer -g -Wfatal-errors #-Wall -Wextra -Wpedantic -Wconversion -Wshadow


### PR DESCRIPTION
The picky compiler options have been turned "off" for
some time due to lots of warnings being converted to
errors. Do the cleanup necessary to re-enable those
options.

Signed-off-by: Ralph Castain <rhc@pmix.org>