### PR TITLE
Add an option to disable package checks

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -751,6 +751,30 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     PMIX_CHECK_VISIBILITY
 
     ##################################
+    # Package checks
+    ##################################
+
+    # Sometimes we are in situations where we cannot check the dependent
+    # libraries for presence or correctness. Allow the user to ask us to
+    # take it all on faith that it will eventually build correctly.
+
+    AC_MSG_CHECKING([disable package checks])
+    AC_ARG_ENABLE([package-checks],
+                  [AS_HELP_STRING([--disable-package-checks],
+                                  [Do not check dependent libraries for presence or correctness.
+                                   Take it on faith that they will be present when needed. This
+                                   is not advisable, but necessary in some circumstances])])
+    if test "$enable_package_checks" = "no" ; then
+        PMIX_DISABLE_PACKAGE_CHECKS=1
+        AC_MSG_RESULT([disabled])
+    else
+        PMIX_DISABLE_PACKAGE_CHECKS=0
+        AC_MSG_RESULT([enabled by default])
+    fi
+    AC_DEFINE_UNQUOTED(PMIX_DISABLE_PACKAGE_CHECKS, $PMIX_DISABLE_PACKAGE_CHECKS,
+                       [Disable package checks])
+
+    ##################################
     # Libevent
     ##################################
     pmix_show_title "Event libraries"

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -34,56 +34,58 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
         AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
+    fi
 
-    else
-        # get rid of any trailing slash(es)
-        hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
-        hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
+    # get rid of any trailing slash(es)
+    hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
+    hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
 
-        AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
-                     [pmix_hwloc_dir="$hwloc_prefix"],
-                     [pmix_hwloc_dir=""])
-        _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
-                                   [pmix_hwloc_support=1],
-                                   [pmix_hwloc_support=0])
+    AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                 [pmix_hwloc_dir="$hwloc_prefix"],
+                 [pmix_hwloc_dir=""])
+    _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                               [pmix_hwloc_support=1],
+                               [pmix_hwloc_support=0])
 
-        if test $pmix_hwloc_support -eq 0 && test -z $pmix_hwloc_dir; then
-            # try default locations
-            if test -d /usr/include; then
-                pmix_hwloc_dir=/usr
-                _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
-                                           [pmix_hwloc_support=1],
-                                           [pmix_hwloc_support=0])
-            fi
-            if test $pmix_hwloc_support -eq 0 && test -d /usr/local/include; then
-                pmix_hwloc_dir=/usr/local
-                _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
-                                           [pmix_hwloc_support=1],
-                                           [pmix_hwloc_support=0])
-            fi
+    if test $pmix_hwloc_support -eq 0 && test -z $pmix_hwloc_dir; then
+        # try default locations
+        if test -d /usr/include; then
+            pmix_hwloc_dir=/usr
+            _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                                       [pmix_hwloc_support=1],
+                                       [pmix_hwloc_support=0])
         fi
-
-        if test $pmix_hwloc_support -eq 0; then
-            AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
-            AC_MSG_WARN([an adequate version of that library was not found.])
-            AC_MSG_WARN([Please reconfigure and point to a location where])
-            AC_MSG_WARN([the HWLOC library can be found.])
-            AC_MSG_ERROR([Cannot continue.])
+        if test $pmix_hwloc_support -eq 0 && test -d /usr/local/include; then
+            pmix_hwloc_dir=/usr/local
+            _PMIX_CHECK_PACKAGE_HEADER([pmix_hwloc], [hwloc.h], [$pmix_hwloc_dir],
+                                       [pmix_hwloc_support=1],
+                                       [pmix_hwloc_support=0])
         fi
+    fi
 
