### PR TITLE
Return NOT_FOUND instead of deprecated PROC_ENTRY_NOF_FOUND

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -635,7 +635,7 @@ static pmix_status_t register_info(pmix_peer_t *peer, pmix_namespace_t *ns, pmix
                             "FETCHING PROC INFO FOR RANK %s", PMIX_RANK_PRINT(rank));
         val = NULL;
         rc = pmix_hash_fetch(ht, rank, NULL, &val);
-        if (PMIX_SUCCESS != rc && PMIX_ERR_PROC_ENTRY_NOT_FOUND != rc) {
+        if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             PMIX_ERROR_LOG(rc);
             if (NULL != val) {
                 PMIX_VALUE_RELEASE(val);

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -115,9 +115,9 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank, const 
     id = (uint64_t) rank;
 
     /* - PMIX_RANK_UNDEF should return following statuses
-     *     PMIX_ERR_PROC_ENTRY_NOT_FOUND | PMIX_SUCCESS
+     *     PMIX_ERR_NOT_FOUND | PMIX_SUCCESS
      * - specified rank can return following statuses
-     *     PMIX_ERR_PROC_ENTRY_NOT_FOUND | PMIX_ERR_NOT_FOUND | PMIX_SUCCESS
+     *     PMIX_ERR_NOT_FOUND | PMIX_ERR_NOT_FOUND | PMIX_SUCCESS
      * special logic is basing on these statuses on a client and a server */
     if (PMIX_RANK_UNDEF == rank) {
         rc = pmix_hash_table_get_first_key_uint64(table, &id, (void **) &proc_data,
@@ -126,7 +126,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank, const 
             pmix_output_verbose(10, pmix_globals.debug_output,
                                 "HASH:FETCH[%s:%d] proc data for rank %d not found", __func__,
                                 __LINE__, rank);
-            return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+            return PMIX_ERR_NOT_FOUND;
         }
     }
 
@@ -136,7 +136,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank, const 
             pmix_output_verbose(10, pmix_globals.debug_output,
                                 "HASH:FETCH[%s:%d] proc data for rank %d not found", __func__,
                                 __LINE__, rank);
-            return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+            return PMIX_ERR_NOT_FOUND;
         }
 
         /* if the key is NULL, then the user wants -all- data
@@ -198,7 +198,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank, const 
             pmix_output_verbose(10, pmix_globals.debug_output,
                                 "%s:%d HASH:FETCH data for key %s not found", __func__, __LINE__,
                                 key);
-            return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+            return PMIX_ERR_NOT_FOUND;
         }
     }
 
@@ -216,11 +216,11 @@ pmix_status_t pmix_hash_fetch_by_key(pmix_hash_table_t *table, const char *key, 
     static const char *key_r = NULL;
 
     if (key == NULL && (node = *last) == NULL) {
-        return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+        return PMIX_ERR_NOT_FOUND;
     }
 
     if (key == NULL && key_r == NULL) {
-        return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+        return PMIX_ERR_NOT_FOUND;
     }
 
     if (key) {
@@ -238,7 +238,7 @@ pmix_status_t pmix_hash_fetch_by_key(pmix_hash_table_t *table, const char *key, 
     if (PMIX_SUCCESS != rc) {
         pmix_output_verbose(10, pmix_globals.debug_output,
                             "HASH:FETCH proc data for key %s not found", key_r);
-        return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+        return PMIX_ERR_NOT_FOUND;
     }
 
     /* find the value from within this proc_data object */

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -279,7 +279,7 @@ typedef struct {
         TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, _key));   \
         if (blocking) {                                                                           \
             if (PMIX_SUCCESS != (rc = PMIx_Get(&_foobar, _key, NULL, 0, &_val))) {                \
-                if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_PROC_ENTRY_NOT_FOUND)           \
+                if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_NOT_FOUND)           \
                       && ok_notfnd)) {                                                            \
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %s from %s:%d, key %s", my_nspace,       \
                                 my_rank, PMIx_Error_string(rc), ns, r, _key));                    \
@@ -309,8 +309,7 @@ typedef struct {
         }                                                                                         \
         if (PMIX_SUCCESS == rc) {                                                                 \
             if (PMIX_SUCCESS != _cbdata.status) {                                                 \
-                if (!((_cbdata.status == PMIX_ERR_NOT_FOUND                                       \
-                       || _cbdata.status == PMIX_ERR_PROC_ENTRY_NOT_FOUND)                        \
+                if (!((_cbdata.status == PMIX_ERR_NOT_FOUND)                                      \
                       && ok_notfnd)) {                                                            \
                     TEST_ERROR(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s", my_nspace,    \
                                 my_rank, PMIx_Error_string(rc), my_nspace, r, _key));             \

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -452,7 +452,7 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
         if (PMIX_ERR_NOT_SUPPORTED == rc) {
             goto cleanout;
         }
-        if (PMIX_ERR_NOT_FOUND != rc && PMIX_ERR_PROC_ENTRY_NOT_FOUND != rc) {
+        if (PMIX_ERR_NOT_FOUND != rc && PMIX_ERR_NOT_FOUND != rc) {
             TEST_ERROR(("%s:%d [ERROR]: PMIx_Get returned %s instead of not_found", my_nspace,
                         my_rank, PMIx_Error_string(rc)));
             exit(PMIX_ERROR);

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -317,7 +317,7 @@ typedef struct {
         TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));  \
         if (blocking) {                                                                         \
             if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                 \
-                if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_PROC_ENTRY_NOT_FOUND)         \
+                if (!((rc == PMIX_ERR_NOT_FOUND)         \
                       && ok_notfnd)) {                                                          \
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %s from %s:%d, key %s", my_nspace,     \
                                 my_rank, PMIx_Error_string(rc), ns, r, key));                   \
@@ -347,8 +347,7 @@ typedef struct {
         }                                                                                       \
         if (PMIX_SUCCESS == rc) {                                                               \
             if (PMIX_SUCCESS != cbdata.status) {                                                \
-                if (!((cbdata.status == PMIX_ERR_NOT_FOUND                                      \
-                       || cbdata.status == PMIX_ERR_PROC_ENTRY_NOT_FOUND)                       \
+                if (!((cbdata.status == PMIX_ERR_NOT_FOUND)                                     \
                       && ok_notfnd)) {                                                          \
                     TEST_ERROR(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s", my_nspace,  \
                                 my_rank, PMIx_Error_string(rc), my_nspace, r, key));            \


### PR DESCRIPTION
Ensure we don't return the deprecated value.

Fixes #2373
Signed-off-by: Ralph Castain <rhc@pmix.org>