### PR TITLE
libev/libevent/hwloc configure cleanups

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -754,16 +754,40 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     ##################################
     pmix_show_title "Event libraries"
 
-    PMIX_LIBEV_CONFIG
-    PMIX_LIBEVENT_CONFIG
+    dnl Only one of Libev or Libevent can be used by OpenPMIX.  The
+    dnl selection logic for the two is:
+    dnl
+    dnl   * libev is used if explicitly requested
+    dnl   * libevent is used if explicitly requested
+    dnl   * if both are explicitly requested, then we report the error
+    dnl     and abort
+    dnl   * if neither is explicitly requested, then we default to
+    dnl     using libevent if it is available. If libevent isn't
+    dnl     available, then we see if libev is available.
+    dnl
+    dnl poking at $with_libevent and $with_libev is a bit of an
+    dnl abstraction break, but makes implementing this logic
+    dnl significantly easier.
+    AS_IF([test ! -z "$with_libevent" -a "$with_libevent" != "no"],
+          [want_libevent=1])
+    AS_IF([test ! -z "$with_libev" -a "$with_libev" != "no"],
+          [want_libev=1])
 
-    AS_IF([test $pmix_libevent_support -eq 1 && test $pmix_libev_support -eq 1],
-      [AC_MSG_WARN([Both libevent and libev support have been specified.])
-       AC_MSG_WARN([Only one can be configured against at a time. Please])
-       AC_MSG_WARN([remove one from the configure command line.])
-       AC_MSG_ERROR([Cannot continue])])
+    AS_IF([test "$want_libevent" = "1" -a "$want_libev" = "1"],
+          [AC_MSG_WARN([Both libevent and libev support have been specified.])
+           AC_MSG_WARN([Only one can be configured against at a time. Please])
+           AC_MSG_WARN([remove one from the configure command line.])
+           AC_MSG_ERROR([Cannot continue])])
 
-    AS_IF([test $pmix_libevent_support -eq 0 && test $pmix_libev_support -eq 0],
+    pmix_found_event_lib=0
+    dnl If libevent succeeds, then we don't need libev, but we skip
+    dnl libevent if libev was explicitly requested.
+    AS_IF([test "$want_libev" != "1"],
+          [PMIX_LIBEVENT_CONFIG([pmix_found_event_lib=1])])
+    AS_IF([test $pmix_found_event_lib -eq 0],
+          [PMIX_LIBEV_CONFIG([pmix_found_event_lib=1])])
+
+    AS_IF([test $pmix_found_event_lib -eq 0],
           [AC_MSG_WARN([Either libevent or libev support is required, but neither])
            AC_MSG_WARN([was found. Please use the configure options to point us])
            AC_MSG_WARN([to where we can find one or the other library])

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -4,6 +4,8 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -77,16 +79,10 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
         AC_MSG_ERROR([Cannot continue.])
     fi
 
-   # update global flags to test for HWLOC version
-    if test ! -z "$pmix_hwloc_CPPFLAGS"; then
-        PMIX_FLAGS_PREPEND_UNIQ(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-    fi
-    if test ! -z "$pmix_hwloc_LDFLAGS"; then
-        PMIX_FLAGS_PREPEND_UNIQ(LDFLAGS, $pmix_hwloc_LDFLAGS)
-    fi
-    if test ! -z "$pmix_hwloc_LIBS"; then
-        PMIX_FLAGS_PREPEND_UNIQ(LIBS, $pmix_hwloc_LIBS)
-    fi
+    # update global flags to test for HWLOC version
+    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+    PMIX_FLAGS_PREPEND_UNIQ([LDFLAGS], [$pmix_hwloc_LDFLAGS])
+    PMIX_FLAGS_PREPEND_UNIQ([LIBS], [$pmix_hwloc_LIBS])
 
     AC_MSG_CHECKING([if hwloc version is 1.5 or greater])
     AC_COMPILE_IFELSE(
@@ -129,18 +125,14 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     LDFLAGS=$pmix_check_hwloc_save_LDFLAGS
     LIBS=$pmix_check_hwloc_save_LIBS
 
-    if test ! -z "$pmix_hwloc_CPPFLAGS"; then
-        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-        PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_hwloc_CPPFLAGS)
-    fi
-    if test ! -z "$pmix_hwloc_LDFLAGS"; then
-        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_hwloc_LDFLAGS)
-        PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_hwloc_LDFLAGS)
-    fi
-    if test ! -z "$pmix_hwloc_LIBS"; then
-        PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_hwloc_LIBS)
-        PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_hwloc_LIBS)
-    fi
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+    PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
+
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LDFLAGS], [$pmix_hwloc_LDFLAGS])
+    PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$pmix_hwloc_LDFLAGS])
+
+    PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$pmix_hwloc_LIBS])
+    PMIX_WRAPPER_FLAGS_ADD([LIBS], [$pmix_hwloc_LIBS])
 
     AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
                        [Whether or not hwloc_topology_dup is available])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -16,33 +16,54 @@
 # $HEADER$
 #
 
