### PR TITLE
Remove stale abstraction names for event and hwloc headers

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -125,9 +125,6 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
           [AC_MSG_RESULT([no])
            pmix_version_high=0])
 
-    # set the header
-    PMIX_HWLOC_HEADER="<hwloc.h>"
-
     CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
     LDFLAGS=$pmix_check_hwloc_save_LDFLAGS
     LIBS=$pmix_check_hwloc_save_LIBS
@@ -144,11 +141,6 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
         PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_hwloc_LIBS)
         PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_hwloc_LIBS)
     fi
-
-    AC_MSG_CHECKING([location of hwloc header])
-    AC_DEFINE_UNQUOTED([PMIX_HWLOC_HEADER], [$PMIX_HWLOC_HEADER],
-                       [Location of hwloc.h])
-    AC_MSG_RESULT([$PMIX_HWLOC_HEADER])
 
     AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
                        [Whether or not hwloc_topology_dup is available])

--- a/config/pmix_setup_libev.m4
+++ b/config/pmix_setup_libev.m4
@@ -86,9 +86,6 @@ AC_DEFUN([PMIX_LIBEV_CONFIG],[
     AC_MSG_CHECKING([will libev support be built])
     if test $pmix_libev_support -eq 1; then
         AC_MSG_RESULT([yes])
-        PMIX_EVENT_HEADER="<event.h>"
-        AC_DEFINE_UNQUOTED([PMIX_EVENT_HEADER], [$PMIX_EVENT_HEADER],
-                           [Location of event.h])
         PMIX_SUMMARY_ADD([[External Packages]],[[libev]],[libev],[$pmix_libev_dir])
     else
         AC_MSG_RESULT([no])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -139,8 +139,6 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     else
         pmix_libevent_source=$pmix_event_dir
     fi
-    PMIX_EVENT_HEADER="<event.h>"
-    PMIX_EVENT2_THREAD_HEADER="<event2/thread.h>"
 
     AC_MSG_CHECKING([will libevent support be built])
     if test $pmix_libevent_support -eq 1; then
@@ -158,10 +156,6 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
             PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
         fi
         # Set output variables
-        AC_DEFINE_UNQUOTED([PMIX_EVENT_HEADER], [$PMIX_EVENT_HEADER],
-                           [Location of event.h])
-        AC_DEFINE_UNQUOTED([PMIX_EVENT2_THREAD_HEADER], [$PMIX_EVENT2_THREAD_HEADER],
-                           [Location of event2/thread.h])
         PMIX_SUMMARY_ADD([[Required Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
     else
         AC_MSG_RESULT([no])

--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -17,7 +17,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include PMIX_EVENT_HEADER
+#include <event.h>
 #include "src/class/pmix_hotel.h"
 
 static void local_eviction_callback(int fd, short flags, void *arg)

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -61,7 +61,7 @@
 #include "src/class/pmix_object.h"
 #include "src/include/prefetch.h"
 #include "src/include/types.h"
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/util/output.h"
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -45,9 +45,9 @@
 #    include <sys/types.h>
 #endif
 
-#include PMIX_EVENT_HEADER
-#ifdef PMIX_EVENT2_THREAD_HEADER
-#    include PMIX_EVENT2_THREAD_HEADER
+#include <event.h>
+#if !PMIX_HAVE_LIBEV
+#    include <event2/thread.h>
 #endif
 
 #ifdef PMIX_GIT_REPO_BUILD

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -44,7 +44,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -44,7 +44,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -43,7 +43,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -44,7 +44,7 @@
 #    include <sys/types.h>
 #endif
 
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -44,7 +44,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -43,7 +43,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -43,7 +43,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -25,7 +25,7 @@
 
 #include "src/include/pmix_config.h"
 #include "src/include/types.h"
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "include/pmix_common.h"
 #include "src/class/pmix_list.h"

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 
-#include PMIX_HWLOC_HEADER
+#include <hwloc.h>
 
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -25,7 +25,7 @@
 
 #include "src/include/pmix_config.h"
 
-#include PMIX_HWLOC_HEADER
+#include <hwloc.h>
 
 #include "include/pmix_common.h"
 

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -16,7 +16,7 @@
 
 #include "src/include/pmix_config.h"
 
-#include PMIX_HWLOC_HEADER
+#include <hwloc.h>
 
 #include "include/pmix_common.h"
 #include "src/mca/bfrops/base/base.h"

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -38,7 +38,7 @@
 #    include <sys/types.h>
 #endif
 #include <ctype.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 #if HAVE_SYS_STAT_H
 #    include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -33,7 +33,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "include/pmix.h"
 #include "include/pmix_common.h"

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -46,9 +46,9 @@
 #ifdef HAVE_ARPA_INET_H
 #    include <arpa/inet.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 #if !PMIX_HAVE_LIBEV
-#    include PMIX_EVENT2_THREAD_HEADER
+#    include <event2/thread.h>
 #endif
 
 #if PMIX_ENABLE_DEBUG

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -18,7 +18,7 @@
 #include "include/pmix_common.h"
 
 #include <pthread.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/include/types.h"

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -24,7 +24,7 @@
 #endif /* HAVE_STRING_H */
 #include <pthread.h>
 #include <stdio.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/ptl/base/base.h"

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -18,7 +18,7 @@
 #include "include/pmix_common.h"
 
 #include <pthread.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/include/types.h"

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -45,7 +45,7 @@
 #endif
 #include <ctype.h>
 #include <sys/stat.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 #include <pthread.h>
 
 #include "src/class/pmix_list.h"

--- a/src/mca/ptl/base/usock.h
+++ b/src/mca/ptl/base/usock.h
@@ -56,7 +56,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 /* usock common variables */
 typedef struct {

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -50,7 +50,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops_types.h"

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -47,7 +47,7 @@
 #include "src/util/keyval_parse.h"
 #include "src/util/output.h"
 #include "src/util/show_help.h"
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -20,7 +20,7 @@
 #endif
 #include <pthread.h>
 #include <string.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_globals.h"

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,7 +15,7 @@
 #include "pmix_config.h"
 
 #include <pthread.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/include/types.h"
 

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/ptl/ptl_types.h"

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -43,7 +43,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -49,7 +49,7 @@
 #ifdef HAVE_TIME_H
 #    include <time.h>
 #endif
-#include PMIX_EVENT_HEADER
+#include <event.h>
 
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"


### PR DESCRIPTION
No longer required - and besides, we kept forgetting to use
the abstractions anyway.

Signed-off-by: Ralph Castain <rhc@pmix.org>