### PR TITLE
Ensure configure cmd line trumps environment

### DIFF
--- a/config/pmix_check_package.m4
+++ b/config/pmix_check_package.m4
@@ -122,7 +122,7 @@ AC_DEFUN([_PMIX_CHECK_PACKAGE_LIB], [
         # No perfect solution
 
         AC_MSG_CHECKING([library $2 in $libdir_prefix])
-        checkloc="`ls $libdir_prefix/lib$2* >& /dev/null`"
+        checkloc="`ls $libdir_prefix/lib$2.* >& /dev/null`"
         if test "$?" == "0"; then
             AC_MSG_RESULT([found])
             $1_LDFLAGS="-L$libdir_prefix"

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -489,6 +489,35 @@ dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
+# PMIX_FLAGS_PREPEND_UNIQ(variable, new_argument)
+# ----------------------------------------------
+# Prepend new_argument to variable if:
+#
+# - the argument does not begin with -I, -L, or -l, or
+# - the argument begins with -I, -L, or -l, and it's not already in variable
+#
+# This macro assumes a space seperated list.
+AC_DEFUN([PMIX_FLAGS_PREPEND_UNIQ], [
+    PMIX_VAR_SCOPE_PUSH([pmix_tmp pmix_append])
+
+    for arg in $2; do
+        pmix_tmp=`echo $arg | cut -c1-2`
+        pmix_prepend=1
+        AS_IF([test "$pmix_tmp" = "-I" || test "$pmix_tmp" = "-L" || test "$pmix_tmp" = "-l"],
+              [for val in ${$1}; do
+                   AS_IF([test "x$val" = "x$arg"], [pmix_prepend=0])
+               done])
+        AS_IF([test "$pmix_prepend" = "1"],
+              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$arg $$1"])])
+    done
+
+    PMIX_VAR_SCOPE_POP
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
 # Macro that serves as an alternative to using `which <prog>`. It is
 # preferable to simply using `which <prog>` because backticks (`) (aka
 # backquotes) invoke a sub-shell which may source a "noisy"

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -79,13 +79,13 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
 
    # update global flags to test for HWLOC version
     if test ! -z "$pmix_hwloc_CPPFLAGS"; then
-        PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
+        PMIX_FLAGS_PREPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
     fi
     if test ! -z "$pmix_hwloc_LDFLAGS"; then
-        PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
+        PMIX_FLAGS_PREPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
     fi
     if test ! -z "$pmix_hwloc_LIBS"; then
-        PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
+        PMIX_FLAGS_PREPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
     fi
 
     AC_MSG_CHECKING([if hwloc version is 1.5 or greater])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -89,13 +89,13 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
         # need to add resulting flags to global ones so we can
         # test for thread support
         if test ! -z "$pmix_libevent_CPPFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
+            PMIX_FLAGS_PREPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
         fi
         if test ! -z "$pmix_libevent_LDFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
+            PMIX_FLAGS_PREPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
         fi
         if test ! -z "$pmix_libevent_LIBS"; then
-            PMIX_FLAGS_APPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
+            PMIX_FLAGS_PREPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
         fi
 
         # Ensure that this libevent has the symbol

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -7,6 +7,7 @@ dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -38,7 +39,7 @@ AC_DEFUN([PMIX_SUMMARY_ADD],[
 
 AC_DEFUN([PMIX_SUMMARY_PRINT],[
     PMIX_VAR_SCOPE_PUSH([pmix_summary_section pmix_summary_section_name])
-    cat <<EOF
+    cat <<EOF >&2
 
 PMIx configuration:
 -----------------------
@@ -47,29 +48,29 @@ PMIx Standard Version: $PMIX_STD_VERSION
 EOF
 
     if test $WANT_DEBUG = 0 ; then
-        echo "Debug build: no"
+        echo "Debug build: no" >&2
     else
-        echo "Debug build: yes"
+        echo "Debug build: yes" >&2
     fi
 
     if test ! -z $with_pmix_platform ; then
-        echo "Platform file: $with_pmix_platform"
+        echo "Platform file: $with_pmix_platform" >&2
     else
-        echo "Platform file: (none)"
+        echo "Platform file: (none)" >&2
     fi
 
-    echo
+    echo >&2
 
     for pmix_summary_section in $(echo $pmix_summary_sections) ; do
         pmix_summary_section_name=$(echo $pmix_summary_section | tr '_' ' ')
-        echo "$pmix_summary_section_name"
-        echo "-----------------------"
-        echo "$(eval echo \$pmix_summary_values_$pmix_summary_section)" | tr ',' $'\n' | sort -f
-        echo " "
+        echo "$pmix_summary_section_name" >&2
+        echo "-----------------------" >&2
+        echo "$(eval echo \$pmix_summary_values_$pmix_summary_section)" | tr ',' $'\n' | sort -f >&2
+        echo " " >&2
     done
 
     if test $WANT_DEBUG = 1 ; then
-        cat <<EOF
+        cat <<EOF >&2
 *****************************************************************************
  THIS IS A DEBUG BUILD!  DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!
 *****************************************************************************


### PR DESCRIPTION
Whatever locations we are told on the cmd line should
trump any correspnding envars.

Signed-off-by: Ralph Castain <rhc@pmix.org>