### PR TITLE
Cleanup configure to correctly handle default paths

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -1,10 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
-#                         reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -13,26 +11,10 @@
 # $HEADER$
 #
 
-#
-# We have two modes for building hwloc.
-#
-# First is as a co-built hwloc.  In this case, PMIx's CPPFLAGS
-# will be set before configure to include the right -Is to pick up
-# hwloc headers and LIBS will point to where the .la file for
-# hwloc will exist.  When co-building, hwloc's configure will be
-# run already, but the library will not yet be built.  It is ok to run
-# any compile-time (not link-time) tests in this mode.  This mode is
-# used when the --with-hwloc=cobuild option is specified.
-#
-# Second is an external package.  In this case, all compile and link
-# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
-# modifications it desires in order to compile and link against
-# hwloc.  This mode is used whenever the other modes are not used.
-#
-# PMIX_SETUP_HWLOC([action-if-found], [action-if-not-found])
+# MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_SETUP_HWLOC],[
-    PMIX_VAR_SCOPE_PUSH([hwloc_build_mode])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_check_hwloc_save_CPPFLAGS pmix_check_hwloc_save_LDFLAGS pmix_check_hwloc_save_LIBS])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -42,163 +24,107 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                 [AS_HELP_STRING([--with-hwloc-libdir=DIR],
                                 [Search for hwloc libraries in DIR ])])
 
-    pmix_hwloc_support=0
-    pmix_hwloc_source=""
-    pmix_hwloc_support_will_build=no
-    pmix_have_topology_dup=0
-
-    # figure out our mode...
-    AS_IF([test "$with_hwloc" = "cobuild"],
-          [_PMIX_HWLOC_EMBEDDED_MODE],
-          [_PMIX_HWLOC_EXTERNAL])
-
-    AS_IF([test $pmix_hwloc_support -eq 1],
-          [AC_MSG_CHECKING([hwloc header])
-           AC_MSG_RESULT([$PMIX_HWLOC_HEADER])],
-          [AC_MSG_WARN([PMIx requires access to topology])
-           AC_MSG_WARN([information due to its increased role])
-           AC_MSG_WARN([in providing information on critical])
-           AC_MSG_WARN([areas such as device distances and fabric])
-           AC_MSG_WARN([interfaces. At this time, only the HWLOC])
-           AC_MSG_WARN([library is supported - and an installation])
-           AC_MSG_WARN([of that library was not found.])
-           AC_MSG_WARN([Please reconfigure PMIx pointing to an HWLOC])
-           AC_MSG_WARN([installation.])
-           AC_MSG_ERROR([Cannot continue.])])
-
-    AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER], [$PMIX_HWLOC_HEADER],
-                   [Location of hwloc.h])
-    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC], [$pmix_hwloc_support],
-                   [Whether or not we have hwloc support])
-    AM_CONDITIONAL([PMIX_HAVE_HWLOC], [test $pmix_hwloc_support -eq 1])
-    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
-                   [Whether or not we have hwloc_topology_dup support])
-
-    PMIX_SUMMARY_ADD([[External Packages]],[[HWLOC]], [pmix_hwloc], [$pmix_hwloc_support_will_build ($pmix_hwloc_source)])
-
-    AS_IF([test $pmix_hwloc_support -eq 1],
-          [$1], [$2])
-])
-
-AC_DEFUN([_PMIX_HWLOC_EMBEDDED_MODE],[
-    AC_MSG_CHECKING([for hwloc])
-    AC_MSG_RESULT([$1])
-
-    AS_IF([test -z "$with_hwloc_header" || test "$with_hwloc_header" = "yes"],
-          [PMIX_HWLOC_HEADER="<hwloc.h>"],
-          [PMIX_HWLOC_HEADER="$with_hwloc_header"])
-
-    AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
-    AC_COMPILE_IFELSE(
-              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-              [[
-    #if HWLOC_API_VERSION < 0x00010500
-    #error "hwloc API version is less than 0x00010500"
-    #endif
-              ]])],
-              [AC_MSG_RESULT([yes])],
-              [AC_MSG_RESULT([no])
-               AC_MSG_ERROR([Cannot continue])])
-
-    AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-          [[
-    #if HWLOC_API_VERSION < 0x00010800
-    #error "hwloc API version is less than 0x00010800"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           pmix_have_topology_dup=1],
-          [AC_MSG_RESULT([no])])
-
-    pmix_hwloc_support=1
-    pmix_hwloc_source=cobuild
-    pmix_hwloc_support_will_build=yes
-])
-
-AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_hwloc_standard_lib_location pmix_hwloc_standard_header_location pmix_check_hwloc_save_CPPFLAGS pmix_check_hwloc_save_LDFLAGS pmix_check_hwloc_save_LIBS])
+    AC_ARG_WITH([hwloc-header],
+                [AS_HELP_STRING([--with-hwloc-header=HEADER],
+                                [The value that should be included in C files to include hwloc.h])])
 
     pmix_hwloc_support=0
