### PR TITLE
Minor cleanup plus fix dmodex operation on local host

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -285,6 +285,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
             continue;
         }
         if (dcd->cd->proc.rank == info->pname.rank) {
+            pmix_list_remove_item(&pmix_server_globals.remote_pnd, &dcd->super);
             /* we can now fulfill this request - collect the
              * remote/global data from this proc - note that there
              * may not be a contribution */
@@ -312,12 +313,11 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
                 free(data);
             }
             /* we have finished this request */
-            pmix_list_remove_item(&pmix_server_globals.remote_pnd, &dcd->super);
             PMIX_RELEASE(dcd);
         }
     }
     /* see if anyone local is waiting on this data- could be more than one */
-    rc = pmix_pending_resolve(nptr, info->pname.rank, PMIX_SUCCESS, NULL);
+    rc = pmix_pending_resolve(nptr, info->pname.rank, PMIX_SUCCESS, PMIX_LOCAL, NULL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -248,7 +248,8 @@ PMIX_EXPORT bool pmix_server_trk_update(pmix_server_trkr_t *trk);
 
 PMIX_EXPORT void pmix_pending_nspace_requests(pmix_namespace_t *nptr);
 PMIX_EXPORT pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
-                                               pmix_status_t status, pmix_dmdx_local_t *lcd);
+                                               pmix_status_t status, pmix_scope_t scope,
+                                               pmix_dmdx_local_t *lcd);
 
 PMIX_EXPORT pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -326,8 +326,7 @@ static void expand_flags(char **argv)
 
 static void filter_flags(char*** argvp)
 {
-    int argc;
-    size_t idx;
+    int argc, idx;
 
     argc = pmix_argv_count(*argvp);
     idx = 0;

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -41,6 +41,8 @@
 static uint32_t nprocs;
 static pmix_proc_t myproc;
 static uint32_t getcount = 0;
+static int msgnum = 0;
+static int exitstatus = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a) \
     do {                            \
@@ -54,7 +56,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     bool *active = (bool *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(status);
 
-    pmix_output(0, "%s:%d completed fence_nb", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: completed fence_nb", myproc.rank, msgnum);
     *active = false;
 }
 
@@ -65,36 +67,46 @@ static void valcbfunc(pmix_status_t status, pmix_value_t *val, void *cbdata)
     if (PMIX_SUCCESS == status) {
         if (NULL != strstr(key, "local")) {
             if (PMIX_UINT64 != val->type) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong type: %d", myproc.nspace,
-                            myproc.rank, key, val->type);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong type: %d",
+                            myproc.rank, msgnum, key, val->type);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
             if (1234 != val->data.uint64) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong value: %d", myproc.nspace,
-                            myproc.rank, key, (int) val->data.uint64);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong value: %d",
+                            myproc.rank, msgnum, key, (int) val->data.uint64);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
         } else if (NULL != strstr(key, "remote")) {
             if (PMIX_STRING != val->type) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong type: %d", myproc.nspace,
-                            myproc.rank, key, val->type);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong type: %d",
+                            myproc.rank, msgnum, key, val->type);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
             if (0 != strcmp(val->data.string, "1234")) {
-                pmix_output(0, "%s:%d: PMIx_Get_nb Key %s returned wrong value: %s", myproc.nspace,
-                            myproc.rank, key, val->data.string);
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned wrong value: %s",
+                            myproc.rank, msgnum, key, val->data.string);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
         } else {
-            pmix_output(0, "%s:%d PMIx_Get_nb returned wrong key: %s", myproc.nspace, myproc.rank,
-                        key);
+            pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb returned wrong key: %s", myproc.rank, msgnum, key);
+            ++msgnum;
+            exitstatus = 1;
             goto done;
         }
-        pmix_output(0, "%s:%d PMIx_Get_nb Key %s returned correctly", myproc.nspace, myproc.rank,
-                    key);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s returned correctly", myproc.rank, msgnum, key);
     } else {
-        pmix_output(0, "%s:%d PMIx_Get_nb Key %s failed: %s", myproc.nspace, myproc.rank, key,
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get_nb Key %s failed: %s", myproc.rank, msgnum, key,
                     PMIx_Error_string(status));
+        ++msgnum;
+        exitstatus = 1;
     }
 done:
     free(key);
