### PR TITLE
Extend NUMA utility and cleanup configure logic errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ test/sshot/mytopo.json
 test/sshot/testcoord
 
 test/util/numa
+test/util/convert
 
 test/test_v2/pmix_test
 test/test_v2/test_fence_basic

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -869,9 +869,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         cpp_includes="$PMIX_top_srcdir $PMIX_top_srcdir/src"
     fi
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
-    CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS $PMIX_FINAL_CPPFLAGS"
-    LDFLAGS="$LDFLAGS $PMIX_FINAL_LDFLAGS"
-    LIBS="$LIBS $PMIX_FINAL_LIBS"
+    CPPFLAGS="$PMIX_FINAL_CPPFLAGS $CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
+    LDFLAGS="$PMIX_FINAL_LDFLAGS $LDFLAGS"
+    LIBS="$PMIX_FINAL_LIBS $LIBS"
 
     ############################################################################
     # final wrapper compiler config

--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -42,7 +42,7 @@ AC_DEFUN([PMIX_CHECK_CURL],[
                     [Search for Curl libraries in DIR])])
 
     pmix_check_curl_happy=no
-    pmix_curl_source=unknown
+    pmix_curl_source=
     pmix_check_curl_dir=unknown
     pmix_check_curl_libdir=
     pmix_check_curl_basedir=
@@ -98,7 +98,11 @@ AC_DEFUN([PMIX_CHECK_CURL],[
     AC_MSG_CHECKING([libcurl support available])
     AC_MSG_RESULT([$pmix_check_curl_happy])
 
-    PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])
+    if test -z $pmix_curl_source; then
+        PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy])
+    else
+        PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])
+    fi
 
     AC_SUBST(pmix_check_curl_CPPFLAGS)
     AC_SUBST(pmix_check_curl_LDFLAGS)

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -42,7 +42,7 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
                     [Search for Jansson libraries in DIR])])
 
     pmix_check_jansson_happy=no
-    pmix_jansson_source=unknown
+    pmix_jansson_source=
     pmix_check_jansson_dir=
     pmix_check_jansson_libdir=
     pmix_check_jansson_basedir=
@@ -109,7 +109,11 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
 
     AM_CONDITIONAL([HAVE_JANSSON], [test "$pmix_check_jansson_happy" = "yes"])
 
-    PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])
+    if test -z $pmix_jansson_source; then
+        PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy])
+    else
+        PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])
+    fi
 
     PMIX_VAR_SCOPE_POP
 ])

--- a/config/pmix_check_lustre.m4
+++ b/config/pmix_check_lustre.m4
@@ -96,5 +96,5 @@ EOF
           [$2],
           [AS_IF([test -n "$with_lustre" && test "$with_lustre" != "no"],
                  [AC_MSG_ERROR([Lustre support requested but not found.  Aborting])])
-                  $3])
+           $3])
 ])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -39,64 +39,50 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
           [pmix_event_dir="$libevent_prefix"],
           [pmix_event_dir=""])
-    _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                               [pmix_libevent_support=1],
-                               [pmix_libevent_support=0])
-    if test $pmix_libevent_support -eq 0 && test -z $pmix_event_dir; then
-        # try default locations
-        if test -d /usr/include; then
-            pmix_event_dir=/usr
-            _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                                       [pmix_libevent_support=1],
-                                       [pmix_libevent_support=0])
-        fi
-        if test $pmix_libevent_support -eq 0 && test -d /usr/local/include; then
-            pmix_event_dir=/usr/local
-            _PMIX_CHECK_PACKAGE_HEADER([pmix_libevent], [event.h], [$pmix_event_dir],
-                                       [pmix_libevent_support=1],
-                                       [pmix_libevent_support=0])
-        fi
-    fi
 
-    if test $pmix_libevent_support -eq 1; then
-        AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
-                     [pmix_event_libdir="$libeventdir_prefix"],
-                     [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-                            [if test -d $libevent_prefix/lib64; then
-                                pmix_event_libdir=$libevent_prefix/lib64
-                             elif test -d $libevent_prefix/lib; then
-                                pmix_event_libdir=$libevent_prefix/lib
-                             else
-                                AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
-                                AC_MSG_ERROR([Can not continue])
-                             fi
-                            ],
-                            [pmix_event_libdir=""])])
-        _PMIX_CHECK_PACKAGE_LIB([pmix_libevent], [event_core], [event_config_new],
-                                [-levent_pthreads], [$pmix_event_dir],
-                                [$pmix_event_libdir],
-                                [pmix_libevent_support=1],
-                                [pmix_libevent_support=0])
+    AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+                 [pmix_event_libdir="$libeventdir_prefix"],
+                 [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                        [if test -d $libevent_prefix/lib64; then
+                            pmix_event_libdir=$libevent_prefix/lib64
+                         elif test -d $libevent_prefix/lib; then
+                            pmix_event_libdir=$libevent_prefix/lib
+                         else
+                            AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                            AC_MSG_ERROR([Can not continue])
+                         fi
+                        ],
+                        [pmix_event_libdir=""])])
 
