### PR TITLE
Cleanup the show_help changes a bit

### DIFF
--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -48,14 +48,6 @@ static int output_stream = -1;
 /* How long to wait between displaying duplicate show_help notices */
 static struct timeval show_help_interval = {5, 0};
 
-typedef struct pmix_log_info_t {
-
-    pmix_info_t *info;
-    pmix_info_t *dirs;
-    char *msg;
-
-} pmix_log_info_t;
-
 static void show_help_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
@@ -66,7 +58,9 @@ static void show_help_cbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-static void local_delivery(const char *file, const char *topic, char *msg)
+static void local_delivery(const char *file,
+                           const char *topic,
+                           const char *msg)
 {
     pmix_shift_caddy_t *cd;
 
@@ -148,7 +142,7 @@ static const char *dash_line
     = "--------------------------------------------------------------------------\n";
 static char **search_dirs = NULL;
 
-static int match(const char *a, const char *b)
+static pmix_status_t match(const char *a, const char *b)
 {
     int rc = PMIX_ERROR; 
     char *p1, *p2, *tmp1 = NULL, *tmp2 = NULL;
@@ -194,7 +188,7 @@ static int match(const char *a, const char *b)
 }
 
 
-static int pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
+static pmix_status_t pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
 {
     tuple_list_item_t *tli = *tli_;
 
@@ -261,7 +255,7 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
 }
 
 
-int pmix_help_check_dups(const char *filename, const char *topic)
+pmix_status_t pmix_help_check_dups(const char *filename, const char *topic)
 {
 
     tuple_list_item_t *tli;
@@ -324,7 +318,7 @@ int pmix_help_check_dups(const char *filename, const char *topic)
 /*
  * Local functions
  */
-int pmix_show_help_init(char *helpdir)
+pmix_status_t pmix_show_help_init(char *helpdir)
 {
     pmix_output_stream_t lds;
 
@@ -341,7 +335,7 @@ int pmix_show_help_init(char *helpdir)
     return PMIX_SUCCESS;
 }
 
-int pmix_show_help_finalize(void)
+pmix_status_t pmix_show_help_finalize(void)
 {
     pmix_output_close(output_stream);
     output_stream = -1;
@@ -361,7 +355,7 @@ int pmix_show_help_finalize(void)
  * efficient method in the world, but we're going for clarity here --
  * not optimization.  :-)
  */
-static int array2string(char **outstring, int want_error_header, char **lines)
+static pmix_status_t array2string(char **outstring, int want_error_header, char **lines)
 {
     int i, count;
     size_t len;
@@ -407,7 +401,7 @@ static int array2string(char **outstring, int want_error_header, char **lines)
 /*
  * Find the right file to open
  */
-static int open_file(const char *base, const char *topic)
+static pmix_status_t open_file(const char *base, const char *topic)
 {
     char *filename;
     char *err_msg = NULL;
@@ -483,7 +477,7 @@ static int open_file(const char *base, const char *topic)
  * In the file that has already been opened, find the topic that we're
  * supposed to output
  */
-static int find_topic(const char *base, const char *topic)
+static pmix_status_t find_topic(const char *base, const char *topic)
 {
     int token, ret;
     char *tmp;
@@ -528,7 +522,7 @@ static int find_topic(const char *base, const char *topic)
  * We have an open file, and we're pointed at the right topic.  So
  * read in all the lines in the topic and make a list of them.
  */
-static int read_topic(char ***array)
+static pmix_status_t read_topic(char ***array)
 {
     int token, rc;
 
@@ -551,7 +545,7 @@ static int read_topic(char ***array)
     /* Never get here */
 }
 
-static int load_array(char ***array, const char *filename, const char *topic)
+static pmix_status_t load_array(char ***array, const char *filename, const char *topic)
 {
     int ret;
 
@@ -612,7 +606,8 @@ char *pmix_show_help_string(const char *filename, const char *topic, int want_er
     return output;
 }
 
-int pmix_show_vhelp(const char *filename, const char *topic, int want_error_header, va_list arglist)
+pmix_status_t pmix_show_vhelp(const char *filename, const char *topic,
+                              int want_error_header, va_list arglist)
 {
     char *output;
 
@@ -627,7 +622,8 @@ int pmix_show_vhelp(const char *filename, const char *topic, int want_error_head
     return (NULL == output) ? PMIX_ERROR : PMIX_SUCCESS;
 }
 
-int pmix_show_help(const char *filename, const char *topic, int want_error_header, ...)
+pmix_status_t pmix_show_help(const char *filename, const char *topic,
+                             int want_error_header, ...)
 {
     va_list arglist;
     char *output;
@@ -645,8 +641,16 @@ int pmix_show_help(const char *filename, const char *topic, int want_error_heade
     return PMIX_SUCCESS;
 }
 
-int pmix_show_help_add_dir(const char *directory)
+pmix_status_t pmix_show_help_add_dir(const char *directory)
 {
     pmix_argv_append_nosize(&search_dirs, directory);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_show_help_norender(const char *filename,
+                                      const char *topic,
+                                      const char *output)
+{
+    local_delivery(filename, topic, output);
     return PMIX_SUCCESS;
 }

--- a/src/util/pmix_show_help.h
+++ b/src/util/pmix_show_help.h
@@ -103,14 +103,14 @@ BEGIN_C_DECLS
  *
  * Initialization of show_help subsystem
  */
-PMIX_EXPORT int pmix_show_help_init(char *helpdir);
+PMIX_EXPORT pmix_status_t pmix_show_help_init(char *helpdir);
 
 /**
  * \internal
  *
  * Finalization of show_help subsystem
  */
-PMIX_EXPORT int pmix_show_help_finalize(void);
+PMIX_EXPORT pmix_status_t pmix_show_help_finalize(void);
 
 /**
  * Look up a text message in a text file and display it to the
@@ -134,14 +134,18 @@ PMIX_EXPORT int pmix_show_help_finalize(void);
  * promotion to va_start() has undefined behavior (according to clang
  * warnings on MacOS High Sierra).
  */
-PMIX_EXPORT int pmix_show_help(const char *filename, const char *topic, int want_error_header, ...);
+PMIX_EXPORT pmix_status_t pmix_show_help(const char *filename,
+                                         const char *topic,
+                                         int want_error_header, ...);
 
 /**
  * This function does the same thing as pmix_show_help(), but accepts
  * a va_list form of varargs.
  */
-PMIX_EXPORT int pmix_show_vhelp(const char *filename, const char *topic, int want_error_header,
-                                va_list ap);
+PMIX_EXPORT pmix_status_t pmix_show_vhelp(const char *filename,
+                                          const char *topic,
+                                          int want_error_header,
+                                          va_list ap);
 
 /**
  * This function does the same thing as pmix_show_help(), but returns
@@ -154,8 +158,10 @@ PMIX_EXPORT char *pmix_show_help_string(const char *filename, const char *topic,
  * This function does the same thing as pmix_show_help_string(), but
  * accepts a va_list form of varargs.
  */
-PMIX_EXPORT char *pmix_show_help_vstring(const char *filename, const char *topic,
-                                         int want_error_header, va_list ap);
+PMIX_EXPORT char *pmix_show_help_vstring(const char *filename,
+                                         const char *topic,
+                                         int want_error_header,
+                                         va_list ap);
 
 /**
  * This function adds another search location for the files that
@@ -170,9 +176,14 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename, const char *topic
  * nees to tell pmix_show_help.how to find its own show_help files - without
  * interfering with the linked ORTE libs when they need to do show_help.
  */
-PMIX_EXPORT int pmix_show_help_add_dir(const char *directory);
+PMIX_EXPORT pmix_status_t pmix_show_help_add_dir(const char *directory);
 
-PMIX_EXPORT int pmix_help_check_dups(const char *filename, const char *topic);
+PMIX_EXPORT pmix_status_t pmix_help_check_dups(const char *filename,
+                                               const char *topic);
+
+PMIX_EXPORT pmix_status_t pmix_show_help_norender(const char *filename,
+                                                  const char *topic,
+                                                  const char *output);
 
 PMIX_EXPORT extern bool pmix_show_help_enabled;
 


### PR DESCRIPTION
It is true that pmix_status_t is an int, but we always
explicitly return pmix_status_t anyway (just in case it
someday changes, which would be hard to believe). Add a
"norender" API that PRRTE uses in only one place, but easier
than trying to figure out a way around it.

Signed-off-by: Ralph Castain <rhc@pmix.org>