### PR TITLE
fix a problem using PMIX_RANK

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -6,6 +6,9 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2021      Triad National Security, LLC. All rights
+ *                         reserved.
+ *
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -2714,6 +2717,8 @@ typedef struct pmix_value {
             (n) = (t)((m)->data.dval);                  \
         } else if (PMIX_PID == (m)->type) {             \
             (n) = (t)((m)->data.pid);                   \
+        } else if (PMIX_PROC_RANK == (m)->type) {       \
+            (n) = (t)((m)->data.rank);                  \
         } else {                                        \
             (s) = PMIX_ERR_BAD_PARAM;                   \
         }                                               \

--- a/test/test_v2/test_get_basic.c
+++ b/test/test_v2/test_get_basic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020      Triad National Security, LLC.
+ * Copyright (c) 2020-2021 Triad National Security, LLC.
  *                         All rights reserved.
  *
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
@@ -83,12 +83,10 @@ int main(int argc, char *argv[])
     free(val);
     TEST_VERBOSE(("after PMIX_HOSTNAME check"));
 
-    // Code hangs when PMIx_Get of PMIX_RANK is enabled
-    /*
-     job_proc.rank = PMIX_RANK_UNDEF;
-     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_RANK, NULL, 0, &val), l_params, v_params);
-     pmixt_validate_predefined(&job_proc, PMIX_RANK, val, PMIX_PROC_RANK, &v_params);
-     */
+    job_proc.rank = PMIX_RANK_INVALID;
+    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_RANK, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, PMIX_RANK, val, PMIX_PROC_RANK, &v_params);
+    TEST_VERBOSE(("after PMIX_RANK check"));
 
     /* finalize */
     PMIXT_CHECK(PMIx_Finalize(NULL, 0), l_params, v_params);


### PR DESCRIPTION
the GET_NUMBER macro didn't know about this pmix type

Signed-off-by: Howard Pritchard <howardp@lanl.gov>