### PR TITLE
Enable buffered IOF output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ test/simple/simpfabric
 test/simple/get_put_example
 test/simple/simpvni
 test/simple/hybrid
+test/simple/asyncio
 
 test/sshot/daemon
 test/sshot/generate

--- a/EXCEPTIONS
+++ b/EXCEPTIONS
@@ -54,6 +54,8 @@ PMIX_IOF_OUTPUT_TO_DIRECTORY        "pmix.iof.dir"          // (char*) direct ap
 PMIX_IOF_OUTPUT_TO_FILE             "pmix.iof.file"         // (char*) direct application output into files of form
                                                             //         "<filename>.rank" with both stdout and stderr redirected into it
 PMIX_IOF_RANK_OUTPUT                "pmix.iof.rank"         // (bool) Tag output with the rank it came from
+PMIX_IOF_OUTPUT_RAW                 "pmix.iof.raw"          // (bool) Do not buffer output to be written as complete lines - output
+                                                            //        characters as the stream delivers them
 PMIX_NODE_OVERSUBSCRIBED            "pmix.ndosub"           // (bool) true if number of procs from this job on this node
                                                             //        exceeds the number of slots allocated to it
 PMIX_SINGLETON                      "pmix.singleton"        // (char*) String representation (nspace.rank) of proc ID for the singleton
@@ -179,6 +181,8 @@ PMIX_IOF_FILE_ONLY                  "pmix.iof.fonly"        // (bool) output onl
 PMIX_IOF_FILE_PATTERN               "pmix.iof.fpt"          // (bool) Specified output file is to be treated as a pattern and not
                                                             //        automatically annotated by nspace, rank, or other parameters
 PMIX_IOF_LOCAL_OUTPUT               "pmix.iof.local"        // (bool) Write output streams to local stdout/err
+PMIX_IOF_OUTPUT_RAW                 "pmix.iof.raw"          // (bool) Do not buffer output to be written as complete lines - output
+                                                            //        characters as the stream delivers them
 PMIX_IOF_MERGE_STDERR_STDOUT        "pmix.iof.mrg"          // (bool) merge stdout and stderr streams from application procs
 PMIX_IOF_OUTPUT_TO_DIRECTORY        "pmix.iof.dir"          // (char*) direct application output into files of form
                                                             //         "<directory>/<jobid>/rank.<rank>/stdout[err]"

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -906,6 +906,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        The original output stream(s) destination is restored upon
                                                                     //        termination of the tool.
 #define PMIX_IOF_LOCAL_OUTPUT               "pmix.iof.local"        // (bool) Write output streams to local stdout/err
+#define PMIX_IOF_OUTPUT_RAW                 "pmix.iof.raw"          // (bool) Do not buffer output to be written as complete lines - output
+                                                                    //        characters as the stream delivers them
 
 /* Attributes for controlling contents of application setup data */
 #define PMIX_SETUP_APP_ENVARS               "pmix.setup.env"        // (bool) harvest and include relevant envars

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -119,10 +119,12 @@ struct pmix_list_item_t {
 typedef struct pmix_list_item_t pmix_list_item_t;
 
 /* static initializer for pmix_list_t */
-#define PMIX_LIST_ITEM_STATIC_INIT                                            \
-    {                                                                         \
-        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t), .pmix_list_next = NULL, \
-        .pmix_list_prev = NULL, .item_free = 0                                \
+#define PMIX_LIST_ITEM_STATIC_INIT                      \
+    {                                                   \
+        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+        .pmix_list_next = NULL,                         \
+        .pmix_list_prev = NULL,                         \
+        .item_free = 0                                  \
     }
 
 /**
@@ -164,10 +166,11 @@ struct pmix_list_t {
 typedef struct pmix_list_t pmix_list_t;
 
 /* static initializer for pmix_list_t */
-#define PMIX_LIST_STATIC_INIT                                                   \
-    {                                                                           \
-        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),                           \
-        .pmix_list_sentinel = PMIX_LIST_ITEM_STATIC_INIT, .pmix_list_length = 0 \
+#define PMIX_LIST_STATIC_INIT                               \
+    {                                                       \
+        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),       \
+        .pmix_list_sentinel = PMIX_LIST_ITEM_STATIC_INIT,   \
+        .pmix_list_length = 0                               \
     }
 
 /** Cleanly destruct a list

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -60,7 +60,6 @@ BEGIN_C_DECLS
  */
 #define PMIX_IOF_BASE_MSG_MAX        8192
 #define PMIX_IOF_BASE_TAG_MAX        1024
-#define PMIX_IOF_BASE_TAGGED_OUT_MAX 16384
 #define PMIX_IOF_MAX_INPUT_BUFFERS   50
 #define PMIX_IOF_MAX_RETRIES         4
 
