### PR TITLE
Generalize MCA support

### DIFF
--- a/src/mca/base/pmix_base.h
+++ b/src/mca/base/pmix_base.h
@@ -117,7 +117,7 @@ enum {
  * invoked during the initialization stage and specifically
  * invoked in the special case of the *_info command.
  */
-PMIX_EXPORT int pmix_mca_base_open(void);
+PMIX_EXPORT int pmix_mca_base_open(const char *add_path);
 
 /**
  * Last function called in the MCA

--- a/src/mca/base/pmix_mca_base_alias.h
+++ b/src/mca/base/pmix_mca_base_alias.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2020      Google, LLC. All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +12,7 @@
 #ifndef PMIX_MCA_BASE_ALIAS_H
 #define PMIX_MCA_BASE_ALIAS_H
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 #include "src/class/pmix_list.h"
 
 BEGIN_C_DECLS

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -181,6 +181,7 @@ struct pmix_mca_base_var_t {
     char *mbv_full_name;
     /** Long variable name <project>_<framework>_<component>_<name> */
     char *mbv_long_name;
+    char *mbv_prefix;
 
     /** List of synonym names for this variable.  This *must* be a
         pointer (vs. a plain pmix_list_t) because we copy this whole
@@ -602,13 +603,6 @@ PMIX_EXPORT int pmix_mca_base_var_dump(int vari, char ***out,
 #define MCA_RUNTIME_VER     "print_runtime_version"
 
 PMIX_EXPORT int pmix_mca_base_var_cache_files(bool rel_path_search);
-
-/*
- * Parse a provided list of envars and add their local value, or
- * their assigned value, to the provided argv
- */
-PMIX_EXPORT int pmix_mca_base_var_process_env_list(char ***argv);
-PMIX_EXPORT int pmix_mca_base_var_process_env_list_from_file(char ***argv);
 
 END_C_DECLS
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -175,7 +175,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     }
 
     /* initialize the mca */
-    if (PMIX_SUCCESS != (ret = pmix_mca_base_open())) {
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_open(NULL))) {
         error = "mca_base_open";
         goto return_error;
     }

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -142,7 +142,7 @@ int pmix_info_init(int argc, char **argv)
     int ret;
     PMIX_HIDE_UNUSED_PARAMS(argc);
 
-    if (PMIX_SUCCESS != pmix_mca_base_open()) {
+    if (PMIX_SUCCESS != pmix_mca_base_open(NULL)) {
         pmix_show_help("help-pinfo.txt", "lib-call-fail", true, "mca_base_open", __FILE__,
                        __LINE__);
         PMIX_RELEASE(pmix_info_cmd_line);
@@ -254,7 +254,7 @@ int pmix_info_register_framework_params(void)
     }
 
     /* Register mca/base parameters */
-    if (PMIX_SUCCESS != pmix_mca_base_open()) {
+    if (PMIX_SUCCESS != pmix_mca_base_open(NULL)) {
         pmix_show_help("help-pmix_info.txt", "lib-call-fail", true, "mca_base_open", __FILE__,
                        __LINE__);
         return PMIX_ERROR;

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
     }
 
     /* initialize the mca */
-    if (PMIX_SUCCESS != (ret = pmix_mca_base_open())) {
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_open(NULL))) {
         pmix_show_help("help-pmix-runtime.txt", "pmix_init:startup:internal-failure", true,
                        "pmix_mca_base_open", ret);
         return ret;

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -107,6 +107,7 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_HELP                   "help"                      // optional
 #define PMIX_CLI_VERSION                "version"                   // none
 #define PMIX_CLI_VERBOSE                "verbose"                   // number of instances => verbosity level
+#define PMIX_CLI_PMIXMCA                "pmixmca"                   // requires TWO
 
 // Tool connection options
 #define PMIX_CLI_SYS_SERVER_FIRST       "system-server-first"       // none


### PR DESCRIPTION
Allow specification of additional paths to component libraries.
Make the MCA prefix (e.g., "PMIX_MCA_") be based on the project
name used to register the variable.

Signed-off-by: Ralph Castain <rhc@pmix.org>