### PR TITLE
build: Fix leak of non-LIBS flags into LIBS

### DIFF
--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -641,10 +641,11 @@ AC_DEFUN([MCA_COMPONENT_COMPILE_MODE],[
 AC_DEFUN([PMIX_MCA_STRIP_LAFILES], [
     PMIX_VAR_SCOPE_PUSH([pmix_tmp])
 
+    $1=
     for arg in $2; do
 	pmix_tmp=`echo $arg | awk '{print substr([$][1], length([$][1])-2) }'`
         AS_IF([test "$pmix_tmp" != ".la"],
-              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$$1 $arg"])])
+              [PMIX_APPEND([$1], [$arg])])
     done
 
     PMIX_VAR_SCOPE_POP


### PR DESCRIPTION
PMIX_MCA_STRIP_LAFILES was supposed to copy the non-.la files into the
first argument, rather than append the non-.la files into the first
argument.  The append behavior caused us to leak component's LDFLAGS
into their LIBS.  Usually, deduping cleaned everything up later,
but it still is a bug.

While we're here, use the recently added PMIX_APPEND instead of
implementing our own append.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>