### PR TITLE
Add -Wno-deprecated-declarations

### DIFF
--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -434,6 +434,7 @@ AC_DEFUN([PMIX_SETUP_PICKY_COMPILERS],[
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror, Werror)
 #        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=address, fsanitize=address)
 #        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=undefined, fsanitize=undefined)
+        _PMIX_CHECK_SPECIFIC_CFLAGS(-Wno-deprecated-declarations, Wno_deprecated_declarations)
     fi
 
 ])


### PR DESCRIPTION
See if we can get past Clang 10's warning of
deprecating a std include file

Signed-off-by: Ralph Castain <rhc@pmix.org>