### PR TITLE
build: Fix common/sse check

### DIFF
--- a/config/pmix_check_curl.m4
+++ b/config/pmix_check_curl.m4
@@ -32,8 +32,6 @@
 # check if CURL support can be found.  sets curl_{CPPFLAGS,
 # LDFLAGS, LIBS}
 AC_DEFUN([PMIX_CHECK_CURL],[
-    PMIX_VAR_SCOPE_PUSH([pmix_check_curl_happy])
-
     dnl Intentionally disable CURL unless explicitly requested
     AC_ARG_WITH([curl],
                 [AS_HELP_STRING([--with-curl(=DIR)],
@@ -51,7 +49,6 @@ AC_DEFUN([PMIX_CHECK_CURL],[
                       [curl/curl.h],
 		      [curl],
 		      [curl_easy_getinfo],
-		      [],
 		      [pmix_check_curl_happy="yes"],
 		      [pmix_check_curl_happy="no"])
 
@@ -66,6 +63,4 @@ AC_DEFUN([PMIX_CHECK_CURL],[
     AC_SUBST(pmix_check_curl_CPPFLAGS)
     AC_SUBST(pmix_check_curl_LDFLAGS)
     AC_SUBST(pmix_check_curl_LIBS)
-
-    PMIX_VAR_SCOPE_POP
 ])

--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -32,7 +32,7 @@
 # check if JANSSON support can be found.  sets jansson_{CPPFLAGS,
 # LDFLAGS, LIBS}
 AC_DEFUN([PMIX_CHECK_JANSSON],[
-    PMIX_VAR_SCOPE_PUSH([pmix_check_jansson_save_CPPFLAGS pmix_check_jansson_happy])
+    PMIX_VAR_SCOPE_PUSH([pmix_check_jansson_save_CPPFLAGS])
 
     dnl Intentionally disable Jansson unless explicitly requested
     AC_ARG_WITH([jansson],


### PR DESCRIPTION
385308 broke building the common/sse package because it hid the Jansson
and Curl happiness variables from the later common/sse check.  The
downside of trying to keep namespace pollution down.  Re-share those
two state variables and fix an issue where we were mis-setting the
Curl happiness variable.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>