### PR TITLE
Correctly handle qualified values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ examples/log
 examples/showkeys
 examples/abi_no_init
 examples/abi_with_init
+examples/group_lcl_cid
 
 include/pmix_version.h
 include/pmix_rename.h
@@ -183,6 +184,7 @@ test/simple/get_put_example
 test/simple/simpvni
 test/simple/hybrid
 test/simple/asyncio
+test/simple/simpqual
 
 test/sshot/daemon
 test/sshot/generate

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -24,7 +24,8 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init group_lcl_cid
+
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -105,8 +106,12 @@ abi_with_init_SOURCES = abi_with_init.c
 abi_with_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 abi_with_init_LDADD =  $(top_builddir)/src/libpmix.la
 
+group_lcl_cid_SOURCES = group_lcl_cid.c examples.h
+group_lcl_cid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_lcl_cid_LDADD =  $(top_builddir)/src/libpmix.la
+
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
         hello jctrl launcher log pub pubi server tool \
-        abi_no_init abi_with_init
+        abi_no_init abi_with_init group_lcl_cid

--- a/examples/group.c
+++ b/examples/group.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -93,9 +93,9 @@ int main(int argc, char **argv)
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
-    /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %s\n", myproc.nspace,
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
     }

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * This test simulates the way Open MPI uses the PMIx_Group_construct to
+ * implement MPI4 functions:
+ * - MPI_Comm_create_from_group
+ * - MPI_Intercomm_create_from_groups
+ */
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+static uint32_t get_timeout = 600; /* default 600 secs to get remote data */
+
+static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source,
+                                info, ninfo, results, nresults,
+                                cbfunc, cbdata);
+
+    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
+}
+
+static void op_callbk(pmix_status_t status, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    fprintf(stderr, "Client %s:%d OP CALLBACK CALLED WITH STATUS %d\n", myproc.nspace, myproc.rank,
+            status);
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    fprintf(stderr,
+            "Client %s:%d ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu\n",
+            myproc.nspace, myproc.rank, status, (unsigned long) errhandler_ref);
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    mylock_t lock;
+    pmix_info_t *results, *info, tinfo[2];
+    size_t nresults, cid, lcid, ninfo;
+    pmix_data_array_t darray;
+    void *grpinfo, *list;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)getpid());
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    /* and our context ID */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_GROUP_CONTEXT_ID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job context ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    cid = 0;
+    PMIX_VALUE_GET_NUMBER(rc, val, cid, size_t);
+    fprintf(stderr, "Client %s:%d job size %d CID %u\n", myproc.nspace, myproc.rank, nprocs, (unsigned)cid);
+
+    /* register our default errhandler */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, errhandler_reg_callbk,
+                                (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        goto done;
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    grpinfo = PMIx_Info_list_start();
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    list = PMIx_Info_list_start();
+    lcid = 1234UL + (unsigned long) myproc.rank;
+    rc = PMIx_Info_list_add(list, PMIX_GROUP_LOCAL_CID, &lcid, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_convert(list, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_convert failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_INFO, &darray, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIx_Info_list_release(list);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_Info_list_convert(grpinfo, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_convert failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    info = (pmix_info_t*)darray.array;
+    ninfo = darray.size;
+    PMIx_Info_list_release(grpinfo);
+
+    rc = PMIx_Group_construct("ourgroup", procs, nprocs, info, ninfo, &results, &nresults);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    /* we should have a single results object */
+    if (NULL != results) {
+        cid = 0;
+        PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
+        fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %ld\n",
+                myproc.rank, PMIx_Error_string(rc), results[0].key, cid);
+    } else {
+        fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
+        goto done;
+    }
+    PMIX_PROC_FREE(procs, nprocs);
+
+    /*
+     * destruct the group
+     */
+    rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+    }
+
+    PMIX_INFO_CONSTRUCT(&tinfo[0]);
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_SIZE);
+    PMIX_INFO_CONSTRUCT(&tinfo[1]);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TIMEOUT, &get_timeout, PMIX_UINT32);
+
+    for (n = 0; n < nprocs; n++) {
+        proc.rank = n;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, tinfo, 2, &val))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get of LOCAL CID for rank %d failed: %s\n",
+                        myproc.nspace, myproc.rank, n, PMIx_Error_string(rc));
+            continue;
+        }
+        if (PMIX_UINT64 != val->type) {
+           fprintf(stderr, "%s:%d: PMIx_Get LOCAL CID for rank %d returned wrong type: %s\n", myproc.nspace,
+                    myproc.rank, n, PMIx_Data_type_string(val->type));
+            PMIX_VALUE_RELEASE(val);
+            continue;
+        }
+        if ((1234UL + (unsigned long)n) != val->data.uint64) {
+            fprintf(stderr, "%s:%d: PMIx_Get LOCAL CID for rank %d returned wrong value: %lu\n",
+                    myproc.nspace, myproc.rank, n, (unsigned long)val->data.uint64);
+            PMIX_VALUE_RELEASE(val);
+            continue;
+        }
+        PMIX_VALUE_RELEASE(val);
+    }
+
+done:
+    /* finalize us */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Deregister_event_handler(1, op_callbk, &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    DEBUG_DESTRUCT_LOCK(&lock);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    fprintf(stderr, "%s:%d COMPLETE\n", myproc.nspace, myproc.rank);
+    fflush(stderr);
+    return (0);
+}
+

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -130,7 +130,9 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
+                                   const char key[],
+                                   pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
@@ -1125,7 +1127,6 @@ PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
 PMIX_EXPORT const char* PMIx_Scope_string(pmix_scope_t scope);
 PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist);
 PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
-PMIX_EXPORT const char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
@@ -1140,6 +1141,7 @@ PMIX_EXPORT const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp);
  * that the user must release when done */
 PMIX_EXPORT char* PMIx_Info_string(pmix_info_t *info);
 PMIX_EXPORT char* PMIx_Value_string(pmix_value_t *value);
+PMIX_EXPORT char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -264,12 +264,6 @@ typedef uint32_t pmix_rank_t;
                                                                     //           "close" (thread located on cpu close to master thread)
                                                                     //           "spread" (threads load-balanced across available cpus)
 
-/* attributes for the USOCK rendezvous socket  */
-#define PMIX_USOCK_DISABLE                  "pmix.usock.disable"    // (bool) disable legacy usock support
-#define PMIX_SOCKET_MODE                    "pmix.sockmode"         // (uint32_t) POSIX mode_t (9 bits valid)
-#define PMIX_SINGLE_LISTENER                "pmix.sing.listnr"      // (bool) use only one rendezvous socket, letting priorities and/or
-                                                                    //        MCA param select the active transport
-
 /* attributes for TCP connections */
 #define PMIX_TCP_REPORT_URI                 "pmix.tcp.repuri"       // (char*) output URI - '-' => stdout, '+' => stderr, or filename
 #define PMIX_TCP_URI                        "pmix.tcp.uri"          // (char*) URI of server to connect to, or file:<name of file containing it>
@@ -289,12 +283,12 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_NODE_OVERSUBSCRIBED            "pmix.ndosub"           // (bool) true if number of procs from this job on this node
                                                                     //        exceeds the number of slots allocated to it
 
-
 /* scratch directory locations for use by applications */
 #define PMIX_TMPDIR                         "pmix.tmpdir"           // (char*) top-level tmp dir assigned to session
 #define PMIX_NSDIR                          "pmix.nsdir"            // (char*) sub-tmpdir assigned to namespace
 #define PMIX_PROCDIR                        "pmix.pdir"             // (char*) sub-nsdir assigned to proc
 #define PMIX_TDIR_RMCLEAN                   "pmix.tdir.rmclean"     // (bool)  Resource Manager will clean session directories
+
 
 /* information about relative ranks as assigned by the RM */
 #define PMIX_CLUSTER_ID                     "pmix.clid"             // (char*) a string name for the cluster this proc is executing on
@@ -313,7 +307,6 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_APPLDR                         "pmix.aldr"             // (pmix_rank_t) lowest rank in this app within this job
 #define PMIX_PROC_PID                       "pmix.ppid"             // (pid_t) pid of specified proc
 #define PMIX_SESSION_ID                     "pmix.session.id"       // (uint32_t) session identifier
-
 #define PMIX_NODE_LIST                      "pmix.nlist"            // (char*) comma-delimited list of nodes running procs for the specified nspace
 #define PMIX_ALLOCATED_NODELIST             "pmix.alist"            // (char*) comma-delimited list of all nodes in this allocation regardless of
                                                                     //         whether or not they currently host procs.
@@ -394,6 +387,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ACCESS_GRPIDS                  "pmix.agids"            // (pmix_data_array_t*) Array of effective GIDs that are allowed to
                                                                     //        access the published data
 #define PMIX_WAIT_FOR_CONNECTION            "pmix.wait.conn"        // (bool) wait until the specified connection has been made
+#define PMIX_QUALIFIED_VALUE                "pmix.qual.val"         // (pmix_data_array_t*) Value being provided consists of the primary
+                                                                    //        key-value pair in first position, followed by one or more
+                                                                    //        key-value qualifiers to be used when subsequently retrieving
+                                                                    //        the primary value
 
 
 /* attributes used by host server to pass data to/from the server convenience library - the
@@ -943,7 +940,16 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_GROUP_ENDPT_DATA               "pmix.grp.endpt"        // (pmix_byte_object_t) data collected to be shared during construction
 #define PMIX_GROUP_NAMES                    "pmix.pgrp.nm"          // (pmix_data_array_t*) Returns an array of string names of the process groups
                                                                     //        in which the given process is a member.
-
+#define PMIX_GROUP_INFO                     "pmix.grp.info"         // (pmix_data_array_t*) Array of pmix_info_t containing data that is to be
+                                                                    //        shared across all members of a group during group construction
+#define PMIX_GROUP_LOCAL_CID                "pmix.grp.lclid"        // (size_t) local context ID for the specified process member of a group
+#define PMIX_GROUP_ADD_MEMBERS              "pmix.grp.add"          // (pmix_data_array_t*) Array of pmix_proc_t identifying procs that are not
+                                                                    //        included in the membership specified in the procs array passed to
+                                                                    //        the PMIx_Group_construct[_nb] call, but are to be included in the
+                                                                    //        final group. The identified procs will be sent an invitation to
+                                                                    //        join the group during the construction procedure. This is used when
+                                                                    //        some members of the proposed group do not know the full membership
+                                                                    //        and therefore cannot include all members in the call to construct.
 
 /* Storage-Related Attributes */
 #define PMIX_QUERY_STORAGE_LIST             "pmix.strg.list"       // (char*) return comma-delimited list of identifiers for all available storage systems
@@ -1467,6 +1473,7 @@ typedef uint32_t pmix_info_directives_t;
 #define PMIX_INFO_REQD              0x00000001
 #define PMIX_INFO_ARRAY_END         0x00000002      // mark the end of an array created by PMIX_INFO_CREATE
 #define PMIX_INFO_REQD_PROCESSED    0x00000004      // reqd attribute has been processed
