### PR TITLE
v4.2: remove `PMIX_CHECK_BROKEN_QSORT` refs #2375

### DIFF
--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -434,19 +434,6 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 #    endif
 
 /*
- * Some platforms (Solaris) have a broken qsort implementation.  Work
- * around by using our own.
- */
-#    if PMIX_HAVE_BROKEN_QSORT
-#        ifdef qsort
-#            undef qsort
-#        endif
-
-#        include "util/qsort.h"
-#        define qsort pmix_qsort
-#    endif
-
-/*
  * Define __func__-preprocessor directive if the compiler does not
  * already define it.  Define it to __FILE__ so that we at least have
  * a clue where the developer is trying to indicate where the error is


### PR DESCRIPTION
Signed-off-by: Thomas Naughton <naughtont@ornl.gov>