@@ -103,50 +115,79 @@ done:
 
 int main(int argc, char **argv)
 {
-    int rc;
+    int rc, i;
     pmix_value_t value;
     pmix_value_t *val = &value;
     char *tmp;
     pmix_proc_t proc;
-    uint32_t n, num_gets, k, nlocal;
+    uint32_t n, num_gets, k, nlocal, sleeptime;
     bool active;
     bool dofence = true;
     bool local, all_local;
     char **peers;
     pmix_rank_t *locals = NULL;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+    pmix_info_t timeout, *iptr;
+    size_t ninfo;
 
-    if (NULL != getenv("PMIX_SIMPDMODEX_ASYNC")) {
-        dofence = false;
+    dofence = false;
+    sleeptime = 2;
+    iptr = NULL;
+    ninfo = 0;
+    for (i=1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "-s") ||
+            0 == strcmp(argv[i], "--sleep")) {
+            if (NULL == argv[i+1]) {
+                fprintf(stderr, "Error: %s requires an integer argument\n", argv[i]);
+                exit(1);
+            }
+            sleeptime = strtoul(argv[i+1], NULL, 10);
+        } else if (0 == strcmp(argv[i], "-f") ||
+                   0 == strcmp(argv[i], "--fence")) {
+            dofence = true;
+        } else if (0 == strcmp(argv[i], "-t") ||
+                   0 == strcmp(argv[i], "--timeout")) {
+            if (NULL == argv[i+1]) {
+                fprintf(stderr, "Error: %s requires an integer argument\n", argv[i]);
+                exit(1);
+            }
+            rc = strtoul(argv[i+1], NULL, 10);
+            PMIX_INFO_LOAD(&timeout, PMIX_TIMEOUT, &rc, PMIX_INT);
+            iptr = &timeout;
+            ninfo = 1;
+        }
     }
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank,
-                    rc);
-        exit(0);
+        pmix_output(0, "Rank %d: PMIx_Init failed: %d", myproc.rank, rc);
+        exit(1);
     }
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: Running", myproc.rank, msgnum);
+    ++msgnum;
 
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get job size failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
+    pmix_output(0, "Rank %d[msg=%d]: job size %d", myproc.rank, msgnum, nprocs);
+    ++msgnum;
 
     /* put a few values */
     (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Store_internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
 
@@ -154,8 +195,9 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Put internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
 
@@ -163,22 +205,25 @@ int main(int argc, char **argv)
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace,
-                    myproc.rank, rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Put internal failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
 
     /* introduce a delay by one rank so we can check what happens
      * if a "get" is received prior to data being provided */
     if (0 == myproc.rank) {
-        sleep(2);
-        pmix_output(0, "\n\n\nWOKE UP");
+        sleep(sleeptime);
+        pmix_output(0, "Rank 0[msg=%d]: WOKE UP", msgnum);
+        ++msgnum;
     }
 
     /* commit the data to the server */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Commit failed: %d", myproc.nspace, myproc.rank,
-                    rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Commit failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
 
@@ -189,16 +234,18 @@ int main(int argc, char **argv)
         proc.rank = PMIX_RANK_WILDCARD;
         active = true;
         if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(&proc, 1, NULL, 0, opcbfunc, &active))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace,
-                        myproc.rank, rc);
+            pmix_output(0, "Rank %d[msg=%d]: PMIx_Fence failed: %d", myproc.rank, msgnum, rc);
+            ++msgnum;
+            exitstatus = 1;
             goto done;
         }
     }
 
     /* get a list of our local peers */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Get local peers failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
     /* split the returned string to get the rank of each local peer */
@@ -233,18 +280,23 @@ int main(int argc, char **argv)
         }
         if (local) {
             (void) asprintf(&tmp, "%s-%d-local", myproc.nspace, n);
+            pmix_output(0, "Rank %u[msg=%d]: retrieving %s from local proc %u", myproc.rank, msgnum, tmp, n);
+            ++msgnum;
             proc.rank = n;
-            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, NULL, 0, valcbfunc, tmp))) {
-                pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, n,
-                            tmp, rc);
+            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, iptr, ninfo, valcbfunc, tmp))) {
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
             ++num_gets;
         } else {
             (void) asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, NULL, 0, valcbfunc, tmp))) {
-                pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, n,
-                            tmp, rc);
+            pmix_output(0, "Rank %u[msg=%d]: retrieving %s from remote proc %u", myproc.rank, msgnum, tmp, n);
+            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, iptr, ninfo, valcbfunc, tmp))) {
+                pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
+                ++msgnum;
+                exitstatus = 1;
                 goto done;
             }
             ++num_gets;
@@ -267,21 +319,21 @@ int main(int argc, char **argv)
     /* call fence again so everyone waits before leaving */
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank,
-                    rc);
+        pmix_output(0, "Rank %d[msg=%d]: PMIx_Fence failed: %d", myproc.rank, msgnum, rc);
+        ++msgnum;
+        exitstatus = 1;
         goto done;
     }
 
 done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    pmix_output(0, "Rank %d[msg=%d]: Finalizing", myproc.rank, msgnum);
+    ++msgnum;
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Rank %d[msg=%d]:PMIx_Finalize failed: %d\n", myproc.rank, msgnum, rc);
     } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
-                myproc.nspace, myproc.rank);
+        fprintf(stderr, "Rank %d[msg=%d]: PMIx_Finalize successfully completed\n", myproc.rank, msgnum);
     }
     fflush(stderr);
-    return (0);
+    return exitstatus;
 }


### PR DESCRIPTION
[Fix warning - compare of different signs](https://github.com/openpmix/openpmix/commit/32d405332dc23a7c6964267f2f863f1ba68f337e)

[Fix dmodex operation on local host](https://github.com/openpmix/openpmix/commit/b445b978834a3e19ea2cab87f4361300a3275b0e)

Pass the scope to pending_resolve so we check the local
scope when appropriate instead of having the function locked
to the remote scope case. This was a change that somehow didn't
get backported from master.

Also ensure that we check the peer's GDS component and not
just our own when looking for requested data. On master, there
currently is only one storage system, so it doesn't matter.
However, that isn't the case on prior release branches, and
data can be stored in the peer's component.

Update the simpdmodex test to track master

Signed-off-by: Ralph Castain <rhc@pmix.org>