-    pmix_hwloc_have_dup=0
+    pmix_hwloc_header_given=0
     pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
     pmix_check_hwloc_save_LDFLAGS="$LDFLAGS"
     pmix_check_hwloc_save_LIBS="$LIBS"
-    pmix_hwloc_standard_header_location=yes
-    pmix_hwloc_standard_lib_location=yes
+    pmix_have_topology_dup=0
 
-    AS_IF([test "$with_hwloc" = "internal" || test "$with_hwloc" = "external"],
-          [with_hwloc=])
+    if test "x$with_hwloc_header" != "x"; then
+        AS_IF([test "$with_hwloc_header" = "yes"],
+              [PMIX_HWLOC_HEADER="<hwloc.h>"],
+              [PMIX_HWLOC_HEADER="\"$with_hwloc_header\""
+               pmix_hwloc_header_given=1])
+        pmix_hwloc_support=1
+        pmix_hwloc_source="external header"
+        pmix_have_topology_dup=1
 
-    if test "$with_hwloc" != "no"; then
-        AC_MSG_CHECKING([for hwloc in])
-        if test ! -z "$with_hwloc" && test "$with_hwloc" != "yes"; then
-            pmix_hwloc_dir=$with_hwloc/include
-            pmix_hwloc_standard_header_location=no
-            pmix_hwloc_standard_lib_location=no
-            AS_IF([test -z "$with_hwloc_libdir" || test "$with_hwloc_libdir" = "yes"],
-                  [if test -d $with_hwloc/lib; then
-                       pmix_hwloc_libdir=$with_hwloc/lib
-                   elif test -d $with_hwloc/lib64; then
-                       pmix_hwloc_libdir=$with_hwloc/lib64
-                   else
-                       AC_MSG_RESULT([Could not find $with_hwloc/lib or $with_hwloc/lib64])
-                       AC_MSG_ERROR([Can not continue])
-                   fi
-                   AC_MSG_RESULT([$pmix_hwloc_dir and $pmix_hwloc_libdir])],
-                  [AC_MSG_RESULT([$with_hwloc_libdir])])
-        else
-            pmix_hwloc_dir=/usr/include
-            if test -d /usr/lib64; then
-                pmix_hwloc_libdir=/usr/lib64
-            elif test -d /usr/lib; then
-                pmix_hwloc_libdir=/usr/lib
-            else
-                AC_MSG_RESULT([not found])
-                AC_MSG_WARN([Could not find /usr/lib or /usr/lib64 - you may])
-                AC_MSG_WARN([need to specify --with-hwloc_libdir=<path>])
-                AC_MSG_ERROR([Can not continue])
+    elif test "$with_hwloc" == "no"; then
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
+        AC_MSG_WARN([Please reconfigure so we can find the library.])
+        AC_MSG_ERROR([Cannot continue.])
+
+    else
+        # get rid of any trailing slash(es)
+        hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
+        hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
+
+        AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                     [pmix_hwloc_dir="$hwloc_prefix"],
+                     [pmix_hwloc_dir=""])
+        _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                                   [pmix_hwloc_support=1],
+                                   [pmix_hwloc_support=0])
+
+        if test $pmix_hwloc_support -eq 0 && test -z $pmix_hwloc_dir; then
+            # try default locations
+            if test -d /usr/include; then
+                pmix_hwloc_dir=/usr
+                _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                                           [pmix_hwloc_support=1],
+                                           [pmix_hwloc_support=0])
             fi
