### PR TITLE
Remove incorrect object release

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -524,7 +524,6 @@ done:
                 }
             }
             cb->cbfunc.valuefn(rc, val, cb->cbdata);
-            PMIX_RELEASE(lg);
             PMIX_RELEASE(cb);
         }
     }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -115,7 +115,8 @@ static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, pmix_server_
 
     if (localonly) {
         /* the client asked that we not wait, so return now */
-        pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d CLIENT REQUESTED IMMEDIATE",
+        pmix_output_verbose(2, pmix_server_globals.get_output,
+                            "%s:%d CLIENT REQUESTED IMMEDIATE",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank);
         return PMIX_ERR_NOT_AVAILABLE;
     }
@@ -138,6 +139,7 @@ static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, pmix_server_
     *locald = lcd;
     return rc;
 }
+
 pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -41,6 +41,7 @@
 static uint32_t nprocs;
 static pmix_proc_t myproc;
 static uint32_t getcount = 0;
+static int msgnum = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a) \
     do {                            \
@@ -54,7 +55,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     bool *active = (bool *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(status);
 
-    pmix_output(0, "%s:%d completed fence_nb", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: completed fence_nb", myproc.rank, msgnum);
     *active = false;
 }
 
@@ -65,36 +66,40 @@ static void valcbfunc(pmix_status_t status, pmix_value_t *val, void *cbdata)
     if (PMIX_SUCCESS == status) {
         if (NULL != strstr(key, "local")) {
             if (PMIX_UINT64 != val->type) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong type: %d", myproc.nspace,
-                            myproc.rank, key, val->type);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong type: %d",
+                            myproc.rank, msgnum, key, val->type);
+                ++msgnum;
                 goto done;
             }
             if (1234 != val->data.uint64) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong value: %d", myproc.nspace,
-                            myproc.rank, key, (int) val->data.uint64);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong value: %d",
+                            myproc.rank, msgnum, key, (int) val->data.uint64);
+                ++msgnum;
                 goto done;
             }
         } else if (NULL != strstr(key, "remote")) {
             if (PMIX_STRING != val->type) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong type: %d", myproc.nspace,
-                            myproc.rank, key, val->type);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong type: %d",
+                            myproc.rank, msgnum, key, val->type);
+                ++msgnum;
                 goto done;
             }
             if (0 != strcmp(val->data.string, "1234")) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong value: %s", myproc.nspace,
-                            myproc.rank, key, val->data.string);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong value: %s",
+                            myproc.rank, msgnum, key, val->data.string);
+                ++msgnum;
                 goto done;
             }
         } else {
-            pmix_output(0, "%s:%d PMIx_Get_nb returned wrong key: %s", myproc.nspace, myproc.rank,
-                        key);
+            pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb returned wrong key: %s", myproc.rank, msgnum, key);
+            ++msgnum;
             goto done;
         }
-        pmix_output(0, "%s:%d PMIx_Get_nb Key %s returned correctly", myproc.nspace, myproc.rank,
-                    key);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned correctly", myproc.rank, msgnum, key);
     } else {
-        pmix_output(0, "%s:%d PMIx_Get_nb Key %s failed: %s", myproc.nspace, myproc.rank, key,
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s failed: %s", myproc.rank, msgnum, key,
                     PMIx_Error_string(status));
+        ++msgnum;
     }
 done:
     free(key);
@@ -122,31 +127,32 @@ int main(int argc, char **argv)
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank,
-                    rc);
-        exit(0);
+        pmix_output(0, "Rank %d: PMIx_Init failed: %d", myproc.rank, rc);
+        exit(1);
     }
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: Running", myproc.rank, msgnum);
+    ++msgnum;
 
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get job size failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
+        ++msgnum;
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
+    pmix_output(0, "Rank %d[msg=%d]: job size %d", myproc.rank, msgnum, nprocs);
+    ++msgnum;
 
     /* put a few values */
     (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Store_internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
         goto done;
     }
 
@@ -154,8 +160,8 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Put internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
         goto done;
     }
 
@@ -163,8 +169,8 @@ int main(int argc, char **argv)
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Put internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
         goto done;
     }
 
@@ -172,14 +178,15 @@ int main(int argc, char **argv)
      * if a "get" is received prior to data being provided */
     if (0 == myproc.rank) {
         sleep(2);
-        pmix_output(0, "\n\n\nWOKE UP");
+        pmix_output(0, "Rank 0[msg=%d]: WOKE UP", msgnum);
+        ++msgnum;
     }
 
     /* commit the data to the server */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Commit failed: %d", myproc.nspace, myproc.rank,
-                    rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Commit failed: %d", myproc.rank, msgnum, rc);
         goto done;
+        ++msgnum;
     }
 
     if (dofence) {
@@ -189,16 +196,16 @@ int main(int argc, char **argv)
         proc.rank = PMIX_RANK_WILDCARD;
         active = true;
         if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(&proc, 1, NULL, 0, opcbfunc, &active))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace,
-                        myproc.rank, rc);
+            pmix_output(0, "Rank %d[msg=%d]: PMIx_Fence failed: %d", myproc.rank, msgnum, rc);
+            ++msgnum;
             goto done;
         }
     }
 
     /* get a list of our local peers */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get local peers failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
+        ++msgnum;
         goto done;
     }
     /* split the returned string to get the rank of each local peer */
@@ -233,18 +240,21 @@ int main(int argc, char **argv)
         }
         if (local) {
             (void) asprintf(&tmp, "%s-%d-local", myproc.nspace, n);
+            pmix_output(0, "Rank %u[msg=%d]: retrieving %s from local proc %u", myproc.rank, msgnum, tmp, n);
+            ++msgnum;
             proc.rank = n;
             if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, NULL, 0, valcbfunc, tmp))) {
-                pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, n,
-                            tmp, rc);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
+                ++msgnum;
                 goto done;
             }
             ++num_gets;
         } else {
             (void) asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
+            pmix_output(0, "Rank %u[msg=%d]: retrieving %s from remote proc %u", myproc.rank, msgnum, tmp, n);
             if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, NULL, 0, valcbfunc, tmp))) {
-                pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, n,
-                            tmp, rc);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
+                ++msgnum;
                 goto done;
             }
             ++num_gets;
@@ -267,20 +277,19 @@ int main(int argc, char **argv)
     /* call fence again so everyone waits before leaving */
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank,
-                    rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Fence failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
         goto done;
     }
 
 done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: Finalizing", myproc.rank, msgnum);
+    ++msgnum;
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Rank %d[msg=%d]:PMIx_Finalize failed: %d\n", myproc.rank, msgnum, rc);
     } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
-                myproc.nspace, myproc.rank);
+        fprintf(stderr, "Rank %d[msg=%d]: PMIx_Finalize successfully completed\n", myproc.rank, msgnum);
     }
     fflush(stderr);
     return (0);


### PR DESCRIPTION
Cannot release the "lg" object as it might be used again
in the loop. Object will be released when the caddy is
released.

Cleanup the simpdmodex test a bit so that all outputs are
properly clumped when run thru "sort" - makes it easier
to debug.

Refs https://github.com/openpmix/prrte/issues/1243
Signed-off-by: Ralph Castain <rhc@pmix.org>