### PR TITLE
Don't check for Python 3.4+ if we aren't building the bindings

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1259,12 +1259,11 @@ if test "$enable_python_bindings" != "yes"; then
 else
     AC_MSG_RESULT([yes])
     WANT_PYTHON_BINDINGS=1
+    AM_PATH_PYTHON([3.4], [pmix_python_good=yes], [pmix_python_good=no])
 fi
 
 AM_CONDITIONAL([WANT_PYTHON_BINDINGS], [test $WANT_PYTHON_BINDINGS -eq 1])
-
-AM_PATH_PYTHON([3.4], [pmix_python_good=yes], [pmix_python_good=no])
-
+PYTHON=
 if test "$WANT_PYTHON_BINDINGS" = "1"; then
     if test "$pmix_python_good" = "no"; then
         AC_MSG_WARN([Python bindings were enabled, but no suitable])
@@ -1310,12 +1309,14 @@ fi
 # If we didn't find a good Python and we don't have dictionary.h, then
 # see if we can find an older Python (because construct_dictionary.py
 # can use an older Python).
-AS_IF([test "$PYTHON" = ":" && test ! -f $srcdir/include/dictionary.h],
-      [PYTHON=
+AS_IF([test "$PYTHON" = "" && test ! -f $srcdir/include/dictionary.h],
+      [AC_MSG_CHECKING([python])
+       PYTHON=
        AM_PATH_PYTHON
        # If we still can't find Python (and we don't have
        # dictionary.h), then give up.
-       AS_IF([test "$PYTHON" = ":"],
+       AC_MSG_RESULT([$PYTHON])
+       AS_IF([test "$PYTHON" = ""],
              [AC_MSG_WARN([Could not find a modern enough Python])
               AC_MSG_WARN([Developer builds (e.g., git clones) of OpenPMIx must have Python available])
               AC_MSG_ERROR([Cannot continue])


### PR DESCRIPTION
Depending on autotool versions, this check can exit with an error
if we fail to find the required Python level.

Signed-off-by: Ralph Castain <rhc@pmix.org>