-            AC_MSG_RESULT([(default search paths)])
-            pmix_hwloc_standard_header_location=yes
-            pmix_hwloc_standard_lib_location=yes
+            if test $pmix_hwloc_support -eq 0 && test -d /usr/local/include; then
+                pmix_hwloc_dir=/usr/local
+                _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                                           [pmix_hwloc_support=1],
+                                           [pmix_hwloc_support=0])
+            fi
         fi
-        AS_IF([test ! -z "$with_hwloc_libdir" && test "$with_hwloc_libdir" != "yes"],
-              [pmix_hwloc_libdir="$with_hwloc_libdir"
-               pmix_hwloc_standard_lib_location=no])
 
-        PMIX_CHECK_PACKAGE([pmix_hwloc],
-                           [hwloc.h],
-                           [hwloc],
-                           [hwloc_topology_init],
-                           [-lhwloc],
-                           [$pmix_hwloc_dir],
-                           [$pmix_hwloc_libdir],
-                           [pmix_hwloc_support=1],
-                           [pmix_hwloc_support=0])
+        if test $pmix_hwloc_support -eq 0; then
+            AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
+            AC_MSG_WARN([an adequate version of that library was not found.])
+            AC_MSG_WARN([Please reconfigure and point to a location where])
+            AC_MSG_WARN([the HWLOC library can be found.])
+            AC_MSG_ERROR([Cannot continue.])
+        fi
 
-        AS_IF([test "$pmix_hwloc_standard_header_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)])
+        AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
+                     [pmix_hwloc_libdir="$hwlocdir_prefix"],
+                     [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                            [if test -d $hwloc_prefix/lib64; then
+                                pmix_hwloc_libdir=$hwloc_prefix/lib64
+                             elif test -d $hwloc_prefix/lib; then
+                                pmix_hwloc_libdir=$hwloc_prefix/lib
+                             else
+                                AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
+                                AC_MSG_ERROR([Can not continue])
+                             fi
+                            ],
+                            [pmix_hwloc_libdir=""])])
+        _PMIX_CHECK_PACKAGE_LIB([pmix_hwloc], [hwloc], [hwloc_topology_init],
+                                [], [$pmix_hwloc_dir],
+                                [$pmix_hwloc_libdir],
+                                [],
+                                [AC_MSG_WARN([PMIX requires HWLOC support using])
+                                 AC_MSG_WARN([an external copy that you supply.])
+                                 AC_MSG_WARN([The library was not found in $pmix_hwloc_libdir.])
+                                 AC_MSG_ERROR([Cannot continue])])
 
