### PR TITLE
build: Fix escaping issue in pkg-config file

### DIFF
--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -312,6 +312,6 @@ AC_DEFUN([PMIX_SETUP_WRAPPER_FINAL],[
    ####################################################################
    # Setup variables for pkg-config file (maint/pmix.pc.in)
    ####################################################################
-   PC_PRIVATE_LIBS="$PMIX_WRAPPER_EXTRA_LDFLAGS $PMIX_WRAPPER_EXTRA_LIBS"
+   PC_PRIVATE_LIBS="$PMIX_PKG_CONFIG_LDFLAGS $PMIX_WRAPPER_EXTRA_LIBS"
    AC_SUBST([PC_PRIVATE_LIBS], ["$PC_PRIVATE_LIBS"])
 ])


### PR DESCRIPTION
Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit d0609f1a7f322f02295eecf845644c21afd91fec)