### PR TITLE
Add a little extra safety

### DIFF
--- a/src/include/pmix_atomic.h
+++ b/src/include/pmix_atomic.h
@@ -99,4 +99,17 @@ static inline void pmix_atomic_rmb(void)
 
 #endif
 
+/* provide a macro for forward-proofing the shifting
+ * of objects between threads - at some point, we
+ * may revamp our threading model */
+
+/* post an object to another thread - for now, we
+ * only have a memory barrier */
+#define PMIX_POST_OBJECT(o) pmix_atomic_wmb()
+
+/* acquire an object from another thread - for now,
+ * we only have a memory barrier */
+#define PMIX_ACQUIRE_OBJECT(o) pmix_atomic_rmb()
+
+
 #endif /* PMIX_SYS_ATOMIC_H */

--- a/src/threads/pmix_threads.h
+++ b/src/threads/pmix_threads.h
@@ -180,18 +180,6 @@ typedef struct {
         pmix_mutex_unlock(&(lck)->mutex);       \
     } while (0)
 
-/* provide a macro for forward-proofing the shifting
- * of objects between threads - at some point, we
- * may revamp our threading model */
-
-/* post an object to another thread - for now, we
- * only have a memory barrier */
-#define PMIX_POST_OBJECT(o) pmix_atomic_wmb()
-
-/* acquire an object from another thread - for now,
- * we only have a memory barrier */
-#define PMIX_ACQUIRE_OBJECT(o) pmix_atomic_rmb()
-
 PMIX_EXPORT int pmix_thread_start(pmix_thread_t *);
 PMIX_EXPORT int pmix_thread_join(pmix_thread_t *, void **thread_return);
 PMIX_EXPORT bool pmix_thread_self_compare(pmix_thread_t *);


### PR DESCRIPTION
Use the PMIX_ACQUIRE_OBJECT and PMIX_POST_OBJECT to
ensure that any updates to the object reference count
get properly stored before some other thread can
access them.

Signed-off-by: Ralph Castain <rhc@pmix.org>