-        AS_IF([test "$pmix_hwloc_standard_lib_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)])
-        PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
-    fi
+        # update global flags to test for HWLOC version
+        if test ! -z "$pmix_hwloc_CPPFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
+        fi
+        if test ! -z "$pmix_hwloc_LDFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
+        fi
+        if test ! -z "$pmix_hwloc_LIBS"; then
+            PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
+        fi
 
-    if test ! -z "$with_hwloc" && test "$with_hwloc" != "no" && test "$pmix_hwloc_support" != "1"; then
-        AC_MSG_WARN([HWLOC SUPPORT REQUESTED AND NOT FOUND])
-        AC_MSG_ERROR([CANNOT CONTINUE])
-    fi
-
-    if test $pmix_hwloc_support = "1"; then
         AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
         AC_COMPILE_IFELSE(
               [AC_LANG_PROGRAM([[#include <hwloc.h>]],
               [[
-    #if HWLOC_API_VERSION < 0x00010500
-    #error "hwloc API version is less than 0x00010500"
-    #endif
+        #if HWLOC_API_VERSION < 0x00010500
+        #error "hwloc API version is less than 0x00010500"
+        #endif
               ]])],
               [AC_MSG_RESULT([yes])],
               [AC_MSG_RESULT([no])
@@ -208,41 +134,50 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
         AC_COMPILE_IFELSE(
               [AC_LANG_PROGRAM([[#include <hwloc.h>]],
               [[
-    #if HWLOC_API_VERSION < 0x00010800
-    #error "hwloc API version is less than 0x00010800"
-    #endif
+        #if HWLOC_API_VERSION < 0x00010800
+        #error "hwloc API version is less than 0x00010800"
+        #endif
               ]])],
               [AC_MSG_RESULT([yes])
                pmix_have_topology_dup=1],
               [AC_MSG_RESULT([no])])
+
+        # set the header
+        PMIX_HWLOC_HEADER="<hwloc.h>"
     fi
 
     CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
     LDFLAGS=$pmix_check_hwloc_save_LDFLAGS
     LIBS=$pmix_check_hwloc_save_LIBS
 
-    AC_MSG_CHECKING([will hwloc support be built])
-    if test "$pmix_hwloc_support" != "1"; then
-        AC_MSG_RESULT([no])
-        pmix_hwloc_source=none
-        pmix_hwloc_support_will_build=no
-    else
-        AC_MSG_RESULT([yes])
-        pmix_hwloc_source=$pmix_hwloc_dir
-        pmix_hwloc_support_will_build=yes
-        AS_IF([test "$pmix_hwloc_standard_header_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_hwloc_CPPFLAGS)])
-
-        AS_IF([test "$pmix_hwloc_standard_lib_location" != "yes"],
-              [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_hwloc_LDFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_hwloc_LDFLAGS)])
+    if test ! -z "$pmix_hwloc_CPPFLAGS"; then
+        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_hwloc_CPPFLAGS)
+        PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
+    fi
+    if test ! -z "$pmix_hwloc_LDFLAGS"; then
+        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_hwloc_LDFLAGS)
+        PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_hwloc_LDFLAGS)
+    fi
+    if test ! -z "$pmix_hwloc_LIBS"; then
         PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_hwloc_LIBS)
         PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_hwloc_LIBS)
     fi
 
-    # Set output variables
-    PMIX_HWLOC_HEADER="<hwloc.h>"
+    AC_MSG_CHECKING([location of hwloc header])
+    AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER], [$PMIX_HWLOC_HEADER],
+                       [Location of hwloc.h])
+    AC_MSG_RESULT([$PMIX_HWLOC_HEADER])
+
+    AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER_GIVEN], [$pmix_hwloc_header_given],
+                       [Whether or not the hwloc header was given to us])
+
+    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
+                       [Whether or not hwloc_topology_dup is available])
+
+    pmix_hwloc_support_will_build=yes
+    pmix_hwloc_source=$pmix_hwloc_dir
+
+    PMIX_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [pmix_hwloc], [$pmix_hwloc_support_will_build ($pmix_hwloc_source)])
 
     PMIX_VAR_SCOPE_POP
-])dnl
+])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -1,13 +1,11 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
-#                         reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -16,197 +14,138 @@
 # $HEADER$
 #
 
-#
-# We have three modes for building libevent.
-#
-# First is an embedded libevent, where PMIx is being built into
-# another library and assumes that libevent is available, that there
-# is a single header (pointed to by --with-libevent-header) which
-# includes all the Libevent bits, and that the right libevent
-# configuration is used.  This mode is used when --enable-embeded-mode
-# is specified to configure.
-#
-# Second is as a co-built libevent.  In this case, PMIx's CPPFLAGS
-# will be set before configure to include the right -Is to pick up
-# libevent headers and LIBS will point to where the .la file for
-# libevent will exist.  When co-building, libevent's configure will be
-# run already, but the library will not yet be built.  It is ok to run
-# any compile-time (not link-time) tests in this mode.  This mode is
-# used when the --with-libevent=cobuild option is specified.
-#
-# Third is an external package.  In this case, all compile and link
-# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
-# modifications it desires in order to compile and link against
-# libevent.  This mode is used whenever the other modes are not used.
-#
-# PMIX_LIBEVENT_CONFIG([action-if-found], [action-if-not-found])
+# MCA_libevent_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
+    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_event_defaults pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
 
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
+    AC_ARG_WITH([libevent-header],
+                [AS_HELP_STRING([--with-libevent-header=HEADER],
+                                [The value that should be included in C files to include event.h])])
 
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
 
