### PR TITLE
Cleanup the configure logic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,10 +38,7 @@ EXTRA_DIST = AUTHORS README HACKING INSTALL VERSION LICENSE autogen.pl EXCEPTION
 # Only install the valgrind suppressions file and man pages
 # if we're building in standalone mode
 dist_pmixdata_DATA =
-if ! PMIX_EMBEDDED_MODE
 dist_pmixdata_DATA += contrib/pmix-valgrind.supp
-
-endif
 
 if PMIX_TESTS_EXAMPLES
 SUBDIRS += . test/test_v2 test examples

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -197,42 +197,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_HEADERS(pmix_config_prefix[src/include/pmix_config.h])
 
 
-    # Add any extra lib?
-    AC_ARG_WITH([pmix-extra-lib],
-                AS_HELP_STRING([--with-pmix-extra-lib=LIB],
-                               [Link the output PMIx library to this extra lib (used in embedded mode)]))
-    AC_MSG_CHECKING([for extra lib])
-    AS_IF([test ! -z "$with_pmix_extra_lib"],
-          [AS_IF([test "$with_pmix_extra_lib" = "yes" || test "$with_pmix_extra_lib" = "no"],
-                 [AC_MSG_RESULT([ERROR])
-                  AC_MSG_WARN([Invalid value for --with-extra-pmix-lib:])
-                  AC_MSG_WARN([    $with_pmix_extra_lib])
-                  AC_MSG_WARN([Must be path name of the library to add])
-                  AC_MSG_ERROR([Cannot continue])],
-                 [AC_MSG_RESULT([$with_pmix_extra_lib])
-                  PMIX_EXTRA_LIB=$with_pmix_extra_lib])],
-          [AC_MSG_RESULT([no])
-           PMIX_EXTRA_LIB=])
-    AC_SUBST(PMIX_EXTRA_LIB)
-
-    # Add any extra libtool lib?
-    AC_ARG_WITH([pmix-extra-ltlib],
-                AS_HELP_STRING([--with-pmix-extra-ltlib=LIB],
-                               [Link any embedded components/tools that require it to the provided libtool lib (used in embedded mode)]))
-    AC_MSG_CHECKING([for extra ltlib])
-    AS_IF([test ! -z "$with_pmix_extra_ltlib"],
-          [AS_IF([test "$with_pmix_extra_ltlib" = "yes" || test "$with_pmix_extra_ltlib" = "no"],
-                 [AC_MSG_RESULT([ERROR])
-                  AC_MSG_WARN([Invalid value for --with-pmix-extra-ltlib:])
-                  AC_MSG_WARN([    $with_pmix_extra_ltlib])
-                  AC_MSG_WARN([Must be path name of the library to add])
-                  AC_MSG_ERROR([Cannot continue])],
-                 [AC_MSG_RESULT([$with_pmix_extra_ltlib])
-                  PMIX_EXTRA_LTLIB=$with_pmix_extra_ltlib])],
-          [AC_MSG_RESULT([no])
-           PMIX_EXTRA_LTLIB=])
-    AC_SUBST(PMIX_EXTRA_LTLIB)
-
     #
     # Package/brand string
     #
@@ -995,11 +959,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/tools/wrapper/pmixcc-wrapper-data.txt]
         )
 
-    # publish any embedded flags so external wrappers can use them
-    AC_SUBST(PMIX_EMBEDDED_LIBS)
-    AC_SUBST(PMIX_EMBEDDED_LDFLAGS)
-    AC_SUBST(PMIX_EMBEDDED_CPPFLAGS)
-
     # Success
     $2
 ])dnl
@@ -1023,19 +982,6 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
            AC_MSG_RESULT([yes])])
     AC_DEFINE_UNQUOTED(PMIX_ENABLE_DLOPEN_SUPPORT, $PMIX_ENABLE_DLOPEN_SUPPORT,
                       [Whether we want to enable dlopen support])
