### PR TITLE
Add missing function and improve error message

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1824,9 +1824,11 @@ static inline void pmix_argv_free(char **argv)
 #define PMIX_ARGV_FREE(a)  pmix_argv_free(a)
 
 static inline
-char **pmix_argv_split(const char *src_string, int delimiter)
+char **pmix_argv_split_inter(const char *src_string,
+                             int delimiter,
+                             bool include_empty)
 {
-    char arg[256];
+    char arg[512];
     char **argv = NULL;
     const char *p;
     char *argtemp;
@@ -1844,6 +1846,12 @@ char **pmix_argv_split(const char *src_string, int delimiter)
         /* zero length argument, skip */
 
         if (src_string == p) {
+            if (include_empty) {
+                arg[0] = '\0';
+                if (PMIX_SUCCESS != pmix_argv_append_nosize(&argv, arg)) {
+                    return NULL;
+                }
+            }
             src_string = p + 1;
             continue;
         }
@@ -1860,7 +1868,7 @@ char **pmix_argv_split(const char *src_string, int delimiter)
 
         /* long argument, malloc buffer, copy and add */
 
-        else if (arglen > 255) {
+        else if (arglen > 511) {
             argtemp = (char *) malloc(arglen + 1);
             if (NULL == argtemp)
                 return NULL;
@@ -1893,6 +1901,18 @@ char **pmix_argv_split(const char *src_string, int delimiter)
     /* All done */
 
     return argv;
+}
+
+static inline
+char **pmix_argv_split_with_empty(const char *src_string, int delimiter)
+{
+    return pmix_argv_split_inter(src_string, delimiter, true);
+}
+
+static inline
+char **pmix_argv_split(const char *src_string, int delimiter)
+{
+    return pmix_argv_split_inter(src_string, delimiter, false);
 }
 
 #define PMIX_ARGV_SPLIT(a, b, c) \

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -456,18 +456,21 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
             err_msg = strdup("pmix_dl_open() error message was NULL!");
         } else if (file_exists(ri->ri_path, "lo") || file_exists(ri->ri_path, "so")
                    || file_exists(ri->ri_path, "dylib") || file_exists(ri->ri_path, "dll")) {
+            char *tmp;
             /* Because libltdl erroneously says "file not found" for any
              * type of error -- which is especially misleading when the file
              * is actually there but cannot be opened for some other reason
              * (e.g., missing symbol) -- do some simple huersitics and if
              * the file [probably] does exist, print a slightly better error
              * message. */
-            err_msg = strdup(
-                "perhaps a missing symbol, or compiled for a different version of OpenPMIx");
+            pmix_asprintf(&tmp,
+                          "\n    dlopen error: %s\n    Perhaps a missing symbol, or compiled for a different version of %s?",
+                          err_msg, framework->framework_project);
+            err_msg = tmp;
         }
         pmix_output_verbose(
             vl, 0, "pmix_mca_base_component_repository_open: unable to open %s: %s (ignored)",
-            ri->ri_base, err_msg);
+            ri->ri_path, err_msg);
 
         if (pmix_mca_base_component_track_load_errors) {
             pmix_mca_base_failed_component_t *f_comp = PMIX_NEW(pmix_mca_base_failed_component_t);

--- a/src/util/pmix_argv.h
+++ b/src/util/pmix_argv.h
@@ -94,24 +94,6 @@ PMIX_EXPORT pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *
  */
 PMIX_EXPORT pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg);
 
-/**
- * Split a string into a NULL-terminated argv array. Include empty
- * strings in result array.
- *
- * @param src_string Input string.
- * @param delimiter Delimiter character.
- *
- * @retval argv pointer to new argv array on success
- * @retval NULL on error
- *
- * All strings are inserted into the argv array by value; the
- * newly-allocated array makes no references to the src_string
- * argument (i.e., it can be freed after calling this function
- * without invalidating the output argv).
- */
-PMIX_EXPORT char **pmix_argv_split_with_empty(const char *src_string, int delimiter)
-    __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
-
 PMIX_EXPORT char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
     __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 


### PR DESCRIPTION
We were declaring pmix_argv_split_with_empty but never instantiated
it - do so. Include the original dlopen error when reporting possible
reasons the library could not be loaded.

Signed-off-by: Ralph Castain <rhc@pmix.org>