### PR TITLE
Fix the client-get function

### DIFF
--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -239,6 +239,16 @@ PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
         return "GROUP LEAVE";
     case PMIX_GROUP_DESTRUCT_CMD:
         return "GROUP DESTRUCT";
+    case PMIX_IOF_DEREG_CMD:
+        return "IOF DEREG";
+    case PMIX_FABRIC_REGISTER_CMD:
+        return "FABRIC REGISTER";
+    case PMIX_FABRIC_UPDATE_CMD:
+        return "FABRIC UPDATE";
+    case PMIX_COMPUTE_DEVICE_DISTANCES_CMD:
+        return "COMPUTE DEVICE DIST";
+    case PMIX_REFRESH_CACHE:
+        return "REFRESH CACHE";
     default:
         return "UNKNOWN";
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -15,7 +15,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -137,6 +137,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_FABRIC_REGISTER_CMD          30
 #define PMIX_FABRIC_UPDATE_CMD            31
 #define PMIX_COMPUTE_DEVICE_DISTANCES_CMD 32
+#define PMIX_REFRESH_CACHE                33
 
 /* provide a "pretty-print" function for cmds */
 const char *pmix_command_string(pmix_cmd_t cmd);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -9,7 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -4725,6 +4725,14 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
     if (PMIX_COMPUTE_DEVICE_DISTANCES_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         if (PMIX_SUCCESS != (rc = pmix_server_device_dists(cd, buf, dist_cbfunc))) {
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+
+    if (PMIX_REFRESH_CACHE == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_refresh_cache(cd, buf, op_cbfunc))) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -4795,6 +4795,14 @@ cleanup:
         pmix_hwloc_destruct_cpuset(&cpuset);
     }
     return rc;
+}
+
+pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
+                                        pmix_buffer_t *buf,
+                                        pmix_op_cbfunc_t cbfunc)
+{
+    PMIX_HIDE_UNUSED_PARAMS(cd, buf, cbfunc);
+    return PMIX_ERR_NOT_SUPPORTED;
 }
 
 /*****    INSTANCE SERVER LIBRARY CLASSES    *****/

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -357,6 +357,10 @@ PMIX_EXPORT pmix_status_t pmix_server_fabric_get_device_index(pmix_server_caddy_
 PMIX_EXPORT pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
                                                    pmix_buffer_t *buf,
                                                    pmix_device_dist_cbfunc_t cbfunc);
+
+PMIX_EXPORT pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
+                                                    pmix_buffer_t *buf,
+                                                    pmix_op_cbfunc_t cbfunc);
 
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;


### PR DESCRIPTION
Prior to this PR, the users thread was penetrating down into
code that accessed global variables that are restricted to
access only from within a PMIx progress event. Refactor the
code to prevent that from happening.

Also add code to support the "refresh cache" request - this
hook was missing from the current code. Still need server-side
implementation.

Signed-off-by: Ralph Castain <rhc@pmix.org>