### PR TITLE
Add project name to MCA component find/open

### DIFF
--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -395,7 +395,7 @@ extern "C" {
 
 `cat $outfile.extern`
 
-const pmix_mca_base_component_t *mca_$1_base_static_components[[]] = {
+const pmix_mca_base_component_t *pmix_mca_$1_base_static_components[[]] = {
 `cat $outfile.struct`
   NULL
 };
@@ -681,10 +681,10 @@ AC_DEFUN([MCA_PROCESS_COMPONENT],[
         else
             # Other frameworks do not have to obey the
             # $FRAMEWORK_LIB_PREFIX prefix.
-            $6="mca/$1/$2/libmca_$1_$2.la $$6"
+            $6="mca/$1/$2/libpmix_mca_$1_$2.la $$6"
         fi
-        echo "extern const pmix_mca_base_component_t mca_$1_$2_component;" >> $outfile.extern
-        echo "  &mca_$1_$2_component, " >> $outfile.struct
+        echo "extern const pmix_mca_base_component_t pmix_mca_$1_$2_component;" >> $outfile.extern
+        echo "  &pmix_mca_$1_$2_component, " >> $outfile.struct
         $4="$$4 $2"
     fi
 

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -224,7 +224,7 @@ int pmix_mca_base_components_filter(pmix_mca_base_framework_t *framework)
  * the specified type (and possibly of a given name).
  *
  * Note that we use our own path iteration functionality because we
- * need to look at companion .ompi_info files in the same directory as
+ * need to look at companion .pmix_info files in the same directory as
  * the library to generate dependencies, etc.
  */
 static void find_dyn_components(const char *path, pmix_mca_base_framework_t *framework,
@@ -239,7 +239,7 @@ static void find_dyn_components(const char *path, pmix_mca_base_framework_t *fra
                         framework->framework_name);
 
     if (NULL != path) {
-        ret = pmix_mca_base_component_repository_add(path);
+        ret = pmix_mca_base_component_repository_add(framework->framework_project, path);
         if (PMIX_SUCCESS != ret) {
             return;
         }

--- a/src/mca/base/pmix_mca_base_component_repository.h
+++ b/src/mca/base/pmix_mca_base_component_repository.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,6 +47,7 @@ BEGIN_C_DECLS
 struct pmix_mca_base_component_repository_item_t {
     pmix_list_item_t super;
 
+    char *ri_project;
     char ri_type[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN + 1];
     char ri_name[PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN + 1];
 
@@ -89,7 +90,8 @@ PMIX_EXPORT int pmix_mca_base_component_repository_init(void);
  *
  * @param[in] path        delimited list of search paths to add
  */
-PMIX_EXPORT int pmix_mca_base_component_repository_add(const char *path);
+PMIX_EXPORT int pmix_mca_base_component_repository_add(const char *project,
+                                                       const char *path);
 
 /**
  * @brief return the list of components that match a given framework

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -121,7 +121,7 @@ static pmix_status_t pmix_bfrop_open(pmix_mca_base_open_flag_t flags)
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, bfrops, "PMIx Buffer Operations", pmix_bfrop_register,
                                 pmix_bfrop_open, pmix_bfrop_close,
-                                mca_bfrops_base_static_components,
+                                pmix_mca_bfrops_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 static void moddes(pmix_bfrops_base_active_module_t *p)

--- a/src/mca/bfrops/v12/Makefile.am
+++ b/src/mca/bfrops/v12/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,10 +39,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v12_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v12.la
+component = pmix_mca_bfrops_v12.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v12.la
+lib = libpmix_mca_bfrops_v12.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -49,12 +50,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v12_la_SOURCES = $(component_sources)
-mca_bfrops_v12_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v12_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v12_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v12_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v12_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v12_la_SOURCES = $(lib_sources)
-libmca_bfrops_v12_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v12_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v12_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,177 +56,177 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix12_bfrop_pack_bool, pmix12_bfrop_unpack_bool,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_bool,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix12_bfrop_pack_byte, pmix12_bfrop_unpack_byte,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_byte,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix12_bfrop_pack_string,
                        pmix12_bfrop_unpack_string, pmix12_bfrop_copy_string,
-                       pmix12_bfrop_print_string, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_string, &pmix_mca_bfrops_v12_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix12_bfrop_pack_sizet, pmix12_bfrop_unpack_sizet,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_size,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix12_bfrop_pack_pid, pmix12_bfrop_unpack_pid,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_pid,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix12_bfrop_pack_int, pmix12_bfrop_unpack_int,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_int,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix12_bfrop_pack_byte, pmix12_bfrop_unpack_byte,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_int8,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix12_bfrop_pack_int16, pmix12_bfrop_unpack_int16,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_int16,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix12_bfrop_pack_int32, pmix12_bfrop_unpack_int32,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_int32,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix12_bfrop_pack_int64, pmix12_bfrop_unpack_int64,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_int64,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix12_bfrop_pack_int, pmix12_bfrop_unpack_int,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_uint,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix12_bfrop_pack_byte, pmix12_bfrop_unpack_byte,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_uint8,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix12_bfrop_pack_int16,
                        pmix12_bfrop_unpack_int16, pmix12_bfrop_std_copy, pmix12_bfrop_print_uint16,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix12_bfrop_pack_int32,
                        pmix12_bfrop_unpack_int32, pmix12_bfrop_std_copy, pmix12_bfrop_print_uint32,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix12_bfrop_pack_int64,
                        pmix12_bfrop_unpack_int64, pmix12_bfrop_std_copy, pmix12_bfrop_print_uint64,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix12_bfrop_pack_float, pmix12_bfrop_unpack_float,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_float,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix12_bfrop_pack_double,
                        pmix12_bfrop_unpack_double, pmix12_bfrop_std_copy, pmix12_bfrop_print_double,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix12_bfrop_pack_timeval,
                        pmix12_bfrop_unpack_timeval, pmix12_bfrop_std_copy,
-                       pmix12_bfrop_print_timeval, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_timeval, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix12_bfrop_pack_time, pmix12_bfrop_unpack_time,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_time,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix12_bfrop_pack_status,
                        pmix12_bfrop_unpack_status, pmix12_bfrop_std_copy, pmix12_bfrop_print_status,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     /* structured values need to be done here as they might
      * callback into standard and/or derived values */
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix12_bfrop_pack_value, pmix12_bfrop_unpack_value,
                        pmix12_bfrop_copy_value, pmix12_bfrop_print_value,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix12_bfrop_pack_proc, pmix12_bfrop_unpack_proc,
                        pmix12_bfrop_copy_proc, pmix12_bfrop_print_proc,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix12_bfrop_pack_app, pmix12_bfrop_unpack_app,
                        pmix12_bfrop_copy_app, pmix12_bfrop_print_app,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix12_bfrop_pack_info, pmix12_bfrop_unpack_info,
                        pmix12_bfrop_copy_info, pmix12_bfrop_print_info,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix12_bfrop_pack_pdata, pmix12_bfrop_unpack_pdata,
                        pmix12_bfrop_copy_pdata, pmix12_bfrop_print_pdata,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix12_bfrop_pack_buf, pmix12_bfrop_unpack_buf,
                        pmix12_bfrop_copy_buf, pmix12_bfrop_print_buf,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix12_bfrop_pack_bo,
                        pmix12_bfrop_unpack_bo, pmix12_bfrop_copy_bo, pmix12_bfrop_print_bo,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix12_bfrop_pack_kval, pmix12_bfrop_unpack_kval,
                        pmix12_bfrop_copy_kval, pmix12_bfrop_print_kval,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX, pmix12_bfrop_pack_modex, pmix12_bfrop_unpack_modex,
                        pmix12_bfrop_copy_modex, pmix12_bfrop_print_modex,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix12_bfrop_pack_persist,
                        pmix12_bfrop_unpack_persist, pmix12_bfrop_std_copy,
-                       pmix12_bfrop_print_persist, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_persist, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix12_bfrop_pack_ptr, pmix12_bfrop_unpack_ptr,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_ptr,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix12_bfrop_pack_scope, pmix12_bfrop_unpack_scope,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_scope,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix12_bfrop_pack_range,
                        pmix12_bfrop_unpack_range, pmix12_bfrop_std_copy, pmix12_bfrop_print_ptr,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix12_bfrop_pack_cmd, pmix12_bfrop_unpack_cmd,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_cmd,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix12_bfrop_pack_info_directives, pmix12_bfrop_unpack_info_directives,
                        pmix12_bfrop_std_copy, pmix12_bfrop_print_info_directives,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix12_bfrop_pack_datatype,
                        pmix12_bfrop_unpack_datatype, pmix12_bfrop_std_copy,
-                       pmix12_bfrop_print_datatype, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_datatype, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix12_bfrop_pack_proc_state,
                        pmix12_bfrop_unpack_proc_state, pmix12_bfrop_std_copy,
-                       pmix12_bfrop_print_proc_state, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_proc_state, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix12_bfrop_pack_proc_info,
                        pmix12_bfrop_unpack_proc_info, pmix12_bfrop_copy_proc_info,
-                       pmix12_bfrop_print_proc_info, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_proc_info, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix12_bfrop_pack_darray,
                        pmix12_bfrop_unpack_darray, pmix12_bfrop_copy_darray,
-                       pmix12_bfrop_print_darray, &mca_bfrops_v12_component.types);
+                       pmix12_bfrop_print_darray, &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix12_bfrop_pack_rank,
                        pmix12_bfrop_unpack_rank, pmix12_bfrop_std_copy, pmix12_bfrop_print_rank,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix12_bfrop_pack_query, pmix12_bfrop_unpack_query,
                        pmix12_bfrop_copy_query, pmix12_bfrop_print_query,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY, pmix12_bfrop_pack_array,
                        pmix12_bfrop_unpack_array, pmix12_bfrop_copy_array, pmix12_bfrop_print_array,
-                       &mca_bfrops_v12_component.types);
+                       &pmix_mca_bfrops_v12_component.types);
     /********************/
 
     return PMIX_SUCCESS;
@@ -237,12 +237,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v12_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v12_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v12_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v12_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v12_component.types, n, NULL);
         }
     }
 }
@@ -253,7 +253,7 @@ static const char *data_type_string(pmix_data_type_t type)
 
     if (NULL
         == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, type))) {
+                pmix_pointer_array_get_item(&pmix_mca_bfrops_v12_component.types, type))) {
         return NULL;
     }
     return info->odti_name;

--- a/src/mca/bfrops/v12/bfrop_v12.h
+++ b/src/mca/bfrops/v12/bfrop_v12.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v12_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v12_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix12_module;
 

--- a/src/mca/bfrops/v12/bfrop_v12_component.c
+++ b/src/mca/bfrops/v12/bfrop_v12_component.c
@@ -47,7 +47,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v12_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v12_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -68,7 +68,7 @@ pmix_bfrops_base_component_t mca_bfrops_v12_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v12_component.types, pmix_pointer_array_t);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v12_component.types, pmix_pointer_array_t);
 
     return PMIX_SUCCESS;
 }
@@ -76,14 +76,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v12_component.priority;
+    *priority = pmix_mca_bfrops_v12_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix12_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v12_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v12_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -48,7 +48,7 @@ pmix_status_t pmix12_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
 
     if (NULL
         == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, type))) {
+                pmix_pointer_array_get_item(&pmix_mca_bfrops_v12_component.types, type))) {
         PMIX_ERROR_LOG(PMIX_ERR_UNKNOWN_DATA_TYPE);
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -40,7 +40,7 @@ pmix_status_t pmix12_bfrop_pack(pmix_buffer_t *buffer, const void *src, int32_t 
                                 pmix_data_type_t type)
 {
     pmix_status_t rc;
-    pmix_pointer_array_t *regtypes = &mca_bfrops_v12_component.types;
+    pmix_pointer_array_t *regtypes = &pmix_mca_bfrops_v12_component.types;
 
     /* check for error */
     if (NULL == buffer) {
@@ -107,7 +107,7 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_pointer_array_t *regtypes, pmix_buff
 
     /* Lookup the pack function for this type and call it */
 
-    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, v1type);
+    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&pmix_mca_bfrops_v12_component.types, v1type);
     if (NULL == info) {
         return PMIX_ERR_PACK_FAILURE;
     }

--- a/src/mca/bfrops/v12/print.c
+++ b/src/mca/bfrops/v12/print.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +46,7 @@ pmix_status_t pmix12_bfrop_print(char **output, char *prefix, void *src, pmix_da
 
     /* Lookup the print function for this type and call it */
 
-    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, type);
+    info = (pmix_bfrop_type_info_t *) pmix_pointer_array_get_item(&pmix_mca_bfrops_v12_component.types, type);
     if (NULL == info) {
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -39,7 +39,7 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer, void *dst, int32_t *num
     pmix_status_t rc, ret;
     int32_t local_num, n = 1;
     pmix_data_type_t local_type;
-    pmix_pointer_array_t *regtypes = &mca_bfrops_v12_component.types;
+    pmix_pointer_array_t *regtypes = &pmix_mca_bfrops_v12_component.types;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: for type %d", (int) type);

--- a/src/mca/bfrops/v20/Makefile.am
+++ b/src/mca/bfrops/v20/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,10 +39,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v20_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v20.la
+component = pmix_mca_bfrops_v20.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v20.la
+lib = libpmix_mca_bfrops_v20.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -49,12 +50,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v20_la_SOURCES = $(component_sources)
-mca_bfrops_v20_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v20_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v20_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v20_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v20_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v20_la_SOURCES = $(lib_sources)
-libmca_bfrops_v20_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v20_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v20_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -59,184 +59,184 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix20_bfrop_pack_bool, pmix20_bfrop_unpack_bool,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_bool,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix20_bfrop_pack_byte, pmix20_bfrop_unpack_byte,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_byte,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix20_bfrop_pack_string,
                        pmix20_bfrop_unpack_string, pmix20_bfrop_copy_string,
-                       pmix20_bfrop_print_string, &mca_bfrops_v20_component.types);
+                       pmix20_bfrop_print_string, &pmix_mca_bfrops_v20_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix20_bfrop_pack_sizet, pmix20_bfrop_unpack_sizet,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_size,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix20_bfrop_pack_pid, pmix20_bfrop_unpack_pid,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_pid,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix20_bfrop_pack_int, pmix20_bfrop_unpack_int,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_int,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix20_bfrop_pack_byte, pmix20_bfrop_unpack_byte,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_int8,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix20_bfrop_pack_int16, pmix20_bfrop_unpack_int16,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_int16,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix20_bfrop_pack_int32, pmix20_bfrop_unpack_int32,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_int32,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix20_bfrop_pack_int64, pmix20_bfrop_unpack_int64,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_int64,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix20_bfrop_pack_int, pmix20_bfrop_unpack_int,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_uint,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix20_bfrop_pack_byte, pmix20_bfrop_unpack_byte,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_uint8,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix20_bfrop_pack_int16,
                        pmix20_bfrop_unpack_int16, pmix20_bfrop_std_copy, pmix20_bfrop_print_uint16,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix20_bfrop_pack_int32,
                        pmix20_bfrop_unpack_int32, pmix20_bfrop_std_copy, pmix20_bfrop_print_uint32,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix20_bfrop_pack_int64,
                        pmix20_bfrop_unpack_int64, pmix20_bfrop_std_copy, pmix20_bfrop_print_uint64,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix20_bfrop_pack_float, pmix20_bfrop_unpack_float,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_float,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix20_bfrop_pack_double,
                        pmix20_bfrop_unpack_double, pmix20_bfrop_std_copy, pmix20_bfrop_print_double,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix20_bfrop_pack_timeval,
                        pmix20_bfrop_unpack_timeval, pmix20_bfrop_std_copy,
-                       pmix20_bfrop_print_timeval, &mca_bfrops_v20_component.types);
+                       pmix20_bfrop_print_timeval, &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix20_bfrop_pack_time, pmix20_bfrop_unpack_time,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_time,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix20_bfrop_pack_status,
                        pmix20_bfrop_unpack_status, pmix20_bfrop_std_copy, pmix20_bfrop_print_status,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix20_bfrop_pack_value, pmix20_bfrop_unpack_value,
                        pmix20_bfrop_copy_value, pmix20_bfrop_print_value,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix20_bfrop_pack_proc, pmix20_bfrop_unpack_proc,
                        pmix20_bfrop_copy_proc, pmix20_bfrop_print_proc,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix20_bfrop_pack_app, pmix20_bfrop_unpack_app,
                        pmix20_bfrop_copy_app, pmix20_bfrop_print_app,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix20_bfrop_pack_info, pmix20_bfrop_unpack_info,
                        pmix20_bfrop_copy_info, pmix20_bfrop_print_info,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix20_bfrop_pack_pdata, pmix20_bfrop_unpack_pdata,
                        pmix20_bfrop_copy_pdata, pmix20_bfrop_print_pdata,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix20_bfrop_pack_buf, pmix20_bfrop_unpack_buf,
                        pmix20_bfrop_copy_buf, pmix20_bfrop_print_buf,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix20_bfrop_pack_bo,
                        pmix20_bfrop_unpack_bo, pmix20_bfrop_copy_bo, pmix20_bfrop_print_bo,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix20_bfrop_pack_kval, pmix20_bfrop_unpack_kval,
                        pmix20_bfrop_copy_kval, pmix20_bfrop_print_kval,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX, pmix20_bfrop_pack_modex, pmix20_bfrop_unpack_modex,
                        pmix20_bfrop_copy_modex, pmix20_bfrop_print_modex,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix20_bfrop_pack_persist,
                        pmix20_bfrop_unpack_persist, pmix20_bfrop_std_copy,
-                       pmix20_bfrop_print_persist, &mca_bfrops_v20_component.types);
+                       pmix20_bfrop_print_persist, &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix20_bfrop_pack_ptr, pmix20_bfrop_unpack_ptr,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_ptr,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix20_bfrop_pack_scope, pmix20_bfrop_unpack_scope,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_scope,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix20_bfrop_pack_range,
                        pmix20_bfrop_unpack_range, pmix20_bfrop_std_copy, pmix20_bfrop_print_ptr,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix20_bfrop_pack_cmd, pmix20_bfrop_unpack_cmd,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_cmd,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES, pmix20_bfrop_pack_infodirs,
                        pmix20_bfrop_unpack_infodirs, pmix20_bfrop_std_copy,
-                       pmix20_bfrop_print_infodirs, &mca_bfrops_v20_component.types);
+                       pmix20_bfrop_print_infodirs, &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix20_bfrop_pack_datatype,
                        pmix20_bfrop_unpack_datatype, pmix20_bfrop_std_copy,
-                       pmix_bfrops_base_print_datatype, &mca_bfrops_v20_component.types);
+                       pmix_bfrops_base_print_datatype, &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix20_bfrop_pack_pstate,
                        pmix20_bfrop_unpack_pstate, pmix20_bfrop_std_copy, pmix20_bfrop_print_pstate,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix20_bfrop_pack_pinfo,
                        pmix20_bfrop_unpack_pinfo, pmix20_bfrop_copy_pinfo, pmix20_bfrop_print_pinfo,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix20_bfrop_pack_darray,
                        pmix20_bfrop_unpack_darray, pmix20_bfrop_copy_darray,
-                       pmix20_bfrop_print_darray, &mca_bfrops_v20_component.types);
+                       pmix20_bfrop_print_darray, &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix20_bfrop_pack_rank,
                        pmix20_bfrop_unpack_rank, pmix20_bfrop_std_copy, pmix20_bfrop_print_rank,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix20_bfrop_pack_query, pmix20_bfrop_unpack_query,
                        pmix20_bfrop_copy_query, pmix20_bfrop_print_query,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix20_bfrop_pack_bo,
                        pmix20_bfrop_unpack_bo, pmix20_bfrop_copy_bo, pmix20_bfrop_print_bo,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE", PMIX_ALLOC_DIRECTIVE,
                        pmix20_bfrop_pack_alloc_directive, pmix20_bfrop_unpack_alloc_directive,
                        pmix20_bfrop_std_copy, pmix20_bfrop_print_alloc_directive,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY, pmix20_bfrop_pack_array,
                        pmix20_bfrop_unpack_array, pmix20_bfrop_copy_array, pmix20_bfrop_print_array,
-                       &mca_bfrops_v20_component.types);
+                       &pmix_mca_bfrops_v20_component.types);
     /********************/
 
     return PMIX_SUCCESS;
@@ -247,12 +247,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v20_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v20_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v20_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v20_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v20_component.types, n, NULL);
         }
     }
 }
@@ -261,7 +261,7 @@ static const char *data_type_string(pmix_data_type_t type)
 {
     pmix_bfrop_type_info_t *info;
 
-    info = (pmix_bfrop_type_info_t *)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type);
+    info = (pmix_bfrop_type_info_t *)pmix_pointer_array_get_item(&pmix_mca_bfrops_v20_component.types, type);
     if (NULL == info) {
         return NULL;
     }

--- a/src/mca/bfrops/v20/bfrop_pmix20.h
+++ b/src/mca/bfrops/v20/bfrop_pmix20.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v20_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v20_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix20_module;
 

--- a/src/mca/bfrops/v20/bfrop_pmix20_component.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20_component.c
@@ -48,7 +48,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v20_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v20_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -69,8 +69,8 @@ pmix_bfrops_base_component_t mca_bfrops_v20_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v20_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v20_component.types, 32, INT_MAX, 16);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v20_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_mca_bfrops_v20_component.types, 32, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -78,14 +78,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v20_component.priority;
+    *priority = pmix_mca_bfrops_v20_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix20_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v20_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v20_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -48,7 +48,7 @@ pmix_status_t pmix20_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
 
     if (NULL
         == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+                pmix_pointer_array_get_item(&pmix_mca_bfrops_v20_component.types, type))) {
         PMIX_ERROR_LOG(PMIX_ERR_UNKNOWN_DATA_TYPE);
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -41,7 +41,7 @@ pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer, const void *src, int32_t 
                                 pmix_data_type_t type)
 {
     pmix_status_t rc;
-    pmix_pointer_array_t *regtypes = &mca_bfrops_v20_component.types;
+    pmix_pointer_array_t *regtypes = &pmix_mca_bfrops_v20_component.types;
 
     /* check for error */
     if (NULL == buffer) {
@@ -94,7 +94,7 @@ pmix_status_t pmix20_bfrop_pack_buffer(pmix_pointer_array_t *regtypes, pmix_buff
 
     if (NULL
         == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, v20type))) {
+                pmix_pointer_array_get_item(&pmix_mca_bfrops_v20_component.types, v20type))) {
         return PMIX_ERR_PACK_FAILURE;
     }
 

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -50,7 +50,7 @@ pmix_status_t pmix20_bfrop_print(char **output, char *prefix, void *src, pmix_da
 
     if (NULL
         == (info = (pmix_bfrop_type_info_t *)
-                pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+                pmix_pointer_array_get_item(&pmix_mca_bfrops_v20_component.types, type))) {
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }
 

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -39,7 +39,7 @@ pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer, void *dst, int32_t *num
     pmix_status_t rc, ret;
     int32_t local_num, n = 1;
     pmix_data_type_t local_type;
-    pmix_pointer_array_t *regtypes = &mca_bfrops_v20_component.types;
+    pmix_pointer_array_t *regtypes = &pmix_mca_bfrops_v20_component.types;
 
     /* check for error */
     if (NULL == buffer || NULL == dst || NULL == num_vals) {

--- a/src/mca/bfrops/v21/Makefile.am
+++ b/src/mca/bfrops/v21/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v21_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v21.la
+component = pmix_mca_bfrops_v21.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v21.la
+lib = libpmix_mca_bfrops_v21.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v21_la_SOURCES = $(component_sources)
-mca_bfrops_v21_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v21_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v21_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v21_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v21_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v21_la_SOURCES = $(lib_sources)
-libmca_bfrops_v21_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v21_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v21_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,185 +94,185 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix_bfrops_base_pack_bool,
                        pmix_bfrops_base_unpack_bool, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_bool, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_bool, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_byte, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_byte, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix_bfrops_base_pack_string,
                        pmix_bfrops_base_unpack_string, pmix_bfrops_base_copy_string,
-                       pmix_bfrops_base_print_string, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_string, &pmix_mca_bfrops_v21_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix_bfrops_base_pack_sizet,
                        pmix_bfrops_base_unpack_sizet, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_size, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_size, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix_bfrops_base_pack_pid, pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_pid,
-                       &mca_bfrops_v21_component.types);
+                       &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix_bfrops_base_pack_int, pmix_bfrops_base_unpack_int,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_int,
-                       &mca_bfrops_v21_component.types);
+                       &pmix_mca_bfrops_v21_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int8, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
                        pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int16, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
                        pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int32, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
                        pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int64, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
                        pmix_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_uint, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint8, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
                        pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint16, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
                        pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint32, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
                        pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint64, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,
                        pmix_bfrops_base_unpack_float, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_float, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_float, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix_bfrops_base_pack_double,
                        pmix_bfrops_base_unpack_double, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_double, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_double, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix_bfrops_base_pack_timeval,
                        pmix_bfrops_base_unpack_timeval, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_timeval, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_timeval, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix_bfrops_base_pack_time,
                        pmix_bfrops_base_unpack_time, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_time, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_time, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix_bfrops_base_pack_status,
                        pmix_bfrops_base_unpack_status, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_status, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_status, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix_bfrops_base_pack_value,
                        pmix_bfrops_base_unpack_value, pmix_bfrops_base_copy_value,
-                       pmix_bfrops_base_print_value, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_value, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix_bfrops_base_pack_proc,
                        pmix_bfrops_base_unpack_proc, pmix_bfrops_base_copy_proc,
-                       pmix_bfrops_base_print_proc, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_proc, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix_bfrops_base_pack_app, pmix_bfrops_base_unpack_app,
                        pmix_bfrops_base_copy_app, pmix_bfrops_base_print_app,
-                       &mca_bfrops_v21_component.types);
+                       &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix_bfrops_base_pack_info,
                        pmix_bfrops_base_unpack_info, pmix_bfrops_base_copy_info,
-                       pmix_bfrops_base_print_info, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_info, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix_bfrops_base_pack_pdata,
                        pmix_bfrops_base_unpack_pdata, pmix_bfrops_base_copy_pdata,
-                       pmix_bfrops_base_print_pdata, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_pdata, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix_bfrops_base_pack_buf,
                        pmix_bfrops_base_unpack_buf, pmix_bfrops_base_copy_buf,
-                       pmix_bfrops_base_print_buf, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_buf, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix_bfrops_base_pack_kval,
                        pmix_bfrops_base_unpack_kval, pmix_bfrops_base_copy_kval,
-                       pmix_bfrops_base_print_kval, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_kval, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX, pmix21_bfrop_pack_modex, pmix21_bfrop_unpack_modex,
                        pmix21_bfrop_copy_modex, pmix21_bfrop_print_modex,
-                       &mca_bfrops_v21_component.types);
+                       &pmix_mca_bfrops_v21_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix_bfrops_base_pack_persist,
                        pmix_bfrops_base_unpack_persist, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_persist, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_persist, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix_bfrops_base_pack_ptr,
                        pmix_bfrops_base_unpack_ptr, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_scope, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_scope, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix_bfrops_base_pack_cmd,
                        pmix_bfrops_base_unpack_cmd, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_cmd, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_cmd, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix_bfrops_base_pack_info_directives,
                        pmix_bfrops_base_unpack_info_directives, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_info_directives, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_info_directives, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix_bfrops_base_pack_datatype,
                        pmix_bfrops_base_unpack_datatype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_datatype, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_datatype, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix_bfrops_base_pack_pstate,
                        pmix_bfrops_base_unpack_pstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pstate, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_pstate, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix_bfrops_base_pack_pinfo,
                        pmix_bfrops_base_unpack_pinfo, pmix_bfrops_base_copy_pinfo,
