### PR TITLE
Enable support for address sanitizers, but only on request

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1088,6 +1088,25 @@ fi
 AC_DEFINE_UNQUOTED(PMIX_PICKY_COMPILERS, $WANT_PICKY_COMPILER,
                    [Whether or not we are using picky compiler settings])
 
+AC_MSG_CHECKING([if want memory sanitizers])
+AC_ARG_ENABLE(memory-sanitizers,
+    AS_HELP_STRING([--memory-sanitizers],
+                   [enable developer-level memory sanitizers when building PMIx (default: disabled)]))
+if test "$enable_memory_sanitizers" = "yes"; then
+    AC_MSG_RESULT([yes])
+    WANT_MEMORY_SANITIZERS=1
+    AC_MSG_WARN([******************************************************])
+    AC_MSG_WARN([**** Memory sanitizers may require that you LD_PRELOAD])
+    AC_MSG_WARN([**** libasan in order to run an executable.])
+    AC_MSG_WARN([******************************************************])
+else
+    AC_MSG_RESULT([no])
+    WANT_MEMORY_SANITIZERS=0
+fi
+
+AC_DEFINE_UNQUOTED(PMIX_MEMORY_SANITIZERS, $WANT_MEMORY_SANITIZERS,
+                   [Whether or not we are using memory sanitizers])
+
 #
 # Developer debugging
 #

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -31,7 +31,7 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
                                     _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
                                    ],
                                     pmix_cv_cc_[$2]=1
-                                    _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown\|error", [$2])
+                                    _PMIX_CFLAGS_FAIL_SEARCH("ignored\|not recognized\|not supported\|not compatible\|unrecognized\|unknown", [$2])
                                  )])
             if test "$pmix_cv_cc_[$2]" = "0" ; then
                 CFLAGS="$CFLAGS_orig"

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -432,8 +432,10 @@ AC_DEFUN([PMIX_SETUP_PICKY_COMPILERS],[
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Wall, Wall)
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Wextra, Wextra)
         _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror, Werror)
-#        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=address, fsanitize=address)
-#        _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=undefined, fsanitize=undefined)
+        if test $WANT_MEMORY_SANITIZERS -eq 1 && test "$pmix_c_vendor" != "pgi"; then
+            _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=address, fsanaddress)
+            _PMIX_CHECK_SPECIFIC_CFLAGS(-fsanitize=undefined, fsanundefined)
+        fi
     fi
 
 ])


### PR DESCRIPTION
Requires that one LD_PRELOAD the ASan library in many
environments (Linux, but not Mac). Execution fails on
multiple (tiny) leaks, so this will be a work-in-progress for
some time.

Fixes #1025 
Signed-off-by: Ralph Castain <rhc@pmix.org>