### PR TITLE
Properly handle queries of tools

### DIFF
--- a/examples/hello.c
+++ b/examples/hello.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,7 +94,6 @@ int main(int argc, char **argv)
     char hostname[1024];
     pmix_value_t *val;
     uint16_t localrank;
-    size_t n;
     pmix_query_t query;
     mylock_t mylock;
     bool refresh = false;
@@ -131,7 +130,6 @@ int main(int argc, char **argv)
             myproc.nspace, myproc.rank, (unsigned long) pid, hostname, (int) localrank);
 
 #if PMIX_VERSION_MAJOR >= 4
-    n = 1;
     PMIX_QUERY_CONSTRUCT(&query);
     PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NUM_PSETS);
     PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_PSET_NAMES);

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1866,7 +1866,7 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix, pmix_da
         free(prefx);
     }
 
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 pmix_status_t pmix_bfrops_base_print_query(char **output, char *prefix, pmix_query_t *src,

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -14,6 +14,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,7 +28,8 @@ dist_pmixdata_DATA += runtime/help-pmix-runtime.txt
 
 headers += \
         runtime/pmix_rte.h \
-        runtime/pmix_progress_threads.h
+        runtime/pmix_progress_threads.h \
+        runtime/pmix_init_util.h
 
 sources += \
         runtime/pmix_finalize.c \

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file **/
+
+#ifndef PMIX_INIT_UTIL_H
+#define PMIX_INIT_UTIL_H
+
+#include "src/include/pmix_config.h"
+#include "pmix_common.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT extern const char* pmix_tool_basename;
+
+PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
+
+END_C_DECLS
+
+#endif /* PMIX_INIT_UTIL_H */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3857,7 +3857,8 @@ static void query_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, 
     pmix_buffer_t *reply;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:query callback with status %s",
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:query callback with status %s",
                         PMIx_Error_string(status));
 
     reply = PMIX_NEW(pmix_buffer_t);
