### PR TITLE
Complete support for group-level info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,8 @@ src/include/pmix_config.h
 src/include/pmix_config.h.in
 src/include/pmix_config.h.in~
 src/include/pmix_frameworks.h
-src/include/dictionary.h
+src/include/pmix_dictionary.c
+src/include/pmix_dictionary.h
 
 src/mca/pinstalldirs/config/pinstall_dirs.h
 src/mca/pdl/base/static-components.h

--- a/examples/group.c
+++ b/examples/group.c
@@ -148,8 +148,8 @@ int main(int argc, char **argv)
         if (NULL != results) {
             cid = 0;
             PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
-            fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %d\n",
-                    myproc.rank, PMIx_Error_string(rc), results[0].key, (int) cid);
+            fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
+                    myproc.rank, PMIx_Error_string(rc), results[0].key, (unsigned long) cid);
         } else {
             fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
         }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -434,7 +434,7 @@ PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
 typedef struct {
     pmix_list_item_t super;
     pmix_proc_t proc;
-    pmix_list_t ilist;  // list of pmix_kval_t provided by this proc
+    pmix_byte_object_t blob;  // packed blob of info provided by this proc
 } pmix_grpinfo_t;
 PMIX_CLASS_DECLARATION(pmix_grpinfo_t);
 

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -236,9 +236,10 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
         return rc;
     }
     pmix_output_verbose(10, pmix_globals.debug_output,
-                        "%s ADDING KEY %s VALUE %u FOR RANK %s WITH %u QUALS TO TABLE %s",
+                        "%s ADDING KEY %s VALUE %s FOR RANK %s WITH %u QUALS TO TABLE %s",
                         PMIX_NAME_PRINT(&pmix_globals.myid),
-                        kin->key, (unsigned)kin->value->data.size, PMIX_RANK_PRINT(rank), (unsigned)m,
+                        kin->key, PMIx_Value_string(kin->value),
+                        PMIX_RANK_PRINT(rank), (unsigned)m,
                         table->ht_label);
     pmix_pointer_array_add(&proc_data->data, hv);
     return PMIX_SUCCESS;


### PR DESCRIPTION
Allow processes to contribute information during calls to
PMIx_Group_construct that are shared with all construct
participants. The values are returned to the participants
as "qualified" values, each value qualified by the assigned
group context ID.

Signed-off-by: Ralph Castain <rhc@pmix.org>