+#define PMIX_INFO_QUALIFIER         0x00000008      // info is a qualifier to the primary value
 /* the top 16-bits are reserved for internal use by
  * implementers - these may be changed inside the
  * PMIx library */
@@ -3311,8 +3318,17 @@ typedef struct pmix_info {
     ((m)->flags & PMIX_INFO_REQD_PROCESSED)
 
 /* macro for testing end of the array */
+#define PMIX_INFO_SET_END(m)    \
+    ((m)->flags |= PMIX_INFO_ARRAY_END)
 #define PMIX_INFO_IS_END(m)         \
     ((m)->flags & PMIX_INFO_ARRAY_END)
+
+/* macro for testing if qualifier */
+#define PMIX_INFO_SET_QUALIFIER(i)   \
+    ((i)->flags |= PMIX_INFO_QUALIFIER)
+#define PMIX_INFO_IS_QUALIFIER(i)    \
+    ((i)->flags & PMIX_INFO_QUALIFIER)
+
 
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -140,6 +140,12 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
                                                                     //         that id's, pids, and other info on the procs is available
                                                                     //         via a query for the nspace's local or global proctable
 #define PMIX_RECONNECT_SERVER               "pmix.cnct.recon"       // (bool) tool is requesting to change server connections
+
+/* attributes for the USOCK rendezvous socket  */
+#define PMIX_USOCK_DISABLE                  "pmix.usock.disable"    // (bool) disable legacy usock support
+#define PMIX_SOCKET_MODE                    "pmix.sockmode"         // (uint32_t) POSIX mode_t (9 bits valid)
+#define PMIX_SINGLE_LISTENER                "pmix.sing.listnr"      // (bool) use only one rendezvous socket, letting priorities and/or
+                                                                    //        MCA param select the active transport
 #define PMIX_ALLOC_NETWORK                  "pmix.alloc.net"        // (pmix_data_array_t*) ***** DEPRECATED *****
 #define PMIX_ALLOC_NETWORK_ID               "pmix.alloc.netid"      // (char*) ***** DEPRECATED *****
 #define PMIX_ALLOC_NETWORK_QOS              "pmix.alloc.netqos"     // (char*) ***** DEPRECATED *****

--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -52,6 +52,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hash_table_t);
 
 struct pmix_hash_table_t {
     pmix_object_t super;                    /**< subclass of pmix_object_t */
+    const char *ht_label;                   /**< label for debugging */
     struct pmix_hash_element_t *ht_table;   /**< table of elements (opaque to users) */
     size_t ht_capacity;                     /**< allocated size (capacity) of table */
     size_t ht_size;                         /**< number of extant entries */
@@ -65,6 +66,7 @@ typedef struct pmix_hash_table_t pmix_hash_table_t;
 #define PMIX_HASH_TABLE_STATIC_INIT                 \
 {                                                   \
     .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .ht_label = NULL,                               \
     .ht_table = NULL,                               \
     .ht_capacity = 0,                               \
     .ht_size = 0,                                   \

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -50,7 +50,6 @@
 #include "src/mca/ptl/ptl.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
 #include "src/util/pmix_output.h"
 
 #include "pmix_client_ops.h"
@@ -183,7 +182,8 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
     pmix_status_t ret;
     int32_t cnt;
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "client:unpack fence called");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "client:unpack fence called");
 
     /* unpack the status code */
     cnt = 1;
@@ -244,9 +244,10 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_status_t rc;
-
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence_nb callback recvd");
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
+
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: fence_nb callback recvd");
 
     if (NULL == cb) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -23,7 +23,7 @@
 #include "src/mca/gds/base/base.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 
 #include "src/common/pmix_attributes.h"
 #include "src/include/dictionary.h"

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -156,14 +156,33 @@ PMIX_EXPORT const char *PMIx_Data_range_string(pmix_data_range_t range)
     }
 }
 
-PMIX_EXPORT const char *PMIx_Info_directives_string(pmix_info_directives_t directives)
+PMIX_EXPORT char *PMIx_Info_directives_string(pmix_info_directives_t directives)
 {
-    switch (directives) {
-    case PMIX_INFO_REQD:
-        return "REQUIRED";
-    default:
-        return "UNSPECIFIED";
+    char **tmp = NULL;
+    char *ret;
+
+    if (PMIX_INFO_QUALIFIER & directives) {
+        pmix_argv_append_nosize(&tmp, "QUALIFIER");
+    } else {
+        if (PMIX_INFO_REQD & directives) {
+            pmix_argv_append_nosize(&tmp, "REQUIRED");
+        } else {
+            pmix_argv_append_nosize(&tmp, "OPTIONAL");
+        }
+        if (PMIX_INFO_REQD_PROCESSED & directives) {
+            pmix_argv_append_nosize(&tmp, "PROCESSED");
+        }
+        if (PMIX_INFO_ARRAY_END & directives) {
+            pmix_argv_append_nosize(&tmp, "END");
+        }
     }
+    if (NULL != tmp) {
+        ret = pmix_argv_join(tmp, ':');
+        pmix_argv_free(tmp);
+    } else {
+        ret = strdup("UNSPECIFIED");
+    }
+    return ret;
 }
 
 PMIX_EXPORT const char *PMIx_Alloc_directive_string(pmix_alloc_directive_t directive)

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -337,6 +337,8 @@ static void lgcon(pmix_get_logic_t *p)
     p->pntrval = false;
     p->stval = false;
     p->optional = false;
+    p->immediate = false;
+    p->add_immediate = false;
     p->refresh_cache = false;
     p->scope = PMIX_SCOPE_UNDEF;
 }

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -78,6 +78,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_LOAD_KEY(dest->key, src->key);
+    dest->flags = src->flags;
     return PMIx_Value_xfer(&dest->value, &src->value);
 }
 

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1123,14 +1123,24 @@ int pmix_bfrops_base_print_info(char **output, char *prefix, pmix_info_t *src,
                                 pmix_data_type_t type)
 {
     char *tmp = NULL, *tmp2 = NULL;
+    char *prefx;
     int ret;
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    pmix_bfrops_base_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    pmix_bfrops_base_print_info_directives(&tmp2, NULL, &src->flags, PMIX_INFO_DIRECTIVES);
-    ret = asprintf(output, "%sKEY: %s\n%s\t%s\n%s\t%s", prefix, src->key, prefix, tmp2, prefix,
-                   tmp);
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    pmix_bfrops_base_print_value(&tmp, prefx, &src->value, PMIX_VALUE);
+    pmix_bfrops_base_print_info_directives(&tmp2, prefx, &src->flags, PMIX_INFO_DIRECTIVES);
+    ret = asprintf(output, "%sKEY: %s\n%s\t%s\n%s\t%s",
+                   prefx, src->key, prefix, tmp2, prefix, tmp);
     free(tmp);
     free(tmp2);
     if (0 > ret) {
@@ -1368,7 +1378,7 @@ pmix_status_t pmix_bfrops_base_print_info_directives(char **output, char *prefix
                                                      pmix_info_directives_t *src,
                                                      pmix_data_type_t type)
 {
-    char *prefx;
+    char *prefx, *tmp;
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
@@ -1380,14 +1390,15 @@ pmix_status_t pmix_bfrops_base_print_info_directives(char **output, char *prefix
     } else {
         prefx = prefix;
     }
-
-    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx,
-                     PMIx_Info_directives_string(*src))) {
+    tmp = PMIx_Info_directives_string(*src);
+    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx, tmp)) {
+        free(tmp);
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_ERR_NOMEM;
     }
+    free(tmp);
     if (prefx != prefix) {
         free(prefx);
     }