@@ -110,7 +109,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_sink_t);
 
 typedef struct {
     pmix_list_item_t super;
-    char data[PMIX_IOF_BASE_TAGGED_OUT_MAX];
+    char *data;
     int numbytes;
 } pmix_iof_write_output_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_write_output_t);
@@ -131,6 +130,18 @@ typedef struct {
     size_t ndirs;
 } pmix_iof_read_event_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_read_event_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t name;
+    pmix_iof_write_event_t *channel;
+    pmix_iof_flags_t flags;
+    pmix_iof_channel_t stream;
+    bool copystdout;
+    bool copystderr;
+    pmix_byte_object_t bo;
+} pmix_iof_residual_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_residual_t);
 
 /* Write event macro's */
 
@@ -265,6 +276,7 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_info_t *info, size_t ninfo,
                                                const pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
+PMIX_EXPORT void pmix_iof_flush_residuals(void);
 
 END_C_DECLS
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -205,6 +205,7 @@ typedef struct {
     bool local_output;
     bool local_output_given;
     bool pattern;
+    bool raw;
 } pmix_iof_flags_t;
 
 /* objects used by servers for tracking active nspaces */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -92,6 +92,7 @@ pmix_server_globals_t pmix_server_globals = {
     .events = PMIX_LIST_STATIC_INIT,
     .groups = PMIX_LIST_STATIC_INIT,
     .iof = PMIX_LIST_STATIC_INIT,
+    .iof_residuals = PMIX_LIST_STATIC_INIT,
     .psets = PMIX_LIST_STATIC_INIT,
     .max_iof_cache = 0,
     .tool_connections_allowed = false,
@@ -400,13 +401,15 @@ pmix_status_t pmix_server_initialize(void)
     /* setup the server-specific globals */
     PMIX_CONSTRUCT(&pmix_server_globals.clients, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_server_globals.clients, 1, INT_MAX, 1);
+    PMIX_CONSTRUCT(&pmix_server_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.collectives, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.remote_pnd, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.gdata, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.events, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_server_globals.iof_residuals, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.psets, pmix_list_t);
 
     pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server init called");
@@ -968,6 +971,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
      * of any events objects may be holding */
     (void) pmix_progress_thread_pause(NULL);
 
+    /* flush any residual IOF into their respective channels */
+    pmix_iof_flush_residuals();
     /* flush anything that is still trying to be written out */
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
@@ -999,6 +1004,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.groups);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.psets);
 
     if (NULL != security_mode) {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -184,13 +184,13 @@ typedef struct {
     pmix_list_t collectives;      // list of active pmix_server_trkr_t
     pmix_list_t remote_pnd; // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing
                             // remote req's
-    pmix_list_t
-        local_reqs;     // list of pmix_dmdx_local_t awaiting arrival of data from local neighbours
+    pmix_list_t local_reqs;     // list of pmix_dmdx_local_t awaiting arrival of data from local neighbours
     pmix_list_t gdata;  // cache of data given to me for passing to all clients
     char **genvars;     // argv array of envars given to me for passing to all clients
     pmix_list_t events; // list of pmix_regevents_info_t registered events
     pmix_list_t groups; // list of pmix_group_t group memberships
     pmix_list_t iof;    // IO to be forwarded to clients
+    pmix_list_t iof_residuals;  // leftover bytes waiting for newline
     pmix_list_t psets;  // list of known psets and memberships
     size_t max_iof_cache; // max number of IOF messages to cache
     bool tool_connections_allowed;

--- a/test/simple/asyncio.c
+++ b/test/simple/asyncio.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+#define REPS 2
+
+char data[1024];
+
+int main(int argc, char *argv[])
+{
+    int n, size, start, end, delay;
+
+    /* write a line out that has a newline at the end */
+    memset(data, 0, sizeof(data));
+    memcpy(data, "BEGIN123456788865432356897654345678END\n", strlen("BEGIN123456788865432356897654345678END\n"));
+    write(1, data, strlen(data));
+
+    for (n=0; n < REPS; n++) {
+        fprintf(stdout, "REP %d\n", n);
+        start = 0;
+        delay = random() % 4;
+ //       sleep(delay);
+        memset(data, 0, sizeof(data));
+        memset(data, 'A', 1024);
+        end = 100;
+        write(1, data, end);
+        start += end;
+        delay = random() % 4;
+   //     sleep(delay);
+        write(1, &data[start], end);
+        start += end;
+        delay = random() % 4;
+  //      sleep(delay);
+        write(1, &data[start], 1024 - start);
+        fprintf(stdout, "\n");
+    }
+}


### PR DESCRIPTION
Output complete lines at a time to eliminate output from
different ranks stepping on each other. Provide a new
attribute PMIX_IOF_OUTPUT_RAW to turn this off since
sometimes users want the output to appear immediately
and not be internally cached while it waits for a newline
character to be output.

Signed-off-by: Ralph Castain <rhc@pmix.org>