### PR TITLE
Provide a "hook" for PRRTE to init a small amount of PMIx

### DIFF
--- a/src/mca/pif/base/base.h
+++ b/src/mca/pif/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,7 +13,7 @@
 #ifndef PMIX_PIF_BASE_H
 #define PMIX_PIF_BASE_H
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 
 #include "src/mca/base/pmix_mca_base_framework.h"
 

--- a/src/mca/pif/pif.h
+++ b/src/mca/pif/pif.h
@@ -71,23 +71,6 @@ BEGIN_C_DECLS
 #define DEFAULT_NUMBER_INTERFACES 10
 #define MAX_PIFCONF_SIZE          10 * 1024 * 1024
 
-typedef struct pmix_pif_t {
-    pmix_list_item_t super;
-    char if_name[PMIX_IF_NAMESIZE + 1];
-    int if_index;
-    uint16_t if_kernel_index;
-    uint16_t af_family;
-    int if_flags;
-    int if_speed;
-    struct sockaddr_storage if_addr;
-    uint32_t if_mask;
-    uint32_t if_bandwidth;
-    uint8_t if_mac[6];
-    int ifmtu; /* Can't use if_mtu because of a
-                  #define collision on some BSDs */
-} pmix_pif_t;
-PMIX_CLASS_DECLARATION(pmix_pif_t);
-
 /* "global" list of available interfaces */
 extern pmix_list_t pmix_if_list;
 

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -14,6 +14,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,7 +28,8 @@ dist_pmixdata_DATA += runtime/help-pmix-runtime.txt
 
 headers += \
         runtime/pmix_rte.h \
-        runtime/pmix_progress_threads.h
+        runtime/pmix_progress_threads.h \
+        runtime/pmix_init_util.h
 
 sources += \
         runtime/pmix_finalize.c \

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file **/
+
+#ifndef PMIX_INIT_UTIL_H
+#define PMIX_INIT_UTIL_H
+
+#include "src/include/pmix_config.h"
+#include "pmix_common.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo);
+
+END_C_DECLS
+
+#endif /* PMIX_INIT_UTIL_H */

--- a/src/util/pmix_if.h
+++ b/src/util/pmix_if.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "pmix_common.h"
+#include "src/class/pmix_list.h"
 
 #define PMIX_IF_NAMESIZE 256
 
@@ -52,6 +53,31 @@ BEGIN_C_DECLS
 #define PMIX_PIF_ASSEMBLE_FABRIC(n1, n2, n3, n4)                                           \
     (((n1) << 24) & 0xFF000000) | (((n2) << 16) & 0x00FF0000) | (((n3) << 8) & 0x0000FF00) \
         | ((n4) &0x000000FF)
+
+typedef struct pmix_pif_t {
+    pmix_list_item_t super;
+    char if_name[PMIX_IF_NAMESIZE + 1];
+    int if_index;
+    uint16_t if_kernel_index;
+    uint16_t af_family;
+    int if_flags;
+    int if_speed;
+    struct sockaddr_storage if_addr;
+    uint32_t if_mask;
+    uint32_t if_bandwidth;
+    uint8_t if_mac[6];
+    int ifmtu; /* Can't use if_mtu because of a
+                #define collision on some BSDs */
+} pmix_pif_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pif_t);
+
+
+/* "global" list of available interfaces */
+PMIX_EXPORT extern pmix_list_t pmix_if_list;
+
+/* global flags */
+PMIX_EXPORT extern bool pmix_if_do_not_resolve;
+PMIX_EXPORT extern bool pmix_if_retain_loopback;
 
 /**
  *  Lookup an interface by name and return its primary address.


### PR DESCRIPTION
Now that PRRTE directly depends on PMIx classes and frameworks,
we need to ensure that some small portion of PMIx is setup
prior to PRRTE attempting to use it. Create a new "pmix_init_util"
for this purpose. Need to isolate that prototype in its own
include header to avoid pulling in a bunch of other stuff.

The PMIx interface framework was the immediate problem as PRRTE
tried to traverse a list prior to it being constructed.

Signed-off-by: Ralph Castain <rhc@pmix.org>