### PR TITLE
Silence warnings in pmixt_validate_predefined().

### DIFF
--- a/test/test_v2/test_clientapp_funcs.c
+++ b/test/test_v2/test_clientapp_funcs.c
@@ -256,7 +256,7 @@ void pmixt_post_finalize(pmix_proc_t *this_proc, test_params *l_params, validati
 
 /* This function is used to validate values returned from calls to PMIx_Get against
    side channel validation data */
-void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key, pmix_value_t *value,
+void pmixt_validate_predefined(pmix_proc_t *myproc, const char *key, pmix_value_t *value,
                                const pmix_data_type_t expected_type, validation_params *v_params)
 {
     pmix_status_t rc = PMIX_ERROR;

--- a/test/test_v2/test_common.h
+++ b/test/test_v2/test_common.h
@@ -239,7 +239,7 @@ void pmixt_post_init(pmix_proc_t *this_proc, test_params *params, validation_par
 void pmixt_post_finalize(pmix_proc_t *this_proc, test_params *params, validation_params *v_params);
 void pmixt_pre_init(int argc, char **argv, test_params *params, validation_params *v_params,
                     int (*parse_tst_ptr)(int *, int, char **, test_params *, validation_params *));
-void pmixt_validate_predefined(pmix_proc_t *myproc, const pmix_key_t key, pmix_value_t *value,
+void pmixt_validate_predefined(pmix_proc_t *myproc, const char *key, pmix_value_t *value,
                                const pmix_data_type_t expected_type, validation_params *val_params);
 
 char *pmixt_encode(const void *val, size_t vallen);


### PR DESCRIPTION
Silence "reading 512 bytes from a region of size X" warnings generated
by GCC 11.2.0. This may be a spurious warning, but once that is
generated nonetheless. The problem seems to come from a function
definition with a static length char buffer (pmix_key_t) with call-sites
passing string constants that are strictly shorter than the size of
pmix_key_t. This usage seems atypical in the codebase, so perhaps there
is a better way to silence these particular warnings.

A similar warning is generated at a call-site in
test/test_v2/server_callbacks.c at line 323 involving a call to
PMIx_server_register_nspace(), but this one is stickier, so someone else
should look into that one. Note: changing the string constant to a char*
variable does not silence this one. Pesky, pesky.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>