-# MCA_libevent_CONFIG([action-if-found], [action-if-not-found])
+# PMIX_LIBEVENT_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
+# Attempt to find a libevent package.  If found, evaluate
+# action-if-found.  Otherwise, evaluate action-if-not-found.
+#
+# Modifies the following in the environment:
+#  * pmix_libevent_CPPFLAGS
+#  * pmix_libevent_LDFLAGS
+#  * pmix_libevent_LIBS
+#
+# Adds the following to the wrapper compilers:
+#  * CPPFLAGS: none
+#  * LDLFGAS: add pmix_libevent_LDFLAGS
+#  * LIBS: add pmix_libevent_LIBS
 AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])
 
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
+
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
 
-    pmix_libevent_support=0
+    pmix_libevent_support=1
 
-    pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
-    pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
-    pmix_check_libevent_save_LIBS="$LIBS"
+    AS_IF([test "$with_libevent" = "no"],
+          [AC_MSG_NOTICE([Libevent support disabled by user.])
+           pmix_libevent_support=0])
 
-    # get rid of any trailing slash(es)
-    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+    AS_IF([test $pmix_libevent_support -eq 1],
+          [PMIX_CHECK_WITHDIR([libevent], [$with_libevent], [include/event.h])
+           PMIX_CHECK_WITHDIR([libevent-libdir], [$with_libevent_libdir], [libevent.*])
 
-    AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-          [pmix_event_dir="$libevent_prefix"],
-          [pmix_event_dir=""])
+           pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
+           pmix_check_libevent_save_LDFLAGS="$LDFLAGS"
+           pmix_check_libevent_save_LIBS="$LIBS"
 
-    AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+           # get rid of any trailing slash(es)
+           libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+           libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+
+           AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                 [pmix_event_dir="$libevent_prefix"],
+                 [pmix_event_dir=""])
+
+           AS_IF([test ! -z "$libeventdir_prefix" -a "$libeventdir_prefix" != "yes"],
                  [pmix_event_libdir="$libeventdir_prefix"],
                  [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
                         [if test -d $libevent_prefix/lib64; then
@@ -56,16 +77,16 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                         ],
                         [pmix_event_libdir=""])])
 
-    PMIX_CHECK_PACKAGE([pmix_libevent],
-                       [event.h],
-                       [event_core],
-                       [event_config_new],
-                       [-levent_pthreads],
-                       [$pmix_event_dir],
-                       [$pmix_event_libdir],
-                       [pmix_libevent_support=1],
-                       [pmix_libevent_support=0],
-                       [])
+           PMIX_CHECK_PACKAGE([pmix_libevent],
+                              [event.h],
+                              [event_core],
+                              [event_config_new],
+                              [-levent_pthreads],
+                              [$pmix_event_dir],
+                              [$pmix_event_libdir],
+                              [],
+                              [pmix_libevent_support=0],
+                              [])])
 
     # Check to see if the above check failed because it conflicted with LSF's libevent.so
     # This can happen if LSF's library is in the LDFLAGS envar or default search
@@ -136,6 +157,11 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
         pmix_libevent_source=$pmix_event_dir
     fi
 
+    # restore global flags
+    CPPFLAGS="$pmix_check_libevent_save_CPPFLAGS"
+    LDFLAGS="$pmix_check_libevent_save_LDFLAGS"
+    LIBS="$pmix_check_libevent_save_LIBS"
+
     AC_MSG_CHECKING([will libevent support be built])
     if test $pmix_libevent_support -eq 1; then
         AC_MSG_RESULT([yes])
