### PR TITLE
Prohibit Python bindings with non-shared lib builds

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1233,6 +1233,14 @@ if test "$enable_python_bindings" != "yes"; then
     WANT_PYTHON_BINDINGS=0
 else
     AC_MSG_RESULT([yes])
+    # cannot build Python bindings if we are doing a purely static build
+    if test "$enable_shared" = "no"; then
+        AC_MSG_WARN([Python bindings cannot be built in purely])
+        AC_MSG_WARN([static configurations. Please either enable])
+        AC_MSG_WARN([shared libraries or remove the request to])
+        AC_MSG_WARN([build the Python bindings])
+        AC_MSG_ERROR([Cannot continue])
+    fi
     WANT_PYTHON_BINDINGS=1
     AM_PATH_PYTHON([3.4], [pmix_python_good=yes], [pmix_python_good=no])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -140,7 +140,7 @@ AC_DEFUN([PMIX_CANONICALIZE_PATH],[
         # of MacOS Cataline / 10.15).  Instead, use Python, because we
         # know MacOS comes with a /usr/bin/python that has
         # os.path.realpath.
-        $2=`/usr/bin/python -c 'import os; print os.path.realpath("'$1'")'`
+        $2=`python -c 'import os, __future__ ; print(os.path.realpath("'$1'"))'`
         ;;
     *)
         $2=`readlink -f $1`


### PR DESCRIPTION
Cython takes issue with purely static builds, so error
out if the user requests the Python bindings but has
specified --disable-shared.

Also fix a problem with the "canonicalize_path" function
in configure - new versions of MacOS (i.e., starting with
Mojave) do _not_ have a /usr/bin/python, but do have
"readlink", so use it instead

Fixes https://github.com/openpmix/openpmix/issues/2482
Signed-off-by: Ralph Castain <rhc@pmix.org>