-                       pmix_bfrops_base_print_pinfo, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_pinfo, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix_bfrops_base_pack_darray,
                        pmix_bfrops_base_unpack_darray, pmix_bfrops_base_copy_darray,
-                       pmix_bfrops_base_print_darray, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_darray, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix_bfrops_base_pack_rank,
                        pmix_bfrops_base_unpack_rank, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_rank, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_rank, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix_bfrops_base_pack_query,
                        pmix_bfrops_base_unpack_query, pmix_bfrops_base_copy_query,
-                       pmix_bfrops_base_print_query, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_query, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v21_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE", PMIX_ALLOC_DIRECTIVE,
                        pmix_bfrops_base_pack_alloc_directive,
                        pmix_bfrops_base_unpack_alloc_directive, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_alloc_directive, &mca_bfrops_v21_component.types);
+                       pmix_bfrops_base_print_alloc_directive, &pmix_mca_bfrops_v21_component.types);
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY, pmix21_bfrop_pack_array,
                        pmix21_bfrop_unpack_array, pmix21_bfrop_copy_array, pmix21_bfrop_print_array,
-                       &mca_bfrops_v21_component.types);
+                       &pmix_mca_bfrops_v21_component.types);
     /********************/
 
     return PMIX_SUCCESS;
@@ -283,12 +283,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v21_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v21_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v21_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v21_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v21_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v21_component.types, n, NULL);
         }
     }
 }
@@ -297,29 +297,29 @@ static pmix_status_t pmix21_pack(pmix_buffer_t *buffer, const void *src, int num
                                  pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v21_component.types, buffer, src, num_vals, type);
+    return pmix_bfrops_base_pack(&pmix_mca_bfrops_v21_component.types, buffer, src, num_vals, type);
 }
 
 static pmix_status_t pmix21_unpack(pmix_buffer_t *buffer, void *dest, int32_t *num_vals,
                                    pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v21_component.types, buffer, dest, num_vals, type);
+    return pmix_bfrops_base_unpack(&pmix_mca_bfrops_v21_component.types, buffer, dest, num_vals, type);
 }
 
 static pmix_status_t pmix21_copy(void **dest, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_copy(&mca_bfrops_v21_component.types, dest, src, type);
+    return pmix_bfrops_base_copy(&pmix_mca_bfrops_v21_component.types, dest, src, type);
 }
 
 static pmix_status_t pmix21_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_print(&mca_bfrops_v21_component.types, output, prefix, src, type);
+    return pmix_bfrops_base_print(&pmix_mca_bfrops_v21_component.types, output, prefix, src, type);
 }
 
 static const char *data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v21_component.types, type);
+    return pmix_bfrops_base_data_type_string(&pmix_mca_bfrops_v21_component.types, type);
 }
 
 /**** DEPRECATED ****/

--- a/src/mca/bfrops/v21/bfrop_pmix21.h
+++ b/src/mca/bfrops/v21/bfrop_pmix21.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v21_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v21_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix21_module;
 

--- a/src/mca/bfrops/v21/bfrop_pmix21_component.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21_component.c
@@ -48,7 +48,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v21_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v21_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -69,8 +69,8 @@ pmix_bfrops_base_component_t mca_bfrops_v21_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v21_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v21_component.types, 32, INT_MAX, 16);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v21_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_mca_bfrops_v21_component.types, 32, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -78,14 +78,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v21_component.priority;
+    *priority = pmix_mca_bfrops_v21_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix21_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v21_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v21_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v3/Makefile.am
+++ b/src/mca/bfrops/v3/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v3_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v3.la
+component = pmix_mca_bfrops_v3.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v3.la
+lib = libpmix_mca_bfrops_v3.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v3_la_SOURCES = $(component_sources)
-mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v3_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v3_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v3_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v3_la_SOURCES = $(lib_sources)
-libmca_bfrops_v3_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v3_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v3_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,193 +92,193 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix_bfrops_base_pack_bool,
                        pmix_bfrops_base_unpack_bool, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_bool, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_bool, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_byte, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_byte, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix_bfrops_base_pack_string,
                        pmix_bfrops_base_unpack_string, pmix_bfrops_base_copy_string,
-                       pmix_bfrops_base_print_string, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_string, &pmix_mca_bfrops_v3_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix_bfrops_base_pack_sizet,
                        pmix_bfrops_base_unpack_sizet, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_size, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_size, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix_bfrops_base_pack_pid, pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_pid,
-                       &mca_bfrops_v3_component.types);
+                       &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix_bfrops_base_pack_int, pmix_bfrops_base_unpack_int,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_int,
-                       &mca_bfrops_v3_component.types);
+                       &pmix_mca_bfrops_v3_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int8, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
                        pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int16, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
                        pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int32, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
                        pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int64, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
                        pmix_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_uint, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint8, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
                        pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint16, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
                        pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint32, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
                        pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint64, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,
                        pmix_bfrops_base_unpack_float, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_float, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_float, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix_bfrops_base_pack_double,
                        pmix_bfrops_base_unpack_double, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_double, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_double, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix_bfrops_base_pack_timeval,
                        pmix_bfrops_base_unpack_timeval, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_timeval, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_timeval, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix_bfrops_base_pack_time,
                        pmix_bfrops_base_unpack_time, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_time, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_time, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix_bfrops_base_pack_status,
                        pmix_bfrops_base_unpack_status, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_status, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_status, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix_bfrops_base_pack_value,
                        pmix_bfrops_base_unpack_value, pmix_bfrops_base_copy_value,
-                       pmix_bfrops_base_print_value, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_value, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix_bfrops_base_pack_proc,
                        pmix_bfrops_base_unpack_proc, pmix_bfrops_base_copy_proc,
-                       pmix_bfrops_base_print_proc, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_proc, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix_bfrops_base_pack_app, pmix_bfrops_base_unpack_app,
                        pmix_bfrops_base_copy_app, pmix_bfrops_base_print_app,
-                       &mca_bfrops_v3_component.types);
+                       &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix_bfrops_base_pack_info,
                        pmix_bfrops_base_unpack_info, pmix_bfrops_base_copy_info,
-                       pmix_bfrops_base_print_info, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_info, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix_bfrops_base_pack_pdata,
                        pmix_bfrops_base_unpack_pdata, pmix_bfrops_base_copy_pdata,
-                       pmix_bfrops_base_print_pdata, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_pdata, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix_bfrops_base_pack_buf,
                        pmix_bfrops_base_unpack_buf, pmix_bfrops_base_copy_buf,
-                       pmix_bfrops_base_print_buf, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_buf, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix_bfrops_base_pack_kval,
                        pmix_bfrops_base_unpack_kval, pmix_bfrops_base_copy_kval,
-                       pmix_bfrops_base_print_kval, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_kval, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX, pmix3_bfrop_pack_modex, pmix3_bfrop_unpack_modex,
                        pmix3_bfrop_copy_modex, pmix3_bfrop_print_modex,
-                       &mca_bfrops_v3_component.types);
+                       &pmix_mca_bfrops_v3_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix_bfrops_base_pack_persist,
                        pmix_bfrops_base_unpack_persist, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_persist, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_persist, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix_bfrops_base_pack_ptr,
                        pmix_bfrops_base_unpack_ptr, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_scope, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_scope, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix_bfrops_base_pack_cmd,
                        pmix_bfrops_base_unpack_cmd, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_cmd, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_cmd, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix_bfrops_base_pack_info_directives,
                        pmix_bfrops_base_unpack_info_directives, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_info_directives, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_info_directives, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix_bfrops_base_pack_datatype,
                        pmix_bfrops_base_unpack_datatype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_datatype, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_datatype, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix_bfrops_base_pack_pstate,
                        pmix_bfrops_base_unpack_pstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pstate, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_pstate, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix_bfrops_base_pack_pinfo,
                        pmix_bfrops_base_unpack_pinfo, pmix_bfrops_base_copy_pinfo,
-                       pmix_bfrops_base_print_pinfo, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_pinfo, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix_bfrops_base_pack_darray,
                        pmix_bfrops_base_unpack_darray, pmix_bfrops_base_copy_darray,
-                       pmix_bfrops_base_print_darray, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_darray, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix_bfrops_base_pack_rank,
                        pmix_bfrops_base_unpack_rank, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_rank, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_rank, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix_bfrops_base_pack_query,
                        pmix_bfrops_base_unpack_query, pmix_bfrops_base_copy_query,
-                       pmix_bfrops_base_print_query, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_query, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE", PMIX_ALLOC_DIRECTIVE,
                        pmix_bfrops_base_pack_alloc_directive,
                        pmix_bfrops_base_unpack_alloc_directive, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_alloc_directive, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_alloc_directive, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL", PMIX_IOF_CHANNEL, pmix_bfrops_base_pack_iof_channel,
                        pmix_bfrops_base_unpack_iof_channel, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_iof_channel, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_iof_channel, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENVAR", PMIX_ENVAR, pmix_bfrops_base_pack_envar,
                        pmix_bfrops_base_unpack_envar, pmix_bfrops_base_copy_envar,
-                       pmix_bfrops_base_print_envar, &mca_bfrops_v3_component.types);
+                       pmix_bfrops_base_print_envar, &pmix_mca_bfrops_v3_component.types);
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY, pmix3_bfrop_pack_array,
                        pmix3_bfrop_unpack_array, pmix3_bfrop_copy_array, pmix3_bfrop_print_array,
-                       &mca_bfrops_v3_component.types);
+                       &pmix_mca_bfrops_v3_component.types);
     /********************/
 
     return PMIX_SUCCESS;
@@ -289,12 +289,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v3_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v3_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v3_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v3_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v3_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v3_component.types, n, NULL);
         }
     }
 }
@@ -303,29 +303,29 @@ static pmix_status_t pmix3_pack(pmix_buffer_t *buffer, const void *src, int num_
                                 pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v3_component.types, buffer, src, num_vals, type);
+    return pmix_bfrops_base_pack(&pmix_mca_bfrops_v3_component.types, buffer, src, num_vals, type);
 }
 
 static pmix_status_t pmix3_unpack(pmix_buffer_t *buffer, void *dest, int32_t *num_vals,
                                   pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v3_component.types, buffer, dest, num_vals, type);
+    return pmix_bfrops_base_unpack(&pmix_mca_bfrops_v3_component.types, buffer, dest, num_vals, type);
 }
 
 static pmix_status_t pmix3_copy(void **dest, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_copy(&mca_bfrops_v3_component.types, dest, src, type);
+    return pmix_bfrops_base_copy(&pmix_mca_bfrops_v3_component.types, dest, src, type);
 }
 
 static pmix_status_t pmix3_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_print(&mca_bfrops_v3_component.types, output, prefix, src, type);
+    return pmix_bfrops_base_print(&pmix_mca_bfrops_v3_component.types, output, prefix, src, type);
 }
 
 static const char *data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v3_component.types, type);
+    return pmix_bfrops_base_data_type_string(&pmix_mca_bfrops_v3_component.types, type);
 }
 
 /**** DEPRECATED ****/

--- a/src/mca/bfrops/v3/bfrop_pmix3.h
+++ b/src/mca/bfrops/v3/bfrop_pmix3.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v3_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v3_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix3_module;
 

--- a/src/mca/bfrops/v3/bfrop_pmix3_component.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3_component.c
@@ -48,7 +48,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v3_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v3_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -69,8 +69,8 @@ pmix_bfrops_base_component_t mca_bfrops_v3_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v3_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v3_component.types, 32, INT_MAX, 16);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v3_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_mca_bfrops_v3_component.types, 32, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -78,14 +78,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v3_component.priority;
+    *priority = pmix_mca_bfrops_v3_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix3_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v3_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v3_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v4/Makefile.am
+++ b/src/mca/bfrops/v4/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v4_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v4.la
+component = pmix_mca_bfrops_v4.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v4.la
+lib = libpmix_mca_bfrops_v4.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v4_la_SOURCES = $(component_sources)
-mca_bfrops_v4_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v4_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v4_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v4_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v4_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v4_la_SOURCES = $(lib_sources)
-libmca_bfrops_v4_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v4_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v4_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -83,237 +83,237 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix_bfrops_base_pack_bool,
                        pmix_bfrops_base_unpack_bool, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_bool, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_bool, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_byte, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_byte, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix_bfrops_base_pack_string,
                        pmix_bfrops_base_unpack_string, pmix_bfrops_base_copy_string,
-                       pmix_bfrops_base_print_string, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_string, &pmix_mca_bfrops_v4_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix4_bfrops_base_pack_sizet,
                        pmix4_bfrops_base_unpack_sizet, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_size, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_size, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix_bfrops_base_pack_pid, pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_pid,
-                       &mca_bfrops_v4_component.types);
+                       &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix4_bfrops_base_pack_int,
                        pmix4_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_int, &pmix_mca_bfrops_v4_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int8, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int16, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int32, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int64, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix4_bfrops_base_pack_int,
                        pmix4_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_uint, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint8, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint16, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint32, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix4_bfrops_base_pack_general_int,
                        pmix4_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint64, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,
                        pmix_bfrops_base_unpack_float, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_float, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_float, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix_bfrops_base_pack_double,
                        pmix_bfrops_base_unpack_double, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_double, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_double, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix_bfrops_base_pack_timeval,
                        pmix_bfrops_base_unpack_timeval, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_timeval, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_timeval, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix_bfrops_base_pack_time,
                        pmix_bfrops_base_unpack_time, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_time, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_time, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix_bfrops_base_pack_status,
                        pmix_bfrops_base_unpack_status, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_status, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_status, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix_bfrops_base_pack_value,
                        pmix_bfrops_base_unpack_value, pmix_bfrops_base_copy_value,
-                       pmix_bfrops_base_print_value, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_value, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix_bfrops_base_pack_proc,
                        pmix_bfrops_base_unpack_proc, pmix_bfrops_base_copy_proc,
-                       pmix_bfrops_base_print_proc, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_proc, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix_bfrops_base_pack_app, pmix_bfrops_base_unpack_app,
                        pmix_bfrops_base_copy_app, pmix_bfrops_base_print_app,
-                       &mca_bfrops_v4_component.types);
+                       &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix_bfrops_base_pack_info,
                        pmix_bfrops_base_unpack_info, pmix_bfrops_base_copy_info,
-                       pmix_bfrops_base_print_info, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_info, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix_bfrops_base_pack_pdata,
                        pmix_bfrops_base_unpack_pdata, pmix_bfrops_base_copy_pdata,
-                       pmix_bfrops_base_print_pdata, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_pdata, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix_bfrops_base_pack_buf,
                        pmix_bfrops_base_unpack_buf, pmix_bfrops_base_copy_buf,
-                       pmix_bfrops_base_print_buf, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_buf, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix_bfrops_base_pack_kval,
                        pmix_bfrops_base_unpack_kval, pmix_bfrops_base_copy_kval,
-                       pmix_bfrops_base_print_kval, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_kval, &pmix_mca_bfrops_v4_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix_bfrops_base_pack_persist,
                        pmix_bfrops_base_unpack_persist, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_persist, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_persist, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix_bfrops_base_pack_ptr,
                        pmix_bfrops_base_unpack_ptr, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_scope, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_scope, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix_bfrops_base_pack_cmd,
                        pmix_bfrops_base_unpack_cmd, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_cmd, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_cmd, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix_bfrops_base_pack_info_directives,
                        pmix_bfrops_base_unpack_info_directives, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_info_directives, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_info_directives, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix_bfrops_base_pack_datatype,
                        pmix_bfrops_base_unpack_datatype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_datatype, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_datatype, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix_bfrops_base_pack_pstate,
                        pmix_bfrops_base_unpack_pstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pstate, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_pstate, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix_bfrops_base_pack_pinfo,
                        pmix_bfrops_base_unpack_pinfo, pmix_bfrops_base_copy_pinfo,
-                       pmix_bfrops_base_print_pinfo, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_pinfo, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix_bfrops_base_pack_darray,
                        pmix_bfrops_base_unpack_darray, pmix_bfrops_base_copy_darray,
-                       pmix_bfrops_base_print_darray, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_darray, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix_bfrops_base_pack_rank,
                        pmix_bfrops_base_unpack_rank, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_rank, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_rank, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix_bfrops_base_pack_query,
                        pmix_bfrops_base_unpack_query, pmix_bfrops_base_copy_query,
-                       pmix_bfrops_base_print_query, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_query, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE", PMIX_ALLOC_DIRECTIVE,
                        pmix_bfrops_base_pack_alloc_directive,
                        pmix_bfrops_base_unpack_alloc_directive, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_alloc_directive, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_alloc_directive, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL", PMIX_IOF_CHANNEL, pmix_bfrops_base_pack_iof_channel,
                        pmix_bfrops_base_unpack_iof_channel, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_iof_channel, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_iof_channel, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENVAR", PMIX_ENVAR, pmix_bfrops_base_pack_envar,
                        pmix_bfrops_base_unpack_envar, pmix_bfrops_base_copy_envar,
-                       pmix_bfrops_base_print_envar, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_envar, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COORD", PMIX_COORD, pmix_bfrops_base_pack_coord,
                        pmix_bfrops_base_unpack_coord, pmix_bfrops_base_copy_coord,
-                       pmix_bfrops_base_print_coord, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_coord, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGATTR", PMIX_REGATTR, pmix_bfrops_base_pack_regattr,
                        pmix_bfrops_base_unpack_regattr, pmix_bfrops_base_copy_regattr,
-                       pmix_bfrops_base_print_regattr, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_regattr, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGEX", PMIX_REGEX, pmix_bfrops_base_pack_regex,
                        pmix_bfrops_base_unpack_regex, pmix_bfrops_base_copy_regex,
-                       pmix_bfrops_base_print_regex, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_regex, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_JOB_STATE", PMIX_JOB_STATE, pmix_bfrops_base_pack_jobstate,
                        pmix_bfrops_base_unpack_jobstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_jobstate, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_jobstate, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LINK_STATE", PMIX_LINK_STATE, pmix_bfrops_base_pack_linkstate,
                        pmix_bfrops_base_unpack_linkstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_linkstate, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_linkstate, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_CPUSET", PMIX_PROC_CPUSET, pmix_bfrops_base_pack_cpuset,
                        pmix_bfrops_base_unpack_cpuset, pmix_bfrops_base_copy_cpuset,
-                       pmix_bfrops_base_print_cpuset, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_cpuset, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_GEOMETRY", PMIX_GEOMETRY, pmix_bfrops_base_pack_geometry,
                        pmix_bfrops_base_unpack_geometry, pmix_bfrops_base_copy_geometry,
-                       pmix_bfrops_base_print_geometry, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_geometry, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVICE_DIST", PMIX_DEVICE_DIST, pmix_bfrops_base_pack_devdist,
                        pmix_bfrops_base_unpack_devdist, pmix_bfrops_base_copy_devdist,
-                       pmix_bfrops_base_print_devdist, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_devdist, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENDPOINT", PMIX_ENDPOINT, pmix_bfrops_base_pack_endpoint,
                        pmix_bfrops_base_unpack_endpoint, pmix_bfrops_base_copy_endpoint,
-                       pmix_bfrops_base_print_endpoint, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_endpoint, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TOPO", PMIX_TOPO, pmix_bfrops_base_pack_topology,
                        pmix_bfrops_base_unpack_topology, pmix_bfrops_base_copy_topology,
-                       pmix_bfrops_base_print_topology, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_topology, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVTYPE", PMIX_DEVTYPE, pmix_bfrops_base_pack_devtype,
                        pmix_bfrops_base_unpack_devtype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_devtype, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_devtype, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LOCTYPE", PMIX_LOCTYPE, pmix_bfrops_base_pack_locality,
                        pmix_bfrops_base_unpack_locality, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_locality, &mca_bfrops_v4_component.types);
+                       pmix_bfrops_base_print_locality, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_BYTE_OBJECT", PMIX_COMPRESSED_BYTE_OBJECT,
                        pmix_bfrops_base_pack_bo, pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo, pmix_bfrops_base_print_bo,
-                       &mca_bfrops_v4_component.types);
+                       &pmix_mca_bfrops_v4_component.types);
 
     return PMIX_SUCCESS;
 }
@@ -323,12 +323,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v4_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v4_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v4_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v4_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v4_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v4_component.types, n, NULL);
         }
     }
 }
@@ -337,29 +337,29 @@ static pmix_status_t pmix4_pack(pmix_buffer_t *buffer, const void *src, int num_
                                 pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v4_component.types, buffer, src, num_vals, type);
+    return pmix_bfrops_base_pack(&pmix_mca_bfrops_v4_component.types, buffer, src, num_vals, type);
 }
 
 static pmix_status_t pmix4_unpack(pmix_buffer_t *buffer, void *dest, int32_t *num_vals,
                                   pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v4_component.types, buffer, dest, num_vals, type);
+    return pmix_bfrops_base_unpack(&pmix_mca_bfrops_v4_component.types, buffer, dest, num_vals, type);
 }
 
 static pmix_status_t pmix4_copy(void **dest, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_copy(&mca_bfrops_v4_component.types, dest, src, type);
+    return pmix_bfrops_base_copy(&pmix_mca_bfrops_v4_component.types, dest, src, type);
 }
 
 static pmix_status_t pmix4_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_print(&mca_bfrops_v4_component.types, output, prefix, src, type);
+    return pmix_bfrops_base_print(&pmix_mca_bfrops_v4_component.types, output, prefix, src, type);
 }
 
 static const char *data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v4_component.types, type);
