### PR TITLE
Ensure we check peer's gds for data

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -741,9 +741,13 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
     pmix_byte_object_t bo;
     char *data = NULL;
     size_t sz = 0;
+    pmix_rank_info_t *rinfo;
+    pmix_peer_t *peer;
 
-    pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d SATISFY REQUEST CALLED FOR %s:%d",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank, nptr->nspace, rank);
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "%s:%d SATISFY REQUEST CALLED FOR %s:%d ON SCOPE %s",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                        nptr->nspace, rank, PMIx_Scope_string(scope));
 
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
     PMIX_LOAD_NSPACE(proc.nspace, nptr->nspace);
@@ -770,6 +774,21 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
     cb.info = cd->info;
     cb.ninfo = cd->ninfo;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    /* if we didn't find it on my peer, it could have
+     * been stored on their peer - so check there */
+    if (PMIX_SUCCESS != rc) {
+        /* all procs in a given nspace must use
+         * the same GDS component */
+        peer = NULL;
+        rinfo = (pmix_rank_info_t*)pmix_list_get_first(&nptr->ranks);
+        while (NULL == peer && NULL != rinfo) {
+            peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, rinfo->peerid);
+            rinfo = (pmix_rank_info_t*)pmix_list_get_next(&rinfo->super);
+        }
+        if (NULL != peer) {
+            PMIX_GDS_FETCH_KV(rc, peer, &cb);
+        }
+    }
     cb.info = NULL;
     cb.ninfo = 0;
     if (PMIX_SUCCESS == rc) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -286,6 +286,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
             continue;
         }
         if (dcd->cd->proc.rank == info->pname.rank) {
+            pmix_list_remove_item(&pmix_server_globals.remote_pnd, &dcd->super);
             /* we can now fulfill this request - collect the
              * remote/global data from this proc - note that there
              * may not be a contribution */
@@ -313,7 +314,6 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
                 free(data);
             }
             /* we have finished this request */
-            pmix_list_remove_item(&pmix_server_globals.remote_pnd, &dcd->super);
             PMIX_RELEASE(dcd);
         }
     }


### PR DESCRIPTION
When resolving data requests that may have been delayed waiting
for the source to commit the requested data, be sure to check
both the server's _and_ the peer's GDS component for the data.
While master currently only has one component, that may not
be true in the future, and it is possible that the committed
data was stored on the peer's component (and not the server's).

Signed-off-by: Ralph Castain <rhc@pmix.org>