-    AC_ARG_WITH([libevent-header],
-                [AS_HELP_STRING([--with-libevent-header=HEADER],
-                                [The value that should be included in C files to include event.h.  This option only has meaning if --enable-embedded-mode is enabled.])])
-
     pmix_libevent_support=0
-
-    # figure out our mode...
-    AS_IF([test "$with_libevent" = "cobuild"],
-          [_PMIX_LIBEVENT_EMBEDDED_MODE(cobuild)],
-          [_PMIX_LIBEVENT_EXTERNAL])
-
-    if test $pmix_libevent_support -eq 1; then
-        AC_MSG_CHECKING([libevent header])
-        AC_DEFINE_UNQUOTED([PMIX_EVENT_HEADER], [$PMIX_EVENT_HEADER],
-                           [Location of event.h])
-        AC_MSG_RESULT([$PMIX_EVENT_HEADER])
-        AC_MSG_CHECKING([libevent2/thread header])
-        AC_DEFINE_UNQUOTED([PMIX_EVENT2_THREAD_HEADER], [$PMIX_EVENT2_THREAD_HEADER],
-                           [Location of event2/thread.h])
-        AC_MSG_RESULT([$PMIX_EVENT2_THREAD_HEADER])
-
-        PMIX_SUMMARY_ADD([[External Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
-    fi
-
-])
-
-AC_DEFUN([_PMIX_LIBEVENT_EMBEDDED_MODE], [
-    AC_MSG_CHECKING([for libevent])
-    AC_MSG_RESULT([$1])
-
-    AS_IF([test -z "$with_libevent_header" || test "$with_libevent_header" = "yes"],
-          [PMIX_EVENT_HEADER="<event.h>"
-           PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"],
-          [PMIX_EVENT_HEADER="$with_libevent_header"
-           PMIX_EVENT2_THREAD_HEADER="$with_libevent_header"])
-
-    AC_MSG_CHECKING([if co-built libevent includes thread support])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-        [
-         #include <event.h>
-         #include <event2/thread.h>
-        ],
-        [
-         #if !(EVTHREAD_LOCK_API_VERSION >= 1)
-         #error "No threads!"
-         #endif
-        ])],
-        [AC_MSG_RESULT([yes])],
-        [AC_MSG_RESULT([no])
-         AC_MSG_ERROR([No thread support in co-build libevent.  Aborting])])
-
-    pmix_libevent_source=$1
-    pmix_libevent_support=1
-])
-
-AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
-    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_event_defaults pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
 
     pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
     pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
     pmix_check_libevent_save_LIBS="$LIBS"
-    pmix_event_defaults=yes
 
-    # get rid of the trailing slash(es)
-    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+    if test "x$with_libevent_header" != "x"; then
+        AS_IF([test "$with_libevent_header" = "yes"],
+              [PMIX_EVENT_HEADER="<event.h>"
+               PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"],
+              [PMIX_EVENT_HEADER="\"$with_libevent_header\""
+               PMIX_EVENT2_THREAD_HEADER="\"$with_libevent_header\""])
+        pmix_libevent_source="external header"
+        pmix_libevent_support=1
 
-    if test "$libevent_prefix" != "no"; then
-        AC_MSG_CHECKING([for libevent in])
-        if test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"; then
-            pmix_event_defaults=no
-            pmix_event_dir=$libevent_prefix/include
-            if test -d $libevent_prefix/lib; then
-                pmix_event_libdir=$libevent_prefix/lib
-            elif test -d $libevent_prefix/lib64; then
-                pmix_event_libdir=$libevent_prefix/lib64
-            elif test -d $libevent_prefix; then
-                pmix_event_libdir=$libevent_prefix
-            else
-                AC_MSG_RESULT([Could not find $libevent_prefix/lib, $libevent_prefix/lib64, or $libevent_prefix])
-                AC_MSG_ERROR([Can not continue])
+    else
+        # get rid of any trailing slash(es)
+        libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+        libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+
+        AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+              [pmix_event_dir="$libevent_prefix"],
+              [pmix_event_dir=""])
+        _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                                   [pmix_libevent_support=1],
+                                   [pmix_libevent_support=0])
+        if test $pmix_libevent_support -eq 0 && test -z $pmix_event_dir; then
+            # try default locations
+            if test -d /usr/include; then
+                pmix_event_dir=/usr
+                _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                                           [pmix_libevent_support=1],
+                                           [pmix_libevent_support=0])
             fi