-
-    # Embedded mode, or standalone?
-    AC_MSG_CHECKING([if embedded mode is enabled])
-    AC_ARG_ENABLE([embedded-mode],
-        [AS_HELP_STRING([--enable-embedded-mode],
-                [Using --enable-embedded-mode causes PMIx to skip a few configure checks and install nothing.  It should only be used when building PMIx within the scope of a larger package.])])
-    AS_IF([test "$enable_embedded_mode" = "yes"],
-          [pmix_mode=embedded
-           pmix_install_primary_headers=no
-           AC_MSG_RESULT([yes])],
-          [pmix_mode=standalone
-           pmix_install_primary_headers=yes
-           AC_MSG_RESULT([no])])
 
 #
 # Is this a developer copy?
@@ -1137,6 +1083,20 @@ else
     WANT_INSTALL_HEADERS=0
 fi
 
+AC_MSG_CHECKING([if want to install PMIx header files])
+AC_ARG_WITH(pmix-headers,
+    AS_HELP_STRING([--with-pmix-headers],
+                   [Install the PMIx header files (default: enabled)]))
+if test "$with_pmix_headers" != "no"; then
+    AC_MSG_RESULT([yes])
+    WANT_PRIMARY_HEADERS=1
+    pmix_install_primary_headers=yes
+else
+    AC_MSG_RESULT([no])
+    WANT_PRIMARY_HEADERS=0
+    pmix_install_primary_headers=no
+fi
+
 # Install tests and examples?
 AC_MSG_CHECKING([if tests and examples are to be installed])
 AC_ARG_WITH([tests-examples],
@@ -1148,8 +1108,6 @@ AS_IF([test "$pmix_install_primary_headers" = "no"],
               AC_MSG_RESULT([no])],
              [AC_MSG_RESULT([no])
               AC_MSG_WARN([Cannot install tests/examples without installing primary headers.])
-              AC_MSG_WARN([This situation arises when configured in embedded mode])
-              AC_MSG_WARN([and without devel headers.])
               AC_MSG_ERROR([Please correct the configure line and retry])])],
       [AS_IF([test ! -z "$with_tests_examples" && test "$with_tests_examples" = "no"],
              [pmix_tests=no
@@ -1342,11 +1300,6 @@ else
     pmix_need_libpmix=1
 fi
 
-# if someone enables embedded mode but doesn't want to install the
-# devel headers, then default nonglobal-dlopen to false
-AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" && test $WANT_INSTALL_HEADERS -eq 0 && test $pmix_need_libpmix -eq 1],
-      [pmix_need_libpmix=0])
-
 #
 # Do we want PTY support?
 #
@@ -1387,7 +1340,6 @@ AM_CONDITIONAL(MCA_BUILD_PSEC_DUMMY_HANDSHAKE, test "$DISABLE_psec_dummy_handsha
 # PMIX_INIT and an external caller (if PMIX_INIT is not invoked).
 AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
     AS_IF([test "$pmix_did_am_conditionals" != "yes"],[
-        AM_CONDITIONAL([PMIX_EMBEDDED_MODE], [test "x$pmix_mode" = "xembedded"])
         AM_CONDITIONAL([PMIX_TESTS_EXAMPLES], [test "x$pmix_tests" = "xyes"])
         AM_CONDITIONAL([PMIX_COMPILE_TIMING], [test "$WANT_TIMING" = "1"])
         AM_CONDITIONAL([PMIX_WANT_MUNGE], [test "$pmix_munge_support" = "1"])

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -24,27 +24,13 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                 [AS_HELP_STRING([--with-hwloc-libdir=DIR],
                                 [Search for hwloc libraries in DIR ])])
 
-    AC_ARG_WITH([hwloc-header],
-                [AS_HELP_STRING([--with-hwloc-header=HEADER],
-                                [The value that should be included in C files to include hwloc.h])])
-
     pmix_hwloc_support=0
-    pmix_hwloc_header_given=0
     pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
     pmix_check_hwloc_save_LDFLAGS="$LDFLAGS"
     pmix_check_hwloc_save_LIBS="$LIBS"
     pmix_have_topology_dup=0
 
-    if test "x$with_hwloc_header" != "x"; then
-        AS_IF([test "$with_hwloc_header" = "yes"],
-              [PMIX_HWLOC_HEADER="<hwloc.h>"],
-              [PMIX_HWLOC_HEADER="\"$with_hwloc_header\""
-               pmix_hwloc_header_given=1])
-        pmix_hwloc_support=1
-        pmix_hwloc_source="external header"
-        pmix_have_topology_dup=1
-
-    elif test "$with_hwloc" == "no"; then
+    if test "$with_hwloc" == "no"; then
         AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
@@ -167,9 +153,6 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER], [$PMIX_HWLOC_HEADER],
                        [Location of hwloc.h])
     AC_MSG_RESULT([$PMIX_HWLOC_HEADER])
-
-    AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER_GIVEN], [$pmix_hwloc_header_given],
-                       [Whether or not the hwloc header was given to us])
 
     AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
                        [Whether or not hwloc_topology_dup is available])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -17,15 +17,11 @@
 # MCA_libevent_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
