### PR TITLE
build: Be more flexible in library handling

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -21,12 +21,17 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
                                 [Search for hwloc headers and libraries in DIR ])])
-
     AC_ARG_WITH([hwloc-libdir],
                 [AS_HELP_STRING([--with-hwloc-libdir=DIR],
                                 [Search for hwloc libraries in DIR ])])
+    AC_ARG_WITH([hwloc-extra-libs],
+                [AS_HELP_STRING([--with-hwloc-extra-libs=LIBS],
+                                [Add LIBS as dependencies of hwloc])])
+    AC_ARG_ENABLE([hwloc-lib-checks],
+                  [AS_HELP_STRING([--disable-hwloc-lib-checks],
+                                  [If --disable-hwloc-lib-checks is specified, configure will assume that -lhwloc is available])])
 
-    pmix_hwloc_support=0
+    pmix_hwloc_support=1
     pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
     pmix_check_hwloc_save_LDFLAGS="$LDFLAGS"
     pmix_check_hwloc_save_LIBS="$LIBS"
@@ -37,6 +42,9 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
     fi
+
+    AS_IF([test "$with_hwloc_extra_libs" = "yes" -o "$with_hwloc_extra_libs" = "no"],
+	  [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
 
     hwloc_prefix=$with_hwloc
     hwlocdir_prefix=$with_hwloc_libdir
@@ -59,16 +67,18 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                         ],
                         [pmix_hwloc_libdir=""])])
 
-    PMIX_CHECK_PACKAGE([pmix_hwloc],
-                       [hwloc.h],
-                       [hwloc],
-                       [hwloc_topology_init],
-                       [],
-                       [$pmix_hwloc_dir],
-                       [$pmix_hwloc_libdir],
-                       [pmix_hwloc_support=1],
-                       [pmix_hwloc_support=0],
-                       [])
+    AS_IF([test "$enable_hwloc_lib_checks" != "no"],
+          [PMIX_CHECK_PACKAGE([pmix_hwloc],
+                              [hwloc.h],
+                              [hwloc],
+                              [hwloc_topology_init],
+                              [$with_hwloc_extra_libs],
+                              [$pmix_hwloc_dir],
+                              [$pmix_hwloc_libdir],
+                              [],
+                              [pmix_hwloc_support=0],
+                              [])],
+          [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
         AC_MSG_WARN([PMIx requires HWLOC topology library support, but])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -36,16 +36,24 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
-
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
+    AC_ARG_WITH([libevent-extra-libs],
+                [AS_HELP_STRING([--with-libevent-extra-libs=LIBS],
+                                [Add LIBS as dependencies of Libevent])])
+    AC_ARG_ENABLE([libevent-lib-checks],
+                   [AS_HELP_STRING([--disable-libevent-lib-checks],
+                                   [If --disable-libevent-lib-checks is specified, configure will assume that -levent is available])])
 
     pmix_libevent_support=1
 
     AS_IF([test "$with_libevent" = "no"],
           [AC_MSG_NOTICE([Libevent support disabled by user.])
            pmix_libevent_support=0])
+
+    AS_IF([test "$with_libevent_extra_libs" = "yes" -o "$with_libevent_extra_libs" = "no"],
+	  [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test $pmix_libevent_support -eq 1],
           [PMIX_CHECK_WITHDIR([libevent], [$with_libevent], [include/event.h])
@@ -77,16 +85,18 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                         ],
                         [pmix_event_libdir=""])])
 
-           PMIX_CHECK_PACKAGE([pmix_libevent],
-                              [event.h],
-                              [event_core],
-                              [event_config_new],
-                              [-levent_pthreads],
-                              [$pmix_event_dir],
-                              [$pmix_event_libdir],
-                              [],
-                              [pmix_libevent_support=0],
-                              [])])
+           AS_IF([test "$enable_libevent_lib_checks" != "no"],
+                 [PMIX_CHECK_PACKAGE([pmix_libevent],
+                                     [event.h],
+                                     [event_core],
+                                     [event_config_new],
+                                     [-levent_pthreads $with_libevent_extra_libs],
+                                     [$pmix_event_dir],
+                                     [$pmix_event_libdir],
+                                     [],
+                                     [pmix_libevent_support=0],
+                                     [])],
+                 [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_libevent_extra_libs])])])
 
     # Check to see if the above check failed because it conflicted with LSF's libevent.so
     # This can happen if LSF's library is in the LDFLAGS envar or default search


### PR DESCRIPTION
Add ability to both add additional libraries into the link
dependencies for libevent, libev, and hwloc (useful if they
have unexpected libraries for static linking) and to disable
library checks for places where we get it really wrong and
users resort to setting LIBS directly.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>