### PR TITLE
Backup a bit to remove disable-package-checks

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -751,30 +751,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     PMIX_CHECK_VISIBILITY
 
     ##################################
-    # Package checks
-    ##################################
-
-    # Sometimes we are in situations where we cannot check the dependent
-    # libraries for presence or correctness. Allow the user to ask us to
-    # take it all on faith that it will eventually build correctly.
-
-    AC_MSG_CHECKING([disable package checks])
-    AC_ARG_ENABLE([package-checks],
-                  [AS_HELP_STRING([--disable-package-checks],
-                                  [Do not check dependent libraries for presence or correctness.
-                                   Take it on faith that they will be present when needed. This
-                                   is not advisable, but necessary in some circumstances])])
-    if test "$enable_package_checks" = "no" ; then
-        PMIX_DISABLE_PACKAGE_CHECKS=1
-        AC_MSG_RESULT([disabled])
-    else
-        PMIX_DISABLE_PACKAGE_CHECKS=0
-        AC_MSG_RESULT([enabled by default])
-    fi
-    AC_DEFINE_UNQUOTED(PMIX_DISABLE_PACKAGE_CHECKS, $PMIX_DISABLE_PACKAGE_CHECKS,
-                       [Disable package checks])
-
-    ##################################
     # Libevent
     ##################################
     pmix_show_title "Event libraries"

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -64,7 +64,7 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     fi
 
     if test $pmix_hwloc_support -eq 0; then
-        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
+        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
         AC_MSG_WARN([an adequate version of that library was not found.])
         AC_MSG_WARN([Please reconfigure and point to a location where])
         AC_MSG_WARN([the HWLOC library can be found.])
@@ -85,53 +85,49 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                         ],
                         [pmix_hwloc_libdir=""])])
 
-    if test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
-        _PMIX_CHECK_PACKAGE_LIB([pmix_hwloc], [hwloc], [hwloc_topology_init],
-                                [], [$pmix_hwloc_dir],
-                                [$pmix_hwloc_libdir],
-                                [],
-                                [AC_MSG_WARN([PMIX requires HWLOC support using])
-                                 AC_MSG_WARN([an external copy that you supply.])
-                                 AC_MSG_WARN([The library was not found in $pmix_hwloc_libdir.])
-                                 AC_MSG_ERROR([Cannot continue])])
+    _PMIX_CHECK_PACKAGE_LIB([pmix_hwloc], [hwloc], [hwloc_topology_init],
+                            [], [$pmix_hwloc_dir],
+                            [$pmix_hwloc_libdir],
+                            [],
+                            [AC_MSG_WARN([PMIX requires HWLOC support using])
+                             AC_MSG_WARN([an external copy that you supply.])
+                             AC_MSG_WARN([The library was not found in $pmix_hwloc_libdir.])
+                             AC_MSG_ERROR([Cannot continue])])
 
-        # update global flags to test for HWLOC version
-        if test ! -z "$pmix_hwloc_CPPFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-        fi
-        if test ! -z "$pmix_hwloc_LDFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
-        fi
-        if test ! -z "$pmix_hwloc_LIBS"; then
-            PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
-        fi
-
-        AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
-        AC_COMPILE_IFELSE(
-              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-              [[
-        #if HWLOC_API_VERSION < 0x00010500
-        #error "hwloc API version is less than 0x00010500"
-        #endif
-              ]])],
-              [AC_MSG_RESULT([yes])],
-              [AC_MSG_RESULT([no])
-               AC_MSG_ERROR([Cannot continue])])
-
-        AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
-        AC_COMPILE_IFELSE(
-              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-              [[
-        #if HWLOC_API_VERSION < 0x00010800
-        #error "hwloc API version is less than 0x00010800"
-        #endif
-              ]])],
-              [AC_MSG_RESULT([yes])
-               pmix_have_topology_dup=1],
-              [AC_MSG_RESULT([no])])
-    else
-        pmix_have_topology_dup=1
+    # update global flags to test for HWLOC version
+    if test ! -z "$pmix_hwloc_CPPFLAGS"; then
+        PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
     fi
+    if test ! -z "$pmix_hwloc_LDFLAGS"; then
+        PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
+    fi
+    if test ! -z "$pmix_hwloc_LIBS"; then
+        PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
+    fi
+
+    AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010500
+    #error "hwloc API version is less than 0x00010500"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_ERROR([Cannot continue])])
+
+    AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+          [[
+    #if HWLOC_API_VERSION < 0x00010800
+    #error "hwloc API version is less than 0x00010800"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([yes])
+           pmix_have_topology_dup=1],
+          [AC_MSG_RESULT([no])])
 
     # set the header
     PMIX_HWLOC_HEADER="<hwloc.h>"

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -72,36 +72,34 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                              fi
                             ],
                             [pmix_event_libdir=""])])
-        if test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
-            _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
-                                    [-levent_pthreads], [$pmix_event_dir],
-                                    [$pmix_event_libdir],
-                                    [pmix_libevent_support=1],
-                                    [pmix_libevent_support=0])
+        _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
+                                [-levent_pthreads], [$pmix_event_dir],
+                                [$pmix_event_libdir],
+                                [pmix_libevent_support=1],
+                                [pmix_libevent_support=0])
 