-            AC_MSG_RESULT([$pmix_event_dir and $pmix_event_libdir])
-        else
-            pmix_event_defaults=yes
-            pmix_event_dir=/usr/include
-            if test -d /usr/lib; then
-                pmix_event_libdir=/usr/lib
-                AC_MSG_RESULT([(default search paths)])
-            elif test -d /usr/lib64; then
-                pmix_event_libdir=/usr/lib64
-                AC_MSG_RESULT([(default search paths)])
-            else
-                AC_MSG_RESULT([default paths not found])
-                pmix_libevent_support=0
+            if test $pmix_libevent_support -eq 0 && test -d /usr/local/include; then
+                pmix_event_dir=/usr/local
+                _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                                           [pmix_libevent_support=1],
+                                           [pmix_libevent_support=0])
             fi
         fi
-        AS_IF([test ! -z "$libeventdir_prefix" && "$libeventdir_prefix" != "yes"],
-              [pmix_event_libdir="$libeventdir_prefix"])
-
-        PMIX_CHECK_PACKAGE([pmix_libevent],
-                           [event.h],
-                           [event_core],
-                           [event_config_new],
-                           [-levent_pthreads],
-                           [$pmix_event_dir],
-                           [$pmix_event_libdir],
-                           [pmix_libevent_support=1],
-                           [pmix_libevent_support=0])
-
-        # Check to see if the above check failed because it conflicted with LSF's libevent.so
-        # This can happen if LSF's library is in the LDFLAGS envar or default search
-        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-        # in Libevent's libevent.so
-        if test $pmix_libevent_support -eq 0; then
-            AC_CHECK_LIB([event], [event_getcode4name],
-                         [AC_MSG_WARN([===================================================================])
-                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                          AC_MSG_WARN([LSF library path.])
-                          AC_MSG_WARN([===================================================================])
-                          ])
-        fi
-
-        # need to add resulting flags to global ones so we can
-        # test for thread support
-        AS_IF([test "$pmix_event_defaults" = "no"],
-              [PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)])
-        PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
 
         if test $pmix_libevent_support -eq 1; then
+            AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+                         [pmix_event_libdir="$libeventdir_prefix"],
+                         [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                                [if test -d $libevent_prefix/lib64; then
+                                    pmix_event_libdir=$libevent_prefix/lib64
+                                 elif test -d $libevent_prefix/lib; then
+                                    pmix_event_libdir=$libevent_prefix/lib
+                                 else
+                                    AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                                    AC_MSG_ERROR([Can not continue])
+                                 fi
+                                ],
+                                [pmix_event_libdir=""])])
+            _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
+                                    [-levent_pthreads], [$pmix_event_dir],
+                                    [$pmix_event_libdir],
+                                    [pmix_libevent_support=1],
+                                    [pmix_libevent_support=0])
+
+            # Check to see if the above check failed because it conflicted with LSF's libevent.so
+            # This can happen if LSF's library is in the LDFLAGS envar or default search
+            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+            # in Libevent's libevent.so
+            if test $pmix_libevent_support -eq 0; then
+                AC_CHECK_LIB([event], [event_getcode4name],
+                             [AC_MSG_WARN([===================================================================])
+                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                              AC_MSG_WARN([LSF library path.])
+                              AC_MSG_WARN([===================================================================])
+                              ])
+            fi
+        fi
+
+        if test $pmix_libevent_support -eq 1; then
+            # need to add resulting flags to global ones so we can
+            # test for thread support
+            if test ! -z "$pmix_libevent_CPPFLAGS"; then
+                PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
+            fi
+            if test ! -z "$pmix_libevent_LDFLAGS"; then
+                PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
+            fi
+            if test ! -z "$pmix_libevent_LIBS"; then
+                PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
+            fi
+
             # Ensure that this libevent has the symbol
             # "evthread_set_lock_callbacks", which will only exist if
             # libevent was configured with thread support.
             AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
                          [],