+    return pmix_bfrops_base_data_type_string(&pmix_mca_bfrops_v4_component.types, type);
 }
 
 /*

--- a/src/mca/bfrops/v4/bfrop_pmix4.h
+++ b/src/mca/bfrops/v4/bfrop_pmix4.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v4_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v4_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix4_module;
 

--- a/src/mca/bfrops/v4/bfrop_pmix4_component.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4_component.c
@@ -48,7 +48,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v4_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v4_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -69,8 +69,8 @@ pmix_bfrops_base_component_t mca_bfrops_v4_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v4_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v4_component.types, 42, INT_MAX, 16);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v4_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_mca_bfrops_v4_component.types, 42, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -78,14 +78,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v4_component.priority;
+    *priority = pmix_mca_bfrops_v4_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix4_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v4_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v4_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/v41/Makefile.am
+++ b/src/mca/bfrops/v41/Makefile.am
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_bfrops_v41_DSO
 lib =
 lib_sources =
-component = mca_bfrops_v41.la
+component = pmix_mca_bfrops_v41.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_bfrops_v41.la
+lib = libpmix_mca_bfrops_v41.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -43,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_bfrops_v41_la_SOURCES = $(component_sources)
-mca_bfrops_v41_la_LDFLAGS = -module -avoid-version
+pmix_mca_bfrops_v41_la_SOURCES = $(component_sources)
+pmix_mca_bfrops_v41_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_bfrops_v41_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_bfrops_v41_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_bfrops_v41_la_SOURCES = $(lib_sources)
-libmca_bfrops_v41_la_LDFLAGS = -module -avoid-version
+libpmix_mca_bfrops_v41_la_SOURCES = $(lib_sources)
+libpmix_mca_bfrops_v41_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v41/bfrop_pmix41.c
+++ b/src/mca/bfrops/v41/bfrop_pmix41.c
@@ -84,277 +84,277 @@ static pmix_status_t init(void)
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL, pmix_bfrops_base_pack_bool,
                        pmix_bfrops_base_unpack_bool, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_bool, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_bool, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_byte, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_byte, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING, pmix_bfrops_base_pack_string,
                        pmix_bfrops_base_unpack_string, pmix_bfrops_base_copy_string,
-                       pmix_bfrops_base_print_string, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_string, &pmix_mca_bfrops_v41_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix41_bfrops_base_pack_sizet,
                        pmix41_bfrops_base_unpack_sizet, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_size, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_size, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix_bfrops_base_pack_pid, pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_pid,
-                       &mca_bfrops_v41_component.types);
+                       &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix41_bfrops_base_pack_int,
                        pmix41_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_int, &pmix_mca_bfrops_v41_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int8, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int16, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int32, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int64, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix41_bfrops_base_pack_int,
                        pmix41_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_uint, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint8, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint16, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint32, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix41_bfrops_base_pack_general_int,
                        pmix41_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint64, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,
                        pmix_bfrops_base_unpack_float, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_float, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_float, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE, pmix_bfrops_base_pack_double,
                        pmix_bfrops_base_unpack_double, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_double, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_double, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL, pmix_bfrops_base_pack_timeval,
                        pmix_bfrops_base_unpack_timeval, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_timeval, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_timeval, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME, pmix_bfrops_base_pack_time,
                        pmix_bfrops_base_unpack_time, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_time, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_time, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS, pmix_bfrops_base_pack_status,
                        pmix_bfrops_base_unpack_status, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_status, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_status, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE, pmix_bfrops_base_pack_value,
                        pmix_bfrops_base_unpack_value, pmix_bfrops_base_copy_value,
-                       pmix_bfrops_base_print_value, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_value, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC, pmix_bfrops_base_pack_proc,
                        pmix_bfrops_base_unpack_proc, pmix_bfrops_base_copy_proc,
-                       pmix_bfrops_base_print_proc, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_proc, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP, pmix_bfrops_base_pack_app, pmix_bfrops_base_unpack_app,
                        pmix_bfrops_base_copy_app, pmix_bfrops_base_print_app,
-                       &mca_bfrops_v41_component.types);
+                       &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO, pmix_bfrops_base_pack_info,
                        pmix_bfrops_base_unpack_info, pmix_bfrops_base_copy_info,
-                       pmix_bfrops_base_print_info, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_info, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA, pmix_bfrops_base_pack_pdata,
                        pmix_bfrops_base_unpack_pdata, pmix_bfrops_base_copy_pdata,
-                       pmix_bfrops_base_print_pdata, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_pdata, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER, pmix_bfrops_base_pack_buf,
                        pmix_bfrops_base_unpack_buf, pmix_bfrops_base_copy_buf,
-                       pmix_bfrops_base_print_buf, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_buf, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL, pmix_bfrops_base_pack_kval,
                        pmix_bfrops_base_unpack_kval, pmix_bfrops_base_copy_kval,
-                       pmix_bfrops_base_print_kval, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_kval, &pmix_mca_bfrops_v41_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST, pmix_bfrops_base_pack_persist,
                        pmix_bfrops_base_unpack_persist, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_persist, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_persist, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER, pmix_bfrops_base_pack_ptr,
                        pmix_bfrops_base_unpack_ptr, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE, pmix_bfrops_base_pack_scope,
                        pmix_bfrops_base_unpack_scope, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_scope, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_scope, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE, pmix_bfrops_base_pack_range,
                        pmix_bfrops_base_unpack_range, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_ptr, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND, pmix_bfrops_base_pack_cmd,
                        pmix_bfrops_base_unpack_cmd, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_cmd, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_cmd, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
                        pmix_bfrops_base_pack_info_directives,
                        pmix_bfrops_base_unpack_info_directives, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_info_directives, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_info_directives, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE, pmix_bfrops_base_pack_datatype,
                        pmix_bfrops_base_unpack_datatype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_datatype, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_datatype, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE, pmix_bfrops_base_pack_pstate,
                        pmix_bfrops_base_unpack_pstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pstate, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_pstate, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO, pmix_bfrops_base_pack_pinfo,
                        pmix_bfrops_base_unpack_pinfo, pmix_bfrops_base_copy_pinfo,
-                       pmix_bfrops_base_print_pinfo, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_pinfo, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY, pmix_bfrops_base_pack_darray,
                        pmix_bfrops_base_unpack_darray, pmix_bfrops_base_copy_darray,
-                       pmix_bfrops_base_print_darray, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_darray, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK, pmix_bfrops_base_pack_rank,
                        pmix_bfrops_base_unpack_rank, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_rank, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_rank, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY, pmix_bfrops_base_pack_query,
                        pmix_bfrops_base_unpack_query, pmix_bfrops_base_copy_query,
-                       pmix_bfrops_base_print_query, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_query, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE", PMIX_ALLOC_DIRECTIVE,
                        pmix_bfrops_base_pack_alloc_directive,
                        pmix_bfrops_base_unpack_alloc_directive, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_alloc_directive, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_alloc_directive, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL", PMIX_IOF_CHANNEL, pmix_bfrops_base_pack_iof_channel,
                        pmix_bfrops_base_unpack_iof_channel, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_iof_channel, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_iof_channel, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENVAR", PMIX_ENVAR, pmix_bfrops_base_pack_envar,
                        pmix_bfrops_base_unpack_envar, pmix_bfrops_base_copy_envar,
-                       pmix_bfrops_base_print_envar, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_envar, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COORD", PMIX_COORD, pmix_bfrops_base_pack_coord,
                        pmix_bfrops_base_unpack_coord, pmix_bfrops_base_copy_coord,
-                       pmix_bfrops_base_print_coord, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_coord, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGATTR", PMIX_REGATTR, pmix_bfrops_base_pack_regattr,
                        pmix_bfrops_base_unpack_regattr, pmix_bfrops_base_copy_regattr,
-                       pmix_bfrops_base_print_regattr, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_regattr, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_REGEX", PMIX_REGEX, pmix_bfrops_base_pack_regex,
                        pmix_bfrops_base_unpack_regex, pmix_bfrops_base_copy_regex,
-                       pmix_bfrops_base_print_regex, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_regex, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_JOB_STATE", PMIX_JOB_STATE, pmix_bfrops_base_pack_jobstate,
                        pmix_bfrops_base_unpack_jobstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_jobstate, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_jobstate, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LINK_STATE", PMIX_LINK_STATE, pmix_bfrops_base_pack_linkstate,
                        pmix_bfrops_base_unpack_linkstate, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_linkstate, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_linkstate, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_CPUSET", PMIX_PROC_CPUSET, pmix_bfrops_base_pack_cpuset,
                        pmix_bfrops_base_unpack_cpuset, pmix_bfrops_base_copy_cpuset,
-                       pmix_bfrops_base_print_cpuset, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_cpuset, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_GEOMETRY", PMIX_GEOMETRY, pmix_bfrops_base_pack_geometry,
                        pmix_bfrops_base_unpack_geometry, pmix_bfrops_base_copy_geometry,
-                       pmix_bfrops_base_print_geometry, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_geometry, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVICE_DIST", PMIX_DEVICE_DIST, pmix_bfrops_base_pack_devdist,
                        pmix_bfrops_base_unpack_devdist, pmix_bfrops_base_copy_devdist,
-                       pmix_bfrops_base_print_devdist, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_devdist, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ENDPOINT", PMIX_ENDPOINT, pmix_bfrops_base_pack_endpoint,
                        pmix_bfrops_base_unpack_endpoint, pmix_bfrops_base_copy_endpoint,
-                       pmix_bfrops_base_print_endpoint, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_endpoint, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TOPO", PMIX_TOPO, pmix_bfrops_base_pack_topology,
                        pmix_bfrops_base_unpack_topology, pmix_bfrops_base_copy_topology,
-                       pmix_bfrops_base_print_topology, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_topology, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DEVTYPE", PMIX_DEVTYPE, pmix_bfrops_base_pack_devtype,
                        pmix_bfrops_base_unpack_devtype, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_devtype, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_devtype, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_LOCTYPE", PMIX_LOCTYPE, pmix_bfrops_base_pack_locality,
                        pmix_bfrops_base_unpack_locality, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_locality, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_locality, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_BYTE_OBJECT", PMIX_COMPRESSED_BYTE_OBJECT,
                        pmix_bfrops_base_pack_bo, pmix_bfrops_base_unpack_bo,
                        pmix_bfrops_base_copy_bo, pmix_bfrops_base_print_bo,
-                       &mca_bfrops_v41_component.types);
+                       &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_NSPACE", PMIX_PROC_NSPACE, pmix_bfrops_base_pack_nspace,
                        pmix_bfrops_base_unpack_nspace, pmix_bfrops_base_copy_nspace,
-                       pmix_bfrops_base_print_nspace, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_nspace, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATS", PMIX_PROC_STATS, pmix_bfrops_base_pack_pstats,
                        pmix_bfrops_base_unpack_pstats, pmix_bfrops_base_copy_pstats,
-                       pmix_bfrops_base_print_pstats, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_pstats, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DISK_STATS", PMIX_DISK_STATS, pmix_bfrops_base_pack_dkstats,
                        pmix_bfrops_base_unpack_dkstats, pmix_bfrops_base_copy_dkstats,
-                       pmix_bfrops_base_print_dkstats, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_dkstats, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_NET_STATS", PMIX_NET_STATS, pmix_bfrops_base_pack_netstats,
                        pmix_bfrops_base_unpack_netstats, pmix_bfrops_base_copy_netstats,
-                       pmix_bfrops_base_print_netstats, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_netstats, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_NODE_STATS", PMIX_NODE_STATS, pmix_bfrops_base_pack_ndstats,
                        pmix_bfrops_base_unpack_ndstats, pmix_bfrops_base_copy_ndstats,
-                       pmix_bfrops_base_print_ndstats, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_ndstats, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_BUFFER", PMIX_DATA_BUFFER, pmix_bfrops_base_pack_dbuf,
                        pmix_bfrops_base_unpack_dbuf, pmix_bfrops_base_copy_dbuf,
-                       pmix_bfrops_base_print_dbuf, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_dbuf, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STOR_MEDIUM", PMIX_STOR_MEDIUM, pmix_bfrops_base_pack_smed,
                        pmix_bfrops_base_unpack_smed, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_smed, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_smed, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STOR_ACCESS", PMIX_STOR_ACCESS, pmix_bfrops_base_pack_sacc,
                        pmix_bfrops_base_unpack_sacc, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_sacc, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_sacc, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STOR_PERSIST", PMIX_STOR_PERSIST, pmix_bfrops_base_pack_spers,
                        pmix_bfrops_base_unpack_spers, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_spers, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_spers, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STOR_ACCESS_TYPE", PMIX_STOR_ACCESS_TYPE, pmix_bfrops_base_pack_satyp,
                        pmix_bfrops_base_unpack_satyp, pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_satyp, &mca_bfrops_v41_component.types);
+                       pmix_bfrops_base_print_satyp, &pmix_mca_bfrops_v41_component.types);
 
     return PMIX_SUCCESS;
 }
@@ -364,12 +364,12 @@ static void finalize(void)
     int n;
     pmix_bfrop_type_info_t *info;
 
-    for (n = 0; n < mca_bfrops_v41_component.types.size; n++) {
+    for (n = 0; n < pmix_mca_bfrops_v41_component.types.size; n++) {
         if (NULL
             != (info = (pmix_bfrop_type_info_t *)
-                    pmix_pointer_array_get_item(&mca_bfrops_v41_component.types, n))) {
+                    pmix_pointer_array_get_item(&pmix_mca_bfrops_v41_component.types, n))) {
             PMIX_RELEASE(info);
-            pmix_pointer_array_set_item(&mca_bfrops_v41_component.types, n, NULL);
+            pmix_pointer_array_set_item(&pmix_mca_bfrops_v41_component.types, n, NULL);
         }
     }
 }
@@ -378,29 +378,29 @@ static pmix_status_t pmix41_pack(pmix_buffer_t *buffer, const void *src, int num
                                  pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v41_component.types, buffer, src, num_vals, type);
+    return pmix_bfrops_base_pack(&pmix_mca_bfrops_v41_component.types, buffer, src, num_vals, type);
 }
 
 static pmix_status_t pmix41_unpack(pmix_buffer_t *buffer, void *dest, int32_t *num_vals,
                                    pmix_data_type_t type)
 {
     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v41_component.types, buffer, dest, num_vals, type);
+    return pmix_bfrops_base_unpack(&pmix_mca_bfrops_v41_component.types, buffer, dest, num_vals, type);
 }
 
 static pmix_status_t pmix41_copy(void **dest, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_copy(&mca_bfrops_v41_component.types, dest, src, type);
+    return pmix_bfrops_base_copy(&pmix_mca_bfrops_v41_component.types, dest, src, type);
 }
 
 static pmix_status_t pmix41_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_print(&mca_bfrops_v41_component.types, output, prefix, src, type);
+    return pmix_bfrops_base_print(&pmix_mca_bfrops_v41_component.types, output, prefix, src, type);
 }
 
 static const char *data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v41_component.types, type);
+    return pmix_bfrops_base_data_type_string(&pmix_mca_bfrops_v41_component.types, type);
 }
 
 /*

--- a/src/mca/bfrops/v41/bfrop_pmix41.h
+++ b/src/mca/bfrops/v41/bfrop_pmix41.h
@@ -10,7 +10,7 @@
  * Copyright (c) 20041-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v41_component;
+PMIX_EXPORT extern pmix_bfrops_base_component_t pmix_mca_bfrops_v41_component;
 
 extern pmix_bfrops_module_t pmix_bfrops_pmix41_module;
 

--- a/src/mca/bfrops/v41/bfrop_pmix41_component.c
+++ b/src/mca/bfrops/v41/bfrop_pmix41_component.c
@@ -48,7 +48,7 @@ static pmix_bfrops_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_bfrops_base_component_t mca_bfrops_v41_component = {
+pmix_bfrops_base_component_t pmix_mca_bfrops_v41_component = {
     .base = {
         PMIX_BFROPS_BASE_VERSION_1_0_0,
 
@@ -69,8 +69,8 @@ pmix_bfrops_base_component_t mca_bfrops_v41_component = {
 pmix_status_t component_open(void)
 {
     /* setup the types array */
-    PMIX_CONSTRUCT(&mca_bfrops_v41_component.types, pmix_pointer_array_t);
-    pmix_pointer_array_init(&mca_bfrops_v41_component.types, 50, INT_MAX, 16);
+    PMIX_CONSTRUCT(&pmix_mca_bfrops_v41_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_mca_bfrops_v41_component.types, 50, INT_MAX, 16);
 
     return PMIX_SUCCESS;
 }
@@ -78,14 +78,14 @@ pmix_status_t component_open(void)
 pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
 
-    *priority = mca_bfrops_v41_component.priority;
+    *priority = pmix_mca_bfrops_v41_component.priority;
     *module = (pmix_mca_base_module_t *) &pmix_bfrops_pmix41_module;
     return PMIX_SUCCESS;
 }
 
 pmix_status_t component_close(void)
 {
-    PMIX_DESTRUCT(&mca_bfrops_v41_component.types);
+    PMIX_DESTRUCT(&pmix_mca_bfrops_v41_component.types);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/gds/base/gds_base_frame.c
+++ b/src/mca/gds/base/gds_base_frame.c
@@ -97,7 +97,7 @@ static pmix_status_t pmix_gds_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, gds, "PMIx Generalized Data Store", NULL, pmix_gds_open,
-                                pmix_gds_close, mca_gds_base_static_components,
+                                pmix_gds_close, pmix_mca_gds_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_gds_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/gds/hash/Makefile.am
+++ b/src/mca/gds/hash/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,10 +39,10 @@ sources = \
 if MCA_BUILD_pmix_gds_hash_DSO
 lib =
 lib_sources =
-component = mca_gds_hash.la
+component = pmix_mca_gds_hash.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_gds_hash.la
+lib = libpmix_mca_gds_hash.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -50,14 +50,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_gds_hash_la_SOURCES = $(component_sources)
-mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
-mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
+pmix_mca_gds_hash_la_SOURCES = $(component_sources)
+pmix_mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
+pmix_mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
 if NEED_LIBPMIX
-mca_gds_hash_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_gds_hash_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_gds_hash_la_SOURCES = $(lib_sources)
-libmca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
-libmca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
+libpmix_mca_gds_hash_la_SOURCES = $(lib_sources)
+libpmix_mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
+libpmix_mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -589,7 +589,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
                         PMIX_ERROR_LOG(rc);
                         return rc;
                     }
