### PR TITLE
Expose the pmix_tool_basename param

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -81,8 +81,6 @@ static int shmemfd = -1;
 static bool space_available = false;
 static uint64_t amount_space_avail = 0;
 
-static int parse_map_line(const char *line, unsigned long *beginp, unsigned long *endp,
-                          pmix_vmem_map_kind_t *kindp);
 static int enough_space(const char *filename, size_t space_req, uint64_t *space_avail,
                         bool *result);
 #endif

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -57,7 +57,6 @@
 
 const char* PMIX_PROXY_VERSION = PMIX_PROXY_VERSION_STRING;
 const char* PMIX_PROXY_BUGREPORT = PMIX_PROXY_BUGREPORT_STRING;
-const char* pmix_tool_basename = NULL;
 
 static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd,
                             pmix_epilog_t *epi);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -43,6 +43,7 @@
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/event/pmix_event.h"
+#include "src/runtime/pmix_init_util.h"
 #include "src/threads/pmix_threads.h"
 
 #include "src/mca/bfrops/bfrops.h"
@@ -621,7 +622,6 @@ PMIX_EXPORT extern pmix_globals_t pmix_globals;
 PMIX_EXPORT extern pmix_lock_t pmix_global_lock;
 PMIX_EXPORT extern const char* PMIX_PROXY_VERSION;
 PMIX_EXPORT extern const char* PMIX_PROXY_BUGREPORT;
-PMIX_EXPORT extern const char* pmix_tool_basename;
 
 static inline bool pmix_check_node_info(const char *key)
 {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -66,6 +66,7 @@
 #include "src/runtime/pmix_init_util.h"
 
 const char pmix_version_string[] = PMIX_IDENT_STRING;
+const char* pmix_tool_basename = NULL;
 
 PMIX_EXPORT int pmix_initialized = 0;
 PMIX_EXPORT bool pmix_init_called = false;

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -30,6 +30,8 @@
 
 BEGIN_C_DECLS
 
+PMIX_EXPORT extern const char* pmix_tool_basename;
+
 PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
 
 END_C_DECLS


### PR DESCRIPTION
Do it in pmix_init_util.h so upper levels can access it
without pulling in a bunch of extra stuff.

Also, fix unused function error.

Signed-off-by: Ralph Castain <rhc@pmix.org>