### PR TITLE
tests: squash unused param warnings

### DIFF
--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -200,6 +200,8 @@ void errhandler(size_t evhdlr_registration_id, pmix_status_t status, const pmix_
                 pmix_info_t info[], size_t ninfo, pmix_info_t results[], size_t nresults,
                 pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, info, ninfo, results, nresults);
+
     TEST_ERROR((" PMIX server event handler for %s:%d with status = %d", source->nspace,
                 source->rank, status));
     cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -207,11 +209,15 @@ void errhandler(size_t evhdlr_registration_id, pmix_status_t status, const pmix_
 
 void op_callbk(pmix_status_t status, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(cbdata);
+
     TEST_VERBOSE(("OP CALLBACK CALLED WITH STATUS %d", status));
 }
 
 void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(cbdata);
+
     TEST_VERBOSE(("ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu", status,
                   (unsigned long) errhandler_ref));
 }

--- a/test/pmix_regex.c
+++ b/test/pmix_regex.c
@@ -50,6 +50,8 @@ int main(int argc, char **argv)
     char **nodes, **procs;
     pmix_status_t rc;
 
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
         TEST_ERROR(("ERROR IN COMPUTING CONSTANTS: PMIX_SUCCESS = %d", PMIX_SUCCESS));

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -65,6 +65,9 @@ pmix_status_t connected(const pmix_proc_t *proc, void *server_object, pmix_op_cb
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
+
+    PMIX_HIDE_UNUSED_PARAMS(proc, server_object);
+
     return PMIX_SUCCESS;
 }
 
