### PR TITLE
Add configure support for the pgpu and pnet components

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -818,11 +818,18 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     PMIX_CHECK_CURL
 
     ##################################
-    # OFI
+    # OFI (for Transports)
     ##################################
     pmix_show_title "OFI"
 
     PMIX_CHECK_OFI
+
+    ##################################
+    # CUDA (for GPUs)
+    ##################################
+    pmix_show_title "CUDA"
+
+    PMIX_CHECK_CUDA
 
     ##################################
     # MCA

--- a/config/pmix_check_cuda.m4
+++ b/config/pmix_check_cuda.m4
@@ -1,0 +1,52 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2009      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2011-2015 NVIDIA Corporation.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([PMIX_CHECK_CUDA],[
+#
+# Check to see if user wants CUDA support
+#
+    AC_ARG_WITH([cuda],
+                [AS_HELP_STRING([--with-cuda(=DIR)],
+                [Build cuda support, optionally adding DIR/include])])
+
+    AS_IF([test ! -z "$with_cuda" && test "$with_cuda" != "yes"],
+          [pmix_cuda_dir="$with_cuda"],
+          [pmix_cuda_dir=""])
+
+    dnl Just check for the presence of the header for now
+
+    _PMIX_CHECK_PACKAGE_HEADER([pmix_cuda], [cuda.h], [pmix_cuda_dir],
+                               [pmix_cuda_happy=yes],
+                               [pmix_cuda_happy=no])
+
+    AC_MSG_CHECKING([if have cuda support])
+    AC_MSG_RESULT([$pmix_cuda_happy])
+
+])

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -1,0 +1,53 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      QLogic Corp. All rights reserved.
+# Copyright (c) 2009-2021 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Intel Corporation. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+#  Copyright (c) 2021     Triad National Security, LLC. All rights
+#                         reserved.
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_CHECK_PSM2(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if PSM2 support can be found. runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([OMPI_CHECK_PSM2],[
+
+	AC_ARG_WITH([psm2],
+		    [AS_HELP_STRING([--with-psm2(=DIR)],
+				    [Build PSM2 (Intel PSM2) support, optionally adding DIR/include to the search path for headers])])
+    AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "yes"],
+          [pmix_psm2_dir="$with_psm2"],
+          [pmix_psm2_dir=""])
+
+    dnl Just check for the presence of the header for now
+
+    _PMIX_CHECK_PACKAGE_HEADER([pmix_psm2], [psm2.h], [pmix_psm2_dir],
+                               [pmix_psm2_happy=yes],
+                               [pmix_psm2_happy=no])
+
+    AC_MSG_CHECKING([if have psm2 support])
+    AC_MSG_RESULT([$pmix_psm2_happy])
+
+])

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -38,9 +38,8 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
         AC_MSG_ERROR([Cannot continue.])
     fi
 
-    # get rid of any trailing slash(es)
-    hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
-    hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
+    hwloc_prefix=$with_hwloc
+    hwlocdir_prefix=$with_hwloc_libdir
 
     AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
                  [pmix_hwloc_dir="$hwloc_prefix"],

--- a/src/mca/pgpu/amd/configure.m4
+++ b/src/mca/pgpu/amd/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pgpu_amd_CONFIG(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if CUDA support can be found.  runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([MCA_pmix_pgpu_amd_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pgpu/amd/Makefile])
+
+    AS_IF([test "$pmix_cuda_happy" = "yes"],
+          [$1],
+          [$2])
+
+    PMIX_SUMMARY_ADD([[GPUs]],[[AMD]],[pgpu_amd],[$pmix_cuda_happy])])])
+])
+

--- a/src/mca/pgpu/intel/configure.m4
+++ b/src/mca/pgpu/intel/configure.m4
@@ -1,0 +1,33 @@
+# -*- shell-script -*-
+#
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pgpu_intel_CONFIG(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if L0 support can be found.  runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([MCA_pmix_pgpu_intel_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pgpu/intel/Makefile])
+
+# eventually need to check for L0 library
+
+    AS_IF([test "yes" = "yes"],
+          [$1],
+          [$2])
+
+    PMIX_SUMMARY_ADD([[GPUs]],[[Intel]],[pgpu_intel],[yes])
+])
+

--- a/src/mca/pgpu/nvd/configure.m4
+++ b/src/mca/pgpu/nvd/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pgpu_nvd_CONFIG(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if CUDA support can be found.  runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([MCA_pmix_pgpu_nvd_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pgpu/nvd/Makefile])
+
+    AS_IF([test "$pmix_cuda_happy" = "yes"],
+          [$1],
+          [$2])
+
+    PMIX_SUMMARY_ADD([[GPUs]],[[NVIDIA]],[pgpu_nvd],[$pmix_cuda_happy])])])
+])
+

