### PR TITLE
Mark dependencies private in pkg-config file

### DIFF
--- a/maint/pmix.pc.in
+++ b/maint/pmix.pc.in
@@ -7,6 +7,7 @@ Name: pmix
 Description: Process Management Interface for Exascale (PMIx)
 Version: @PACKAGE_VERSION@
 URL: https://pmix.org/
-Requires: @PC_REQUIRES@
-Libs: -L${libdir} -lpmix @PC_PRIVATE_LIBS@
+Requires.private: @PC_REQUIRES@
+Libs: -L${libdir} -lpmix
+Libs.private: @PC_PRIVATE_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
PMIX's dependencies are only needed when static linking, so they
should be marked as .private dependencies.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit e2102a569873e476ee41e634382ac3c275b95932)