-        AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
-                     [pmix_hwloc_libdir="$hwlocdir_prefix"],
-                     [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
-                            [if test -d $hwloc_prefix/lib64; then
-                                pmix_hwloc_libdir=$hwloc_prefix/lib64
-                             elif test -d $hwloc_prefix/lib; then
-                                pmix_hwloc_libdir=$hwloc_prefix/lib
-                             else
-                                AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
-                                AC_MSG_ERROR([Can not continue])
-                             fi
-                            ],
-                            [pmix_hwloc_libdir=""])])
+    if test $pmix_hwloc_support -eq 0; then
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
+        AC_MSG_WARN([an adequate version of that library was not found.])
+        AC_MSG_WARN([Please reconfigure and point to a location where])
+        AC_MSG_WARN([the HWLOC library can be found.])
+        AC_MSG_ERROR([Cannot continue.])
+    fi
+
+    AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
+                 [pmix_hwloc_libdir="$hwlocdir_prefix"],
+                 [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
+                        [if test -d $hwloc_prefix/lib64; then
+                            pmix_hwloc_libdir=$hwloc_prefix/lib64
+                         elif test -d $hwloc_prefix/lib; then
+                            pmix_hwloc_libdir=$hwloc_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [pmix_hwloc_libdir=""])])
+
+    if test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
         _PMIX_CHECK_PACKAGE_LIB([pmix_hwloc], [hwloc], [hwloc_topology_init],
                                 [], [$pmix_hwloc_dir],
                                 [$pmix_hwloc_libdir],
@@ -127,10 +129,12 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
               [AC_MSG_RESULT([yes])
                pmix_have_topology_dup=1],
               [AC_MSG_RESULT([no])])
-
-        # set the header
-        PMIX_HWLOC_HEADER="<hwloc.h>"
+    else
+        pmix_have_topology_dup=1
     fi
+
+    # set the header
+    PMIX_HWLOC_HEADER="<hwloc.h>"
 
     CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
     LDFLAGS=$pmix_check_hwloc_save_LDFLAGS

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -72,34 +72,36 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                              fi
                             ],
                             [pmix_event_libdir=""])])
-        _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
-                                [-levent_pthreads], [$pmix_event_dir],
-                                [$pmix_event_libdir],
-                                [pmix_libevent_support=1],
-                                [pmix_libevent_support=0])
+        if test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
+            _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
+                                    [-levent_pthreads], [$pmix_event_dir],
+                                    [$pmix_event_libdir],
+                                    [pmix_libevent_support=1],
+                                    [pmix_libevent_support=0])
 
-        # Check to see if the above check failed because it conflicted with LSF's libevent.so
-        # This can happen if LSF's library is in the LDFLAGS envar or default search
-        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-        # in Libevent's libevent.so
-        if test $pmix_libevent_support -eq 0; then
-            AC_CHECK_LIB([event], [event_getcode4name],
-                         [AC_MSG_WARN([===================================================================])
-                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                          AC_MSG_WARN([LSF library path.])
-                          AC_MSG_WARN([===================================================================])
-                          ])
+            # Check to see if the above check failed because it conflicted with LSF's libevent.so
+            # This can happen if LSF's library is in the LDFLAGS envar or default search
+            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+            # in Libevent's libevent.so
+            if test $pmix_libevent_support -eq 0; then
+                AC_CHECK_LIB([event], [event_getcode4name],
+                             [AC_MSG_WARN([===================================================================])
+                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                              AC_MSG_WARN([LSF library path.])
+                              AC_MSG_WARN([===================================================================])
+                              ])
+            fi
         fi
     fi
 
-    if test $pmix_libevent_support -eq 1; then
+    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
         # need to add resulting flags to global ones so we can
         # test for thread support
         if test ! -z "$pmix_libevent_CPPFLAGS"; then
@@ -123,7 +125,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                       pmix_libevent_support=0])
     fi
 
-    if test $pmix_libevent_support -eq 1; then
+    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
         AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
                      [],
                      [AC_MSG_WARN([libevent does not have thread support])
@@ -132,7 +134,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                       pmix_libevent_support=0])
     fi
 
-    if test $pmix_libevent_support -eq 1; then
+    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
         # Pin the "oldest supported" version to 2.0.21
         AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],


### PR DESCRIPTION
There are scenarios where we need to skip the package
library checks for libevent and hwloc - i.e., to simply
trust that the user knows what they are doing, and that
the libraries are both present and functional. In those
rare scenarios, allow the user to disable those checks.

Signed-off-by: Ralph Castain <rhc@pmix.org>