@@ -149,14 +175,13 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
         PMIX_WRAPPER_FLAGS_ADD([LIBS], [$pmix_libevent_LIBS])
         # Set output variables
         PMIX_SUMMARY_ADD([[Required Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
+
+        $1
     else
         AC_MSG_RESULT([no])
-    fi
 
-    # restore global flags
-    CPPFLAGS="$pmix_check_libevent_save_CPPFLAGS"
-    LDFLAGS="$pmix_check_libevent_save_LDFLAGS"
-    LIBS="$pmix_check_libevent_save_LIBS"
+        $2
+    fi
 
     AC_DEFINE_UNQUOTED([PMIX_HAVE_LIBEVENT], [$pmix_libevent_support], [Whether we are building against libevent])
 

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -7,6 +7,8 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -88,15 +90,9 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     if test $pmix_libevent_support -eq 1; then
         # need to add resulting flags to global ones so we can
         # test for thread support
-        if test ! -z "$pmix_libevent_CPPFLAGS"; then
-            PMIX_FLAGS_PREPEND_UNIQ(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-        fi
-        if test ! -z "$pmix_libevent_LDFLAGS"; then
-            PMIX_FLAGS_PREPEND_UNIQ(LDFLAGS, $pmix_libevent_LDFLAGS)
-        fi
-        if test ! -z "$pmix_libevent_LIBS"; then
-            PMIX_FLAGS_PREPEND_UNIQ(LIBS, $pmix_libevent_LIBS)
-        fi
+        PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+        PMIX_FLAGS_PREPEND_UNIQ([LDFLAGS], [$pmix_libevent_LDFLAGS])
+        PMIX_FLAGS_PREPEND_UNIQ([LIBS], [$pmix_libevent_LIBS])
 
         # Ensure that this libevent has the symbol
         # "evthread_set_lock_callbacks", which will only exist if
@@ -143,18 +139,14 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     AC_MSG_CHECKING([will libevent support be built])
     if test $pmix_libevent_support -eq 1; then
         AC_MSG_RESULT([yes])
-        if test ! -z "$pmix_libevent_CPPFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_CPPFLAGS, $pmix_libevent_CPPFLAGS)
-            PMIX_WRAPPER_FLAGS_ADD(CPPFLAGS, $pmix_libevent_CPPFLAGS)
-        fi
-        if test ! -z "$pmix_libevent_LDFLAGS"; then
-            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LDFLAGS, $pmix_libevent_LDFLAGS)
-            PMIX_WRAPPER_FLAGS_ADD(LDFLAGS, $pmix_libevent_LDFLAGS)
-        fi
-        if test ! -z "$pmix_libevent_LIBS"; then
-            PMIX_FLAGS_APPEND_UNIQ(PMIX_FINAL_LIBS, $pmix_libevent_LIBS)
-            PMIX_WRAPPER_FLAGS_ADD(LIBS, $pmix_libevent_LIBS)
-        fi
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+        PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_libevent_CPPFLAGS])
+
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LDFLAGS], [$pmix_libevent_LDFLAGS])
+        PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$pmix_libevent_LDFLAGS])
+
+        PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$pmix_libevent_LIBS])
+        PMIX_WRAPPER_FLAGS_ADD([LIBS], [$pmix_libevent_LIBS])
         # Set output variables
         PMIX_SUMMARY_ADD([[Required Packages]],[[Libevent]], [pmix_libevent], [yes ($pmix_libevent_source)])
     else

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -115,24 +115,36 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
         PMIX_FLAGS_PREPEND_UNIQ([LDFLAGS], [$pmix_libevent_LDFLAGS])
         PMIX_FLAGS_PREPEND_UNIQ([LIBS], [$pmix_libevent_LIBS])
 
-        # Ensure that this libevent has the symbol
-        # "evthread_set_lock_callbacks", which will only exist if
-        # libevent was configured with thread support.
-        AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
-                     [],
-                     [AC_MSG_WARN([libevent does not have thread support])
-                      AC_MSG_WARN([PMIX requires libevent to be compiled with])
-                      AC_MSG_WARN([thread support enabled])
-                      pmix_libevent_support=0])
+        # Check for general threading support
+        AC_MSG_CHECKING([if libevent threads enabled])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <event.h>
+#include <event2/thread.h>
+          ], [[
+#if !(EVTHREAD_LOCK_API_VERSION >= 1)
+#  error "No threads!"
+#endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_WARN([PMIX rquires libevent to be compiled with thread support enabled])
+           pmix_libevent_support=0])
     fi
 
     if test $pmix_libevent_support -eq 1; then
-        AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
-                     [],
-                     [AC_MSG_WARN([libevent does not have thread support])
-                      AC_MSG_WARN([PMIX requires libevent to be compiled with])
-                      AC_MSG_WARN([thread support enabled])
-                      pmix_libevent_support=0])
+        AC_MSG_CHECKING([for libevent pthreads support])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <event.h>
+#include <event2/thread.h>
+          ], [[
+#if !defined(EVTHREAD_USE_PTHREADS_IMPLEMENTED) || !EVTHREAD_USE_PTHREADS_IMPLEMENTED
+#  error "No pthreads!"
+#endif
+          ]])],
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           AC_MSG_WARN([PMIX requires libevent to be compiled with pthread support enabled])
+           pmix_libevent_support=0])
     fi
 
     if test $pmix_libevent_support -eq 1; then


### PR DESCRIPTION
A bit of a grab-bag PR, but fix three issues related to libev/libevent/hwloc configure:

  * clean up some duplicate string tests
  * Properly handle (and document) all the libev vs. libevent selection cases
  * In libevent configure, use header macro checks instead of library function checks for package configuration details.