### PR TITLE
Silence Flex warnings from show_help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,8 +111,8 @@ src/tools/wrapper/pmixcc-wrapper-data.txt
 src/tools/wrapper/pmixcc
 
 
-src/util/show_help_lex.c
 src/util/keyval/keyval_lex.c
+src/util/showhelp/showhelp_lex.c
 
 test/pmi2_client
 test/pmi_client

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -990,6 +990,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/Makefile]
         pmix_config_prefix[src/include/Makefile]
         pmix_config_prefix[src/util/keyval/Makefile]
+        pmix_config_prefix[src/util/showhelp/Makefile]
         pmix_config_prefix[src/mca/base/Makefile]
         pmix_config_prefix[src/tools/pevent/Makefile]
         pmix_config_prefix[src/tools/pmix_info/Makefile]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@
 SUBDIRS = \
     include \
     util/keyval \
+    util/showhelp \
     mca/base \
     $(MCA_pmix_FRAMEWORKS_SUBDIRS) \
     $(MCA_pmix_FRAMEWORK_COMPONENT_STATIC_SUBDIRS) \
@@ -34,6 +35,7 @@ SUBDIRS = \
 DIST_SUBDIRS = \
     include \
     util/keyval \
+    util/showhelp \
     mca/base \
     $(MCA_pmix_FRAMEWORKS_SUBDIRS) \
     $(MCA_pmix_FRAMEWORK_COMPONENT_ALL_SUBDIRS)

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -23,9 +23,6 @@
 # $HEADER$
 #
 
-AM_LFLAGS = -Ppmix_show_help_yy
-LEX_OUTPUT_ROOT = lex.pmix_show_help_yy
-
 # Source code files
 
 headers += \
@@ -44,7 +41,6 @@ headers += \
         util/basename.h \
         util/keyval_parse.h \
         util/show_help.h \
-        util/show_help_lex.h \
         util/path.h \
         util/getid.h \
         util/strnlen.h \
@@ -75,7 +71,6 @@ sources += \
         util/basename.c \
         util/keyval_parse.c \
         util/show_help.c \
-        util/show_help_lex.l \
         util/path.c \
         util/getid.c \
         util/hash.c \
@@ -90,6 +85,8 @@ sources += \
         util/pmix_getcwd.c
 
 libpmix_la_LIBADD += \
-        util/keyval/libpmixutilkeyval.la
+        util/keyval/libpmixutilkeyval.la \
+        util/showhelp/libpmixutilshowhelp.la
 libpmix_la_DEPENDENCIES += \
-        util/keyval/libpmixutilkeyval.la
+        util/keyval/libpmixutilkeyval.la \
+        util/showhelp/libpmixutilshowhelp.la

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -35,7 +35,7 @@
 #include "src/util/output.h"
 #include "src/util/printf.h"
 #include "src/util/show_help.h"
-#include "src/util/show_help_lex.h"
+#include "src/util/showhelp/showhelp_lex.h"
 
 /*
  * Private variables
@@ -149,8 +149,8 @@ static int open_file(const char *base, const char *topic)
          */
         for (i = 0; NULL != search_dirs[i]; i++) {
             filename = pmix_os_path(false, search_dirs[i], base, NULL);
-            pmix_show_help_yyin = fopen(filename, "r");
-            if (NULL == pmix_show_help_yyin) {
+            pmix_showhelp_yyin = fopen(filename, "r");
+            if (NULL == pmix_showhelp_yyin) {
                 if (0 > asprintf(&err_msg, "%s: %s", filename, strerror(errno))) {
                     return PMIX_ERR_OUT_OF_RESOURCE;
                 }
@@ -161,18 +161,18 @@ static int open_file(const char *base, const char *topic)
                         > asprintf(&filename, "%s%s%s.txt", search_dirs[i], PMIX_PATH_SEP, base)) {
                         return PMIX_ERR_OUT_OF_RESOURCE;
                     }
-                    pmix_show_help_yyin = fopen(filename, "r");
+                    pmix_showhelp_yyin = fopen(filename, "r");
                 }
             }
             free(filename);
-            if (NULL != pmix_show_help_yyin) {
+            if (NULL != pmix_showhelp_yyin) {
                 break;
             }
         }
     }
 
     /* If we still couldn't open it, then something is wrong */
