### PR TITLE
Add PMIX_QUERY_ABI_VERSION key for PMIx_Query_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ examples/daemon_error_notify
 examples/launcher
 examples/log
 examples/showkeys
+examples/abi_no_init
+examples/abi_with_init
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/VERSION
+++ b/VERSION
@@ -4,6 +4,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2022      IBM Corporation. All rights reserved.
 
 # This is the VERSION file for PMIx, describing the precise
 # version of PMIx in this distribution.  The various components of
@@ -43,6 +44,17 @@ greek=a1
 std_major=4
 std_minor=1
 std_extension=2
+
+# PMIx Standard ABI Compliance Level
+# The major and minor numbers indicate the version
+# of the official PMIx Standard ABI that is supported
+# by this release. Generally, the PMIx Standard ABI
+# should match the PMIx Standard Compliance Level
+# major/minor levels. However, they are listed separately
+# for maximal flexibility.
+# Since no PMIx Standard ABI exists at the moment, set to "0.0"
+std_abi_major=0
+std_abi_minor=0
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2009-2021 IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2009-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
@@ -156,6 +156,16 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_STD_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_STD_VERSION], ["$PMIX_STD_VERSION"],
                        [The PMIx Standard compliance level])
+
+    AC_MSG_CHECKING([for pmix standard ABI version])
+    PMIX_STD_ABI_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-version`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_MSG_RESULT([$PMIX_STD_ABI_VERSION])
+    AC_SUBST(PMIX_STD_ABI_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_VERSION], ["$PMIX_STD_ABI_VERSION"],
+                       [The PMIx Standard ABI compliance level])
 
     PMIX_REPO_REV="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --repo-rev`"
     if test "$?" != "0"; then

--- a/config/pmix_get_version.sh
+++ b/config/pmix_get_version.sh
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -57,6 +57,8 @@ else
     s/^greek/PMIX_GREEK_VERSION/
     s/^std_major/PMIX_STD_MAJOR_VERSION/
     s/^std_minor/PMIX_STD_MINOR_VERSION/
+    s/^std_abi_major/PMIX_STD_ABI_MAJOR_VERSION/
+    s/^std_abi_minor/PMIX_STD_ABI_MINOR_VERSION/
     s/^repo_rev/PMIX_REPO_REV/
     s/^tarball_version/PMIX_TARBALL_VERSION/
     s/^date/PMIX_RELEASE_DATE/
@@ -70,6 +72,7 @@ else
         PMIX_VERSION="${PMIX_VERSION}${PMIX_GREEK_VERSION}"
 
         PMIX_STD_VERSION="$PMIX_STD_MAJOR_VERSION.$PMIX_STD_MINOR_VERSION"
+        PMIX_STD_ABI_VERSION="$PMIX_STD_ABI_MAJOR_VERSION.$PMIX_STD_ABI_MINOR_VERSION"
 
         if test "$PMIX_TARBALL_VERSION" = ""; then
             PMIX_TARBALL_VERSION=$PMIX_VERSION
@@ -128,6 +131,9 @@ case "$option" in
     ;;
     --std-version)
     echo $PMIX_STD_VERSION
+    ;;
+    --std-abi-version)
+    echo $PMIX_STD_ABI_VERSION
     ;;
     --repo-rev)
     echo $PMIX_REPO_REV

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -6,7 +6,7 @@ dnl Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
@@ -97,6 +97,7 @@ PMIx configuration:
 -----------------------
 Version: $PMIX_MAJOR_VERSION.$PMIX_MINOR_VERSION.$PMIX_RELEASE_VERSION$PMIX_GREEK_VERSION
 PMIx Standard Version: $PMIX_STD_VERSION
+PMIx Standard ABI Version: $PMIX_STD_ABI_VERSION
 EOF
 
     if test $WANT_DEBUG = 0 ; then

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,7 +24,7 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -96,7 +97,16 @@ hello_SOURCES = hello.c examples.h
 hello_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hello_LDADD =  $(top_builddir)/src/libpmix.la
 
+abi_no_init_SOURCES = abi_no_init.c
+abi_no_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+abi_no_init_LDADD =  $(top_builddir)/src/libpmix.la
+
+abi_with_init_SOURCES = abi_with_init.c
+abi_with_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+abi_with_init_LDADD =  $(top_builddir)/src/libpmix.la
+
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
-        hello jctrl launcher log pub pubi server tool
+        hello jctrl launcher log pub pubi server tool \
+        abi_no_init abi_with_init

