### PR TITLE
Modify pmix_show_help_init() to take an addition helpdir.

### DIFF
--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -102,7 +102,7 @@ static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel, int room_n
 
 static bool util_initialized = false;
 
-int pmix_init_util(pmix_info_t info[], size_t ninfo)
+int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir)
 {
     pmix_status_t ret;
 
@@ -135,7 +135,7 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo)
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(helpdir);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (ret = pmix_util_keyval_parse_init())) {
@@ -208,7 +208,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 
     pmix_init_called = true;
 
-    if (PMIX_SUCCESS != pmix_init_util(info, ninfo)) {
+    if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;
     }
 

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -30,7 +30,7 @@
 
 BEGIN_C_DECLS
 
-PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
 
 END_C_DECLS
 

--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {

--- a/src/tools/pmix_info/pmix_info.c
+++ b/src/tools/pmix_info/pmix_info.c
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (ret = pmix_util_keyval_parse_init())) {

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -474,7 +474,7 @@ int main(int argc, char *argv[])
     }
 
     /* initialize the help system */
-    pmix_show_help_init();
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (ret = pmix_util_keyval_parse_init())) {

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -49,7 +49,7 @@ static char **search_dirs = NULL;
 /*
  * Local functions
  */
-int pmix_show_help_init(void)
+int pmix_show_help_init(char *helpdir)
 {
     pmix_output_stream_t lds;
 
@@ -58,6 +58,9 @@ int pmix_show_help_init(void)
     output_stream = pmix_output_open(&lds);
 
     pmix_argv_append_nosize(&search_dirs, pmix_pinstall_dirs.pmixdatadir);
+    if(NULL != helpdir) {
+        pmix_argv_append_nosize(&search_dirs, helpdir);
+    }
 
     return PMIX_SUCCESS;
 }

--- a/src/util/pmix_show_help.h
+++ b/src/util/pmix_show_help.h
@@ -103,7 +103,7 @@ BEGIN_C_DECLS
  *
  * Initialization of show_help subsystem
  */
-PMIX_EXPORT int pmix_show_help_init(void);
+PMIX_EXPORT int pmix_show_help_init(char *helpdir);
 
 /**
  * \internal


### PR DESCRIPTION
This way prte help files can be added to the search path.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>