@@ -4598,8 +4599,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_NOTIFY_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        if (PMIX_SUCCESS
-            != (rc = pmix_server_event_recvd_from_client(peer, buf, notifyerror_cbfunc, cd))) {
+        rc = pmix_server_event_recvd_from_client(peer, buf, notifyerror_cbfunc, cd);
+        if (PMIX_SUCCESS != rc) {
             PMIX_RELEASE(cd);
         }
         return rc;
@@ -4607,7 +4608,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_QUERY_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        if (PMIX_SUCCESS != (rc = pmix_server_query(peer, buf, query_cbfunc, cd))) {
+        rc = pmix_server_query(peer, buf, query_cbfunc, cd);
+        if (PMIX_SUCCESS != rc) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -69,6 +69,7 @@
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 
+#include "src/client/pmix_client_ops.h"
 #include "pmix_server_ops.h"
 
 /* The rank_blob_t type to collect processes blobs,
@@ -2679,17 +2680,12 @@ exit:
     return rc;
 }
 
-pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_info_cbfunc_t cbfunc,
-                                void *cbdata)
+pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     int32_t cnt;
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
-    pmix_proc_t proc;
-    pmix_cb_t cb;
-    size_t n, p;
-    pmix_list_t results;
-    pmix_kval_t *kv, *kvnxt;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd query from client");
@@ -2724,122 +2720,10 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_info
         }
     }
 
-    /* check the directives to see if they want us to refresh
-     * the local cached results - if we wanted to optimize this
-     * more, we would check each query and allow those that don't
-     * want to be refreshed to be executed locally, and those that
-     * did would be sent to the host. However, for now we simply
-     * determine that if we don't have it, then ask for everything */
-    memset(proc.nspace, 0, PMIX_MAX_NSLEN + 1);
-    proc.rank = PMIX_RANK_INVALID;
-    PMIX_CONSTRUCT(&results, pmix_list_t);
+    /* let the query function handle it */
+    rc = PMIx_Query_info_nb(cd->queries, cd->nqueries,
+                            cbfunc, (void*)cd);
 
-    for (n = 0; n < cd->nqueries; n++) {
-        /* if they are asking for information on support, then go get it */
-        if (0 == strcmp(cd->queries[n].keys[0], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
-            /* we are already in an event, but shift it as the handler expects to */
-            cd->cbfunc = cbfunc;
-            PMIX_RETAIN(cd); // protect against early release
-            PMIX_THREADSHIFT(cd, pmix_attrs_query_support);
-            PMIX_LIST_DESTRUCT(&results);
-            return PMIX_SUCCESS;
-        }
-        for (p = 0; p < cd->queries[n].nqual; p++) {
-            if (PMIX_CHECK_KEY(&cd->queries[n].qualifiers[p], PMIX_QUERY_REFRESH_CACHE)) {
-                if (PMIX_INFO_TRUE(&cd->queries[n].qualifiers[p])) {
-                    PMIX_LIST_DESTRUCT(&results);
-                    goto query;
-                }
-            } else if (PMIX_CHECK_KEY(&cd->queries[n].qualifiers[p], PMIX_PROCID)) {
-                PMIX_LOAD_NSPACE(proc.nspace, cd->queries[n].qualifiers[p].value.data.proc->nspace);
-                proc.rank = cd->queries[n].qualifiers[p].value.data.proc->rank;
-            } else if (PMIX_CHECK_KEY(&cd->queries[n].qualifiers[p], PMIX_NSPACE)) {
-                PMIX_LOAD_NSPACE(proc.nspace, cd->queries[n].qualifiers[p].value.data.string);
-            } else if (PMIX_CHECK_KEY(&cd->queries[n].qualifiers[p], PMIX_RANK)) {
-                proc.rank = cd->queries[n].qualifiers[p].value.data.rank;
-            } else if (PMIX_CHECK_KEY(&cd->queries[n].qualifiers[p], PMIX_HOSTNAME)) {
-                if (0 != strcmp(cd->queries[n].qualifiers[p].value.data.string,
-                                 pmix_globals.hostname)) {
-                    /* asking about a different host, so ask for the info */
-                    PMIX_LIST_DESTRUCT(&results);
-                    goto query;
-                }
-            }
-        }
-        /* we get here if a refresh isn't required - first try a local
-         * "get" on the data to see if we already have it */
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.copy = false;
-        /* set the proc */
-        if (PMIX_RANK_INVALID == proc.rank && 0 == strlen(proc.nspace)) {
-            /* use our id */
-            cb.proc = &pmix_globals.myid;
-        } else {
-            if (0 == strlen(proc.nspace)) {
-                /* use our nspace */
-                PMIX_LOAD_NSPACE(cb.proc->nspace, pmix_globals.myid.nspace);
-            }
-            if (PMIX_RANK_INVALID == proc.rank) {
-                /* user the wildcard rank */
-                proc.rank = PMIX_RANK_WILDCARD;
-            }
-            cb.proc = &proc;
-        }
-        for (p = 0; NULL != cd->queries[n].keys[p]; p++) {
-            cb.key = cd->queries[n].keys[p];
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != rc) {
-                /* needs to be passed to the host */
-                PMIX_LIST_DESTRUCT(&results);
-                PMIX_DESTRUCT(&cb);
-                goto query;
-            }
-            /* need to retain this result */
-            PMIX_LIST_FOREACH_SAFE (kv, kvnxt, &cb.kvs, pmix_kval_t) {
-                pmix_list_remove_item(&cb.kvs, &kv->super);
-                pmix_list_append(&results, &kv->super);
-            }
-            PMIX_DESTRUCT(&cb);
-        }
-    }
-
-    /* if we get here, then all queries were completely locally
-     * resolved, so construct the results for return */
-    rc = PMIX_ERR_NOT_FOUND;
-    if (0 < (cd->ninfo = pmix_list_get_size(&results))) {
-        PMIX_INFO_CREATE(cd->info, cd->ninfo);
-        n = 0;
-        PMIX_LIST_FOREACH_SAFE (kv, kvnxt, &results, pmix_kval_t) {
-            PMIX_LOAD_KEY(cd->info[n].key, kv->key);
-            rc = PMIx_Value_xfer(&cd->info[n].value, kv->value);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_INFO_FREE(cd->info, cd->ninfo);
-                cd->info = NULL;
-                cd->ninfo = 0;
-                break;
-            }
-            ++n;
-        }
-    }
-    /* done with the list of results */
-    PMIX_LIST_DESTRUCT(&results);
-    /* we can just call the cbfunc here as we are already
-     * in an event - let our internal cbfunc do a threadshift
-     * if necessary */
-    cbfunc(PMIX_SUCCESS, cd->info, cd->ninfo, cd, NULL, NULL);
-    return PMIX_SUCCESS;
-
-query:
-    if (NULL == pmix_host_server.query) {
-        PMIX_RELEASE(cd);
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-
-    /* setup the requesting peer name */
-    PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
-
-    /* ask the host for the info */
-    rc = pmix_host_server.query(&proc, cd->queries, cd->nqueries, cbfunc, cd);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(cd);
     }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -358,6 +358,14 @@ PMIX_EXPORT pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
                                                    pmix_buffer_t *buf,
                                                    pmix_device_dist_cbfunc_t cbfunc);
 