-                         [AC_MSG_WARN([External libevent does not have thread support])
-                          AC_MSG_WARN([PMIx requires libevent to be compiled with])
+                         [AC_MSG_WARN([libevent does not have thread support])
+                          AC_MSG_WARN([PMIX requires libevent to be compiled with])
                           AC_MSG_WARN([thread support enabled])
                           pmix_libevent_support=0])
         fi
+
         if test $pmix_libevent_support -eq 1; then
             AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
                          [],
-                         [AC_MSG_WARN([External libevent does not have thread support])
-                          AC_MSG_WARN([PMIx requires libevent to be compiled with])
+                         [AC_MSG_WARN([libevent does not have thread support])
+                          AC_MSG_WARN([PMIX requires libevent to be compiled with])
                           AC_MSG_WARN([thread support enabled])
                           pmix_libevent_support=0])
         fi
+
         if test $pmix_libevent_support -eq 1; then
             # Pin the "oldest supported" version to 2.0.21
             AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
@@ -223,33 +162,42 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
                                AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
                                pmix_libevent_support=0])
         fi
+        pmix_libevent_source=$pmix_event_dir
+        PMIX_EVENT_HEADER="<event.h>"
+        PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
     fi
-
-    CPPFLAGS="$pmix_check_libevent_save_CPPFLAGS"
-    LDFLAGS="$pmix_check_libevent_save_LDFLAGS"
-    LIBS="$pmix_check_libevent_save_LIBS"
 
     AC_MSG_CHECKING([will libevent support be built])
     if test $pmix_libevent_support -eq 1; then
         AC_MSG_RESULT([yes])
+        if test ! -z "$pmix_libevent_CPPFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_libevent_CPPFLAGS)
+            PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libevent_CPPFLAGS)
+        fi
+        if test ! -z "$pmix_libevent_LDFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_libevent_LDFLAGS)
+            PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)
+        fi
+        if test ! -z "$pmix_libevent_LIBS"; then
+            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_libevent_LIBS)
+            PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
+        fi
         # Set output variables
-        PMIX_EVENT_HEADER="<event.h>"
-        PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
         AC_DEFINE_UNQUOTED([PMIX_EVENT_HEADER], [$PMIX_EVENT_HEADER],
                            [Location of event.h])
-        pmix_libevent_source=$pmix_event_dir
-        AS_IF([test "$pmix_event_defaults" = "no"],
-              [PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-               PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_libevent_LDFLAGS)
-               PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)])
-        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_libevent_LIBS)
-        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
+        AC_DEFINE_UNQUOTED([PMIX_EVENT2_THREAD_HEADER], [$PMIX_EVENT2_THREAD_HEADER],
+                           [Location of event2/thread.h])
+        PMIX_SUMMARY_ADD([[Required Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
     else
         AC_MSG_RESULT([no])
     fi
 
+    # restore global flags
+    CPPFLAGS="$pmix_check_libevent_save_CPPFLAGS"
+    LDFLAGS="$pmix_check_libevent_save_LDFLAGS"
+    LIBS="$pmix_check_libevent_save_LIBS"
+
     AC_DEFINE_UNQUOTED([PMIX_HAVE_LIBEVENT], [$pmix_libevent_support], [Whether we are building against libevent])
 
     PMIX_VAR_SCOPE_POP
-])dnl
+])


### PR DESCRIPTION
We had hardcoded default paths to be some standard
Linux locations, but ignored what someone might have
specified in their CPPFLAGS and friends. Thus, environments
that used a slightly different default path would error
out even when the user's environment specified where
things could be found by default.

Fix that so we respect the provided flags, falling back
to the hardcoded option IFF the specified library cannot
be found anywhere else.

Signed-off-by: Ralph Castain <rhc@pmix.org>