@@ -73,6 +76,8 @@ pmix_status_t finalized(const pmix_proc_t *proc, void *server_object, pmix_op_cb
 {
     cli_info_t *cli = NULL;
     int i;
+    PMIX_HIDE_UNUSED_PARAMS(server_object);
+
     for (i = 0; i < cli_info_cnt; i++) {
         if ((proc->rank == cli_info[i].rank) && (0 == strcmp(proc->nspace, cli_info[i].ns))) {
             cli = &cli_info[i];
@@ -107,6 +112,7 @@ pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object, int status,
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
+    PMIX_HIDE_UNUSED_PARAMS(proc, server_object, procs, nprocs);
     TEST_VERBOSE(("Abort is called with status = %d, msg = %s", status, msg));
     test_abort = true;
     return PMIX_SUCCESS;
@@ -116,6 +122,7 @@ pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs, const pmix_in
                          size_t ninfo, char *data, size_t ndata, pmix_modex_cbfunc_t cbfunc,
                          void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(procs, nprocs, info, ninfo);
     TEST_VERBOSE(("Getting data for %s:%d", procs[0].nspace, procs[0].rank));
 
     if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
@@ -189,6 +196,9 @@ pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_info_t 
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_pdata_t *pdata;
     pmix_test_info_t *tinfo;
+
+    PMIX_HIDE_UNUSED_PARAMS(proc, info, ninfo);
+
     if (NULL == pmix_test_published_list) {
         return PMIX_ERR_NOT_FOUND;
     }
@@ -225,6 +235,9 @@ pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys, const pmix_info
 {
     size_t i;
     pmix_test_info_t *iptr, *next;
+
+    PMIX_HIDE_UNUSED_PARAMS(proc, info);
+
     if (NULL == pmix_test_published_list) {
         return PMIX_ERR_NOT_FOUND;
     }
@@ -272,6 +285,8 @@ static void release_cb(pmix_status_t status, void *cbdata)
 {
     pthread_t thread;
 
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     if (0 > pthread_create(&thread, NULL, _release_cb, cbdata)) {
         spawn_wait = false;
         return;
@@ -283,6 +298,8 @@ pmix_status_t spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[], si
                        const pmix_app_t apps[], size_t napps, pmix_spawn_cbfunc_t cbfunc,
                        void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(proc, job_info, ninfo, apps);
+
     release_cbdata *cb = malloc(sizeof(release_cbdata));
     pmix_nspace_t foobar;
 
@@ -300,6 +317,8 @@ static int numconnect = 0;
 pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs, const pmix_info_t info[],
                          size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(procs, nprocs, info, ninfo);
+
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
@@ -310,6 +329,8 @@ pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs, const pmix_in
 pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs, const pmix_info_t info[],
                             size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(procs, nprocs, info, ninfo);
+
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
@@ -319,6 +340,8 @@ pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs, const pmix
 pmix_status_t regevents_fn(pmix_status_t *codes, size_t ncodes, const pmix_info_t info[],
                            size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(ncodes, codes, info, ninfo);
+
     TEST_VERBOSE((" pmix host server regevents_fn called "));
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
@@ -329,6 +352,8 @@ pmix_status_t regevents_fn(pmix_status_t *codes, size_t ncodes, const pmix_info_
 pmix_status_t deregevents_fn(pmix_status_t *codes, size_t ncodes, pmix_op_cbfunc_t cbfunc,
                              void *cbdata)
 {
+    PMIX_HIDE_UNUSED_PARAMS(ncodes, codes);
+
     TEST_VERBOSE((" pmix host server deregevents_fn called "));
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -22,6 +22,9 @@ static void comfail_errhandler(size_t evhdlr_registration_id, pmix_status_t stat
 {
     TEST_ERROR(("comfail errhandler called for error status = %d ninfo = %lu", status,
                 (unsigned long) ninfo));
+
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, info, results, nresults);
+
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
@@ -33,6 +36,9 @@ static void timeout_errhandler(size_t evhdlr_registration_id, pmix_status_t stat
                                pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     TEST_ERROR(("timeout errhandler called for error status = %d ninfo = %d", status, (int) ninfo));
+
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, info, results, nresults);
+
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
@@ -41,6 +47,9 @@ static void timeout_errhandler(size_t evhdlr_registration_id, pmix_status_t stat
 static void op1_callbk(pmix_status_t status, void *cbdata)
 {
     TEST_VERBOSE(("op1_callbk CALLED WITH STATUS %d", status));
+
+    PMIX_HIDE_UNUSED_PARAMS(cbdata);
+
     done = true;
 }
 
@@ -58,6 +67,8 @@ int test_error(char *my_nspace, int my_rank, test_params params)
     struct timespec ts;
     pmix_status_t status;
     pmix_proc_t source;
+
+    PMIX_HIDE_UNUSED_PARAMS(params);
 
     TEST_VERBOSE(("test-error: running  error handling test cases"));
     /* register specific client error handlers and test their invocation

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -51,6 +51,9 @@ static void add_noise(char *noise_param, char *my_nspace, pmix_rank_t my_rank)
 static void release_cb(pmix_status_t status, void *cbdata)
 {
     int *ptr = (int *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     *ptr = 0;
 }
 

--- a/test/test_internal.c
+++ b/test/test_internal.c
@@ -16,6 +16,9 @@
 static void release_cb(pmix_status_t status, void *cbdata)
 {
     int *ptr = (int *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     *ptr = 0;
 }
 

--- a/test/test_publish.c
+++ b/test/test_publish.c
@@ -24,6 +24,9 @@ typedef struct {
 static void release_cb(pmix_status_t status, void *cbdata)
 {
     int *ptr = (int *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     *ptr = 0;
 }
 
@@ -32,6 +35,8 @@ static void lookup_cb(pmix_status_t status, pmix_pdata_t pdata[], size_t npdata,
     size_t i, j;
     lookup_cbdata *cb = (lookup_cbdata *) cbdata;
     pmix_pdata_t *tgt = cb->pdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     /* find the matching key in the provided info array - error if not found */
     for (i = 0; i < npdata; i++) {

--- a/test/test_replace.c
+++ b/test/test_replace.c
@@ -16,6 +16,9 @@
 static void release_cb(pmix_status_t status, void *cbdata)
 {
     int *ptr = (int *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     *ptr = 0;
 }
 

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -93,6 +93,9 @@ static void _dmdx_cb(int status, char *data, size_t sz, void *cbdata);
 static void release_cb(pmix_status_t status, void *cbdata)
 {
     int *ptr = (int *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     *ptr = 0;
 }
 
@@ -425,6 +428,7 @@ static int server_send_msg(msg_hdr_t *msg_hdr, char *data, size_t size)
 {
     size_t ret = 0;
     server_info_t *server = NULL, *server_tmp;
+
     if (0 == my_server_id) {
         PMIX_LIST_FOREACH (server_tmp, server_list, server_info_t) {
             if (server_tmp->idx == msg_hdr->dst_id) {
@@ -450,6 +454,8 @@ static int server_send_msg(msg_hdr_t *msg_hdr, char *data, size_t size)
 static void _send_procs_cb(pmix_status_t status, const char *data, size_t ndata, void *cbdata,
                            pmix_release_cbfunc_t relfn, void *relcbd)
 {
+    PMIX_HIDE_UNUSED_PARAMS(status, relfn, relcbd);
+
     server_info_t *server = (server_info_t *) cbdata;
 
     server_unpack_procs((char *) data, ndata);
@@ -538,6 +544,8 @@ static void server_read_cb(int fd, short event, void *arg)
     static size_t barrier_cnt = 0;
     static size_t contrib_cnt = 0;
     static size_t fence_buf_offset = 0;
+
+    PMIX_HIDE_UNUSED_PARAMS(fd, event);
 
     rc = read(server->rd_fd, &msg_hdr, sizeof(msg_hdr_t));
     if (rc <= 0) {
@@ -705,6 +713,8 @@ static void _dmdx_cb(int status, char *data, size_t sz, void *cbdata)
     msg_hdr_t msg_hdr;
     int *sender_id = (int *) cbdata;
 
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     msg_hdr.cmd = CMD_DMDX_RESPONSE;
     msg_hdr.src_id = my_server_id;
     msg_hdr.size = sz;
@@ -778,6 +788,8 @@ static void wait_signal_callback(int fd, short event, void *arg)
     int status;
     pid_t pid;
     int i;
+
+    PMIX_HIDE_UNUSED_PARAMS(fd, event);
 
     if (SIGCHLD != pmix_event_get_signal(sig)) {
         return;

--- a/test/test_spawn.c
+++ b/test/test_spawn.c
@@ -23,6 +23,8 @@ static void spawn_cb(pmix_status_t status, char nspace[], void *cbdata)
 {
     spawn_cbdata *cb = (spawn_cbdata *) cbdata;
 
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
     PMIX_LOAD_NSPACE(cb->nspace, nspace);
     cb->in_progress = 0;
 }
@@ -33,6 +35,9 @@ static int test_spawn_common(char *my_nspace, int my_rank, int blocking)
     pmix_app_t *apps;
     size_t napps;
     pmix_nspace_t nspace;
+
+    PMIX_HIDE_UNUSED_PARAMS(my_nspace, my_rank);
+
     memset(nspace, 0, PMIX_MAX_NSLEN + 1);
     napps = 1;
     PMIX_APP_CREATE(apps, napps);


### PR DESCRIPTION
Use PMIX_HIDE_UNUSED_PARAMS() macro to silence warnings
to allow for builds with "picky" compile options.

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>