@@ -1659,195 +1670,195 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix, pmix_da
         switch (src->type) {
             case PMIX_BOOL:
                 bptr = (bool*)src->array;
-                rc = pmix_bfrops_base_print_bool(&tp, NULL, &bptr[n], PMIX_BOOL);
+                rc = pmix_bfrops_base_print_bool(&tp, prefx, &bptr[n], PMIX_BOOL);
                 break;
             case PMIX_BYTE:
                 u8ptr = (uint8_t*)src->array;
-                rc = pmix_bfrops_base_print_byte(&tp, NULL, &u8ptr[n], PMIX_STRING);
+                rc = pmix_bfrops_base_print_byte(&tp, prefx, &u8ptr[n], PMIX_STRING);
                 break;
             case PMIX_STRING:
                 strings = (char**)src->array;
-                rc = pmix_bfrops_base_print_string(&tp, NULL, strings[n], PMIX_STRING);
+                rc = pmix_bfrops_base_print_string(&tp, prefx, strings[n], PMIX_STRING);
                 break;
             case PMIX_SIZE:
                 szptr = (size_t*)src->array;
-                rc = pmix_bfrops_base_print_size(&tp, NULL, &szptr[n], PMIX_SIZE);
+                rc = pmix_bfrops_base_print_size(&tp, prefx, &szptr[n], PMIX_SIZE);
                 break;
             case PMIX_PID:
                 pidptr = (pid_t*)src->array;
-                rc = pmix_bfrops_base_print_pid(&tp, NULL, &pidptr[n], PMIX_PID);
+                rc = pmix_bfrops_base_print_pid(&tp, prefx, &pidptr[n], PMIX_PID);
                 break;
             case PMIX_INT:
                 intptr = (int*)src->array;
-                rc = pmix_bfrops_base_print_int(&tp, NULL, &intptr[n], PMIX_INT);
+                rc = pmix_bfrops_base_print_int(&tp, prefx, &intptr[n], PMIX_INT);
                 break;
             case PMIX_INT8:
                 i8ptr = (int8_t*)src->array;
-                rc = pmix_bfrops_base_print_int8(&tp, NULL, &i8ptr[n], PMIX_INT8);
+                rc = pmix_bfrops_base_print_int8(&tp, prefx, &i8ptr[n], PMIX_INT8);
                 break;
             case PMIX_INT16:
                 i16ptr = (int16_t*)src->array;
-                rc = pmix_bfrops_base_print_int16(&tp, NULL, &i16ptr[n], PMIX_INT16);
+                rc = pmix_bfrops_base_print_int16(&tp, prefx, &i16ptr[n], PMIX_INT16);
                 break;
             case PMIX_INT32:
                 i32ptr = (int32_t*)src->array;
-                rc = pmix_bfrops_base_print_int32(&tp, NULL, &i32ptr[n], PMIX_INT32);
+                rc = pmix_bfrops_base_print_int32(&tp, prefx, &i32ptr[n], PMIX_INT32);
                 break;
             case PMIX_INT64:
                 i64ptr = (int64_t*)src->array;
-                rc = pmix_bfrops_base_print_int64(&tp, NULL, &i64ptr[n], PMIX_INT64);
+                rc = pmix_bfrops_base_print_int64(&tp, prefx, &i64ptr[n], PMIX_INT64);
                 break;
             case PMIX_UINT:
                 uintptr = (unsigned int*)src->array;
-                rc = pmix_bfrops_base_print_uint(&tp, NULL, &uintptr[n], PMIX_UINT);
+                rc = pmix_bfrops_base_print_uint(&tp, prefx, &uintptr[n], PMIX_UINT);
                 break;
             case PMIX_UINT8:
                 u8ptr = (uint8_t*)src->array;
-                rc = pmix_bfrops_base_print_uint8(&tp, NULL, &u8ptr[n], PMIX_UINT8);
+                rc = pmix_bfrops_base_print_uint8(&tp, prefx, &u8ptr[n], PMIX_UINT8);
                 break;
             case PMIX_UINT16:
                 u16ptr = (uint16_t*)src->array;
-                rc = pmix_bfrops_base_print_uint16(&tp, NULL, &u16ptr[n], PMIX_UINT16);
+                rc = pmix_bfrops_base_print_uint16(&tp, prefx, &u16ptr[n], PMIX_UINT16);
                 break;
             case PMIX_UINT32:
                 u32ptr = (uint32_t*)src->array;
-                rc = pmix_bfrops_base_print_uint32(&tp, NULL, &u32ptr[n], PMIX_UINT32);
+                rc = pmix_bfrops_base_print_uint32(&tp, prefx, &u32ptr[n], PMIX_UINT32);
                 break;
             case PMIX_UINT64:
                 u64ptr = (uint64_t*)src->array;
-                rc = pmix_bfrops_base_print_uint64(&tp, NULL, &u64ptr[n], PMIX_UINT64);
+                rc = pmix_bfrops_base_print_uint64(&tp, prefx, &u64ptr[n], PMIX_UINT64);
                 break;
             case PMIX_FLOAT:
                 fltptr = (float*)src->array;
-                rc = pmix_bfrops_base_print_float(&tp, NULL, &fltptr[n], PMIX_FLOAT);
+                rc = pmix_bfrops_base_print_float(&tp, prefx, &fltptr[n], PMIX_FLOAT);
                 break;
             case PMIX_DOUBLE:
                 dblptr = (double*)src->array;
-                rc = pmix_bfrops_base_print_double(&tp, NULL, &dblptr[n], PMIX_DOUBLE);
+                rc = pmix_bfrops_base_print_double(&tp, prefx, &dblptr[n], PMIX_DOUBLE);
                 break;
             case PMIX_TIMEVAL:
                 tvlptr = (struct timeval*)src->array;
-                rc = pmix_bfrops_base_print_timeval(&tp, NULL, &tvlptr[n], PMIX_TIMEVAL);
+                rc = pmix_bfrops_base_print_timeval(&tp, prefx, &tvlptr[n], PMIX_TIMEVAL);
                 break;
             case PMIX_TIME:
                 tmptr = (time_t*)src->array;
-                rc = pmix_bfrops_base_print_time(&tp, NULL, &tmptr[n], PMIX_TIME);
+                rc = pmix_bfrops_base_print_time(&tp, prefx, &tmptr[n], PMIX_TIME);
                 break;
             case PMIX_STATUS:
                 stptr = (pmix_status_t*)src->array;
-                rc = pmix_bfrops_base_print_status(&tp, NULL, &stptr[n], PMIX_STATUS);
+                rc = pmix_bfrops_base_print_status(&tp, prefx, &stptr[n], PMIX_STATUS);
                 break;
             case PMIX_PROC_RANK:
                 rkptr = (pmix_rank_t*)src->array;
-                rc = pmix_bfrops_base_print_rank(&tp, NULL, &rkptr[n], PMIX_PROC_RANK);
+                rc = pmix_bfrops_base_print_rank(&tp, prefx, &rkptr[n], PMIX_PROC_RANK);
                 break;
             case PMIX_PROC_NSPACE:
                 nsptr = (pmix_nspace_t*)src->array;
-                rc = pmix_bfrops_base_print_nspace(&tp, NULL, &nsptr[n], PMIX_PROC_NSPACE);
+                rc = pmix_bfrops_base_print_nspace(&tp, prefx, &nsptr[n], PMIX_PROC_NSPACE);
                 break;
             case PMIX_PROC:
                 procptr = (pmix_proc_t*)src->array;
-                rc = pmix_bfrops_base_print_proc(&tp, NULL, &procptr[n], PMIX_PROC);
+                rc = pmix_bfrops_base_print_proc(&tp, prefx, &procptr[n], PMIX_PROC);
                 break;
             case PMIX_INFO:
                 iptr = (pmix_info_t*)src->array;
-                rc = pmix_bfrops_base_print_info(&tp, NULL, &iptr[n], PMIX_INFO);
+                rc = pmix_bfrops_base_print_info(&tp, prefx, &iptr[n], PMIX_INFO);
                 break;
             case PMIX_BYTE_OBJECT:
                 boptr = (pmix_byte_object_t*)src->array;
-                rc = pmix_bfrops_base_print_bo(&tp, NULL, &boptr[n], PMIX_BYTE_OBJECT);
+                rc = pmix_bfrops_base_print_bo(&tp, prefx, &boptr[n], PMIX_BYTE_OBJECT);
                 break;
             case PMIX_PERSIST:
                 prstptr = (pmix_persistence_t*)src->array;
-                rc = pmix_bfrops_base_print_persist(&tp, NULL, &prstptr[n], PMIX_PERSIST);
+                rc = pmix_bfrops_base_print_persist(&tp, prefx, &prstptr[n], PMIX_PERSIST);
                 break;
             case PMIX_SCOPE:
                 scptr = (pmix_scope_t*)src->array;
-                rc = pmix_bfrops_base_print_scope(&tp, NULL, &scptr[n], PMIX_SCOPE);
+                rc = pmix_bfrops_base_print_scope(&tp, prefx, &scptr[n], PMIX_SCOPE);
                 break;
             case PMIX_DATA_RANGE:
                 drptr = (pmix_data_range_t*)src->array;
-                rc = pmix_bfrops_base_print_range(&tp, NULL, &drptr[n], PMIX_DATA_RANGE);
+                rc = pmix_bfrops_base_print_range(&tp, prefx, &drptr[n], PMIX_DATA_RANGE);
                 break;
             case PMIX_PROC_STATE:
                 psptr = (pmix_proc_state_t*)src->array;
-                rc = pmix_bfrops_base_print_pstate(&tp, NULL, &psptr[n], PMIX_PROC_STATE);
+                rc = pmix_bfrops_base_print_pstate(&tp, prefx, &psptr[n], PMIX_PROC_STATE);
                 break;
             case PMIX_PROC_INFO:
                 piptr = (pmix_proc_info_t*)src->array;
-                rc = pmix_bfrops_base_print_pinfo(&tp, NULL, &piptr[n], PMIX_PROC_INFO);
+                rc = pmix_bfrops_base_print_pinfo(&tp, prefx, &piptr[n], PMIX_PROC_INFO);
                 break;
             case PMIX_DATA_ARRAY:
                 daptr = (pmix_data_array_t*)src->array;
-                rc = pmix_bfrops_base_print_darray(&tp, NULL, &daptr[n], PMIX_DATA_ARRAY);
+                rc = pmix_bfrops_base_print_darray(&tp, prefx, &daptr[n], PMIX_DATA_ARRAY);
                 break;
             case PMIX_REGATTR:
                 rgptr = (pmix_regattr_t*)src->array;
-                rc = pmix_bfrops_base_print_regattr(&tp, NULL, &rgptr[n], PMIX_REGATTR);
+                rc = pmix_bfrops_base_print_regattr(&tp, prefx, &rgptr[n], PMIX_REGATTR);
                 break;
             case PMIX_ALLOC_DIRECTIVE:
                 adptr = (pmix_alloc_directive_t*)src->array;
-                rc = pmix_bfrops_base_print_alloc_directive(&tp, NULL, &adptr[n], PMIX_ALLOC_DIRECTIVE);
+                rc = pmix_bfrops_base_print_alloc_directive(&tp, prefx, &adptr[n], PMIX_ALLOC_DIRECTIVE);
                 break;
             case PMIX_ENVAR:
                 evptr = (pmix_envar_t*)src->array;
-                rc = pmix_bfrops_base_print_envar(&tp, NULL, &evptr[n], PMIX_ENVAR);
+                rc = pmix_bfrops_base_print_envar(&tp, prefx, &evptr[n], PMIX_ENVAR);
                 break;
             case PMIX_COORD:
                 coptr = (pmix_coord_t*)src->array;
-                rc = pmix_bfrops_base_print_coord(&tp, NULL, &coptr[n], PMIX_COORD);
+                rc = pmix_bfrops_base_print_coord(&tp, prefx, &coptr[n], PMIX_COORD);
                 break;
             case PMIX_LINK_STATE:
                 lkptr = (pmix_link_state_t*)src->array;
-                rc = pmix_bfrops_base_print_linkstate(&tp, NULL, &lkptr[n], PMIX_LINK_STATE);
+                rc = pmix_bfrops_base_print_linkstate(&tp, prefx, &lkptr[n], PMIX_LINK_STATE);
                 break;
             case PMIX_JOB_STATE:
                 jsptr = (pmix_job_state_t*)src->array;
-                rc = pmix_bfrops_base_print_jobstate(&tp, NULL, &jsptr[n], PMIX_JOB_STATE);
+                rc = pmix_bfrops_base_print_jobstate(&tp, prefx, &jsptr[n], PMIX_JOB_STATE);
                 break;
             case PMIX_TOPO:
                 tptr = (pmix_topology_t*)src->array;
-                rc = pmix_bfrops_base_print_topology(&tp, NULL, &tptr[n], PMIX_TOPO);
+                rc = pmix_bfrops_base_print_topology(&tp, prefx, &tptr[n], PMIX_TOPO);
                 break;
             case PMIX_PROC_CPUSET:
                 cpsptr = (pmix_cpuset_t*)src->array;
-                rc = pmix_bfrops_base_print_cpuset(&tp, NULL, &cpsptr[n], PMIX_PROC_CPUSET);
+                rc = pmix_bfrops_base_print_cpuset(&tp, prefx, &cpsptr[n], PMIX_PROC_CPUSET);
                 break;
             case PMIX_LOCTYPE:
                 lcptr = (pmix_locality_t*)src->array;
-                rc = pmix_bfrops_base_print_locality(&tp, NULL, &lcptr[n], PMIX_LOCTYPE);
+                rc = pmix_bfrops_base_print_locality(&tp, prefx, &lcptr[n], PMIX_LOCTYPE);
                 break;
             case PMIX_GEOMETRY:
                 geoptr = (pmix_geometry_t*)src->array;
-                rc = pmix_bfrops_base_print_geometry(&tp, NULL, &geoptr[n], PMIX_GEOMETRY);
+                rc = pmix_bfrops_base_print_geometry(&tp, prefx, &geoptr[n], PMIX_GEOMETRY);
                 break;
             case PMIX_DEVTYPE:
                 dvptr = (pmix_device_type_t*)src->array;
-                rc = pmix_bfrops_base_print_devtype(&tp, NULL, &dvptr[n], PMIX_DEVTYPE);
+                rc = pmix_bfrops_base_print_devtype(&tp, prefx, &dvptr[n], PMIX_DEVTYPE);
                 break;
             case PMIX_DEVICE_DIST:
                 ddptr = (pmix_device_distance_t*)src->array;
-                rc = pmix_bfrops_base_print_devdist(&tp, NULL, &ddptr[n], PMIX_DEVICE_DIST);
+                rc = pmix_bfrops_base_print_devdist(&tp, prefx, &ddptr[n], PMIX_DEVICE_DIST);
                 break;
             case PMIX_ENDPOINT:
                 endptr = (pmix_endpoint_t*)src->array;
-                rc = pmix_bfrops_base_print_endpoint(&tp, NULL, &endptr[n], PMIX_ENDPOINT);
+                rc = pmix_bfrops_base_print_endpoint(&tp, prefx, &endptr[n], PMIX_ENDPOINT);
                 break;
             case PMIX_STOR_MEDIUM:
                 smptr = (pmix_storage_medium_t*)src->array;
-                rc = pmix_bfrops_base_print_smed(&tp, NULL, &smptr[n], PMIX_STOR_MEDIUM);
+                rc = pmix_bfrops_base_print_smed(&tp, prefx, &smptr[n], PMIX_STOR_MEDIUM);
                 break;
             case PMIX_STOR_ACCESS:
                 saptr = (pmix_storage_accessibility_t*)src->array;
-                rc = pmix_bfrops_base_print_sacc(&tp, NULL, &saptr[n], PMIX_STOR_ACCESS);
+                rc = pmix_bfrops_base_print_sacc(&tp, prefx, &saptr[n], PMIX_STOR_ACCESS);
                 break;
             case PMIX_STOR_PERSIST:
                 spptr = (pmix_storage_persistence_t*)src->array;
-                rc = pmix_bfrops_base_print_spers(&tp, NULL, &spptr[n], PMIX_STOR_PERSIST);
+                rc = pmix_bfrops_base_print_spers(&tp, prefx, &spptr[n], PMIX_STOR_PERSIST);
                 break;
             case PMIX_STOR_ACCESS_TYPE:
                 satptr = (pmix_storage_access_type_t*)src->array;
-                rc = pmix_bfrops_base_print_satyp(&tp, NULL, &satptr[n], PMIX_STOR_ACCESS_TYPE);
+                rc = pmix_bfrops_base_print_satyp(&tp, prefx, &satptr[n], PMIX_STOR_ACCESS_TYPE);
                 break;
             default:
                 pmix_asprintf(&tp, " Data type: %s(%d)\tValue: UNPRINTABLE",

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -1296,7 +1296,7 @@ pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix, pmix_cmd_t *sr
 pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix, pmix_info_directives_t *src,
                                           pmix_data_type_t type)
 {
-    char *prefx;
+    char *prefx, *tmp;
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
@@ -1309,13 +1309,15 @@ pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix, pmix_info
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx,
-                     PMIx_Info_directives_string(*src))) {
+    tmp = PMIx_Info_directives_string(*src);
+    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx, tmp)) {
+        free(tmp);
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_ERR_NOMEM;
     }