-    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_event_defaults pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
+    PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
 
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
-    AC_ARG_WITH([libevent-header],
-                [AS_HELP_STRING([--with-libevent-header=HEADER],
-                                [The value that should be included in C files to include event.h])])
-
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
@@ -36,136 +32,125 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
     pmix_check_libevent_save_LIBS="$LIBS"
 
-    if test "x$with_libevent_header" != "x"; then
-        AS_IF([test "$with_libevent_header" = "yes"],
-              [PMIX_EVENT_HEADER="<event.h>"
-               PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"],
-              [PMIX_EVENT_HEADER="\"$with_libevent_header\""
-               PMIX_EVENT2_THREAD_HEADER="\"$with_libevent_header\""])
-        pmix_libevent_source="external header"
-        pmix_libevent_support=1
+    # get rid of any trailing slash(es)
+    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
 
-    else
-        # get rid of any trailing slash(es)
-        libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-        libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
-
-        AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-              [pmix_event_dir="$libevent_prefix"],
-              [pmix_event_dir=""])
-        _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                                   [pmix_libevent_support=1],
-                                   [pmix_libevent_support=0])
-        if test $pmix_libevent_support -eq 0 && test -z $pmix_event_dir; then
-            # try default locations
-            if test -d /usr/include; then
-                pmix_event_dir=/usr
-                _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                                           [pmix_libevent_support=1],
-                                           [pmix_libevent_support=0])
-            fi
-            if test $pmix_libevent_support -eq 0 && test -d /usr/local/include; then
-                pmix_event_dir=/usr/local
-                _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                                           [pmix_libevent_support=1],
-                                           [pmix_libevent_support=0])
-            fi
+    AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+          [pmix_event_dir="$libevent_prefix"],
+          [pmix_event_dir=""])
+    _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                               [pmix_libevent_support=1],
+                               [pmix_libevent_support=0])
+    if test $pmix_libevent_support -eq 0 && test -z $pmix_event_dir; then
+        # try default locations
+        if test -d /usr/include; then
+            pmix_event_dir=/usr
+            _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                                       [pmix_libevent_support=1],
+                                       [pmix_libevent_support=0])
         fi
