### PR TITLE
Enable ability to bind PMIx progress thread

### DIFF
--- a/EXCEPTIONS
+++ b/EXCEPTIONS
@@ -67,6 +67,9 @@ PMIX_SPAWN_TIMEOUT                  "pmix.sp.time"          // (int) time in sec
                                                             //       it from the PMIX_JOB_TIMEOUT attribute
 PMIX_LOCAL_COLLECTIVE_STATUS        "pmix.loc.col.st"       // (pmix_status_t) status code for local collective operation bei>
                                                             //         reported to host by server library
+PMIX_BIND_PROGRESS_THREAD           "pmix.bind.pt"          // (char*) Comma-delimited ranges of CPUs that the internal PMIx progress
+                                                            //         thread shall be bound to
+PMIX_BIND_REQUIRED                  "pmix.bind.reqd"        // (bool) Return error if the internal PMIx progress thread cannot be bound
 
 
 

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -733,6 +733,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_PROG_GREP
     AC_PROG_EGREP
 
+    # This check must come after PMIX_CONFIG_THREADS
+    AC_CHECK_FUNCS([pthread_setaffinity_np])
+
     ##################################
     # Visibility
     ##################################

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -46,7 +46,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -184,6 +184,10 @@ typedef uint32_t pmix_rank_t;
                                                                     //        GPU, and other devices
 #define PMIX_SINGLETON                      "pmix.singleton"        // (char*) String representation (nspace.rank) of proc ID for the singleton
                                                                     //         the server was started to support
+#define PMIX_BIND_PROGRESS_THREAD           "pmix.bind.pt"          // (char*) Comma-delimited ranges of CPUs that the internal PMIx progress
+                                                                    //         thread shall be bound to
+#define PMIX_BIND_REQUIRED                  "pmix.bind.reqd"        // (bool) Return error if the internal PMIx progress thread cannot be bound
+
 
 /* tool-related attributes */
 #define PMIX_TOOL_NSPACE                    "pmix.tool.nspace"      // (char*) Name of the nspace to use for this tool

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +33,9 @@
  * already-running progress thread will be returned (i.e., no new
  * progress thread will be started).
  */
-PMIX_EXPORT pmix_event_base_t *pmix_progress_thread_init(const char *name);
+PMIX_EXPORT pmix_event_base_t *pmix_progress_thread_init(const char *name,
+                                                         const char *cpuset,
+                                                         bool bind_reqd);
 
 PMIX_EXPORT pmix_status_t pmix_progress_thread_start(const char *name);
 

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
     PMIX_INFO_FREE(info, ninfo);
 
     /* get our own event base */
-    simptest_evbase = pmix_progress_thread_init("simptest");
+    simptest_evbase = pmix_progress_thread_init("simptest", NULL, false);
     pmix_progress_thread_start("simptest");
 
     /* register the default errhandler */


### PR DESCRIPTION
In some scenarios, it is desirable to bind progress threads
to one or more specific cores - e.g., a core designated for
utility usage and not assigned application processes. Provide
an attribute by which the user can specify the core(s) to
which the internal PMIx progress thread is to be bound, and
to indicate if the binding is mandatory (i.e., return an
error if the thread cannot be bound).

Signed-off-by: Ralph Castain <rhc@pmix.org>