### PR TITLE
v4.2: Refactor show_help() to use the PMIx_Log() api. 

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -672,6 +672,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOG_XML_OUTPUT                 "pmix.log.xml"          // (bool) print the output stream in xml format
 #define PMIX_LOG_ONCE                       "pmix.log.once"         // (bool) only log this once with whichever channel can first support it
 #define PMIX_LOG_MSG                        "pmix.log.msg"          // (pmix_byte_object_t) message blob to be sent somewhere
+#define PMIX_LOG_KEY                        "pmix.log.key"          // (char*) key to a logging message
+#define PMIX_LOG_VAL                        "pmix.log.val"          // (char*) value to a logging message
+#define PMIX_LOG_AGG                        "pmix.log.agg"          // (bool) Whether to aggregate and prevent duplicate logging messages
+                                                                    //        based on key value pairs.
 
 #define PMIX_LOG_EMAIL                      "pmix.log.email"        // (pmix_data_array_t*) log via email based on array of pmix_info_t
                                                                     //         containing directives

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -78,6 +78,7 @@ static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 #include "src/util/name_fns.h"
 #include "src/util/output.h"
 #include "src/util/printf.h"
+#include "src/util/show_help.h"
 
 #include "pmix_client_ops.h"
 
@@ -856,6 +857,8 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
+    // enable show_help subsystem
+    pmix_show_help_enabled = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* look for a debugger attach key */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -293,6 +293,7 @@ static void scon(pmix_shift_caddy_t *p)
     p->codes = NULL;
     p->ncodes = 0;
     p->peer = NULL;
+    p->proc = NULL;
     p->pname.nspace = NULL;
     p->pname.rank = PMIX_RANK_UNDEF;
     p->data = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -358,7 +358,9 @@ typedef struct {
     pmix_proc_t *targets;
     size_t ntargets;
     pmix_info_t *info;
+    pmix_info_t *dirs;
     size_t ninfo;
+    size_t ndirs;
     pmix_list_t results;
     size_t nreplies;
     size_t nrequests;
@@ -431,6 +433,7 @@ typedef struct {
     pmix_status_t *codes;
     size_t ncodes;
     pmix_name_t pname;
+    pmix_proc_t *proc;
     pmix_peer_t *peer;
     const char *data;
     size_t ndata;
@@ -623,6 +626,8 @@ PMIX_EXPORT pmix_status_t pmix_notify_event_cache(pmix_notify_caddy_t *cd);
 
 PMIX_EXPORT extern pmix_globals_t pmix_globals;
 PMIX_EXPORT extern pmix_lock_t pmix_global_lock;
+
+PMIX_EXPORT void pmix_log_local_op(int sd, short args, void *cbdata_);
 
 static inline bool pmix_check_node_info(const char *key)
 {

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -116,6 +116,7 @@ pmix_status_t pmix_register_params(void)
                                       PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                       &pmix_suppress_missing_data_warning);
 
+
     /****   CLIENT: VERBOSE OUTPUT PARAMS   ****/
     (void) pmix_mca_base_var_register("pmix", "pmix", "client", "get_verbose",
                                       "Verbosity for client get operations",

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -833,6 +833,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     }
 
     ++pmix_globals.init_cntr;
+    // enable show_help subsystem
+    pmix_show_help_enabled = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* register a handler to catch/aggregate PMIX_EVENT_WAITING_FOR_NOTIFY

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -939,6 +939,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         }
         PMIX_DESTRUCT(&cb);
     }
+    // enable show_help subsystem
+    pmix_show_help_enabled = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* if we are acting as a server, then start listening */

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -49,14 +49,6 @@ static int output_stream = -1;
 /* How long to wait between displaying duplicate show_help notices */
 static struct timeval show_help_interval = {5, 0};
 
-typedef struct pmix_log_info_t {
-
-    pmix_info_t *info;
-    pmix_info_t *dirs;
-    char *msg;
-
-} pmix_log_info_t;
-
 static void show_help_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