-    if (NULL == pmix_show_help_yyin) {
+    if (NULL == pmix_showhelp_yyin) {
         pmix_output(output_stream,
                     "%sSorry!  You were supposed to get help about:\n    %s\nBut I couldn't open "
                     "the help file:\n    %s.  Sorry!\n%s",
@@ -187,7 +187,7 @@ static int open_file(const char *base, const char *topic)
 
     /* Set the buffer */
 
-    pmix_show_help_init_buffer(pmix_show_help_yyin);
+    pmix_showhelp_init_buffer(pmix_showhelp_yyin);
 
     /* Happiness */
 
@@ -206,10 +206,10 @@ static int find_topic(const char *base, const char *topic)
     /* Examine every topic */
 
     while (1) {
-        token = pmix_show_help_yylex();
+        token = pmix_showhelp_yylex();
         switch (token) {
         case PMIX_SHOW_HELP_PARSE_TOPIC:
-            tmp = strdup(pmix_show_help_yytext);
+            tmp = strdup(pmix_showhelp_yytext);
             if (NULL == tmp) {
                 return PMIX_ERR_OUT_OF_RESOURCE;
             }
@@ -248,11 +248,11 @@ static int read_topic(char ***array)
     int token, rc;
 
     while (1) {
-        token = pmix_show_help_yylex();
+        token = pmix_showhelp_yylex();
         switch (token) {
         case PMIX_SHOW_HELP_PARSE_MESSAGE:
             /* pmix_argv_append_nosize does strdup(pmix_show_help_yytext) */
-            rc = pmix_argv_append_nosize(array, pmix_show_help_yytext);
+            rc = pmix_argv_append_nosize(array, pmix_showhelp_yytext);
             if (rc != PMIX_SUCCESS) {
                 return rc;
             }
@@ -279,8 +279,8 @@ static int load_array(char ***array, const char *filename, const char *topic)
         ret = read_topic(array);
     }
 
-    fclose(pmix_show_help_yyin);
-    pmix_show_help_yylex_destroy();
+    fclose(pmix_showhelp_yyin);
+    pmix_showhelp_yylex_destroy();
 
     if (PMIX_SUCCESS != ret) {
         pmix_argv_free(*array);

--- a/src/util/showhelp/Makefile.am
+++ b/src/util/showhelp/Makefile.am
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2016      Intel, Inc. All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+
+AM_LFLAGS = -Ppmix_showhelp_yy
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
+
+LEX_OUTPUT_ROOT = lex.pmix_showhelp_yy
+
+noinst_LTLIBRARIES = libpmixutilshowhelp.la
+
+# Source code files
+
+libpmixutilshowhelp_la_SOURCES = \
+	showhelp_lex.h \
+    showhelp_lex.l
+
+MAINTAINERCLEANFILES = showhelp_lex.c

--- a/src/util/showhelp/showhelp_lex.h
+++ b/src/util/showhelp/showhelp_lex.h
@@ -37,14 +37,14 @@
 
 #include <stdio.h>
 BEGIN_C_DECLS
-PMIX_EXPORT int pmix_show_help_yylex(void);
-PMIX_EXPORT int pmix_show_help_init_buffer(FILE *file);
-PMIX_EXPORT int pmix_show_help_yylex_destroy(void);
+PMIX_EXPORT int pmix_showhelp_yylex(void);
+PMIX_EXPORT int pmix_showhelp_init_buffer(FILE *file);
+PMIX_EXPORT int pmix_showhelp_yylex_destroy(void);
 
-extern FILE *pmix_show_help_yyin;
-PMIX_EXPORT extern bool pmix_show_help_parse_done;
-PMIX_EXPORT extern char *pmix_show_help_yytext;
-PMIX_EXPORT extern int pmix_show_help_yynewlines;
+extern FILE *pmix_showhelp_yyin;
+PMIX_EXPORT extern bool pmix_showhelp_parse_done;
+PMIX_EXPORT extern char *pmix_showhelp_yytext;
+PMIX_EXPORT extern int pmix_showhelp_yynewlines;
 
 /*
  * Make lex-generated files not issue compiler warnings

--- a/src/util/showhelp/showhelp_lex.l
+++ b/src/util/showhelp/showhelp_lex.l
@@ -14,6 +14,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,27 +29,27 @@
 #include <unistd.h>
 #endif
 
-#include "src/util/show_help_lex.h"
+#include "src/util/showhelp/showhelp_lex.h"
 
 BEGIN_C_DECLS
 
 /*
  * public functions
  */
-extern int pmix_show_help_finish_parsing(void);
+extern int pmix_showhelp_finish_parsing(void);
 
 /*
  * local functions
  */
-static int pmix_show_help_yywrap(void);
+static int pmix_showhelp_yywrap(void);
 
 END_C_DECLS
 
 /*
  * global variables
  */
-int pmix_show_help_yynewlines = 1;
-bool pmix_show_help_parse_done = false;
+int pmix_showhelp_yynewlines = 1;
+bool pmix_showhelp_parse_done = false;
 
 %}
 
@@ -75,7 +76,7 @@ CHAR        [A-Za-z0-9_\-\.]
 #endif
 
 #if (YY_FLEX_MAJOR_VERSION < 2) || (YY_FLEX_MAJOR_VERSION == 2 && (YY_FLEX_MINOR_VERSION < 5 || (YY_FLEX_MINOR_VERSION == 5 && YY_FLEX_SUBMINOR_VERSION < 5)))
-int pmix_show_help_yylex_destroy(void)
+int pmix_showhelp_yylex_destroy(void)
 {
     if (NULL != YY_CURRENT_BUFFER) {
         yy_delete_buffer(YY_CURRENT_BUFFER);
@@ -89,9 +90,9 @@ int pmix_show_help_yylex_destroy(void)
 }
 #endif
 
-static int pmix_show_help_yywrap(void)
+static int pmix_showhelp_yywrap(void)
 {
-    pmix_show_help_parse_done = true;
+    pmix_showhelp_parse_done = true;
     return 1;
 }
 
@@ -105,7 +106,7 @@ static int pmix_show_help_yywrap(void)
  * have a valid buffer.  Hence, here we ensure to give it a valid
  * buffer.
  */
-int pmix_show_help_init_buffer(FILE *file)
+int pmix_showhelp_init_buffer(FILE *file)
 {
     YY_BUFFER_STATE buf = yy_create_buffer(file, YY_BUF_SIZE);
     yy_switch_to_buffer(buf);


### PR DESCRIPTION
Move the flex processing to its own directory and
turn off picky compilers there

Fixes https://github.com/openpmix/openpmix/issues/2319
Signed-off-by: Ralph Castain <rhc@pmix.org>