### PR TITLE
v4.0: configure.ac: update directory space check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -131,30 +131,11 @@ AC_DEFUN([PMIX_CHECK_DIR_FOR_SPACES],[
            AC_MSG_ERROR([Cannot continue.])])
 ])
 
-AC_DEFUN([PMIX_CANONICALIZE_PATH],[
-    case $host_os in
-    darwin*)
-        # MacOS does not have "readlink -f" or realpath (at least as
-        # of MacOS Cataline / 10.15).  Instead, use Python, because we
-        # know MacOS comes with a /usr/bin/python that has
-        # os.path.realpath.
-        $2=`/usr/bin/python -c 'import os; print os.path.realpath("'$1'")'`
-        ;;
-    *)
-        $2=`readlink -f $1`
-        ;;
-    esac
-])
-
 PMIX_VAR_SCOPE_PUSH(pmix_checkdir)
-PMIX_CHECK_DIR_FOR_SPACES([$srcdir], [a], [source tree])
-PMIX_CANONICALIZE_PATH([$srcdir], [pmix_checkdir])
-PMIX_CHECK_DIR_FOR_SPACES([$pmix_checkdir], [an], [absolute source tree])
-PMIX_CANONICALIZE_PATH([.], [pmix_checkdir])
+pmix_checkdir=`pwd`
 PMIX_CHECK_DIR_FOR_SPACES([$pmix_checkdir], [a], [build tree])
 PMIX_CHECK_DIR_FOR_SPACES([$prefix], [a], [prefix])
-PMIX_CANONICALIZE_PATH([$prefix], [pmix_checkdir])
-PMIX_CHECK_DIR_FOR_SPACES([$pmix_checkdir], [an], [absolute prefix])
+PMIX_CHECK_DIR_FOR_SPACES([$srcdir], [a], [source tree])
 PMIX_VAR_SCOPE_POP
 
 ####################################################################


### PR DESCRIPTION
PMIX_CANONICALIZE_PATH broke on MacOS when `/usr/bin/python`
disappeared (in favor of `/usr/bin/python3`) in MacOS Monterrey.  Make
things simpler by not canonicalizing the path to begin with.

Specifically: just look at `pwd`, $srcdir, and $prefix.  Even if
$srcdir and/or $prefix are relative to the build dir, the union of all
the checks will ensure that none of the target paths will contain
spaces.

Back-ported from
https://github.com/open-mpi/ompi/commit/6992c642437af1135ccb6f159683853fe63c58cc

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 594303dfa704daf9b3dde8ee1448bed06d4196d5)