--- a/src/mca/pnet/nvd/configure.m4
+++ b/src/mca/pnet/nvd/configure.m4
@@ -1,0 +1,52 @@
+# -*- shell-script -*-
+#
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_nvd_CONFIG(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if UCX support can be found.  runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pnet/nvd/Makefile])
+
+    PMIX_VAR_SCOPE_PUSH([pmix_check_ucx_dir])
+
+    AS_IF([test -z "$pmix_check_ucx_happy"],
+          [AC_ARG_WITH([ucx],
+		       [AS_HELP_STRING([--with-ucx(=DIR)],
+				       [Build with Unified Communication X library support])])
+
+    AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
+          [pmix_ucx_dir="$with_ucx"],
+          [pmix_ucx_dir=""])
+
+    dnl Just check for the presence of the header for now
+
+    _PMIX_CHECK_PACKAGE_HEADER([pmix_ucx], [include/ucp/api/ucp.h], [pmix_ucx_dir],
+                               [pmix_ucx_happy=yes],
+                               [pmix_ucx_happy=no])
+
+    AS_IF([test "$pmix_ucx_happy" = "yes"],
+          [$1],
+          [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "no"],
+                 [AC_MSG_ERROR([NVIDIA support requested but UCX not found.  Aborting])])
+           $2])
+
+    PMIX_SUMMARY_ADD([[Transports]],[[NVIDIA]],[pnet_nvd],[$pmix_ucx_happy])])])
+
+    PMIX_VAR_SCOPE_POP
+])
+

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -1,0 +1,25 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_opa_CONFIG([action-if-can-compile],
+#                          [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_opa_CONFIG], [
+    AC_CONFIG_FILES([src/mca/pnet/opa/Makefile])
+
+    AS_IF([test "$pmix_ofi_happy" = "yes" || test "$pmix_psm2_happy" = "yes"],
+          [$1
+           pmix_pnet_opa=yes],
+          [$2
+           pmix_pnet_opa=no])
+
+    PMIX_SUMMARY_ADD([[Transports]],[[OmniPath]],[[pnet_opa]],[$pmix_pnet_opa])
+
+])dnl

--- a/src/mca/pnet/tcp/configure.m4
+++ b/src/mca/pnet/tcp/configure.m4
@@ -1,0 +1,22 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_tcp_CONFIG([action-if-can-compile],
+#                          [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_tcp_CONFIG], [
+    AC_CONFIG_FILES([src/mca/pnet/tcp/Makefile])
+
+    AS_IF([test "yes" = "yes"],
+          [$1], [$2])
+
+    PMIX_SUMMARY_ADD([[Transports]],[[TCP]],[[pnet_tcp]],[yes])
+
+])dnl

--- a/src/mca/pnet/usnic/configure.m4
+++ b/src/mca/pnet/usnic/configure.m4
@@ -1,0 +1,90 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Sandia National Laboratories. All rights
+#                         reserved.
+# Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
+#                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_usnic_CONFIG([action-if-can-compile],
+#                            [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_usnic_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pnet/usnic/Makefile])
+
+    AC_ARG_WITH([usnic],
+                [AS_HELP_STRING([--with-usnic],
+                                [If specified, cause an error if usNIC
+                                 support cannot be built])])
+
+    # If --without-usnic was specified, then gracefully exit.
+    # Otherwise, do the rest of the config.
+    AS_IF([test "x$with_usnic" = "xno"],
+          [AC_MSG_WARN([--without-usnic specified; skipping usnic transport])
+           $2],
+          [_PMIX_PNET_USNIC_DO_CONFIG($1, $2)])
+])
+
+AC_DEFUN([_PMIX_PNET_USNIC_DO_CONFIG],[
+    PMIX_VAR_SCOPE_PUSH([pmix_pnet_usnic_CPPFLAGS_save])
+
+    pmix_pnet_usnic_happy=yes
+
+    # We only want to build on 64 bit Linux.
+    AC_CHECK_SIZEOF([void *])
+    AC_MSG_CHECKING([for 64 bit Linux])
+    case $host_os in
+       *linux*)
+           AS_IF([test $ac_cv_sizeof_void_p -eq 8],
+                 [],
+                 [pmix_pnet_usnic_happy=no])
+           ;;
+       *)
+           pmix_pnet_usnic_happy=no
+           ;;
+    esac
+    AC_MSG_RESULT([$pmix_pnet_usnic_happy])
+
+    AS_IF([test "$pmix_pnet_usnic_happy" = "yes"],
+          [ # The usnic PNET component requires OFI libfabric support
+           pmix_pnet_usnic_happy=$pmix_ofi_happy])
+
+    # Make sure we can find the OFI libfabric usnic extensions header
+    AS_IF([test "$pmix_pnet_usnic_happy" = "yes" ],
+          [pmix_pnet_usnic_CPPFLAGS_save=$CPPFLAGS
+           CPPFLAGS="$pmix_ofi_CPPFLAGS $CPPFLAGS"
+           AC_CHECK_HEADER([rdma/fi_ext_usnic.h],
+                            [],
+                            [pmix_pnet_usnic_happy=no])
+           CPPFLAGS=$pmix_pnet_usnic_CPPFLAGS_save
+          ])
+
+    # All done
+    AS_IF([test "$pmix_pnet_usnic_happy" = "yes"],
+          [$1],
+          [AS_IF([test "$with_usnic" = "yes"],
+                 [AC_MSG_WARN([--with-usnic was specified, but Cisco usNIC support cannot be built])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [$2])
+          ])
+
+    PMIX_SUMMARY_ADD([[Transports]],[[Cisco usNIC]],[[pnet_usnic]],[$pmix_pnet_usnic_happy])
+    PMIX_VAR_SCOPE_POP
+])dnl


### PR DESCRIPTION
Don't build the components if we lack the corresponding
support. We may not use those libraries in the components
at this time, but no point in grabbing/moving envars and
allocating resources for non-existent things

Signed-off-by: Ralph Castain <rhc@pmix.org>