### PR TITLE
Add an attribute to retrieve the lib config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ test/simple/simpfabric
 test/simple/get_put_example
 test/simple/simpvni
 test/simple/hybrid
+test/simple/simpconfig
 
 test/sshot/daemon
 test/sshot/generate

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,8 @@ pmix_show_title "Configuring PMIx"
 
 # This must be before AM_INIT_AUTOMAKE
 AC_CANONICAL_TARGET
+PMIX_ARCH_STRING="$target"
+AC_SUBST(PMIX_ARCH_STRING)
 
 # Init automake
 AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4])

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -236,7 +236,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //          the members of the newly defined process set.
 #define PMIX_REINCARNATION                  "pmix.reinc"            // (uint32_t) number of times this process has been instantiated - i.e.,
                                                                     //            tracks the number of times it has been restarted
-#define PMIX_CONFIGURATION                  "pmix.config"           // (pmix_data_array_t*) Returns an array containing information on
+#define PMIX_LIBRARY_CONFIGURATION          "pmix.config"           // (pmix_data_array_t*) Returns an array containing information on
                                                                     //          the implementation's configuration and control parameters
                                                                     //          (e.g., the OpenPMIx MCA parameters)
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -236,6 +236,10 @@ typedef uint32_t pmix_rank_t;
                                                                     //          the members of the newly defined process set.
 #define PMIX_REINCARNATION                  "pmix.reinc"            // (uint32_t) number of times this process has been instantiated - i.e.,
                                                                     //            tracks the number of times it has been restarted
+#define PMIX_CONFIGURATION                  "pmix.config"           // (pmix_data_array_t*) Returns an array containing information on
+                                                                    //          the implementation's configuration and control parameters
+                                                                    //          (e.g., the OpenPMIx MCA parameters)
+
 
 /* model attributes */
 #define PMIX_PROGRAMMING_MODEL              "pmix.pgm.model"        // (char*) programming model being initialized (e.g., "MPI" or "OpenMP")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,23 @@
 # $HEADER$
 #
 
+AM_CFLAGS = \
+            -DPMIX_CONFIGURE_USER="\"@PMIX_CONFIGURE_USER@\"" \
+            -DPMIX_CONFIGURE_HOST="\"@PMIX_CONFIGURE_HOST@\"" \
+            -DPMIX_CONFIGURE_DATE="\"@PMIX_CONFIGURE_DATE@\"" \
+            -DPMIX_BUILD_USER="\"$$USER\"" \
+            -DPMIX_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
+            -DPMIX_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
+            -DPMIX_BUILD_CFLAGS="\"@CFLAGS@\"" \
+            -DPMIX_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
+            -DPMIX_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
+            -DPMIX_BUILD_LIBS="\"@LIBS@\"" \
+            -DPMIX_CC_ABSOLUTE="\"@PMIX_CC_ABSOLUTE@\"" \
+            -DPMIX_GREEK_VERSION="\"@PMIX_GREEK_VERSION@\"" \
+            -DPMIX_REPO_REV="\"@PMIX_REPO_REV@\"" \
+            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\"" \
+            -DPMIX_ARCH_STRING="\"@PMIX_ARCH_STRING@\""
+
 SUBDIRS = \
     include \
     util/keyval \

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -53,6 +53,7 @@
 #include "src/mca/ptl/base/base.h"
 #include "src/threads/threads.h"
 #include "src/util/argv.h"
+#include "src/util/construct_config.h"
 #include "src/util/error.h"
 #include "src/util/hash.h"
 #include "src/util/name_fns.h"
@@ -79,6 +80,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
 {
     pmix_value_t *ival;
     size_t n;
+    pmix_status_t rc;
 
     /* if the proc is NULL, then the caller is assuming
      * that the key is universally unique within the caller's
@@ -150,6 +152,15 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             *val = ival;
         }
         return PMIX_OPERATION_SUCCEEDED;
+    }
+
+    /* if they want the library's config, pass it back */
+    if (NULL != key && 0 == strncmp(key, PMIX_CONFIGURATION, PMIX_MAX_KEYLEN)) {
+        rc = pmix_util_construct_config(val, lg);
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIX_OPERATION_SUCCEEDED;
+        }
+        return rc;
     }
 
     /* if the given proc param is NULL, or the nspace is

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -155,7 +155,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     }
 
     /* if they want the library's config, pass it back */
