### PR TITLE
Publicize virtual memory utility functions.

### DIFF
--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,25 +61,6 @@ BEGIN_C_DECLS
 #    define HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC 1
 
 #endif
-
-typedef enum {
-    VM_HOLE_NONE = -1,
-    VM_HOLE_BEGIN = 0,        /* use hole at the very beginning */
-    VM_HOLE_AFTER_HEAP = 1,   /* use hole right after heap */
-    VM_HOLE_BEFORE_STACK = 2, /* use hole right before stack */
-    VM_HOLE_BIGGEST = 3,      /* use biggest hole */
-    VM_HOLE_IN_LIBS = 4,      /* use biggest hole between heap and stack */
-    VM_HOLE_CUSTOM = 5,       /* use given address if available */
-} pmix_hwloc_vm_hole_kind_t;
-
-typedef enum {
-    VM_MAP_FILE = 0,
-    VM_MAP_ANONYMOUS = 1,
-    VM_MAP_HEAP = 2,
-    VM_MAP_STACK = 3,
-    VM_MAP_OTHER = 4 /* vsyscall/vdso/vvar shouldn't occur since we stop after stack */
-} pmix_hwloc_vm_map_kind_t;
-
 
 /**
  * Register params

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -5,8 +5,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
  * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,21 +15,6 @@
  */
 
 #include "src/include/pmix_config.h"
-
-#include <string.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
-#include <time.h>
 
 #include "include/pmix_common.h"
 
@@ -51,97 +36,69 @@
 #include "src/mca/gds/base/base.h"
 #include "gds_shmem.h"
 
-static pmix_status_t shmem_init(pmix_info_t info[], size_t ninfo);
-static void shmem_finalize(void);
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
 
-static pmix_status_t shmem_assign_module(pmix_info_t *info, size_t ninfo,
-                                        int *priority);
-
-static pmix_status_t shmem_cache_job_info(struct pmix_namespace_t *ns, pmix_info_t info[],
-                                          size_t ninfo);
-
-static pmix_status_t shmem_register_job_info(struct pmix_peer_t *pr, pmix_buffer_t *reply);
-
-static pmix_status_t shmem_store_job_info(const char *nspace, pmix_buffer_t *buf);
-
-static pmix_status_t shmem_store(const pmix_proc_t *proc, pmix_scope_t scope,
-                                 pmix_kval_t *kv);
-
-static pmix_status_t shmem_store_modex(struct pmix_namespace_t *ns,
-                                       pmix_buffer_t *buff,
-                                       void *cbdata);
-
-static pmix_status_t shmem_fetch(const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
-                                 const char *key, pmix_info_t qualifiers[], size_t nqual,
-                                 pmix_list_t *kvs);
-
-static pmix_status_t setup_fork(const pmix_proc_t *peer, char ***env);
-
-static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs, pmix_info_t info[],
-                                size_t ninfo);
-
-static pmix_status_t nspace_del(const char *nspace);
-
-static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, pmix_buffer_t *bo,
-                                    void *cbdata);
-
-static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
-
-pmix_gds_base_module_t pmix_shmem_module = {
-    .name = "shmem",
-    .is_tsafe = false,
-    .init = shmem_init,
-    .finalize = shmem_finalize,
-    .assign_module = shmem_assign_module,
-    .cache_job_info = shmem_cache_job_info,
-    .register_job_info = shmem_register_job_info,
-    .store_job_info = shmem_store_job_info,
-    .store = shmem_store,
-    .store_modex = shmem_store_modex,
-    .fetch = shmem_fetch,
-    .setup_fork = setup_fork,
-    .add_nspace = nspace_add,
-    .del_nspace = nspace_del,
-    .assemb_kvs_req = assemb_kvs_req,
-    .accept_kvs_resp = accept_kvs_resp
-};
-
-static pmix_status_t shmem_init(pmix_info_t info[], size_t ninfo)
-{
+static pmix_status_t
+init(
+    pmix_info_t info[],
+    size_t ninfo
+) {
     PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "gds: shmem init");
+    pmix_output_verbose(
+        2, pmix_gds_base_framework.framework_output,
+        "gds: %s init", PMIX_GDS_SHMEM_NAME
+    );
 
     return PMIX_SUCCESS;
 }
 
