### PR TITLE
Require flex only when keyval_lex.c is not provided

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1027,25 +1027,6 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
                       [Whether we want to enable dlopen support])
 
 #
-# Is this a developer copy?
-#
-
-if test -e $PMIX_TOP_SRCDIR/.git; then
-    PMIX_DEVEL=1
-    # check for Flex
-    AC_PROG_LEX(yywrap)
-    if test "x$LEX" != xflex; then
-        AC_MSG_WARN([PMIx requires Flex to build from non-tarball sources,])
-        AC_MSG_WARN([but Flex was not found. Please install Flex into])
-        AC_MSG_WARN([your path and try again])
-        AC_MSG_ERROR([Cannot continue])
-    fi
-else
-    PMIX_DEVEL=0
-fi
-
-
-#
 # Developer picky compiler options
 #
 

--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,25 @@ PMIX_SETUP_WRAPPER_INIT
 # This did not exist pre AM 1.11.x (where x is somewhere >0 and <3),
 # but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AC_PROG_LEX(yywrap)
+
+#
+# Is this a developer copy?
+#
+
+if test -e $PMIX_TOP_SRCDIR/.git; then
+    PMIX_DEVEL=1
+else
+    PMIX_DEVEL=0
+fi
+# check for Flex
+AC_PROG_LEX(noyywrap)
+if test "x$LEX" != xflex && test ! -e $PMIX_TOP_SRCDIR/util/keyval/keyval_lex.c; then
+    AC_MSG_WARN([PMIx requires Flex to build from sources that were not])
+    AC_MSG_WARN([fully pre-processed (e.g., an official release tarball),])
+    AC_MSG_WARN([but Flex was not found. Please install Flex into])
+    AC_MSG_WARN([your path and try again])
+    AC_MSG_ERROR([Cannot continue])
+fi
 
 ############################################################################
 # Configuration options


### PR DESCRIPTION
We currently require flex whenever we are in a Git clone, but that
really isn't the requirement. We need flex whenever the flex output
files are not present - otherwise, you can build just fine. So open
things up a bit by tying the flex requirement to the actual one
(i.e., that the flex output file exist).

This also patches the configure logic to fix a reported situation
where configure incorrectly reports that `flex` is not available.

Refs https://github.com/openpmix/openpmix/issues/2605
Refs https://github.com/openpmix/openpmix/issues/2599

Signed-off-by: Ralph Castain <rhc@pmix.org>