### PR TITLE
fix corner case on iof flags

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -923,10 +923,14 @@ void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_FILE)) {
         flags->file = strdup(info->value.data.string);
         flags->set = true;
+        flags->local_output = true;
+        flags->local_output_given = true;
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_DIRECTORY) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
         flags->directory = strdup(info->value.data.string);
         flags->set = true;
+        flags->local_output = true;
+        flags->local_output_given = true;
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_FILE_ONLY) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_NOCOPY)) {
         flags->nocopy = PMIX_INFO_TRUE(info);


### PR DESCRIPTION
Ensure IOF flags set for case where want to send
App output to directory or file.

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>