### PR TITLE
Fix a crash with --enable-debug

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -184,9 +184,6 @@ static void ncdcon(pmix_nspace_caddy_t *p)
 static void ncddes(pmix_nspace_caddy_t *p)
 {
     if (NULL != p->ns) {
-        if (NULL != p->ns->jobbkt) {
-            PMIX_RELEASE(p->ns->jobbkt);
-        }
         PMIX_RELEASE(p->ns);
     }
 }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -553,7 +553,7 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     pmix_status_t reply;
     pmix_status_t rc;
     struct timeval save;
-    pmix_socklen_t sz;
+    pmix_socklen_t sz = sizeof(save);
     bool sockopt = true;
     uint32_t u32;
 


### PR DESCRIPTION
- Revert "Leak: Always free ns->jobbkt in pmix_nspace_caddy_t destructor."

This reverts commit https://github.com/openpmix/openpmix/commit/aeb4145563eb3ed48a5445009213b806df2ccbfa.

Not sure why I did this, ns->jobbkt is free'd in the ns
destructor, called two lines down. If it isn't getting released,
that is a leak somewhere else where its reference count is incremented.
This was the wrong fix.

FWIW - that leak elsewhere may have since been fixed, causing me
to see this bug now.

This corrects a crash with --enable-debug where remote daemons
will crash with an assert on jobbkt's ref count.

- Initialize size for getsockopt().

This parameter is technically an in and out
for getsockopt() calls. Reported as uninitialized
by valgrind.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>