### PR TITLE
build: Fix output stream bug in summary

### DIFF
--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -118,7 +118,7 @@ EOF
         AS_VAR_COPY([pmix_summary_section_value], [pmix_summary_section_${pmix_summary_section}_value])
         echo "${pmix_summary_section_name}" >&2
         echo "-----------------------" >&2
-        echo "${pmix_summary_section_value}" | sort -f
+        echo "${pmix_summary_section_value}" | sort -f >&2
         echo " " >&2
     done
 


### PR DESCRIPTION
38530 introduced a bug where the summary section values were
sent to stdout instead of stderror like the rest of the summary.
This patch fixes that issue.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>