### PR TITLE
build: Delay adding DELAYED_LIBS even more

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -870,11 +870,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     fi
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
     CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
-    # PMIX_DELAYED_LIBS is used to allow us to add some libraries to the build, but
-    # not add them to all the tests that are run through configure, since that
-    # can cause some bundled build situations.  This is the last minute, so time
-    # to add them to LIBS.
-    PMIX_FLAGS_APPEND_MOVE([LIBS], [$PMIX_DELAYED_LIBS])
 
     ############################################################################
     # final wrapper compiler config
@@ -927,6 +922,12 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(pmixincludedir)
 
     PMIX_SETUP_WRAPPER_FINAL
+
+    # PMIX_DELAYED_LIBS is used to allow us to add some libraries to the build, but
+    # not add them to all the tests that are run through configure, since that
+    # can cause some bundled build situations.  This is the last minute, so time
+    # to add them to LIBS.
+    PMIX_FLAGS_APPEND_MOVE([LIBS], [$PMIX_DELAYED_LIBS])
 
     ############################################################################
     # setup "make check"


### PR DESCRIPTION
We use the DELAYED_LIBS for threading .la files through the build
system, but need to wait until after the wrapper compiler finalize
(which is the last place in configure that LIBS are tested) before
adding DELAYED_LIBS to LIBS.  Note that all users of DELAYED_LIBS
directly add the right -l<lib> arguments to the wrapper compilers.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>