### PR TITLE
Protect critical zone in pmix_obj_update().

### DIFF
--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -709,9 +709,9 @@ static inline int pmix_obj_update(pmix_object_t *object, int inc)
         perror("pthread_mutex_lock()");
         abort();
     }
-    object->obj_reference_count += inc;
+    ret = (object->obj_reference_count += inc);
     pthread_mutex_unlock(&object->obj_lock);
-    return object->obj_reference_count;
+    return ret;
 }
 
 END_C_DECLS


### PR DESCRIPTION
Fix a very subtle bug where it is
possible that another thread will win the race
and update obj_reference_count before its value is returned.
This can result in asserts being hit with debug builds.

Cache the updated value before the lock is let go and return it
seems to fix intermittent crashes in various MPI routines.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>