-
-        if test $pmix_libevent_support -eq 1; then
-            AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
-                         [pmix_event_libdir="$libeventdir_prefix"],
-                         [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-                                [if test -d $libevent_prefix/lib64; then
-                                    pmix_event_libdir=$libevent_prefix/lib64
-                                 elif test -d $libevent_prefix/lib; then
-                                    pmix_event_libdir=$libevent_prefix/lib
-                                 else
-                                    AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
-                                    AC_MSG_ERROR([Can not continue])
-                                 fi
-                                ],
-                                [pmix_event_libdir=""])])
-            _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
-                                    [-levent_pthreads], [$pmix_event_dir],
-                                    [$pmix_event_libdir],
-                                    [pmix_libevent_support=1],
-                                    [pmix_libevent_support=0])
-
-            # Check to see if the above check failed because it conflicted with LSF's libevent.so
-            # This can happen if LSF's library is in the LDFLAGS envar or default search
-            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-            # in Libevent's libevent.so
-            if test $pmix_libevent_support -eq 0; then
-                AC_CHECK_LIB([event], [event_getcode4name],
-                             [AC_MSG_WARN([===================================================================])
-                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                              AC_MSG_WARN([LSF library path.])
-                              AC_MSG_WARN([===================================================================])
-                              ])
-            fi
+        if test $pmix_libevent_support -eq 0 && test -d /usr/local/include; then
+            pmix_event_dir=/usr/local
+            _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
+                                       [pmix_libevent_support=1],
+                                       [pmix_libevent_support=0])
         fi
-
-        if test $pmix_libevent_support -eq 1; then
-            # need to add resulting flags to global ones so we can
-            # test for thread support
-            if test ! -z "$pmix_libevent_CPPFLAGS"; then
-                PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-            fi
-            if test ! -z "$pmix_libevent_LDFLAGS"; then
-                PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
-            fi
-            if test ! -z "$pmix_libevent_LIBS"; then
-                PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
-            fi
-
-            # Ensure that this libevent has the symbol
-            # "evthread_set_lock_callbacks", which will only exist if
-            # libevent was configured with thread support.
-            AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
-                         [],
-                         [AC_MSG_WARN([libevent does not have thread support])
-                          AC_MSG_WARN([PMIX requires libevent to be compiled with])
-                          AC_MSG_WARN([thread support enabled])
-                          pmix_libevent_support=0])
-        fi
-
-        if test $pmix_libevent_support -eq 1; then
-            AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
-                         [],
-                         [AC_MSG_WARN([libevent does not have thread support])
-                          AC_MSG_WARN([PMIX requires libevent to be compiled with])
-                          AC_MSG_WARN([thread support enabled])
-                          pmix_libevent_support=0])
-        fi
-
-        if test $pmix_libevent_support -eq 1; then
-            # Pin the "oldest supported" version to 2.0.21
-            AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                               [[
-                                                 #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                                 #error "libevent API version is less than 0x02001500"
-                                                 #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                                 #error "libevent API version is less than 0x02001500"
-                                                 #endif
-                                               ]])],
-                              [AC_MSG_RESULT([yes])],
-                              [AC_MSG_RESULT([no])
-                               AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                               pmix_libevent_support=0])
-        fi
-        pmix_libevent_source=$pmix_event_dir
-        PMIX_EVENT_HEADER="<event.h>"
-        PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
     fi