@@ -67,7 +59,9 @@ static void show_help_cbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-static void local_delivery(const char *file, const char *topic, char *msg)
+static void local_delivery(const char *file,
+                           const char *topic,
+                           const char *msg)
 {
     pmix_shift_caddy_t *cd;
 
@@ -149,7 +143,7 @@ static const char *dash_line
     = "--------------------------------------------------------------------------\n";
 static char **search_dirs = NULL;
 
-static int match(const char *a, const char *b)
+static pmix_status_t match(const char *a, const char *b)
 {
     int rc = PMIX_ERROR; 
     char *p1, *p2, *tmp1 = NULL, *tmp2 = NULL;
@@ -195,7 +189,7 @@ static int match(const char *a, const char *b)
 }
 
 
-static int pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
+static pmix_status_t pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
 {
     tuple_list_item_t *tli = *tli_;
 
@@ -262,7 +256,7 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
 }
 
 
-int pmix_help_check_dups(const char *filename, const char *topic)
+pmix_status_t pmix_help_check_dups(const char *filename, const char *topic)
 {
 
     tuple_list_item_t *tli;
@@ -325,7 +319,7 @@ int pmix_help_check_dups(const char *filename, const char *topic)
 /*
  * Local functions
  */
-int pmix_show_help_init(void)
+pmix_status_t pmix_show_help_init(void)
 {
     pmix_output_stream_t lds;
 
@@ -339,7 +333,7 @@ int pmix_show_help_init(void)
     return PMIX_SUCCESS;
 }
 
-int pmix_show_help_finalize(void)
+pmix_status_t pmix_show_help_finalize(void)
 {
     pmix_output_close(output_stream);
     output_stream = -1;
@@ -359,7 +353,7 @@ int pmix_show_help_finalize(void)
  * efficient method in the world, but we're going for clarity here --
  * not optimization.  :-)
  */
-static int array2string(char **outstring, int want_error_header, char **lines)
+static pmix_status_t array2string(char **outstring, int want_error_header, char **lines)
 {
     int i, count;
     size_t len;
@@ -405,7 +399,7 @@ static int array2string(char **outstring, int want_error_header, char **lines)
 /*
  * Find the right file to open
  */
-static int open_file(const char *base, const char *topic)
+static pmix_status_t open_file(const char *base, const char *topic)
 {
     char *filename;
     char *err_msg = NULL;
@@ -481,7 +475,7 @@ static int open_file(const char *base, const char *topic)
  * In the file that has already been opened, find the topic that we're
  * supposed to output
  */
-static int find_topic(const char *base, const char *topic)
+static pmix_status_t find_topic(const char *base, const char *topic)
 {
     int token, ret;
     char *tmp;
@@ -526,7 +520,7 @@ static int find_topic(const char *base, const char *topic)
  * We have an open file, and we're pointed at the right topic.  So
  * read in all the lines in the topic and make a list of them.
  */
-static int read_topic(char ***array)
+static pmix_status_t read_topic(char ***array)
 {
     int token, rc;
 
@@ -549,7 +543,7 @@ static int read_topic(char ***array)
     /* Never get here */
 }
 
-static int load_array(char ***array, const char *filename, const char *topic)
+static pmix_status_t load_array(char ***array, const char *filename, const char *topic)
 {
     int ret;
 
@@ -610,7 +604,8 @@ char *pmix_show_help_string(const char *filename, const char *topic, int want_er
     return output;
 }
 
-int pmix_show_vhelp(const char *filename, const char *topic, int want_error_header, va_list arglist)
+pmix_status_t pmix_show_vhelp(const char *filename, const char *topic,
+                              int want_error_header, va_list arglist)
 {
     char *output;
 
@@ -625,7 +620,8 @@ int pmix_show_vhelp(const char *filename, const char *topic, int want_error_head
     return (NULL == output) ? PMIX_ERROR : PMIX_SUCCESS;
 }
 
-int pmix_show_help(const char *filename, const char *topic, int want_error_header, ...)
+pmix_status_t pmix_show_help(const char *filename, const char *topic,
+                             int want_error_header, ...)
 {
     va_list arglist;
     char *output;
@@ -643,8 +639,16 @@ int pmix_show_help(const char *filename, const char *topic, int want_error_heade
     return PMIX_SUCCESS;
 }
 
-int pmix_show_help_add_dir(const char *directory)
+pmix_status_t pmix_show_help_add_dir(const char *directory)
 {
     pmix_argv_append_nosize(&search_dirs, directory);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_show_help_norender(const char *filename,
+                                      const char *topic,
+                                      const char *output)
+{
+    local_delivery(filename, topic, output);
     return PMIX_SUCCESS;
 }

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -172,6 +172,10 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename, const char *topic
  */
 PMIX_EXPORT int pmix_show_help_add_dir(const char *directory);
 
+PMIX_EXPORT int pmix_help_check_dups(const char *filename, const char *topic);
+
+PMIX_EXPORT extern bool pmix_show_help_enabled;
+
 END_C_DECLS
 
 #endif

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -103,14 +103,14 @@ BEGIN_C_DECLS
  *
  * Initialization of show_help subsystem
  */
-PMIX_EXPORT int pmix_show_help_init(void);
+PMIX_EXPORT pmix_status_t pmix_show_help_init(void);
 
 /**
  * \internal
  *
  * Finalization of show_help subsystem
  */
-PMIX_EXPORT int pmix_show_help_finalize(void);
+PMIX_EXPORT pmix_status_t pmix_show_help_finalize(void);
 
 /**
  * Look up a text message in a text file and display it to the
@@ -134,14 +134,18 @@ PMIX_EXPORT int pmix_show_help_finalize(void);
  * promotion to va_start() has undefined behavior (according to clang
  * warnings on MacOS High Sierra).
  */
-PMIX_EXPORT int pmix_show_help(const char *filename, const char *topic, int want_error_header, ...);
+PMIX_EXPORT pmix_status_t pmix_show_help(const char *filename,
+                                         const char *topic,
+                                         int want_error_header, ...);
 
 /**
  * This function does the same thing as pmix_show_help(), but accepts
  * a va_list form of varargs.
  */
-PMIX_EXPORT int pmix_show_vhelp(const char *filename, const char *topic, int want_error_header,
-                                va_list ap);
+PMIX_EXPORT pmix_status_t pmix_show_vhelp(const char *filename,
+                                          const char *topic,
+                                          int want_error_header,
+                                          va_list ap);
 
 /**
  * This function does the same thing as pmix_show_help(), but returns
@@ -154,8 +158,10 @@ PMIX_EXPORT char *pmix_show_help_string(const char *filename, const char *topic,
  * This function does the same thing as pmix_show_help_string(), but
  * accepts a va_list form of varargs.
  */
-PMIX_EXPORT char *pmix_show_help_vstring(const char *filename, const char *topic,
-                                         int want_error_header, va_list ap);
+PMIX_EXPORT char *pmix_show_help_vstring(const char *filename,
+                                         const char *topic,
+                                         int want_error_header,
+                                         va_list ap);
 
 /**
  * This function adds another search location for the files that
@@ -170,9 +176,14 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename, const char *topic
  * nees to tell show_help how to find its own show_help files - without
  * interfering with the linked ORTE libs when they need to do show_help.
  */
-PMIX_EXPORT int pmix_show_help_add_dir(const char *directory);
+PMIX_EXPORT pmix_status_t pmix_show_help_add_dir(const char *directory);
 
-PMIX_EXPORT int pmix_help_check_dups(const char *filename, const char *topic);
+PMIX_EXPORT pmix_status_t pmix_help_check_dups(const char *filename,
+                                               const char *topic);
+
+PMIX_EXPORT pmix_status_t pmix_show_help_norender(const char *filename,
+                                                  const char *topic,
+                                                  const char *output);
 
 PMIX_EXPORT extern bool pmix_show_help_enabled;
 

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1166,8 +1166,14 @@ static void log_fn(const pmix_proc_t *client, const pmix_info_t data[], size_t n
                    void *cbdata)
 {
     mylog_t *lg = (mylog_t *) malloc(sizeof(mylog_t));
+    size_t n;
     PMIX_HIDE_UNUSED_PARAMS(client, data, ndata, directives, ndirs);
 
+    for (n=0; n < ndata; n++) {
+        if (PMIX_STRING == data[n].value.type) {
+            fprintf(stderr, "%s-%d LOG: %s\n", client->nspace, client->rank, data[n].value.data.string);
+        }
+    }
     lg->cbfunc = cbfunc;
     lg->cbdata = cbdata;
     SIMPTEST_THREADSHIFT(lg, foobar);


### PR DESCRIPTION
[Refactor show_help() to use the PMIx_Log() api.](https://github.com/openpmix/openpmix/commit/51e71155bb7af89382deb6ef6af7e17d8a6d900f) 

- Port over the de-dupping code from prrte.
- Add some additional keys to support a request
  to de-dup logging messages.
- Remove locks from the high level PMIx_Log() api's - they
  don't seem necessary, and make it very easy to deadlock
  when the current thread already holds the global lock.
- Likewise - use PMIx_Log_nb() instead of PMIx_Log() - the
  non-blocking counterpart will allow libevent to trigger the
  callbacks on its own time. Otherwise, in the case of a
  show_help() message from prted that happens before the main thread
  hits the event loop, it will hang forever.
- We can avoid deadlock in show_help calls made prior to
  completing client/server/tool "init" by simply leaving
  the show_help system disabled until we get far enough
  along, and then explicitly "enabling" it. We also never
  call a PMIx API from inside the code base as that can
  lead to loopbacks that deadlock.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
Signed-off-by: Ralph Castain <rhc@pmix.org>

Co-authored-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/66bdfaeee24d36844291869fe988d78572e8df79)

[Cleanup the show_help changes a bit](https://github.com/openpmix/openpmix/commit/40a61b403e44021c5d1dc1ab5ce3df58071d789f) 

It is true that pmix_status_t is an int, but we always
explicitly return pmix_status_t anyway (just in case it
someday changes, which would be hard to believe). Add a
"norender" API that PRRTE uses in only one place, but easier
than trying to figure out a way around it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/26ff1684378e1c5859e377249a3e78f287b04216)