-static void shmem_finalize(void)
+static void
+finalize(void)
 {
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "gds: shmem finalize");
-
+    pmix_output_verbose(
+        2, pmix_gds_base_framework.framework_output,
+        "gds: %s finalize", PMIX_GDS_SHMEM_NAME
+    );
 }
 
-static pmix_status_t shmem_assign_module(pmix_info_t *info, size_t ninfo,
-                                        int *priority)
-{
-    size_t n, m;
-    char **options;
-    bool specified = false;
-
+static pmix_status_t
+assign_module(
+    pmix_info_t *info,
+    size_t ninfo,
+    int *priority
+) {
     /* ONLY CLIENTS ENTER HERE */
-    /* the incoming info always overrides anything in the environment
-     * as it is set by the application itself */
+    bool specified = false;
+    /* The incoming info always overrides anything in the
+     * environment as it is set by the application itself. */
     *priority = 0;
     if (NULL != info) {
-        for (n=0; n < ninfo; n++) {
+        char **options = NULL;
+        for (size_t n = 0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {
-                specified = true;  // they specified who they want
+                specified = true;  /* They specified who they want. */
                 options = pmix_argv_split(info[n].value.data.string, ',');
-                for (m=0; NULL != options[m]; m++) {
-                    if (0 == strcmp(options[m], "shmem")) {
-                        /* they specifically asked for us */
+                for (size_t m = 0; NULL != options[m]; m++) {
+                    if (0 == strcmp(options[m], PMIX_GDS_SHMEM_NAME)) {
+                        /* They specifically asked for us. */
                         *priority = 100;
                         break;
                     }
@@ -151,103 +108,153 @@ static pmix_status_t shmem_assign_module(pmix_info_t *info, size_t ninfo,
             }
         }
     }
-    /* if they didn't specify, or they specified us, then we are
-     * a candidate for use */
+    /* If they didn't specify, or they specified us,
+     * then we are a candidate for use. */
     if (!specified || 100 == *priority) {
-        /* look for the rendezvous envars - if they are found, then
+        /* Look for the rendezvous envars: if they are found, then
          * we connect to that hole. Otherwise, we have to reject */
         *priority = 0;
     }
-
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t shmem_cache_job_info(struct pmix_namespace_t *ns, pmix_info_t info[],
-                                          size_t ninfo)
-{
-    PMIX_HIDE_UNUSED_PARAMS(ns, info, ninfo);
-
+static pmix_status_t
+cache_job_info(
+    struct pmix_namespace_t *ns,
+    pmix_info_t info[],
+    size_t ninfo
+) {
     /* ONLY SERVERS ENTER HERE */
-    /* go and get a hole for this nspace, then record the
+    PMIX_HIDE_UNUSED_PARAMS(ns, info, ninfo);
+    /* Go and get a hole for this nspace, then record the
      * provided data in the shmem */
     return PMIX_ERR_NOT_SUPPORTED;
 
 }
 
-static pmix_status_t shmem_register_job_info(struct pmix_peer_t *pr, pmix_buffer_t *reply)
-{
-    PMIX_HIDE_UNUSED_PARAMS(pr, reply);
-
+static pmix_status_t
+register_job_info(
+    struct pmix_peer_t *pr,
+    pmix_buffer_t *reply
+) {
     /* ONLY SERVERS ENTER HERE */
-    /* since the data is already in the shmem when we cached it, there
-     * is nothing to do here */
+    PMIX_HIDE_UNUSED_PARAMS(pr, reply);
+    /* Since the data is already in the shmem when we
+     * cached it, there is nothing to do here. */
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t shmem_store_job_info(const char *nspace, pmix_buffer_t *buf)
-{
+static pmix_status_t
+store_job_info(
+    const char *nspace,
+    pmix_buffer_t *buf
+) {
     PMIX_HIDE_UNUSED_PARAMS(nspace, buf);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t shmem_store(const pmix_proc_t *proc,
-                                pmix_scope_t scope,
-                                pmix_kval_t *kv)
-{
+static pmix_status_t
+store(
+    const pmix_proc_t *proc,
+    pmix_scope_t scope,
+    pmix_kval_t *kv
+) {
     PMIX_HIDE_UNUSED_PARAMS(proc, scope, kv);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t shmem_store_modex(struct pmix_namespace_t *ns,
-                                      pmix_buffer_t *buff,
-                                      void *cbdata)
-{
+static pmix_status_t
+store_modex(
+    struct pmix_namespace_t *ns,
+    pmix_buffer_t *buff,
+    void *cbdata
+) {
     PMIX_HIDE_UNUSED_PARAMS(ns, buff, cbdata);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t shmem_fetch(const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
-                                 const char *key, pmix_info_t qualifiers[], size_t nqual,
-                                 pmix_list_t *kvs)
-{
+static pmix_status_t
+fetch(
+    const pmix_proc_t *proc,
+    pmix_scope_t scope,
+    bool copy,
+    const char *key,
+    pmix_info_t qualifiers[],
+    size_t nqual,
+    pmix_list_t *kvs
+) {
     PMIX_HIDE_UNUSED_PARAMS(proc, scope, copy, key, qualifiers, nqual, kvs);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-
-static pmix_status_t setup_fork(const pmix_proc_t *peer, char ***env)
-{
+static pmix_status_t
+setup_fork(
+    const pmix_proc_t *peer,
+    char ***env
+) {
     PMIX_HIDE_UNUSED_PARAMS(peer, env);
-
     /* add the hole rendezvous info for this proc's nspace
      * to the proc's environment */
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs, pmix_info_t info[],
-                                size_t ninfo)
-{
+static pmix_status_t
+nspace_add(
+    const char *nspace,
+    uint32_t nlocalprocs,
+    pmix_info_t info[],
+    size_t ninfo
+) {
     PMIX_HIDE_UNUSED_PARAMS(nspace, nlocalprocs, info, ninfo);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t nspace_del(const char *nspace)
-{
+static pmix_status_t
+nspace_del(
+    const char *nspace
+) {
     PMIX_HIDE_UNUSED_PARAMS(nspace);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc,
-                                    pmix_list_t *kvs,
-                                    pmix_buffer_t *bo,
-                                    void *cbdata)
-{
+static pmix_status_t
+assemb_kvs_req(
+    const pmix_proc_t *proc,
+    pmix_list_t *kvs,
+    pmix_buffer_t *bo,
+    void *cbdata
+) {
     PMIX_HIDE_UNUSED_PARAMS(proc, kvs, bo, cbdata);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
-{
+static pmix_status_t
+accept_kvs_resp(
+    pmix_buffer_t *buf
+) {
     PMIX_HIDE_UNUSED_PARAMS(buf);
     return PMIX_ERR_NOT_SUPPORTED;
 }
+
+pmix_gds_base_module_t pmix_shmem_module = {
+    .name = PMIX_GDS_SHMEM_NAME,
+    .is_tsafe = false,
+    .init = init,
+    .finalize = finalize,
+    .assign_module = assign_module,
+    .cache_job_info = cache_job_info,
+    .register_job_info = register_job_info,
+    .store_job_info = store_job_info,
+    .store = store,
+    .store_modex = store_modex,
+    .fetch = fetch,
+    .setup_fork = setup_fork,
+    .add_nspace = nspace_add,
+    .del_nspace = nspace_del,
+    .assemb_kvs_req = assemb_kvs_req,
+    .accept_kvs_resp = accept_kvs_resp
+};
+
+/*
+ * vim: ft=cpp ts=4 sts=4 sw=4 expandtab
+ */

--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- *
  * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +17,11 @@
 #include "src/class/pmix_pointer_array.h"
 #include "src/mca/gds/gds.h"
 
+/**
+ * The name of this module.
+ */
+#define PMIX_GDS_SHMEM_NAME "shmem"
+
 BEGIN_C_DECLS
 
 typedef struct {
@@ -24,7 +29,7 @@ typedef struct {
     pmix_pointer_array_t assignments;
 } pmix_gds_shmem_component_t;
 
-/* the component must be visible data for the linker to find it */
+/* The component must be visible data for the linker to find it. */
 PMIX_EXPORT extern pmix_gds_shmem_component_t pmix_mca_gds_shmem_component;
 extern pmix_gds_base_module_t pmix_shmem_module;
 

--- a/src/mca/gds/shmem/gds_shmem_component.c
+++ b/src/mca/gds/shmem/gds_shmem_component.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,54 +31,31 @@
 #include "src/include/pmix_config.h"
 #include "include/pmix_common.h"
 
+#include "gds_shmem.h"
+
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
-#include "src/mca/gds/gds.h"
-#include "gds_shmem.h"
-
-static pmix_status_t component_open(void);
-static pmix_status_t component_close(void);
-static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
-
-/*
- * Instantiate the public struct with all of our public information
- * and pointers to our public functions in it
- */
-pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
-    .base = {
-        PMIX_GDS_BASE_VERSION_1_0_0,
-
-        /* Component name and version */
-        .pmix_mca_component_name = "shmem",
-        PMIX_MCA_BASE_MAKE_VERSION(component,
-                                   PMIX_MAJOR_VERSION,
-                                   PMIX_MINOR_VERSION,
-                                   PMIX_RELEASE_VERSION),
-
-        /* Component open and close functions */
-        .pmix_mca_open_component = component_open,
-        .pmix_mca_close_component = component_close,
-        .pmix_mca_query_component = component_query,
-    },
-    .assignments = PMIX_POINTER_ARRAY_STATIC_INIT
-};
-
-
-static int component_open(void)
+static int
+component_open(void)
 {
     return PMIX_SUCCESS;
 }
 
-static int component_query(pmix_mca_base_module_t **module, int *priority)
-{
-    /* see if the required system file is present */
+static int
+component_query(
+    pmix_mca_base_module_t **module,
+    int *priority
+) {
+    /* See if the required system file is present.
+     * See pmix_vmem_find_hole() for more information. */
     if (access("/proc/self/maps", F_OK) == -1) {
         *priority = 0;
         *module = NULL;
         return PMIX_ERROR;
-    } else {
+    }
+    else {
         *priority = 0;
         *module = NULL;
         return PMIX_ERROR;
@@ -88,8 +66,33 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
     return PMIX_SUCCESS;
 }
 
-
-static int component_close(void)
+static int
+component_close(void)
 {
     return PMIX_SUCCESS;
 }
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
+    .base = {
+        PMIX_GDS_BASE_VERSION_1_0_0,
+        /* Component name and version */
+        .pmix_mca_component_name = PMIX_GDS_SHMEM_NAME,
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_query_component = component_query,
+    },
+    .assignments = PMIX_POINTER_ARRAY_STATIC_INIT
+};
+
+/*
+ * vim: ft=cpp ts=4 sts=4 sw=4 expandtab
+ */

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -54,6 +54,7 @@ headers = \
         getid.h \
         strnlen.h \
         pmix_shmem.h \
+        pmix_vmem.h \
         hash.h \
         pmix_name_fns.h \
         pmix_net.h \
@@ -83,6 +84,7 @@ sources = \
         pmix_path.c \
         getid.c \
         pmix_shmem.c \
+        pmix_vmem.c \
         hash.c \
         pmix_name_fns.c \
         pmix_net.c \

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -105,7 +105,7 @@ pmix_shmem_segment_unlink(
 
 static void tkcon(pmix_vm_tracker_t *p)
 {
-    p->hole_kind = VM_HOLE_BIGGEST;
+    p->hole_kind = VMEM_HOLE_BIGGEST;
     p->size = 0;
     p->address = 0;
     p->fd = -1;

--- a/src/util/pmix_shmem.h
+++ b/src/util/pmix_shmem.h
@@ -14,6 +14,8 @@
 #include "src/include/pmix_config.h"
 #include "include/pmix_common.h"
 #include "src/class/pmix_object.h"
+// TODO(skg) We may be able to remove this. See below, if refactored.
+#include "src/util/pmix_vmem.h"
 
 typedef struct pmix_shmem_t {
     /* Size of shared-memory segment. */
@@ -47,28 +49,10 @@ pmix_shmem_segment_unlink(
     pmix_shmem_t *shmem
 );
 
-typedef enum {
-    VM_HOLE_NONE = -1,
-    VM_HOLE_BEGIN = 0,        /* use hole at the very beginning */
-    VM_HOLE_AFTER_HEAP = 1,   /* use hole right after heap */
-    VM_HOLE_BEFORE_STACK = 2, /* use hole right before stack */
-    VM_HOLE_BIGGEST = 3,      /* use biggest hole */
-    VM_HOLE_IN_LIBS = 4,      /* use biggest hole between heap and stack */
-    VM_HOLE_CUSTOM = 5,       /* use given address if available */
-} pmix_vm_hole_kind_t;
-
-typedef enum {
-    VM_MAP_FILE = 0,
-    VM_MAP_ANONYMOUS = 1,
-    VM_MAP_HEAP = 2,
-    VM_MAP_STACK = 3,
-    VM_MAP_OTHER = 4 /* vsyscall/vdso/vvar shouldn't occur since we stop after stack */
-} pmix_vm_map_kind_t;
-
-
+// TODO(skg) Think about restructuring this.
 typedef struct {
     pmix_object_t super;
-    pmix_vm_hole_kind_t hole_kind;
+    pmix_vmem_hole_kind_t hole_kind;
     size_t size;
     uintptr_t address;
     int fd;

--- a/src/util/pmix_vmem.c
+++ b/src/util/pmix_vmem.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2021-2022 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/util/pmix_vmem.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_string_copy.h"
+
+#ifdef HAVE_ERRNO_H
+#include "errno.h"
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <sys/mman.h>
+
+#define ALIGN2MB  (2 * 1024 * 1024UL)
+#define ALIGN64MB (64 * 1024 * 1024UL)
+
+static int
+parse_map_line(
+    const char *line,
+    unsigned long *beginp,
+    unsigned long *endp,
+    pmix_vmem_map_kind_t *kindp
+) {
+    const char *tmp = line, *next;
+    unsigned long value;
+
+    /* "beginaddr-endaddr " */
+    value = strtoull(tmp, (char **) &next, 16);
+    if (next == tmp) {
+        return PMIX_ERROR;
+    }
+
+    *beginp = (unsigned long) value;
+
+    if (*next != '-') {
+        return PMIX_ERROR;
+    }
+
+    tmp = next + 1;
+
+    value = strtoull(tmp, (char **) &next, 16);
+    if (next == tmp) {
+        return PMIX_ERROR;
+    }
+    *endp = (unsigned long) value;
+    tmp = next;
+
+    if (*next != ' ') {
+        return PMIX_ERROR;
+    }
+    tmp = next + 1;
+
+    /* look for ending absolute path */
+    next = strchr(tmp, '/');
+    if (next) {
+        *kindp = VMEM_MAP_FILE;
+    } else {
+        /* look for ending special tag [foo] */
+        next = strchr(tmp, '[');
+        if (next) {
+            if (!strncmp(next, "[heap]", 6)) {
+                *kindp = VMEM_MAP_HEAP;
+            } else if (!strncmp(next, "[stack]", 7)) {
+                *kindp = VMEM_MAP_STACK;
+            } else {
+                char *end;
+                if ((end = strchr(next, '\n')) != NULL) {
+                    *end = '\0';
+                }
+                *kindp = VMEM_MAP_OTHER;
+            }
+        } else {
+            *kindp = VMEM_MAP_ANONYMOUS;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t
+use_hole(
+    unsigned long holebegin,
+    unsigned long holesize,
+    unsigned long *addrp,
+    unsigned long size
+) {
+    unsigned long aligned;
+    unsigned long middle = holebegin + holesize / 2;
+
+    if (holesize < size) {
+        return PMIX_ERROR;
+    }
+
+    /* try to align the middle of the hole on 64MB for POWER's 64k-page PMD */
+    aligned = (middle + ALIGN64MB) & ~(ALIGN64MB - 1);
+    if (aligned + size <= holebegin + holesize) {
+        *addrp = aligned;
+        return PMIX_SUCCESS;
+    }
+
+    /* try to align the middle of the hole on 2MB for x86 PMD */
+    aligned = (middle + ALIGN2MB) & ~(ALIGN2MB - 1);
+    if (aligned + size <= holebegin + holesize) {
+        *addrp = aligned;
+        return PMIX_SUCCESS;
+    }
+
+    /* just use the end of the hole */
+    *addrp = holebegin + holesize - size;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t
+pmix_vmem_find_hole(
+    pmix_vmem_hole_kind_t hkind,
+    size_t *addrp,
+    size_t size
+) {
+    unsigned long biggestbegin = 0;
+    unsigned long biggestsize = 0;
+    unsigned long prevend = 0;
+    pmix_vmem_map_kind_t prevmkind = VMEM_MAP_OTHER;
+    int in_libs = 0;
+    FILE *file;
+    char line[96];
+
+    file = fopen("/proc/self/maps", "r");
+    if (!file) {
+        return PMIX_ERROR;
+    }
+
+    while (fgets(line, sizeof(line), file) != NULL) {
+        unsigned long begin = 0, end = 0;
+        pmix_vmem_map_kind_t mkind = VMEM_MAP_OTHER;
+
+        if (!parse_map_line(line, &begin, &end, &mkind)) {
+            switch (hkind) {
+                case VMEM_HOLE_BEGIN:
+                    fclose(file);
+                    return use_hole(0, begin, addrp, size);
+
+                case VMEM_HOLE_AFTER_HEAP:
+                    if (prevmkind == VMEM_MAP_HEAP && mkind != VMEM_MAP_HEAP) {
+                        /* only use HEAP when there's no other HEAP after it
+                         * (there can be several of them consecutively).
+                         */
+                        fclose(file);
+                        return use_hole(prevend, begin - prevend, addrp, size);
+                    }
+                    break;
+
+                case VMEM_HOLE_BEFORE_STACK:
+                    if (mkind == VMEM_MAP_STACK) {
+                        fclose(file);
+                        return use_hole(prevend, begin - prevend, addrp, size);
+                    }
+                    break;
+
+                case VMEM_HOLE_IN_LIBS:
+                    /* see if we are between heap and stack */
+                    if (prevmkind == VMEM_MAP_HEAP) {
+                        in_libs = 1;
+                    }
+                    if (mkind == VMEM_MAP_STACK) {
+                        in_libs = 0;
+                    }
+                    if (!in_libs) {
+                        /* we're not in libs, ignore this entry */
+                        break;
+                    }
+                    /* we're in libs, consider this entry for searching the biggest hole below */
+                    /* fallthrough */
+
+                case VMEM_HOLE_BIGGEST:
+                    if (begin - prevend > biggestsize) {
+                        biggestbegin = prevend;
+                        biggestsize = begin - prevend;
+                    }
+                    break;
+
+                default:
+                    assert(0);
+            }
+        }
+
+        while (!strchr(line, '\n')) {
+            if (!fgets(line, sizeof(line), file)) {
+                goto done;
+            }
+        }
+
+        if (mkind == VMEM_MAP_STACK) {
+            /* Don't go beyond the stack. Other VMAs are special (vsyscall, vvar, vdso, etc),
+             * There's no spare room there. And vsyscall is even above the userspace limit.
+             */
+            break;
+        }
+
+        prevend = end;
+        prevmkind = mkind;
+    }
+
+done:
+    fclose(file);
+    if (hkind == VMEM_HOLE_IN_LIBS || hkind == VMEM_HOLE_BIGGEST) {
+        return use_hole(biggestbegin, biggestsize, addrp, size);
+    }
+
+    return PMIX_ERROR;
+}

--- a/src/util/pmix_vmem.h
+++ b/src/util/pmix_vmem.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_UTIL_VMEM_H
+#define PMIX_UTIL_VMEM_H
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_common.h"
+
+typedef enum {
+    VMEM_HOLE_NONE = -1,
+    /** Use hole at the very beginning. */
+    VMEM_HOLE_BEGIN = 0,
+    /** Use hole right after the heap. */
+    VMEM_HOLE_AFTER_HEAP = 1,
+    /* Use hole right before stack. */
+    VMEM_HOLE_BEFORE_STACK = 2,
+    /* Use the biggest hole. */
+    VMEM_HOLE_BIGGEST = 3,
+    /* Use the biggest hole between heap and stack. */
+    VMEM_HOLE_IN_LIBS = 4,
+    /* Use given address, if available. */
+    VMEM_HOLE_CUSTOM = 5,
+} pmix_vmem_hole_kind_t;
+
+typedef enum {
+    VMEM_MAP_FILE = 0,
+    VMEM_MAP_ANONYMOUS = 1,
+    VMEM_MAP_HEAP = 2,
+    VMEM_MAP_STACK = 3,
+    /** vsyscall/vdso/vvar shouldn't occur since we stop after stack. */
+    VMEM_MAP_OTHER = 4
+} pmix_vmem_map_kind_t;
+
+PMIX_EXPORT pmix_status_t
+pmix_vmem_find_hole(
+    pmix_vmem_hole_kind_t hkind,
+    size_t *addrp,
+    size_t size
+);
+
+#endif


### PR DESCRIPTION
Make public virtual memory utility functions previously found in
src/hwloc. In particular, find_hole() is now made public as
pmix_vmem_find_hole() in utils/pmix_vmem.c. Other infrastructure will
soon make use this capability, namely gds/shmem.

Additionally, this commit checkpoints insignificant changes to
gds/shmem and utils/pmix_shmem.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>