### PR TITLE
Silence Coverity warning

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -444,7 +444,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_cb_t *cb2;
-    pmix_status_t rc, ret;
+    pmix_status_t rc, ret = PMIX_ERR_NOT_FOUND;
     pmix_value_t *val = NULL;
     int32_t cnt;
     pmix_kval_t *kv;


### PR DESCRIPTION
Ensure the return status is set in case where the
return buffer is empty due to lost connection

Signed-off-by: Ralph Castain <rhc@pmix.org>