### PR TITLE
Fix library linking in static link cases

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -882,6 +882,34 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # executables) need perl.
     AC_PATH_PROG(PERL, perl, perl)
 
+    # What's the suffix of shared libraries?  Inspired by generated
+    # Libtool code (even though we don't support several of these
+    # platforms, there didn't seem to be any harm in leaving in some of
+    # them, alhtough I did remove some that we have never/will never
+    # support, like OS/2).
+    case $host_os in
+    mingw* | pw32* | cegcc*)
+        PMIX_DYN_LIB_SUFFIX=dll
+        ;;
+    darwin* | rhapsody*)
+        PMIX_DYN_LIB_SUFFIX=dylib
+        ;;
+    hpux9* | hpux10* | hpux11*)
+        case $host_cpu in
+            ia64*)
+            PMIX_DYN_LIB_SUFFIX=so
+          ;;
+        *)
+            PMIX_DYN_LIB_SUFFIX=sl
+            ;;
+        esac
+        ;;
+    *)
+       PMIX_DYN_LIB_SUFFIX=so
+       ;;
+    esac
+    AC_SUBST(PMIX_DYN_LIB_SUFFIX)
+
     # Need the libtool executable before the rpathify stuff
     LT_OUTPUT
 

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -18,6 +18,8 @@ dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -430,6 +432,18 @@ dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
+# PMIX_APPEND(variable, new_argument)
+# ----------------------------------------
+# Append new_argument to variable, assuming a space separated list.
+#
+AC_DEFUN([PMIX_APPEND], [
+  AS_IF([test -z "$$1"], [$1="$2"], [$1="$$1 $2"])
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
 # PMIX_APPEND_UNIQ(variable, new_argument)
 # ----------------------------------------
 # Append new_argument to variable if not already in variable.  This assumes a
@@ -446,11 +460,7 @@ for arg in $2; do
         fi
     done
     if test "$pmix_found" = "0" ; then
-        if test -z "$$1"; then
-            $1="$arg"
-        else
-            $1="$$1 $arg"
-        fi
+        PMIX_APPEND([$1], [$arg])
     fi
 done
 unset pmix_found
@@ -479,7 +489,7 @@ AC_DEFUN([PMIX_FLAGS_APPEND_UNIQ], [
                    AS_IF([test "x$val" = "x$arg"], [pmix_append=0])
                done])
         AS_IF([test "$pmix_append" = "1"],
-              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$$1 $arg"])])
+              [PMIX_APPEND([$1], [$arg])])
     done
 
     PMIX_VAR_SCOPE_POP
@@ -508,7 +518,50 @@ AC_DEFUN([PMIX_FLAGS_PREPEND_UNIQ], [
                    AS_IF([test "x$val" = "x$arg"], [pmix_prepend=0])
                done])
         AS_IF([test "$pmix_prepend" = "1"],
-              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$arg $$1"])])
+              [PMIX_APPEND([$1], [$arg])])
+    done
+
+    PMIX_VAR_SCOPE_POP
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# PMIX_FLAGS_APPEND_MOVE(variable, new_argument)
+# ----------------------------------------------
+# add new_arguments to the end of variable.
+#
+# If an argument in new_arguments does not begin with -I, -L, or -l OR
+# the argument begins with -I, -L, or -l and it is not already in
+# variable, it is appended to variable.
+#
+# If an argument in new_argument begins with a -l and is already in
+# variable, the existing occurances of the argument are removed from
+# variable and the argument is appended to variable.  This behavior
+# is most useful in LIBS, where ordering matters and being rightmost
+# is usually the right behavior.
+#
+# This macro assumes a space separated list.
+AC_DEFUN([PMIX_FLAGS_APPEND_MOVE], [
+    PMIX_VAR_SCOPE_PUSH([pmix_tmp_variable pmix_tmp pmix_append])
+
+    for arg in $2; do
+        AS_CASE([$arg],
+                [-I*|-L*],
+                [pmix_append=1
+                 for val in ${$1} ; do
+                     AS_IF([test "x$val" = "x$arg"], [pmix_append=0])
+                 done
+                 AS_IF([test $pmix_append -eq 1], [PMIX_APPEND([$1], [$arg])])],
+                [-l*],
+                [pmix_tmp_variable=
+                 for val in ${$1}; do
+                     AS_IF([test "x$val" != "x$arg"],
+                           [PMIX_APPEND([pmix_tmp_variable], [$val])])
+                 done
+                 PMIX_APPEND([pmix_tmp_variable], [$arg])])
+                 $1="$pmix_tmp_variable"
     done
 
     PMIX_VAR_SCOPE_POP

--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -17,6 +17,8 @@ dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -306,4 +308,10 @@ AC_DEFUN([PMIX_SETUP_WRAPPER_FINAL],[
    PMIX_FLAGS_UNIQ(PMIX_WRAPPER_EXTRA_LIBS)
    AC_SUBST([PMIX_WRAPPER_EXTRA_LIBS])
    AC_MSG_RESULT([$PMIX_WRAPPER_EXTRA_LIBS])
+
+   ####################################################################
+   # Setup variables for pkg-config file (maint/pmix.pc.in)
+   ####################################################################
+   PC_PRIVATE_LIBS="$PMIX_WRAPPER_EXTRA_LDFLAGS $PMIX_WRAPPER_EXTRA_LIBS"
+   AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -298,32 +300,6 @@ AC_MSG_RESULT([$LDFLAGS])
 
 AC_MSG_CHECKING([final LIBS])
 AC_MSG_RESULT([$LIBS])
-
-####################################################################
-# Setup variables for pkg-config file (maint/pmix.pc.in)
-####################################################################
-
-#
-# Dependencies that themselves have a pkg-config file available.
-#
-PC_REQUIRES=""
-AS_IF([test $pmix_hwloc_support -eq 1],
-      [PC_REQUIRES="$PC_REQUIRES hwloc"])
-AS_IF([test $pmix_libevent_support -eq 1],
-      [PC_REQUIRES="$PC_REQUIRES libevent"])
-AS_IF([test "$pmix_zlib_support" = "1"],
-      [PC_REQUIRES="$PC_REQUIRES zlib"])
-AC_SUBST([PC_REQUIRES], ["$PC_REQUIRES"])
-
-#
-# Dependencies that don't have a pkg-config file available.
-# In this case we need to manually add -L<path> and -l<lib>
-# to the PC_PRIVATE_LIBS variable.
-#
-PC_PRIVATE_LIBS=""
-AS_IF([test $pmix_libev_support -eq 1],
-      [PC_PRIVATE_LIBS="$PC_PRIVATE_LIBS $pmix_libev_LDFLAGS $pmix_libev_LIBS"])
-AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
 
 ####################################################################
 # -Werror for CI scripts

--- a/maint/pmix.pc.in
+++ b/maint/pmix.pc.in
@@ -7,7 +7,6 @@ Name: pmix
 Description: Process Management Interface for Exascale (PMIx)
 Version: @PACKAGE_VERSION@
 URL: https://pmix.org/
-Requires.private: @PC_REQUIRES@
 Libs: -L${libdir} -lpmix
 Libs.private: @PC_PRIVATE_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Fix logic to figure out what libraries to link with an application.  In the dynamic case, no longer include dependent libraries, since the aren't needed (this was a missing macro expansion in the wrapper compiler).  In the dynamic case, we need to thread the MCA libraries into the wrapper compiler.  Finally, switch from using pkg-config package requires and list the libraries out explicitly, due to problems with libevent and the MCA system (details in the commit message).