### PR TITLE
Support colocation of processes

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -462,6 +462,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"         // (bool) spawned app consists of debugger daemons
 #define PMIX_COSPAWN_APP                    "pmix.cospawn"          // (bool) designated app is to be spawned as a disconnected
                                                                     //        job - i.e., not part of the "comm_world" of the job
+#define PMIX_COLOCATE_PROCS                 "pmix.colproc"          // (pmix_data_array_t*) Array of pmix_proc_t identifying the procs
+                                                                    //        with which the new job's procs are to be colocated
+#define PMIX_COLOCATE_NPERPROC              "pmix.colnum.proc"      // (uint16_t) Number of procs to colocate with each identified proc
+#define PMIX_COLOCATE_NPERNODE              "pmix.colnum.node"      // (uint16_t) Number of procs to colocate on the node of each identified proc
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
 #define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc


### PR DESCRIPTION
When spawning a new job, support the case where the user
wants to spawn the new procs at locations where current
procs are executing. Provide for both specification of
the number of new procs to start on each node where the
current procs are executing, or the number of new procs
to start for each current proc that is executing.

Note that these are not required to be daemons - they can
be any application code, and can have any desired ranking
and/or binding policy. Mapping policy, however, will be
ignored as it is overridden by the "colocate" directive.

Signed-off-by: Ralph Castain <rhc@pmix.org>