+    free(tmp);
     if (prefx != prefix) {
         free(prefx);
     }

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -209,7 +209,7 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace, pmix_bu
                 break;
             }
             found = false;
-            /* calculate proc form the relative rank */
+            /* calculate proc from the relative rank */
             if (pmix_list_get_size(&trk->nslist) == 1) {
                 found = true;
                 nm = (pmix_nspace_caddy_t *) pmix_list_get_first(&trk->nslist);

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -43,101 +43,13 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
 #include "gds_hash.h"
 #include "src/mca/gds/base/base.h"
-
-static pmix_status_t dohash(pmix_hash_table_t *ht, const char *key, pmix_rank_t rank,
-                            int skip_genvals, pmix_list_t *kvs)
-{
-    pmix_status_t rc;
-    pmix_value_t *val;
-    pmix_kval_t *kv, *k2;
-    pmix_info_t *info;
-    size_t n, ninfo;
-    bool found;
-
-    rc = pmix_hash_fetch(ht, rank, key, &val);
-    if (PMIX_SUCCESS == rc) {
-        /* if the key was NULL, then all found keys will be
-         * returned as a pmix_data_array_t in the value */
-        if (NULL == key) {
-            if (NULL == val->data.darray || PMIX_INFO != val->data.darray->type
-                || 0 == val->data.darray->size) {
-                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-                PMIX_VALUE_RELEASE(val);
-                return PMIX_ERR_NOT_FOUND;
-            }
-            /* if they want the value returned in its array form,
-             * then we are done */
-            if (2 == skip_genvals) {
-                kv = PMIX_NEW(pmix_kval_t);
-                if (NULL == kv) {
-                    PMIX_VALUE_RELEASE(val);
-                    return PMIX_ERR_NOMEM;
-                }
-                kv->value = val;
-                pmix_list_append(kvs, &kv->super);
-                return PMIX_SUCCESS;
-            }
-            info = (pmix_info_t *) val->data.darray->array;
-            ninfo = val->data.darray->size;
-            for (n = 0; n < ninfo; n++) {
-                /* if the rank is UNDEF, then we don't want
-                 * anything that starts with "pmix" */
-                if (1 == skip_genvals && 0 == strncmp(info[n].key, "pmix", 4)) {
-                    continue;
-                }
-                /* see if we already have this on the list */
-                found = false;
-                PMIX_LIST_FOREACH (k2, kvs, pmix_kval_t) {
-                    if (PMIX_CHECK_KEY(&info[n], k2->key)) {
-                        found = true;
-                        break;
-                    }
-                }
-                if (found) {
-                    continue;
-                }
-                kv = PMIX_NEW(pmix_kval_t);
-                if (NULL == kv) {
-                    PMIX_VALUE_RELEASE(val);
-                    return PMIX_ERR_NOMEM;
-                }
-                kv->key = strdup(info[n].key);
-                kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                if (NULL == kv->value) {
-                    PMIX_VALUE_RELEASE(val);
-                    PMIX_RELEASE(kv);
-                    return PMIX_ERR_NOMEM;
-                }
-                PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, &info[n].value);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_VALUE_RELEASE(val);
-                    PMIX_RELEASE(kv);
-                    return rc;
-                }
-                pmix_list_append(kvs, &kv->super);
-            }
-            PMIX_VALUE_RELEASE(val);
-        } else {
-            kv = PMIX_NEW(pmix_kval_t);
-            if (NULL == kv) {
-                PMIX_VALUE_RELEASE(val);
-                return PMIX_ERR_NOMEM;
-            }
-            kv->key = strdup(key);
-            kv->value = val;
-            pmix_list_append(kvs, &kv->super);
-        }
-    }
-    return rc;
-}
 
 pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmix_list_t *tgt,
                                            pmix_info_t *info, size_t ninfo, pmix_list_t *kvs)
@@ -476,7 +388,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     pmix_job_t *trk;
     pmix_status_t rc;
     pmix_kval_t *kv, *kvptr;
-    pmix_info_t *info, *iptr;
+    pmix_info_t *iptr;
     size_t m, n, ninfo, niptr;
     pmix_hash_table_t *ht;
     pmix_session_t *sptr;
@@ -511,7 +423,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
      * info for this nspace - retrieve it */
     if (NULL == key && PMIX_RANK_WILDCARD == proc->rank) {
         /* fetch all values from the hash table tied to rank=wildcard */
-        rc = dohash(&trk->internal, NULL, PMIX_RANK_WILDCARD, 0, kvs);
+        rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             return rc;
         }
@@ -540,33 +452,30 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
         /* finally, we need the job-level info for each rank in the job */
         for (rnk = 0; rnk < trk->nptr->nprocs; rnk++) {
             PMIX_CONSTRUCT(&rkvs, pmix_list_t);
-            rc = dohash(&trk->internal, NULL, rnk, 2, &rkvs);
+            rc = pmix_hash_fetch(&trk->internal, rnk, NULL, NULL, 0, &rkvs);
             if (PMIX_ERR_NOMEM == rc) {
+                PMIX_LIST_DESTRUCT(&rkvs);
                 return rc;
             }
             if (0 == pmix_list_get_size(&rkvs)) {
                 PMIX_DESTRUCT(&rkvs);
                 continue;
             }
-            /* should only have one entry on list */
-            kvptr = (pmix_kval_t *) pmix_list_get_first(&rkvs);
-            /* we have to assemble the results into a proc blob
-             * so the remote end will know what to do with it */
-            info = (pmix_info_t *) kvptr->value->data.darray->array;
-            ninfo = kvptr->value->data.darray->size;
+            ninfo = pmix_list_get_size(&rkvs);
             /* setup to return the result */
-            kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(PMIX_PROC_DATA);
-            kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+            PMIX_KVAL_NEW(kv, PMIX_PROC_DATA);
             kv->value->type = PMIX_DATA_ARRAY;
             niptr = ninfo + 1; // need space for the rank
             PMIX_DATA_ARRAY_CREATE(kv->value->data.darray, niptr, PMIX_INFO);
-            iptr = (pmix_info_t *) kv->value->data.darray->array;
+            iptr = (pmix_info_t*)kv->value->data.darray->array;
             /* start with the rank */
             PMIX_INFO_LOAD(&iptr[0], PMIX_RANK, &rnk, PMIX_PROC_RANK);
             /* now transfer rest of data across */
-            for (n = 0; n < ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n + 1], &info[n]);
+            n = 1;
+            PMIX_LIST_FOREACH(kvptr, &rkvs, pmix_kval_t) {
+                PMIX_LOAD_KEY(&iptr[n].key, kvptr->key);
+                PMIx_Value_xfer(&iptr[n].value, kvptr->value);
+                ++n;
             }
             /* add to the results */
             pmix_list_append(kvs, &kv->super);
@@ -663,8 +572,8 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     /* fetch from the corresponding hash table - note that
      * we always provide a copy as we don't support
      * shared memory */
