### PR TITLE
Ensure we always install the internal headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,14 +44,8 @@ if PMIX_TESTS_EXAMPLES
 SUBDIRS += . test/test_v2 test examples
 endif
 
-if WANT_INSTALL_HEADERS
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-
-else
-
-noinst_HEADERS = $(headers)
-endif
 
 include man/Makefile.include
 

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1096,26 +1096,10 @@ AC_ARG_ENABLE(debug-symbols,
               AS_HELP_STRING([--disable-debug-symbols],
                              [Disable adding compiler flags to enable debugging symbols if --enable-debug is specified.  For non-debugging builds, this flag has no effect.]))
 
-#
-# Do we want to install the internal devel headers?
-#
-AC_MSG_CHECKING([if want to install project-internal header files])
-AC_ARG_WITH(devel-headers,
-    AS_HELP_STRING([--with-devel-headers],
-                   [normal PMIx users/applications do not need this (pmix.h and friends are ALWAYS installed).  Developer headers are only necessary for authors doing deeper integration (default: disabled).]))
-if test "$with_devel_headers" = "yes"; then
-    AC_MSG_RESULT([yes])
-    WANT_INSTALL_HEADERS=1
-    pmix_install_primary_headers=yes
-else
-    AC_MSG_RESULT([no])
-    WANT_INSTALL_HEADERS=0
-fi
-
 AC_MSG_CHECKING([if want to install PMIx header files])
 AC_ARG_WITH(pmix-headers,
     AS_HELP_STRING([--with-pmix-headers],
-                   [Install the PMIx header files (default: enabled)]))
+                   [Install the PMIx header files (pmix.h and friends) (default: enabled)]))
 if test "$with_pmix_headers" != "no"; then
     AC_MSG_RESULT([yes])
     WANT_PRIMARY_HEADERS=1
@@ -1219,8 +1203,6 @@ fi
 
 AC_DEFINE_UNQUOTED([PMIX_ENABLE_TIMING], [$WANT_PMIX_TIMING],
                    [Whether we want developer-level timing support or not])
-
-AM_CONDITIONAL([WANT_INSTALL_HEADERS], [test $WANT_INSTALL_HEADERS -eq 1])
 
 #
 # Do we want to install binaries?
@@ -1393,7 +1375,6 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([PMIX_WANT_MUNGE], [test "$pmix_munge_support" = "1"])
         AM_CONDITIONAL([PMIX_WANT_SASL], [test "$pmix_sasl_support" = "1"])
         AM_CONDITIONAL([WANT_PRIMARY_HEADERS], [test "x$pmix_install_primary_headers" = "xyes"])
-        AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
         AM_CONDITIONAL(NEED_LIBPMIX, [test "$pmix_need_libpmix" = "1"])
         AM_CONDITIONAL([PMIX_HAVE_JANSSON], [test "x$pmix_check_jansson_happy" = "xyes"])
         AM_CONDITIONAL([PMIX_HAVE_CURL], [test "x$pmix_check_curl_happy" = "xyes"])

--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -16,7 +16,7 @@ dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -266,9 +266,7 @@ AC_DEFUN([PMIX_SETUP_WRAPPER_FINAL],[
 
     # We now have all relevant flags.  Substitute them in everywhere.
    AC_MSG_CHECKING([for PMIX CPPFLAGS])
-   if test "$WANT_INSTALL_HEADERS" = "1" ; then
-       PMIX_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}'
-   fi
+   PMIX_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}'
    PMIX_WRAPPER_EXTRA_CPPFLAGS="$PMIX_WRAPPER_EXTRA_CPPFLAGS $pmix_mca_wrapper_extra_cppflags $wrapper_extra_cppflags $with_wrapper_cppflags"
    PMIX_FLAGS_UNIQ(PMIX_WRAPPER_EXTRA_CPPFLAGS)
    AC_SUBST([PMIX_WRAPPER_EXTRA_CPPFLAGS])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,8 +82,6 @@ include tool/Makefile.include
 include tools/Makefile.include
 include common/Makefile.include
 
-if WANT_INSTALL_HEADERS
 nobase_pmix_HEADERS += $(headers)
-endif
 
 CLEANFILES = core.* *~

--- a/src/mca/bfrops/Makefile.am
+++ b/src/mca/bfrops/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_bfrops_la_SOURCES =
 headers = bfrops.h bfrops_types.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/common/sse/Makefile.am