-                    PMIX_LIST_FOREACH (sptr, &mca_gds_hash_component.mysessions, pmix_session_t) {
+                    PMIX_LIST_FOREACH (sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
                         if (sptr->session == sid) {
                             /* see if they want info for a specific node */
                             rc = pmix_gds_hash_fetch_nodeinfo(key, trk, &sptr->nodeinfo, qualifiers,

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -186,7 +186,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
             }
             /* see if we have this session */
             s = NULL;
-            PMIX_LIST_FOREACH (sptr, &mca_gds_hash_component.mysessions, pmix_session_t) {
+            PMIX_LIST_FOREACH (sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
                 if (sptr->session == sid) {
                     s = sptr;
                     break;
@@ -195,7 +195,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_
             if (NULL == s) {
                 s = PMIX_NEW(pmix_session_t);
                 s->session = sid;
-                pmix_list_append(&mca_gds_hash_component.mysessions, &s->super);
+                pmix_list_append(&pmix_mca_gds_hash_component.mysessions, &s->super);
             }
             /* point the job at it */
             if (NULL == trk->session) {
@@ -1312,10 +1312,10 @@ static pmix_status_t nspace_del(const char *nspace)
 
 
     /* find the hash table for this nspace */
-    PMIX_LIST_FOREACH (t, &mca_gds_hash_component.myjobs, pmix_job_t) {
+    PMIX_LIST_FOREACH (t, &pmix_mca_gds_hash_component.myjobs, pmix_job_t) {
         if (0 == strcmp(nspace, t->ns)) {
             /* release it */
-            pmix_list_remove_item(&mca_gds_hash_component.myjobs, &t->super);
+            pmix_list_remove_item(&pmix_mca_gds_hash_component.myjobs, &t->super);
             PMIX_RELEASE(t);
             break;
         }

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -33,7 +33,7 @@ typedef struct {
 } pmix_gds_hash_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_gds_hash_component_t mca_gds_hash_component;
+PMIX_EXPORT extern pmix_gds_hash_component_t pmix_mca_gds_hash_component;
 extern pmix_gds_base_module_t pmix_hash_module;
 
 /* Define a bitmask to track what information may not have

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -41,7 +41,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_gds_hash_component_t mca_gds_hash_component = {
+pmix_gds_hash_component_t pmix_mca_gds_hash_component = {
     .super = {
         .base = {
             PMIX_GDS_BASE_VERSION_1_0_0,
@@ -67,8 +67,8 @@ pmix_gds_hash_component_t mca_gds_hash_component = {
 
 static int component_open(void)
 {
-    PMIX_CONSTRUCT(&mca_gds_hash_component.mysessions, pmix_list_t);
-    PMIX_CONSTRUCT(&mca_gds_hash_component.myjobs, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.mysessions, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.myjobs, pmix_list_t);
 
     return PMIX_SUCCESS;
 }
@@ -82,8 +82,8 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
 
 static int component_close(void)
 {
-    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.mysessions);
-    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.myjobs);
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.mysessions);
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.myjobs);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/gds/hash/gds_utils.c
+++ b/src/mca/gds/hash/gds_utils.c
@@ -58,7 +58,7 @@ pmix_job_t *pmix_gds_hash_get_tracker(const pmix_nspace_t nspace, bool create)
 
     /* find the hash table for this nspace */
     trk = NULL;
-    PMIX_LIST_FOREACH (t, &mca_gds_hash_component.myjobs, pmix_job_t) {
+    PMIX_LIST_FOREACH (t, &pmix_mca_gds_hash_component.myjobs, pmix_job_t) {
         if (0 == strcmp(nspace, t->ns)) {
             trk = t;
             break;
@@ -87,7 +87,7 @@ pmix_job_t *pmix_gds_hash_get_tracker(const pmix_nspace_t nspace, bool create)
         }
         PMIX_RETAIN(nptr);
         trk->nptr = nptr;
-        pmix_list_append(&mca_gds_hash_component.myjobs, &trk->super);
+        pmix_list_append(&pmix_mca_gds_hash_component.myjobs, &trk->super);
     }
     return trk;
 }

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -485,7 +485,7 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
             }
             /* see if we already have this session - it could have
              * been defined by a separate PMIX_SESSION_ID key */
-            PMIX_LIST_FOREACH (sptr, &mca_gds_hash_component.mysessions, pmix_session_t) {
+            PMIX_LIST_FOREACH (sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
                 if (sptr->session == sid) {
                     s = sptr;
                     break;
@@ -495,7 +495,7 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
                 /* wasn't found, so create one */
                 s = PMIX_NEW(pmix_session_t);
                 s->session = sid;
-                pmix_list_append(&mca_gds_hash_component.mysessions, &s->super);
+                pmix_list_append(&pmix_mca_gds_hash_component.mysessions, &s->super);
             }
         } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
             if (PMIX_SUCCESS != (rc = pmix_gds_hash_process_node_array(&iptr[j].value, &ncache))) {

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -120,5 +120,5 @@ static int pmix_compress_base_close(void)
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pcompress, "PCOMPRESS MCA", pmix_compress_base_register,
                                 pmix_compress_base_open, pmix_compress_base_close,
-                                mca_pcompress_base_static_components,
+                                pmix_mca_pcompress_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/pcompress/zlib/Makefile.am
+++ b/src/mca/pcompress/zlib/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,22 +25,22 @@ sources = \
 
 if MCA_BUILD_pmix_pcompress_zlib_DSO
 component_noinst =
-component_install = mca_pcompress_zlib.la
+component_install = pmix_mca_pcompress_zlib.la
 else
-component_noinst = libmca_pcompress_zlib.la
+component_noinst = libpmix_mca_pcompress_zlib.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_pcompress_zlib_la_SOURCES = $(sources)
-mca_pcompress_zlib_la_LDFLAGS = -module -avoid-version $(pcompress_zlib_LDFLAGS)
-mca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS)
+pmix_mca_pcompress_zlib_la_SOURCES = $(sources)
+pmix_mca_pcompress_zlib_la_LDFLAGS = -module -avoid-version $(pcompress_zlib_LDFLAGS)
+pmix_mca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS)
 if NEED_LIBPMIX
-mca_pcompress_zlib_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_pcompress_zlib_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_pcompress_zlib_la_SOURCES = $(sources)
-libmca_pcompress_zlib_la_LDFLAGS = -module -avoid-version $(pcompress_zlib_LDFLAGS)
-libmca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS)
+libpmix_mca_pcompress_zlib_la_SOURCES = $(sources)
+libpmix_mca_pcompress_zlib_la_LDFLAGS = -module -avoid-version $(pcompress_zlib_LDFLAGS)
+libpmix_mca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS)

--- a/src/mca/pcompress/zlib/compress_zlib.h
+++ b/src/mca/pcompress/zlib/compress_zlib.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_mca_base_component_t mca_pcompress_zlib_component;
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_pcompress_zlib_component;
 extern pmix_compress_base_module_t pmix_pcompress_zlib_module;
 
 #if defined(c_plusplus) || defined(__cplusplus)

--- a/src/mca/pcompress/zlib/compress_zlib_component.c
+++ b/src/mca/pcompress/zlib/compress_zlib_component.c
@@ -34,7 +34,7 @@ static int compress_zlib_query(pmix_mca_base_module_t **module, int *priority);
  * Instantiate the public struct with all of our public information
  * and pointer to our public functions in it
  */
-PMIX_EXPORT pmix_mca_base_component_t mca_pcompress_zlib_component = {
+PMIX_EXPORT pmix_mca_base_component_t pmix_mca_pcompress_zlib_component = {
     /* Handle the general mca_component_t struct containing
      *  meta information about the component zlib
      */

--- a/src/mca/pdl/base/pdl_base_open.c
+++ b/src/mca/pdl/base/pdl_base_open.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,5 +48,5 @@ int pmix_pdl_base_open(pmix_mca_base_open_flag_t flags)
    framework. */
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pdl, "Dynamic loader framework", NULL /* register */,
                                 pmix_pdl_base_open /* open */, NULL /* close */,
-                                mca_pdl_base_static_components,
+                                pmix_mca_pdl_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_NO_DSO);

--- a/src/mca/pdl/pdlopen/Makefile.am
+++ b/src/mca/pdl/pdlopen/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2010 The Trustees of Indiana University.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,8 +17,8 @@ sources = \
 
 # This component will only ever be built statically -- never as a DSO.
 
-noinst_LTLIBRARIES = libmca_pdl_pdlopen.la
+noinst_LTLIBRARIES = libpmix_mca_pdl_pdlopen.la
 
-libmca_pdl_pdlopen_la_SOURCES = $(sources)
-libmca_pdl_pdlopen_la_LDFLAGS = -module -avoid-version
-libmca_pdl_pdlopen_la_LIBADD = $(pmix_pdl_pdlopen_LIBS)
+libpmix_mca_pdl_pdlopen_la_SOURCES = $(sources)
+libpmix_mca_pdl_pdlopen_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pdl_pdlopen_la_LIBADD = $(pmix_pdl_pdlopen_LIBS)

--- a/src/mca/pdl/pdlopen/pdl_pdlopen.h
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015     Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +37,6 @@ typedef struct {
     char **filename_suffixes;
 } pmix_pdl_pdlopen_component_t;
 
-extern pmix_pdl_pdlopen_component_t mca_pdl_pdlopen_component;
+extern pmix_pdl_pdlopen_component_t pmix_mca_pdl_pdlopen_component;
 
 #endif /* PMIX_PDL_PDLOPEN */

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_component.c
@@ -39,7 +39,7 @@ static int pdlopen_component_query(pmix_mca_base_module_t **module, int *priorit
  * and pointers to our public functions in it
  */
 
-pmix_pdl_pdlopen_component_t mca_pdl_pdlopen_component = {
+pmix_pdl_pdlopen_component_t pmix_mca_pdl_pdlopen_component = {
 
     /* Fill in the mca_pdl_base_component_t */
     .base = {
@@ -70,17 +70,17 @@ static int pdlopen_component_register(void)
 {
     int ret;
 
-    mca_pdl_pdlopen_component.filename_suffixes_mca_storage = ".so,.dylib,.dll,.sl";
+    pmix_mca_pdl_pdlopen_component.filename_suffixes_mca_storage = ".so,.dylib,.dll,.sl";
     ret = pmix_mca_base_component_var_register(
-        &mca_pdl_pdlopen_component.base.base_version, "filename_suffixes",
+        &pmix_mca_pdl_pdlopen_component.base.base_version, "filename_suffixes",
         "Comma-delimited list of filename suffixes that the pdlopen component will try",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pdl_pdlopen_component.filename_suffixes_mca_storage);
+        &pmix_mca_pdl_pdlopen_component.filename_suffixes_mca_storage);
     if (ret < 0) {
         return ret;
     }
-    mca_pdl_pdlopen_component.filename_suffixes
-        = pmix_argv_split(mca_pdl_pdlopen_component.filename_suffixes_mca_storage, ',');
+    pmix_mca_pdl_pdlopen_component.filename_suffixes
+        = pmix_argv_split(pmix_mca_pdl_pdlopen_component.filename_suffixes_mca_storage, ',');
 
     return PMIX_SUCCESS;
 }
@@ -92,9 +92,9 @@ static int pdlopen_component_open(void)
 
 static int pdlopen_component_close(void)
 {
-    if (NULL != mca_pdl_pdlopen_component.filename_suffixes) {
-        pmix_argv_free(mca_pdl_pdlopen_component.filename_suffixes);
-        mca_pdl_pdlopen_component.filename_suffixes = NULL;
+    if (NULL != pmix_mca_pdl_pdlopen_component.filename_suffixes) {
+        pmix_argv_free(pmix_mca_pdl_pdlopen_component.filename_suffixes);
+        pmix_mca_pdl_pdlopen_component.filename_suffixes = NULL;
     }
 
     return PMIX_SUCCESS;
@@ -105,7 +105,7 @@ static int pdlopen_component_query(pmix_mca_base_module_t **module, int *priorit
     /* The priority value is somewhat meaningless here; by
        pmix/mca/pdl/configure.m4, there's at most one component
        available. */
-    *priority = mca_pdl_pdlopen_component.base.priority;
+    *priority = pmix_mca_pdl_pdlopen_component.base.priority;
     *module = &pmix_pdl_pdlopen_module.super;
 
     return PMIX_SUCCESS;

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -71,8 +71,8 @@ static int pdlopen_open(const char *fname, bool use_ext, bool private_namespace,
         int i;
         char *ext;
 
-        for (i = 0, ext = mca_pdl_pdlopen_component.filename_suffixes[i]; NULL != ext;
-             ext = mca_pdl_pdlopen_component.filename_suffixes[++i]) {
+        for (i = 0, ext = pmix_mca_pdl_pdlopen_component.filename_suffixes[i]; NULL != ext;
+             ext = pmix_mca_pdl_pdlopen_component.filename_suffixes[++i]) {
             char *name;
 
             rc = asprintf(&name, "%s%s", fname, ext);

--- a/src/mca/pdl/plibltdl/Makefile.am
+++ b/src/mca/pdl/plibltdl/Makefile.am
@@ -3,6 +3,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,11 +18,11 @@ sources = \
 
 # This component will only ever be built statically -- never as a DSO.
 
-noinst_LTLIBRARIES = libmca_pdl_plibltdl.la
+noinst_LTLIBRARIES = libpmix_mca_pdl_plibltdl.la
 
-libmca_pdl_plibltdl_la_SOURCES = $(sources)
-libmca_pdl_plibltdl_la_CPPFLAGS = $(pmix_pdl_plibltdl_CPPFLAGS)
-libmca_pdl_plibltdl_la_LDFLAGS = \
+libpmix_mca_pdl_plibltdl_la_SOURCES = $(sources)
+libpmix_mca_pdl_plibltdl_la_CPPFLAGS = $(pmix_pdl_plibltdl_CPPFLAGS)
+libpmix_mca_pdl_plibltdl_la_LDFLAGS = \
         $(pmix_pdl_plibltdl_LDFLAGS) \
         -module -avoid-version
-libmca_pdl_plibltdl_la_LIBADD = $(pmix_pdl_plibltdl_LIBS)
+libpmix_mca_pdl_plibltdl_la_LIBADD = $(pmix_pdl_plibltdl_LIBS)

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -225,7 +225,7 @@ static int pmix_pfexec_base_open(pmix_mca_base_open_flag_t flags)
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pfexec, "PMIx fork/exec Subsystem", pmix_pfexec_register,
                                 pmix_pfexec_base_open, pmix_pfexec_base_close,
-                                mca_pfexec_base_static_components,
+                                pmix_mca_pfexec_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 /**** FRAMEWORK CLASS INSTANTIATIONS ****/

--- a/src/mca/pfexec/linux/Makefile.am
+++ b/src/mca/pfexec/linux/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,17 +33,17 @@ sources = \
 
 if MCA_BUILD_pmix_pfexec_linux_DSO
 component_noinst =
-component_install = mca_pfexec_linux.la
+component_install = pmix_mca_pfexec_linux.la
 else
-component_noinst = libmca_pfexec_linux.la
+component_noinst = libpmix_mca_pfexec_linux.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_pfexec_linux_la_SOURCES = $(sources)
-mca_pfexec_linux_la_LDFLAGS = -module -avoid-version
+pmix_mca_pfexec_linux_la_SOURCES = $(sources)
+pmix_mca_pfexec_linux_la_LDFLAGS = -module -avoid-version
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_pfexec_linux_la_SOURCES =$(sources)
-libmca_pfexec_linux_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pfexec_linux_la_SOURCES =$(sources)
+libpmix_mca_pfexec_linux_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pfexec/linux/pfexec_linux.h
+++ b/src/mca/pfexec/linux/pfexec_linux.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@ BEGIN_C_DECLS
  * PFEXEC Linux module
  */
 PMIX_EXPORT extern pmix_pfexec_base_module_t pmix_pfexec_linux_module;
-PMIX_EXPORT extern pmix_pfexec_base_component_t mca_pfexec_linux_component;
+PMIX_EXPORT extern pmix_pfexec_base_component_t pmix_mca_pfexec_linux_component;
 
 END_C_DECLS
 

--- a/src/mca/pfexec/linux/pfexec_linux_component.c
+++ b/src/mca/pfexec/linux/pfexec_linux_component.c
@@ -51,7 +51,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * and pointers to our public functions in it
  */
 
-pmix_pfexec_base_component_t mca_pfexec_linux_component = {
+pmix_pfexec_base_component_t pmix_mca_pfexec_linux_component = {
     PMIX_PFEXEC_BASE_VERSION_1_0_0,
     /* Component name and version */
     .pmix_mca_component_name = "linux",

--- a/src/mca/pgpu/amd/Makefile.am
+++ b/src/mca/pgpu/amd/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pgpu_amd_DSO
 lib =
 lib_sources =
-component = mca_pgpu_amd.la
+component = pmix_mca_pgpu_amd.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pgpu_amd.la
+lib = libpmix_mca_pgpu_amd.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pgpu_amd_la_SOURCES = $(component_sources)
-mca_pgpu_amd_la_LDFLAGS = -module -avoid-version
+pmix_mca_pgpu_amd_la_SOURCES = $(component_sources)
+pmix_mca_pgpu_amd_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pgpu_amd_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pgpu_amd_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pgpu_amd_la_SOURCES = $(lib_sources)
-libmca_pgpu_amd_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pgpu_amd_la_SOURCES = $(lib_sources)
+libpmix_mca_pgpu_amd_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pgpu/amd/pgpu_amd.c
+++ b/src/mca/pgpu/amd/pgpu_amd.c
@@ -100,15 +100,15 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (envars) {
         pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
                             "pgpu: amd harvesting envars %s excluding %s",
-                            (NULL == mca_pgpu_amd_component.incparms)
-                                ? "NONE" : mca_pgpu_amd_component.incparms,
-                            (NULL == mca_pgpu_amd_component.excparms)
-                                ? "NONE" : mca_pgpu_amd_component.excparms);
+                            (NULL == pmix_mca_pgpu_amd_component.incparms)
+                                ? "NONE" : pmix_mca_pgpu_amd_component.incparms,
+                            (NULL == pmix_mca_pgpu_amd_component.excparms)
+                                ? "NONE" : pmix_mca_pgpu_amd_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pgpu_amd_component.include) {
-            rc = pmix_util_harvest_envars(mca_pgpu_amd_component.include,
-                                          mca_pgpu_amd_component.exclude, &cache);
+        if (NULL != pmix_mca_pgpu_amd_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pgpu_amd_component.include,
+                                          pmix_mca_pgpu_amd_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pgpu/amd/pgpu_amd.h
+++ b/src/mca/pgpu/amd/pgpu_amd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pgpu_amd_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pgpu_amd_component_t mca_pgpu_amd_component;
+PMIX_EXPORT extern pmix_pgpu_amd_component_t pmix_mca_pgpu_amd_component;
 extern pmix_pgpu_module_t pmix_pgpu_amd_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pgpu/amd/pgpu_amd_component.c
+++ b/src/mca/pgpu/amd/pgpu_amd_component.c
@@ -45,7 +45,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pgpu_amd_component_t mca_pgpu_amd_component = {
+pmix_pgpu_amd_component_t pmix_mca_pgpu_amd_component = {
     .super = {
         PMIX_PGPU_BASE_VERSION_1_0_0,
 
@@ -68,26 +68,26 @@ pmix_pgpu_amd_component_t mca_pgpu_amd_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pgpu_amd_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_amd_component.super.base;
 
-    mca_pgpu_amd_component.incparms = NULL;
+    pmix_mca_pgpu_amd_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_amd_component.incparms);
-    if (NULL != mca_pgpu_amd_component.incparms) {
-        mca_pgpu_amd_component.include = pmix_argv_split(mca_pgpu_amd_component.incparms, ',');
+        &pmix_mca_pgpu_amd_component.incparms);
+    if (NULL != pmix_mca_pgpu_amd_component.incparms) {
+        pmix_mca_pgpu_amd_component.include = pmix_argv_split(pmix_mca_pgpu_amd_component.incparms, ',');
     }
 
-    mca_pgpu_amd_component.excparms = NULL;
+    pmix_mca_pgpu_amd_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_amd_component.excparms);
-    if (NULL != mca_pgpu_amd_component.excparms) {
-        mca_pgpu_amd_component.exclude = pmix_argv_split(mca_pgpu_amd_component.excparms, ',');
+        &pmix_mca_pgpu_amd_component.excparms);
+    if (NULL != pmix_mca_pgpu_amd_component.excparms) {
+        pmix_mca_pgpu_amd_component.exclude = pmix_argv_split(pmix_mca_pgpu_amd_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pgpu/base/pgpu_base_frame.c
+++ b/src/mca/pgpu/base/pgpu_base_frame.c
@@ -91,7 +91,7 @@ static pmix_status_t pmix_pgpu_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pgpu, "PMIx GPU Operations", NULL, pmix_pgpu_open,
-                                pmix_pgpu_close, mca_pgpu_base_static_components,
+                                pmix_pgpu_close, pmix_mca_pgpu_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_pgpu_base_active_module_t,

--- a/src/mca/pgpu/intel/Makefile.am
+++ b/src/mca/pgpu/intel/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pgpu_intel_DSO
 lib =
 lib_sources =
-component = mca_pgpu_intel.la
+component = pmix_mca_pgpu_intel.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pgpu_intel.la
+lib = libpmix_mca_pgpu_intel.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pgpu_intel_la_SOURCES = $(component_sources)
-mca_pgpu_intel_la_LDFLAGS = -module -avoid-version
+pmix_mca_pgpu_intel_la_SOURCES = $(component_sources)
+pmix_mca_pgpu_intel_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pgpu_intel_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pgpu_intel_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pgpu_intel_la_SOURCES = $(lib_sources)
-libmca_pgpu_intel_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pgpu_intel_la_SOURCES = $(lib_sources)
+libpmix_mca_pgpu_intel_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pgpu/intel/pgpu_intel.c
+++ b/src/mca/pgpu/intel/pgpu_intel.c
@@ -100,15 +100,15 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (envars) {
         pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
                             "pgpu: intel harvesting envars %s excluding %s",
-                            (NULL == mca_pgpu_intel_component.incparms)
-                                ? "NONE" : mca_pgpu_intel_component.incparms,
-                            (NULL == mca_pgpu_intel_component.excparms)
-                                ? "NONE" : mca_pgpu_intel_component.excparms);
+                            (NULL == pmix_mca_pgpu_intel_component.incparms)
+                                ? "NONE" : pmix_mca_pgpu_intel_component.incparms,
+                            (NULL == pmix_mca_pgpu_intel_component.excparms)
+                                ? "NONE" : pmix_mca_pgpu_intel_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pgpu_intel_component.include) {
-            rc = pmix_util_harvest_envars(mca_pgpu_intel_component.include,
-                                          mca_pgpu_intel_component.exclude, &cache);
+        if (NULL != pmix_mca_pgpu_intel_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pgpu_intel_component.include,
+                                          pmix_mca_pgpu_intel_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pgpu/intel/pgpu_intel.h
+++ b/src/mca/pgpu/intel/pgpu_intel.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pgpu_intel_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pgpu_intel_component_t mca_pgpu_intel_component;
+PMIX_EXPORT extern pmix_pgpu_intel_component_t pmix_mca_pgpu_intel_component;
 extern pmix_pgpu_module_t pmix_pgpu_intel_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pgpu/intel/pgpu_intel_component.c
+++ b/src/mca/pgpu/intel/pgpu_intel_component.c
@@ -45,7 +45,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pgpu_intel_component_t mca_pgpu_intel_component = {
+pmix_pgpu_intel_component_t pmix_mca_pgpu_intel_component = {
     .super = {
         PMIX_PGPU_BASE_VERSION_1_0_0,
 
@@ -68,26 +68,26 @@ pmix_pgpu_intel_component_t mca_pgpu_intel_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pgpu_intel_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_intel_component.super.base;
 
-    mca_pgpu_intel_component.incparms = NULL;
+    pmix_mca_pgpu_intel_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_intel_component.incparms);
-    if (NULL != mca_pgpu_intel_component.incparms) {
-        mca_pgpu_intel_component.include = pmix_argv_split(mca_pgpu_intel_component.incparms, ',');
+        &pmix_mca_pgpu_intel_component.incparms);
+    if (NULL != pmix_mca_pgpu_intel_component.incparms) {
+        pmix_mca_pgpu_intel_component.include = pmix_argv_split(pmix_mca_pgpu_intel_component.incparms, ',');
     }
 
-    mca_pgpu_intel_component.excparms = NULL;
+    pmix_mca_pgpu_intel_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_intel_component.excparms);
-    if (NULL != mca_pgpu_intel_component.excparms) {
-        mca_pgpu_intel_component.exclude = pmix_argv_split(mca_pgpu_intel_component.excparms, ',');
+        &pmix_mca_pgpu_intel_component.excparms);
+    if (NULL != pmix_mca_pgpu_intel_component.excparms) {
+        pmix_mca_pgpu_intel_component.exclude = pmix_argv_split(pmix_mca_pgpu_intel_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pgpu/nvd/Makefile.am
+++ b/src/mca/pgpu/nvd/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pgpu_nvd_DSO
 lib =
 lib_sources =
-component = mca_pgpu_nvd.la
+component = pmix_mca_pgpu_nvd.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pgpu_nvd.la
+lib = libpmix_mca_pgpu_nvd.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pgpu_nvd_la_SOURCES = $(component_sources)
-mca_pgpu_nvd_la_LDFLAGS = -module -avoid-version
+pmix_mca_pgpu_nvd_la_SOURCES = $(component_sources)
+pmix_mca_pgpu_nvd_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pgpu_nvd_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pgpu_nvd_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pgpu_nvd_la_SOURCES = $(lib_sources)
-libmca_pgpu_nvd_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pgpu_nvd_la_SOURCES = $(lib_sources)
+libpmix_mca_pgpu_nvd_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pgpu/nvd/pgpu_nvd.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd.c
@@ -100,15 +100,15 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (envars) {
         pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
                             "pgpu: nvd harvesting envars %s excluding %s",
-                            (NULL == mca_pgpu_nvd_component.incparms)
-                            ? "NONE" : mca_pgpu_nvd_component.incparms,
-                            (NULL == mca_pgpu_nvd_component.excparms)
-                            ? "NONE" : mca_pgpu_nvd_component.excparms);
+                            (NULL == pmix_mca_pgpu_nvd_component.incparms)
+                            ? "NONE" : pmix_mca_pgpu_nvd_component.incparms,
+                            (NULL == pmix_mca_pgpu_nvd_component.excparms)
+                            ? "NONE" : pmix_mca_pgpu_nvd_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pgpu_nvd_component.include) {
-            rc = pmix_util_harvest_envars(mca_pgpu_nvd_component.include,
-                                          mca_pgpu_nvd_component.exclude, &cache);
+        if (NULL != pmix_mca_pgpu_nvd_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pgpu_nvd_component.include,
+                                          pmix_mca_pgpu_nvd_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pgpu/nvd/pgpu_nvd.h
+++ b/src/mca/pgpu/nvd/pgpu_nvd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pgpu_nvd_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pgpu_nvd_component_t mca_pgpu_nvd_component;
+PMIX_EXPORT extern pmix_pgpu_nvd_component_t pmix_mca_pgpu_nvd_component;
 extern pmix_pgpu_module_t pmix_pgpu_nvd_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pgpu/nvd/pgpu_nvd_component.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd_component.c
@@ -45,7 +45,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pgpu_nvd_component_t mca_pgpu_nvd_component = {
+pmix_pgpu_nvd_component_t pmix_mca_pgpu_nvd_component = {
     .super = {
         PMIX_PGPU_BASE_VERSION_1_0_0,
 
@@ -68,26 +68,26 @@ pmix_pgpu_nvd_component_t mca_pgpu_nvd_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pgpu_nvd_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_nvd_component.super.base;
 
-    mca_pgpu_nvd_component.incparms = "CUDA_*,NCCL_*";
+    pmix_mca_pgpu_nvd_component.incparms = "CUDA_*,NCCL_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_nvd_component.incparms);
-    if (NULL != mca_pgpu_nvd_component.incparms) {
-        mca_pgpu_nvd_component.include = pmix_argv_split(mca_pgpu_nvd_component.incparms, ',');
+        &pmix_mca_pgpu_nvd_component.incparms);
+    if (NULL != pmix_mca_pgpu_nvd_component.incparms) {
+        pmix_mca_pgpu_nvd_component.include = pmix_argv_split(pmix_mca_pgpu_nvd_component.incparms, ',');
     }
 
-    mca_pgpu_nvd_component.excparms = NULL;
+    pmix_mca_pgpu_nvd_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &mca_pgpu_nvd_component.excparms);
-    if (NULL != mca_pgpu_nvd_component.excparms) {
-        mca_pgpu_nvd_component.exclude = pmix_argv_split(mca_pgpu_nvd_component.excparms, ',');
+        &pmix_mca_pgpu_nvd_component.excparms);
+    if (NULL != pmix_mca_pgpu_nvd_component.excparms) {
+        pmix_mca_pgpu_nvd_component.exclude = pmix_argv_split(pmix_mca_pgpu_nvd_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pif/base/pif_base_components.c
+++ b/src/mca/pif/base/pif_base_components.c
@@ -37,7 +37,7 @@ static bool frameopen = false;
 PMIX_CLASS_INSTANCE(pmix_pif_t, pmix_list_item_t, pmix_pif_construct, NULL);
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pif, NULL, pmix_pif_base_register, pmix_pif_base_open,
-                                pmix_pif_base_close, mca_pif_base_static_components,
+                                pmix_pif_base_close, pmix_mca_pif_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 static int pmix_pif_base_register(pmix_mca_base_register_flag_t flags)

--- a/src/mca/pif/bsdx_ipv4/Makefile.am
+++ b/src/mca/pif/bsdx_ipv4/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,6 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pif_bsdx_ipv4.la
+noinst_LTLIBRARIES = libpmix_mca_pif_bsdx_ipv4.la
 
-libmca_pif_bsdx_ipv4_la_SOURCES = pif_bsdx.c
+libpmix_mca_pif_bsdx_ipv4_la_SOURCES = pif_bsdx.c

--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -59,7 +59,7 @@ static int if_bsdx_open(void);
  * OpenBSD
  * DragonFly
  */
-pmix_pif_base_component_t mca_pif_bsdx_ipv4_component = {
+pmix_pif_base_component_t pmix_mca_pif_bsdx_ipv4_component = {
     PMIX_PIF_BASE_VERSION_2_0_0,
 
     /* Component name and version */

--- a/src/mca/pif/bsdx_ipv6/Makefile.am
+++ b/src/mca/pif/bsdx_ipv6/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,6 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pif_bsdx_ipv6.la
+noinst_LTLIBRARIES = libpmix_mca_pif_bsdx_ipv6.la
 
-libmca_pif_bsdx_ipv6_la_SOURCES = pif_bsdx_ipv6.c
+libpmix_mca_pif_bsdx_ipv6_la_SOURCES = pif_bsdx_ipv6.c

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -62,7 +62,7 @@ static int if_bsdx_ipv6_open(void);
  * bsdi
  * Apple
  */
-pmix_pif_base_component_t mca_pif_bsdx_ipv6_component = {
+pmix_pif_base_component_t pmix_mca_pif_bsdx_ipv6_component = {
     PMIX_PIF_BASE_VERSION_2_0_0,
 
     /* Component name and version */

--- a/src/mca/pif/linux_ipv6/Makefile.am
+++ b/src/mca/pif/linux_ipv6/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,6 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pif_linux_ipv6.la
+noinst_LTLIBRARIES = libpmix_mca_pif_linux_ipv6.la
 
-libmca_pif_linux_ipv6_la_SOURCES = pif_linux_ipv6.c
+libpmix_mca_pif_linux_ipv6_la_SOURCES = pif_linux_ipv6.c

--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -54,7 +54,7 @@
 static int if_linux_ipv6_open(void);
 
 /* Discovers Linux IPv6 interfaces */
-pmix_pif_base_component_t mca_pif_linux_ipv6_component = {
+pmix_pif_base_component_t pmix_mca_pif_linux_ipv6_component = {
     PMIX_PIF_BASE_VERSION_2_0_0,
 
     /* Component name and version */

--- a/src/mca/pif/posix_ipv4/Makefile.am
+++ b/src/mca/pif/posix_ipv4/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,6 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pif_posix_ipv4.la
+noinst_LTLIBRARIES = libpmix_mca_pif_posix_ipv4.la
 
-libmca_pif_posix_ipv4_la_SOURCES = pif_posix.c
+libpmix_mca_pif_posix_ipv4_la_SOURCES = pif_posix.c

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -59,7 +59,7 @@ static int if_posix_open(void);
 /* Supports all flavors of posix except those
  * BSD-flavors supported elsewhere
  */
-pmix_pif_base_component_t mca_pif_posix_ipv4_component = {
+pmix_pif_base_component_t pmix_mca_pif_posix_ipv4_component = {
     PMIX_PIF_BASE_VERSION_2_0_0,
 
     /* Component name and version */

--- a/src/mca/pif/solaris_ipv6/Makefile.am
+++ b/src/mca/pif/solaris_ipv6/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,6 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pif_solaris_ipv6.la
+noinst_LTLIBRARIES = libpmix_mca_pif_solaris_ipv6.la
 
-libmca_pif_solaris_ipv6_la_SOURCES = pif_solaris_ipv6.c
+libpmix_mca_pif_solaris_ipv6_la_SOURCES = pif_solaris_ipv6.c

--- a/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
+++ b/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
@@ -72,7 +72,7 @@
 static int if_solaris_ipv6_open(void);
 
 /* Discovers Solaris IPv6 interfaces */
-pmix_pif_base_component_t mca_pif_solaris_ipv6_component = {
+pmix_pif_base_component_t pmix_mca_pif_solaris_ipv6_component = {
     PMIX_PIF_BASE_VERSION_2_0_0,
 
     /* Component name and version */

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_components.c
@@ -166,6 +166,6 @@ static int pmix_pinstalldirs_base_close(void)
 /* Declare the pinstalldirs framework */
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pinstalldirs, NULL, NULL, pmix_pinstalldirs_base_open,
                                 pmix_pinstalldirs_base_close,
-                                mca_pinstalldirs_base_static_components,
+                                pmix_mca_pinstalldirs_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_NOREGISTER
                                     | PMIX_MCA_BASE_FRAMEWORK_FLAG_NO_DSO);

--- a/src/mca/pinstalldirs/config/Makefile.am
+++ b/src/mca/pinstalldirs/config/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -12,11 +13,11 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pinstalldirs_config.la
+noinst_LTLIBRARIES = libpmix_mca_pinstalldirs_config.la
 
-libmca_pinstalldirs_config_la_SOURCES = \
+libpmix_mca_pinstalldirs_config_la_SOURCES = \
         pmix_pinstalldirs_config.c
 
 # This file is generated; we do not want to include it in the tarball
-nodist_libmca_pinstalldirs_config_la_SOURCES = \
+nodist_libpmix_mca_pinstalldirs_config_la_SOURCES = \
         pinstall_dirs.h

--- a/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
+++ b/src/mca/pinstalldirs/config/pmix_pinstalldirs_config.c
@@ -15,7 +15,7 @@
 #include "src/mca/pinstalldirs/config/pinstall_dirs.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 
-const pmix_pinstalldirs_base_component_t mca_pinstalldirs_config_component = {
+const pmix_pinstalldirs_base_component_t pmix_mca_pinstalldirs_config_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
     .component = {

--- a/src/mca/pinstalldirs/env/Makefile.am
+++ b/src/mca/pinstalldirs/env/Makefile.am
@@ -3,6 +3,7 @@
 #                         reserved.
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -10,7 +11,7 @@
 # $HEADER$
 #
 
-noinst_LTLIBRARIES = libmca_pinstalldirs_env.la
+noinst_LTLIBRARIES = libpmix_mca_pinstalldirs_env.la
 
-libmca_pinstalldirs_env_la_SOURCES = \
+libpmix_mca_pinstalldirs_env_la_SOURCES = \
 	pmix_pinstalldirs_env.c

--- a/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
+++ b/src/mca/pinstalldirs/env/pmix_pinstalldirs_env.c
@@ -21,7 +21,7 @@
 
 static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo);
 
-pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
+pmix_pinstalldirs_base_component_t pmix_mca_pinstalldirs_env_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
     .component = {
@@ -62,7 +62,7 @@ pmix_pinstalldirs_base_component_t mca_pinstalldirs_env_component = {
         if (NULL != tmp && 0 == strlen(tmp)) {                        \
             tmp = NULL;                                               \
         }                                                             \
-        mca_pinstalldirs_env_component.install_dirs_data.field = tmp; \
+        pmix_mca_pinstalldirs_env_component.install_dirs_data.field = tmp; \
     } while (0)
 
 static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo)
@@ -73,7 +73,7 @@ static void pinstalldirs_env_init(pmix_info_t info[], size_t ninfo)
     /* check for a prefix value */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_PREFIX)) {
-            mca_pinstalldirs_env_component.install_dirs_data.prefix = info[n].value.data.string;
+            pmix_mca_pinstalldirs_env_component.install_dirs_data.prefix = info[n].value.data.string;
             prefix_given = true;
             break;
         }

--- a/src/mca/plog/base/plog_base_frame.c
+++ b/src/mca/plog/base/plog_base_frame.c
@@ -101,7 +101,7 @@ static pmix_status_t pmix_plog_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, plog, "PMIx Logging Operations", pmix_plog_register,
-                                pmix_plog_open, pmix_plog_close, mca_plog_base_static_components,
+                                pmix_plog_open, pmix_plog_close, pmix_mca_plog_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 static void acon(pmix_plog_base_active_module_t *p)

--- a/src/mca/plog/default/Makefile.am
+++ b/src/mca/plog/default/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,20 +31,20 @@ sources = \
 
 if MCA_BUILD_pmix_plog_default_DSO
 component_noinst =
-component_install = mca_plog_default.la
+component_install = pmix_mca_plog_default.la
 else
-component_noinst = libmca_plog_default.la
+component_noinst = libpmix_mca_plog_default.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_plog_default_la_SOURCES = $(sources)
-mca_plog_default_la_LDFLAGS = -module -avoid-version
+pmix_mca_plog_default_la_SOURCES = $(sources)
+pmix_mca_plog_default_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_plog_default_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_plog_default_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_plog_default_la_SOURCES =$(sources)
-libmca_plog_default_la_LDFLAGS = -module -avoid-version
+libpmix_mca_plog_default_la_SOURCES =$(sources)
+libpmix_mca_plog_default_la_LDFLAGS = -module -avoid-version

--- a/src/mca/plog/default/plog_default.h
+++ b/src/mca/plog/default/plog_default.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ BEGIN_C_DECLS
  * Plog interfaces
  */
 
-PMIX_EXPORT extern pmix_plog_base_component_t mca_plog_default_component;
+PMIX_EXPORT extern pmix_plog_base_component_t pmix_mca_plog_default_component;
 extern pmix_plog_module_t pmix_plog_default_module;
 
 END_C_DECLS

--- a/src/mca/plog/default/plog_default_component.c
+++ b/src/mca/plog/default/plog_default_component.c
@@ -22,7 +22,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 /*
  * Struct of function pointers that need to be initialized
  */
-pmix_plog_base_component_t mca_plog_default_component = {
+pmix_plog_base_component_t pmix_mca_plog_default_component = {
     PMIX_PLOG_BASE_VERSION_1_0_0,
 
     .pmix_mca_component_name = "default",

--- a/src/mca/plog/smtp/Makefile.am
+++ b/src/mca/plog/smtp/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc. All rights reserved.
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,22 +36,22 @@ sources = \
 
 if MCA_BUILD_pmix_plog_smtp_DSO
 component_noinst =
-component_install = mca_plog_smtp.la
+component_install = pmix_mca_plog_smtp.la
 else
-component_noinst = libmca_plog_smtp.la
+component_noinst = libpmix_mca_plog_smtp.la
 component_install =
 endif
 
 mcacomponentdir = $(pmnixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_plog_smtp_la_SOURCES = $(sources)
-mca_plog_smtp_la_LDFLAGS = -module -avoid-version $(plog_smtp_LDFLAGS)
-mca_plog_smtp_la_LIBADD = $(plog_smtp_LIBS) $(top_builddir)/src/libpmix.la
+pmix_mca_plog_smtp_la_SOURCES = $(sources)
+pmix_mca_plog_smtp_la_LDFLAGS = -module -avoid-version $(plog_smtp_LDFLAGS)
+pmix_mca_plog_smtp_la_LIBADD = $(plog_smtp_LIBS) $(top_builddir)/src/libpmix.la
 if NEED_LIBPMIX
-mca_plog_smtp_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_plog_smtp_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_plog_smtp_la_SOURCES =$(sources)
-libmca_plog_smtp_la_LDFLAGS = -module -avoid-version $(plog_smtp_LDFLAGS)
-libmca_plog_smtp_la_LIBADD = $(plog_smtp_LIBS)
+libpmix_mca_plog_smtp_la_SOURCES =$(sources)
+libpmix_mca_plog_smtp_la_LDFLAGS = -module -avoid-version $(plog_smtp_LDFLAGS)
+libpmix_mca_plog_smtp_la_LIBADD = $(plog_smtp_LIBS)

--- a/src/mca/plog/smtp/plog_smtp.c
+++ b/src/mca/plog/smtp/plog_smtp.c
@@ -125,9 +125,9 @@ static const char *message_cb(void **buf, int *len, void *arg)
         return "\r\n";
 
     case SENT_HEADER:
-        if (NULL != mca_plog_smtp_component.body_prefix) {
+        if (NULL != pmix_mca_plog_smtp_component.body_prefix) {
             ms->sent_flag = SENT_BODY_PREFIX;
-            ms->prev_string = crnl(mca_plog_smtp_component.body_prefix);
+            ms->prev_string = crnl(pmix_mca_plog_smtp_component.body_prefix);
             *len = strlen(ms->prev_string);
             return ms->prev_string;
         }
@@ -139,9 +139,9 @@ static const char *message_cb(void **buf, int *len, void *arg)
         return ms->prev_string;
 
     case SENT_BODY:
-        if (NULL != mca_plog_smtp_component.body_suffix) {
+        if (NULL != pmix_mca_plog_smtp_component.body_suffix) {
             ms->sent_flag = SENT_BODY_SUFFIX;
-            ms->prev_string = crnl(mca_plog_smtp_component.body_suffix);
+            ms->prev_string = crnl(pmix_mca_plog_smtp_component.body_suffix);
             *len = strlen(ms->prev_string);
             return ms->prev_string;
         }
@@ -168,7 +168,7 @@ static int send_email(char *msg)
     smtp_session_t session = NULL;
     smtp_message_t message = NULL;
     message_status_t ms;
-    pmix_plog_smtp_component_t *c = &mca_plog_smtp_component;
+    pmix_plog_smtp_component_t *c = &pmix_mca_plog_smtp_component;
 
     if (NULL == c->to_argv) {
         c->to_argv = pmix_argv_split(c->to, ',');

--- a/src/mca/plog/smtp/plog_smtp.h
+++ b/src/mca/plog/smtp/plog_smtp.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009 Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,7 +59,7 @@ typedef struct {
 /*
  * Plog interfaces
  */
-PMIX_EXPORT extern pmix_plog_smtp_component_t mca_plog_smtp_component;
+PMIX_EXPORT extern pmix_plog_smtp_component_t pmix_mca_plog_smtp_component;
 extern pmix_plog_module_t pmix_plog_smtp_module;
 
 END_C_DECLS

--- a/src/mca/plog/smtp/plog_smtp_component.c
+++ b/src/mca/plog/smtp/plog_smtp_component.c
@@ -42,7 +42,7 @@ static pmix_status_t smtp_register(void);
 /*
  * Struct of function pointers that need to be initialized
  */
-pmix_plog_smtp_component_t mca_plog_smtp_component = {
+pmix_plog_smtp_component_t pmix_mca_plog_smtp_component = {
     PMIX_PLOG_BASE_VERSION_1_0_0,
 
     .pmix_mca_component_name = "smtp",
@@ -59,78 +59,78 @@ static pmix_status_t smtp_register(void)
     char version[256];
 
     /* Server stuff */
-    mca_plog_smtp_component.server = strdup("localhost");
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "server",
+    pmix_mca_plog_smtp_component.server = strdup("localhost");
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "server",
                                                 "SMTP server name or IP address",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.server);
+                                                &pmix_mca_plog_smtp_component.server);
 
-    mca_plog_smtp_component.port = 25;
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "port",
+    pmix_mca_plog_smtp_component.port = 25;
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "port",
                                                 "SMTP server port", PMIX_MCA_BASE_VAR_TYPE_INT,
                                                 NULL, 0, 0, PMIX_INFO_LVL_9,
                                                 PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.port);
+                                                &pmix_mca_plog_smtp_component.port);
 
     /* Email stuff */
-    mca_plog_smtp_component.to = NULL;
+    pmix_mca_plog_smtp_component.to = NULL;
     (void)
-        pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "to",
+        pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "to",
                                              "Comma-delimited list of email addresses to send to",
                                              PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                              PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                             &mca_plog_smtp_component.to);
-    mca_plog_smtp_component.from_addr = NULL;
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "from_addr",
+                                             &pmix_mca_plog_smtp_component.to);
+    pmix_mca_plog_smtp_component.from_addr = NULL;
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "from_addr",
                                                 "Email address that messages will be from",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.from_addr);
-    mca_plog_smtp_component.from_name = strdup("PMIx Plog");
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "from_name",
+                                                &pmix_mca_plog_smtp_component.from_addr);
+    pmix_mca_plog_smtp_component.from_name = strdup("PMIx Plog");
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "from_name",
                                                 "Email name that messages will be from",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.from_name);
-    mca_plog_smtp_component.subject = strdup("PMIx Plog");
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "subject",
+                                                &pmix_mca_plog_smtp_component.from_name);
+    pmix_mca_plog_smtp_component.subject = strdup("PMIx Plog");
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "subject",
                                                 "Email subject", PMIX_MCA_BASE_VAR_TYPE_STRING,
                                                 NULL, 0, 0, PMIX_INFO_LVL_9,
                                                 PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.subject);
+                                                &pmix_mca_plog_smtp_component.subject);
 
     /* Mail body prefix and suffix */
-    mca_plog_smtp_component.body_prefix = strdup(
+    pmix_mca_plog_smtp_component.body_prefix = strdup(
         "The PMIx SMTP plog wishes to inform you of the following message:\n\n");
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "body_prefix",
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "body_prefix",
                                                 "Text to put at the beginning of the mail message",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.body_prefix);
-    mca_plog_smtp_component.body_suffix = strdup("\n\nSincerely,\nOscar the PMIx Owl");
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "body_prefix",
+                                                &pmix_mca_plog_smtp_component.body_prefix);
+    pmix_mca_plog_smtp_component.body_suffix = strdup("\n\nSincerely,\nOscar the PMIx Owl");
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "body_prefix",
                                                 "Text to put at the end of the mail message",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.body_suffix);
+                                                &pmix_mca_plog_smtp_component.body_suffix);
 
     /* Priority */
-    mca_plog_smtp_component.priority = 10;
-    (void) pmix_mca_base_component_var_register(&mca_plog_smtp_component.super.base, "priority",
+    pmix_mca_plog_smtp_component.priority = 10;
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super.base, "priority",
                                                 "Priority of this component",
                                                 PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                                 PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                                                &mca_plog_smtp_component.priority);
+                                                &pmix_mca_plog_smtp_component.priority);
     /* Libesmtp version */
     smtp_version(version, sizeof(version), 0);
     version[sizeof(version) - 1] = '\0';
-    mca_plog_smtp_component.version = strdup(version);
+    pmix_mca_plog_smtp_component.version = strdup(version);
     (void) pmix_mca_base_component_var_register(
-        &mca_plog_smtp_component.super.base, "libesmtp_version",
+        &pmix_mca_plog_smtp_component.super.base, "libesmtp_version",
         "Version of libesmtp that this component is linked against", PMIX_MCA_BASE_VAR_TYPE_STRING,
         NULL, 0, 0, PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_plog_smtp_component.version);
+        &pmix_mca_plog_smtp_component.version);
 
     return PMIX_SUCCESS;
 }
@@ -146,15 +146,15 @@ static pmix_status_t smtp_component_query(pmix_mca_base_module_t **module, int *
     *module = NULL;
 
     /* If there's no to or from, there's no love */
-    if (NULL == mca_plog_smtp_component.to || '\0' == mca_plog_smtp_component.to[0]
-        || NULL == mca_plog_smtp_component.from_addr
-        || '\0' == mca_plog_smtp_component.from_addr[0]) {
+    if (NULL == pmix_mca_plog_smtp_component.to || '\0' == pmix_mca_plog_smtp_component.to[0]
+        || NULL == pmix_mca_plog_smtp_component.from_addr
+        || '\0' == pmix_mca_plog_smtp_component.from_addr[0]) {
         pmix_show_help("help-pmix-plog-smtp.txt", "to/from not specified", true);
         return PMIX_ERR_NOT_FOUND;
     }
 
     /* Sanity checks */
-    if (NULL == mca_plog_smtp_component.server || '\0' == mca_plog_smtp_component.server[0]) {
+    if (NULL == pmix_mca_plog_smtp_component.server || '\0' == pmix_mca_plog_smtp_component.server[0]) {
         pmix_show_help("help-pmix-plog-smtp.txt", "server not specified", true);
         return PMIX_ERR_NOT_FOUND;
     }
@@ -162,10 +162,10 @@ static pmix_status_t smtp_component_query(pmix_mca_base_module_t **module, int *
     /* Since we have to open a socket later, try to resolve the IP
        address of the server now.  Save the result, or abort if we
        can't resolve it. */
-    mca_plog_smtp_component.server_hostent = gethostbyname(mca_plog_smtp_component.server);
-    if (NULL == mca_plog_smtp_component.server_hostent) {
+    pmix_mca_plog_smtp_component.server_hostent = gethostbyname(pmix_mca_plog_smtp_component.server);
+    if (NULL == pmix_mca_plog_smtp_component.server_hostent) {
         pmix_show_help("help-pmix-plog-smtp.txt", "unable to resolve server", true,
-                       mca_plog_smtp_component.server);
+                       pmix_mca_plog_smtp_component.server);
         return PMIX_ERR_NOT_FOUND;
     }
 

--- a/src/mca/plog/stdfd/Makefile.am
+++ b/src/mca/plog/stdfd/Makefile.am
@@ -31,20 +31,20 @@ sources = \
 
 if MCA_BUILD_pmix_plog_stdfd_DSO
 component_noinst =
-component_install = mca_plog_stdfd.la
+component_install = pmix_mca_plog_stdfd.la
 else
-component_noinst = libmca_plog_stdfd.la
+component_noinst = libpmix_mca_plog_stdfd.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_plog_stdfd_la_SOURCES = $(sources)
-mca_plog_stdfd_la_LDFLAGS = -module -avoid-version
+pmix_mca_plog_stdfd_la_SOURCES = $(sources)
+pmix_mca_plog_stdfd_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_plog_stdfd_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_plog_stdfd_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_plog_stdfd_la_SOURCES =$(sources)
-libmca_plog_stdfd_la_LDFLAGS = -module -avoid-version
+libpmix_mca_plog_stdfd_la_SOURCES =$(sources)
+libpmix_mca_plog_stdfd_la_LDFLAGS = -module -avoid-version

--- a/src/mca/plog/stdfd/plog_stdfd.h
+++ b/src/mca/plog/stdfd/plog_stdfd.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ BEGIN_C_DECLS
  * Plog interfaces
  */
 
-PMIX_EXPORT extern pmix_plog_base_component_t mca_plog_stdfd_component;
+PMIX_EXPORT extern pmix_plog_base_component_t pmix_mca_plog_stdfd_component;
 extern pmix_plog_module_t pmix_plog_stdfd_module;
 
 END_C_DECLS

--- a/src/mca/plog/stdfd/plog_stdfd_component.c
+++ b/src/mca/plog/stdfd/plog_stdfd_component.c
@@ -22,7 +22,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 /*
  * Struct of function pointers that need to be initialized
  */
-pmix_plog_base_component_t mca_plog_stdfd_component = {
+pmix_plog_base_component_t pmix_mca_plog_stdfd_component = {
     PMIX_PLOG_BASE_VERSION_1_0_0,
 
     .pmix_mca_component_name = "stdfd",

--- a/src/mca/plog/syslog/Makefile.am
+++ b/src/mca/plog/syslog/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,20 +31,20 @@ sources = \
 
 if MCA_BUILD_pmix_plog_syslog_DSO
 component_noinst =
-component_install = mca_plog_syslog.la
+component_install = pmix_mca_plog_syslog.la
 else
-component_noinst = libmca_plog_syslog.la
+component_noinst = libpmix_mca_plog_syslog.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_plog_syslog_la_SOURCES = $(sources)
-mca_plog_syslog_la_LDFLAGS = -module -avoid-version
+pmix_mca_plog_syslog_la_SOURCES = $(sources)
+pmix_mca_plog_syslog_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_plog_syslog_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_plog_syslog_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_plog_syslog_la_SOURCES =$(sources)
-libmca_plog_syslog_la_LDFLAGS = -module -avoid-version
+libpmix_mca_plog_syslog_la_SOURCES =$(sources)
+libpmix_mca_plog_syslog_la_LDFLAGS = -module -avoid-version

--- a/src/mca/plog/syslog/plog_syslog.c
+++ b/src/mca/plog/syslog/plog_syslog.c
@@ -85,7 +85,7 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
                            void *cbdata)
 {
     size_t n;
-    int pri = mca_plog_syslog_component.level;
+    int pri = pmix_mca_plog_syslog_component.level;
     pmix_status_t rc;
     time_t timestamp = 0;
 

--- a/src/mca/plog/syslog/plog_syslog.h
+++ b/src/mca/plog/syslog/plog_syslog.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +40,7 @@ typedef struct {
     int facility;
 } pmix_plog_syslog_component_t;
 
-PMIX_EXPORT extern pmix_plog_syslog_component_t mca_plog_syslog_component;
+PMIX_EXPORT extern pmix_plog_syslog_component_t pmix_mca_plog_syslog_component;
 extern pmix_plog_module_t pmix_plog_syslog_module;
 
 END_C_DECLS

--- a/src/mca/plog/syslog/plog_syslog_component.c
+++ b/src/mca/plog/syslog/plog_syslog_component.c
@@ -28,7 +28,7 @@ static pmix_status_t syslog_register(void);
 /*
  * Struct of function pointers that need to be initialized
  */
-pmix_plog_syslog_component_t mca_plog_syslog_component = {
+pmix_plog_syslog_component_t pmix_mca_plog_syslog_component = {
     .super = {
         PMIX_PLOG_BASE_VERSION_1_0_0,
 
@@ -51,32 +51,32 @@ static pmix_status_t syslog_register(void)
     pmix_status_t rc = PMIX_SUCCESS;
 
     (void) pmix_mca_base_component_var_register(
-        &mca_plog_syslog_component.super, "console",
+        &pmix_mca_plog_syslog_component.super, "console",
         "Write directly to system console if there is an error while sending to system logger",
         PMIX_MCA_BASE_VAR_TYPE_BOOL,
-        &mca_plog_syslog_component.console);
+        &pmix_mca_plog_syslog_component.console);
 
     level = "info";
-    (void) pmix_mca_base_component_var_register(&mca_plog_syslog_component.super, "level",
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_syslog_component.super, "level",
                                                 "Default syslog logging level (err, alert, crit, "
                                                 "emerg, warning, notice, info[default], or debug)",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING, &level);
     if (0 == strncasecmp(level, "err", 3)) {
-        mca_plog_syslog_component.level = LOG_ERR;
+        pmix_mca_plog_syslog_component.level = LOG_ERR;
     } else if (0 == strcasecmp(level, "alert")) {
-        mca_plog_syslog_component.level = LOG_ALERT;
+        pmix_mca_plog_syslog_component.level = LOG_ALERT;
     } else if (0 == strncasecmp(level, "crit", 4)) {
-        mca_plog_syslog_component.level = LOG_CRIT;
+        pmix_mca_plog_syslog_component.level = LOG_CRIT;
     } else if (0 == strncasecmp(level, "emerg", 5)) {
-        mca_plog_syslog_component.level = LOG_EMERG;
+        pmix_mca_plog_syslog_component.level = LOG_EMERG;
     } else if (0 == strncasecmp(level, "warn", 4)) {
-        mca_plog_syslog_component.level = LOG_WARNING;
+        pmix_mca_plog_syslog_component.level = LOG_WARNING;
     } else if (0 == strncasecmp(level, "not", 3)) {
-        mca_plog_syslog_component.level = LOG_NOTICE;
+        pmix_mca_plog_syslog_component.level = LOG_NOTICE;
     } else if (0 == strcasecmp(level, "info")) {
-        mca_plog_syslog_component.level = LOG_INFO;
+        pmix_mca_plog_syslog_component.level = LOG_INFO;
     } else if (0 == strcasecmp(level, "debug") || 0 == strcasecmp(level, "dbg")) {
-        mca_plog_syslog_component.level = LOG_DEBUG;
+        pmix_mca_plog_syslog_component.level = LOG_DEBUG;
     } else {
         pmix_show_help("help-pmix-plog.txt", "syslog:unrec-level", true, level);
         rc = PMIX_ERR_NOT_SUPPORTED;
@@ -84,18 +84,18 @@ static pmix_status_t syslog_register(void)
 
     facility = "user";
     (void) pmix_mca_base_component_var_register(
-        &mca_plog_syslog_component.super, "facility",
+        &pmix_mca_plog_syslog_component.super, "facility",
         "Specify what type of program is logging the message "
         "(only \"auth\", \"priv\", \"daemon\", and \"user\" are supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING, &facility);
     if (0 == strncasecmp(facility, "auth", 4)) {
-        mca_plog_syslog_component.facility = LOG_AUTH;
+        pmix_mca_plog_syslog_component.facility = LOG_AUTH;
     } else if (0 == strncasecmp(facility, "priv", 4)) {
-        mca_plog_syslog_component.facility = LOG_AUTHPRIV;
+        pmix_mca_plog_syslog_component.facility = LOG_AUTHPRIV;
     } else if (0 == strcasecmp(facility, "daemon")) {
-        mca_plog_syslog_component.facility = LOG_DAEMON;
+        pmix_mca_plog_syslog_component.facility = LOG_DAEMON;
     } else if (0 == strcasecmp(facility, "user")) {
-        mca_plog_syslog_component.facility = LOG_USER;
+        pmix_mca_plog_syslog_component.facility = LOG_USER;
     } else {
         pmix_show_help("help-pmix-plog.txt", "syslog:unrec-facility", true, facility);
         rc = PMIX_ERR_NOT_SUPPORTED;

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -131,7 +131,7 @@ static pmix_status_t pmix_pmdl_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pmdl, "PMIx Network Operations", pmix_pmdl_register,
-                                pmix_pmdl_open, pmix_pmdl_close, mca_pmdl_base_static_components,
+                                pmix_pmdl_open, pmix_pmdl_close, pmix_mca_pmdl_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_pmdl_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/pmdl/mpich/Makefile.am
+++ b/src/mca/pmdl/mpich/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pmdl_mpich_DSO
 lib =
 lib_sources =
-component = mca_pmdl_mpich.la
+component = pmix_mca_pmdl_mpich.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pmdl_mpich.la
+lib = libpmix_mca_pmdl_mpich.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pmdl_mpich_la_SOURCES = $(component_sources)
-mca_pmdl_mpich_la_LDFLAGS = -module -avoid-version
+pmix_mca_pmdl_mpich_la_SOURCES = $(component_sources)
+pmix_mca_pmdl_mpich_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pmdl_mpich_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pmdl_mpich_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pmdl_mpich_la_SOURCES = $(lib_sources)
-libmca_pmdl_mpich_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pmdl_mpich_la_SOURCES = $(lib_sources)
+libpmix_mca_pmdl_mpich_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pmdl/mpich/pmdl_mpich.c
+++ b/src/mca/pmdl/mpich/pmdl_mpich.c
@@ -190,17 +190,17 @@ harvest:
     }
 
     /* harvest our local envars */
-    if (NULL != mca_pmdl_mpich_component.include) {
+    if (NULL != pmix_mca_pmdl_mpich_component.include) {
         pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
                             "pmdl: mpich harvesting envars %s excluding %s",
-                            (NULL == mca_pmdl_mpich_component.incparms)
+                            (NULL == pmix_mca_pmdl_mpich_component.incparms)
                             ? "NONE"
-                            : mca_pmdl_mpich_component.incparms,
-                            (NULL == mca_pmdl_mpich_component.excparms)
+                            : pmix_mca_pmdl_mpich_component.incparms,
+                            (NULL == pmix_mca_pmdl_mpich_component.excparms)
                             ? "NONE"
-                            : mca_pmdl_mpich_component.excparms);
-        rc = pmix_util_harvest_envars(mca_pmdl_mpich_component.include,
-                                      mca_pmdl_mpich_component.exclude, ilist);
+                            : pmix_mca_pmdl_mpich_component.excparms);
+        rc = pmix_util_harvest_envars(pmix_mca_pmdl_mpich_component.include,
+                                      pmix_mca_pmdl_mpich_component.exclude, ilist);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }

--- a/src/mca/pmdl/mpich/pmdl_mpich.h
+++ b/src/mca/pmdl/mpich/pmdl_mpich.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pmdl_mpich_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pmdl_mpich_component_t mca_pmdl_mpich_component;
+PMIX_EXPORT extern pmix_pmdl_mpich_component_t pmix_mca_pmdl_mpich_component;
 extern pmix_pmdl_module_t pmix_pmdl_mpich_module;
 
 END_C_DECLS

--- a/src/mca/pmdl/mpich/pmdl_mpich_component.c
+++ b/src/mca/pmdl/mpich/pmdl_mpich_component.c
@@ -36,7 +36,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pmdl_mpich_component_t mca_pmdl_mpich_component = {
+pmix_pmdl_mpich_component_t pmix_mca_pmdl_mpich_component = {
     .super = {
         PMIX_PMDL_BASE_VERSION_1_0_0,
 
@@ -57,26 +57,26 @@ pmix_pmdl_mpich_component_t mca_pmdl_mpich_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pmdl_mpich_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pmdl_mpich_component.super;
 
-    mca_pmdl_mpich_component.incparms = "MPIR_CVAR*";
+    pmix_mca_pmdl_mpich_component.incparms = "MPIR_CVAR*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pmdl_mpich_component.incparms);
-    if (NULL != mca_pmdl_mpich_component.incparms) {
-        mca_pmdl_mpich_component.include = pmix_argv_split(mca_pmdl_mpich_component.incparms, ',');
+        &pmix_mca_pmdl_mpich_component.incparms);
+    if (NULL != pmix_mca_pmdl_mpich_component.incparms) {
+        pmix_mca_pmdl_mpich_component.include = pmix_argv_split(pmix_mca_pmdl_mpich_component.incparms, ',');
     }
 
-    mca_pmdl_mpich_component.excparms = NULL;
+    pmix_mca_pmdl_mpich_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pmdl_mpich_component.excparms);
-    if (NULL != mca_pmdl_mpich_component.excparms) {
-        mca_pmdl_mpich_component.exclude = pmix_argv_split(mca_pmdl_mpich_component.excparms, ',');
+        &pmix_mca_pmdl_mpich_component.excparms);
+    if (NULL != pmix_mca_pmdl_mpich_component.excparms) {
+        pmix_mca_pmdl_mpich_component.exclude = pmix_argv_split(pmix_mca_pmdl_mpich_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pmdl/ompi/Makefile.am
+++ b/src/mca/pmdl/ompi/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pmdl_ompi_DSO
 lib =
 lib_sources =
-component = mca_pmdl_ompi.la
+component = pmix_mca_pmdl_ompi.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pmdl_ompi.la
+lib = libpmix_mca_pmdl_ompi.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pmdl_ompi_la_SOURCES = $(component_sources)
-mca_pmdl_ompi_la_LDFLAGS = -module -avoid-version
+pmix_mca_pmdl_ompi_la_SOURCES = $(component_sources)
+pmix_mca_pmdl_ompi_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pmdl_ompi_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pmdl_ompi_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pmdl_ompi_la_SOURCES = $(lib_sources)
-libmca_pmdl_ompi_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pmdl_ompi_la_SOURCES = $(lib_sources)
+libpmix_mca_pmdl_ompi_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -299,17 +299,17 @@ harvest:
     }
 
     /* harvest our local envars */
-    if (NULL != mca_pmdl_ompi_component.include) {
+    if (NULL != pmix_mca_pmdl_ompi_component.include) {
         pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
                             "pmdl: ompi harvesting envars %s excluding %s",
-                            (NULL == mca_pmdl_ompi_component.incparms)
+                            (NULL == pmix_mca_pmdl_ompi_component.incparms)
                             ? "NONE"
-                            : mca_pmdl_ompi_component.incparms,
-                            (NULL == mca_pmdl_ompi_component.excparms)
+                            : pmix_mca_pmdl_ompi_component.incparms,
+                            (NULL == pmix_mca_pmdl_ompi_component.excparms)
                             ? "NONE"
-                            : mca_pmdl_ompi_component.excparms);
-        rc = pmix_util_harvest_envars(mca_pmdl_ompi_component.include,
-                                      mca_pmdl_ompi_component.exclude, ilist);
+                            : pmix_mca_pmdl_ompi_component.excparms);
+        rc = pmix_util_harvest_envars(pmix_mca_pmdl_ompi_component.include,
+                                      pmix_mca_pmdl_ompi_component.exclude, ilist);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }

--- a/src/mca/pmdl/ompi/pmdl_ompi.h
+++ b/src/mca/pmdl/ompi/pmdl_ompi.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pmdl_ompi_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pmdl_ompi_component_t mca_pmdl_ompi_component;
+PMIX_EXPORT extern pmix_pmdl_ompi_component_t pmix_mca_pmdl_ompi_component;
 extern pmix_pmdl_module_t pmix_pmdl_ompi_module;
 
 END_C_DECLS

--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -36,7 +36,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pmdl_ompi_component_t mca_pmdl_ompi_component = {
+pmix_pmdl_ompi_component_t pmix_mca_pmdl_ompi_component = {
     .super = {
         PMIX_PMDL_BASE_VERSION_1_0_0,
 
@@ -57,26 +57,26 @@ pmix_pmdl_ompi_component_t mca_pmdl_ompi_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pmdl_ompi_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pmdl_ompi_component.super;
 
-    mca_pmdl_ompi_component.incparms = "OMPI_*";
+    pmix_mca_pmdl_ompi_component.incparms = "OMPI_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pmdl_ompi_component.incparms);
-    if (NULL != mca_pmdl_ompi_component.incparms) {
-        mca_pmdl_ompi_component.include = pmix_argv_split(mca_pmdl_ompi_component.incparms, ',');
+        &pmix_mca_pmdl_ompi_component.incparms);
+    if (NULL != pmix_mca_pmdl_ompi_component.incparms) {
+        pmix_mca_pmdl_ompi_component.include = pmix_argv_split(pmix_mca_pmdl_ompi_component.incparms, ',');
     }
 
-    mca_pmdl_ompi_component.excparms = NULL;
+    pmix_mca_pmdl_ompi_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-         &mca_pmdl_ompi_component.excparms);
-    if (NULL != mca_pmdl_ompi_component.excparms) {
-        mca_pmdl_ompi_component.exclude = pmix_argv_split(mca_pmdl_ompi_component.excparms, ',');
+         &pmix_mca_pmdl_ompi_component.excparms);
+    if (NULL != pmix_mca_pmdl_ompi_component.excparms) {
+        pmix_mca_pmdl_ompi_component.exclude = pmix_argv_split(pmix_mca_pmdl_ompi_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pmdl/oshmem/Makefile.am
+++ b/src/mca/pmdl/oshmem/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pmdl_oshmem_DSO
 lib =
 lib_sources =
-component = mca_pmdl_oshmem.la
+component = pmix_mca_pmdl_oshmem.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pmdl_oshmem.la
+lib = libpmix_mca_pmdl_oshmem.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -44,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pmdl_oshmem_la_SOURCES = $(component_sources)
-mca_pmdl_oshmem_la_LDFLAGS = -module -avoid-version
+pmix_mca_pmdl_oshmem_la_SOURCES = $(component_sources)
+pmix_mca_pmdl_oshmem_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pmdl_oshmem_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pmdl_oshmem_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pmdl_oshmem_la_SOURCES = $(lib_sources)
-libmca_pmdl_oshmem_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pmdl_oshmem_la_SOURCES = $(lib_sources)
+libpmix_mca_pmdl_oshmem_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pmdl/oshmem/pmdl_oshmem.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem.c
@@ -191,17 +191,17 @@ harvest:
     }
 
     /* harvest our local envars */
-    if (NULL != mca_pmdl_oshmem_component.include) {
+    if (NULL != pmix_mca_pmdl_oshmem_component.include) {
         pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
                             "pmdl: oshmem harvesting envars %s excluding %s",
-                            (NULL == mca_pmdl_oshmem_component.incparms)
+                            (NULL == pmix_mca_pmdl_oshmem_component.incparms)
                                 ? "NONE"
-                                : mca_pmdl_oshmem_component.incparms,
-                            (NULL == mca_pmdl_oshmem_component.excparms)
+                                : pmix_mca_pmdl_oshmem_component.incparms,
+                            (NULL == pmix_mca_pmdl_oshmem_component.excparms)
                                 ? "NONE"
-                                : mca_pmdl_oshmem_component.excparms);
-        rc = pmix_util_harvest_envars(mca_pmdl_oshmem_component.include,
-                                      mca_pmdl_oshmem_component.exclude, ilist);
+                                : pmix_mca_pmdl_oshmem_component.excparms);
+        rc = pmix_util_harvest_envars(pmix_mca_pmdl_oshmem_component.include,
+                                      pmix_mca_pmdl_oshmem_component.exclude, ilist);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }

--- a/src/mca/pmdl/oshmem/pmdl_oshmem.h
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pmdl_oshmem_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pmdl_oshmem_component_t mca_pmdl_oshmem_component;
+PMIX_EXPORT extern pmix_pmdl_oshmem_component_t pmix_mca_pmdl_oshmem_component;
 extern pmix_pmdl_module_t pmix_pmdl_oshmem_module;
 
 END_C_DECLS

--- a/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
+++ b/src/mca/pmdl/oshmem/pmdl_oshmem_component.c
@@ -36,7 +36,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pmdl_oshmem_component_t mca_pmdl_oshmem_component = {
+pmix_pmdl_oshmem_component_t pmix_mca_pmdl_oshmem_component = {
     .super = {
         PMIX_PMDL_BASE_VERSION_1_0_0,
 
@@ -57,27 +57,27 @@ pmix_pmdl_oshmem_component_t mca_pmdl_oshmem_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pmdl_oshmem_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pmdl_oshmem_component.super;
 
-    mca_pmdl_oshmem_component.incparms = "SHMEM_*,SMA_*";
+    pmix_mca_pmdl_oshmem_component.incparms = "SHMEM_*,SMA_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-         &mca_pmdl_oshmem_component.incparms);
-    if (NULL != mca_pmdl_oshmem_component.incparms) {
-        mca_pmdl_oshmem_component.include = pmix_argv_split(mca_pmdl_oshmem_component.incparms,
+         &pmix_mca_pmdl_oshmem_component.incparms);
+    if (NULL != pmix_mca_pmdl_oshmem_component.incparms) {
+        pmix_mca_pmdl_oshmem_component.include = pmix_argv_split(pmix_mca_pmdl_oshmem_component.incparms,
                                                             ',');
     }
 
-    mca_pmdl_oshmem_component.excparms = NULL;
+    pmix_mca_pmdl_oshmem_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pmdl_oshmem_component.excparms);
-    if (NULL != mca_pmdl_oshmem_component.excparms) {
-        mca_pmdl_oshmem_component.exclude = pmix_argv_split(mca_pmdl_oshmem_component.excparms,
+        &pmix_mca_pmdl_oshmem_component.excparms);
+    if (NULL != pmix_mca_pmdl_oshmem_component.excparms) {
+        pmix_mca_pmdl_oshmem_component.exclude = pmix_argv_split(pmix_mca_pmdl_oshmem_component.excparms,
                                                             ',');
     }
 

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -96,7 +96,7 @@ static pmix_status_t pmix_pnet_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pnet, "PMIx Network Operations", NULL, pmix_pnet_open,
-                                pmix_pnet_close, mca_pnet_base_static_components,
+                                pmix_pnet_close, pmix_mca_pnet_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_pnet_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/pnet/nvd/Makefile.am
+++ b/src/mca/pnet/nvd/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_nvd_DSO
 lib =
 lib_sources =
-component = mca_pnet_nvd.la
+component = pmix_mca_pnet_nvd.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_nvd.la
+lib = libpmix_mca_pnet_nvd.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_nvd_la_SOURCES = $(component_sources)
-mca_pnet_nvd_la_LDFLAGS = -module -avoid-version
+pmix_mca_pnet_nvd_la_SOURCES = $(component_sources)
+pmix_mca_pnet_nvd_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pnet_nvd_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_nvd_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_nvd_la_SOURCES = $(lib_sources)
-libmca_pnet_nvd_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pnet_nvd_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_nvd_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/nvd/pnet_nvd.c
+++ b/src/mca/pnet/nvd/pnet_nvd.c
@@ -98,15 +98,15 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
     if (envars) {
         pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                             "pnet: nvd harvesting envars %s excluding %s",
-                            (NULL == mca_pnet_nvd_component.incparms)
-                            ? "NONE" : mca_pnet_nvd_component.incparms,
-                            (NULL == mca_pnet_nvd_component.excparms)
-                            ? "NONE" : mca_pnet_nvd_component.excparms);
+                            (NULL == pmix_mca_pnet_nvd_component.incparms)
+                            ? "NONE" : pmix_mca_pnet_nvd_component.incparms,
+                            (NULL == pmix_mca_pnet_nvd_component.excparms)
+                            ? "NONE" : pmix_mca_pnet_nvd_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pnet_nvd_component.include) {
-            rc = pmix_util_harvest_envars(mca_pnet_nvd_component.include,
-                                          mca_pnet_nvd_component.exclude, &cache);
+        if (NULL != pmix_mca_pnet_nvd_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_nvd_component.include,
+                                          pmix_mca_pnet_nvd_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pnet/nvd/pnet_nvd.h
+++ b/src/mca/pnet/nvd/pnet_nvd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pnet_nvd_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_nvd_component_t mca_pnet_nvd_component;
+PMIX_EXPORT extern pmix_pnet_nvd_component_t pmix_mca_pnet_nvd_component;
 extern pmix_pnet_module_t pmix_pnet_nvd_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pnet/nvd/pnet_nvd_component.c
+++ b/src/mca/pnet/nvd/pnet_nvd_component.c
@@ -45,7 +45,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_nvd_component_t mca_pnet_nvd_component = {
+pmix_pnet_nvd_component_t pmix_mca_pnet_nvd_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -68,26 +68,26 @@ pmix_pnet_nvd_component_t mca_pnet_nvd_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_nvd_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_nvd_component.super;
 
-    mca_pnet_nvd_component.incparms = "UCX_*,HCOLL_*,UCC_*,SHARP_*,NCCL_*";
+    pmix_mca_pnet_nvd_component.incparms = "UCX_*,HCOLL_*,UCC_*,SHARP_*,NCCL_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_nvd_component.incparms);
-    if (NULL != mca_pnet_nvd_component.incparms) {
-        mca_pnet_nvd_component.include = pmix_argv_split(mca_pnet_nvd_component.incparms, ',');
+        &pmix_mca_pnet_nvd_component.incparms);
+    if (NULL != pmix_mca_pnet_nvd_component.incparms) {
+        pmix_mca_pnet_nvd_component.include = pmix_argv_split(pmix_mca_pnet_nvd_component.incparms, ',');
     }
 
-    mca_pnet_nvd_component.excparms = NULL;
+    pmix_mca_pnet_nvd_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_nvd_component.excparms);
-    if (NULL != mca_pnet_nvd_component.excparms) {
-        mca_pnet_nvd_component.exclude = pmix_argv_split(mca_pnet_nvd_component.excparms, ',');
+        &pmix_mca_pnet_nvd_component.excparms);
+    if (NULL != pmix_mca_pnet_nvd_component.excparms) {
+        pmix_mca_pnet_nvd_component.exclude = pmix_argv_split(pmix_mca_pnet_nvd_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_opa_DSO
 lib =
 lib_sources =
-component = mca_pnet_opa.la
+component = pmix_mca_pnet_opa.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_opa.la
+lib = libpmix_mca_pnet_opa.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_opa_la_SOURCES = $(component_sources)
-mca_pnet_opa_la_LDFLAGS = -module -avoid-version
+pmix_mca_pnet_opa_la_SOURCES = $(component_sources)
+pmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pnet_opa_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_opa_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_opa_la_SOURCES = $(lib_sources)
-libmca_pnet_opa_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pnet_opa_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -233,17 +233,17 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
     if (envars) {
         pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                             "pnet: opa harvesting envars %s excluding %s",
-                            (NULL == mca_pnet_opa_component.incparms)
+                            (NULL == pmix_mca_pnet_opa_component.incparms)
                                 ? "NONE"
-                                : mca_pnet_opa_component.incparms,
-                            (NULL == mca_pnet_opa_component.excparms)
+                                : pmix_mca_pnet_opa_component.incparms,
+                            (NULL == pmix_mca_pnet_opa_component.excparms)
                                 ? "NONE"
-                                : mca_pnet_opa_component.excparms);
+                                : pmix_mca_pnet_opa_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pnet_opa_component.include) {
-            rc = pmix_util_harvest_envars(mca_pnet_opa_component.include,
-                                          mca_pnet_opa_component.exclude, &cache);
+        if (NULL != pmix_mca_pnet_opa_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_opa_component.include,
+                                          pmix_mca_pnet_opa_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pnet/opa/pnet_opa.h
+++ b/src/mca/pnet/opa/pnet_opa.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pnet_opa_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_opa_component_t mca_pnet_opa_component;
+PMIX_EXPORT extern pmix_pnet_opa_component_t pmix_mca_pnet_opa_component;
 extern pmix_pnet_module_t pmix_opa_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -45,7 +45,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_opa_component_t mca_pnet_opa_component = {
+pmix_pnet_opa_component_t pmix_mca_pnet_opa_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -68,26 +68,26 @@ pmix_pnet_opa_component_t mca_pnet_opa_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_opa_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_opa_component.super;
 
-    mca_pnet_opa_component.incparms = "HFI_*,PSM2_*";
+    pmix_mca_pnet_opa_component.incparms = "HFI_*,PSM2_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_opa_component.incparms);
-    if (NULL != mca_pnet_opa_component.incparms) {
-        mca_pnet_opa_component.include = pmix_argv_split(mca_pnet_opa_component.incparms, ',');
+        &pmix_mca_pnet_opa_component.incparms);
+    if (NULL != pmix_mca_pnet_opa_component.incparms) {
+        pmix_mca_pnet_opa_component.include = pmix_argv_split(pmix_mca_pnet_opa_component.incparms, ',');
     }
 
-    mca_pnet_opa_component.excparms = NULL;
+    pmix_mca_pnet_opa_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_opa_component.excparms);
-    if (NULL != mca_pnet_opa_component.excparms) {
-        mca_pnet_opa_component.exclude = pmix_argv_split(mca_pnet_opa_component.excparms, ',');
+        &pmix_mca_pnet_opa_component.excparms);
+    if (NULL != pmix_mca_pnet_opa_component.excparms) {
+        pmix_mca_pnet_opa_component.exclude = pmix_argv_split(pmix_mca_pnet_opa_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/simptest/Makefile.am
+++ b/src/mca/pnet/simptest/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_simptest_DSO
 lib =
 lib_sources =
-component = mca_pnet_simptest.la
+component = pmix_mca_pnet_simptest.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_simptest.la
+lib = libpmix_mca_pnet_simptest.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -44,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_simptest_la_SOURCES = $(component_sources)
-mca_pnet_simptest_la_LDFLAGS = -module -avoid-version
+pmix_mca_pnet_simptest_la_SOURCES = $(component_sources)
+pmix_mca_pnet_simptest_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pnet_simptest_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_simptest_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_simptest_la_SOURCES = $(lib_sources)
-libmca_pnet_simptest_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pnet_simptest_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_simptest_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/simptest/pnet_simptest.c
+++ b/src/mca/pnet/simptest/pnet_simptest.c
@@ -135,15 +135,15 @@ static pmix_status_t simptest_init(void)
 
     /* if the configuration was given in a file, then build
      * the topology so we can respond to requests */
-    if (NULL == mca_pnet_simptest_component.configfile) {
+    if (NULL == pmix_mca_pnet_simptest_component.configfile) {
         /* we cannot function */
         return PMIX_ERR_INIT;
     }
 
-    fp = fopen(mca_pnet_simptest_component.configfile, "r");
+    fp = fopen(pmix_mca_pnet_simptest_component.configfile, "r");
     if (NULL == fp) {
         pmix_show_help("help-pnet-simptest.txt", "missing-file", true,
-                       mca_pnet_simptest_component.configfile);
+                       pmix_mca_pnet_simptest_component.configfile);
         return PMIX_ERR_FATAL;
     }
     while (NULL != (line = localgetline(fp))) {

--- a/src/mca/pnet/simptest/pnet_simptest.h
+++ b/src/mca/pnet/simptest/pnet_simptest.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,7 @@ typedef struct {
 } pmix_pnet_simptest_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_simptest_component_t mca_pnet_simptest_component;
+PMIX_EXPORT extern pmix_pnet_simptest_component_t pmix_mca_pnet_simptest_component;
 extern pmix_pnet_module_t pmix_simptest_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pnet/simptest/pnet_simptest_component.c
+++ b/src/mca/pnet/simptest/pnet_simptest_component.c
@@ -43,7 +43,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_simptest_component_t mca_pnet_simptest_component = {
+pmix_pnet_simptest_component_t pmix_mca_pnet_simptest_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -65,12 +65,12 @@ pmix_pnet_simptest_component_t mca_pnet_simptest_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_simptest_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_simptest_component.super;
 
     (void) pmix_mca_base_component_var_register(
         component, "config_file", "Path of file containing network coordinate configuration",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_simptest_component.configfile);
+        &pmix_mca_pnet_simptest_component.configfile);
     return PMIX_SUCCESS;
 }
 
@@ -79,7 +79,7 @@ static pmix_status_t component_open(void)
     int index;
     const pmix_mca_base_var_storage_t *value = NULL;
 
-    if (NULL == mca_pnet_simptest_component.configfile
+    if (NULL == pmix_mca_pnet_simptest_component.configfile
         || !PMIX_PROC_IS_SERVER(&pmix_globals.mypeer->proc_type)) {
         /* nothing we can do without a description
          * of the fabric topology */

--- a/src/mca/pnet/sshot/Makefile.am
+++ b/src/mca/pnet/sshot/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,10 +39,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_sshot_DSO
 lib =
 lib_sources =
-component = mca_pnet_sshot.la
+component = pmix_mca_pnet_sshot.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_sshot.la
+lib = libpmix_mca_pnet_sshot.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -49,15 +50,15 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_sshot_la_SOURCES = $(component_sources)
-mca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS) \
+pmix_mca_pnet_sshot_la_SOURCES = $(component_sources)
+pmix_mca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS) \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/sse/libmca_common_sse.la
-mca_pnet_sshot_la_LIBADD = -ljansson
+pmix_mca_pnet_sshot_la_LIBADD = -ljansson
 if NEED_LIBPMIX
-mca_pnet_sshot_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_sshot_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_sshot_la_SOURCES = $(lib_sources)
-libmca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS)
-libmca_pnet_sshot_la_LIBADD = -ljansson
+libpmix_mca_pnet_sshot_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_sshot_la_LDFLAGS = -module -avoid-version $(pmix_check_jansson_LDFLAGS)
+libpmix_mca_pnet_sshot_la_LIBADD = -ljansson

--- a/src/mca/pnet/sshot/pnet_fabric.c
+++ b/src/mca/pnet/sshot/pnet_fabric.c
@@ -163,7 +163,7 @@ pmix_status_t pmix_pnet_sshot_register_fabric(pmix_fabric_t *fabric, const pmix_
 
     /* if we were given a fabric topology configuration file, then parse
      * it to get the fabric groups and switches */
-    if (NULL == mca_pnet_sshot_component.configfile) {
+    if (NULL == pmix_mca_pnet_sshot_component.configfile) {
         /* we were not given a file - see if we can get it
          * from the fabric controller via REST interface */
         return ask_fabric_controller(fabric, directives, ndirs, cbfunc, cbdata);
@@ -178,7 +178,7 @@ pmix_status_t pmix_pnet_sshot_register_fabric(pmix_fabric_t *fabric, const pmix_
     pmix_pointer_array_init(&myvertices, 128, INT_MAX, 64);
 
     /* load the file */
-    root = json_load_file(mca_pnet_sshot_component.configfile, 0, &error);
+    root = json_load_file(pmix_mca_pnet_sshot_component.configfile, 0, &error);
     if (NULL == root) {
         /* the error object contains info on the error */
         pmix_show_help("help-pnet-sshot.txt", "json-load", true, error.text, error.source,

--- a/src/mca/pnet/sshot/pnet_sshot.c
+++ b/src/mca/pnet/sshot/pnet_sshot.c
@@ -199,7 +199,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
      * Device coordinates (both physical and logical)
      *
      */
-    if (0 == mca_pnet_sshot_component.numnodes) {
+    if (0 == pmix_mca_pnet_sshot_component.numnodes) {
         /* check directives to get the node map */
         for (n = 0; n < (int) ninfo; n++) {
             pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
@@ -216,12 +216,12 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             }
         }
     } else {
-        for (n = 0; n < mca_pnet_sshot_component.numnodes; n++) {
+        for (n = 0; n < pmix_mca_pnet_sshot_component.numnodes; n++) {
             pmix_asprintf(&tmp, "nid%06d", n);
             pmix_argv_append_nosize(&nodes, tmp);
             free(tmp);
 
-            for (m = 0; m < mca_pnet_sshot_component.numdevs; m++) {
+            for (m = 0; m < pmix_mca_pnet_sshot_component.numdevs; m++) {
                 pmix_asprintf(&tmp, "%02d:%02d:%02d:%02d:%02d:%02d", n % 100, (n + 1) % 100,
                               (n + 2) % 100, (n + 3) % 100, (n + 4) % 100, m);
                 pmix_argv_append_nosize(&targs, tmp);
@@ -233,7 +233,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             pmix_argv_free(targs);
             targs = NULL;
 
-            for (m = 0; m < mca_pnet_sshot_component.numdevs; m++) {
+            for (m = 0; m < pmix_mca_pnet_sshot_component.numdevs; m++) {
                 pmix_asprintf(&tmp, "x30000c%1dr%02da%04d", n % 10, n % 100, m);
                 pmix_argv_append_nosize(&targs, tmp);
                 free(tmp);
@@ -244,7 +244,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             pmix_argv_free(targs);
             targs = NULL;
 
-            for (m = 0; m < mca_pnet_sshot_component.numdevs; m++) {
+            for (m = 0; m < pmix_mca_pnet_sshot_component.numdevs; m++) {
                 pmix_asprintf(&tmp, "eth%1d", m);
                 pmix_argv_append_nosize(&targs, tmp);
                 free(tmp);
@@ -387,7 +387,7 @@ complete:
         sessioninfo = true;
     }
 
-    if (0 < mca_pnet_sshot_component.numnodes) {
+    if (0 < pmix_mca_pnet_sshot_component.numnodes) {
         gettimeofday(&end, NULL);
         pmix_output(0, "TIME SPENT ALLOCATING DATA: %f seconds",
                     (float) (end.tv_sec - start.tv_sec)
@@ -452,7 +452,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
             pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                                 "pnet:sshot:setup_local_network found my blob");
 
-            if (0 < mca_pnet_sshot_component.numnodes) {
+            if (0 < pmix_mca_pnet_sshot_component.numnodes) {
                 gettimeofday(&start, NULL);
             }
 
@@ -585,11 +585,11 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
                 }
 
                 /* get the list of local peers for this node */
-                if (0 < mca_pnet_sshot_component.numnodes) {
-                    if (0 < mca_pnet_sshot_component.ppn) {
+                if (0 < pmix_mca_pnet_sshot_component.numnodes) {
+                    if (0 < pmix_mca_pnet_sshot_component.ppn) {
                         /* simulating procs */
                         prs = NULL;
-                        for (m = 0; m < (size_t) mca_pnet_sshot_component.ppn; m++) {
+                        for (m = 0; m < (size_t) pmix_mca_pnet_sshot_component.ppn; m++) {
                             pmix_asprintf(&peers, "%d", (int) rank);
                             pmix_argv_append_nosize(&prs, peers);
                             free(peers);
@@ -681,7 +681,7 @@ cleanup:
         iptr->value.data.bo.bytes = bkt.base_ptr;
         iptr->value.data.bo.size = bkt.bytes_used;
     }
-    if (0 < mca_pnet_sshot_component.numnodes) {
+    if (0 < pmix_mca_pnet_sshot_component.numnodes) {
         gettimeofday(&end, NULL);
         pmix_output(0, "TIME SPENT CONSTRUCTING BACKEND DATA: %f seconds",
                     (float) (end.tv_sec - start.tv_sec)

--- a/src/mca/pnet/sshot/pnet_sshot.h
+++ b/src/mca/pnet/sshot/pnet_sshot.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ typedef struct {
 } pmix_pnet_sshot_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_sshot_component_t mca_pnet_sshot_component;
+PMIX_EXPORT extern pmix_pnet_sshot_component_t pmix_mca_pnet_sshot_component;
 PMIX_EXPORT extern pmix_pnet_module_t pmix_sshot_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pnet/sshot/pnet_sshot_component.c
+++ b/src/mca/pnet/sshot/pnet_sshot_component.c
@@ -44,7 +44,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_sshot_component_t mca_pnet_sshot_component = {
+pmix_pnet_sshot_component_t pmix_mca_pnet_sshot_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -69,25 +69,25 @@ pmix_pnet_sshot_component_t mca_pnet_sshot_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_sshot_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_sshot_component.super;
 
     (void) pmix_mca_base_component_var_register(
         component, "config_file", "Path of file containing Slingshot fabric configuration",
         PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-        &mca_pnet_sshot_component.configfile);
+        &pmix_mca_pnet_sshot_component.configfile);
 
     (void) pmix_mca_base_component_var_register(component, "num_nodes",
                                                 "Number of nodes to simulate (0 = no simulation)",
                                                 PMIX_MCA_BASE_VAR_TYPE_INT,
-                                                &mca_pnet_sshot_component.numnodes);
+                                                &pmix_mca_pnet_sshot_component.numnodes);
     (void) pmix_mca_base_component_var_register(
         component, "devs_per_node", "Number of devices/node to simulate (0 = no simulation)",
         PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-        &mca_pnet_sshot_component.numdevs);
+        &pmix_mca_pnet_sshot_component.numdevs);
 
     (void) pmix_mca_base_component_var_register(component, "ppn", "PPN to simulate",
                                                 PMIX_MCA_BASE_VAR_TYPE_INT,
-                                                &mca_pnet_sshot_component.ppn);
+                                                &pmix_mca_pnet_sshot_component.ppn);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/tcp/Makefile.am
+++ b/src/mca/pnet/tcp/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,10 +36,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_tcp_DSO
 lib =
 lib_sources =
-component = mca_pnet_tcp.la
+component = pmix_mca_pnet_tcp.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_tcp.la
+lib = libpmix_mca_pnet_tcp.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -46,14 +47,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_tcp_la_SOURCES = $(component_sources)
-mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
-mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
+pmix_mca_pnet_tcp_la_SOURCES = $(component_sources)
+pmix_mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
+pmix_mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
 if NEED_LIBPMIX
-mca_pnet_tcp_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_tcp_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_tcp_la_SOURCES = $(lib_sources)
-libmca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
-libmca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
+libpmix_mca_pnet_tcp_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
+libpmix_mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -198,12 +198,12 @@ static pmix_status_t tcp_init(void)
      *
      * NOTE: need to check inventory in addition to MCA param as
      * the inventory may have reported back static ports */
-    if (NULL == mca_pnet_tcp_component.static_ports) {
+    if (NULL == pmix_mca_pnet_tcp_component.static_ports) {
         return PMIX_SUCCESS;
     }
 
     /* split on semi-colons */
-    grps = pmix_argv_split(mca_pnet_tcp_component.static_ports, ';');
+    grps = pmix_argv_split(pmix_mca_pnet_tcp_component.static_ports, ';');
     for (n = 0; NULL != grps[n]; n++) {
         trk = PMIX_NEW(tcp_available_ports_t);
         if (NULL == trk) {
@@ -334,17 +334,17 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
     }
 
     if (envars) {
-        if (NULL != mca_pnet_tcp_component.include) {
+        if (NULL != pmix_mca_pnet_tcp_component.include) {
             pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                                 "pnet: tcp harvesting envars %s excluding %s",
-                                (NULL == mca_pnet_tcp_component.incparms)
+                                (NULL == pmix_mca_pnet_tcp_component.incparms)
                                     ? "NONE"
-                                    : mca_pnet_tcp_component.incparms,
-                                (NULL == mca_pnet_tcp_component.excparms)
+                                    : pmix_mca_pnet_tcp_component.incparms,
+                                (NULL == pmix_mca_pnet_tcp_component.excparms)
                                     ? "NONE"
-                                    : mca_pnet_tcp_component.excparms);
-            rc = pmix_util_harvest_envars(mca_pnet_tcp_component.include,
-                                          mca_pnet_tcp_component.exclude, ilist);
+                                    : pmix_mca_pnet_tcp_component.excparms);
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_tcp_component.include,
+                                          pmix_mca_pnet_tcp_component.exclude, ilist);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
@@ -544,11 +544,11 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             /* if they didn't specify either type or plane, then we got here because
              * nobody of a higher priority could act as a default transport - so try
              * to provide something here, starting by looking at any provided setting */
-            if (NULL != mca_pnet_tcp_component.default_request) {
+            if (NULL != pmix_mca_pnet_tcp_component.default_request) {
                 pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                                     "pnet:tcp:allocate allocating default ports %s for nspace %s",
-                                    mca_pnet_tcp_component.default_request, nptr->nspace);
-                reqs = pmix_argv_split(mca_pnet_tcp_component.default_request, ';');
+                                    pmix_mca_pnet_tcp_component.default_request, nptr->nspace);
+                reqs = pmix_argv_split(pmix_mca_pnet_tcp_component.default_request, ';');
                 for (n = 0; NULL != reqs[n]; n++) {
                     /* if there is no colon, then it is just
                      * a number of ports to use */

--- a/src/mca/pnet/tcp/pnet_tcp.h
+++ b/src/mca/pnet/tcp/pnet_tcp.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +31,7 @@ typedef struct {
 } pmix_pnet_tcp_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_tcp_component_t mca_pnet_tcp_component;
+PMIX_EXPORT extern pmix_pnet_tcp_component_t pmix_mca_pnet_tcp_component;
 extern pmix_pnet_module_t pmix_tcp_module;
 
 END_C_DECLS

--- a/src/mca/pnet/tcp/pnet_tcp_component.c
+++ b/src/mca/pnet/tcp/pnet_tcp_component.c
@@ -31,7 +31,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_tcp_component_t mca_pnet_tcp_component = {
+pmix_pnet_tcp_component_t pmix_mca_pnet_tcp_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -56,16 +56,16 @@ pmix_pnet_tcp_component_t mca_pnet_tcp_component = {
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_tcp_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_tcp_component.super;
 
-    mca_pnet_tcp_component.static_ports = NULL;
+    pmix_mca_pnet_tcp_component.static_ports = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "static_ports",
         "Static ports for procs, expressed as a semi-colon delimited "
         "list of type:(optional)plane:Comma-delimited list of ranges (e.g., "
         "\"tcp:10.10.10.0/24:32000-32100,33000;udp:40000,40005\")",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_tcp_component.static_ports);
+        &pmix_mca_pnet_tcp_component.static_ports);
 
     (void) pmix_mca_base_component_var_register(
         component, "default_network_allocation",
@@ -74,26 +74,26 @@ static pmix_status_t component_register(void)
         "(e.g., \"udp:10.10.10.0/24:3\", or \"5\" if the choice of "
         "type and plane isn't critical)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-         &mca_pnet_tcp_component.default_request);
+         &pmix_mca_pnet_tcp_component.default_request);
 
-    mca_pnet_tcp_component.incparms = NULL;
+    pmix_mca_pnet_tcp_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_tcp_component.incparms);
-    if (NULL != mca_pnet_tcp_component.incparms) {
-        mca_pnet_tcp_component.include = pmix_argv_split(mca_pnet_tcp_component.incparms, ',');
+        &pmix_mca_pnet_tcp_component.incparms);
+    if (NULL != pmix_mca_pnet_tcp_component.incparms) {
+        pmix_mca_pnet_tcp_component.include = pmix_argv_split(pmix_mca_pnet_tcp_component.incparms, ',');
     }
 
-    mca_pnet_tcp_component.excparms = NULL;
+    pmix_mca_pnet_tcp_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_tcp_component.excparms);
-    if (NULL != mca_pnet_tcp_component.excparms) {
-        mca_pnet_tcp_component.exclude = pmix_argv_split(mca_pnet_tcp_component.excparms, ',');
+        &pmix_mca_pnet_tcp_component.excparms);
+    if (NULL != pmix_mca_pnet_tcp_component.excparms) {
+        pmix_mca_pnet_tcp_component.exclude = pmix_argv_split(pmix_mca_pnet_tcp_component.excparms, ',');
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/usnic/Makefile.am
+++ b/src/mca/pnet/usnic/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_pnet_usnic_DSO
 lib =
 lib_sources =
-component = mca_pnet_usnic.la
+component = pmix_mca_pnet_usnic.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pnet_usnic.la
+lib = libpmix_mca_pnet_usnic.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -45,12 +45,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pnet_usnic_la_SOURCES = $(component_sources)
-mca_pnet_usnic_la_LDFLAGS = -module -avoid-version
+pmix_mca_pnet_usnic_la_SOURCES = $(component_sources)
+pmix_mca_pnet_usnic_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_pnet_usnic_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pnet_usnic_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pnet_usnic_la_SOURCES = $(lib_sources)
-libmca_pnet_usnic_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pnet_usnic_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_usnic_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/usnic/pnet_usnic.c
+++ b/src/mca/pnet/usnic/pnet_usnic.c
@@ -99,15 +99,15 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
     if (envars) {
         pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                             "pnet: usnic harvesting envars %s excluding %s",
-                            (NULL == mca_pnet_usnic_component.incparms)
-                            ? "NONE" : mca_pnet_usnic_component.incparms,
-                            (NULL == mca_pnet_usnic_component.excparms)
-                            ? "NONE" : mca_pnet_usnic_component.excparms);
+                            (NULL == pmix_mca_pnet_usnic_component.incparms)
+                            ? "NONE" : pmix_mca_pnet_usnic_component.incparms,
+                            (NULL == pmix_mca_pnet_usnic_component.excparms)
+                            ? "NONE" : pmix_mca_pnet_usnic_component.excparms);
         /* harvest envars to pass along */
         PMIX_CONSTRUCT(&cache, pmix_list_t);
-        if (NULL != mca_pnet_usnic_component.include) {
-            rc = pmix_util_harvest_envars(mca_pnet_usnic_component.include,
-                                          mca_pnet_usnic_component.exclude, &cache);
+        if (NULL != pmix_mca_pnet_usnic_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_usnic_component.include,
+                                          pmix_mca_pnet_usnic_component.exclude, &cache);
             if (PMIX_SUCCESS != rc) {
                 PMIX_LIST_DESTRUCT(&cache);
                 PMIX_DESTRUCT(&mydata);

--- a/src/mca/pnet/usnic/pnet_usnic.h
+++ b/src/mca/pnet/usnic/pnet_usnic.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +29,7 @@ typedef struct {
 } pmix_pnet_usnic_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pnet_usnic_component_t mca_pnet_usnic_component;
+PMIX_EXPORT extern pmix_pnet_usnic_component_t pmix_mca_pnet_usnic_component;
 extern pmix_pnet_module_t pmix_pnet_usnic_module;
 
 /* define a key for any blob we need to send in a launch msg */

--- a/src/mca/pnet/usnic/pnet_usnic_component.c
+++ b/src/mca/pnet/usnic/pnet_usnic_component.c
@@ -46,7 +46,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pnet_usnic_component_t mca_pnet_usnic_component = {
+pmix_pnet_usnic_component_t pmix_mca_pnet_usnic_component = {
     .super = {
         PMIX_PNET_BASE_VERSION_1_0_0,
 
@@ -74,26 +74,26 @@ static char *static_port_string6 = NULL;
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &mca_pnet_usnic_component.super;
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_usnic_component.super;
 
-    mca_pnet_usnic_component.incparms = NULL;
+    pmix_mca_pnet_usnic_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_usnic_component.incparms);
-    if (NULL != mca_pnet_usnic_component.incparms) {
-        mca_pnet_usnic_component.include = pmix_argv_split(mca_pnet_usnic_component.incparms, ',');
+        &pmix_mca_pnet_usnic_component.incparms);
+    if (NULL != pmix_mca_pnet_usnic_component.incparms) {
+        pmix_mca_pnet_usnic_component.include = pmix_argv_split(pmix_mca_pnet_usnic_component.incparms, ',');
     }
 
-    mca_pnet_usnic_component.excparms = NULL;
+    pmix_mca_pnet_usnic_component.excparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
         PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &mca_pnet_usnic_component.excparms);
-    if (NULL != mca_pnet_usnic_component.excparms) {
-        mca_pnet_usnic_component.exclude = pmix_argv_split(mca_pnet_usnic_component.excparms, ',');
+        &pmix_mca_pnet_usnic_component.excparms);
+    if (NULL != pmix_mca_pnet_usnic_component.excparms) {
+        pmix_mca_pnet_usnic_component.exclude = pmix_argv_split(pmix_mca_pnet_usnic_component.excparms, ',');
     }
 
     static_port_string = NULL;
@@ -103,13 +103,13 @@ static pmix_status_t component_register(void)
                                                 &static_port_string);
     /* if ports were provided, parse the provided range */
     if (NULL != static_port_string) {
-        pmix_util_parse_range_options(static_port_string, &mca_pnet_usnic_component.tcp_static_ports);
-        if (0 == strcmp(mca_pnet_usnic_component.tcp_static_ports[0], "-1")) {
-            pmix_argv_free(mca_pnet_usnic_component.tcp_static_ports);
-            mca_pnet_usnic_component.tcp_static_ports = NULL;
+        pmix_util_parse_range_options(static_port_string, &pmix_mca_pnet_usnic_component.tcp_static_ports);
+        if (0 == strcmp(pmix_mca_pnet_usnic_component.tcp_static_ports[0], "-1")) {
+            pmix_argv_free(pmix_mca_pnet_usnic_component.tcp_static_ports);
+            pmix_mca_pnet_usnic_component.tcp_static_ports = NULL;
         }
     } else {
-        mca_pnet_usnic_component.tcp_static_ports = NULL;
+        pmix_mca_pnet_usnic_component.tcp_static_ports = NULL;
     }
 
     static_port_string6 = NULL;
@@ -119,13 +119,13 @@ static pmix_status_t component_register(void)
                                                 &static_port_string6);
     /* if ports were provided, parse the provided range */
     if (NULL != static_port_string6) {
-        pmix_util_parse_range_options(static_port_string6, &mca_pnet_usnic_component.tcp6_static_ports);
-        if (0 == strcmp(mca_pnet_usnic_component.tcp6_static_ports[0], "-1")) {
-            pmix_argv_free(mca_pnet_usnic_component.tcp6_static_ports);
-            mca_pnet_usnic_component.tcp6_static_ports = NULL;
+        pmix_util_parse_range_options(static_port_string6, &pmix_mca_pnet_usnic_component.tcp6_static_ports);
+        if (0 == strcmp(pmix_mca_pnet_usnic_component.tcp6_static_ports[0], "-1")) {
+            pmix_argv_free(pmix_mca_pnet_usnic_component.tcp6_static_ports);
+            pmix_mca_pnet_usnic_component.tcp6_static_ports = NULL;
         }
     } else {
-        mca_pnet_usnic_component.tcp6_static_ports = NULL;
+        pmix_mca_pnet_usnic_component.tcp6_static_ports = NULL;
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -86,7 +86,7 @@ static pmix_status_t pmix_preg_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, preg, "PMIx Regex Operations", NULL, pmix_preg_open,
-                                pmix_preg_close, mca_preg_base_static_components,
+                                pmix_preg_close, pmix_mca_preg_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_preg_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/preg/compress/Makefile.am
+++ b/src/mca/preg/compress/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_preg_compress_DSO
 lib =
 lib_sources =
-component = mca_preg_compress.la
+component = pmix_mca_preg_compress.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_preg_compress.la
+lib = libpmix_mca_preg_compress.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_preg_compress_la_SOURCES = $(component_sources)
-mca_preg_compress_la_LDFLAGS = -module -avoid-version
+pmix_mca_preg_compress_la_SOURCES = $(component_sources)
+pmix_mca_preg_compress_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_preg_compress_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_preg_compress_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_preg_compress_la_SOURCES = $(lib_sources)
-libmca_preg_compress_la_LDFLAGS = -module -avoid-version
+libpmix_mca_preg_compress_la_SOURCES = $(lib_sources)
+libpmix_mca_preg_compress_la_LDFLAGS = -module -avoid-version

--- a/src/mca/preg/compress/preg_compress.h
+++ b/src/mca/preg/compress/preg_compress.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_mca_base_component_t mca_preg_compress_component;
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_preg_compress_component;
 extern pmix_preg_module_t pmix_preg_compress_module;
 
 END_C_DECLS

--- a/src/mca/preg/compress/preg_compress_component.c
+++ b/src/mca/preg/compress/preg_compress_component.c
@@ -42,7 +42,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_mca_base_component_t mca_preg_compress_component = {
+pmix_mca_base_component_t pmix_mca_preg_compress_component = {
     PMIX_PREG_BASE_VERSION_1_0_0,
 
     /* Component name and version */

--- a/src/mca/preg/native/Makefile.am
+++ b/src/mca/preg/native/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_preg_native_DSO
 lib =
 lib_sources =
-component = mca_preg_native.la
+component = pmix_mca_preg_native.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_preg_native.la
+lib = libpmix_mca_preg_native.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_preg_native_la_SOURCES = $(component_sources)
-mca_preg_native_la_LDFLAGS = -module -avoid-version
+pmix_mca_preg_native_la_SOURCES = $(component_sources)
+pmix_mca_preg_native_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_preg_native_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_preg_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_preg_native_la_SOURCES = $(lib_sources)
-libmca_preg_native_la_LDFLAGS = -module -avoid-version
+libpmix_mca_preg_native_la_SOURCES = $(lib_sources)
+libpmix_mca_preg_native_la_LDFLAGS = -module -avoid-version

--- a/src/mca/preg/native/preg_native.h
+++ b/src/mca/preg/native/preg_native.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_mca_base_component_t mca_preg_native_component;
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_preg_native_component;
 extern pmix_preg_module_t pmix_preg_native_module;
 
 END_C_DECLS

--- a/src/mca/preg/native/preg_native_component.c
+++ b/src/mca/preg/native/preg_native_component.c
@@ -41,7 +41,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_mca_base_component_t mca_preg_native_component = {
+pmix_mca_base_component_t pmix_mca_preg_native_component = {
     PMIX_PREG_BASE_VERSION_1_0_0,
 
     /* Component name and version */

--- a/src/mca/preg/raw/Makefile.am
+++ b/src/mca/preg/raw/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_preg_raw_DSO
 lib =
 lib_sources =
-component = mca_preg_raw.la
+component = pmix_mca_preg_raw.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_preg_raw.la
+lib = libpmix_mca_preg_raw.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_preg_raw_la_SOURCES = $(component_sources)
-mca_preg_raw_la_LDFLAGS = -module -avoid-version
+pmix_mca_preg_raw_la_SOURCES = $(component_sources)
+pmix_mca_preg_raw_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_preg_raw_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_preg_raw_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_preg_raw_la_SOURCES = $(lib_sources)
-libmca_preg_raw_la_LDFLAGS = -module -avoid-version
+libpmix_mca_preg_raw_la_SOURCES = $(lib_sources)
+libpmix_mca_preg_raw_la_LDFLAGS = -module -avoid-version

--- a/src/mca/preg/raw/preg_raw.h
+++ b/src/mca/preg/raw/preg_raw.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_mca_base_component_t mca_preg_raw_component;
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_preg_raw_component;
 extern pmix_preg_module_t pmix_preg_raw_module;
 
 END_C_DECLS

--- a/src/mca/preg/raw/preg_raw_component.c
+++ b/src/mca/preg/raw/preg_raw_component.c
@@ -41,7 +41,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_mca_base_component_t mca_preg_raw_component = {
+pmix_mca_base_component_t pmix_mca_preg_raw_component = {
     PMIX_PREG_BASE_VERSION_1_0_0,
 
     /* Component name and version */

--- a/src/mca/prm/base/prm_base_frame.c
+++ b/src/mca/prm/base/prm_base_frame.c
@@ -93,7 +93,7 @@ static pmix_status_t pmix_prm_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, prm, "PMIx Network Operations", NULL, pmix_prm_open,
-                                pmix_prm_close, mca_prm_base_static_components,
+                                pmix_prm_close, pmix_mca_prm_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_prm_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/prm/default/Makefile.am
+++ b/src/mca/prm/default/Makefile.am
@@ -1,6 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,10 +21,10 @@ sources = \
 if MCA_BUILD_pmix_prm_default_DSO
 lib =
 lib_sources =
-component = mca_prm_default.la
+component = pmix_mca_prm_default.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_prm_default.la
+lib = libpmix_mca_prm_default.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -31,12 +32,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_prm_default_la_SOURCES = $(component_sources)
-mca_prm_default_la_LDFLAGS = -module -avoid-version
+pmix_mca_prm_default_la_SOURCES = $(component_sources)
+pmix_mca_prm_default_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_prm_default_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_prm_default_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_prm_default_la_SOURCES = $(lib_sources)
-libmca_prm_default_la_LDFLAGS = -module -avoid-version
+libpmix_mca_prm_default_la_SOURCES = $(lib_sources)
+libpmix_mca_prm_default_la_LDFLAGS = -module -avoid-version

--- a/src/mca/prm/default/prm_default.c
+++ b/src/mca/prm/default/prm_default.c
@@ -49,7 +49,10 @@ static pmix_status_t default_notify(pmix_status_t status, const pmix_proc_t *sou
                                     pmix_data_range_t range, const pmix_info_t info[], size_t ninfo,
                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-pmix_prm_module_t pmix_prm_default_module = {.name = "default", .notify = default_notify};
+pmix_prm_module_t pmix_prm_default_module = {
+    .name = "default",
+    .notify = default_notify
+};
 
 static pmix_status_t default_notify(pmix_status_t status, const pmix_proc_t *source,
                                     pmix_data_range_t range, const pmix_info_t info[], size_t ninfo,

--- a/src/mca/prm/default/prm_default.h
+++ b/src/mca/prm/default/prm_default.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_default_component;
+PMIX_EXPORT extern pmix_prm_base_component_t pmix_mca_prm_default_component;
 extern pmix_prm_module_t pmix_prm_default_module;
 
 END_C_DECLS

--- a/src/mca/prm/default/prm_default_component.c
+++ b/src/mca/prm/default/prm_default_component.c
@@ -27,7 +27,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_prm_base_component_t mca_prm_default_component = {
+pmix_prm_base_component_t pmix_mca_prm_default_component = {
     PMIX_PRM_BASE_VERSION_1_0_0,
 
     /* Component name and version */

--- a/src/mca/prm/hpesmf/Makefile.am
+++ b/src/mca/prm/hpesmf/Makefile.am
@@ -1,6 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,10 +23,10 @@ sources = \
 if MCA_BUILD_pmix_prm_hpesmf_DSO
 lib =
 lib_sources =
-component = mca_prm_hpesmf.la
+component = pmix_mca_prm_hpesmf.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_prm_hpesmf.la
+lib = libpmix_mca_prm_hpesmf.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -33,13 +34,13 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_prm_hpesmf_la_SOURCES = $(component_sources)
-mca_prm_hpesmf_la_LIBADD = $(prm_hpesmf_LIBS)
-mca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)
+pmix_mca_prm_hpesmf_la_SOURCES = $(component_sources)
+pmix_mca_prm_hpesmf_la_LIBADD = $(prm_hpesmf_LIBS)
+pmix_mca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)
 if NEED_LIBPMIX
-mca_prm_hpesmf_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_prm_hpesmf_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_prm_hpesmf_la_SOURCES = $(lib_sources)
-libmca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)
+libpmix_mca_prm_hpesmf_la_SOURCES = $(lib_sources)
+libpmix_mca_prm_hpesmf_la_LDFLAGS = -module -avoid-version $(prm_hpesmf_LDFLAGS)

--- a/src/mca/prm/hpesmf/prm_hpesmf.h
+++ b/src/mca/prm/hpesmf/prm_hpesmf.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_hpesmf_component;
+PMIX_EXPORT extern pmix_prm_base_component_t pmix_mca_prm_hpesmf_component;
 extern pmix_prm_module_t pmix_prm_hpesmf_module;
 
 END_C_DECLS

--- a/src/mca/prm/hpesmf/prm_hpesmf_component.c
+++ b/src/mca/prm/hpesmf/prm_hpesmf_component.c
@@ -27,7 +27,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_prm_base_component_t mca_prm_hpesmf_component = {
+pmix_prm_base_component_t pmix_mca_prm_hpesmf_component = {
     .base = {
         PMIX_PRM_BASE_VERSION_1_0_0,
 

--- a/src/mca/prm/slurm/Makefile.am
+++ b/src/mca/prm/slurm/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,20 +21,20 @@ sources = \
 
 if MCA_BUILD_pmix_prm_slurm_DSO
 component_noinst =
-component_install = mca_prm_slurm.la
+component_install = pmix_mca_prm_slurm.la
 else
-component_noinst = libmca_prm_slurm.la
+component_noinst = libpmix_mca_prm_slurm.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_prm_slurm_la_SOURCES = $(sources)
-mca_prm_slurm_la_LDFLAGS = -module -avoid-version
+pmix_mca_prm_slurm_la_SOURCES = $(sources)
+pmix_mca_prm_slurm_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_prm_slurm_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_prm_slurm_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_prm_slurm_la_SOURCES = $(sources)
-libmca_prm_slurm_la_LDFLAGS = -module -avoid-version
+libpmix_mca_prm_slurm_la_SOURCES = $(sources)
+libpmix_mca_prm_slurm_la_LDFLAGS = -module -avoid-version

--- a/src/mca/prm/slurm/prm_slurm.h
+++ b/src/mca/prm/slurm/prm_slurm.h
@@ -22,7 +22,7 @@
 
 BEGIN_C_DECLS
 
-PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_slurm_component;
+PMIX_EXPORT extern pmix_prm_base_component_t pmix_mca_prm_slurm_component;
 extern pmix_prm_module_t pmix_prm_slurm_module;
 
 END_C_DECLS

--- a/src/mca/prm/slurm/prm_slurm_component.c
+++ b/src/mca/prm/slurm/prm_slurm_component.c
@@ -24,7 +24,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
 /*
  * Struct of function pointers and all that to let us be initialized
  */
-pmix_prm_base_component_t mca_prm_slurm_component = {
+pmix_prm_base_component_t pmix_mca_prm_slurm_component = {
     PMIX_PRM_BASE_VERSION_1_0_0,
     .pmix_mca_component_name = "slurm",
     PMIX_MCA_BASE_MAKE_VERSION(component, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,

--- a/src/mca/prm/tm/Makefile.am
+++ b/src/mca/prm/tm/Makefile.am
@@ -1,6 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,10 +23,10 @@ sources = \
 if MCA_BUILD_pmix_prm_tm_DSO
 lib =
 lib_sources =
-component = mca_prm_tm.la
+component = pmix_mca_prm_tm.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_prm_tm.la
+lib = libpmix_mca_prm_tm.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -33,13 +34,13 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_prm_tm_la_SOURCES = $(component_sources)
-mca_prm_tm_la_LIBADD = $(prm_tm_LIBS)
-mca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)
+pmix_mca_prm_tm_la_SOURCES = $(component_sources)
+pmix_mca_prm_tm_la_LIBADD = $(prm_tm_LIBS)
+pmix_mca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)
 if NEED_LIBPMIX
-mca_prm_tm_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_prm_tm_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_prm_tm_la_SOURCES = $(lib_sources)
-libmca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)
+libpmix_mca_prm_tm_la_SOURCES = $(lib_sources)
+libpmix_mca_prm_tm_la_LDFLAGS = -module -avoid-version $(prm_tm_LDFLAGS)

--- a/src/mca/prm/tm/prm_tm.h
+++ b/src/mca/prm/tm/prm_tm.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_prm_base_component_t mca_prm_tm_component;
+PMIX_EXPORT extern pmix_prm_base_component_t pmix_mca_prm_tm_component;
 extern pmix_prm_module_t pmix_prm_tm_module;
 
 END_C_DECLS

--- a/src/mca/prm/tm/prm_tm_component.c
+++ b/src/mca/prm/tm/prm_tm_component.c
@@ -27,7 +27,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_prm_base_component_t mca_prm_tm_component = {
+pmix_prm_base_component_t pmix_mca_prm_tm_component = {
     PMIX_PRM_BASE_VERSION_1_0_0,
 
     /* Component name and version */

--- a/src/mca/psec/base/psec_base_frame.c
+++ b/src/mca/psec/base/psec_base_frame.c
@@ -85,7 +85,7 @@ static pmix_status_t pmix_psec_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, psec, "PMIx Security Operations", NULL, pmix_psec_open,
-                                pmix_psec_close, mca_psec_base_static_components,
+                                pmix_psec_close, pmix_mca_psec_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_psec_base_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/psec/dummy_handshake/Makefile.am
+++ b/src/mca/psec/dummy_handshake/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,10 +36,10 @@ sources = \
 if MCA_BUILD_pmix_psec_dummy_handshake_DSO
 lib =
 lib_sources =
-component = mca_psec_dummy_handshake.la
+component = pmix_mca_psec_dummy_handshake.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psec_dummy_handshake.la
+lib = libpmix_mca_psec_dummy_handshake.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -46,14 +47,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psec_dummy_handshake_la_SOURCES = $(component_sources)
-mca_psec_dummy_handshake_la_LDFLAGS = -module -avoid-version
+pmix_mca_psec_dummy_handshake_la_SOURCES = $(component_sources)
+pmix_mca_psec_dummy_handshake_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psec_dummy_handshake_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psec_dummy_handshake_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psec_dummy_handshake_la_SOURCES = $(lib_sources)
-libmca_psec_dummy_handshake_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psec_dummy_handshake_la_SOURCES = $(lib_sources)
+libpmix_mca_psec_dummy_handshake_la_LDFLAGS = -module -avoid-version
 
 endif

--- a/src/mca/psec/dummy_handshake/psec_dummy_handshake.h
+++ b/src/mca/psec/dummy_handshake/psec_dummy_handshake.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_dummy_handshake_component;
+PMIX_EXPORT extern pmix_psec_base_component_t pmix_mca_psec_dummy_handshake_component;
 extern pmix_psec_module_t pmix_dummy_handshake_module;
 
 END_C_DECLS

--- a/src/mca/psec/dummy_handshake/psec_dummy_handshake_component.c
+++ b/src/mca/psec/dummy_handshake/psec_dummy_handshake_component.c
@@ -27,7 +27,7 @@ static pmix_psec_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psec_base_component_t mca_psec_dummy_handshake_component = {
+pmix_psec_base_component_t pmix_mca_psec_dummy_handshake_component = {
     .base = {
         PMIX_PSEC_BASE_VERSION_1_0_0,
 

--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,10 +34,10 @@ sources = \
 if MCA_BUILD_pmix_psec_munge_DSO
 lib =
 lib_sources =
-component = mca_psec_munge.la
+component = pmix_mca_psec_munge.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psec_munge.la
+lib = libpmix_mca_psec_munge.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -44,14 +45,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psec_munge_la_SOURCES = $(component_sources)
-mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
-mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
+pmix_mca_psec_munge_la_SOURCES = $(component_sources)
+pmix_mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+pmix_mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
 if NEED_LIBPMIX
-mca_psec_munge_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_psec_munge_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psec_munge_la_SOURCES = $(lib_sources)
-libmca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
-libmca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
+libpmix_mca_psec_munge_la_SOURCES = $(lib_sources)
+libpmix_mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+libpmix_mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)

--- a/src/mca/psec/munge/psec_munge.h
+++ b/src/mca/psec/munge/psec_munge.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,7 +18,7 @@ BEGIN_C_DECLS
 #include "src/mca/psec/psec.h"
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_munge_component;
+PMIX_EXPORT extern pmix_psec_base_component_t pmix_mca_psec_munge_component;
 extern pmix_psec_module_t pmix_munge_module;
 
 END_C_DECLS

--- a/src/mca/psec/munge/psec_munge_component.c
+++ b/src/mca/psec/munge/psec_munge_component.c
@@ -42,7 +42,7 @@ static pmix_psec_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psec_base_component_t mca_psec_munge_component = {
+pmix_psec_base_component_t pmix_mca_psec_munge_component = {
     .base = {
         PMIX_PSEC_BASE_VERSION_1_0_0,
 

--- a/src/mca/psec/native/Makefile.am
+++ b/src/mca/psec/native/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_psec_native_DSO
 lib =
 lib_sources =
-component = mca_psec_native.la
+component = pmix_mca_psec_native.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psec_native.la
+lib = libpmix_mca_psec_native.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psec_native_la_SOURCES = $(component_sources)
-mca_psec_native_la_LDFLAGS = -module -avoid-version
+pmix_mca_psec_native_la_SOURCES = $(component_sources)
+pmix_mca_psec_native_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psec_native_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psec_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psec_native_la_SOURCES = $(lib_sources)
-libmca_psec_native_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psec_native_la_SOURCES = $(lib_sources)
+libpmix_mca_psec_native_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psec/native/psec_native.h
+++ b/src/mca/psec/native/psec_native.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_native_component;
+PMIX_EXPORT extern pmix_psec_base_component_t pmix_mca_psec_native_component;
 extern pmix_psec_module_t pmix_native_module;
 
 END_C_DECLS

--- a/src/mca/psec/native/psec_native_component.c
+++ b/src/mca/psec/native/psec_native_component.c
@@ -42,7 +42,7 @@ static pmix_psec_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psec_base_component_t mca_psec_native_component = {
+pmix_psec_base_component_t pmix_mca_psec_native_component = {
     .base = {
         PMIX_PSEC_BASE_VERSION_1_0_0,
 

--- a/src/mca/psec/none/Makefile.am
+++ b/src/mca/psec/none/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_psec_none_DSO
 lib =
 lib_sources =
-component = mca_psec_none.la
+component = pmix_mca_psec_none.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psec_none.la
+lib = libpmix_mca_psec_none.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psec_none_la_SOURCES = $(component_sources)
-mca_psec_none_la_LDFLAGS = -module -avoid-version
+pmix_mca_psec_none_la_SOURCES = $(component_sources)
+pmix_mca_psec_none_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psec_none_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psec_none_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psec_none_la_SOURCES = $(lib_sources)
-libmca_psec_none_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psec_none_la_SOURCES = $(lib_sources)
+libpmix_mca_psec_none_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psec/none/psec_none.h
+++ b/src/mca/psec/none/psec_none.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_none_component;
+PMIX_EXPORT extern pmix_psec_base_component_t pmix_mca_psec_none_component;
 extern pmix_psec_module_t pmix_none_module;
 
 END_C_DECLS

--- a/src/mca/psec/none/psec_none_component.c
+++ b/src/mca/psec/none/psec_none_component.c
@@ -43,7 +43,7 @@ static pmix_psec_module_t *assign_module(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psec_base_component_t mca_psec_none_component = {
+pmix_psec_base_component_t pmix_mca_psec_none_component = {
     .base = {
         PMIX_PSEC_BASE_VERSION_1_0_0,
 

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -101,7 +101,7 @@ static int pmix_psensor_base_open(pmix_mca_base_open_flag_t flags)
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, psensor, "PMIx Monitoring Sensors", pmix_psensor_register,
                                 pmix_psensor_base_open, pmix_psensor_base_close,
-                                mca_psensor_base_static_components,
+                                pmix_mca_psensor_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_psensor_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/psensor/file/Makefile.am
+++ b/src/mca/psensor/file/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,20 +22,20 @@ sources = \
 
 if MCA_BUILD_pmix_psensor_file_DSO
 component_noinst =
-component_install = mca_psensor_file.la
+component_install = pmix_mca_psensor_file.la
 else
-component_noinst = libmca_psensor_file.la
+component_noinst = libpmix_mca_psensor_file.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_psensor_file_la_SOURCES = $(sources)
-mca_psensor_file_la_LDFLAGS = -module -avoid-version
+pmix_mca_psensor_file_la_SOURCES = $(sources)
+pmix_mca_psensor_file_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psensor_file_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psensor_file_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_psensor_file_la_SOURCES =$(sources)
-libmca_psensor_file_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psensor_file_la_SOURCES =$(sources)
+libpmix_mca_psensor_file_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -157,7 +157,7 @@ static void add_tracker(int sd, short flags, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* add the tracker to our list */
-    pmix_list_append(&mca_psensor_file_component.trackers, &ft->super);
+    pmix_list_append(&pmix_mca_psensor_file_component.trackers, &ft->super);
 
     /* setup the timer event */
     pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev, file_sample, ft);
@@ -233,12 +233,12 @@ static void del_tracker(int sd, short flags, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* remove the tracker from our list */
-    PMIX_LIST_FOREACH_SAFE (ft, ftnext, &mca_psensor_file_component.trackers, file_tracker_t) {
+    PMIX_LIST_FOREACH_SAFE (ft, ftnext, &pmix_mca_psensor_file_component.trackers, file_tracker_t) {
         if (ft->requestor != cd->requestor) {
             continue;
         }
         if (NULL == cd->id || (NULL != ft->id && 0 == strcmp(ft->id, cd->id))) {
-            pmix_list_remove_item(&mca_psensor_file_component.trackers, &ft->super);
+            pmix_list_remove_item(&pmix_mca_psensor_file_component.trackers, &ft->super);
             PMIX_RELEASE(ft);
         }
     }
@@ -338,7 +338,7 @@ static void file_sample(int sd, short args, void *cbdata)
                            ft->last_size, ctime(&ft->last_access), ctime(&ft->last_mod));
         }
         /* stop monitoring this client */
-        pmix_list_remove_item(&mca_psensor_file_component.trackers, &ft->super);
+        pmix_list_remove_item(&pmix_mca_psensor_file_component.trackers, &ft->super);
         /* generate an event */
         pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         source.rank = ft->requestor->info->pname.rank;

--- a/src/mca/psensor/file/psensor_file.h
+++ b/src/mca/psensor/file/psensor_file.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  *
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +30,7 @@ typedef struct {
     pmix_list_t trackers;
 } pmix_psensor_file_component_t;
 
-PMIX_EXPORT extern pmix_psensor_file_component_t mca_psensor_file_component;
+PMIX_EXPORT extern pmix_psensor_file_component_t pmix_mca_psensor_file_component;
 extern pmix_psensor_base_module_t pmix_psensor_file_module;
 
 END_C_DECLS

--- a/src/mca/psensor/file/psensor_file_component.c
+++ b/src/mca/psensor/file/psensor_file_component.c
@@ -24,7 +24,7 @@ static int psensor_file_open(void);
 static int psensor_file_close(void);
 static int psensor_file_query(pmix_mca_base_module_t **module, int *priority);
 
-pmix_psensor_file_component_t mca_psensor_file_component = {
+pmix_psensor_file_component_t pmix_mca_psensor_file_component = {
     .super = {
         PMIX_PSENSOR_BASE_VERSION_1_0_0,
 
@@ -44,7 +44,7 @@ pmix_psensor_file_component_t mca_psensor_file_component = {
 
 static int psensor_file_open(void)
 {
-    PMIX_CONSTRUCT(&mca_psensor_file_component.trackers, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_psensor_file_component.trackers, pmix_list_t);
     return PMIX_SUCCESS;
 }
 
@@ -61,6 +61,6 @@ static int psensor_file_query(pmix_mca_base_module_t **module, int *priority)
 
 static int psensor_file_close(void)
 {
-    PMIX_LIST_DESTRUCT(&mca_psensor_file_component.trackers);
+    PMIX_LIST_DESTRUCT(&pmix_mca_psensor_file_component.trackers);
     return PMIX_SUCCESS;
 }

--- a/src/mca/psensor/heartbeat/Makefile.am
+++ b/src/mca/psensor/heartbeat/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,20 +23,20 @@ sources = \
 
 if MCA_BUILD_pmix_psensor_heartbeat_DSO
 component_noinst =
-component_install = mca_psensor_heartbeat.la
+component_install = pmix_mca_psensor_heartbeat.la
 else
-component_noinst = libmca_psensor_heartbeat.la
+component_noinst = libpmix_mca_psensor_heartbeat.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_psensor_heartbeat_la_SOURCES = $(sources)
-mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
+pmix_mca_psensor_heartbeat_la_SOURCES = $(sources)
+pmix_mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psensor_heartbeat_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psensor_heartbeat_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_psensor_heartbeat_la_SOURCES =$(sources)
-libmca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psensor_heartbeat_la_SOURCES =$(sources)
+libpmix_mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -149,7 +149,7 @@ static void add_tracker(int sd, short flags, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* add the tracker to our list */
-    pmix_list_append(&mca_psensor_heartbeat_component.trackers, &ft->super);
+    pmix_list_append(&pmix_mca_psensor_heartbeat_component.trackers, &ft->super);
 
     /* setup the timer event */
     pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev, check_heartbeat, ft);
@@ -199,14 +199,14 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
     }
 
     /* if the recv hasn't been posted, so so now */
-    if (!mca_psensor_heartbeat_component.recv_active) {
+    if (!pmix_mca_psensor_heartbeat_component.recv_active) {
         /* setup to receive heartbeats */
         rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
         rcv->tag = PMIX_PTL_TAG_HEARTBEAT;
         rcv->cbfunc = pmix_psensor_heartbeat_recv_beats;
         /* add it to the beginning of the list of recvs */
         pmix_list_prepend(&pmix_ptl_base.posted_recvs, &rcv->super);
-        mca_psensor_heartbeat_component.recv_active = true;
+        pmix_mca_psensor_heartbeat_component.recv_active = true;
     }
 
     /* need to push into our event base to add this to our trackers */
@@ -226,13 +226,13 @@ static void del_tracker(int sd, short flags, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* remove the tracker from our list */
-    PMIX_LIST_FOREACH_SAFE (ft, ftnext, &mca_psensor_heartbeat_component.trackers,
+    PMIX_LIST_FOREACH_SAFE (ft, ftnext, &pmix_mca_psensor_heartbeat_component.trackers,
                             pmix_heartbeat_trkr_t) {
         if (ft->requestor != cd->requestor) {
             continue;
         }
         if (NULL == cd->id || (NULL != ft->id && 0 == strcmp(ft->id, cd->id))) {
-            pmix_list_remove_item(&mca_psensor_heartbeat_component.trackers, &ft->super);
+            pmix_list_remove_item(&pmix_mca_psensor_heartbeat_component.trackers, &ft->super);
             PMIX_RELEASE(ft);
         }
     }
@@ -326,7 +326,7 @@ static void add_beat(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* find this peer in our trackers */
-    PMIX_LIST_FOREACH (ft, &mca_psensor_heartbeat_component.trackers, pmix_heartbeat_trkr_t) {
+    PMIX_LIST_FOREACH (ft, &pmix_mca_psensor_heartbeat_component.trackers, pmix_heartbeat_trkr_t) {
         if (ft->requestor == b->peer) {
             /* increment the beat count */
             ++ft->nbeats;

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.h
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.h
@@ -33,7 +33,7 @@ typedef struct {
     pmix_list_t trackers;
 } pmix_psensor_heartbeat_component_t;
 
-PMIX_EXPORT extern pmix_psensor_heartbeat_component_t mca_psensor_heartbeat_component;
+PMIX_EXPORT extern pmix_psensor_heartbeat_component_t pmix_mca_psensor_heartbeat_component;
 extern pmix_psensor_base_module_t pmix_psensor_heartbeat_module;
 
 void pmix_psensor_heartbeat_recv_beats(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,

--- a/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
@@ -25,7 +25,7 @@ static int heartbeat_open(void);
 static int heartbeat_close(void);
 static int heartbeat_query(pmix_mca_base_module_t **module, int *priority);
 
-pmix_psensor_heartbeat_component_t mca_psensor_heartbeat_component = {
+pmix_psensor_heartbeat_component_t pmix_mca_psensor_heartbeat_component = {
     .super = {
           PMIX_PSENSOR_BASE_VERSION_1_0_0,
 
@@ -46,7 +46,7 @@ pmix_psensor_heartbeat_component_t mca_psensor_heartbeat_component = {
  */
 static int heartbeat_open(void)
 {
-    PMIX_CONSTRUCT(&mca_psensor_heartbeat_component.trackers, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_psensor_heartbeat_component.trackers, pmix_list_t);
 
     return PMIX_SUCCESS;
 }
@@ -64,7 +64,7 @@ static int heartbeat_query(pmix_mca_base_module_t **module, int *priority)
 
 static int heartbeat_close(void)
 {
-    PMIX_LIST_DESTRUCT(&mca_psensor_heartbeat_component.trackers);
+    PMIX_LIST_DESTRUCT(&pmix_mca_psensor_heartbeat_component.trackers);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/psquash/base/psquash_base_frame.c
+++ b/src/mca/psquash/base/psquash_base_frame.c
@@ -81,5 +81,5 @@ static pmix_status_t pmix_psquash_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, psquash, "PMIx Squash Operations", NULL, pmix_psquash_open,
-                                pmix_psquash_close, mca_psquash_base_static_components,
+                                pmix_psquash_close, pmix_mca_psquash_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/psquash/base/psquash_base_select.c
+++ b/src/mca/psquash/base/psquash_base_select.c
@@ -49,7 +49,6 @@ int pmix_psquash_base_select(void)
         return PMIX_SUCCESS;
     }
     pmix_psquash_globals.selected = true;
-
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH (cli, &pmix_psquash_base_framework.framework_components,
                        pmix_mca_base_component_list_item_t) {

--- a/src/mca/psquash/flex128/Makefile.am
+++ b/src/mca/psquash/flex128/Makefile.am
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2019      IBM Corporation.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,10 +22,10 @@ sources = \
 if MCA_BUILD_pmix_psquash_flex128_DSO
 lib =
 lib_sources =
-component = mca_psquash_flex128.la
+component = pmix_mca_psquash_flex128.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psquash_flex128.la
+lib = libpmix_mca_psquash_flex128.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -32,12 +33,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psquash_flex128_la_SOURCES = $(component_sources)
-mca_psquash_flex128_la_LDFLAGS = -module -avoid-version
+pmix_mca_psquash_flex128_la_SOURCES = $(component_sources)
+pmix_mca_psquash_flex128_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psquash_flex128_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psquash_flex128_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psquash_flex128_la_SOURCES = $(lib_sources)
-libmca_psquash_flex128_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psquash_flex128_la_SOURCES = $(lib_sources)
+libpmix_mca_psquash_flex128_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psquash/flex128/psquash_flex128.h
+++ b/src/mca/psquash/flex128/psquash_flex128.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psquash_base_component_t mca_psquash_flex128_component;
+PMIX_EXPORT extern pmix_psquash_base_component_t pmix_mca_psquash_flex128_component;
 extern pmix_psquash_base_module_t pmix_flex128_module;
 
 END_C_DECLS

--- a/src/mca/psquash/flex128/psquash_flex128_component.c
+++ b/src/mca/psquash/flex128/psquash_flex128_component.c
@@ -25,7 +25,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psquash_base_component_t mca_psquash_flex128_component = {
+pmix_psquash_base_component_t pmix_mca_psquash_flex128_component = {
     .base = {
         PMIX_PSQUASH_BASE_VERSION_1_0_0,
 

--- a/src/mca/psquash/native/Makefile.am
+++ b/src/mca/psquash/native/Makefile.am
@@ -5,6 +5,7 @@
 #                         All rights reserved.
 #
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,10 +25,10 @@ sources = \
 if MCA_BUILD_pmix_psquash_native_DSO
 lib =
 lib_sources =
-component = mca_psquash_native.la
+component = pmix_mca_psquash_native.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_psquash_native.la
+lib = libpmix_mca_psquash_native.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -35,12 +36,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_psquash_native_la_SOURCES = $(component_sources)
-mca_psquash_native_la_LDFLAGS = -module -avoid-version
+pmix_mca_psquash_native_la_SOURCES = $(component_sources)
+pmix_mca_psquash_native_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_psquash_native_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_psquash_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_psquash_native_la_SOURCES = $(lib_sources)
-libmca_psquash_native_la_LDFLAGS = -module -avoid-version
+libpmix_mca_psquash_native_la_SOURCES = $(lib_sources)
+libpmix_mca_psquash_native_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psquash/native/psquash_native.h
+++ b/src/mca/psquash/native/psquash_native.h
@@ -4,7 +4,7 @@
  *                         All rights reserve
  *
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +22,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psquash_base_component_t mca_psquash_native_component;
+PMIX_EXPORT extern pmix_psquash_base_component_t pmix_mca_psquash_native_component;
 extern pmix_psquash_base_module_t pmix_psquash_native_module;
 
 END_C_DECLS

--- a/src/mca/psquash/native/psquash_native_component.c
+++ b/src/mca/psquash/native/psquash_native_component.c
@@ -28,7 +28,7 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_psquash_base_component_t mca_psquash_native_component = {
+pmix_psquash_base_component_t pmix_mca_psquash_native_component = {
     .base = {
         PMIX_PSQUASH_BASE_VERSION_1_0_0,
 

--- a/src/mca/pstat/base/pstat_base_open.c
+++ b/src/mca/pstat/base/pstat_base_open.c
@@ -72,7 +72,7 @@ static int pmix_pstat_base_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pstat, "process statistics", NULL, pmix_pstat_base_open,
-                                pmix_pstat_base_close, mca_pstat_base_static_components, 0);
+                                pmix_pstat_base_close, pmix_mca_pstat_base_static_components, 0);
 
 static int pmix_pstat_base_unsupported_init(void)
 {

--- a/src/mca/pstat/linux/Makefile.am
+++ b/src/mca/pstat/linux/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,18 +31,18 @@ sources = \
 
 if MCA_BUILD_pmix_pstat_linux_DSO
 component_noinst =
-component_install = mca_pstat_linux.la
+component_install = pmix_mca_pstat_linux.la
 else
-component_noinst = libmca_pstat_linux.la
+component_noinst = libpmix_mca_pstat_linux.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_pstat_linux_la_SOURCES = $(sources)
-mca_pstat_linux_la_LDFLAGS = -module -avoid-version
-mca_pstat_linux_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pstat_linux_la_SOURCES = $(sources)
+pmix_mca_pstat_linux_la_LDFLAGS = -module -avoid-version
+pmix_mca_pstat_linux_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_pstat_linux_la_SOURCES =$(sources)
-libmca_pstat_linux_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pstat_linux_la_SOURCES =$(sources)
+libpmix_mca_pstat_linux_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pstat/linux/pstat_linux.h
+++ b/src/mca/pstat/linux/pstat_linux.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +41,7 @@ BEGIN_C_DECLS
 /**
  * Globally exported variable
  */
-PMIX_EXPORT extern const pmix_pstat_base_component_t mca_pstat_linux_component;
+PMIX_EXPORT extern const pmix_pstat_base_component_t pmix_mca_pstat_linux_component;
 
 PMIX_EXPORT extern const pmix_pstat_base_module_t pmix_pstat_linux_module;
 

--- a/src/mca/pstat/linux/pstat_linux_component.c
+++ b/src/mca/pstat/linux/pstat_linux_component.c
@@ -52,7 +52,7 @@ static int pstat_linux_component_query(pmix_mca_base_module_t **module, int *pri
  * and pointers to our public functions in it
  */
 
-const pmix_pstat_base_component_t mca_pstat_linux_component = {
+const pmix_pstat_base_component_t pmix_mca_pstat_linux_component = {
 
     PMIX_PSTAT_BASE_VERSION_1_0_0,
 

--- a/src/mca/pstat/test/Makefile.am
+++ b/src/mca/pstat/test/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,18 +31,18 @@ sources = \
 
 if MCA_BUILD_pmix_pstat_test_DSO
 component_noinst =
-component_install = mca_pstat_test.la
+component_install = pmix_mca_pstat_test.la
 else
-component_noinst = libmca_pstat_test.la
+component_noinst = libpmix_mca_pstat_test.la
 component_install =
 endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
-mca_pstat_test_la_SOURCES = $(sources)
-mca_pstat_test_la_LDFLAGS = -module -avoid-version
-mca_pstat_test_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_pstat_test_la_SOURCES = $(sources)
+pmix_mca_pstat_test_la_LDFLAGS = -module -avoid-version
+pmix_mca_pstat_test_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_pstat_test_la_SOURCES =$(sources)
-libmca_pstat_test_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pstat_test_la_SOURCES =$(sources)
+libpmix_mca_pstat_test_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pstat/test/pstat_test.h
+++ b/src/mca/pstat/test/pstat_test.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +35,7 @@ BEGIN_C_DECLS
  * Globally exported variable
  */
 
-PMIX_EXPORT extern const pmix_pstat_base_component_t mca_pstat_test_component;
+PMIX_EXPORT extern const pmix_pstat_base_component_t pmix_mca_pstat_test_component;
 
 PMIX_EXPORT extern const pmix_pstat_base_module_t pmix_pstat_test_module;
 

--- a/src/mca/pstat/test/pstat_test_component.c
+++ b/src/mca/pstat/test/pstat_test_component.c
@@ -52,7 +52,7 @@ static int pstat_test_component_query(pmix_mca_base_module_t **module, int *prio
  * and pointers to our public functions in it
  */
 
-const pmix_pstat_base_component_t mca_pstat_test_component = {
+const pmix_pstat_base_component_t pmix_mca_pstat_test_component = {
     /* Indicate that we are a pstat v1.1.0 component (which also
        implies a specific MCA version) */
 

--- a/src/mca/pstrg/base/pstrg_base_frame.c
+++ b/src/mca/pstrg/base/pstrg_base_frame.c
@@ -90,7 +90,7 @@ static int pmix_pstrg_base_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pstrg, "PMIx Storage Support", NULL, pmix_pstrg_base_open,
-                                pmix_pstrg_base_close, mca_pstrg_base_static_components,
+                                pmix_pstrg_base_close, pmix_mca_pstrg_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 PMIX_CLASS_INSTANCE(pmix_pstrg_active_module_t, pmix_list_item_t, NULL, NULL);

--- a/src/mca/pstrg/lustre/Makefile.am
+++ b/src/mca/pstrg/lustre/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,10 +36,10 @@ sources = \
 if MCA_BUILD_pmix_pstrg_lustre_DSO
 lib =
 lib_sources =
-component = mca_pstrg_lustre.la
+component = pmix_mca_pstrg_lustre.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pstrg_lustre.la
+lib = libpmix_mca_pstrg_lustre.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -46,14 +47,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pstrg_lustre_la_SOURCES = $(component_sources)
-mca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
-mca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)
+pmix_mca_pstrg_lustre_la_SOURCES = $(component_sources)
+pmix_mca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
+pmix_mca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)
 if NEED_LIBPMIX
-mca_pstrg_lustre_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_pstrg_lustre_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pstrg_lustre_la_SOURCES = $(lib_sources)
-libmca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
-libmca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)
+libpmix_mca_pstrg_lustre_la_SOURCES = $(lib_sources)
+libpmix_mca_pstrg_lustre_la_LIBADD = $(pstrg_lustre_LIBS)
+libpmix_mca_pstrg_lustre_la_LDFLAGS = -module -avoid-version $(pstrg_lustre_LDFLAGS)

--- a/src/mca/pstrg/lustre/pstrg_lustre.h
+++ b/src/mca/pstrg/lustre/pstrg_lustre.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +23,7 @@ typedef struct {
 } pmix_pstrg_lustre_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pstrg_lustre_component_t mca_pstrg_lustre_component;
+PMIX_EXPORT extern pmix_pstrg_lustre_component_t pmix_mca_pstrg_lustre_component;
 extern pmix_pstrg_base_module_t pmix_pstrg_lustre_module;
 
 END_C_DECLS

--- a/src/mca/pstrg/lustre/pstrg_lustre_component.c
+++ b/src/mca/pstrg/lustre/pstrg_lustre_component.c
@@ -43,7 +43,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pstrg_lustre_component_t mca_pstrg_lustre_component = {
+pmix_pstrg_lustre_component_t pmix_mca_pstrg_lustre_component = {
     .super = {
         PMIX_PSTRG_BASE_VERSION_1_0_0,
 
@@ -64,7 +64,7 @@ pmix_pstrg_lustre_component_t mca_pstrg_lustre_component = {
 
 static pmix_status_t component_register(void)
 {
-    //  pmix_mca_base_component_t *component = &mca_pstrg_lustre_component.super.base;
+    //  pmix_mca_base_component_t *component = &pmix_mca_pstrg_lustre_component.super.base;
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pstrg/vfs/Makefile.am
+++ b/src/mca/pstrg/vfs/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,10 +36,10 @@ sources = \
 if MCA_BUILD_pmix_pstrg_vfs_DSO
 lib =
 lib_sources =
-component = mca_pstrg_vfs.la
+component = pmix_mca_pstrg_vfs.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_pstrg_vfs.la
+lib = libpmix_mca_pstrg_vfs.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -46,14 +47,14 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_pstrg_vfs_la_SOURCES = $(component_sources)
-mca_pstrg_vfs_la_LIBADD = $(pstrg_vfs_LIBS)
-mca_pstrg_vfs_la_LDFLAGS = -module -avoid-version $(pstrg_vfs_LDFLAGS)
+pmix_mca_pstrg_vfs_la_SOURCES = $(component_sources)
+pmix_mca_pstrg_vfs_la_LIBADD = $(pstrg_vfs_LIBS)
+pmix_mca_pstrg_vfs_la_LDFLAGS = -module -avoid-version $(pstrg_vfs_LDFLAGS)
 if NEED_LIBPMIX
-mca_pstrg_vfs_la_LIBADD += $(top_builddir)/src/libpmix.la
+pmix_mca_pstrg_vfs_la_LIBADD += $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_pstrg_vfs_la_SOURCES = $(lib_sources)
-libmca_pstrg_vfs_la_LIBADD = $(pstrg_vfs_LIBS)
-libmca_pstrg_vfs_la_LDFLAGS = -module -avoid-version $(pstrg_vfs_LDFLAGS)
+libpmix_mca_pstrg_vfs_la_SOURCES = $(lib_sources)
+libpmix_mca_pstrg_vfs_la_LIBADD = $(pstrg_vfs_LIBS)
+libpmix_mca_pstrg_vfs_la_LDFLAGS = -module -avoid-version $(pstrg_vfs_LDFLAGS)

--- a/src/mca/pstrg/vfs/pstrg_vfs.h
+++ b/src/mca/pstrg/vfs/pstrg_vfs.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +23,7 @@ typedef struct {
 } pmix_pstrg_vfs_component_t;
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_pstrg_vfs_component_t mca_pstrg_vfs_component;
+PMIX_EXPORT extern pmix_pstrg_vfs_component_t pmix_mca_pstrg_vfs_component;
 extern pmix_pstrg_base_module_t pmix_pstrg_vfs_module;
 
 END_C_DECLS

--- a/src/mca/pstrg/vfs/pstrg_vfs_component.c
+++ b/src/mca/pstrg/vfs/pstrg_vfs_component.c
@@ -43,7 +43,7 @@ static pmix_status_t component_register(void);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-pmix_pstrg_vfs_component_t mca_pstrg_vfs_component = {
+pmix_pstrg_vfs_component_t pmix_mca_pstrg_vfs_component = {
     .super = {
         PMIX_PSTRG_BASE_VERSION_1_0_0,
 
@@ -64,7 +64,7 @@ pmix_pstrg_vfs_component_t mca_pstrg_vfs_component = {
 
 static pmix_status_t component_register(void)
 {
-    //  pmix_mca_base_component_t *component = &mca_pstrg_vfs_component.super.base;
+    //  pmix_mca_base_component_t *component = &pmix_mca_pstrg_vfs_component.super.base;
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -402,7 +402,7 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, ptl, "PMIx Transfer Layer", pmix_ptl_register, pmix_ptl_open,
-                                pmix_ptl_close, mca_ptl_base_static_components,
+                                pmix_ptl_close, pmix_mca_ptl_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
 /***   INSTANTIATE INTERNAL CLASSES   ***/

--- a/src/mca/ptl/client/Makefile.am
+++ b/src/mca/ptl/client/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_ptl_client_DSO
 lib =
 lib_sources =
-component = mca_ptl_client.la
+component = pmix_mca_ptl_client.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_ptl_client.la
+lib = libpmix_mca_ptl_client.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_ptl_client_la_SOURCES = $(component_sources)
-mca_ptl_client_la_LDFLAGS = -module -avoid-version
+pmix_mca_ptl_client_la_SOURCES = $(component_sources)
+pmix_mca_ptl_client_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_ptl_client_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_ptl_client_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_ptl_client_la_SOURCES = $(lib_sources)
-libmca_ptl_client_la_LDFLAGS = -module -avoid-version
+libpmix_mca_ptl_client_la_SOURCES = $(lib_sources)
+libpmix_mca_ptl_client_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ptl/client/ptl_client.h
+++ b/src/mca/ptl/client/ptl_client.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +26,7 @@
 
 BEGIN_C_DECLS
 
-extern pmix_ptl_base_component_t mca_ptl_client_component;
+extern pmix_ptl_base_component_t pmix_mca_ptl_client_component;
 
 extern pmix_ptl_module_t pmix_ptl_client_module;
 

--- a/src/mca/ptl/client/ptl_client_component.c
+++ b/src/mca/ptl/client/ptl_client_component.c
@@ -45,7 +45,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-PMIX_EXPORT pmix_ptl_base_component_t mca_ptl_client_component = {
+PMIX_EXPORT pmix_ptl_base_component_t pmix_mca_ptl_client_component = {
     .base = {
         PMIX_PTL_BASE_VERSION_2_0_0,
 
@@ -70,6 +70,6 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
     }
 
     *module = (pmix_mca_base_module_t *) &pmix_ptl_client_module;
-    *priority = mca_ptl_client_component.priority;
+    *priority = pmix_mca_ptl_client_component.priority;
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/server/Makefile.am
+++ b/src/mca/ptl/server/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_ptl_server_DSO
 lib =
 lib_sources =
-component = mca_ptl_server.la
+component = pmix_mca_ptl_server.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_ptl_server.la
+lib = libpmix_mca_ptl_server.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_ptl_server_la_SOURCES = $(component_sources)
-mca_ptl_server_la_LDFLAGS = -module -avoid-version
+pmix_mca_ptl_server_la_SOURCES = $(component_sources)
+pmix_mca_ptl_server_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_ptl_server_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_ptl_server_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_ptl_server_la_SOURCES = $(lib_sources)
-libmca_ptl_server_la_LDFLAGS = -module -avoid-version
+libpmix_mca_ptl_server_la_SOURCES = $(lib_sources)
+libpmix_mca_ptl_server_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ptl/server/ptl_server.h
+++ b/src/mca/ptl/server/ptl_server.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +26,7 @@
 
 BEGIN_C_DECLS
 
-extern pmix_ptl_base_component_t mca_ptl_server_component;
+extern pmix_ptl_base_component_t pmix_mca_ptl_server_component;
 
 extern pmix_ptl_module_t pmix_ptl_server_module;
 

--- a/src/mca/ptl/server/ptl_server_component.c
+++ b/src/mca/ptl/server/ptl_server_component.c
@@ -45,7 +45,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-PMIX_EXPORT pmix_ptl_base_component_t mca_ptl_server_component = {
+PMIX_EXPORT pmix_ptl_base_component_t pmix_mca_ptl_server_component = {
     .base = {
         PMIX_PTL_BASE_VERSION_2_0_0,
 
@@ -66,7 +66,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
     /* if I am a server and not a tool, then take me */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         *module = (pmix_mca_base_module_t *) &pmix_ptl_server_module;
-        *priority = mca_ptl_server_component.priority;
+        *priority = pmix_mca_ptl_server_component.priority;
         return PMIX_SUCCESS;
     }
 

--- a/src/mca/ptl/tool/Makefile.am
+++ b/src/mca/ptl/tool/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,10 +32,10 @@ sources = \
 if MCA_BUILD_pmix_ptl_tool_DSO
 lib =
 lib_sources =
-component = mca_ptl_tool.la
+component = pmix_mca_ptl_tool.la
 component_sources = $(headers) $(sources)
 else
-lib = libmca_ptl_tool.la
+lib = libpmix_mca_ptl_tool.la
 lib_sources = $(headers) $(sources)
 component =
 component_sources =
@@ -42,12 +43,12 @@ endif
 
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
-mca_ptl_tool_la_SOURCES = $(component_sources)
-mca_ptl_tool_la_LDFLAGS = -module -avoid-version
+pmix_mca_ptl_tool_la_SOURCES = $(component_sources)
+pmix_mca_ptl_tool_la_LDFLAGS = -module -avoid-version
 if NEED_LIBPMIX
-mca_ptl_tool_la_LIBADD = $(top_builddir)/src/libpmix.la
+pmix_mca_ptl_tool_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif
 
 noinst_LTLIBRARIES = $(lib)
-libmca_ptl_tool_la_SOURCES = $(lib_sources)
-libmca_ptl_tool_la_LDFLAGS = -module -avoid-version
+libpmix_mca_ptl_tool_la_SOURCES = $(lib_sources)
+libpmix_mca_ptl_tool_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ptl/tool/ptl_tool.h
+++ b/src/mca/ptl/tool/ptl_tool.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +36,7 @@
 
 BEGIN_C_DECLS
 
-extern pmix_ptl_base_component_t mca_ptl_tool_component;
+extern pmix_ptl_base_component_t pmix_mca_ptl_tool_component;
 
 extern pmix_ptl_module_t pmix_ptl_tool_module;
 

--- a/src/mca/ptl/tool/ptl_tool_component.c
+++ b/src/mca/ptl/tool/ptl_tool_component.c
@@ -45,7 +45,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
  */
-PMIX_EXPORT pmix_ptl_base_component_t mca_ptl_tool_component = {
+PMIX_EXPORT pmix_ptl_base_component_t pmix_mca_ptl_tool_component = {
     .base = {
         PMIX_PTL_BASE_VERSION_2_0_0,
 
@@ -71,6 +71,6 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
     }
 
     *module = (pmix_mca_base_module_t *) &pmix_ptl_tool_module;
-    *priority = mca_ptl_tool_component.priority;
+    *priority = pmix_mca_ptl_tool_component.priority;
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Separate MCA components by their project by including the
project name in the required MCA component library and
symbol.

Signed-off-by: Ralph Castain <rhc@pmix.org>