### PR TITLE
Don't limit message size unless requested

### DIFF
--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -61,8 +61,6 @@
 
 #include "src/mca/ptl/base/static-components.h"
 
-#define PMIX_MAX_MSG_SIZE 16
-
 /* Instantiate the global vars */
 pmix_ptl_base_t pmix_ptl_base = {
     .initialized = false,
@@ -121,7 +119,7 @@ pmix_ptl_module_t pmix_ptl = {
     .setup_fork = NULL
 };
 
-static size_t max_msg_size = PMIX_MAX_MSG_SIZE;
+static size_t max_msg_size = 0;
 
 static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
 {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -527,7 +527,8 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
                                     "ptl:base:recv:handler allocate data region of size %lu",
                                     (unsigned long) peer->recv_msg->hdr.nbytes);
                 /* allocate the data region */
-                if (pmix_ptl_base.max_msg_size < peer->recv_msg->hdr.nbytes) {
+                if (0 < pmix_ptl_base.max_msg_size &&
+                    pmix_ptl_base.max_msg_size < peer->recv_msg->hdr.nbytes) {
                     pmix_show_help("help-pmix-runtime.txt", "ptl:msg_size", true,
                                    (unsigned long) peer->recv_msg->hdr.nbytes,
                                    (unsigned long) pmix_ptl_base.max_msg_size);


### PR DESCRIPTION
Only cap the client/server message size if requested to do
so by setting the limit using the MCA param.

Signed-off-by: Ralph Castain <rhc@pmix.org>