+PMIX_EXPORT pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
+                                                    pmix_buffer_t *buf,
+                                                    pmix_op_cbfunc_t cbfunc);
+
+PMIX_EXPORT void pmix_server_query_cbfunc(pmix_status_t status,
+                                          pmix_info_t *info, size_t ninfo, void *cbdata,
+                                          pmix_release_cbfunc_t release_fn, void *release_cbdata);
+
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;
 

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -555,11 +555,9 @@ void pmix_info_do_type(void)
     int count;
     char *type, *str;
     int i, j, k, len, ret;
-    char *p;
     const pmix_mca_base_var_t *var;
     char **strings, *message;
     const pmix_mca_base_var_group_t *group;
-    p = "type";
 
     if (NULL != (str = pmix_cmd_line_get_param(pmix_info_cmd_line, "level", 0, 0))) {
         char *tmp;
@@ -575,11 +573,11 @@ void pmix_info_do_type(void)
         }
     }
 
-    count = pmix_cmd_line_get_ninsts(pmix_info_cmd_line, p);
+    count = pmix_cmd_line_get_ninsts(pmix_info_cmd_line, "type");
     len = pmix_mca_base_var_get_count();
 
     for (k = 0; k < count; ++k) {
-        type = pmix_cmd_line_get_param(pmix_info_cmd_line, p, k, 0);
+        type = pmix_cmd_line_get_param(pmix_info_cmd_line, "type", k, 0);
         for (i = 0; i < len; ++i) {
             ret = pmix_mca_base_var_get(i, &var);
             if (PMIX_SUCCESS != ret) {

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -39,6 +39,7 @@
 #include "src/common/pmix_attributes.h"
 #include "src/mca/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"
+#include "src/runtime/pmix_init_util.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/threads/threads.h"
 #include "src/util/cmd_line.h"
@@ -80,6 +81,7 @@ static void querycbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
     myquery_data_t *mq = (myquery_data_t *) cbdata;
     size_t n;
 
+    fprintf(stderr, "pquery: Query returned status %s\n", PMIx_Error_string(status));
     mq->status = status;
     /* save the returned info - the PMIx library "owns" it
      * and will release it and perform other cleanup actions
@@ -228,52 +230,20 @@ int main(int argc, char **argv)
     pmix_infolist_t *iptr;
     char *str, *args = NULL, *result;
     pmix_query_t *queries;
+    pmix_rank_t rank = 0;
+    char hostname[PMIX_PATH_MAX];
+
+    PMIX_HIDE_UNUSED_PARAMS(argc);
 
     /* protect against problems if someone passes us thru a pipe
      * and then abnormally terminates the pipe early */
     signal(SIGPIPE, SIG_IGN);
 
-    /* initialize the output system */
-    if (!pmix_output_init()) {
-        return PMIX_ERROR;
-    }
+    /* init globals */
+    pmix_tool_basename = "pquery";
+    gethostname(hostname, sizeof(hostname));
 
-    /* initialize install dirs code */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
-        fprintf(stderr,
-                "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, "
-                "returned %d instead of PMIX_SUCCESS)\n",
-                __FILE__, __LINE__, rc);
-        return rc;
-    }
-    if (PMIX_SUCCESS != (rc = pmix_pinstall_dirs_base_init(NULL, 0))) {
-        fprintf(stderr,
-                "pmix_pinstalldirs_base_init() failed -- process will likely abort (%s:%d, "
-                "returned %d instead of PMIX_SUCCESS)\n",
-                __FILE__, __LINE__, rc);
-        return rc;
-    }
-
-    /* initialize the help system */
-    pmix_show_help_init();
-
-    /* keyval lex-based parser */
-    if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {
-        fprintf(stderr, "pmix_util_keyval_parse_init failed with %d\n", rc);
-        return PMIX_ERROR;
-    }
-
-    /* Setup the parameter system */
-    if (PMIX_SUCCESS != (rc = pmix_mca_base_var_init())) {
-        fprintf(stderr, "pmix_mca_base_var_init failed with %d\n", rc);
-        return PMIX_ERROR;
-    }
-
-    /* register params for pmix */
-    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
-        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
         return PMIX_ERROR;
     }
 
@@ -327,7 +297,7 @@ int main(int argc, char **argv)
 
     /* if we were given the pid of a starter, then direct that
      * we connect to it */
-    n = 1;
+    n = 3;
     PMIX_INFO_CREATE(info, n);
     if (0 < pmix_pquery_globals.pid) {
         PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pmix_pquery_globals.pid, PMIX_PID);
@@ -346,6 +316,12 @@ int main(int argc, char **argv)
         server = true;
         ;
     }
