### PR TITLE
Ensure we terminate the input channel when done

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1643,18 +1643,6 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
         numbytes = 0;
     }
 
-    /* if the number of bytes is zero, then we just delete the event - there
-     * is no need to pass it upstream as WE are the ones holding the event
-     * and associated file descriptor */
-    if (0 == numbytes) {
-        if (NULL != child && child->completed &&
-            (NULL == child->stdoutev || !child->stdoutev->active) &&
-            (NULL == child->stderrev || !child->stderrev->active)) {
-            PMIX_PFEXEC_CHK_COMPLETE(child);
-        }
-        return;
-    }
-
     bo.bytes = (char *) data;
     bo.size = numbytes;
 


### PR DESCRIPTION
Need to let the server and our own write output function
know when the stdin is complete so the job won't hang

Signed-off-by: Ralph Castain <rhc@pmix.org>