-        # Check to see if the above check failed because it conflicted with LSF's libevent.so
-        # This can happen if LSF's library is in the LDFLAGS envar or default search
-        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-        # in Libevent's libevent.so
-        if test $pmix_libevent_support -eq 0; then
-            AC_CHECK_LIB([event], [event_getcode4name],
-                         [AC_MSG_WARN([===================================================================])
-                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                          AC_MSG_WARN([LSF library path.])
-                          AC_MSG_WARN([===================================================================])
-                          ])
-        fi
+    PMIX_CHECK_PACKAGE([pmix_libevent],
+                       [event.h],
+                       [event_core],
+                       [event_config_new],
+                       [-levent_pthreads],
+                       [$pmix_event_dir],
+                       [$pmix_event_libdir],
+                       [pmix_libevent_support=1],
+                       [pmix_libevent_support=0],
+                       [])
+
+    # Check to see if the above check failed because it conflicted with LSF's libevent.so
+    # This can happen if LSF's library is in the LDFLAGS envar or default search
+    # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+    # in Libevent's libevent.so
+    if test $pmix_libevent_support -eq 0; then
+        AC_CHECK_LIB([event], [event_getcode4name],
+                     [AC_MSG_WARN([===================================================================])
+                      AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                      AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                      AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                      AC_MSG_WARN([])
+                      AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                      AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                      AC_MSG_WARN([LSF library path.])
+                      AC_MSG_WARN([===================================================================])
+                      ])
     fi
 
     if test $pmix_libevent_support -eq 1; then
@@ -148,7 +134,11 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                            AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
                            pmix_libevent_support=0])
     fi
-    pmix_libevent_source=$pmix_event_dir
+    if test -z "$pmix_event_dir"; then
+        pmix_libevent_source="Standard locations"
+    else
+        pmix_libevent_source=$pmix_event_dir
+    fi
     PMIX_EVENT_HEADER="<event.h>"
     PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
 

--- a/src/mca/common/sse/configure.m4
+++ b/src/mca/common/sse/configure.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +24,6 @@ AC_DEFUN([MCA_pmix_common_sse_CONFIG], [
           [$2
            pmix_common_sse_happy=no])
 
-    PMIX_SUMMARY_ADD([[Optional Support]],[[SSE]], [common_sse], [$pmix_check_curl_happy])
+    PMIX_SUMMARY_ADD([[Optional Support]],[[SSE]], [common_sse], [$pmix_common_sse_happy])
 
 ])dnl

