### PR TITLE
Update configure logic

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -431,10 +431,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     pmix_show_title "Header file tests"
 
-    PMIX_VAR_SCOPE_PUSH(PMIX_CFLAGS_save_for_headers)
-    PMIX_CFLAGS_save_for_headers=$CFLAGS
-    _PMIX_CHECK_SPECIFIC_CFLAGS(-Werror, Werror)
-
     AC_CHECK_HEADERS([arpa/inet.h \
                       fcntl.h ifaddrs.h inttypes.h libgen.h \
                       net/uio.h netinet/in.h \
@@ -513,9 +509,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED(PMIX_USE_STDBOOL_H, $PMIX_USE_STDBOOL_H,
                        [Whether to use <stdbool.h> or not])
     AC_MSG_RESULT([$MSG])
-
-    CFLAGS=$PMIX_CFLAGS_save_for_headers
-    PMIX_VAR_SCOPE_POP
 
     # checkpoint results
     AC_CACHE_SAVE
@@ -1068,22 +1061,16 @@ fi
 #
 
 AC_MSG_CHECKING([if want developer-level compiler pickyness])
-AC_ARG_ENABLE(picky,
-    AS_HELP_STRING([--enable-picky],
+AC_ARG_ENABLE(devel-check,
+    AS_HELP_STRING([--enable-devel-check],
                    [enable developer-level compiler pickyness when building PMIx (default: disabled)]))
-if test "$enable_picky" = "yes"; then
+if test "$enable_devel_check" = "yes"; then
     AC_MSG_RESULT([yes])
     WANT_PICKY_COMPILER=1
 else
     AC_MSG_RESULT([no])
     WANT_PICKY_COMPILER=0
 fi
-#################### Early development override ####################
-if test "$WANT_PICKY_COMPILER" = "0" && test -z "$enable_picky" && test "$PMIX_DEVEL" = "1"; then
-    WANT_PICKY_COMPILER=1
-    echo "--> developer override: enable picky compiler by default"
-fi
-#################### Early development override ####################
 
 AC_DEFINE_UNQUOTED(PMIX_PICKY_COMPILERS, $WANT_PICKY_COMPILER,
                    [Whether or not we are using picky compiler settings])
@@ -1407,7 +1394,6 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([PMIX_WANT_SASL], [test "$pmix_sasl_support" = "1"])
         AM_CONDITIONAL([WANT_PRIMARY_HEADERS], [test "x$pmix_install_primary_headers" = "xyes"])
         AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
-        AM_CONDITIONAL(WANT_PMI_BACKWARD, test "$WANT_PMI_BACKWARD" = 1)
         AM_CONDITIONAL(NEED_LIBPMIX, [test "$pmix_need_libpmix" = "1"])
         AM_CONDITIONAL([PMIX_HAVE_JANSSON], [test "x$pmix_check_jansson_happy" = "xyes"])
         AM_CONDITIONAL([PMIX_HAVE_CURL], [test "x$pmix_check_curl_happy" = "xyes"])

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -39,7 +39,6 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 # we do NOT want picky compilers down here
-CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 noinst_SCRIPTS = pmix_client_otheruser.sh \
 	run_tests00.pl \

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -22,7 +22,6 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 # we do NOT want picky compilers down here
-CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 headers = simptest.h
 

--- a/test/sshot/Makefile.am
+++ b/test/sshot/Makefile.am
@@ -10,7 +10,6 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix $(pmix_check_jansson_CPPFLAGS)
 # we do NOT want picky compilers down here
-CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 if HAVE_JANSSON
 noinst_PROGRAMS = generate server daemon testcoord

--- a/test/test_v2/Makefile.am
+++ b/test/test_v2/Makefile.am
@@ -27,8 +27,6 @@
 headers = cli_stages.h server_callbacks.h test_common.h test_server.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
-# we do NOT want picky compilers down here
-CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 
 # Can be added in for purposes of debugging on platforms building with gcc (gcc-specific flags)
 #AM_CFLAGS = -fno-omit-frame-pointer -g -Wfatal-errors #-Wall -Wextra -Wpedantic -Wconversion -Wshadow


### PR DESCRIPTION
Add "picky" flags ONLY when requested, using a non-standard
option "--enable-devel-check" so it doesn't get enabled
by automated builders.

Signed-off-by: Ralph Castain <rhc@pmix.org>