### PR TITLE
Fix two bugs in OPAL_FLAGS_APPEND_MOVE

### DIFF
--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -560,8 +560,9 @@ AC_DEFUN([PMIX_FLAGS_APPEND_MOVE], [
                      AS_IF([test "x$val" != "x$arg"],
                            [PMIX_APPEND([pmix_tmp_variable], [$val])])
                  done
-                 PMIX_APPEND([pmix_tmp_variable], [$arg])])
-                 $1="$pmix_tmp_variable"
+                 PMIX_APPEND([pmix_tmp_variable], [$arg])
+                 $1="$pmix_tmp_variable"],
+                [PMIX_APPEND([$1], [$arg])])
     done
 
     PMIX_VAR_SCOPE_POP


### PR DESCRIPTION
Fix two issues in OPAL_FLAGS_APPEND_MOVE, which impacted the static
library list in the wrapper compilers.  First, an assignment was
outside the conditional clause, resulting in the original array
being wiped out if the input did not contain any -l arguments.
Second, we did not have the default case to handle arguments that
did not begin with -I, -L, or -l.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>