--- a/src/mca/pcompress/zlib/configure.m4
+++ b/src/mca/pcompress/zlib/configure.m4
@@ -53,7 +53,7 @@ AC_DEFUN([MCA_pmix_pcompress_zlib_CONFIG],[
                   [AC_MSG_RESULT([$with_zlib_libdir])])
         else
             AC_MSG_RESULT([(default search paths)])
-            pmix_zlib_source=standard
+            pmix_zlib_source="Standard locations"
             pmix_zlib_standard_header_location=yes
             pmix_zlib_standard_lib_location=yes
         fi

--- a/src/mca/pstrg/lustre/configure.m4
+++ b/src/mca/pstrg/lustre/configure.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,8 +32,12 @@ AC_DEFUN([MCA_pmix_pstrg_lustre_CONFIG],[
                       [pstrg_lustre_happy="no"])
 
 
-    AS_IF([test "$pstrg_lustre_happy" = "yes" || test "1" = "1"],
-          [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [yes ($pmix_check_lustre_dir)])
+    AS_IF([test "$pstrg_lustre_happy" = "yes"],
+          [if test -z "$pmix_check_lustre_dir"; then
+               PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [yes (Standard locations)])
+           else
+               PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [yes ($pmix_check_lustre_dir)])
+           fi
            $1],
           [PMIX_SUMMARY_ADD([[Optional Support]],[[Lustre]], [pstrg_lustre], [no])
            $2])

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -20,14 +20,25 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
-# we do NOT want picky compilers down here
-
 noinst_PROGRAMS = numa
+
+if PMIX_HWLOC_VERSION_HIGH
+noinst_PROGRAMS += convert
+endif
 
 numa_SOURCES =  \
         numa.c
 numa_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 numa_LDADD = \
+    $(pmix_hwloc_LIBS) \
     $(top_builddir)/src/libpmix.la
 
+convert_SOURCES =  \
+        convert.c
+convert_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+convert_LDADD = \
+    $(pmix_hwloc_LIBS) \
+    $(top_builddir)/src/libpmix.la
+
+clean-local:
+	rm -f convert numa

--- a/test/util/convert.c
+++ b/test/util/convert.c
@@ -1,0 +1,58 @@
+#include <unistd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <hwloc.h>
+#include <hwloc/bitmap.h>
+
+int main(int argc, char **argv)
+{
+    hwloc_topology_t topo;
+    char *tmp;
+    int ret;
+
+    if (2 != argc) {
+        fprintf(stderr, "Usage: %s input-xml-filename\n", argv[0]);
+        return -1;
+    }
+
+    if (0 != hwloc_topology_init(&topo)) {
+        return -1;
+    }
+    if (0 != hwloc_topology_set_xml(topo, argv[1])) {
+        fprintf(stderr, "SETXML FAILED\n");
+        return -1;
+    }
+    /* since we are loading this from an external source, we have to
+     * explicitly set a flag so hwloc sets things up correctly
+     */
+    ret = hwloc_topology_set_io_types_filter(topo, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
+    if (0 != ret) {
+        fprintf(stderr, "IOTYPES FAILED\n");
+        hwloc_topology_destroy(topo);
+        return ret;
+    }
+
+    if (0 != hwloc_topology_set_flags(topo, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)) {
+        fprintf(stderr, "SETFLAGS FAILED\n");
+        hwloc_topology_destroy(topo);
+        return -1;
+    }
+    /* now load the topology */
+    if (0 != hwloc_topology_load(topo)) {
+        fprintf(stderr, "LOAD FAILED\n");
+        hwloc_topology_destroy(topo);
+        return -1;
+    }
+
+    /* output it in v1 format */
+    asprintf(&tmp, "%s.v1", argv[1]);
+    if (0 != hwloc_topology_export_xml(topo, tmp, HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
+        fprintf(stderr, "EXPORT FAILED\n");
+        hwloc_topology_destroy(topo);
+        return -1;
+    }
+    hwloc_topology_destroy(topo);
+    return 0;
+}

--- a/test/util/numa.c
+++ b/test/util/numa.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     unsigned width, w;
     hwloc_bitmap_t numas[100], result;
     int n, m;
-    char *tmp;
+    char *tmp, cpus[2048];
     bool overlap = false;
 
     if (2 != argc) {
@@ -65,7 +65,8 @@ int main(int argc, char **argv)
         obj = hwloc_get_obj_by_type(topo, HWLOC_OBJ_NUMANODE, w);
         /* how many pu's are under it? */
         weight = hwloc_bitmap_weight(obj->cpuset);
-        fprintf(stderr, "NUMA: %u NPUS: %d\n", w, weight);
+        hwloc_bitmap_list_snprintf(cpus, 2048, obj->cpuset);
+        fprintf(stderr, "NUMA: %u OSINDX: %u NPUS: %d PUS: %s\n", w, obj->os_index, weight, cpus);
         /* check for overlap with all preceding numas */
         for (m=0; m < N; m++) {
             if (hwloc_bitmap_intersects(obj->cpuset, numas[m])) {


### PR DESCRIPTION
Cleanup configuration logic

We still weren't dealing with the scenario where there is
a copy of HWLOC in the standard location, but we pass our
own path to a different HWLOC install that we want to use.
Problem turned out to be the common mistake we keep rolling
back to making - AC_CHECK_HEADERS _always_ looks in the default
paths in addition to whetever you may add. Ditto for its
AC_SEARCH_LIBS companion.

So you have to be more careful about handling this situation. We
periodically seem to forget and rollback the configure logic
into this error, so try to provide a big comment explaining
why you can't do it.

If I felt like taking the time to search for it, I could swear
I could just have copied that comment from prior times...

`<shrug>`

Also, cleanup a few of the summary lines at the end of configure,
and add a utility to convert HWLOC XML between versions 2 and 1.

Signed-off-by: Ralph Castain <rhc@pmix.org>
