### PR TITLE
Fix the network support components

### DIFF
--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -63,7 +63,7 @@ AC_DEFUN([PMIX_MCA],[
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
                         platform.]),
-                        [], [enable_mca_dso=pcompress-zlib,ploc-hwloc,pnet-opa,pnet-sshot,prm])
+                        [], [enable_mca_dso=pcompress-zlib,pnet-sshot,prm])
     AC_ARG_ENABLE(mca-static,
         AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -48,14 +48,15 @@
 #include "src/mca/bfrops/base/static-components.h"
 
 /* Instantiate the global vars */
-pmix_bfrops_globals_t pmix_bfrops_globals = {.actives = PMIX_LIST_STATIC_INIT,
-                                             .initialized = false,
-                                             .initial_size = 0,
-                                             .threshold_size = 0,
+pmix_bfrops_globals_t pmix_bfrops_globals = {
+    .actives = PMIX_LIST_STATIC_INIT,
+    .initialized = false,
+    .initial_size = 0,
+    .threshold_size = 0,
 #if PMIX_ENABLE_DEBUG
-                                             .default_type = PMIX_BFROP_BUFFER_FULLY_DESC
+    .default_type = PMIX_BFROP_BUFFER_FULLY_DESC
 #else
-                                             .default_type = PMIX_BFROP_BUFFER_NON_DESC
+    .default_type = PMIX_BFROP_BUFFER_NON_DESC
 #endif
 };
 int pmix_bfrops_base_output = 0;
@@ -141,7 +142,7 @@ PMIX_CLASS_INSTANCE(pmix_bfrops_base_active_module_t, pmix_list_item_t, NULL, mo
 static void pmix_buffer_construct(pmix_buffer_t *buffer)
 {
     /** set the default buffer type */
-    buffer->type = PMIX_BFROP_BUFFER_UNDEF;
+    buffer->type = pmix_bfrops_globals.default_type;
 
     /* Make everything NULL to begin with */
     buffer->base_ptr = buffer->pack_ptr = buffer->unpack_ptr = NULL;

--- a/src/mca/bfrops/bfrops_types.h
+++ b/src/mca/bfrops/bfrops_types.h
@@ -141,6 +141,16 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_buffer_t);
         (s) = 0;                                        \
     } while (0)
 
+#define PMIX_LOAD_BUFFER_NON_DESTRUCT(p, b, d, s)       \
+    do {                                                \
+        (b)->type = (p)->nptr->compat.type;             \
+        (b)->base_ptr = (char *) (d);                   \
+        (b)->bytes_used = (s);                          \
+        (b)->bytes_allocated = (s);                     \
+        (b)->pack_ptr = ((char *) (b)->base_ptr) + (s); \
+        (b)->unpack_ptr = (b)->base_ptr;                \
+    } while (0)
+
 /* Convenience macro for extracting a pmix_buffer_t's payload
  * as a data blob
  *

--- a/src/mca/pgpu/amd/pgpu_amd.c
+++ b/src/mca/pgpu/amd/pgpu_amd.c
@@ -187,10 +187,7 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
 
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);

--- a/src/mca/pgpu/intel/pgpu_intel.c
+++ b/src/mca/pgpu/intel/pgpu_intel.c
@@ -187,11 +187,8 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
-
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
+            
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);
             cnt = 1;

--- a/src/mca/pgpu/nvd/pgpu_nvd.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd.c
@@ -187,10 +187,7 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
 
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);

--- a/src/mca/pnet/nvd/pnet_nvd.c
+++ b/src/mca/pnet/nvd/pnet_nvd.c
@@ -185,10 +185,7 @@ static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
 
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -251,8 +251,8 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             }
             /* pack anything that was found */
             PMIX_LIST_FOREACH (kv, &cache, pmix_kval_t) {
-                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata, &kv->value->data.envar, 1,
-                                 PMIX_ENVAR);
+                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata,
+                                 &kv->value->data.envar, 1, PMIX_ENVAR);
             }
             PMIX_LIST_DESTRUCT(&cache);
         }
@@ -325,10 +325,7 @@ static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
 
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);
@@ -337,8 +334,7 @@ static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
             while (PMIX_SUCCESS == rc) {
                 pmix_list_append(&ns->envars, &ev->super);
                 /* if this is the transport key, save it */
-                if (0 == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports",
-                               PMIX_MAX_KEYLEN)) {
+                if (0 == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports", PMIX_MAX_KEYLEN)) {
                     /* add it to the job-level info */
                     PMIX_LOAD_PROCID(&proc, ns->ns->nspace, PMIX_RANK_WILDCARD);
                     PMIX_KVAL_NEW(kv, PMIX_CREDENTIAL);

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -104,7 +104,7 @@ static pmix_status_t component_open(void)
 {
     pmix_status_t rc;
 
-    rc = pmix_hwloc_check_vendor(&pmix_globals.topology, 0x8086, 0x207);
+    rc = pmix_hwloc_check_vendor(&pmix_globals.topology, 0x8086, 0x208);
     return rc;
 }
 

--- a/src/mca/pnet/usnic/pnet_usnic.c
+++ b/src/mca/pnet/usnic/pnet_usnic.c
@@ -186,10 +186,7 @@ static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
                 data = (uint8_t *) info[n].value.data.bo.bytes;
                 size = info[n].value.data.bo.size;
             }
-
-            bkt.base_ptr = (char*)data;
-            bkt.unpack_ptr = bkt.base_ptr;
-            bkt.bytes_used = size;
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
 
             /* all we packed was envars, so just cycle thru */
             ev = PMIX_NEW(pmix_envar_list_item_t);


### PR DESCRIPTION
When we allocate information to support a particular fabric,
we pack that info into a buffer and then transport the "blob"
to the backend for unpacking and processing. During the unpack
operation, we tried to be clever and simply assign the blob
into the various buffer fields.

Bad idea - missed a critical one and that caused the unpack
to fail. Instead, define a suitable macro for this purpose
to ensure that ALL the required buffer fields get set.

Also, OPA fabric is device type 0x208 - correct the typo.

Thanks to Howard Pritchard and Michael Heinz for identifying
the problem.

Signed-off-by: Ralph Castain <rhc@pmix.org>