### PR TITLE
Ensure a param is always initialized

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -111,6 +111,7 @@ pmix_status_t pmix_hwloc_register(void)
         pmix_output_set_verbosity(pmix_hwloc_verbose, pmix_hwloc_verbose);
     }
 
+    vmhole = "biggest";
     (void) pmix_mca_base_var_register("pmix", "pmix", "hwloc", "hole_kind",
                                       "Kind of VM hole to identify - none, begin, biggest, libs, heap, stack (default=biggest)",
                                       PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0,


### PR DESCRIPTION
Need to reinit a param prior to registration in case
it was NULL'd so we can cycle PMIx_Init/Finalize

Fixes #2377
Signed-off-by: Ralph Castain <rhc@pmix.org>