+
+    if test $pmix_libevent_support -eq 1; then
+        AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+                     [pmix_event_libdir="$libeventdir_prefix"],
+                     [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                            [if test -d $libevent_prefix/lib64; then
+                                pmix_event_libdir=$libevent_prefix/lib64
+                             elif test -d $libevent_prefix/lib; then
+                                pmix_event_libdir=$libevent_prefix/lib
+                             else
+                                AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                                AC_MSG_ERROR([Can not continue])
+                             fi
+                            ],
+                            [pmix_event_libdir=""])])
+        _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
+                                [-levent_pthreads], [$pmix_event_dir],
+                                [$pmix_event_libdir],
+                                [pmix_libevent_support=1],
+                                [pmix_libevent_support=0])
+
+        # Check to see if the above check failed because it conflicted with LSF's libevent.so
+        # This can happen if LSF's library is in the LDFLAGS envar or default search
+        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+        # in Libevent's libevent.so
+        if test $pmix_libevent_support -eq 0; then
+            AC_CHECK_LIB([event], [event_getcode4name],
+                         [AC_MSG_WARN([===================================================================])
+                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                          AC_MSG_WARN([LSF library path.])
+                          AC_MSG_WARN([===================================================================])
+                          ])
+        fi
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        # need to add resulting flags to global ones so we can
+        # test for thread support
+        if test ! -z "$pmix_libevent_CPPFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
+        fi
+        if test ! -z "$pmix_libevent_LDFLAGS"; then
+            PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
+        fi
+        if test ! -z "$pmix_libevent_LIBS"; then
+            PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
+        fi
+
+        # Ensure that this libevent has the symbol
+        # "evthread_set_lock_callbacks", which will only exist if
+        # libevent was configured with thread support.
+        AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
+                     [],
+                     [AC_MSG_WARN([libevent does not have thread support])
+                      AC_MSG_WARN([PMIX requires libevent to be compiled with])
+                      AC_MSG_WARN([thread support enabled])
+                      pmix_libevent_support=0])
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
+                     [],
+                     [AC_MSG_WARN([libevent does not have thread support])
+                      AC_MSG_WARN([PMIX requires libevent to be compiled with])
+                      AC_MSG_WARN([thread support enabled])
+                      pmix_libevent_support=0])
+    fi
+
+    if test $pmix_libevent_support -eq 1; then
+        # Pin the "oldest supported" version to 2.0.21
+        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
+                                           [[
+                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #endif
+                                           ]])],
+                          [AC_MSG_RESULT([yes])],
+                          [AC_MSG_RESULT([no])
+                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
+                           pmix_libevent_support=0])
+    fi
+    pmix_libevent_source=$pmix_event_dir
+    PMIX_EVENT_HEADER="<event.h>"
+    PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
 
     AC_MSG_CHECKING([will libevent support be built])
     if test $pmix_libevent_support -eq 1; then

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 #
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,9 +9,10 @@
 # $HEADER$
 #
 
-# Only install the headers if we're in standalone mode
+# Install the PMIx headers unless told not to
 
 if WANT_PRIMARY_HEADERS
+
 include_HEADERS = \
         pmix.h \
         pmix_server.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,24 +56,6 @@ libpmix_la_DEPENDENCIES = \
 	mca/base/libpmix_mca_base.la \
 	$(MCA_pmix_FRAMEWORK_LIBS)
 
-if PMIX_EMBEDDED_MODE
-
-if WANT_INSTALL_HEADERS
-
-lib_LTLIBRARIES = libpmix.la
-libpmix_la_SOURCES = $(headers) $(sources)
-libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
-
-else
-
-noinst_LTLIBRARIES = libpmix.la
-libpmix_la_SOURCES = $(headers) $(sources)
-libpmix_la_LDFLAGS =
-
-endif
-
-else
-
 lib_LTLIBRARIES = libpmix.la
 libpmix_la_SOURCES = $(headers) $(sources)
 libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
@@ -81,8 +63,6 @@ libpmix_la_LIBADD += \
         include/libpmixglobal.la
 libpmix_la_DEPENDENCIES += \
         include/libpmixglobal.la
-
-endif !PMIX_EMBEDDED_MODE
 
 include atomics/sys/Makefile.include
 include threads/Makefile.include

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -35,7 +35,6 @@ headers = pmix_globals.h
 nodist_headers = \
     pmix_config.h
 
-if ! PMIX_EMBEDDED_MODE
 headers += \
         align.h \
         hash_string.h \
@@ -50,8 +49,6 @@ headers += \
         frameworks.h \
         pmix_stdatomic.h \
         dictionary.h
-
-endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
 nobase_pmix_HEADERS = $(headers)


### PR DESCRIPTION
Remove "embedded" mode and the hwloc/libevent "header" options
and rely instead on the CPPFLAGS/LDFLAGS/LIBS combination to
find things. The effectively removes the OMPI-specific
customizations of the PMIx configure logic, which contained
errors that compensated for errors in the OMPI side.

Signed-off-by: Ralph Castain <rhc@pmix.org>