### PR TITLE
Reset getopt() to 0, not 1.

### DIFF
--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -112,7 +112,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
 
     /* reset the parser - must be done each time we use it
      * to avoid hysteresis */
-    optind = 1;
+    optind = 0;
     opterr = 0;
     optopt = 0;
     optarg = NULL;
@@ -122,7 +122,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
         argind = optind;
         // This is the executable, or we are at the last argument.
         // Don't process any further.
-        if (optind == argc || '-' != argv[optind][0]) {
+        if (optind == argc || (optind > 0 && '-' != argv[optind][0])) {
             break;
         }
         opt = getopt_long(argc, argv, shorts, myoptions, &option_index);


### PR DESCRIPTION
According to the getopt_long() docs, it should be reset on the
second invocation when parsing the same command line:

"A program that scans multiple argument vectors, or rescans the
same vector more than once, and wants to make use of GNU
extensions such as '+' and '-' at the start of optstring, or
changes the value of POSIXLY_CORRECT between scans, must
reinitialize getopt() by resetting optind to 0, rather than the
traditional value of 1. (Resetting to 0 forces the invocation of
an internal initialization routine that rechecks POSIXLY_CORRECT
and checks for GNU extensions in optstring.)"
https://man7.org/linux/man-pages/man3/getopt.3.html

Since prrte makes use of '-' at the start of opt-string - this seems
to apply. I made the mistake of resetting this to 1 to fix a different
bug, instead make sure we don't check for a '-' on the first optind
to ignore prterun/mpirun/prun/ect.

Introduced here: 48a68cfe0e7fd99c06f4a0ed1770c9c7f00454bc

Port from prte v2.1 branch: https://github.com/openpmix/prrte/pull/1233

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>