### PR TITLE
Runtime: Add tool version, org, and custom message.

### DIFF
--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -67,6 +67,10 @@
 
 const char pmix_version_string[] = PMIX_IDENT_STRING;
 const char* pmix_tool_basename = NULL;
+const char* pmix_tool_version = PMIX_VERSION;
+const char* pmix_tool_org = "PMIx";
+const char* pmix_tool_msg = PMIX_PROXY_BUGREPORT_STRING;
+
 
 PMIX_EXPORT int pmix_initialized = 0;
 PMIX_EXPORT bool pmix_init_called = false;

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -31,6 +31,9 @@
 BEGIN_C_DECLS
 
 PMIX_EXPORT extern const char* pmix_tool_basename;
+PMIX_EXPORT extern const char* pmix_tool_version;
+PMIX_EXPORT extern const char* pmix_tool_org;
+PMIX_EXPORT extern const char* pmix_tool_msg;
 
 PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
 

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -231,10 +231,10 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 } else if (NULL == optarg) {
                     // high-level help request
                     str = pmix_show_help_string(helpfile, "usage", false,
-                                                pmix_tool_basename, "PMIx",
-                                                PMIX_PROXY_VERSION,
+                                                pmix_tool_basename, pmix_tool_org,
+                                                pmix_tool_version,
                                                 pmix_tool_basename,
-                                                PMIX_PROXY_BUGREPORT);
+                                                pmix_tool_msg);
                     if (NULL != str) {
                         printf("%s", str);
                         free(str);
@@ -251,9 +251,9 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 return PMIX_ERR_SILENT;
             case 'V':
                 str = pmix_show_help_string(helpfile, "version", false,
-                                            pmix_tool_basename, "PMIx",
-                                            PMIX_PROXY_VERSION,
-                                            PMIX_PROXY_BUGREPORT);
+                                            pmix_tool_basename, pmix_tool_org,
+                                            pmix_tool_version,
+                                            pmix_tool_msg);
                 if (NULL != str) {
                     printf("%s", str);
                     free(str);


### PR DESCRIPTION
To be used for --version and --help messages, instead
of always displaying "PMIx" and its compiled version for
all tools.

Refs: https://github.com/open-mpi/ompi/pull/10120
Refs: https://github.com/open-mpi/ompi/issues/10096
Refs: https://github.com/openpmix/prrte/pull/1287

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>