+++ b/src/mca/common/sse/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2020      Intel, Inc. All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,11 +40,8 @@ libmca_common_sse_la_LDFLAGS += -version-info $(libmca_common_sse_so_version)
 endif
 libmca_common_sse_la_LIBADD = $(pmix_check_curl_LIBS)
 
-# Conditionally install the header files
-
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)
-endif
 
 MAINTAINERCLEANFILES = sse_lex.c

--- a/src/mca/gds/Makefile.am
+++ b/src/mca/gds/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_gds_la_SOURCES =
 headers = gds.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/pcompress/Makefile.am
+++ b/src/mca/pcompress/Makefile.am
@@ -4,6 +4,7 @@
 #                         Corporation.  All rights reserved.
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,11 +25,9 @@ libmca_pcompress_la_SOURCES += $(headers)
 # therefore the release date or version may have changed)
 $(nodist_man_MANS): $(top_builddir)/pmix/include/pmix_config.h
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/pdl/Makefile.am
+++ b/src/mca/pdl/Makefile.am
@@ -3,6 +3,7 @@
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,11 +24,10 @@ libmca_pdl_la_SOURCES += $(headers)
 # therefore the release date or version may have changed)
 $(nodist_man_MANS): $(top_builddir)/pmix/include/pmix_config.h
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
+
 
 include base/Makefile.am
 

--- a/src/mca/pfexec/Makefile.am
+++ b/src/mca/pfexec/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,11 +30,9 @@ dist_pmixdata_DATA =
 headers = pfexec.h
 libmca_pfexec_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/pgpu/Makefile.am
+++ b/src/mca/pgpu/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,11 +31,9 @@ libmca_pgpu_la_SOURCES =
 headers = pgpu.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/pif/Makefile.am
+++ b/src/mca/pif/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,11 +17,9 @@ libmca_pif_la_SOURCES =
 headers = pif.h
 libmca_pif_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/pinstalldirs/Makefile.am
+++ b/src/mca/pinstalldirs/Makefile.am
@@ -3,6 +3,7 @@
 #                         reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,11 +19,9 @@ libmca_pinstalldirs_la_SOURCES =
 headers = pinstalldirs.h
 libmca_pinstalldirs_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/plog/Makefile.am
+++ b/src/mca/plog/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_plog_la_SOURCES =
 headers = plog.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/pmdl/Makefile.am
+++ b/src/mca/pmdl/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_pmdl_la_SOURCES =
 headers = pmdl.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/pnet/Makefile.am
+++ b/src/mca/pnet/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_pnet_la_SOURCES =
 headers = pnet.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/preg/Makefile.am
+++ b/src/mca/preg/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_preg_la_SOURCES =
 headers = preg.h preg_types.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/prm/Makefile.am
+++ b/src/mca/prm/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_prm_la_SOURCES =
 headers = prm.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/psec/Makefile.am
+++ b/src/mca/psec/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_psec_la_SOURCES =
 headers = psec.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/psensor/Makefile.am
+++ b/src/mca/psensor/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,11 +21,9 @@ headers = psensor.h
 
 libmca_psensor_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/psquash/Makefile.am
+++ b/src/mca/psquash/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,11 +32,9 @@ libmca_psquash_la_SOURCES =
 headers = psquash.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 

--- a/src/mca/pstat/Makefile.am
+++ b/src/mca/pstat/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,11 +27,9 @@ libmca_pstat_la_SOURCES =
 headers = pstat.h
 libmca_pstat_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/pstrg/Makefile.am
+++ b/src/mca/pstrg/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,11 +21,9 @@ headers = pstrg.h
 
 libmca_pstrg_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.am
 

--- a/src/mca/ptl/Makefile.am
+++ b/src/mca/ptl/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,11 +31,9 @@ libmca_ptl_la_SOURCES =
 headers = ptl.h ptl_types.h
 sources =
 
-# Conditionally install the header files
-if WANT_INSTALL_HEADERS
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
-endif
 
 include base/Makefile.include
 


### PR DESCRIPTION
Always install the headers as they are now required by PRRTE.

Fixes https://github.com/openpmix/prrte/issues/1219

Signed-off-by: Ralph Castain <rhc@pmix.org>