### PR TITLE
Push additional include in pkg-config/wrappers

### DIFF
--- a/maint/pmix.pc.in
+++ b/maint/pmix.pc.in
@@ -9,4 +9,4 @@ Version: @PACKAGE_VERSION@
 URL: https://pmix.org/
 Libs: -L${libdir} -lpmix
 Libs.private: @PC_PRIVATE_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I@pmixincludedir@

--- a/src/tools/wrapper/pmixcc-wrapper-data.txt.in
+++ b/src/tools/wrapper/pmixcc-wrapper-data.txt.in
@@ -21,5 +21,5 @@ libs_static=-lpmix @PMIX_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=libpmix.@PMIX_DYN_LIB_SUFFIX@
 static_lib_file=libpmix.a
 required_file=
-includedir=${includedir}
+includedir=${includedir} @pmixincludedir@
 libdir=${libdir}


### PR DESCRIPTION
With the changes to allow PRRTE to rely on PMIx's utilities, we
need extra include directories for packages to pull in those
dependencies.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>