### PR TITLE
Fix environment variable name in help-pmix-runtime

### DIFF
--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -53,7 +53,7 @@ by any of the following:
   directives versus built plugins (i.e., you excluded all the plugins
   that were built and/or could execute)
 
-* the PMIX_INSTALL_PREFIX environment variable, or the MCA parameter
+* the PMIX_PREFIX environment variable, or the MCA parameter
   "mca_base_component_path", is set and doesn't point to any location
   that includes at least one usable plugin for this framework.
 


### PR DESCRIPTION
The actual name is `PMIX_PREFIX` https://github.com/openpmix/openpmix/issues/2405#issuecomment-981217180

fixes #2405