-            # Check to see if the above check failed because it conflicted with LSF's libevent.so
-            # This can happen if LSF's library is in the LDFLAGS envar or default search
-            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-            # in Libevent's libevent.so
-            if test $pmix_libevent_support -eq 0; then
-                AC_CHECK_LIB([event], [event_getcode4name],
-                             [AC_MSG_WARN([===================================================================])
-                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                              AC_MSG_WARN([LSF library path.])
-                              AC_MSG_WARN([===================================================================])
-                              ])
-            fi
+        # Check to see if the above check failed because it conflicted with LSF's libevent.so
+        # This can happen if LSF's library is in the LDFLAGS envar or default search
+        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+        # in Libevent's libevent.so
+        if test $pmix_libevent_support -eq 0; then
+            AC_CHECK_LIB([event], [event_getcode4name],
+                         [AC_MSG_WARN([===================================================================])
+                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                          AC_MSG_WARN([LSF library path.])
+                          AC_MSG_WARN([===================================================================])
+                          ])
         fi
     fi
 
-    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
+    if test $pmix_libevent_support -eq 1; then
         # need to add resulting flags to global ones so we can
         # test for thread support
         if test ! -z "$pmix_libevent_CPPFLAGS"; then
@@ -125,7 +123,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                       pmix_libevent_support=0])
     fi
 
-    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
+    if test $pmix_libevent_support -eq 1; then
         AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
                      [],
                      [AC_MSG_WARN([libevent does not have thread support])
@@ -134,7 +132,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                       pmix_libevent_support=0])
     fi
 
-    if test $pmix_libevent_support -eq 1 && test $PMIX_DISABLE_PACKAGE_CHECKS -eq 0; then
+    if test $pmix_libevent_support -eq 1; then
         # Pin the "oldest supported" version to 2.0.21
         AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,8 +50,7 @@ pmixdir = $(pmixincludedir)/$(subdir)
 
 libpmix_la_LIBADD = \
 	mca/base/libpmix_mca_base.la \
-	$(MCA_pmix_FRAMEWORK_LIBS) \
-	$(PMIX_EXTRA_LIB)
+	$(MCA_pmix_FRAMEWORK_LIBS)
 libpmix_la_DEPENDENCIES = \
 	mca/base/libpmix_mca_base.la \
 	$(MCA_pmix_FRAMEWORK_LIBS)

--- a/src/tools/pattrs/Makefile.am
+++ b/src/tools/pattrs/Makefile.am
@@ -46,5 +46,4 @@ endif # PMIX_INSTALL_BINARIES
 
 pattrs_SOURCES = pattrs.c
 pattrs_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
 	$(top_builddir)/src/libpmix.la

--- a/src/tools/pevent/Makefile.am
+++ b/src/tools/pevent/Makefile.am
@@ -46,5 +46,4 @@ endif # PMIX_INSTALL_BINARIES
 
 pevent_SOURCES = pevent.c
 pevent_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
 	$(top_builddir)/src/libpmix.la

--- a/src/tools/plookup/Makefile.am
+++ b/src/tools/plookup/Makefile.am
@@ -46,5 +46,4 @@ endif # PMIX_INSTALL_BINARIES
 
 plookup_SOURCES = plookup.c
 plookup_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
     $(top_builddir)/src/libpmix.la

--- a/src/tools/pmix_info/Makefile.am
+++ b/src/tools/pmix_info/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -50,5 +51,4 @@ pmix_info_SOURCES =  \
     support.c
 
 pmix_info_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
     $(top_builddir)/src/libpmix.la

--- a/src/tools/pps/Makefile.am
+++ b/src/tools/pps/Makefile.am
@@ -46,5 +46,4 @@ endif # PMIX_INSTALL_BINARIES
 
 pps_SOURCES = pps.c
 pps_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
     $(top_builddir)/src/libpmix.la

--- a/src/tools/pquery/Makefile.am
+++ b/src/tools/pquery/Makefile.am
@@ -46,5 +46,4 @@ endif # PMIX_INSTALL_BINARIES
 
 pquery_SOURCES = pquery.c
 pquery_LDADD = \
-    $(PMIX_EXTRA_LTLIB) \
 	$(top_builddir)/src/libpmix.la

--- a/src/tools/wrapper/Makefile.am
+++ b/src/tools/wrapper/Makefile.am
@@ -23,7 +23,7 @@
 # $HEADER$
 #
 
-AM_LDFLAGS = $(PMIX_EXTRA_LIB_LDFLAGS) $(pmix_hwloc_LDFLAGS) $(pmix_libevent_LDFLAGS)
+AM_LDFLAGS = $(pmix_hwloc_LDFLAGS) $(pmix_libevent_LDFLAGS)
 
 if PMIX_INSTALL_BINARIES
 
@@ -37,7 +37,6 @@ pmixcc_SOURCES = \
         pmixcc.c
 
 pmixcc_LDADD = \
-    $(PMIXEXTRA_LTLIB) \
     $(pmix_libevent_LIBS) \
     $(pmix_hwloc_LIBS) \
 	$(top_builddir)/src/libpmix.la


### PR DESCRIPTION
Disabling these checks opens a can of worms - anyone
embedding pmix just needs to treat us like a 3rd-party
package and take responsibility for feeding our configure
logic what it needs to operate.

Signed-off-by: Ralph Castain <rhc@pmix.org>