### PR TITLE
Checkpoint gds/shmem work.

### DIFF
--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -214,19 +214,23 @@ typedef void (*pmix_destruct_t)(pmix_object_t *);
 /** Memory allocator for objects */
 typedef struct pmix_tma {
     /** Pointer to the TMA's malloc() function. */
-    void *(*malloc)(struct pmix_tma *, size_t);
+    void *(*tma_malloc)(struct pmix_tma *, size_t);
     /** Pointer to the TMA's calloc() function. */
-    void *(*calloc)(struct pmix_tma *, size_t, size_t);
+    void *(*tma_calloc)(struct pmix_tma *, size_t, size_t);
     /** Pointer to the TMA's realloc() function. */
-    void *(*realloc)(struct pmix_tma *, void *, size_t);
+    void *(*tma_realloc)(struct pmix_tma *, void *, size_t);
+    /*
+     * NOTE: The seemingly unnecessary name mangling here is in response to
+     * certain compilers not liking the use of a function pointer named strdup.
+     */
     /** Pointer to the TMA's strdup() function. */
-    char *(*strdup)(struct pmix_tma *, const char *s);
+    char *(*tma_strdup)(struct pmix_tma *, const char *s);
     /**
      * A memmove()-like function that copies the provided contents to an
      * appropriate location in the memory area maintained by the allocator.
      * Like memmove(), it returns a pointer to the content's destination.
      */
-    void *(*memmove)(struct pmix_tma *tma, const void *src, size_t n);
+    void *(*tma_memmove)(struct pmix_tma *tma, const void *src, size_t n);
     /** Pointer inside the memory allocation arena. */
     void *arena;
     /**
@@ -239,7 +243,7 @@ typedef struct pmix_tma {
 static inline void *pmix_tma_malloc(pmix_tma_t *tma, size_t size)
 {
     if (NULL != tma) {
-        return tma->malloc(tma, size);
+        return tma->tma_malloc(tma, size);
     } else {
         return malloc(size);
     }
@@ -248,7 +252,7 @@ static inline void *pmix_tma_malloc(pmix_tma_t *tma, size_t size)
 static inline void *pmix_tma_realloc(pmix_tma_t *tma, void *ptr, size_t size)
 {
     if (NULL != tma) {
-        return tma->realloc(tma, ptr, size);
+        return tma->tma_realloc(tma, ptr, size);
     } else {
         return realloc(ptr, size);
     }
@@ -257,7 +261,7 @@ static inline void *pmix_tma_realloc(pmix_tma_t *tma, void *ptr, size_t size)
 static inline char *pmix_tma_strdup(pmix_tma_t *tma, const char *src)
 {
     if (NULL != tma) {
-        return tma->strdup(tma, src);
+        return tma->tma_strdup(tma, src);
     } else {
         return strdup(src);
     }
@@ -297,11 +301,11 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.malloc = NULL,                 \
-            .obj_tma.calloc = NULL,                 \
-            .obj_tma.realloc = NULL,                \
-            .obj_tma.strdup = NULL,                 \
-            .obj_tma.memmove = NULL,                \
+            .obj_tma.tma_malloc = NULL,             \
+            .obj_tma.tma_calloc = NULL,             \
+            .obj_tma.tma_realloc = NULL,            \
+            .obj_tma.tma_strdup = NULL,             \
+            .obj_tma.tma_memmove = NULL,            \
             .obj_tma.arena = NULL,                  \
             .obj_tma.dontfree = false,              \
             .cls_init_file_name = __FILE__,         \
@@ -313,11 +317,11 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.malloc = NULL,                 \
-            .obj_tma.calloc = NULL,                 \
-            .obj_tma.realloc = NULL,                \
-            .obj_tma.strdup = NULL,                 \
-            .obj_tma.memmove = NULL,                \
+            .obj_tma.tma_malloc = NULL,             \
+            .obj_tma.tma_calloc = NULL,             \
+            .obj_tma.tma_realloc = NULL,            \
+            .obj_tma.tma_strdup = NULL,             \
+            .obj_tma.tma_memmove = NULL,            \
             .obj_tma.arena = NULL,                  \
             .obj_tma.dontfree = false               \
         }
@@ -511,19 +515,19 @@ static inline pmix_object_t *pmix_obj_new_debug_tma(pmix_class_t *type, pmix_tma
 static inline void pmix_obj_construct_tma(pmix_object_t *obj, pmix_tma_t *t)
 {
     if (NULL == t) {
-        obj->obj_tma.malloc = NULL;
-        obj->obj_tma.calloc = NULL;
-        obj->obj_tma.realloc = NULL;
-        obj->obj_tma.strdup = NULL;
-        obj->obj_tma.memmove = NULL;
+        obj->obj_tma.tma_malloc = NULL;
+        obj->obj_tma.tma_calloc = NULL;
+        obj->obj_tma.tma_realloc = NULL;
+        obj->obj_tma.tma_strdup = NULL;
+        obj->obj_tma.tma_memmove = NULL;
         obj->obj_tma.arena = NULL;
         obj->obj_tma.dontfree = false;
     } else {
-        obj->obj_tma.malloc = t->malloc;
-        obj->obj_tma.calloc = t->calloc;
-        obj->obj_tma.realloc = t->realloc;
-        obj->obj_tma.strdup = t->strdup;
-        obj->obj_tma.memmove = t->memmove;
+        obj->obj_tma.tma_malloc = t->tma_malloc;
+        obj->obj_tma.tma_calloc = t->tma_calloc;
+        obj->obj_tma.tma_realloc = t->tma_realloc;
+        obj->obj_tma.tma_strdup = t->tma_strdup;
+        obj->obj_tma.tma_memmove = t->tma_memmove;
         obj->obj_tma.arena = t->arena;
         obj->obj_tma.dontfree = t->dontfree;
     }
@@ -696,10 +700,10 @@ static inline pmix_object_t *pmix_obj_new_tma(pmix_class_t *cls, pmix_tma_t *tma
         object->obj_class = cls;
         object->obj_reference_count = 1;
         if (NULL == tma) {
-            object->obj_tma.malloc = NULL;
-            object->obj_tma.calloc = NULL;
-            object->obj_tma.realloc = NULL;
-            object->obj_tma.strdup = NULL;
+            object->obj_tma.tma_malloc = NULL;
+            object->obj_tma.tma_calloc = NULL;
+            object->obj_tma.tma_realloc = NULL;
+            object->obj_tma.tma_strdup = NULL;
             object->obj_tma.arena = NULL;
             object->obj_tma.dontfree = false;
         } else {

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -92,7 +92,7 @@ do {                                                                           \
 // appropriate place. This modifies PMIX_PROC_CREATE() for our needs.
 #define PMIX_GDS_SHMEM_PROC_CREATE(m, n, tma)                                  \
 do {                                                                           \
-    (m) = (pmix_proc_t *)(tma)->calloc((tma), (n), sizeof(pmix_proc_t));       \
+    (m) = (pmix_proc_t *)(tma)->tma_calloc((tma), (n), sizeof(pmix_proc_t));   \
 } while (0)
 
 // TODO(skg) This shouldn't live here. Figure out a way to get this in an
@@ -100,7 +100,7 @@ do {                                                                           \
 #define PMIX_GDS_SHMEM_VALUE_XFER(r, v, s, tma)                                \
 do {                                                                           \
     if (NULL == (v)) {                                                         \
-        (v) = (pmix_value_t *)(tma)->malloc((tma), sizeof(pmix_value_t));      \
+        (v) = (pmix_value_t *)(tma)->tma_malloc((tma), sizeof(pmix_value_t));  \
         if (NULL == (v)) {                                                     \
             (r) = PMIX_ERR_NOMEM;                                              \
         } else {                                                               \
@@ -116,7 +116,7 @@ do {                                                                           \
 #define PMIX_GDS_SHMEM_INFO_CREATE(m, n, tma)                                  \
 do {                                                                           \
     pmix_info_t *i;                                                            \
-    (m) = (pmix_info_t *)(tma)->calloc((tma), (n), sizeof(pmix_info_t));       \
+    (m) = (pmix_info_t *)(tma)->tma_calloc((tma), (n), sizeof(pmix_info_t));   \
     if (NULL != (m)) {                                                         \
         i = (pmix_info_t *)(m);                                                \
         i[(n) - 1].flags = PMIX_INFO_ARRAY_END;                                \
@@ -158,7 +158,7 @@ pmix_gds_shmem_value_xfer(
             break;
         case PMIX_STRING:
             if (NULL != src->data.string) {
-                p->data.string = tma->strdup(tma, src->data.string);
+                p->data.string = tma->tma_strdup(tma, src->data.string);
             } else {
                 p->data.string = NULL;
             }
@@ -242,7 +242,7 @@ pmix_gds_shmem_value_xfer(
         case PMIX_COMPRESSED_BYTE_OBJECT:
             memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
             if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
-                p->data.bo.bytes = tma->malloc(tma, src->data.bo.size);
+                p->data.bo.bytes = tma->tma_malloc(tma, src->data.bo.size);
                 memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
                 p->data.bo.size = src->data.bo.size;
             } else {
@@ -287,10 +287,10 @@ pmix_gds_shmem_value_xfer(
             // NOTE(skg) This one is okay because all it does is set members.
             PMIX_ENVAR_CONSTRUCT(&p->data.envar);
             if (NULL != src->data.envar.envar) {
-                p->data.envar.envar = tma->strdup(tma, src->data.envar.envar);
+                p->data.envar.envar = tma->tma_strdup(tma, src->data.envar.envar);
             }
             if (NULL != src->data.envar.value) {
-                p->data.envar.value = tma->strdup(tma, src->data.envar.value);
+                p->data.envar.value = tma->tma_strdup(tma, src->data.envar.value);
             }
             p->data.envar.separator = src->data.envar.separator;
             break;
@@ -376,7 +376,7 @@ pmix_gds_shmem_copy_darray(
 
     PMIX_GDS_SHMEM_UNUSED(type);
 
-    p = (pmix_data_array_t *)tma->calloc(tma, 1, sizeof(pmix_data_array_t));
+    p = (pmix_data_array_t *)tma->tma_calloc(tma, 1, sizeof(pmix_data_array_t));
     if (NULL == p) {
         rc = PMIX_ERR_NOMEM;
         goto out;
@@ -395,7 +395,7 @@ pmix_gds_shmem_copy_darray(
         case PMIX_UINT8:
         case PMIX_INT8:
         case PMIX_BYTE:
-            p->array = (char *)tma->malloc(tma, src->size);
+            p->array = (char *)tma->tma_malloc(tma, src->size);
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -404,7 +404,7 @@ pmix_gds_shmem_copy_darray(
             break;
         case PMIX_UINT16:
         case PMIX_INT16:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint16_t));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(uint16_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -413,7 +413,7 @@ pmix_gds_shmem_copy_darray(
             break;
         case PMIX_UINT32:
         case PMIX_INT32:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint32_t));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(uint32_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -422,7 +422,7 @@ pmix_gds_shmem_copy_darray(
             break;
         case PMIX_UINT64:
         case PMIX_INT64:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint64_t));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(uint64_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -430,7 +430,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(uint64_t));
             break;
         case PMIX_BOOL:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(bool));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(bool));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -438,7 +438,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(bool));
             break;
         case PMIX_SIZE:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(size_t));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(size_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -446,7 +446,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(size_t));
             break;
         case PMIX_PID:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(pid_t));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(pid_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -455,7 +455,7 @@ pmix_gds_shmem_copy_darray(
             break;
         case PMIX_STRING: {
             char **prarray, **strarray;
-            p->array = (char **)tma->malloc(tma, src->size * sizeof(char *));
+            p->array = (char **)tma->tma_malloc(tma, src->size * sizeof(char *));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -464,7 +464,7 @@ pmix_gds_shmem_copy_darray(
             strarray = (char **)src->array;
             for (size_t n = 0; n < src->size; n++) {
                 if (NULL != strarray[n]) {
-                    prarray[n] = tma->strdup(tma, strarray[n]);
+                    prarray[n] = tma->tma_strdup(tma, strarray[n]);
                     if (NULL == prarray[n]) {
                         rc = PMIX_ERR_NOMEM;
                         goto out;
@@ -475,7 +475,7 @@ pmix_gds_shmem_copy_darray(
         }
         case PMIX_INT:
         case PMIX_UINT:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(int));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(int));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -483,7 +483,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(int));
             break;
         case PMIX_FLOAT:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(float));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(float));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -491,7 +491,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(float));
             break;
         case PMIX_DOUBLE:
-            p->array = (char *)tma->malloc(tma, src->size * sizeof(double));
+            p->array = (char *)tma->tma_malloc(tma, src->size * sizeof(double));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -499,7 +499,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(double));
             break;
         case PMIX_TIMEVAL:
-            p->array = (struct timeval *)tma->malloc(
+            p->array = (struct timeval *)tma->tma_malloc(
                 tma, src->size * sizeof(struct timeval)
             );
             if (NULL == p->array) {
@@ -509,7 +509,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(struct timeval));
             break;
         case PMIX_TIME:
-            p->array = (time_t *)tma->malloc(tma, src->size * sizeof(time_t));
+            p->array = (time_t *)tma->tma_malloc(tma, src->size * sizeof(time_t));
             if (NULL == p->array) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
@@ -517,7 +517,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(time_t));
             break;
         case PMIX_STATUS:
-            p->array = (pmix_status_t *)tma->malloc(
+            p->array = (pmix_status_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_status_t)
             );
             if (NULL == p->array) {
@@ -535,7 +535,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(pmix_proc_t));
             break;
         case PMIX_PROC_RANK:
-            p->array = (pmix_rank_t *)tma->malloc(
+            p->array = (pmix_rank_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_rank_t)
             );
             if (NULL == p->array) {
@@ -561,7 +561,7 @@ pmix_gds_shmem_copy_darray(
         case PMIX_BYTE_OBJECT:
         case PMIX_COMPRESSED_STRING: {
             pmix_byte_object_t *pbo, *sbo;
-            p->array = (pmix_byte_object_t *)tma->malloc(
+            p->array = (pmix_byte_object_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_byte_object_t)
             );
             if (NULL == p->array) {
@@ -573,7 +573,7 @@ pmix_gds_shmem_copy_darray(
             for (size_t n = 0; n < src->size; n++) {
                 if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
                     pbo[n].size = sbo[n].size;
-                    pbo[n].bytes = (char *)tma->malloc(tma, pbo[n].size);
+                    pbo[n].bytes = (char *)tma->tma_malloc(tma, pbo[n].size);
                     memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
                 } else {
                     pbo[n].bytes = NULL;
@@ -583,7 +583,7 @@ pmix_gds_shmem_copy_darray(
             break;
         }
         case PMIX_PERSIST:
-            p->array = (pmix_persistence_t *)tma->malloc(
+            p->array = (pmix_persistence_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_persistence_t)
             );
             if (NULL == p->array) {
@@ -593,7 +593,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(pmix_persistence_t));
             break;
         case PMIX_SCOPE:
-            p->array = (pmix_scope_t *)tma->malloc(
+            p->array = (pmix_scope_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_scope_t)
             );
             if (NULL == p->array) {
@@ -603,7 +603,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(pmix_scope_t));
             break;
         case PMIX_DATA_RANGE:
-            p->array = (pmix_data_range_t *)tma->malloc(
+            p->array = (pmix_data_range_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_data_range_t)
             );
             if (NULL == p->array) {
@@ -613,7 +613,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(pmix_data_range_t));
             break;
         case PMIX_COMMAND:
-            p->array = (pmix_cmd_t *)tma->malloc(
+            p->array = (pmix_cmd_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_cmd_t)
             );
             if (NULL == p->array) {
@@ -623,7 +623,7 @@ pmix_gds_shmem_copy_darray(
             memcpy(p->array, src->array, src->size * sizeof(pmix_cmd_t));
             break;
         case PMIX_INFO_DIRECTIVES:
-            p->array = (pmix_info_directives_t *)tma->malloc(
+            p->array = (pmix_info_directives_t *)tma->tma_malloc(
                 tma, src->size * sizeof(pmix_info_directives_t)
             );
             if (NULL == p->array) {
@@ -669,7 +669,7 @@ pmix_gds_shmem_copy_darray(
 out:
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        // TODO(skg) We could add a tma->free() for this situation. Then it will
+        // TODO(skg) We could add a tma->tma_free() for this situation. Then it will
         // be up to the tma backend what happens during its free().
         //free(p);
         p = NULL;
@@ -773,12 +773,12 @@ static void
 tma_construct(
     pmix_tma_t *tma
 ) {
-    tma->malloc = tma_malloc;
-    tma->calloc = tma_calloc;
+    tma->tma_malloc = tma_malloc;
+    tma->tma_calloc = tma_calloc;
     // We don't currently support realloc.
-    tma->realloc = NULL;
-    tma->strdup = tma_strdup;
-    tma->memmove = tma_memmove;
+    tma->tma_realloc = NULL;
+    tma->tma_strdup = tma_strdup;
+    tma->tma_memmove = tma_memmove;
     tma->arena = NULL;
     tma->dontfree = 1;
 }
@@ -787,11 +787,11 @@ static void
 tma_destruct(
     pmix_tma_t *tma
 ) {
-    tma->malloc = NULL;
-    tma->calloc = NULL;
-    tma->realloc = NULL;
-    tma->strdup = NULL;
-    tma->memmove = NULL;
+    tma->tma_malloc = NULL;
+    tma->tma_calloc = NULL;
+    tma->tma_realloc = NULL;
+    tma->tma_strdup = NULL;
+    tma->tma_memmove = NULL;
     tma->arena = NULL;
 }
 
@@ -1527,7 +1527,7 @@ add_info_to_job(
         goto out;
     }
     // Similarly, cache the provided key in shared-memory.
-    kval->key = job->tma.strdup(&job->tma, info->key);
+    kval->key = job->tma.tma_strdup(&job->tma, info->key);
     if (!kval->key) {
         rc = PMIX_ERR_NOMEM;
         goto out;
@@ -1550,7 +1550,7 @@ add_info_to_job(
             }
             kval->value->type = PMIX_COMPRESSED_STRING;
             // We need to copy into our shared-memory segment.
-            sm_cdata = job->tma.memmove(&job->tma, cdata, cdata_size);
+            sm_cdata = job->tma.tma_memmove(&job->tma, cdata, cdata_size);
             kval->value->data.bo.bytes = sm_cdata;
             kval->value->data.bo.size = cdata_size;
             // Now we can free the compressed data we copied.
@@ -1577,8 +1577,8 @@ add_info_to_job(
         goto out;
     }
     // Notice that we don't do a PMIX_RELEASE(kval) here, because we don't
-    // currently support free(). TODO(skg) We should probably add tma->free() so
-    // that the usage conventions are preserved.
+    // currently support free(). TODO(skg) We should probably add
+    // tma->tma_free() so that the usage conventions are preserved.
 out:
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -25,6 +25,7 @@
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
+#include "src/mca/pcompress/base/base.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
@@ -64,8 +65,18 @@ do {                                                                           \
                         "gds:" PMIX_GDS_SHMEM_NAME ":" __VA_ARGS__);           \
 } while (0)
 
-#define PMIX_GDS_SHMEM_MALLOC_ALIGN(p, s)                                      \
+/**
+ * 8-byte address alignment.
+ */
+#define PMIX_GDS_SHMEM_ADDR_ALIGN_8(p, s)                                      \
     (uint8_t *)(p) + (((s) + 8UL - 1) & ~(8UL - 1))
+
+/*
+ * TODO(skg) Look at PMIX_BFROPS_PACK code.
+ * TODO(skg) Look at PMIX_DATA_ARRAY_CONSTRUCT
+ * TODO(skg) Look at mca/bfrops/base/bfrop_base_fns.c
+ * TODO(skg) Look at pmix_gds_hash_fetch()
+ */
 
 /*
  * TODO(skg) Think about reallocs. Pointer arrays may change size.
@@ -77,16 +88,611 @@ do {                                                                           \
  *   info.
  */
 
-/*
- * TODO(skg) Ideally these would (somehow) be integrated directory into the code
- * in ./include/pmix_common.h. For now we will just match it the best we can.
- */
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_PROC_CREATE() for our needs.
+#define PMIX_GDS_SHMEM_PROC_CREATE(m, n, tma)                                  \
+do {                                                                           \
+    (m) = (pmix_proc_t *)(tma)->calloc((tma), (n), sizeof(pmix_proc_t));       \
+} while (0)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_VALUE_XFER() for our needs.
+#define PMIX_GDS_SHMEM_VALUE_XFER(r, v, s, tma)                                \
+do {                                                                           \
+    if (NULL == (v)) {                                                         \
+        (v) = (pmix_value_t *)(tma)->malloc((tma), sizeof(pmix_value_t));      \
+        if (NULL == (v)) {                                                     \
+            (r) = PMIX_ERR_NOMEM;                                              \
+        } else {                                                               \
+            (r) = pmix_gds_shmem_value_xfer((v), (s), (tma));                  \
+        }                                                                      \
+    } else {                                                                   \
+        (r) = pmix_gds_shmem_value_xfer((v), (s), (tma));                      \
+    }                                                                          \
+} while(0)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_CREATE() for our needs.
 #define PMIX_GDS_SHMEM_INFO_CREATE(m, n, tma)                                  \
 do {                                                                           \
-    (m) = (pmix_info_t *)(tma)->malloc((tma), (n) * sizeof(pmix_info_t));      \
-    pmix_info_t *i = (pmix_info_t *)(m);                                       \
-    i[(n) - 1].flags = PMIX_INFO_ARRAY_END;                                    \
+    pmix_info_t *i;                                                            \
+    (m) = (pmix_info_t *)(tma)->calloc((tma), (n), sizeof(pmix_info_t));       \
+    if (NULL != (m)) {                                                         \
+        i = (pmix_info_t *)(m);                                                \
+        i[(n) - 1].flags = PMIX_INFO_ARRAY_END;                                \
+    }                                                                          \
 } while (0)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_XFER() for our needs.
+#define PMIX_GDS_SHMEM_INFO_XFER(d, s, tma)                                    \
+    (void)pmix_gds_shmem_info_xfer(d, s, tma)
+
+// TODO(skg) This will eventually go away.
+static pmix_status_t
+pmix_gds_shmem_copy_darray(
+    pmix_data_array_t **dest,
+    pmix_data_array_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+);
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies pmix_bfrops_base_value_xfer() for our needs.
+static pmix_status_t
+pmix_gds_shmem_value_xfer(
+    pmix_value_t *p,
+    const pmix_value_t *src,
+    pmix_tma_t *tma
+) {
+    p->type = src->type;
+
+    switch (src->type) {
+        case PMIX_UNDEF:
+            break;
+        case PMIX_BOOL:
+            p->data.flag = src->data.flag;
+            break;
+        case PMIX_BYTE:
+            p->data.byte = src->data.byte;
+            break;
+        case PMIX_STRING:
+            if (NULL != src->data.string) {
+                p->data.string = tma->strdup(tma, src->data.string);
+            } else {
+                p->data.string = NULL;
+            }
+            break;
+        case PMIX_SIZE:
+            p->data.size = src->data.size;
+            break;
+        case PMIX_PID:
+            p->data.pid = src->data.pid;
+            break;
+        case PMIX_INT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.integer, &src->data.integer, sizeof(int));
+            break;
+        case PMIX_INT8:
+            p->data.int8 = src->data.int8;
+            break;
+        case PMIX_INT16:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int16, &src->data.int16, 2);
+            break;
+        case PMIX_INT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int32, &src->data.int32, 4);
+            break;
+        case PMIX_INT64:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int64, &src->data.int64, 8);
+            break;
+        case PMIX_UINT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint, &src->data.uint, sizeof(unsigned int));
+            break;
+        case PMIX_UINT8:
+            p->data.uint8 = src->data.uint8;
+            break;
+        case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint16, &src->data.uint16, 2);
+            break;
+        case PMIX_UINT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint32, &src->data.uint32, 4);
+            break;
+        case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
+           /* to avoid alignment issues */
+            memcpy(&p->data.uint64, &src->data.uint64, 8);
+            break;
+        case PMIX_FLOAT:
+            p->data.fval = src->data.fval;
+            break;
+        case PMIX_DOUBLE:
+            p->data.dval = src->data.dval;
+            break;
+        case PMIX_TIMEVAL:
+            memcpy(&p->data.tv, &src->data.tv, sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            memcpy(&p->data.time, &src->data.time, sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC_RANK:
+            memcpy(&p->data.rank, &src->data.rank, sizeof(pmix_rank_t));
+            break;
+        case PMIX_PROC:
+            PMIX_GDS_SHMEM_PROC_CREATE(p->data.proc, 1, tma);
+            if (NULL == p->data.proc) {
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->data.proc, src->data.proc, sizeof(pmix_proc_t));
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_REGEX:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
+            if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
+                p->data.bo.bytes = tma->malloc(tma, src->data.bo.size);
+                memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
+                p->data.bo.size = src->data.bo.size;
+            } else {
+                p->data.bo.bytes = NULL;
+                p->data.bo.size = 0;
+            }
+            break;
+        case PMIX_PERSIST:
+            memcpy(
+                &p->data.persist,
+                &src->data.persist,
+                sizeof(pmix_persistence_t)
+            );
+            break;
+        case PMIX_SCOPE:
+            memcpy(&p->data.scope, &src->data.scope, sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            memcpy(&p->data.range, &src->data.range, sizeof(pmix_data_range_t));
+            break;
+        case PMIX_PROC_STATE:
+            memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
+            break;
+        case PMIX_DATA_ARRAY:
+            return pmix_gds_shmem_copy_darray(
+                &p->data.darray,
+                src->data.darray,
+                PMIX_DATA_ARRAY,
+                tma
+            );
+        case PMIX_POINTER:
+            p->data.ptr = src->data.ptr;
+            break;
+        case PMIX_ALLOC_DIRECTIVE:
+            memcpy(
+                &p->data.adir,
+                &src->data.adir,
+                sizeof(pmix_alloc_directive_t)
+            );
+            break;
+        case PMIX_ENVAR:
+            // NOTE(skg) This one is okay because all it does is set members.
+            PMIX_ENVAR_CONSTRUCT(&p->data.envar);
+            if (NULL != src->data.envar.envar) {
+                p->data.envar.envar = tma->strdup(tma, src->data.envar.envar);
+            }
+            if (NULL != src->data.envar.value) {
+                p->data.envar.value = tma->strdup(tma, src->data.envar.value);
+            }
+            p->data.envar.separator = src->data.envar.separator;
+            break;
+        case PMIX_LINK_STATE:
+            memcpy(
+                &p->data.linkstate,
+                &src->data.linkstate,
+                sizeof(pmix_link_state_t)
+            );
+            break;
+        case PMIX_JOB_STATE:
+            memcpy(
+                &p->data.jstate,
+                &src->data.jstate,
+                sizeof(pmix_job_state_t)
+            );
+            break;
+        case PMIX_LOCTYPE:
+            memcpy(
+                &p->data.locality,
+                &src->data.locality,
+                sizeof(pmix_locality_t)
+            );
+            break;
+        case PMIX_DEVTYPE:
+            memcpy(
+                &p->data.devtype,
+                &src->data.devtype,
+                sizeof(pmix_device_type_t)
+            );
+            break;
+        // TODO(skg) Implement currently unsupported types.
+        case PMIX_PROC_NSPACE:
+        case PMIX_PROC_INFO:
+        case PMIX_COORD:
+        case PMIX_TOPO:
+        case PMIX_PROC_CPUSET:
+        case PMIX_GEOMETRY:
+        case PMIX_DEVICE_DIST:
+        case PMIX_ENDPOINT:
+        case PMIX_REGATTR:
+        case PMIX_DATA_BUFFER:
+        case PMIX_PROC_STATS:
+        case PMIX_DISK_STATS:
+        case PMIX_NET_STATS:
+        case PMIX_NODE_STATS:
+        default:
+            pmix_output(
+                0, "%s: UNSUPPORTED TYPE: %s",
+                __func__, PMIx_Data_type_string(src->type)
+            );
+            return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_XFER() for our needs.
+static pmix_status_t
+pmix_gds_shmem_info_xfer(
+    pmix_info_t *dest,
+    const pmix_info_t *src,
+    pmix_tma_t *tma
+) {
+    if (NULL == dest || NULL == src) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_LOAD_KEY(dest->key, src->key);
+    return pmix_gds_shmem_value_xfer(&dest->value, &src->value, tma);
+}
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies pmix_bfrops_base_copy_darray() for our needs.
+static pmix_status_t
+pmix_gds_shmem_copy_darray(
+    pmix_data_array_t **dest,
+    pmix_data_array_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_data_array_t *p = NULL;
+
+    PMIX_GDS_SHMEM_UNUSED(type);
+
+    p = (pmix_data_array_t *)tma->calloc(tma, 1, sizeof(pmix_data_array_t));
+    if (NULL == p) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
+
+    p->type = src->type;
+    p->size = src->size;
+
+    if (0 == p->size || NULL == src->array) {
+        // Done!
+        goto out;
+    }
+
+    // Process based on type of array element.
+    switch (src->type) {
+        case PMIX_UINT8:
+        case PMIX_INT8:
+        case PMIX_BYTE:
+            p->array = (char *)tma->malloc(tma, src->size);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size);
+            break;
+        case PMIX_UINT16:
+        case PMIX_INT16:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint16_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint16_t));
+            break;
+        case PMIX_UINT32:
+        case PMIX_INT32:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint32_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint32_t));
+            break;
+        case PMIX_UINT64:
+        case PMIX_INT64:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(uint64_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint64_t));
+            break;
+        case PMIX_BOOL:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(bool));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(bool));
+            break;
+        case PMIX_SIZE:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(size_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(size_t));
+            break;
+        case PMIX_PID:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(pid_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pid_t));
+            break;
+        case PMIX_STRING: {
+            char **prarray, **strarray;
+            p->array = (char **)tma->malloc(tma, src->size * sizeof(char *));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            prarray = (char **)p->array;
+            strarray = (char **)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                if (NULL != strarray[n]) {
+                    prarray[n] = tma->strdup(tma, strarray[n]);
+                    if (NULL == prarray[n]) {
+                        rc = PMIX_ERR_NOMEM;
+                        goto out;
+                    }
+                }
+            }
+            break;
+        }
+        case PMIX_INT:
+        case PMIX_UINT:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(int));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(int));
+            break;
+        case PMIX_FLOAT:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(float));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(float));
+            break;
+        case PMIX_DOUBLE:
+            p->array = (char *)tma->malloc(tma, src->size * sizeof(double));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(double));
+            break;
+        case PMIX_TIMEVAL:
+            p->array = (struct timeval *)tma->malloc(
+                tma, src->size * sizeof(struct timeval)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            p->array = (time_t *)tma->malloc(tma, src->size * sizeof(time_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            p->array = (pmix_status_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_status_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC:
+            PMIX_GDS_SHMEM_PROC_CREATE(p->array, src->size, tma);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_proc_t));
+            break;
+        case PMIX_PROC_RANK:
+            p->array = (pmix_rank_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_rank_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_rank_t));
+            break;
+        case PMIX_INFO: {
+            pmix_info_t *p1, *s1;
+            PMIX_GDS_SHMEM_INFO_CREATE(p->array, src->size, tma);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            p1 = (pmix_info_t *)p->array;
+            s1 = (pmix_info_t *)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                PMIX_GDS_SHMEM_INFO_XFER(&p1[n], &s1[n], tma);
+            }
+            break;
+        }
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING: {
+            pmix_byte_object_t *pbo, *sbo;
+            p->array = (pmix_byte_object_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_byte_object_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            pbo = (pmix_byte_object_t *)p->array;
+            sbo = (pmix_byte_object_t *)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
+                    pbo[n].size = sbo[n].size;
+                    pbo[n].bytes = (char *)tma->malloc(tma, pbo[n].size);
+                    memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
+                } else {
+                    pbo[n].bytes = NULL;
+                    pbo[n].size = 0;
+                }
+            }
+            break;
+        }
+        case PMIX_PERSIST:
+            p->array = (pmix_persistence_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_persistence_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_persistence_t));
+            break;
+        case PMIX_SCOPE:
+            p->array = (pmix_scope_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_scope_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            p->array = (pmix_data_range_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_data_range_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_data_range_t));
+            break;
+        case PMIX_COMMAND:
+            p->array = (pmix_cmd_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_cmd_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_cmd_t));
+            break;
+        case PMIX_INFO_DIRECTIVES:
+            p->array = (pmix_info_directives_t *)tma->malloc(
+                tma, src->size * sizeof(pmix_info_directives_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_info_directives_t));
+            break;
+        case PMIX_DATA_ARRAY:
+            // We don't support nested arrays.
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            break;
+        case PMIX_VALUE:
+        case PMIX_APP:
+        case PMIX_PDATA:
+        case PMIX_BUFFER:
+        case PMIX_KVAL:
+        // TODO(skg) How are we going to handle this case? My guess is that
+        // since these are pointers then the assumption is that they are only
+        // valid within the process that asked to store them.
+        case PMIX_POINTER:
+        case PMIX_PROC_INFO:
+        case PMIX_QUERY:
+        case PMIX_ENVAR:
+        case PMIX_COORD:
+        case PMIX_REGATTR:
+        case PMIX_PROC_CPUSET:
+        case PMIX_GEOMETRY:
+        case PMIX_DEVICE_DIST:
+        case PMIX_ENDPOINT:
+        case PMIX_PROC_NSPACE:
+        case PMIX_PROC_STATS:
+        case PMIX_DISK_STATS:
+        case PMIX_NET_STATS:
+        case PMIX_NODE_STATS:
+        default:
+            pmix_output(
+                0, "%s: UNSUPPORTED TYPE: %s",
+                __func__, PMIx_Data_type_string(src->type)
+            );
+            rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+out:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        // TODO(skg) We could add a tma->free() for this situation. Then it will
+        // be up to the tma backend what happens during its free().
+        //free(p);
+        p = NULL;
+    }
+    *dest = p;
+    return rc;
+}
+
+/**
+ * Checks if an info's string value exceeds the length limit and therefore
+ * requires compression.
+ *
+ * Note that we cannot use PMIX_STRING_SIZE_CHECK because we need to inspect
+ * pmix_info_t structures, not pmix_kval_ts.
+ */
+static inline bool
+string_value_requires_compression(
+    const pmix_value_t *value
+) {
+    return PMIX_STRING == value->type &&
+           NULL != value->data.string &&
+           strlen(value->data.string) > pmix_compress_base.compress_limit;
+}
 
 /**
  * Returns page size.
@@ -110,48 +716,90 @@ pad_amount_to_page(
     size_t size
 ) {
     const size_t page_size = get_page_size();
-    return (((~size) + page_size + 1) & (page_size - 1));
+    return ((~size) + page_size + 1) & (page_size - 1);
 }
 
+// TODO(skg) Add memory arena boundary checks.
 static inline void *
 tma_malloc(
-    struct pmix_gds_shmem_tma *tma,
+    pmix_tma_t *tma,
     size_t size
 ) {
-    void *current = tma->data;
+    void *current = tma->arena;
     memset(current, 0, size);
-    tma->data = PMIX_GDS_SHMEM_MALLOC_ALIGN(tma->data, size);
+    tma->arena = PMIX_GDS_SHMEM_ADDR_ALIGN_8(tma->arena, size);
     return current;
+}
+
+// TODO(skg) Add memory arena boundary checks.
+static inline void *
+tma_calloc(
+    struct pmix_tma *tma,
+    size_t nmemb,
+    size_t size
+) {
+    const size_t real_size = nmemb * size;
+    void *current = tma->arena;
+    memset(current, 0, real_size);
+    tma->arena = PMIX_GDS_SHMEM_ADDR_ALIGN_8(tma->arena, real_size);
+    return current;
+}
+
+// TODO(skg) Add memory arena boundary checks.
+static inline char *
+tma_strdup(
+    pmix_tma_t *tma,
+    const char *s
+) {
+    void *current = tma->arena;
+    const size_t size = strlen(s) + 1;
+    tma->arena = PMIX_GDS_SHMEM_ADDR_ALIGN_8(tma->arena, size);
+    return (char *)memmove(current, s, size);
+}
+
+// TODO(skg) Add memory arena boundary checks.
+static inline void *
+tma_memmove(
+    struct pmix_tma *tma,
+    const void *src,
+    size_t size
+) {
+    void *current = tma->arena;
+    tma->arena = PMIX_GDS_SHMEM_ADDR_ALIGN_8(tma->arena, size);
+    return memmove(current, src, size);
 }
 
 static void
 tma_construct(
-    pmix_gds_shmem_tma_t *s
+    pmix_tma_t *tma
 ) {
-    s->malloc = tma_malloc;
-    s->data = NULL;
+    tma->malloc = tma_malloc;
+    tma->calloc = tma_calloc;
+    // We don't currently support realloc.
+    tma->realloc = NULL;
+    tma->strdup = tma_strdup;
+    tma->memmove = tma_memmove;
+    tma->arena = NULL;
+    tma->dontfree = 1;
 }
 
 static void
 tma_destruct(
-    pmix_gds_shmem_tma_t *s
+    pmix_tma_t *tma
 ) {
-    s->malloc = NULL;
-    s->data = NULL;
+    tma->malloc = NULL;
+    tma->calloc = NULL;
+    tma->realloc = NULL;
+    tma->strdup = NULL;
+    tma->memmove = NULL;
+    tma->arena = NULL;
 }
-
-PMIX_CLASS_INSTANCE(
-    pmix_gds_shmem_tma_t,
-    pmix_object_t,
-    tma_construct,
-    tma_destruct
-);
 
 static void
 session_construct(
     pmix_gds_shmem_session_t *s
 ) {
-    s->session = UINT32_MAX;
+    s->id = UINT32_MAX;
     PMIX_CONSTRUCT(&s->sessioninfo, pmix_list_t);
     PMIX_CONSTRUCT(&s->nodeinfo, pmix_list_t);
 }
@@ -175,22 +823,27 @@ static void
 job_construct(
     pmix_gds_shmem_job_t *j
 ) {
-    j->ns = NULL;
+    j->nspace_id = NULL;
+    j->nspace = NULL;
     j->shmem = PMIX_NEW(pmix_shmem_t);
-    j->tma = PMIX_NEW(pmix_gds_shmem_tma_t);
-    j->nptr = NULL;
+    tma_construct(&j->tma);
     j->session = NULL;
+    pmix_hash_table_init(&j->hashtab_internal, 256);
 }
 
 static void
 job_destruct(
-    pmix_gds_shmem_job_t *p
+    pmix_gds_shmem_job_t *j
 ) {
-    free(p->ns);
-    PMIX_RELEASE(p->shmem);
-    PMIX_RELEASE(p->tma);
-    PMIX_RELEASE(p->nptr);
-    PMIX_RELEASE(p->session);
+    free(j->nspace_id);
+    PMIX_RELEASE(j->nspace);
+    PMIX_RELEASE(j->shmem);
+    tma_destruct(&j->tma);
+    PMIX_RELEASE(j->session);
+    pmix_hash_remove_data(
+        &j->hashtab_internal, PMIX_RANK_WILDCARD, NULL
+    );
+    PMIX_DESTRUCT(&j->hashtab_internal);
 }
 
 PMIX_CLASS_INSTANCE(
@@ -299,6 +952,8 @@ server_register_job_info(
     struct pmix_peer_t *pr,
     pmix_buffer_t *reply
 ) {
+    // TODO(skg) Look at pmix_gds_hash_fetch(). It looks like this is where we
+    // would interface with the requester.
     // TODO(skg) GDS_GET pass own peer to get info; cache in sm.
     // TODO(skg) Look at pmix_hash_fetch(ht, PMIX_RANK_WILDCARD, NULL, &val);
     PMIX_GDS_SHMEM_UNUSED(pr);
@@ -395,13 +1050,15 @@ store_job_info(
     const char *nspace,
     pmix_buffer_t *buf
 ) {
+    PMIX_GDS_SHMEM_VOUT_HERE();
+
     PMIX_GDS_SHMEM_UNUSED(buf);
 
     pmix_status_t rc = PMIX_SUCCESS;
     uintptr_t mmap_addr = 0;
-    // Get the job tracker for the given namespace.
+    // Create a job tracker for the given namespace.
     pmix_gds_shmem_job_t *job = NULL;
-    rc = pmix_gds_shmem_get_job_tracker(nspace, &job);
+    rc = pmix_gds_shmem_get_job_tracker(nspace, true, &job);
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
@@ -497,9 +1154,10 @@ server_setup_fork(
         "%s: peer (rank=%d) namespace=%s",
         __func__, peer->rank, peer->nspace
     );
-    // Get the tracker for this job.
+    // Get the tracker for this job. We should have already created one, so
+    // that's why we pass false in pmix_gds_shmem_get_job_tracker().
     pmix_gds_shmem_job_t *job = NULL;
-    rc = pmix_gds_shmem_get_job_tracker(peer->nspace, &job);
+    rc = pmix_gds_shmem_get_job_tracker(peer->nspace, false, &job);
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
@@ -563,6 +1221,9 @@ unhandled_type(
     return rc;
 }
 
+/**
+ * Returns the size required to store the given type.
+ */
 static inline pmix_status_t
 get_value_size(
     const pmix_value_t *value,
@@ -570,7 +1231,6 @@ get_value_size(
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
     size_t total = 0;
-    pmix_value_t *tmp_value = NULL;
 
     const pmix_data_type_t type = value->type;
     // NOTE(skg) This follows the size conventions set in include/pmix_common.h.
@@ -589,20 +1249,29 @@ get_value_size(
         case PMIX_BOOL:
             total += sizeof(bool);
             break;
+        // TODO(skg) This needs more work. For example, we can potentially miss
+        // the storage requirements of scaffolding around things like
+        // PMIX_STRINGs, for example. See pmix_gds_shmem_copy_darray().
         case PMIX_DATA_ARRAY: {
-            size_t n = 0, sizeofn = 0;
             total += sizeof(pmix_data_array_t);
-            n = value->data.darray->size;
-            // TODO(skg) This probably needs lots of work: need to potentially
-            // set more value info to recursively find sizes of complex types.
-            PMIX_VALUE_CREATE(tmp_value, 1);
-            tmp_value->type = value->data.darray->type;
-            rc = get_value_size(tmp_value, &sizeofn);
-            PMIX_VALUE_RELEASE(tmp_value);
+            const size_t n = value->data.darray->size;
+            PMIX_GDS_SHMEM_VOUT(
+                "%s: %s of type=%s has size=%zd",
+                __func__, PMIx_Data_type_string(type),
+                PMIx_Data_type_string(value->data.darray->type), n
+            );
+            // We don't construct or destruct tmp_value because we are only
+            // interested in inspecting its values for the purposes of
+            // estimating its size using this function.
+            pmix_value_t tmp_value = {
+                .type = value->data.darray->type
+            };
+            size_t sizeofn = 0;
+            rc = get_value_size(&tmp_value, &sizeofn);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
-            total += (n * sizeofn);
+            total += n * sizeofn;
             break;
         }
         case PMIX_DOUBLE:
@@ -645,15 +1314,14 @@ get_value_size(
             total += sizeof(pmix_rank_t);
             break;
         case PMIX_REGEX:
-            // TODO(skg) Is this fine? Looks like it's just a string.
+            total += sizeof(pmix_byte_object_t);
+            total += value->data.bo.size;
+            break;
+        case PMIX_STRING:
             total += strlen(value->data.string) + 1;
             break;
         case PMIX_SIZE:
             total += sizeof(size_t);
-            break;
-        case PMIX_STRING:
-            // TODO(skg) Is there a special case for this?
-            total += strlen(value->data.string) + 1;
             break;
         case PMIX_UINT16:
             total += sizeof(uint16_t);
@@ -702,6 +1370,10 @@ get_value_size(
     return rc;
 }
 
+/**
+ * Calculates a rough (upper bound) estimate on the amount of storage required
+ * to store the values associated with this namespace.
+ */
 static pmix_status_t
 get_estimated_segment_size(
     const char *nspace,
@@ -712,9 +1384,9 @@ get_estimated_segment_size(
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
     size_t total = 0, size = 0;
-    // Calculate a rough (upper bound) estimate on the amount of storage
-    // required to store the values associated with this namespace.
-    total += (ninfo * sizeof(pmix_info_t));
+    // Each pmix_info_t has all the associated data structures
+    // that we must ultimately store, so account for those.
+    total += ninfo * sizeof(pmix_kval_t);
     for (size_t i = 0; i < ninfo; ++i) {
         const pmix_value_t *value = &info[i].value;
         rc = get_value_size(value, &size);
@@ -735,12 +1407,15 @@ get_estimated_segment_size(
     return PMIX_SUCCESS;
 }
 
+/**
+ * Returns a valid path or NULL on error.
+ */
 static const char *
 get_shmem_backing_path(
     pmix_info_t info[],
     size_t ninfo
 ) {
-    static char path[PMIX_PATH_MAX];
+    static char path[PMIX_PATH_MAX] = {0};
     static const char *basedir = NULL;
 
     for (size_t i = 0; i < ninfo; ++i) {
@@ -764,8 +1439,7 @@ get_shmem_backing_path(
         basedir, PMIX_GDS_SHMEM_NAME, getpid()
     );
     if (nw >= PMIX_PATH_MAX) {
-        // Best we can do. Sorry.
-        return basedir;
+        return NULL;
     }
     return path;
 }
@@ -794,6 +1468,10 @@ segment_create_and_attach(
     );
     // Find a unique path for the shared-memory backing file.
     segment_path = get_shmem_backing_path(info, ninfo);
+    if (!segment_path) {
+        rc = PMIX_ERROR;
+        goto out;
+    }
     PMIX_GDS_SHMEM_VOUT(
         "%s: segment backing file path is %s (%zd B)",
         __func__, segment_path, size
@@ -821,11 +1499,92 @@ segment_create_and_attach(
         "%s: mmapd at address=0x%zx", __func__, (size_t)mmap_addr
     );
     // Let our allocator know where its base address is.
-    job->tma->data = (void *)mmap_addr;
+    job->tma.arena = (void *)mmap_addr;
 out:
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(job->shmem);
         PMIX_ERROR_LOG(rc);
+    }
+    return rc;
+}
+
+// NOTE(skg) This methodology comes from hash_cache_job_info().
+static pmix_status_t
+add_info_to_job(
+    const pmix_info_t *info,
+    pmix_gds_shmem_job_t *job
+) {
+    PMIX_GDS_SHMEM_VOUT(
+        "%s: Storing k=%s, v=%s", __func__,
+        info->key, PMIx_Data_type_string(info->value.type)
+    );
+
+    pmix_status_t rc = PMIX_SUCCESS;
+    // Create and store a pmix_kval_t structure in shared memory.
+    pmix_kval_t *kval = PMIX_NEW(pmix_kval_t, &job->tma);
+    if (!kval) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
+    // Similarly, cache the provided key in shared-memory.
+    kval->key = job->tma.strdup(&job->tma, info->key);
+    if (!kval->key) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
+    // First check the special case where the string value requires compression.
+    // We do this first because we want to avoid having to free the provided
+    // value if compression is required, as we don't currently support free().
+    //
+    // TODO(skg) Best I can tell, this should probably happen automatically in
+    // pmix_bfrops_base_value_xfer().
+    if (string_value_requires_compression(&info->value)) {
+        char *str = info->value.data.string;
+        uint8_t *cdata = NULL;
+        size_t cdata_size = 0;
+        if (pmix_compress.compress_string(str, &cdata, &cdata_size)) {
+            char *sm_cdata = NULL;
+            if (!cdata) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            kval->value->type = PMIX_COMPRESSED_STRING;
+            // We need to copy into our shared-memory segment.
+            sm_cdata = job->tma.memmove(&job->tma, cdata, cdata_size);
+            kval->value->data.bo.bytes = sm_cdata;
+            kval->value->data.bo.size = cdata_size;
+            // Now we can free the compressed data we copied.
+            free(cdata);
+        }
+        // The compression didn't happen for some reason, so return an error.
+        else {
+            rc = PMIX_ERROR;
+            goto out;
+        }
+    }
+    else {
+        // TODO(skg) We cannot use PMIX_VALUE_XFER directly because there are
+        // memory allocation operations that are outside of our allocator's
+        // purview.
+        PMIX_GDS_SHMEM_VALUE_XFER(rc, kval->value, &info->value, &job->tma);
+        if (PMIX_SUCCESS != rc) {
+            goto out;
+        }
+    }
+    // Store the kval into our internal hash table.
+    rc = pmix_hash_store(&job->hashtab_internal, PMIX_RANK_WILDCARD, kval);
+    if (PMIX_SUCCESS != rc) {
+        goto out;
+    }
+    // Notice that we don't do a PMIX_RELEASE(kval) here, because we don't
+    // currently support free(). TODO(skg) We should probably add tma->free() so
+    // that the usage conventions are preserved.
+out:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        // TODO(skg) kvdes needs to know about the
+        // tma or we avoid use of PMIX_RELEASE().
+        //PMIX_RELEASE(kval);
     }
     return rc;
 }
@@ -841,9 +1600,9 @@ server_add_nspace(
         "%s: adding namespace=%s with nlocalprocs=%d",
         __func__, nspace, nlocalprocs
     );
+
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_gds_shmem_job_t *job = NULL;
-    pmix_info_t *infosm = NULL;
     // Get the shared-memory segment size. Mas o menos.
     size_t segment_size = 0;
     rc = get_estimated_segment_size(
@@ -854,31 +1613,25 @@ server_add_nspace(
         goto out;
     }
     // Create a job tracker.
-    rc = pmix_gds_shmem_get_job_tracker(nspace, &job);
+    rc = pmix_gds_shmem_get_job_tracker(nspace, true, &job);
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
-    // Create and attached to the shared-memory segment, update job tracker.
+    // Create and attach to the shared-memory segment and update job tracker
+    // with the shared-memory backing store information.
     rc = segment_create_and_attach(
         info, ninfo, job, segment_size
     );
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
-    // TODO(skg) Look at PMIX_BFROPS_PACK code.
-    // TODO(skg) Look at PMIX_DATA_ARRAY_CONSTRUCT
-    // Now add the information to the shared-memory segment.
-    // First, create the infos.
-    PMIX_GDS_SHMEM_INFO_CREATE(infosm, ninfo, job->tma);
+    // Now add the information to the shared-memory
+    // segment associated with this namespace.
     for (size_t i = 0; i < ninfo; ++i) {
-        const char *key = info[i].key;
-        const pmix_value_t value = info[i].value;
-        const pmix_data_type_t val_type = value.type;
-
-        PMIX_GDS_SHMEM_VOUT(
-            "%s: Storing k=%s, v=%s", __func__,
-            key, PMIx_Data_type_string(val_type)
-        );
+        rc = add_info_to_job(&info[i], job);
+        if (PMIX_SUCCESS != rc) {
+            break;
+        }
     }
 out:
     if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/shmem/gds_shmem_component.c
+++ b/src/mca/gds/shmem/gds_shmem_component.c
@@ -40,7 +40,8 @@
 static int
 component_open(void)
 {
-    PMIX_CONSTRUCT(&pmix_mca_gds_shmem_component.myjobs, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_gds_shmem_component.jobs, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_gds_shmem_component.sessions, pmix_list_t);
     return PMIX_SUCCESS;
 }
 
@@ -70,7 +71,8 @@ component_query(
 static int
 component_close(void)
 {
-    PMIX_LIST_DESTRUCT(&pmix_mca_gds_shmem_component.myjobs);
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_shmem_component.jobs);
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_shmem_component.sessions);
     return PMIX_SUCCESS;
 }
 
@@ -81,7 +83,7 @@ component_close(void)
 pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
     .super = {
         PMIX_GDS_BASE_VERSION_1_0_0,
-        /* Component name and version */
+        /** Component name and version */
         .pmix_mca_component_name = PMIX_GDS_SHMEM_NAME,
         PMIX_MCA_BASE_MAKE_VERSION(
             component,
@@ -89,12 +91,13 @@ pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
             PMIX_MINOR_VERSION,
             PMIX_RELEASE_VERSION
         ),
-        /* Component open, close, and query functions */
+        /** Component open, close, and query functions */
         .pmix_mca_open_component = component_open,
         .pmix_mca_close_component = component_close,
         .pmix_mca_query_component = component_query,
     },
-    .myjobs = PMIX_LIST_STATIC_INIT
+    .jobs = PMIX_LIST_STATIC_INIT,
+    .sessions = PMIX_LIST_STATIC_INIT
 };
 
 /*

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -25,6 +25,7 @@
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem_get_job_tracker(
     const pmix_nspace_t nspace,
+    bool create,
     pmix_gds_shmem_job_t **job
 );
 


### PR DESCRIPTION
Please note that this commit reimplements---internally within the gds
shmem component---some core PMIx functionality. The reason for this
approach is to first prototype the infrastructure required to implement
this component, with the ultimate goal of eventually finding a
reasonable way to reintegrate the duplicated infrastructure. This
approach minimizes sweeping changes to core infrastructure used by other
components, while also supporting forward progress in gds/shmem development.
Don't panic :).

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>