### PR TITLE
Properly deal with delayed local get requests

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -481,7 +481,8 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     }
 
     if (PMIX_SUCCESS != ret) {
-        pmix_output_verbose(2, pmix_client_globals.get_output, "pmix: get_nb server returned %s",
+        pmix_output_verbose(2, pmix_client_globals.get_output,
+                            "pmix: get_nb server returned %s",
                             PMIx_Error_string(ret));
         goto done;
     }
@@ -502,6 +503,11 @@ done:
     PMIX_LIST_FOREACH_SAFE (cb, cb2, &pmix_client_globals.pending_requests, pmix_cb_t) {
         if (PMIX_CHECK_NSPACE(lg->p.nspace, cb->pname.nspace) && cb->pname.rank == lg->p.rank) {
             pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
+            if (PMIX_SUCCESS != ret) {
+                cb->cbfunc.valuefn(ret, NULL, cb->cbdata);
+                PMIX_RELEASE(cb);
+                continue;
+            }
             /* we have the data for this proc - see if we can find the key */
             cb->proc = &lg->p;
             cb->scope = PMIX_SCOPE_UNDEF;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -845,7 +845,10 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
 }
 
 /* Resolve pending requests to this namespace/rank */
-pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank, pmix_status_t status,
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr,
+                                   pmix_rank_t rank,
+                                   pmix_status_t status,
+                                   pmix_scope_t scope,
                                    pmix_dmdx_local_t *lcd)
 {
     pmix_dmdx_local_t *cd, *ptr;
@@ -895,8 +898,8 @@ pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank, pmi
         PMIX_LIST_FOREACH (req, &ptr->loc_reqs, pmix_dmdx_request_t) {
             pmix_status_t rc;
             bool diffnspace = !PMIX_CHECK_NSPACE(nptr->nspace, req->lcd->proc.nspace);
-            rc = _satisfy_request(nptr, rank, &scd, diffnspace, PMIX_REMOTE, req->cbfunc,
-                                  req->cbdata);
+            rc = _satisfy_request(nptr, rank, &scd, diffnspace, scope,
+                                  req->cbfunc, req->cbdata);
             if (PMIX_SUCCESS != rc) {
                 /* if we can't satisfy this particular request (missing key?) */
                 req->cbfunc(rc, NULL, 0, req->cbdata, NULL, NULL);
@@ -1091,7 +1094,8 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
 
 complete:
     /* always execute the callback to avoid having the client hang */
-    pmix_pending_resolve(nptr, caddy->lcd->proc.rank, caddy->status, caddy->lcd);
+    pmix_pending_resolve(nptr, caddy->lcd->proc.rank,
+                         caddy->status, PMIX_REMOTE, caddy->lcd);
 
     /* now call the release function so the host server
      * knows it can release the data */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -209,7 +209,8 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
     pmix_strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
     proc.rank = info->pname.rank;
 
-    pmix_output_verbose(2, pmix_server_globals.fence_output, "%s:%d EXECUTE COMMIT FOR %s:%d",
+    pmix_output_verbose(2, pmix_server_globals.fence_output,
+                        "%s:%d EXECUTE COMMIT FOR %s:%d",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, nptr->nspace,
                         info->pname.rank);
 
@@ -317,7 +318,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
         }
     }
     /* see if anyone local is waiting on this data- could be more than one */
-    rc = pmix_pending_resolve(nptr, info->pname.rank, PMIX_SUCCESS, NULL);
+    rc = pmix_pending_resolve(nptr, info->pname.rank, PMIX_SUCCESS, PMIX_LOCAL, NULL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -248,7 +248,8 @@ PMIX_EXPORT bool pmix_server_trk_update(pmix_server_trkr_t *trk);
 
 PMIX_EXPORT void pmix_pending_nspace_requests(pmix_namespace_t *nptr);
 PMIX_EXPORT pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
-                                               pmix_status_t status, pmix_dmdx_local_t *lcd);
+                                               pmix_status_t status, pmix_scope_t scope,
+                                               pmix_dmdx_local_t *lcd);
 
 PMIX_EXPORT pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -452,8 +452,8 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
         if (PMIX_ERR_NOT_SUPPORTED == rc) {
             goto cleanout;
         }
-        if (PMIX_ERR_NOT_FOUND != rc && PMIX_ERR_NOT_FOUND != rc) {
-            TEST_ERROR(("%s:%d [ERROR]: PMIx_Get returned %s instead of not_found", my_nspace,
+        if (PMIX_ERR_NOT_FOUND != rc && PMIX_ERR_TIMEOUT != rc) {
+            TEST_ERROR(("%s:%d [ERROR]: PMIx_Get returned %s instead of not_found or timeout", my_nspace,
                         my_rank, PMIx_Error_string(rc)));
             exit(PMIX_ERROR);
         }


### PR DESCRIPTION
Current code only supported delayed "get" requests
(i.e., a request for data not yet received) from
remote procs. If a local proc requested data from
another local proc, and the posting hadn't already
been done, then we would wait - but the retrieval
after waiting was locked to PMIX_REMOTE scope, and
so the data would never be found.

Also fix the return code so that we get the original
issue ("timeout") and not a bogus "not found".

Increase the flexibility of the simpdmodex test to
allow passing timeout, sleep, and async flags on
the cmd line.

Adjust the tests to not error on timeout when expected
to fail

Refs https://github.com/openpmix/prrte/issues/1243
Signed-off-by: Ralph Castain <rhc@pmix.org>