### PR TITLE
Select all adapters with IPV4 addresses within specified subnet ranges.

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -170,7 +170,8 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct ti
 PMIX_EXPORT void pmix_ptl_base_setup_socket(pmix_peer_t *peer);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_client_handshake(pmix_peer_t *peer, pmix_status_t reply);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_tool_handshake(pmix_peer_t *peer, pmix_status_t rp);
-PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(char **orig_str, char *name);
+PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(const char *orig_str,
+                                                   const char *name);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info,
                                                         size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar);

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -324,10 +324,10 @@ pmix_status_t pmix_ptl_base_setup_listener(void)
      * subnet+mask
      */
     if (NULL != pmix_ptl_base.if_include) {
-        interfaces = pmix_ptl_base_split_and_resolve(&pmix_ptl_base.if_include, "include");
+        interfaces = pmix_ptl_base_split_and_resolve(pmix_ptl_base.if_include, "include");
         including = true;
     } else if (NULL != pmix_ptl_base.if_exclude) {
-        interfaces = pmix_ptl_base_split_and_resolve(&pmix_ptl_base.if_exclude, "exclude");
+        interfaces = pmix_ptl_base_split_and_resolve(pmix_ptl_base.if_exclude, "exclude");
         including = false;
     }
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -436,7 +436,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     pmix_iof_req_t *iofreq;
     pmix_lock_t reglock, releaselock;
     pmix_status_t code;
-    pmix_value_t *val, value;
+    pmix_value_t value;
     bool outputio = true;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);

--- a/test/util/numa.c
+++ b/test/util/numa.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
     hwloc_obj_t obj;
     unsigned width, w;
     hwloc_bitmap_t numas[100], result;
-    int n, m;
+    int m;
     char *tmp, cpus[2048];
     bool overlap = false;
 


### PR DESCRIPTION
Change processing for the --pmixmca ptl_base_if_include and --pmixmca ptl_base_if_exclude options so that all adapters that are within the specified subnet range are selected or excluded, respectively.

The changes to the split_and_resolve function create a list of unique adapter names selected for processing in the order they are seen, and that list is returned to the caller.

The use case here is: Given a system with three ethernet devices:

eth0: 192.168.1.10
eth1: 192.168.2.10
eth2: 9.10.11.10

All three interfaces can route to other nodes, but we only want to use eth0 and eth1 for TCP traffic for this job.
Currently, I need to specify either the individual devices or non-overlapping subnets: --pmixmca ptl_base_if_include 192.168.1.0/24,192.168.2.0/24 because if I specify --pmixmca ptl_base_if_include 192.168.0.0/16 only one of the two devices would be selected

With this fix, I can specify --pmixmca ptl_base_if_exclude 192.168.1.0/16 and pick up both interfaces.

Related Open MPI Issue: #5818
Signed-off-by: David Wootton <dwootton@us.ibm.com>