-    if (NULL != key && 0 == strncmp(key, PMIX_CONFIGURATION, PMIX_MAX_KEYLEN)) {
+    if (NULL != key && 0 == strncmp(key, PMIX_LIBRARY_CONFIGURATION, PMIX_MAX_KEYLEN)) {
         rc = pmix_util_construct_config(val, lg);
         if (PMIX_SUCCESS == rc) {
             rc = PMIX_OPERATION_SUCCEEDED;

--- a/src/tools/pmix_info/Makefile.am
+++ b/src/tools/pmix_info/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ AM_CFLAGS = \
             -DPMIX_CC_ABSOLUTE="\"@PMIX_CC_ABSOLUTE@\"" \
             -DPMIX_GREEK_VERSION="\"@PMIX_GREEK_VERSION@\"" \
             -DPMIX_REPO_REV="\"@PMIX_REPO_REV@\"" \
-            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
+            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\"" \
+            -DPMIX_ARCH_STRING="\"@PMIX_ARCH_STRING@\""
 
 if PMIX_INSTALL_BINARIES
 

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -756,7 +756,7 @@ void pmix_info_show_mca_params(const char *type, const char *component,
 
 void pmix_info_do_arch()
 {
-    pmix_info_out("Configured architecture", "config:arch", PMIX_ARCH);
+    pmix_info_out("Configured architecture", "config:arch", PMIX_ARCH_STRING);
 }
 
 void pmix_info_do_hostname()
@@ -1288,18 +1288,18 @@ void pmix_info_show_pmix_version(const char *scope)
     }
     tmp2 = pmix_info_make_version_str(scope, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
                                       PMIX_RELEASE_VERSION, PMIX_GREEK_VERSION, PMIX_REPO_REV);
-    pmix_info_out("PMIX", tmp, tmp2);
+    pmix_info_out("PMIx", tmp, tmp2);
     free(tmp);
     free(tmp2);
     if (0 > asprintf(&tmp, "%s:version:repo", pmix_info_type_pmix)) {
         return;
     }
-    pmix_info_out("PMIX repo revision", tmp, PMIX_REPO_REV);
+    pmix_info_out("PMIx repo revision", tmp, PMIX_REPO_REV);
     free(tmp);
     if (0 > asprintf(&tmp, "%s:version:release_date", pmix_info_type_pmix)) {
         return;
     }
-    pmix_info_out("PMIX release date", tmp, PMIX_RELEASE_DATE);
+    pmix_info_out("PMIx release date", tmp, PMIX_RELEASE_DATE);
     free(tmp);
 }
 

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -55,7 +55,8 @@ headers += \
         util/pmix_pty.h \
         util/few.h \
         util/string_copy.h \
-        util/pmix_getcwd.h
+        util/pmix_getcwd.h \
+        util/construct_config.h
 
 sources += \
         util/alfg.c \
@@ -84,7 +85,8 @@ sources += \
         util/pmix_pty.c \
         util/few.c \
         util/string_copy.c \
-        util/pmix_getcwd.c
+        util/pmix_getcwd.c \
+        util/construct_config.c
 
 libpmix_la_LIBADD += \
         util/keyval/libpmixutilkeyval.la \

--- a/src/util/construct_config.c
+++ b/src/util/construct_config.c
@@ -42,6 +42,8 @@
 #include "include/pmix_common.h"
 #include "src/util/construct_config.h"
 
+#define BFRSIZE 1024
+
 /* Return a pmix_data_array_t of key-value pairs corresponding
  * to what pmix_info presents */
 pmix_status_t pmix_util_construct_config(pmix_value_t **val,
@@ -49,11 +51,17 @@ pmix_status_t pmix_util_construct_config(pmix_value_t **val,
 {
     void *list;
     pmix_status_t rc;
-    char *tmp;
+    char *tmp, *debug, *have_dl, *symbol_visibility;
+    char bfr[BFRSIZE];
     pmix_data_array_t *darray;
     pmix_value_t *ival;
 
     PMIX_INFO_LIST_START(list);
+
+    /* setup the strings that don't require allocations*/
+    debug = PMIX_ENABLE_DEBUG ? "yes" : "no";
+    have_dl = PMIX_HAVE_PDL_SUPPORT ? "yes" : "no";
+    symbol_visibility = PMIX_HAVE_VISIBILITY ? "yes" : "no";
 
     PMIX_INFO_LIST_ADD(rc, list, "Package", PMIX_PACKAGE_STRING, PMIX_STRING);
 
@@ -77,6 +85,30 @@ pmix_status_t pmix_util_construct_config(pmix_value_t **val,
     PMIX_INFO_LIST_ADD(rc, list, "Prefix", pmix_pinstall_dirs.prefix, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "Configured architecture", PMIX_ARCH_STRING, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "Configure host", PMIX_CONFIGURE_HOST, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Configured by", PMIX_CONFIGURE_USER, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Configured on", PMIX_CONFIGURE_DATE, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Configure command line", PMIX_CONFIGURE_CLI, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Built by", PMIX_BUILD_USER, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Built on", PMIX_BUILD_DATE, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Built host", PMIX_BUILD_HOST, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "C compiler", PMIX_CC, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "C compiler absolute", PMIX_CC_ABSOLUTE, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "C compiler family name",
+                       PLATFORM_STRINGIFY(PLATFORM_COMPILER_FAMILYNAME), PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "C compiler version",
+                       PLATFORM_STRINGIFY(PLATFORM_COMPILER_VERSION_STR), PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "C compiler absolute", PMIX_CC_ABSOLUTE, PMIX_STRING);
+
+    PMIX_INFO_LIST_ADD(rc, list, "Build CFLAGS", PMIX_BUILD_CFLAGS, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Build LDFLAGS", PMIX_BUILD_LDFLAGS, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Build LIBS", PMIX_BUILD_LIBS, PMIX_STRING);
+
+    PMIX_INFO_LIST_ADD(rc, list, "Internal debug support", debug, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "dl support", have_dl, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Symbol vis. support", symbol_visibility, PMIX_STRING);
+
+    pmix_snprintf(bfr, BFRSIZE, "%"PRIsize_t"", sizeof(char));
+    PMIX_INFO_LIST_ADD(rc, list, "C char size", bfr, PMIX_STRING);
 
     darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
     PMIX_INFO_LIST_CONVERT(rc, list, darray);

--- a/src/util/construct_config.c
+++ b/src/util/construct_config.c
@@ -33,16 +33,88 @@
 
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_object.h"
+#include "src/class/pmix_value_array.h"
 #include "src/include/frameworks.h"
 #include "src/include/pmix_portable_platform.h"
 #include "src/mca/base/pmix_mca_base_component_repository.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
+#include "src/util/error.h"
 #include "src/util/printf.h"
 
 #include "include/pmix_common.h"
 #include "src/util/construct_config.h"
 
 #define BFRSIZE 1024
+
+static void do_group_params(const pmix_mca_base_var_group_t *group,
+                            void *list)
+{
+    const int *variables, *groups;
+    const char *group_component;
+    const pmix_mca_base_var_t *var;
+    char **strings, *message;
+    bool requested = true;
+    int ret, i, j, count;
+    const pmix_mca_base_var_group_t *curr_group = NULL;
+    char *component_msg = NULL;
+
+    variables = PMIX_VALUE_ARRAY_GET_BASE(&group->group_vars, const int);
+    count = pmix_value_array_get_size((pmix_value_array_t *) &group->group_vars);
+
+    /* the default component name is "base". depending on how the
+     * group was registered the group may or not have this set.  */
+    group_component = group->group_component ? group->group_component : "base";
+
+    if (0 > asprintf(&component_msg, " %s", group_component)) {
+        return;
+    }
+
+    for (i = 0; i < count; ++i) {
+        ret = pmix_mca_base_var_get(variables[i], &var);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            continue;
+        }
+        ret = pmix_mca_base_var_dump(variables[i], &strings, PMIX_MCA_BASE_VAR_DUMP_READABLE);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            continue;
+        }
+        // join the strings to make the description
+        message = pmix_argv_join(strings, '\n');
+        PMIX_INFO_LIST_ADD(ret, list, component_msg, message, PMIX_STRING);
+
+        groups = PMIX_VALUE_ARRAY_GET_BASE(&group->group_subgroups, const int);
+        count = pmix_value_array_get_size((pmix_value_array_t *) &group->group_subgroups);
+
+        for (i = 0; i < count; ++i) {
+            ret = pmix_mca_base_var_group_get(groups[i], &group);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                continue;
+            }
+            do_group_params(group, list);
+        }
+    }
+    free(component_msg);
+}
+
+static pmix_status_t do_params(const char *type,
+                               void *list)
+{
+    pmix_status_t rc;
+    const pmix_mca_base_var_group_t *group;
+
+    pmix_output(0, "LOOKING FOR %s", type);
+    rc = pmix_mca_base_var_group_find("*", type, NULL);
+    if (0 > rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    (void) pmix_mca_base_var_group_get(rc, &group);
+    do_group_params(group, list);
+    return PMIX_SUCCESS;
+}
 
 /* Return a pmix_data_array_t of key-value pairs corresponding
  * to what pmix_info presents */
@@ -80,9 +152,31 @@ pmix_status_t pmix_util_construct_config(pmix_value_t **val,
     PMIX_INFO_LIST_ADD(rc, list, "PMIx", tmp, PMIX_STRING);
     free(tmp);
 
+    // version
     PMIX_INFO_LIST_ADD(rc, list, "PMIx repo revision", PMIX_REPO_REV, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "PMIx release date", PMIX_RELEASE_DATE, PMIX_STRING);
+
+    // paths
     PMIX_INFO_LIST_ADD(rc, list, "Prefix", pmix_pinstall_dirs.prefix, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Exec_prefix", pmix_pinstall_dirs.exec_prefix, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Bindir", pmix_pinstall_dirs.bindir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Sbindir", pmix_pinstall_dirs.sbindir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Libdir", pmix_pinstall_dirs.libdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Incdir", pmix_pinstall_dirs.includedir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Mandir", pmix_pinstall_dirs.mandir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Pkglibdir", pmix_pinstall_dirs.pmixlibdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Libexecdir", pmix_pinstall_dirs.libexecdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Datarootdir", pmix_pinstall_dirs.datarootdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Datadir", pmix_pinstall_dirs.datadir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Sysconfdir", pmix_pinstall_dirs.sysconfdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Sharedstatedir", pmix_pinstall_dirs.sharedstatedir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Localstatedir", pmix_pinstall_dirs.localstatedir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Infodir", pmix_pinstall_dirs.infodir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Pkgdatadir", pmix_pinstall_dirs.pmixdatadir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Pkglibdir", pmix_pinstall_dirs.pmixlibdir, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Pkgincludedir", pmix_pinstall_dirs.pmixincludedir, PMIX_STRING);
+
+    // config
     PMIX_INFO_LIST_ADD(rc, list, "Configured architecture", PMIX_ARCH_STRING, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "Configure host", PMIX_CONFIGURE_HOST, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "Configured by", PMIX_CONFIGURE_USER, PMIX_STRING);
@@ -107,8 +201,12 @@ pmix_status_t pmix_util_construct_config(pmix_value_t **val,
     PMIX_INFO_LIST_ADD(rc, list, "dl support", have_dl, PMIX_STRING);
     PMIX_INFO_LIST_ADD(rc, list, "Symbol vis. support", symbol_visibility, PMIX_STRING);
 
-    pmix_snprintf(bfr, BFRSIZE, "%"PRIsize_t"", sizeof(char));
-    PMIX_INFO_LIST_ADD(rc, list, "C char size", bfr, PMIX_STRING);
+    // base MCA params
+    rc = do_params("mca", list);
+    if (0 > rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
 
     darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
     PMIX_INFO_LIST_CONVERT(rc, list, darray);

--- a/src/util/construct_config.c
+++ b/src/util/construct_config.c
@@ -1,0 +1,93 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_object.h"
+#include "src/include/frameworks.h"
+#include "src/include/pmix_portable_platform.h"
+#include "src/mca/base/pmix_mca_base_component_repository.h"
+#include "src/mca/pinstalldirs/pinstalldirs.h"
+#include "src/util/printf.h"
+
+#include "include/pmix_common.h"
+#include "src/util/construct_config.h"
+
+/* Return a pmix_data_array_t of key-value pairs corresponding
+ * to what pmix_info presents */
+pmix_status_t pmix_util_construct_config(pmix_value_t **val,
+                                         pmix_get_logic_t *lg)
+{
+    void *list;
+    pmix_status_t rc;
+    char *tmp;
+    pmix_data_array_t *darray;
+    pmix_value_t *ival;
+
+    PMIX_INFO_LIST_START(list);
+
+    PMIX_INFO_LIST_ADD(rc, list, "Package", PMIX_PACKAGE_STRING, PMIX_STRING);
+
+    if (NULL != PMIX_GREEK_VERSION) {
+        pmix_asprintf(&tmp, "%d.%d.%d%s",
+                      PMIX_MAJOR_VERSION,
+                      PMIX_MINOR_VERSION,
+                      PMIX_RELEASE_VERSION,
+                      PMIX_GREEK_VERSION);
+    } else {
+        pmix_asprintf(&tmp, "%d.%d.%d",
+                      PMIX_MAJOR_VERSION,
+                      PMIX_MINOR_VERSION,
+                      PMIX_RELEASE_VERSION);
+    }
+    PMIX_INFO_LIST_ADD(rc, list, "PMIx", tmp, PMIX_STRING);
+    free(tmp);
+
+    PMIX_INFO_LIST_ADD(rc, list, "PMIx repo revision", PMIX_REPO_REV, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "PMIx release date", PMIX_RELEASE_DATE, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Prefix", pmix_pinstall_dirs.prefix, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Configured architecture", PMIX_ARCH_STRING, PMIX_STRING);
+    PMIX_INFO_LIST_ADD(rc, list, "Configure host", PMIX_CONFIGURE_HOST, PMIX_STRING);
+
+    darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
+    PMIX_INFO_LIST_CONVERT(rc, list, darray);
+    PMIX_INFO_LIST_RELEASE(list);
+
+    PMIX_VALUE_CREATE(ival, 1);
+    if (NULL == ival) {
+        return PMIX_ERR_NOMEM;
+    }
+    ival->type = PMIX_DATA_ARRAY;
+    ival->data.darray = darray;
+    *val = ival;
+    return PMIX_OPERATION_SUCCEEDED;
+}

--- a/src/util/construct_config.h
+++ b/src/util/construct_config.h
@@ -1,0 +1,45 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ */
+
+#ifndef PMIX_CONSTRUCT_CONFIG_H
+#define PMIX_CONSTRUCT_CONFIG_H
+
+#include "pmix_config.h"
+
+#include "src/include/pmix_globals.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT pmix_status_t pmix_util_construct_config(pmix_value_t **val,
+                                                     pmix_get_logic_t *lg);
+
+END_C_DECLS
+
+#endif /* PMIX_CMD_LINE_H */

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid
+                  hybrid simpconfig
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -175,3 +175,8 @@ hybrid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hybrid_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+simpconfig_SOURCES = $(headers) \
+        simpconfig.c
+simpconfig_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpconfig_LDADD = \
+    $(top_builddir)/src/libpmix.la

--- a/test/simple/simpconfig.c
+++ b/test/simple/simpconfig.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
                 myproc.nspace, myproc.rank, pmix_globals.hostname);
 
     /* get the config */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_CONFIGURATION, NULL, 0, &val))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LIBRARY_CONFIGURATION, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get configuration failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -81,13 +81,9 @@ int main(int argc, char **argv)
     }
 
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_tool_finalize())) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
-    } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
-                myproc.nspace, myproc.rank);
     }
     fflush(stderr);
     return (rc);

--- a/test/simple/simpconfig.c
+++ b/test/simple/simpconfig.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/class/pmix_object.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+#define MAXCNT 1
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_info_t info, *iptr;
+    size_t nsize, n;
+
+    /* init us without connecting */
+    PMIX_INFO_LOAD(&info, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, &info, 1))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "Client ns %s rank %d: Running on node %s",
+                myproc.nspace, myproc.rank, pmix_globals.hostname);
+
+    /* get the config */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_CONFIGURATION, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get configuration failed: %s", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    if (NULL == val || PMIX_DATA_ARRAY != val->type) {
+        pmix_output(0, "Bad configuration returned");
+        exit(-1);
+    }
+
+    // print it out
+    iptr = (pmix_info_t*)val->data.darray->array;
+    nsize = val->data.darray->size;
+
+    for (n=0; n < nsize; n++) {
+        pmix_output(0, "%s: %s", iptr[n].key, iptr[n].value.data.string);
+    }
+
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_tool_finalize())) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (rc);
+}


### PR DESCRIPTION
Add the PMIX_CONFIGURATION attribute to return the library
configuration. Add a function to construct it for return.

Signed-off-by: Ralph Castain <rhc@pmix.org>