### PR TITLE
Remove curl/jansson default search assumption

### DIFF
--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -32,10 +32,12 @@
 AC_DEFUN([PMIX_CHECK_CURL],[
 
     PMIX_VAR_SCOPE_PUSH(pmix_check_curl_save_CPPFLAGS pmix_check_curl_save_LDFLAGS pmix_check_curl_save_LIBS)
-	AC_ARG_WITH([curl],
-		    [AS_HELP_STRING([--with-curl(=DIR)],
-				    [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
-            [], [with_curl=no])
+
+    dnl Intentionally disable CURL unless explicitly requested
+    AC_ARG_WITH([curl],
+                [AS_HELP_STRING([--with-curl(=DIR)],
+                   [Build curl support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
+                [], [with_curl=no])
 
     AC_ARG_WITH([curl-libdir],
             [AS_HELP_STRING([--with-curl-libdir=DIR],
@@ -43,42 +45,24 @@ AC_DEFUN([PMIX_CHECK_CURL],[
 
     pmix_check_curl_happy=no
     pmix_curl_source=
-    pmix_check_curl_dir=unknown
+    pmix_check_curl_dir=
     pmix_check_curl_libdir=
-    pmix_check_curl_basedir=
 
     if test "$with_curl" != "no"; then
-        AC_MSG_CHECKING([where to find curl.h])
-        AS_IF([test "$with_curl" = "yes" || test -z "$with_curl"],
-              [AS_IF([test -f /usr/include/curl.h],
-                     [pmix_check_curl_dir=/usr
-                      pmix_check_curl_basedir=/usr
-                      pmix_curl_source=standard],
-                     [AS_IF([test -f /usr/include/curl/curl.h],
-                            [pmix_check_curl_dir=/usr/include/curl
-                             pmix_check_curl_basedir=/usr
-                             pmix_curl_source=standard])])],
-    	      [AS_IF([test -f $with_curl/include/curl.h],
-                     [pmix_check_curl_dir=$with_curl/include
-                      pmix_check_curl_basedir=$with_curl
-                      pmix_curl_source=$with_curl],
-                      [AS_IF([test -f $with_curl/include/curl/curl.h],
-                             [pmix_check_curl_dir=$with_curl/include/curl
-                              pmix_check_curl_basedir=$with_curl
-                              pmix_curl_source=$with_curl])])])
-        AC_MSG_RESULT([$pmix_check_curl_dir])
+        PMIX_CHECK_WITHDIR([curl-libdir], [$with_curl_libdir], [libcurl.*])
 
-        AS_IF([test -z "$with_curl_libdir" || test "$with_curl_libdir" = "yes"],
-              [pmix_check_curl_libdir=$pmix_check_curl_basedir],
-    	      [PMIX_CHECK_WITHDIR([curl-libdir], [$with_curl_libdir], [libcurl.*])
-               pmix_check_curl_libdir=$with_curl_libdir])
+        AS_IF([test "$with_curl" = "yes" -o -z "$with_curl"],
+              [pmix_curl_source="Standard locations"],
+              [pmix_check_curl_dir="$with_curl"])
+        AS_IF([test "$with_curl_libdir" != "yes" -a "$with_curl_libdir" != "no"],
+              [pmix_check_curl_libdir="$with_curl_libdir"])
 
     	pmix_check_curl_save_CPPFLAGS="$CPPFLAGS"
     	pmix_check_curl_save_LDFLAGS="$LDFLAGS"
     	pmix_check_curl_save_LIBS="$LIBS"
 
         PMIX_CHECK_PACKAGE([pmix_check_curl],
-		   [curl.h],
+		   [curl/curl.h],
 		   [curl],
 		   [curl_easy_getinfo],
 		   [],
@@ -98,7 +82,7 @@ AC_DEFUN([PMIX_CHECK_CURL],[
     AC_MSG_CHECKING([libcurl support available])
     AC_MSG_RESULT([$pmix_check_curl_happy])
 
-    if test -z $pmix_curl_source; then
+    if test -z "$pmix_curl_source"; then
         PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy])
     else
         PMIX_SUMMARY_ADD([[External Packages]],[[Curl]], [pmix_curl], [$pmix_check_curl_happy ($pmix_curl_source)])

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -32,10 +32,12 @@
 AC_DEFUN([PMIX_CHECK_JANSSON],[
 
     PMIX_VAR_SCOPE_PUSH(pmix_check_jansson_save_CPPFLAGS pmix_check_jansson_save_LDFLAGS pmix_check_jansson_save_LIBS)
-	AC_ARG_WITH([jansson],
-		    [AS_HELP_STRING([--with-jansson(=DIR)],
-				    [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
-            [], [with_jansson=no])
+
+    dnl Intentionally disable Jansson unless explicitly requested
+    AC_ARG_WITH([jansson],
+                [AS_HELP_STRING([--with-jansson(=DIR)],
+                   [Build jansson support (default=no), optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])],
+                [], [with_jansson=no])
 
     AC_ARG_WITH([jansson-libdir],
             [AS_HELP_STRING([--with-jansson-libdir=DIR],
@@ -45,22 +47,15 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
     pmix_jansson_source=
     pmix_check_jansson_dir=
     pmix_check_jansson_libdir=
-    pmix_check_jansson_basedir=
 
     if test "$with_jansson" != "no"; then
-        AS_IF([test "$with_jansson" = "yes" || test -z "$with_jansson"],
-              [pmix_check_jansson_dir=/usr
-               pmix_check_jansson_basedir=/usr
-               pmix_jansson_source=standard],
-    	      [PMIX_CHECK_WITHDIR([jansson], [$with_jansson], [include/jansson.h])
-               pmix_check_jansson_dir=$with_jansson/include
-               pmix_check_jansson_basedir=$with_jansson
-               pmix_jansson_source=$with_jansson])
+        PMIX_CHECK_WITHDIR([jansson-libdir], [$with_jansson_libdir], [libjansson.*])
 
-        AS_IF([test -z "$with_jansson_libdir" || test "$with_jansson_libdir" = "yes"],
-              [pmix_check_jansson_libdir=$pmix_check_jansson_basedir/lib],
-    	      [PMIX_CHECK_WITHDIR([jansson-libdir], [$with_jansson_libdir], [libjansson.*])
-               pmix_check_jansson_libdir=$with_jansson_libdir])
+        AS_IF([test "$with_jansson" = "yes" -o -z "$with_jansson"],
+              [pmix_jansson_source="Standard locations"],
+              [pmix_check_jansson_dir="$with_jansson"])
+        AS_IF([test "$with_jansson_libdir" != "yes" -a "$with_jansson_libdir" != "no"],
+              [pmix_check_jansson_libdir="$with_jansson_libdir"])
 
     	pmix_check_jansson_save_CPPFLAGS="$CPPFLAGS"
     	pmix_check_jansson_save_LDFLAGS="$LDFLAGS"
@@ -109,7 +104,7 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
 
     AM_CONDITIONAL([HAVE_JANSSON], [test "$pmix_check_jansson_happy" = "yes"])
 
-    if test -z $pmix_jansson_source; then
+    if test -z "$pmix_jansson_source"; then
         PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy])
     else
         PMIX_SUMMARY_ADD([[External Packages]],[[Jansson]], [pmix_jansson], [$pmix_check_jansson_happy ($pmix_jansson_source)])


### PR DESCRIPTION
Remove the assumption that the default search path for headers
and libraries is /usr/include and /usr/lib,/usr/lib64.  Ubuntu
20.04 on ARM uses /usr/lib/aarch64-linux-gnu for most of its
libraries (which is in the compiler default search paths).  MacOS
has a default search path for includes that is inside the XCode
package.

I can't find any platforms on which curl.h is installed in
include instead of curl/curl.h and the pathing setup for
trying to handle both cases was broken (it would result in
a broken library search unless the user also gave the libdir),
so simplify that logic as well.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>