### PR TITLE
Add constants and support for atomistic reporting of context checks

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -451,6 +451,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ADD_HOSTFILE                   "pmix.addhostfile"      // (char*) hostfile to add to existing allocation
 #define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to use for starting spawned procs
 #define PMIX_WDIR                           "pmix.wdir"             // (char*) working directory for spawned procs
+#define PMIX_WDIR_USER_SPECIFIED            "pmix.wdir.user"        // (bool) User specified the working directory
 #define PMIX_DISPLAY_MAP                    "pmix.dispmap"          // (bool) display process map upon spawn
 #define PMIX_PPR                            "pmix.ppr"              // (char*) #procs to spawn on each identified resource
 #define PMIX_MAPBY                          "pmix.mapby"            // (char*) mapping policy

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -110,6 +110,8 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 #define PMIX_ERR_SYS_LIMITS_PIPES                   -70
 #define PMIX_ERR_SYS_LIMITS_CHILDREN                -71
 #define PMIX_ERR_PIPE_SETUP_FAILURE                 -72
+#define PMIX_ERR_EXE_NOT_ACCESSIBLE                 -73
+#define PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE            -74
 #define PMIX_ERR_LOST_CONNECTION_TO_SERVER          -101
 #define PMIX_ERR_LOST_PEER_CONNECTION               -102
 #define PMIX_ERR_LOST_CONNECTION_TO_CLIENT          -103

--- a/src/util/pmix_context_fns.c
+++ b/src/util/pmix_context_fns.c
@@ -93,10 +93,10 @@ pmix_status_t pmix_util_check_context_cwd(char **incwd,
         if (user_cwd) {
             /* if the directory does not exist, then report that */
             if (!check_exist(cwd)) {
-                return PMIX_ERR_NOT_FOUND;
+                return PMIX_ERR_JOB_WDIR_NOT_FOUND;
             }
             /* if it does exist, then we must lack permissions */
-            return PMIX_ERR_NO_PERMISSIONS;
+            return PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE;
         }
 
         /* If the user didn't specifically ask for it, then it
@@ -109,10 +109,10 @@ pmix_status_t pmix_util_check_context_cwd(char **incwd,
             if (want_chdir && 0 != chdir(tmp)) {
                 /* if the directory does not exist, then report that */
                 if (!check_exist(cwd)) {
-                    return PMIX_ERR_NOT_FOUND;
+                    return PMIX_ERR_JOB_WDIR_NOT_FOUND;
                 }
                 /* if it does exist, then we must lack permissions */
-                return PMIX_ERR_NO_PERMISSIONS;
+                return PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE;
             }
 
             /* Reset the pwd in this local copy of the
@@ -158,14 +158,14 @@ pmix_status_t pmix_util_check_context_app(char **incmd,
         free(tmp);
         tmp = pmix_path_findv(cmd, X_OK, env, cwd);
         if (NULL == tmp) {
-            return PMIX_ERR_NOT_FOUND;
+            return PMIX_ERR_JOB_EXE_NOT_FOUND;
         }
         free(cmd);
         *incmd = tmp;
     } else {
         free(tmp);
         if (0 != access(cmd, X_OK)) {
-            return PMIX_ERR_NO_PERMISSIONS;
+            return PMIX_ERR_EXE_NOT_ACCESSIBLE;
         }
     }
 

--- a/src/util/pmix_error.c
+++ b/src/util/pmix_error.c
@@ -343,6 +343,10 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
         return "SESSION STARTED";
     case PMIX_EVENT_SESSION_END:
         return "SESSION ENDED";
+    case PMIX_ERR_EXE_NOT_ACCESSIBLE:
+        return "EXE NOT ACCESSIBLE";
+    case PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE:
+        return "WDIR NOT ACCESSIBLE";
 
     default:
         return "ERROR STRING NOT FOUND";


### PR DESCRIPTION
Provide an atomistic error code for the context check_app and check_cwd
functions so callers can better know exactly what went wrong.

Signed-off-by: Ralph Castain <rhc@pmix.org>