--- a/examples/abi_no_init.c
+++ b/examples/abi_no_init.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Test PMIx_Query_info outside of init/finalize by asking for a
+ * key (PMIX_QUERY_ABI_VERSION) that is allowed to be accessed
+ * outside of the init/finalize region.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <pmix.h>
+
+int main(int argc, char **argv) {
+    int rc, i;
+    size_t ninfo, nqueries;
+    pmix_info_t *info = NULL;
+    pmix_query_t *query = NULL;
+
+    nqueries = 1;
+
+    PMIX_QUERY_CREATE(query, nqueries);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+
+    rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
+    if (PMIX_SUCCESS != rc ) {
+        fprintf(stderr, "Error: PMIx_Query_info failed: %d (%s)\n", rc, PMIx_Error_string(rc));
+        return rc;
+    }
+
+    printf("--> Query returned (ninfo %d)\n", ninfo);
+    for(i = 0; i < ninfo; ++i) {
+        printf("--> KEY: %s\n", info[i].key);
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
+            printf("----> ABI: String: %s\n",
+                   info[i].value.data.string);
+        }
+    }
+
+    /*
+     * Cleanup
+     */
+    PMIX_INFO_FREE(info, ninfo);
+    PMIX_QUERY_FREE(query, nqueries);
+
+    return 0;
+}

--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Test PMIx_Query_info with a locally resolved key (PMIX_QUERY_ABI_VERSION)
+ * and a key that the server will need to resolve.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <pmix.h>
+
+int main(int argc, char **argv) {
+    int rc, i;
+    size_t ninfo, nqueries;
+    pmix_info_t *info = NULL;
+    pmix_query_t *query = NULL;
+    static pmix_proc_t myproc;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "PMIx_Init failed: %d\n", rc);
+        exit(rc);
+    }
+
+    nqueries = 2;
+
+    PMIX_QUERY_CREATE(query, nqueries);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_NAMESPACES);
+
+    rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
+    if (PMIX_SUCCESS != rc ) {
+        fprintf(stderr, "Error: PMIx_Query_info failed: %d (%s)\n", rc, PMIx_Error_string(rc));
+        return rc;
+    }
+
+    printf("--> Query returned (ninfo %d)\n", ninfo);
+    for(i = 0; i < ninfo; ++i) {
+        printf("--> KEY: %s\n", info[i].key);
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
+            printf("----> ABI: String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_NAMESPACES)) {
+            printf("----> Namespaces: String: %s\n",
+                   info[i].value.data.string);
+        }
+    }
+
+    /*
+     * Cleanup
+     */
+    PMIX_INFO_FREE(info, ninfo);
+    PMIX_QUERY_FREE(query, nqueries);
+
+    PMIx_Finalize(NULL, 0);
+
+    return 0;
+}

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2021      Triad National Security, LLC. All rights
@@ -1108,6 +1108,8 @@ typedef uint32_t pmix_rank_t;
                                                                    //         Named values (i.e., values defined by constant names via a
                                                                    //         typical C-language enum declaration) must be provided as
                                                                    //         their numerical equivalent.
+#define PMIX_QUERY_ABI_VERSION              "pmix.qry.abiversion"  // (char*) The PMIx Standard ABI version supported returned in the form "MAJOR.MINOR"
+                                                                   //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
 
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -52,10 +52,10 @@
 
 #ifdef PMIX_GIT_REPO_BUILD
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION ", repo rev: " PMIX_REPO_REV
-                                          " (PMIx Standard: " PMIX_STD_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
 #else
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION
-                                          " (PMIx Standard: " PMIX_STD_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
 #endif
 static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 


### PR DESCRIPTION
 * `PMIx_Query_info` can now query the ABI level via the `PMIX_QUERY_ABI_VERSION` key
 * The `PMIX_QUERY_ABI_VERSION` is only resolvable locally to the caller and should not be sent to the server. So add a mechanism to, when this situation is identified, strip out this key from the query sent to the server. When the server response comes back then add the locally resolved information before passing it back to the client.
 * Add the PMIx Standard ABI version level to the `VERSION` file (similar to the PMIx Standard level)
   * Since the PMIx Standard ABI is not yet finalized set it to `0.0` for now. I'm assuming that we will change that to `5.0` once the ABI is ratified.
 * Ref
   * PMIx Standard PR: https://github.com/pmix/pmix-standard/pull/397
   * PMIx Standard ABI Discussion: https://github.com/pmix/pmix-standard/issues/365