-    if (PMIX_INTERNAL == scope || PMIX_SCOPE_UNDEF == scope || PMIX_GLOBAL == scope
-        || PMIX_RANK_WILDCARD == proc->rank) {
+    if (PMIX_INTERNAL == scope || PMIX_SCOPE_UNDEF == scope ||
+        PMIX_GLOBAL == scope || PMIX_RANK_WILDCARD == proc->rank) {
         ht = &trk->internal;
     } else if (PMIX_LOCAL == scope || PMIX_GLOBAL == scope) {
         ht = &trk->local;
@@ -681,7 +590,7 @@ doover:
      * be the source */
     if (PMIX_RANK_UNDEF == proc->rank) {
         for (rnk = 0; rnk < trk->nptr->nprocs; rnk++) {
-            rc = dohash(ht, key, rnk, true, kvs);
+            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs);
             if (PMIX_ERR_NOMEM == rc) {
                 return rc;
             }
@@ -709,12 +618,12 @@ doover:
         if (NULL == key) {
             /* and need to add all job info just in case that was
              * passed via a different GDS component */
-            rc = dohash(&trk->internal, NULL, PMIX_RANK_WILDCARD, false, kvs);
+            rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs);
         } else {
             rc = PMIX_ERR_NOT_FOUND;
         }
     } else {
-        rc = dohash(ht, key, proc->rank, false, kvs);
+        rc = pmix_hash_fetch(ht, proc->rank, key, qualifiers, nqual, kvs);
     }
     if (PMIX_SUCCESS == rc) {
         if (PMIX_GLOBAL == scope) {
@@ -750,7 +659,7 @@ doover:
         if (PMIX_RANK_IS_VALID(proc->rank)) {
             if (PMIX_LOCAL == scope) {
                 /* check the remote scope */
-                rc = dohash(&trk->remote, key, proc->rank, false, kvs);
+                rc = pmix_hash_fetch(&trk->remote, proc->rank, key, qualifiers, nqual, kvs);
                 if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
                     while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
                         PMIX_RELEASE(kv);
@@ -761,7 +670,7 @@ doover:
                 }
             } else if (PMIX_REMOTE == scope) {
                 /* check the local scope */
-                rc = dohash(&trk->local, key, proc->rank, false, kvs);
+                rc = pmix_hash_fetch(&trk->local, proc->rank, key, qualifiers, nqual, kvs);
                 if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
                     while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
                         PMIX_RELEASE(kv);

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -18,7 +18,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 
@@ -120,6 +120,10 @@ extern pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *tr
 
 extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t scope,
                                          pmix_kval_t *kv);
+
+extern pmix_status_t pmix_gds_hash_store_qualified(pmix_hash_table_t *ht,
+                                                   pmix_rank_t rank,
+                                                   pmix_value_t *value);
 
 END_C_DECLS
 

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -30,6 +30,9 @@
 #include "src/include/pmix_config.h"
 #include "pmix_common.h"
 
+#include "src/class/pmix_hash_table.h"
+#include "src/util/pmix_hash.h"
+
 #include "gds_hash.h"
 #include "src/mca/gds/gds.h"
 
@@ -107,10 +110,13 @@ static void htcon(pmix_job_t *p)
     PMIX_CONSTRUCT(&p->jobinfo, pmix_list_t);
     PMIX_CONSTRUCT(&p->internal, pmix_hash_table_t);
     pmix_hash_table_init(&p->internal, 256);
+    p->internal.ht_label = "internal";
     PMIX_CONSTRUCT(&p->remote, pmix_hash_table_t);
     pmix_hash_table_init(&p->remote, 256);
+    p->remote.ht_label = "remote";
     PMIX_CONSTRUCT(&p->local, pmix_hash_table_t);
     pmix_hash_table_init(&p->local, 256);
+    p->local.ht_label = "local";
     p->gdata_added = false;
     PMIX_CONSTRUCT(&p->apps, pmix_list_t);
     PMIX_CONSTRUCT(&p->nodeinfo, pmix_list_t);

--- a/src/mca/gds/hash/gds_utils.c
+++ b/src/mca/gds/hash/gds_utils.c
@@ -43,7 +43,7 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
@@ -213,7 +213,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map adding key %s to job info",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -329,7 +329,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                 "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                 pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                 kp2->key);
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kp2);
                 pmix_argv_free(procs);
@@ -347,7 +347,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
                 kp2->value->data.uint32 = n;
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     pmix_argv_free(procs);
@@ -364,7 +364,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     pmix_argv_free(procs);
@@ -382,7 +382,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     pmix_argv_free(procs);
@@ -405,7 +405,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-    if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
+    if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(kp2);
         return rc;
@@ -424,7 +424,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -446,7 +446,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -456,4 +456,40 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
     }
 
     return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_gds_hash_store_qualified(pmix_hash_table_t *ht,
+                                            pmix_rank_t rank,
+                                            pmix_value_t *value)
+{
+    pmix_info_t *iptr, *quals;
+    size_t n, sz, nquals;
+    pmix_kval_t kv;
+    pmix_status_t rc;
+
+    /* the value contains a pmix_data_array_t whose first position
+     * contains the key-value being stored, followed by one or more
+     * qualifiers */
+    iptr = (pmix_info_t*)value->data.darray->array;
+    sz = value->data.darray->size;
+
+    /* extract the primary value */
+    PMIX_CONSTRUCT(&kv, pmix_kval_t);
+    kv.key = iptr[0].key;
+    kv.value = &iptr[0].value;
+
+    nquals = sz - 1;
+    PMIX_INFO_CREATE(quals, nquals);
+    for (n=1; n < sz; n++) {
+        PMIX_INFO_SET_QUALIFIER(&quals[n-1]);
+        PMIX_INFO_XFER(&quals[n-1], &iptr[n]);
+    }
+
+    /* store the result */
+    rc = pmix_hash_store(ht, rank, &kv, quals, nquals);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    PMIX_INFO_FREE(quals, nquals);
+    return rc;
 }

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -43,7 +43,7 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
@@ -65,7 +65,8 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
     pmix_nodeinfo_t *nd = NULL, *ndptr;
     bool update;
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output, "PROCESSING NODE ARRAY");
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "PROCESSING NODE ARRAY");
 
     /* array of node-level info for a specific node */
     if (PMIX_DATA_ARRAY != val->type) {

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -1183,7 +1183,7 @@ store_kv_in_hashtab_by_rank(
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
-    rc = pmix_hash_store(target_ht, rank, kv);
+    rc = pmix_hash_store(target_ht, rank, kv, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }
@@ -1267,28 +1267,28 @@ store(
                 return rc;
             }
         }
-        rc = pmix_hash_store(&job->hashtab_internal, proc->rank, kval);
+        rc = pmix_hash_store(&job->hashtab_internal, proc->rank, kval, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
     }
     else if (PMIX_REMOTE == scope) {
-        rc = pmix_hash_store(&job->hashtab_remote, proc->rank, kval);
+        rc = pmix_hash_store(&job->hashtab_remote, proc->rank, kval, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
     }
     else if (PMIX_LOCAL == scope) {
-        rc = pmix_hash_store(&job->hashtab_local, proc->rank, kval);
+        rc = pmix_hash_store(&job->hashtab_local, proc->rank, kval, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
     }
     else if (PMIX_GLOBAL == scope) {
-        rc = pmix_hash_store(&job->hashtab_remote, proc->rank, kval);
+        rc = pmix_hash_store(&job->hashtab_remote, proc->rank, kval, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
@@ -1760,7 +1760,7 @@ add_info_to_job(
         }
     }
     // Store the kval into our internal hash table.
-    rc = pmix_hash_store(&job->hashtab_internal, PMIX_RANK_WILDCARD, kval);
+    rc = pmix_hash_store(&job->hashtab_internal, PMIX_RANK_WILDCARD, kval, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         goto out;
     }

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -37,6 +37,7 @@ node_info_fetch(
     pmix_data_array_t *darray;
     pmix_info_t *iptr;
 #endif
+    PMIX_HIDE_UNUSED_PARAMS(job, key, tgt, info, ninfo, kvs);
 
     PMIX_GDS_SHMEM_VOUT(
         "%s fetching NODE INFO",

--- a/src/mca/gds/shmem/gds_shmem_store.c
+++ b/src/mca/gds/shmem/gds_shmem_store.c
@@ -520,7 +520,7 @@ pmix_gds_shmem_store_proc_data_in_hashtab(
             namespace_id, rank, kv->key
         );
         // Store it in the target hash table.
-        rc = pmix_hash_store(target_ht, rank, kv);
+        rc = pmix_hash_store(target_ht, rank, kv, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kv);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -71,7 +71,6 @@ const char* pmix_tool_version = PMIX_VERSION;
 const char* pmix_tool_org = "PMIx";
 const char* pmix_tool_msg = PMIX_PROXY_BUGREPORT_STRING;
 
-
 PMIX_EXPORT int pmix_initialized = 0;
 PMIX_EXPORT bool pmix_init_called = false;
 /* we have to export the pmix_globals object so

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -166,7 +166,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     pmix_scope_t scope = PMIX_SCOPE_UNDEF;
     pmix_rank_info_t *iptr;
 
-    pmix_output_verbose(2, pmix_server_globals.get_output, "%s recvd GET",
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "%s recvd GET",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
     /* setup */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -28,7 +28,7 @@
 #include "src/class/pmix_hotel.h"
 #include "src/include/pmix_globals.h"
 #include "src/threads/pmix_threads.h"
-#include "src/util/hash.h"
+#include "src/util/pmix_hash.h"
 
 #define PMIX_IOF_HOTEL_SIZE 256
 #define PMIX_IOF_MAX_STAY   300000000

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -67,7 +67,6 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/hash.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -55,7 +55,7 @@ headers = \
         strnlen.h \
         pmix_shmem.h \
         pmix_vmem.h \
-        hash.h \
+        pmix_hash.h \
         pmix_name_fns.h \
         pmix_net.h \
         pmix_if.h \
@@ -85,7 +85,7 @@ sources = \
         getid.c \
         pmix_shmem.c \
         pmix_vmem.c \
-        hash.c \
+        pmix_hash.c \
         pmix_name_fns.c \
         pmix_net.c \
         pmix_if.c \

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -1,0 +1,707 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "src/include/pmix_hash_string.h"
+#include "src/include/pmix_stdint.h"
+
+#include <string.h>
+
+#include "src/class/pmix_hash_table.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_hash_string.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_output.h"
+
+#include "src/util/pmix_hash.h"
+
+/**
+ * Data for a particular pmix process
+ * The name association is maintained in the
+ * proc_data hash table.
+ */
+typedef struct {
+    pmix_object_t super;
+    /* Array of pmix_dstor_t structures containing all data
+     received from this process */
+    pmix_pointer_array_t data;
+    pmix_pointer_array_t quals;
+} pmix_proc_data_t;
+static void pdcon(pmix_proc_data_t *p)
+{
+    PMIX_CONSTRUCT(&p->data, pmix_pointer_array_t);
+    pmix_pointer_array_init(&p->data, 128, INT_MAX, 128);
+    PMIX_CONSTRUCT(&p->quals, pmix_pointer_array_t);
+    pmix_pointer_array_init(&p->quals, 1, INT_MAX, 1);
+}
+static void pddes(pmix_proc_data_t *p)
+{
+    int n;
+    size_t nq;
+    pmix_dstor_t *d;
+    pmix_qual_t *q;
+    pmix_data_array_t *darray;
+
+    for (n=0; n < p->data.size; n++) {
+        d = (pmix_dstor_t*)pmix_pointer_array_get_item(&p->data, n);
+        if (NULL != d) {
+            PMIX_DSTOR_RELEASE(d);
+            pmix_pointer_array_set_item(&p->data, n, NULL);
+        }
+    }
+    PMIX_DESTRUCT(&p->data);
+    for (n=0; n < p->quals.size; n++) {
+        darray = (pmix_data_array_t*)pmix_pointer_array_get_item(&p->quals, n);
+        if (NULL != darray) {
+            q = (pmix_qual_t*)darray->array;
+            for (nq=0; nq < darray->size; nq++) {
+                if (NULL != q[nq].value) {
+                    PMIX_VALUE_RELEASE(q[nq].value);
+                }
+            }
+            free(darray->array);
+            free(darray);
+        }
+        pmix_pointer_array_set_item(&p->quals, n, NULL);
+    }
+    PMIX_DESTRUCT(&p->quals);
+}
+static PMIX_CLASS_INSTANCE(pmix_proc_data_t, pmix_object_t, pdcon, pddes);
+
+static pmix_dstor_t *lookup_keyval(pmix_proc_data_t *proc, uint32_t kid,
+                                   pmix_info_t *qualifiers, size_t nquals);
+static pmix_proc_data_t *lookup_proc(pmix_hash_table_t *jtable, uint32_t id, bool create);
+static void erase_qualifiers(pmix_proc_data_t *proc,
+                             uint32_t index);
+
+
+pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
+                              pmix_rank_t rank, pmix_kval_t *kin,
+                              pmix_info_t *qualifiers, size_t nquals)
+{
+    pmix_proc_data_t *proc_data;
+    uint32_t kid;
+    pmix_dstor_t *hv;
+    pmix_regattr_input_t *p;
+    pmix_status_t rc;
+    pmix_data_array_t *darray;
+    pmix_qual_t *qarray;
+    size_t n, m;
+
+    pmix_output_verbose(10, pmix_globals.debug_output,
+                        "HASH:STORE:QUAL rank %s key %s",
+                        PMIX_RANK_PRINT(rank),
+                        (NULL == kin) ? "NULL KVAL" : kin->key);
+
+    if (NULL == kin) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* lookup the key's corresponding index - this should be
+     * moved to the periphery of the PMIx library so we can
+     * refer to the key numerically throughout the internals
+     */
+    p = pmix_hash_lookup_key(UINT32_MAX, kin->key);
+    if (NULL == p) {
+        /* we don't know this key */
+        pmix_output_verbose(10, pmix_globals.debug_output,
+                            "%s UNKNOWN KEY: %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            kin->key);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    kid = p->index;
+
+    /* lookup the proc data object for this proc - create
+     * it if we don't already have it */
+    if (NULL == (proc_data = lookup_proc(table, rank, true))) {
+        return PMIX_ERR_NOMEM;
+    }
+
+    /* see if we already have this key-value */
+    hv = lookup_keyval(proc_data, kid, qualifiers, nquals);
+    if (NULL != hv) {
+        if (9 < pmix_output_get_verbosity(pmix_globals.debug_output)) {
+            char *tmp;
+            tmp = PMIx_Value_string(hv->value);
+            pmix_output(0, "%s PREEXISTING ENTRY FOR PROC %s KEY %s: %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_RANK_PRINT(rank), kin->key, tmp);
+            free(tmp);
+        }
+        /* yes we do - so just replace the current value if it changed */
+        if (NULL != hv->value) {
+            if (PMIX_EQUAL == PMIx_Value_compare(hv->value, kin->value)) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "EQUAL VALUE - IGNORING");
+                return PMIX_SUCCESS;
+            }
+            if (9 < pmix_output_get_verbosity(pmix_globals.debug_output)) {
+                char *tmp;
+                tmp = PMIx_Value_string(kin->value);
+                pmix_output(0, "%s VALUE UPDATING TO: %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid), tmp);
+                free(tmp);
+            }
+            PMIX_VALUE_RELEASE(hv->value);
+        }
+        /* eventually, we want to eliminate this copy */
+        PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void **)&hv->value, kin->value, PMIX_VALUE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+        return PMIX_SUCCESS;
+    }
+
+    /* we don't already have it, so create it */
+    PMIX_DSTOR_NEW(hv, kid);
+    if (NULL == hv) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (NULL != qualifiers) {
+        /* count the number of actual qualifiers */
+        for (n=0, m=0; n < nquals; n++) {
+            if (PMIX_INFO_IS_QUALIFIER(&qualifiers[n])) {
+                ++m;
+            }
+        }
+        if (0 < m) {
+            darray = (pmix_data_array_t*)pmix_malloc(sizeof(pmix_data_array_t));
+            darray->array = (pmix_qual_t*)pmix_malloc(m * sizeof(pmix_qual_t));
+            darray->size = m;
+            hv->qualindex = pmix_pointer_array_add(&proc_data->quals, darray);
+            qarray = (pmix_qual_t*)darray->array;
+            for (n=0, m=0; n < nquals; n++) {
+                if (PMIX_INFO_IS_QUALIFIER(&qualifiers[n])) {
+                    p = pmix_hash_lookup_key(UINT32_MAX, qualifiers[n].key);
+                    if (NULL == p) {
+                        /* we don't know this key */
+                        pmix_output_verbose(10, pmix_globals.debug_output,
+                                            "%s UNKNOWN KEY: %s",
+                                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                                            kin->key);
+                        erase_qualifiers(proc_data, hv->qualindex);
+                        PMIX_DSTOR_RELEASE(hv);
+                        return PMIX_ERR_BAD_PARAM;
+                    }
+                    qarray[n].index = p->index;
+                    PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void **)&qarray[m].value, &qualifiers[n].value, PMIX_VALUE);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        erase_qualifiers(proc_data, hv->qualindex);
+                        PMIX_DSTOR_RELEASE(hv);
+                        return rc;
+                    }
+                    ++m;
+                }
+            }
+        }
+    }
+
+    /* eventually, we want to eliminate this copy */
+    PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void **)&hv->value, kin->value, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        if (UINT32_MAX != hv->qualindex) {
+            /* release the associated qualifiers */
+            erase_qualifiers(proc_data, hv->qualindex);
+        }
+        PMIX_DSTOR_RELEASE(hv);
+        return rc;
+    }
+    pmix_output_verbose(10, pmix_globals.debug_output,
+                        "%s ADDING KEY %s VALUE %u FOR RANK %s WITH %u QUALS TO TABLE %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        kin->key, (unsigned)kin->value->data.size, PMIX_RANK_PRINT(rank), (unsigned)m,
+                        table->ht_label);
+    pmix_pointer_array_add(&proc_data->data, hv);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
+                              pmix_rank_t rank,
+                              const char *key,
+                              pmix_info_t *qualifiers, size_t nquals,
+                              pmix_list_t *kvals)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_proc_data_t *proc_data;
+    pmix_dstor_t *hv;
+    uint32_t id, kid;
+    char *node;
+    pmix_regattr_input_t *p;
+    pmix_info_t *iptr;
+    size_t nq, m;
+    int n;
+    pmix_kval_t *kv;
+    bool fullsearch = false;
+    pmix_data_array_t *darray;
+    pmix_qual_t *quals;
+
+    pmix_output_verbose(10, pmix_globals.debug_output,
+                        "%s HASH:FETCH id %s key %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_RANK_PRINT(rank),
+                        (NULL == key) ? "NULL" : key);
+
+    /* - PMIX_RANK_UNDEF should return following statuses
+     *     PMIX_ERR_NOT_FOUND | PMIX_SUCCESS
+     * - specified rank can return following statuses
+     *     PMIX_ERR_NOT_FOUND | PMIX_ERR_NOT_FOUND | PMIX_SUCCESS
+     * special logic is basing on these statuses on a client and a server */
+    if (PMIX_RANK_UNDEF == rank) {
+        rc = pmix_hash_table_get_first_key_uint32(table, &id, (void **) &proc_data,
+                                                  (void **) &node);
+        if (PMIX_SUCCESS != rc) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "HASH:FETCH[%s:%d] proc data for rank %s not found",
+                                __func__, __LINE__, PMIX_RANK_PRINT(rank));
+            return PMIX_ERR_NOT_FOUND;
+        }
+        fullsearch = true;
+    } else {
+        id = rank;
+    }
+
+    if (NULL != key) {
+        /* lookup the key's corresponding index - this should be
+         * moved to the periphery of the PMIx library so we can
+         * refer to the key numerically throughout the internals
+         */
+        p = pmix_hash_lookup_key(UINT32_MAX, key);
+        if (NULL == p) {
+            /* we don't know this key */
+            return PMIX_ERR_BAD_PARAM;
+        }
+        kid = p->index;
+    }
+
+    while (PMIX_SUCCESS == rc) {
+        proc_data = lookup_proc(table, id, false);
+        if (NULL == proc_data) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                        "HASH:FETCH[%s:%d] proc data for rank %s not found",
+                        __func__, __LINE__,
+                        PMIX_RANK_PRINT(rank));
+            return PMIX_ERR_NOT_FOUND;
+        }
+
+        /* if the key is NULL, then the user wants -all- data
+         * put by the specified rank */
+        if (NULL == key) {
+            /* copy the data */
+            for (n=0; n < proc_data->data.size; n++) {
+                hv = (pmix_dstor_t*)pmix_pointer_array_get_item(&proc_data->data, n);
+                if (NULL != hv) {
+                    p = pmix_hash_lookup_key(hv->index, NULL);
+                    if (NULL == p) {
+                        return PMIX_ERR_NOT_FOUND;
+                    }
+                    pmix_output_verbose(10, pmix_globals.debug_output,
+                                        "%s FETCH NULL LOOKING AT %s",
+                                        PMIX_NAME_PRINT(&pmix_globals.myid), p->name);
+                    /* if the rank is UNDEF, we ignore reserved keys */
+                    if (PMIX_RANK_UNDEF == rank &&
+                        PMIX_CHECK_RESERVED_KEY(p->string)) {
+                        continue;
+                    }
+                    if (UINT32_MAX != hv->qualindex) {
+                        pmix_output_verbose(10, pmix_globals.debug_output,
+                                            "%s INCLUDE %s VALUE %u FROM TABLE %s FOR RANK %s",
+                                            PMIX_NAME_PRINT(&pmix_globals.myid), p->name,
+                                            (unsigned)hv->value->data.size, table->ht_label, PMIX_RANK_PRINT(rank));
+                        /* this is a qualified value - need to return it as such */
+                        PMIX_KVAL_NEW(kv, PMIX_QUALIFIED_VALUE);
+                        darray = (pmix_data_array_t*)pmix_pointer_array_get_item(&proc_data->quals, hv->qualindex);
+                        quals = (pmix_qual_t*)darray->array;
+                        nq = darray->size;
+                        PMIX_DATA_ARRAY_CREATE(darray, nq+1, PMIX_INFO);
+                        iptr = (pmix_info_t*)darray->array;
+                        /* the first location is the actual value */
+                        PMIX_LOAD_KEY(&iptr[0].key, p->string);
+                        PMIx_Value_xfer(&iptr[0].value, hv->value);
+                        /* now add the qualifiers */
+                        for (m=0; m < nq; m++) {
+                            p = pmix_hash_lookup_key(quals[m].index, NULL);
+                            if (NULL == p) {
+                                /* should never happen */
+                                PMIX_RELEASE(kv);
+                                PMIX_DATA_ARRAY_FREE(darray);
+                                return PMIX_ERR_BAD_PARAM;
+                            }
+                            PMIX_LOAD_KEY(&iptr[m+1].key, p->string);
+                            PMIx_Value_xfer(&iptr[m+1].value, quals[m].value);
+                            PMIX_INFO_SET_QUALIFIER(&iptr[m+1]);
+                        }
+                        kv->value->type = PMIX_DATA_ARRAY;
+                        kv->value->data.darray = darray;
+                        pmix_list_append(kvals, &kv->super);
+                    } else {
+                        PMIX_KVAL_NEW(kv, p->string);
+                        PMIx_Value_xfer(kv->value, hv->value);
+                        pmix_list_append(kvals, &kv->super);
+                    }
+                }
+            }
+            return PMIX_SUCCESS;
+        } else {
+            /* find the value from within this data object */
+            hv = lookup_keyval(proc_data, kid, qualifiers, nquals);
+            if (NULL != hv) {
+                /* create the copy */
+                PMIX_KVAL_NEW(kv, key);
+                PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void **)&kv->value, hv->value, PMIX_VALUE);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(kv);
+                    return rc;
+                }
+                pmix_list_append(kvals, &kv->super);
+                break;
+            } else if (!fullsearch) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "HASH:FETCH data for key %s not found", key);
+                return PMIX_ERR_NOT_FOUND;
+            }
+        }
+
+        rc = pmix_hash_table_get_next_key_uint32(table, &id, (void **) &proc_data, node,
+                                                 (void **) &node);
+        if (PMIX_SUCCESS != rc) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "%s:%d HASH:FETCH data for key %s not found",
+                                __func__, __LINE__, key);
+            return PMIX_ERR_NOT_FOUND;
+        }
+    }
+
+    return rc;
+}
+
+pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
+                                    pmix_rank_t rank, const char *key)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_proc_data_t *proc_data;
+    pmix_dstor_t *d;
+    uint32_t id, kid;
+    int n;
+    char *node;
+    pmix_regattr_input_t *p;
+
+    if (NULL != key) {
+        p = pmix_hash_lookup_key(UINT32_MAX, key);
+        if (NULL == p) {
+            /* we don't know this key */
+            return PMIX_ERR_BAD_PARAM;
+        }
+        kid = p->index;
+    }
+
+    /* if the rank is wildcard, we want to apply this to
+     * all rank entries */
+    if (PMIX_RANK_WILDCARD == rank) {
+        rc = pmix_hash_table_get_first_key_uint32(table, &id, (void **) &proc_data,
+                                                  (void **) &node);
+        while (PMIX_SUCCESS == rc) {
+            if (NULL != proc_data) {
+                if (NULL == key) {
+                    PMIX_RELEASE(proc_data);
+                } else {
+                    for (n=0; n < proc_data->data.size; n++) {
+                        d = (pmix_dstor_t*)pmix_pointer_array_get_item(&proc_data->data, n);
+                        if (NULL != d && kid == d->index) {
+                            if (NULL != d->value) {
+                                PMIX_VALUE_RELEASE(d->value);
+                            }
+                            if (UINT32_MAX != d->qualindex) {
+                                erase_qualifiers(proc_data, d->qualindex);
+                            }
+                            free(d);
+                            pmix_pointer_array_set_item(&proc_data->data, n, NULL);
+                            break;
+                        }
+                    }
+                }
+            }
+            rc = pmix_hash_table_get_next_key_uint32(table, &id, (void **) &proc_data, node,
+                                                     (void **) &node);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    /* lookup the specified proc */
+    if (NULL == (proc_data = lookup_proc(table, rank, false))) {
+        /* no data for this proc */
+        return PMIX_SUCCESS;
+    }
+
+    /* if key is NULL, remove all data for this proc */
+    if (NULL == key) {
+        for (n=0; n < proc_data->data.size; n++) {
+            d = (pmix_dstor_t*)pmix_pointer_array_get_item(&proc_data->data, n);
+            if (NULL != d) {
+                if (NULL != d->value) {
+                    PMIX_VALUE_RELEASE(d->value);
+                }
+                if (UINT32_MAX != d->qualindex) {
+                    erase_qualifiers(proc_data, d->qualindex);
+                }
+                free(d);
+                pmix_pointer_array_set_item(&proc_data->data, n, NULL);
+            }
+        }
+        /* remove the proc_data object itself from the jtable */
+        pmix_hash_table_remove_value_uint32(table, rank);
+        /* cleanup */
+        PMIX_RELEASE(proc_data);
+        return PMIX_SUCCESS;
+    }
+
+    /* remove this item */
+    for (n=0; n < proc_data->data.size; n++) {
+        d = (pmix_dstor_t*)pmix_pointer_array_get_item(&proc_data->data, n);
+        if (NULL != d && kid == d->index) {
+            if (NULL != d->value) {
+                PMIX_VALUE_RELEASE(d->value);
+            }
+            if (UINT32_MAX != d->qualindex) {
+                erase_qualifiers(proc_data, d->qualindex);
+            }
+            free(d);
+            pmix_pointer_array_set_item(&proc_data->data, n, NULL);
+            break;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/**
+ * Find data for a given key in a given pmix_list_t.
+ */
+static pmix_dstor_t *lookup_keyval(pmix_proc_data_t *proc_data, uint32_t kid,
+                                   pmix_info_t *qualifiers, size_t nquals)
+{
+    pmix_dstor_t *d;
+    pmix_data_array_t *darray;
+    pmix_qual_t *qarray;
+    pmix_regattr_input_t *p;
+    size_t m, numquals = 0, nq, nfound;
+    int n;
+
+    p = pmix_hash_lookup_key(kid, NULL);
+
+    if (NULL != qualifiers) {
+        /* count the qualifiers */
+        for (m=0; m < nquals; m++) {
+            /* if this isn't marked as a qualifier, skip it */
+            if (PMIX_INFO_IS_QUALIFIER(&qualifiers[m])) {
+                ++numquals;
+            }
+        }
+    }
+
+    for (n=0; n < proc_data->data.size; n++) {
+        d = (pmix_dstor_t*)pmix_pointer_array_get_item(&proc_data->data, n);
+        if (NULL == d) {
+            continue;
+        }
+        if (kid == d->index) {
+            if (0 < numquals) {
+                if (UINT32_MAX == d->qualindex) {
+                    continue;
+                }
+                darray = (pmix_data_array_t*)pmix_pointer_array_get_item(&proc_data->quals, d->qualindex);
+                qarray = (pmix_qual_t*)darray->array;
+                nfound = 0;
+                /* check the qualifiers */
+                for (m=0; m < nquals; m++) {
+                    /* if this isn't marked as a qualifier, skip it */
+                    if (!PMIX_INFO_IS_QUALIFIER(&qualifiers[m])) {
+                        continue;
+                    }
+                    p = pmix_hash_lookup_key(UINT32_MAX, qualifiers[m].key);
+                    if (NULL == p) {
+                        /* we don't know this key */
+                        return NULL;
+                    }
+                    for (nq=0; nq < darray->size; nq++) {
+                        /* see if the keys match */
+                        if (qarray[nq].index == p->index) {
+                            /* if the values don't match, then we reject
+                             * this entry */
+                            if (PMIX_EQUAL == PMIx_Value_compare(&qualifiers[m].value, qarray[nq].value)) {
+                                /* match! */
+                                ++nfound;
+                                break;
+                            }
+                        }
+                    }
+                }
+                /* did we get a complete match? */
+                if (nfound == numquals) {
+                    return d;
+                }
+            } else {
+                /* if the stored key is also "unqualified",
+                 * then return it */
+                if (UINT32_MAX == d->qualindex) {
+                    return d;
+                }
+            }
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * Find proc_data_t container associated with given
+ * pmix_identifier_t.
+ */
+static pmix_proc_data_t *lookup_proc(pmix_hash_table_t *jtable, uint32_t id, bool create)
+{
+    pmix_proc_data_t *proc_data = NULL;
+
+    pmix_hash_table_get_value_uint32(jtable, id, (void **) &proc_data);
+    if (NULL == proc_data && create) {
+        /* The proc clearly exists, so create a data structure for it */
+        proc_data = PMIX_NEW(pmix_proc_data_t);
+        if (NULL == proc_data) {
+            return NULL;
+        }
+        pmix_hash_table_set_value_uint32(jtable, id, proc_data);
+    }
+
+    return proc_data;
+}
+
+void pmix_hash_register_key(uint32_t inid,
+                            pmix_regattr_input_t *ptr)
+{
+    uint32_t id;
+    pmix_regattr_input_t *p = NULL;
+
+    if (UINT32_MAX == inid) {
+        /* compute a hash of the string representation */
+        PMIX_HASH_STR(ptr->string, id);
+    } else {
+        id = inid;
+    }
+    /* check to see if this key was already registered */
+    pmix_hash_table_get_value_uint32(&pmix_globals.keyindex,
+                                     id, (void**)&p);
+    if (NULL != p) {
+        /* already have this one */
+        return;
+    }
+    /* store the pointer in the hash */
+    pmix_hash_table_set_value_uint32(&pmix_globals.keyindex,
+                                     id, ptr);
+}
+
+pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
+                                           const char *key)
+{
+    uint32_t id;
+    pmix_regattr_input_t *ptr = NULL;
+    char *node;
+    pmix_status_t rc;
+
+    if (UINT32_MAX == inid) {
+        if (NULL == key) {
+            /* they have to give us something! */
+            return NULL;
+        }
+        /* if it is a PMIx standard key, then we look up the
+         * index - this needs to be optimized and provided
+         * as a separate function as we will need it at
+         * all APIs to convert incoming keys! */
+        if (PMIX_CHECK_RESERVED_KEY(key)) {
+            id = UINT32_MAX;
+            rc = pmix_hash_table_get_first_key_uint32(&pmix_globals.keyindex,
+                                                      &id, (void **) &ptr,
+                                                      (void **) &node);
+            while (PMIX_SUCCESS == rc) {
+                if (0 == strcmp(key, ptr->string)) {
+                    break;
+                }
+                rc = pmix_hash_table_get_next_key_uint32(&pmix_globals.keyindex, &id,
+                                                         (void **) &ptr, node,
+                                                         (void **) &node);
+            }
+            if (UINT32_MAX == id) {
+                return NULL;
+            }
+        } else {
+            /* compute a hash of the string representation */
+            PMIX_HASH_STR(key, id);
+        }
+    } else {
+        id = inid;
+    }
+    /* get the pointer from the hash */
+    pmix_hash_table_get_value_uint32(&pmix_globals.keyindex,
+                                     id, (void**)&ptr);
+
+    if (NULL == ptr && !PMIX_CHECK_RESERVED_KEY(key)) {
+        /* register this one */
+        ptr = (pmix_regattr_input_t*)pmix_malloc(sizeof(pmix_regattr_input_t));
+        ptr->index = id;
+        ptr->name = strdup(key);
+        ptr->string = strdup(key);
+        ptr->type = PMIX_UNDEF;
+        ptr->description = (char**)pmix_malloc(2 * sizeof(char*));
+        ptr->description[0] = strdup("USER DEFINED");
+        ptr->description[1] = NULL;
+        pmix_hash_register_key(ptr->index, ptr);
+    }
+    return ptr;  // will be NULL if nothing found
+}
+
+static void erase_qualifiers(pmix_proc_data_t *proc,
+                             uint32_t index)
+{
+    pmix_data_array_t *darray;
+    pmix_qual_t *qarray;
+    size_t n;
+
+    darray = (pmix_data_array_t*)pmix_pointer_array_get_item(&proc->quals, index);
+    if (NULL == darray || NULL == darray->array) {
+        return;
+    }
+    qarray = (pmix_qual_t*)darray->array;
+    for (n=0; n < darray->size; n++) {
+        if (NULL != qarray[n].value) {
+            PMIX_VALUE_RELEASE(qarray[n].value);
+        }
+    }
+    free(qarray);
+    free(darray);
+    pmix_pointer_array_set_item(&proc->quals, index, NULL);
+}

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -25,13 +25,16 @@ BEGIN_C_DECLS
 
 /* store a value in the given hash table for the specified
  * rank index.*/
-PMIX_EXPORT pmix_status_t pmix_hash_store(pmix_hash_table_t *table, pmix_rank_t rank,
-                                          pmix_kval_t *kv);
+PMIX_EXPORT pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
+                                          pmix_rank_t rank, pmix_kval_t *kin,
+                                          pmix_info_t *qualifiers, size_t nquals);
 
 /* Fetch the value for a specified key and rank from within
  * the given hash_table */
 PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
-                                          const char *key, pmix_value_t **kvs);
+                                          const char *key,
+                                          pmix_info_t *qualifiers, size_t nquals,
+                                          pmix_list_t *kvals);
 
 /* remove the specified key-value from the given hash_table.
  * A NULL key will result in removal of all data for the
@@ -40,7 +43,8 @@ PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t 
  * ranks in the table. Combining key=NULL with rank=PMIX_RANK_WILDCARD
  * will therefore result in removal of all data from the
  * table */
-PMIX_EXPORT pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table, pmix_rank_t rank,
+PMIX_EXPORT pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
+                                                pmix_rank_t rank,
                                                 const char *key);
 
 PMIX_EXPORT void pmix_hash_register_key(uint32_t inid,

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid
+                  hybrid simpqual
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -173,5 +173,11 @@ hybrid_SOURCES = $(headers) \
         hybrid.c
 hybrid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hybrid_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpqual_SOURCES = $(headers) \
+        simpqual.c
+simpqual_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpqual_LDADD = \
     $(top_builddir)/src/libpmix.la
 

--- a/test/simple/simpqual.c
+++ b/test/simple/simpqual.c
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/class/pmix_object.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
+
+#define MAXCNT 1
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    pmix_info_t *iptr;
+    size_t sz;
+    pmix_data_array_t darray;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "%s: PMIx_Init failed: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "%s: Running on node %s",
+                PMIX_NAME_PRINT(&myproc),
+                pmix_globals.hostname);
+
+    /* get number of procs */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "%s: PMIx_Get job size failed: %s",
+                    PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+        exit(rc);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    pmix_output(0, "%s job size %d", PMIX_NAME_PRINT(&myproc), nprocs);
+
+    /* put a qualified value */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 2, PMIX_INFO);
+    iptr = (pmix_info_t*)darray.array;
+    /* load the primary key-value */
+    sz = myproc.rank * 100;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_GROUP_LOCAL_CID, &sz, PMIX_SIZE);
+    /* provide a qualifier */
+    sz = 123456;
+    PMIX_INFO_LOAD(&iptr[1], "OURQUALIFIER", &sz, PMIX_SIZE);
+    PMIX_INFO_SET_QUALIFIER(&iptr[1]);  // mark it as a qualifier
+    /* load the value */
+    PMIX_VALUE_LOAD(&value, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    rc = PMIx_Put(PMIX_GLOBAL, PMIX_QUALIFIED_VALUE, &value);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "%s failed to put qualified value: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+
+    /* put another qualified value of the same key */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 2, PMIX_INFO);
+    iptr = (pmix_info_t*)darray.array;
+    /* load the primary key-value */
+    sz = 1 + myproc.rank * 100;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_GROUP_LOCAL_CID, &sz, PMIX_SIZE);
+    /* provide a qualifier */
+    sz = 891011;
+    PMIX_INFO_LOAD(&iptr[1], "OURQUALIFIER", &sz, PMIX_SIZE);
+    PMIX_INFO_SET_QUALIFIER(&iptr[1]);  // mark it as a qualifier
+    /* load the value */
+    PMIX_VALUE_LOAD(&value, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    rc = PMIx_Put(PMIX_GLOBAL, PMIX_QUALIFIED_VALUE, &value);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "%s failed to put another qualified value: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+    /* put an unqualified value of the same key */
+    sz = 2 + (myproc.rank * 100);
+    PMIX_VALUE_LOAD(&value, &sz, PMIX_SIZE);
+    rc = PMIx_Put(PMIX_GLOBAL, PMIX_GROUP_LOCAL_CID, &value);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "%s failed to put unqualified value: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        pmix_output(0, "%s: PMIx_Commit failed: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+
+        exit(rc);
+    }
+
+    /* call fence to ensure the data is received */
+    PMIX_PROC_CONSTRUCT(&proc);
+    pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        pmix_output(0, "%s: PMIx_Fence failed: %s",
+                    PMIX_NAME_PRINT(&myproc),
+                    PMIx_Error_string(rc));
+        exit(rc);
+    }
+
+    /* first my own value without qualifiers */
+    pmix_output(0, "%s Looking for my own value w/o quals",
+                PMIX_NAME_PRINT(&myproc));
+    rc = PMIx_Get(&myproc, PMIX_GROUP_LOCAL_CID, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "%s UNABLE TO GET MY OWN VALUE W/O QUALS: %s",
+                    PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+    } else if (val->data.size == ((100*myproc.rank)+2)) {
+        pmix_output(0, "%s Returned my own correct value w/o quals: %s",
+                    PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+    } else {
+        pmix_output(0, "%s Returned my own incorrect value w/o quals: %s",
+                    PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+        exit(-1);
+    }
+
+    /* now with the correct qualifier */
+    /* get the qualified value for a peer */
+    if (1 < nprocs) {
+        proc.rank = myproc.rank + 1;
+        if (proc.rank == nprocs) {
+            proc.rank = 0;
+        }
+        /* first without qualifiers */
+        pmix_output(0, "%s Looking for value w/o quals",
+                    PMIX_NAME_PRINT(&myproc));
+        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, NULL, 0, &val);
+        if (PMIX_SUCCESS != rc) {
+            pmix_output(0, "%s UNABLE TO GET VALUE W/O QUALS: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+        } else if (val->data.size == ((100*proc.rank)+2)) {
+            pmix_output(0, "%s Returned correct value w/o quals: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+        } else {
+            pmix_output(0, "%s Returned incorrect value w/o quals: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+            exit(-1);
+        }
+
+        /* now with the correct qualifier */
+        pmix_output(0, "%s Looking for first qualified value with correct qual",
+                    PMIX_NAME_PRINT(&myproc));
+        PMIX_INFO_CREATE(iptr, 1);
+        sz = 123456;
+        PMIX_INFO_LOAD(&iptr[0], "OURQUALIFIER", &sz, PMIX_SIZE);
+        PMIX_INFO_SET_QUALIFIER(&iptr[0]);  // mark it as a qualifier
+        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, iptr, 1, &val);
+        if (PMIX_SUCCESS != rc) {
+            pmix_output(0, "%s UNABLE TO GET QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+        } else if (val->data.size == (100*proc.rank)) {
+            pmix_output(0, "%s GOT CORRECT QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+        } else {
+            pmix_output(0, "%s GOT INCORRECT QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+            exit(-1);
+        }
+        PMIX_INFO_FREE(iptr, 1);
+
+        /* now second value with the correct qualifier */
+        pmix_output(0, "%s Looking for second qualified value with correct qual",
+                    PMIX_NAME_PRINT(&myproc));
+        PMIX_INFO_CREATE(iptr, 1);
+        sz = 891011;
+        PMIX_INFO_LOAD(&iptr[0], "OURQUALIFIER", &sz, PMIX_SIZE);
+        PMIX_INFO_SET_QUALIFIER(&iptr[0]);  // mark it as a qualifier
+        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, iptr, 1, &val);
+        if (PMIX_SUCCESS != rc) {
+            pmix_output(0, "%s UNABLE TO GET SECOND QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+        } else if (val->data.size == (100*proc.rank)+1) {
+            pmix_output(0, "%s GOT CORRECT SECOND QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+        } else {
+            pmix_output(0, "%s GOT INCORRECT SECOND QUALIFIED VALUE WITH CORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+            exit(-1);
+        }
+        PMIX_INFO_FREE(iptr, 1);
+
+        /* and now with an incorrect qualifier - should not return success */
+        pmix_output(0, "%s Looking for qualified value with incorrect qual",
+                    PMIX_NAME_PRINT(&myproc));
+        PMIX_INFO_CREATE(iptr, 1);
+        sz = 0;
+        PMIX_INFO_LOAD(&iptr[0], "OURQUALIFIER", &sz, PMIX_SIZE);
+        PMIX_INFO_SET_QUALIFIER(&iptr[0]);  // mark it as a qualifier
+        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, iptr, 1, &val);
+        if (PMIX_SUCCESS == rc) {
+            pmix_output(0, "%s GOT QUALIFIED VALUE WITH INCORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Value_string(val));
+        } else if (PMIX_ERR_NOT_FOUND == rc) {
+            pmix_output(0, "%s DID NOT GET QUALIFIED VALUE WITH INCORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+        } else {
+            pmix_output(0, "%s GOT INCORRECT STATUS FOR QUALIFIED VALUE WITH INCORRECT QUAL: %s",
+                        PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+            exit(-1);
+        }
+        PMIX_INFO_FREE(iptr, 1);
+    }
+
+    /* finalize us */
+    pmix_output(0, "%s: Finalizing", PMIX_NAME_PRINT(&myproc));
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "%s:PMIx_Finalize failed: %s\n",
+                PMIX_NAME_PRINT(&myproc), PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "%s:PMIx_Finalize successfully completed\n",
+                PMIX_NAME_PRINT(&myproc));
+    }
+    fflush(stderr);
+    return (rc);
+}


### PR DESCRIPTION
Allow the user to put/get values that are qualified - i.e., a process
might store multiple values for the same key, each value being
qualified to specify when that value (as opposed to the others) shall
be returned. When a user issues a "get" for the key, return the
value which matches the provided qualifiers - a "get" without
qualifiers will only return a value that was "put" without qualifiers.

Signed-off-by: Ralph Castain <rhc@pmix.org>