### PR TITLE
Remove the "<option> help" support

### DIFF
--- a/src/util/help-cli.txt
+++ b/src/util/help-cli.txt
@@ -12,7 +12,7 @@
 # This is the US/English general help file for PRTE CLI options.
 #
 [help]
-Help can be requested in three ways:
+Help can be requested in two ways:
 
 - a directive to the cmd. For example, the command
     "%s --help" or "%s -h"
@@ -23,19 +23,6 @@ Help can be requested in three ways:
     "%s --help foo" or "%s -h foo"
   will provide detailed help about the "foo" command line
   directive.
-
-- specifying "help" as an option to the directive of interest.
-  For example, the command
-    "%s --foo --help" or "%s --foo -h"
-  will provide detailed help about the "foo" command line
-  directive. Note that the "help" and "h" options do not
-  require the dash prefixes - i.e., the following commands
-    "%s --foo help" or "%s --foo h"
-  will also output detailed help for "foo". Thus, directives
-  are precluded from defining options of "help" and "h".
-
-Note that the last two methods are functionally equivalent
-and will return the same output.
 #
 [unknown-option]
 Help was requested for an unknown option:
@@ -84,3 +71,12 @@ An unrecognized option was included on the %s command line:
 
 Please use the "%s --help" command to obtain a list of all
 supported options.
+#
+[short-arg-error]
+A short option was provided to %s and recognized by the parser,
+but included an argument while the option does not support one:
+
+  Short option: %s
+  Given argument: %s
+
+Please correct the command line and try again.

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -131,22 +131,6 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
         }
         switch (opt) {
             case 0:
-                /* we allow someone to specify an option followed by
-                 * the "help" directive - thus requesting detailed help
-                 * on that specific option */
-                if (NULL != optarg) {
-                    if (0 == strcmp(optarg, "--help") || 0 == strcmp(optarg, "-help") ||
-                        0 == strcmp(optarg, "help") || 0 == strcmp(optarg, "h") ||
-                        0 == strcmp(optarg, "-h")) {
-                        str = pmix_show_help_string(helpfile, myoptions[option_index].name, false);
-                        if (NULL != str) {
-                            printf("%s", str);
-                            free(str);
-                        }
-                        pmix_argv_free(argv);
-                        return PMIX_ERR_SILENT;
-                    }
-                }
                 /* if this is an MCA param of some type, store it */
                 if (0 == endswith(myoptions[option_index].name, "mca")) {
                     /* format mca params as param:value - the optind value
@@ -304,13 +288,13 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         }
                         for (n=0; NULL != myoptions[n].name; n++) {
                             if (ascii == myoptions[n].val) {
-                                if (NULL != ptr) {
-                                    /* we allow someone to specify an option followed by
-                                     * the "help" directive - thus requesting detailed help
-                                     * on that specific option */
-                                    if (0 == strcmp(ptr, "--help") || 0 == strcmp(ptr, "-h") ||
-                                        0 == strcmp(ptr, "help") || 0 == strcmp(ptr, "h")) {
-                                        str = pmix_show_help_string(helpfile, myoptions[n].name, true);
+                                if (PMIX_ARG_NONE == myoptions[n].has_arg) {
+                                    /* if ptr isn't NULL, then that means we were given
+                                     * an argument to an option that doesn't take one.
+                                     * Report the error */
+                                    if (NULL != ptr) {
+                                        str = pmix_show_help_string("help-cli.txt", "short-arg-error", true,
+                                                                    pmix_tool_basename, shorts[n], ptr);
                                         if (NULL != str) {
                                             printf("%s", str);
                                             free(str);
@@ -318,9 +302,6 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                         pmix_argv_free(argv);
                                         return PMIX_ERR_SILENT;
                                     }
-                                }
-                                /* store actual option */
-                                if (PMIX_ARG_NONE == myoptions[n].has_arg) {
                                     ptr = NULL;
                                 }
                                 mystore(myoptions[n].name, ptr, results);


### PR DESCRIPTION
It has been correctly pointed out that a number of the cmd line
options could accept "help" as an input value as opposed to
meaning a request for "help". Until we can figure out a way to
separate those instances out from legitimate requests for help,
let's remove that method.

We therefore only accept two methods for requesting help:

- a directive to the cmd itself: e.g., "prte --help"

- an option to the help cmd line option: e.g., "--help map-by"

Hopefully, we will someday come up with a solution - perhaps
need to take a closer look at how "hydra" currently supports it.

Closes https://github.com/openpmix/openpmix/pull/2544
Signed-off-by: Ralph Castain <rhc@pmix.org>