### PR TITLE
Properly handle tools that have tools connected to them

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -146,7 +146,7 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_recv_blocking(int sd, char *data, size_t
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect(struct sockaddr_storage *addr, pmix_socklen_t len,
                                                 int *fd);
 PMIX_EXPORT void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata);
-PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_listener(void);
+PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_listener(pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_send_connect_ack(int sd);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_recv_connect_ack(int sd);
 PMIX_EXPORT void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err);

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -218,9 +218,9 @@ static void lost_connection(pmix_peer_t *peer)
             }
         }
 
-    } else {
-        /* if I am a client, there is only
-         * one connection we can have */
+    } else if (peer == pmix_client_globals.myserver) {
+        /* if this was the server to which I am connected,
+         * then we need to exit */
         pmix_globals.connected = false;
         /* it is possible that we have sendrecv's in progress where
          * we are waiting for a response to arrive. Since we have

--- a/src/mca/ptl/server/ptl_server.c
+++ b/src/mca/ptl/server/ptl_server.c
@@ -31,63 +31,9 @@
 #include "ptl_server.h"
 #include "src/mca/ptl/base/base.h"
 
-static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo);
-
-pmix_ptl_module_t pmix_ptl_server_module = {.name = "server",
-                                            .connect_to_peer = pmix_ptl_base_connect_to_peer,
-                                            .setup_fork = pmix_ptl_base_setup_fork,
-                                            .setup_listener = setup_listener};
-
-static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo)
-{
-    pmix_status_t rc;
-    size_t n;
-
-    for (n = 0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, PMIX_SERVER_SESSION_SUPPORT)) {
-            pmix_ptl_base.session_tool = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SYSTEM_SUPPORT)) {
-            pmix_ptl_base.system_tool = PMIX_INFO_TRUE(&info[n]);
-        } else if (0 == strcmp(info[n].key, PMIX_SERVER_TOOL_SUPPORT)) {
-            pmix_ptl_base.tool_support = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_REMOTE_CONNECTIONS)) {
-            pmix_ptl_base.remote_connections = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_INCLUDE)) {
-            pmix_ptl_base.if_include = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_EXCLUDE)) {
-            pmix_ptl_base.if_exclude = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV4_PORT)) {
-            pmix_ptl_base.ipv4_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV6_PORT)) {
-            pmix_ptl_base.ipv6_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV4)) {
-            pmix_ptl_base.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
-            pmix_ptl_base.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_REPORT_URI)) {
-            if (NULL != pmix_ptl_base.report_uri) {
-                free(pmix_ptl_base.report_uri);
-            }
-            pmix_ptl_base.report_uri = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
-            if (NULL != pmix_ptl_base.session_tmpdir) {
-                free(pmix_ptl_base.session_tmpdir);
-            }
-            pmix_ptl_base.session_tmpdir = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
-            if (NULL != pmix_ptl_base.system_tmpdir) {
-                free(pmix_ptl_base.system_tmpdir);
-            }
-            pmix_ptl_base.system_tmpdir = strdup(info[n].value.data.string);
-        }
-    }
-
-    if (NULL != pmix_ptl_base.if_include && NULL != pmix_ptl_base.if_exclude) {
-        pmix_show_help("help-ptl-base.txt", "include-exclude", true, pmix_ptl_base.if_include,
-                       pmix_ptl_base.if_exclude);
-        return PMIX_ERR_SILENT;
-    }
-
-    rc = pmix_ptl_base_setup_listener();
-    return rc;
-}
+pmix_ptl_module_t pmix_ptl_server_module = {
+    .name = "server",
+    .connect_to_peer = pmix_ptl_base_connect_to_peer,
+    .setup_fork = pmix_ptl_base_setup_fork,
+    .setup_listener = pmix_ptl_base_setup_listener
+};

--- a/src/mca/ptl/tool/ptl_tool.c
+++ b/src/mca/ptl/tool/ptl_tool.c
@@ -34,41 +34,20 @@
 
 static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo);
 
-pmix_ptl_module_t pmix_ptl_tool_module = {.name = "tool",
-                                          .connect_to_peer = pmix_ptl_base_connect_to_peer,
-                                          .setup_fork = pmix_ptl_base_setup_fork,
-                                          .setup_listener = setup_listener};
+pmix_ptl_module_t pmix_ptl_tool_module = {
+    .name = "tool",
+    .connect_to_peer = pmix_ptl_base_connect_to_peer,
+    .setup_fork = pmix_ptl_base_setup_fork,
+    .setup_listener = setup_listener
+};
 
 static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo)
 {
     pmix_status_t rc;
     char **clnup = NULL, *cptr = NULL;
     pmix_info_t dir;
-    size_t n;
 
-    for (n = 0; n < ninfo; n++) {
-        if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_INCLUDE)) {
-            pmix_ptl_base.if_include = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_EXCLUDE)) {
-            pmix_ptl_base.if_exclude = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV4_PORT)) {
-            pmix_ptl_base.ipv4_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV6_PORT)) {
-            pmix_ptl_base.ipv6_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV4)) {
-            pmix_ptl_base.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
-            pmix_ptl_base.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
-        }
-    }
-
-    if (NULL != pmix_ptl_base.if_include && NULL != pmix_ptl_base.if_exclude) {
-        pmix_show_help("help-ptl-base.txt", "include-exclude", true, pmix_ptl_base.if_include,
-                       pmix_ptl_base.if_exclude);
-        return PMIX_ERR_SILENT;
-    }
-
-    rc = pmix_ptl_base_setup_listener();
+    rc = pmix_ptl_base_setup_listener(info, ninfo);
     if (PMIX_SUCCESS != rc) {
         return rc;
     }


### PR DESCRIPTION
Don't automatically terminate if a connection is dropped
unless it is to the "active" server. Consolidate some of
the connection code between servers and tools to remove
duplication.

Signed-off-by: Ralph Castain <rhc@pmix.org>