+
+    /* assign our own name */
+    pmix_asprintf(&kptr, "%s.%s.%lu", pmix_tool_basename, hostname, (unsigned long)getpid());
+    PMIX_INFO_LOAD(&info[1], PMIX_TOOL_NSPACE, kptr, PMIX_STRING);
+    free(kptr);
+    PMIX_INFO_LOAD(&info[2], PMIX_TOOL_RANK, &rank, PMIX_PROC_RANK);
 
     if (server) {
         /* initialize as a server so we can process the query ourselves */
@@ -413,6 +389,7 @@ int main(int argc, char **argv)
                 kptr++;
                 iptr = PMIX_NEW(pmix_infolist_t);
                 if (NULL == (attr = pmix_attributes_lookup(qprs[m]))) {
+                    fprintf(stderr, "Failed to lookup %s\n", qprs[m]);
                     exit(1);
                 }
                 PMIX_INFO_LOAD(&iptr->info, attr, kptr, PMIX_STRING);
@@ -421,6 +398,7 @@ int main(int argc, char **argv)
         }
         /* convert the key */
         if (NULL == (attr = pmix_attributes_lookup(qkeys[n]))) {
+            fprintf(stderr, "Failed to lookup %s\n", qkeys[n]);
             exit(1);
         }
         pmix_argv_append_nosize(&qry->query.keys, attr);
@@ -462,6 +440,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "PMIx_Query_info returned: %s\n", PMIx_Error_string(mq.status));
         rc = mq.status;
     } else {
+        if (0 == mq.ninfo) {
+            fprintf(stderr, "Query returned zero results\n");
+            goto done;
+        }
         /* print out the returned value(s) */
         for (n = 0; n < mq.ninfo; n++) {
             if (NULL == (attr = pmix_attributes_reverse_lookup(mq.info[n].key))) {


### PR DESCRIPTION
If a tool receives a query, it may (and is likely) not be able
to find the data being requested. For example, if a tool requests
the proc table for a job that another tool spawned, then that
request has to be relayed to the RM for an answer - and then the
answer has to be relayed back to the original requestor.

Fix a problem in simptest where a threadshift left a value on
the stack, which could subsequently be lost.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 460ee2e9b4e9c8a1b5acd9cad7eed9580be67008)