### PR TITLE
Some initial valgrind cleanup

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1087,6 +1087,8 @@ PMIX_EXPORT pmix_status_t PMIx_Parse_cpuset_string(const char *cpuset_string,
 
 PMIX_EXPORT pmix_status_t PMIx_Get_cpuset(pmix_cpuset_t *cpuset, pmix_bind_envelope_t ref);
 
+PMIX_EXPORT void PMIx_Cpuset_destruct(pmix_cpuset_t *cpuset);
+
 /* Get the relative locality of two local processes given their locality strings.
  *
  * locality1 - String returned by the PMIx_server_generate_locality_string API
@@ -1580,6 +1582,8 @@ PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
 
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
+
 /* Transfer data from one pmix_value_t to another - this is actually
  * executed as a COPY operation, so the original data is not altered.
  */
@@ -1589,6 +1593,8 @@ PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
 /* Compre the contents of two pmix_value_t structures */
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
+
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
 
 /* Load key/value data into a pmix_info_t struct. Note that this
  * effectively is a PMIX_LOAD_KEY operation to copy the key,
@@ -1622,6 +1628,8 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const char *key,
                                              const void *value,
                                              pmix_data_type_t type);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 /* Transfer the data in an existing pmix_info_t struct to a list. This
  * is executed as a COPY operation, so the original data is not altered.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1478,6 +1478,7 @@ typedef uint32_t pmix_info_directives_t;
 #define PMIX_INFO_ARRAY_END         0x00000002      // mark the end of an array created by PMIX_INFO_CREATE
 #define PMIX_INFO_REQD_PROCESSED    0x00000004      // reqd attribute has been processed
 #define PMIX_INFO_QUALIFIER         0x00000008      // info is a qualifier to the primary value
+#define PMIX_INFO_PERSISTENT        0x00000010      // do not release included value
 /* the top 16-bits are reserved for internal use by
  * implementers - these may be changed inside the
  * PMIx library */
@@ -1844,10 +1845,10 @@ static inline void pmix_argv_free(char **argv)
         return;
 
     for (p = argv; NULL != *p; ++p) {
-        free(*p);
+        pmix_free(*p);
     }
 
-    free(argv);
+    pmix_free(argv);
 }
 
 #define PMIX_ARGV_FREE(a)  pmix_argv_free(a)
@@ -2336,7 +2337,7 @@ typedef struct pmix_geometry {
             for (_i=0; _i < (n); _i++) {            \
                 PMIX_GEOMETRY_DESTRUCT(&(m)[_i]);   \
             }                                       \
-            free((m));                              \
+            pmix_free((m));                         \
             (m) = NULL;                             \
         }                                           \
     } while(0)
@@ -2380,10 +2381,10 @@ typedef struct pmix_device_distance {
 #define PMIX_DEVICE_DIST_DESTRUCT(m)    \
     do {                                \
         if (NULL != ((m)->uuid)) {      \
-            free((m)->uuid);            \
+            pmix_free((m)->uuid);       \
         }                               \
         if (NULL != ((m)->osname)) {    \
-            free((m)->osname);          \
+            pmix_free((m)->osname);     \
         }                               \
     } while(0)
 
@@ -2408,7 +2409,7 @@ typedef struct pmix_device_distance {
             for (_i=0; _i < (n); _i++) {                \
                 PMIX_DEVICE_DIST_DESTRUCT(&(m)[_i]);    \
             }                                           \
-            free((m));                                  \
+            pmix_free((m));                             \
             (m) = NULL;                                 \
         }                                               \
     } while(0)
@@ -2671,7 +2672,7 @@ typedef struct pmix_proc {
 #define PMIX_PROC_FREE(m, n)                    \
     do {                                        \
         if (NULL != (m)) {                      \
-            pmix_free((m));                          \
+            pmix_free((m));                     \
             (m) = NULL;                         \
         }                                       \
     } while (0)
@@ -2888,16 +2889,23 @@ typedef struct pmix_proc_stats {
         }                               \
     } while(0)
 
-#define PMIX_PROC_STATS_FREE(m, n)                  \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_PROC_STATS_DESTRUCT(&(m)[_k]); \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_proc_stats_free(pmix_proc_stats_t *ps, size_t n)
+{
+    size_t k;
+
+    if (NULL != ps) {
+        for (k=0; k < n; k++) {
+            PMIX_PROC_STATS_DESTRUCT(&ps[k]);
+        }
+    }
+}
+
+#define PMIX_PROC_STATS_FREE(m, n)  \
+do {                                \
+    pmix_proc_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *disk;
@@ -2953,16 +2961,23 @@ typedef struct {
         }                               \
     } while(0)
 
-#define PMIX_DISK_STATS_FREE(m, n)                  \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_DISK_STATS_DESTRUCT(&(m)[_k]); \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_disk_stats_free(pmix_disk_stats_t *d, size_t n)
+{
+    size_t k;
+
+    if (NULL != d) {
+        for (k=0; k < n; k++) {
+            PMIX_DISK_STATS_DESTRUCT(&d[k]);
+        }
+    }
+}
+
+#define PMIX_DISK_STATS_FREE(m, n)  \
+do {                                \
+    pmix_disk_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *net_interface;
@@ -3008,16 +3023,23 @@ typedef struct {
         }                                   \
     } while(0)
 
-#define PMIX_NET_STATS_FREE(m, n)                   \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_NET_STATS_DESTRUCT(&(m)[_k]);  \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_net_stats_free(pmix_net_stats_t *nst, size_t n)
+{
+    size_t k;
+
+    if (NULL != nst) {
+        for (k=0; k < n; k++) {
+            PMIX_NET_STATS_DESTRUCT(&nst[k]);
+        }
+    }
+}
+
+#define PMIX_NET_STATS_FREE(m, n)   \
+do {                                \
+    pmix_net_stats_free(m, n);      \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *node;
@@ -3070,11 +3092,6 @@ typedef struct {
         (m) = (pmix_node_stats_t*)pmix_calloc((n) , sizeof(pmix_node_stats_t)); \
     } while (0)
 
-#define PMIX_NODE_STATS_RELEASE(m)      \
-    do {                                \
-        PMIX_NODE_STATS_FREE((m), 1);   \
-    } while (0)
-
 #define PMIX_NODE_STATS_CONSTRUCT(m)                \
     do {                                            \
         memset((m), 0, sizeof(pmix_node_stats_t));  \
@@ -3094,16 +3111,27 @@ typedef struct {
         }                                                           \
     } while(0)
 
-#define PMIX_NET_STATS_FREE(m, n)                   \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_NET_STATS_DESTRUCT(&(m)[_k]);  \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_node_stats_free(pmix_node_stats_t *nd, size_t n)
+{
+    size_t k;
+
+    if (NULL != nd) {
+        for (k=0; k < n; k++) {
+            PMIX_NODE_STATS_DESTRUCT(&nd[k]);
+        }
+    }
+}
+
+#define PMIX_NODE_STATS_FREE(m, n)  \
+do {                                \
+    pmix_node_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
+
+#define PMIX_NODE_STATS_RELEASE(m)  \
+    pmix_node_stats_free(m, 1)
+
 
 /****    PMIX VALUE STRUCT    ****/
 
@@ -3186,34 +3214,11 @@ typedef struct pmix_value {
         }                                                       \
     } while (0)
 
-/* release a single pmix_value_t struct, including its data */
-#define PMIX_VALUE_RELEASE(m)       \
-    do {                            \
-        PMIX_VALUE_DESTRUCT((m));   \
-        pmix_free((m));                  \
-        (m) = NULL;                 \
-    } while (0)
-
 /* initialize a single value struct */
 #define PMIX_VALUE_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_value_t));   \
         (m)->type = PMIX_UNDEF;                 \
-    } while (0)
-
-/* release the memory in the value struct data field */
-#define PMIX_VALUE_DESTRUCT(m) pmix_value_destruct(m)
-
-#define PMIX_VALUE_FREE(m, n)                           \
-    do {                                                \
-        size_t _vv;                                     \
-        if (NULL != (m)) {                              \
-            for (_vv=0; _vv < (n); _vv++) {             \
-                PMIX_VALUE_DESTRUCT(&((m)[_vv]));       \
-            }                                           \
-            pmix_free((m));                                  \
-            (m) = NULL;                                 \
-        }                                               \
     } while (0)
 
 #define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
@@ -3285,23 +3290,6 @@ typedef struct pmix_info {
         (m)->value.type = PMIX_UNDEF;           \
     } while (0)
 
-#define PMIX_INFO_DESTRUCT(m) \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while (0)
-
-#define PMIX_INFO_FREE(m, n)                        \
-    do {                                            \
-        size_t _is;                                 \
-        if (NULL != (m)) {                          \
-            for (_is=0; _is < (n); _is++) {         \
-                PMIX_INFO_DESTRUCT(&((m)[_is]));    \
-            }                                       \
-            pmix_free((m));                         \
-            (m) = NULL;                             \
-        }                                           \
-    } while (0)
-
 /* macros for setting and unsetting the "reqd" flag
  * in a pmix_info_t */
 #define PMIX_INFO_REQUIRED(m)       \
@@ -3333,6 +3321,11 @@ typedef struct pmix_info {
 #define PMIX_INFO_IS_QUALIFIER(i)    \
     ((i)->flags & PMIX_INFO_QUALIFIER)
 
+/* macro for setting and testing the "donot release" flag */
+#define PMIX_INFO_SET_PERSISTENT(ii) \
+    ((ii)->flags |= PMIX_INFO_PERSISTENT)
+#define PMIX_INFO_IS_PERSISTENT(ii)  \
+    ((ii)->flags & PMIX_INFO_PERSISTENT)
 
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
@@ -3363,35 +3356,10 @@ typedef struct pmix_pdata {
         (m) = (pmix_pdata_t*)pmix_calloc((n), sizeof(pmix_pdata_t)); \
     } while (0)
 
-#define PMIX_PDATA_RELEASE(m)                   \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-        pmix_free((m));                              \
-        (m) = NULL;                             \
-    } while (0)
-
 #define PMIX_PDATA_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_pdata_t));   \
         (m)->value.type = PMIX_UNDEF;           \
-    } while (0)
-
-#define PMIX_PDATA_DESTRUCT(m)                  \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while (0)
-
-#define PMIX_PDATA_FREE(m, n)                           \
-    do {                                                \
-        size_t _ps;                                     \
-        pmix_pdata_t *_pdf = (pmix_pdata_t*)(m);        \
-        if (NULL != _pdf) {                             \
-            for (_ps=0; _ps < (n); _ps++) {             \
-                PMIX_PDATA_DESTRUCT(&(_pdf[_ps]));      \
-            }                                           \
-            pmix_free((m));                                  \
-            (m) = NULL;                                 \
-        }                                               \
     } while (0)
 
 
@@ -3439,50 +3407,6 @@ typedef struct pmix_app {
 #define PMIX_APP_CONSTRUCT(m)                   \
     do {                                        \
         memset((m), 0, sizeof(pmix_app_t));     \
-    } while (0)
-
-#define PMIX_APP_DESTRUCT(m)                                    \
-    do {                                                        \
-        size_t _aii;                                            \
-        if (NULL != (m)->cmd) {                                 \
-            pmix_free((m)->cmd);                                     \
-            (m)->cmd = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->argv) {                                \
-            for (_aii=0; NULL != (m)->argv[_aii]; _aii++) {     \
-                pmix_free((m)->argv[_aii]);                          \
-            }                                                   \
-            pmix_free((m)->argv);                                    \
-            (m)->argv = NULL;                                   \
-        }                                                       \
-        if (NULL != (m)->env) {                                 \
-            for (_aii=0; NULL != (m)->env[_aii]; _aii++) {      \
-                pmix_free((m)->env[_aii]);                           \
-            }                                                   \
-            pmix_free((m)->env);                                     \
-            (m)->env = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->cwd) {                                 \
-            pmix_free((m)->cwd);                                     \
-            (m)->cwd = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->info) {                                \
-            PMIX_INFO_FREE((m)->info, (m)->ninfo);              \
-            (m)->info = NULL;                                   \
-            (m)->ninfo = 0;                                     \
-        }                                                       \
-    } while (0)
-
-#define PMIX_APP_FREE(m, n)                     \
-    do {                                        \
-        size_t _as;                             \
-        if (NULL != (m)) {                      \
-            for (_as=0; _as < (n); _as++) {     \
-                PMIX_APP_DESTRUCT(&((m)[_as])); \
-            }                                   \
-            pmix_free((m));                          \
-            (m) = NULL;                         \
-        }                                       \
     } while (0)
 
 
@@ -3906,80 +3830,6 @@ typedef void (*pmix_device_dist_cbfunc_t)(pmix_status_t status,
                                           void *release_cbdata);
 
 
-/********    STANDARD MACROS FOR DARRAY AND VALUE SUPPORT     ********/
-static inline void pmix_darray_destruct(pmix_data_array_t *m);
-
-static inline void pmix_value_destruct(pmix_value_t * m)
-{
-    if (PMIX_STRING == (m)->type) {
-        if (NULL != (m)->data.string) {
-            pmix_free((m)->data.string);
-            (m)->data.string = NULL;
-        }
-    } else if ((PMIX_BYTE_OBJECT == (m)->type) ||
-               (PMIX_COMPRESSED_STRING == (m)->type)) {
-        if (NULL != (m)->data.bo.bytes) {
-            pmix_free((m)->data.bo.bytes);
-            (m)->data.bo.bytes = NULL;
-            (m)->data.bo.size = 0;
-        }
-    } else if (PMIX_DATA_ARRAY == (m)->type) {
-        if (NULL != (m)->data.darray) {
-            pmix_darray_destruct((m)->data.darray);
-            pmix_free((m)->data.darray);
-            (m)->data.darray = NULL;
-        }
-    } else if (PMIX_ENVAR == (m)->type) {
-        PMIX_ENVAR_DESTRUCT(&(m)->data.envar);
-    } else if (PMIX_PROC == (m)->type) {
-        PMIX_PROC_RELEASE((m)->data.proc);
-    }
-}
-
-static inline void pmix_darray_destruct(pmix_data_array_t *m)
-{
-    if (NULL != m) {
-        if (PMIX_INFO == m->type) {
-            pmix_info_t *_info = (pmix_info_t*)m->array;
-            PMIX_INFO_FREE(_info, m->size);
-        } else if (PMIX_PROC == m->type) {
-            pmix_proc_t *_p = (pmix_proc_t*)m->array;
-            PMIX_PROC_FREE(_p, m->size);
-        } else if (PMIX_PROC_INFO == m->type) {
-            pmix_proc_info_t *_pi = (pmix_proc_info_t*)m->array;
-            PMIX_PROC_INFO_FREE(_pi, m->size);
-        } else if (PMIX_ENVAR == m->type) {
-            pmix_envar_t *_e = (pmix_envar_t*)m->array;
-            PMIX_ENVAR_FREE(_e, m->size);
-        } else if (PMIX_VALUE == m->type) {
-            pmix_value_t *_v = (pmix_value_t*)m->array;
-            PMIX_VALUE_FREE(_v, m->size);
-        } else if (PMIX_PDATA == m->type) {
-            pmix_pdata_t *_pd = (pmix_pdata_t*)m->array;
-            PMIX_PDATA_FREE(_pd, m->size);
-        } else if (PMIX_QUERY == m->type) {
-            pmix_query_t *_q = (pmix_query_t*)m->array;
-            PMIX_QUERY_FREE(_q, m->size);
-        } else if (PMIX_APP == m->type) {
-            pmix_app_t *_a = (pmix_app_t*)m->array;
-            PMIX_APP_FREE(_a, m->size);
-        } else if (PMIX_BYTE_OBJECT == m->type ||
-                   PMIX_COMPRESSED_STRING == m->type) {
-            pmix_byte_object_t *_b = (pmix_byte_object_t*)m->array;
-            PMIX_BYTE_OBJECT_FREE(_b, m->size);
-        } else if (PMIX_STRING == m->type) {
-            char **_s = (char**)m->array;
-            size_t _si;
-            for (_si=0; _si < m->size; _si++) {
-                pmix_free(_s[_si]);
-            }
-            pmix_free(m->array);
-            m->array = NULL;
-        } else {
-            pmix_free(m->array);
-        }
-    }
-}
 
 #define PMIX_DATA_ARRAY_INIT(m, t)      \
     do {                                \
@@ -4131,7 +3981,97 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         }                                                                       \
     } while(0)
 
-#define PMIX_DATA_ARRAY_DESTRUCT(m) pmix_darray_destruct(m)
+#include <pmix_deprecated.h>
+
+/********    STANDARD MACROS FOR DARRAY AND VALUE SUPPORT     ********/
+
+/* release the memory in the value struct data field */
+#define PMIX_VALUE_DESTRUCT(m) PMIx_Value_destruct(m)
+
+/* release a single pmix_value_t struct, including its data */
+#define PMIX_VALUE_RELEASE(m)       \
+    do {                            \
+        PMIX_VALUE_DESTRUCT((m));   \
+        pmix_free((m));                  \
+        (m) = NULL;                 \
+    } while (0)
+
+#define PMIX_VALUE_FREE(m, n)                           \
+    do {                                                \
+        size_t _vv;                                     \
+        if (NULL != (m)) {                              \
+            for (_vv=0; _vv < (n); _vv++) {             \
+                PMIX_VALUE_DESTRUCT(&((m)[_vv]));       \
+            }                                           \
+            pmix_free((m));                             \
+            (m) = NULL;                                 \
+        }                                               \
+    } while (0)
+
+#define PMIX_INFO_DESTRUCT(m)                   \
+    do {                                        \
+        if (!PMIX_INFO_IS_PERSISTENT((m))) {    \
+            PMIX_VALUE_DESTRUCT(&(m)->value);   \
+        }                                       \
+    } while (0)
+
+#define PMIX_INFO_FREE(m, n)                        \
+    do {                                            \
+        size_t _is;                                 \
+        if (NULL != (m)) {                          \
+            for (_is=0; _is < (n); _is++) {         \
+                PMIX_INFO_DESTRUCT(&((m)[_is]));    \
+            }                                       \
+            pmix_free((m));                         \
+            (m) = NULL;                             \
+        }                                           \
+    } while (0)
+
+#define PMIX_APP_DESTRUCT(m)                                    \
+    do {                                                        \
+        if (NULL != (m)->cmd) {                                 \
+            pmix_free((m)->cmd);                                \
+            (m)->cmd = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->argv) {                                \
+            pmix_argv_free((m)->argv);                          \
+            (m)->argv = NULL;                                   \
+        }                                                       \
+        if (NULL != (m)->env) {                                 \
+            pmix_argv_free((m)->env);                           \
+            (m)->env = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->cwd) {                                 \
+            pmix_free((m)->cwd);                                \
+            (m)->cwd = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->info) {                                \
+            PMIX_INFO_FREE((m)->info, (m)->ninfo);              \
+            (m)->info = NULL;                                   \
+            (m)->ninfo = 0;                                     \
+        }                                                       \
+    } while (0)
+
+static inline void pmix_app_free(pmix_app_t *ap, size_t n)
+{
+    size_t k;
+
+    if (NULL != ap) {
+        for (k=0; k < n; k++) {
+            PMIX_APP_DESTRUCT(&ap[k]);
+        }
+    }
+}
+
+#define PMIX_APP_FREE(m, n)     \
+    do {                        \
+        pmix_app_free(m, n);    \
+        pmix_free(m);           \
+        (m) = NULL;             \
+    } while (0)
+
+
+#define PMIX_DATA_ARRAY_DESTRUCT(m) PMIx_Data_array_destruct(m)
 
 #define PMIX_DATA_ARRAY_FREE(m)             \
     do {                                    \
@@ -4142,7 +4082,35 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         }                                   \
     } while(0)
 
-#include <pmix_deprecated.h>
+#define PMIX_PDATA_RELEASE(m)                   \
+    do {                                        \
+        PMIX_VALUE_DESTRUCT(&(m)->value);       \
+        pmix_free((m));                         \
+        (m) = NULL;                             \
+    } while (0)
+
+#define PMIX_PDATA_DESTRUCT(m)                  \
+    do {                                        \
+        PMIX_VALUE_DESTRUCT(&(m)->value);       \
+    } while (0)
+
+static inline void pmix_pdata_free(pmix_pdata_t *pd, size_t n)
+{
+    size_t k;
+
+    if (NULL != pd) {
+        for (k=0; k < n; k++) {
+            PMIX_PDATA_DESTRUCT(&pd[k]);
+        }
+    }
+}
+
+#define PMIX_PDATA_FREE(m, n)   \
+do {                            \
+    pmix_pdata_free(m, n);      \
+    pmix_free(m);               \
+    (m) = NULL;                 \
+} while(0)
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -214,10 +214,12 @@ PMIX_EXPORT pmix_status_t PMIx_Value_load(pmix_value_t *val,
 PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src);
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
                                          const char *key,
@@ -233,6 +235,8 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const char *key,
                                              const void *value,
                                              pmix_data_type_t type);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr,
                                               const pmix_info_t *info);
@@ -297,6 +301,9 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 
 #define PMIX_INFO_LIST_ADD(r, p, a, v, t)     \
     (r) = PMIx_Info_list_add((p), (a), (v), (t))
+
+#define PMIX_INFO_LIST_INSERT(r, p, i)     \
+    (r) = PMIx_Info_list_insert((p), (i))
 
 #define PMIX_INFO_LIST_XFER(r, p, a)     \
     (r) = PMIx_Info_list_xfer((p), (a))

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -71,6 +71,19 @@ void PMIx_Topology_destruct(pmix_topology_t *topo)
     pmix_hwloc_destruct_topology(topo);
 }
 
+void PMIx_Cpuset_destruct(pmix_cpuset_t *cpuset)
+{
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    pmix_hwloc_destruct_cpuset(cpuset);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Parse_cpuset_string(const char *cpuset_string, pmix_cpuset_t *cpuset)
 {
     pmix_status_t rc;

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -164,7 +164,8 @@ pmix_status_t pmix_hwloc_setup_topology(pmix_info_t *info, size_t ninfo)
     char *xmlbuffer = NULL;
     int len;
     size_t n;
-    pmix_kval_t *kv;
+    pmix_kval_t kv, *kptr;
+    pmix_value_t val;
     bool share = false;
     bool found_dep = false;
     bool found_new = false;
@@ -209,11 +210,11 @@ pmix_status_t pmix_hwloc_setup_topology(pmix_info_t *info, size_t ninfo)
         pmix_output_verbose(2, pmix_hwloc_output,
                             "%s:%s topology externally provided", __FILE__, __func__);
         /* record locally in case someone does a PMIx_Get to retrieve it */
-        PMIX_KVAL_NEW(kv, PMIX_TOPOLOGY2);
-        kv->value->type = PMIX_TOPO;
-        kv->value->data.topo = &pmix_globals.topology;
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-        PMIX_RELEASE(kv);
+        kv.key = PMIX_TOPOLOGY2;
+        kv.value = &val;
+        val.type = PMIX_TOPO;
+        val.data.topo = &pmix_globals.topology;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
         pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored", __FILE__, __func__);
         if (PMIX_SUCCESS != rc) {
             return rc;
@@ -290,11 +291,11 @@ pmix_status_t pmix_hwloc_setup_topology(pmix_info_t *info, size_t ninfo)
         pmix_globals.topology.source = strdup("hwloc");
 #    endif
         /* record locally in case someone does a PMIx_Get to retrieve it */
-        PMIX_KVAL_NEW(kv, PMIX_TOPOLOGY2);
-        kv->value->type = PMIX_TOPO;
-        kv->value->data.topo = &pmix_globals.topology;
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-        PMIX_RELEASE(kv);
+        kv.key = PMIX_TOPOLOGY2;
+        kv.value = &val;
+        val.type = PMIX_TOPO;
+        val.data.topo = &pmix_globals.topology;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
         pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored", __FILE__,
                             __func__);
         topo_in_shmem = true;
@@ -326,11 +327,11 @@ tryxml:
             pmix_output_verbose(2, pmix_hwloc_output,
                                 "%s:%s v2 xml adopted", __FILE__, __func__);
             /* record locally in case someone does a PMIx_Get to retrieve it */
-            PMIX_KVAL_NEW(kv, PMIX_TOPOLOGY2);
-            kv->value->type = PMIX_TOPO;
-            kv->value->data.topo = &pmix_globals.topology;
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-            PMIX_RELEASE(kv);
+            kv.key = PMIX_TOPOLOGY2;
+            kv.value = &val;
+            val.type = PMIX_TOPO;
+            val.data.topo = &pmix_globals.topology;
+            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
             pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
                                 __FILE__, __func__);
             if (PMIX_SUCCESS != rc) {
@@ -365,11 +366,11 @@ tryxml:
                                 "%s:%s v1 xml adopted", __FILE__, __func__);
 
             /* record locally in case someone does a PMIx_Get to retrieve it */
-            PMIX_KVAL_NEW(kv, PMIX_TOPOLOGY2);
-            kv->value->type = PMIX_TOPO;
-            kv->value->data.topo = &pmix_globals.topology;
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-            PMIX_RELEASE(kv);
+            kv.key = PMIX_TOPOLOGY2;
+            kv.value = &val;
+            val.type = PMIX_TOPO;
+            val.data.topo = &pmix_globals.topology;
+            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
             pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
                                 __FILE__, __func__);
             if (PMIX_SUCCESS != rc) {
@@ -438,11 +439,11 @@ tryself:
                             pmix_globals.topology.source);
     }
     /* record locally in case someone does a PMIx_Get to retrieve it */
-    PMIX_KVAL_NEW(kv, PMIX_TOPOLOGY2);
-    kv->value->type = PMIX_TOPO;
-    kv->value->data.topo = &pmix_globals.topology;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-    PMIX_RELEASE(kv);
+    kv.key = PMIX_TOPOLOGY2;
+    kv.value = &val;
+    val.type = PMIX_TOPO;
+    val.data.topo = &pmix_globals.topology;
+    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
     pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored", __FILE__,
                         __func__);
 
@@ -467,17 +468,17 @@ sharetopo:
         pmix_output_verbose(2, pmix_hwloc_output,
                             "%s:%s export v1 xml",
                             __FILE__, __func__);
-        kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_HWLOC_XML_V1);
-        kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        PMIX_VALUE_LOAD(kv->value, xmlbuffer, PMIX_STRING);
-        pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_HWLOC_XML_V1);
+        kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        PMIX_VALUE_LOAD(kptr->value, xmlbuffer, PMIX_STRING);
+        pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
         /* save it with the deprecated key for older RMs */
-        kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_LOCAL_TOPO);
-        kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        PMIX_VALUE_LOAD(kv->value, xmlbuffer, PMIX_STRING);
-        pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCAL_TOPO);
+        kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        PMIX_VALUE_LOAD(kptr->value, xmlbuffer, PMIX_STRING);
+        pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
         /* done with the buffer */
         hwloc_free_xmlbuffer(pmix_globals.topology.topology, xmlbuffer);
     }
@@ -488,17 +489,17 @@ sharetopo:
     if (0 == hwloc_topology_export_xmlbuffer(pmix_globals.topology.topology, &xmlbuffer, &len, 0)) {
         pmix_output_verbose(2, pmix_hwloc_output, "%s:%s export v2 xml",
                             __FILE__, __func__);
-        kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_HWLOC_XML_V2);
-        kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        PMIX_VALUE_LOAD(kv->value, xmlbuffer, PMIX_STRING);
-        pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_HWLOC_XML_V2);
+        kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        PMIX_VALUE_LOAD(kptr->value, xmlbuffer, PMIX_STRING);
+        pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
         /* save it with the deprecated key for older RMs */
-        kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_LOCAL_TOPO);
-        kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        PMIX_VALUE_LOAD(kv->value, xmlbuffer, PMIX_STRING);
-        pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCAL_TOPO);
+        kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        PMIX_VALUE_LOAD(kptr->value, xmlbuffer, PMIX_STRING);
+        pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
         hwloc_free_xmlbuffer(pmix_globals.topology.topology, xmlbuffer);
     }
     /* and as a v1 xml string, should an older client attach */
@@ -506,12 +507,12 @@ sharetopo:
                                              HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
         pmix_output_verbose(2, pmix_hwloc_output, "%s:%s export v1 xml",
                             __FILE__, __func__);
-        kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_HWLOC_XML_V1);
-        kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        PMIX_VALUE_LOAD(kv->value, xmlbuffer, PMIX_STRING);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_HWLOC_XML_V1);
+        kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        PMIX_VALUE_LOAD(kptr->value, xmlbuffer, PMIX_STRING);
         hwloc_free_xmlbuffer(pmix_globals.topology.topology, xmlbuffer);
-        pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+        pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
         /* cannot support the deprecated PMIX_LOCAL_TOPO key here as it would
          * overwrite the HWLOC v2 string */
     }
@@ -594,23 +595,23 @@ sharetopo:
 
     /* add the requisite key-values to the global data to be
      * given to each client for older PMIx versions */
-    kv = PMIX_NEW(pmix_kval_t);
-    kv->key = strdup(PMIX_HWLOC_SHMEM_FILE);
-    kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-    PMIX_VALUE_LOAD(kv->value, shmemfile, PMIX_STRING);
-    pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+    kptr = PMIX_NEW(pmix_kval_t);
+    kptr->key = strdup(PMIX_HWLOC_SHMEM_FILE);
+    kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+    PMIX_VALUE_LOAD(kptr->value, shmemfile, PMIX_STRING);
+    pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
 
-    kv = PMIX_NEW(pmix_kval_t);
-    kv->key = strdup(PMIX_HWLOC_SHMEM_ADDR);
-    kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-    PMIX_VALUE_LOAD(kv->value, &shmemaddr, PMIX_SIZE);
-    pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+    kptr = PMIX_NEW(pmix_kval_t);
+    kptr->key = strdup(PMIX_HWLOC_SHMEM_ADDR);
+    kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+    PMIX_VALUE_LOAD(kptr->value, &shmemaddr, PMIX_SIZE);
+    pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
 
-    kv = PMIX_NEW(pmix_kval_t);
-    kv->key = strdup(PMIX_HWLOC_SHMEM_SIZE);
-    kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-    PMIX_VALUE_LOAD(kv->value, &shmemsize, PMIX_SIZE);
-    pmix_list_append(&pmix_server_globals.gdata, &kv->super);
+    kptr = PMIX_NEW(pmix_kval_t);
+    kptr->key = strdup(PMIX_HWLOC_SHMEM_SIZE);
+    kptr->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+    PMIX_VALUE_LOAD(kptr->value, &shmemsize, PMIX_SIZE);
+    pmix_list_append(&pmix_server_globals.gdata, &kptr->super);
 
 #endif
 

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1001,6 +1001,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void *
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p, const pmix_value_t *src);
 
 PMIX_EXPORT pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p, pmix_value_t *p1);
+
+PMIX_EXPORT void pmix_bfrops_base_value_destruct(pmix_value_t *v);
+
+PMIX_EXPORT void pmix_bfrops_base_darray_destruct(pmix_data_array_t *d);
 
 END_C_DECLS
 

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -54,10 +54,20 @@ PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *kv,
     return pmix_bfrops_base_value_unload(kv, data, sz);
 }
 
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val)
+{
+    pmix_bfrops_base_value_destruct(val);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src)
 {
     return pmix_bfrops_base_value_xfer(dest, src);
+}
+
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d)
+{
+    pmix_bfrops_base_darray_destruct(d);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
@@ -76,12 +86,20 @@ PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
 PMIX_EXPORT pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
                                          const pmix_info_t *src)
 {
+    pmix_status_t rc;
+
     if (NULL == dest || NULL == src) {
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_LOAD_KEY(dest->key, src->key);
     dest->flags = src->flags;
-    return PMIx_Value_xfer(&dest->value, &src->value);
+    if (PMIX_INFO_IS_PERSISTENT(src)) {
+        memcpy(&dest->value, &src->value, sizeof(pmix_value_t));
+        rc = PMIX_SUCCESS;
+    } else {
+        rc = PMIx_Value_xfer(&dest->value, &src->value);
+    }
+    return rc;
 }
 
 void pmix_bfrops_base_value_load(pmix_value_t *v,
@@ -678,6 +696,294 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
     }
     return rc;
 }
+
+void pmix_bfrops_base_darray_destruct(pmix_data_array_t *d)
+{
+    size_t n;
+    char **s;
+    pmix_value_t *vt;
+    pmix_app_t *ap;
+    pmix_info_t *info;
+    pmix_pdata_t *pd;
+    pmix_buffer_t *pb;
+    pmix_byte_object_t *bo;
+    pmix_kval_t *kv;
+    pmix_proc_info_t *pi;
+    pmix_data_array_t *darray;
+    pmix_query_t *q;
+    pmix_envar_t *ev;
+    pmix_coord_t *coord;
+    pmix_regattr_t *reg;
+    pmix_cpuset_t *cp;
+    pmix_topology_t *topo;
+    pmix_geometry_t *geo;
+    pmix_device_distance_t *dvd;
+    pmix_endpoint_t *endpt;
+    pmix_data_buffer_t *db;
+    pmix_proc_stats_t *pstats;
+    pmix_disk_stats_t *dkstats;
+    pmix_net_stats_t *netstats;
+    pmix_node_stats_t *ndstats;
+
+    switch (d->type) {
+        case PMIX_STRING:
+            s = (char**)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != s[n]) {
+                    pmix_free(s[n]);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_VALUE:
+            vt = (pmix_value_t*)d->array;
+            PMIX_VALUE_FREE(vt, d->size);
+            break;
+        case PMIX_APP:
+            ap = (pmix_app_t*)d->array;
+            PMIX_APP_FREE(ap, d->size);
+            break;
+        case PMIX_INFO:
+            info = (pmix_info_t*)d->array;
+            PMIX_INFO_FREE(info, d->size);
+            break;
+        case PMIX_PDATA:
+            pd = (pmix_pdata_t*)d->array;
+            PMIX_PDATA_FREE(pd, d->size);
+            break;
+        case PMIX_BUFFER:
+            pb = (pmix_buffer_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                PMIX_DESTRUCT(&pb[n]);
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            bo = (pmix_byte_object_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != bo[n].bytes) {
+                    pmix_free(bo[n].bytes);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_KVAL:
+            kv = (pmix_kval_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != kv[n].key) {
+                    pmix_free(kv[n].key);
+                }
+                if (NULL != kv[n].value) {
+                    PMIX_VALUE_FREE(kv[n].value, 1);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_PROC_INFO:
+            pi = (pmix_proc_info_t*)d->array;
+            PMIX_PROC_INFO_FREE(pi, d->size);
+            break;
+        case PMIX_DATA_ARRAY:
+            darray = (pmix_data_array_t *) d->array;
+            pmix_bfrops_base_darray_destruct(darray);
+            break;
+        case PMIX_QUERY:
+            q = (pmix_query_t*)d->array;
+            PMIX_QUERY_FREE(q, d->size);
+            break;
+        case PMIX_ENVAR:
+            ev = (pmix_envar_t*)d->array;
+            PMIX_ENVAR_FREE(ev, d->size);
+            break;
+        case PMIX_COORD:
+            coord = (pmix_coord_t*)d->array;
+            PMIX_COORD_FREE(coord, d->size);
+            break;
+        case PMIX_REGATTR:
+            reg = (pmix_regattr_t*)d->array;
+            PMIX_REGATTR_FREE(reg, d->size);
+            break;
+        case PMIX_PROC_CPUSET:
+            cp = (pmix_cpuset_t*)d->array;
+            pmix_hwloc_release_cpuset(cp, d->size);
+            break;
+        case PMIX_TOPO:
+            topo = (pmix_topology_t*)d->array;
+            pmix_hwloc_release_topology(topo, d->size);
+            break;
+        case PMIX_GEOMETRY:
+            geo = (pmix_geometry_t*)d->array;
+            PMIX_GEOMETRY_FREE(geo, d->size);
+            break;
+        case PMIX_DEVICE_DIST:
+            dvd = (pmix_device_distance_t*)d->array;
+            PMIX_DEVICE_DIST_FREE(dvd, d->size);
+            break;
+        case PMIX_ENDPOINT:
+            endpt = (pmix_endpoint_t*)d->array;
+            PMIX_ENDPOINT_FREE(endpt, d->size);
+            break;
+        case PMIX_REGEX:
+            bo = (pmix_byte_object_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != bo[n].bytes) {
+                    pmix_preg.release(bo[n].bytes);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_DATA_BUFFER:
+            db = (pmix_data_buffer_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                PMIX_DATA_BUFFER_DESTRUCT(&db[n]);
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_PROC_STATS:
+            pstats = (pmix_proc_stats_t*)d->array;
+            PMIX_PROC_STATS_FREE(pstats, d->size);
+            break;
+        case PMIX_DISK_STATS:
+            dkstats = (pmix_disk_stats_t*)d->array;
+            PMIX_DISK_STATS_FREE(dkstats, d->size);
+            break;
+        case PMIX_NET_STATS:
+            netstats = (pmix_net_stats_t*)d->array;
+            PMIX_NET_STATS_FREE(netstats, d->size);
+            break;
+        case PMIX_NODE_STATS:
+            ndstats = (pmix_node_stats_t*)d->array;
+            PMIX_NODE_STATS_FREE(ndstats, d->size);
+            break;
+
+        default:
+            if (NULL != d->array) {
+                pmix_free(d->array);
+            }
+            break;
+    }
+    d->array = NULL;
+    d->type = PMIX_UNDEF;
+    d->size = 0;
+    return;
+}
+
+void pmix_bfrops_base_value_destruct(pmix_value_t *v)
+{
+    switch (v->type) {
+        case PMIX_STRING:
+            if (NULL != v->data.string) {
+                free(v->data.string);
+            }
+            break;
+        case PMIX_PROC:
+            if (NULL != v->data.proc) {
+                PMIX_PROC_FREE(v->data.proc, 1);
+            }
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            if (NULL != v->data.bo.bytes) {
+                free(v->data.bo.bytes);
+            }
+            break;
+        case PMIX_PROC_INFO:
+            if (NULL != v->data.pinfo) {
+                PMIX_PROC_INFO_FREE(v->data.pinfo, 1);
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            if (NULL != v->data.darray) {
+                pmix_bfrops_base_darray_destruct(v->data.darray);
+            }
+            break;
+        case PMIX_ENVAR:
+            if (NULL != v->data.envar.envar) {
+                free(v->data.envar.envar);
+            }
+            if (NULL != v->data.envar.value) {
+                free(v->data.envar.value);
+            }
+            break;
+        case PMIX_COORD:
+            if (NULL != v->data.coord) {
+                PMIX_COORD_FREE(v->data.coord, 1);
+            }
+            break;
+        case PMIX_TOPO:
+            if (NULL != v->data.topo) {
+                pmix_hwloc_release_topology(v->data.topo, 1);
+            }
+            break;
+        case PMIX_PROC_CPUSET:
+            if (NULL != v->data.cpuset) {
+                pmix_hwloc_release_cpuset(v->data.cpuset, 1);
+            }
+            break;
+        case PMIX_GEOMETRY:
+            if (NULL != v->data.geometry) {
+                PMIX_GEOMETRY_FREE(v->data.geometry, 1);
+            }
+            break;
+        case PMIX_DEVICE_DIST:
+            if (NULL != v->data.devdist) {
+                PMIX_DEVICE_DIST_DESTRUCT(v->data.devdist);
+            }
+            break;
+        case PMIX_ENDPOINT:
+            if (NULL != v->data.endpoint) {
+                PMIX_ENDPOINT_DESTRUCT(v->data.endpoint);
+            }
+            break;
+        case PMIX_REGATTR:
+            if (NULL != v->data.ptr) {
+                PMIX_REGATTR_DESTRUCT((pmix_regattr_t*)v->data.ptr);
+            }
+            break;
+        case PMIX_REGEX:
+            if (NULL != v->data.bo.bytes) {
+                pmix_preg.release(v->data.bo.bytes);
+            }
+            break;
+        case PMIX_DATA_BUFFER:
+            if (NULL != v->data.dbuf) {
+                PMIX_DATA_BUFFER_RELEASE(v->data.dbuf);
+            }
+            break;
+        case PMIX_PROC_STATS:
+            if (NULL != v->data.pstats) {
+                PMIX_PROC_STATS_RELEASE(v->data.pstats);
+            }
+            break;
+        case PMIX_DISK_STATS:
+            if (NULL != v->data.dkstats) {
+                PMIX_DISK_STATS_RELEASE(v->data.dkstats);
+            }
+            break;
+        case PMIX_NET_STATS:
+            if (NULL != v->data.netstats) {
+                PMIX_NET_STATS_RELEASE(v->data.netstats);
+            }
+            break;
+        case PMIX_NODE_STATS:
+            if (NULL != v->data.ndstats) {
+                PMIX_NODE_STATS_RELEASE(v->data.ndstats);
+            }
+            break;
+
+        default:
+            /* silence warnings */
+            break;
+    }
+    // mark the value as no longer defined
+    memset(v, 0, sizeof(pmix_value_t));
+    v->type = PMIX_UNDEF;
+    return;
+}
+
 /* Xfer FUNCTIONS FOR GENERIC PMIX TYPES */
 pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p, const pmix_value_t *src)
 {
@@ -1016,6 +1322,26 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
     return PMIX_SUCCESS;
 }
 
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr,
+                                                pmix_info_t *info)
+{
+    pmix_list_t *p = (pmix_list_t *) ptr;
+    pmix_infolist_t *iptr;
+
+    iptr = PMIX_NEW(pmix_infolist_t);
+    if (NULL == iptr) {
+        return PMIX_ERR_NOMEM;
+    }
+    /* we want to preserve any pointes in the provided
+     * info struct so the result points to the same
+     * memory location */
+    memcpy(&iptr->info, info, sizeof(pmix_info_t));
+    // mark that this value should not be released
+    PMIX_INFO_SET_PERSISTENT(&iptr->info);
+    pmix_list_append(p, &iptr->super);
+    return PMIX_SUCCESS;
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr, const pmix_info_t *info)
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
@@ -1025,7 +1351,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr, const pmix_info_t *info
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
     }
-    PMIX_INFO_XFER(&iptr->info, info);
+    PMIx_Info_xfer(&iptr->info, info);
     pmix_list_append(p, &iptr->super);
     return PMIX_SUCCESS;
 }
@@ -1057,7 +1383,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
     /* transfer the elements across */
     n = 0;
     PMIX_LIST_FOREACH (iptr, p, pmix_infolist_t) {
-        PMIX_INFO_XFER(&array[n], &iptr->info);
+        PMIx_Info_xfer(&array[n], &iptr->info);
         ++n;
     }
 

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -696,7 +696,7 @@ pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src)
                 PMIX_LOAD_KEY(pd[n].key, sd[n].key);
                 rc = PMIx_Value_xfer(&pd[n].value, &sd[n].value);
                 if (PMIX_SUCCESS != rc) {
-                    PMIX_INFO_FREE(pd, src->data.darray->size);
+                    PMIX_PDATA_FREE(pd, src->data.darray->size);
                     return rc;
                 }
             }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -106,11 +106,16 @@ static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 
     PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
 
+    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.mysessions, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.myjobs, pmix_list_t);
+
     return PMIX_SUCCESS;
 }
 
 static void hash_finalize(void)
 {
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.mysessions);
+    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.myjobs);
     return;
 }
 
@@ -139,7 +144,8 @@ static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo, int *pr
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns, pmix_info_t info[],
+static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
+                                         pmix_info_t info[],
                                          size_t ninfo)
 {
     pmix_namespace_t *nptr = (pmix_namespace_t *) ns;
@@ -1253,7 +1259,6 @@ static pmix_status_t nspace_add(const char *nspace, uint32_t nlocalprocs, pmix_i
 static pmix_status_t nspace_del(const char *nspace)
 {
     pmix_job_t *t;
-
 
     /* find the hash table for this nspace */
     PMIX_LIST_FOREACH (t, &pmix_mca_gds_hash_component.myjobs, pmix_job_t) {

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -36,8 +36,6 @@
 #include "gds_hash.h"
 #include "src/mca/gds/gds.h"
 
-static pmix_status_t component_open(void);
-static pmix_status_t component_close(void);
 static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
 
 /*
@@ -56,8 +54,6 @@ pmix_gds_hash_component_t pmix_mca_gds_hash_component = {
                                    PMIX_RELEASE_VERSION),
 
         /* Component open and close functions */
-        .pmix_mca_open_component = component_open,
-        .pmix_mca_close_component = component_close,
         .pmix_mca_query_component = component_query,
         .reserved = {0}
     },
@@ -65,26 +61,10 @@ pmix_gds_hash_component_t pmix_mca_gds_hash_component = {
     .myjobs = PMIX_LIST_STATIC_INIT
 };
 
-static int component_open(void)
-{
-    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.mysessions, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_mca_gds_hash_component.myjobs, pmix_list_t);
-
-    return PMIX_SUCCESS;
-}
-
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     *priority = 10;
     *module = (pmix_mca_base_module_t *) &pmix_hash_module;
-    return PMIX_SUCCESS;
-}
-
-static int component_close(void)
-{
-    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.mysessions);
-    PMIX_LIST_DESTRUCT(&pmix_mca_gds_hash_component.myjobs);
-
     return PMIX_SUCCESS;
 }
 
@@ -156,9 +136,6 @@ static void apdes(pmix_apptrkr_t *p)
 {
     PMIX_LIST_DESTRUCT(&p->appinfo);
     PMIX_LIST_DESTRUCT(&p->nodeinfo);
-    if (NULL != p->job) {
-        PMIX_RELEASE(p->job);
-    }
 }
 PMIX_CLASS_INSTANCE(pmix_apptrkr_t, pmix_list_item_t, apcon, apdes);
 

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -316,7 +316,10 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
     }
     /* point the app at its job */
     if (NULL == app->job) {
-        PMIX_RETAIN(trk);
+        /* do NOT retain the tracker - we will not release
+         * it in the app destructor. If we retain the tracker,
+         * then we won't release it later because the refcount
+         * is wrong */
         app->job = trk;
     }
 

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,6 +85,8 @@ PMIX_EXPORT pmix_status_t pmix_preg_base_copy(char **dest, size_t *len, const ch
 PMIX_EXPORT pmix_status_t pmix_preg_base_pack(pmix_buffer_t *buffer, const char *input);
 
 PMIX_EXPORT pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex);
+
+PMIX_EXPORT pmix_status_t pmix_preg_base_release(char *regexp);
 
 END_C_DECLS
 

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -59,7 +59,8 @@ pmix_preg_module_t pmix_preg = {
     .parse_procs = pmix_preg_base_parse_procs,
     .copy = pmix_preg_base_copy,
     .pack = pmix_preg_base_pack,
-    .unpack = pmix_preg_base_unpack
+    .unpack = pmix_preg_base_unpack,
+    .release = pmix_preg_base_release
 };
 
 static pmix_status_t pmix_preg_close(void)

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -154,3 +154,17 @@ pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex)
     PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buffer, regex, &cnt, PMIX_STRING);
     return rc;
 }
+
+pmix_status_t pmix_preg_base_release(char *regexp)
+{
+    pmix_preg_base_active_module_t *active;
+
+    PMIX_LIST_FOREACH (active, &pmix_preg_globals.actives, pmix_preg_base_active_module_t) {
+        if (NULL != active->module->release) {
+            if (PMIX_SUCCESS == active->module->release(regexp)) {
+                return PMIX_SUCCESS;
+            }
+        }
+    }
+    return PMIX_ERR_BAD_PARAM;
+}

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -50,15 +50,19 @@ static pmix_status_t parse_procs(const char *regexp, char ***procs);
 static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+static pmix_status_t release(char *regexp);
 
-pmix_preg_module_t pmix_preg_compress_module = {.name = "compress",
-                                                .generate_node_regex = generate_node_regex,
-                                                .generate_ppn = generate_ppn,
-                                                .parse_nodes = parse_nodes,
-                                                .parse_procs = parse_procs,
-                                                .copy = copy,
-                                                .pack = pack,
-                                                .unpack = unpack};
+pmix_preg_module_t pmix_preg_compress_module = {
+    .name = "compress",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack,
+    .release = release
+};
 
 #define PREG_COMPRESS_PREFIX "blob: component=zlib: size="
 
@@ -310,3 +314,27 @@ static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex)
 
     return PMIX_SUCCESS;
 }
+
+static pmix_status_t release(char *regexp)
+{
+    int idx;
+
+    if (NULL == regexp) {
+        return PMIX_SUCCESS;
+    }
+
+    if (0 != strncmp(regexp, "blob", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    idx = strlen(regexp) + 1; // step over the NULL terminator
+
+    /* ensure we were the one who generated this blob */
+    if (0 != strncmp(&regexp[idx], "component=zlib:", strlen("component=zlib:"))) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    // just free it
+    free(regexp);
+    return PMIX_SUCCESS;
+}
+

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -50,15 +50,19 @@ static pmix_status_t parse_procs(const char *regexp, char ***procs);
 static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+static pmix_status_t release(char *regexp);
 
-pmix_preg_module_t pmix_preg_native_module = {.name = "pmix",
-                                              .generate_node_regex = generate_node_regex,
-                                              .generate_ppn = generate_ppn,
-                                              .parse_nodes = parse_nodes,
-                                              .parse_procs = parse_procs,
-                                              .copy = copy,
-                                              .pack = pack,
-                                              .unpack = unpack};
+pmix_preg_module_t pmix_preg_native_module = {
+    .name = "pmix",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack,
+    .release = release
+};
 
 static pmix_status_t regex_parse_value_ranges(char *base, char *ranges, int num_digits,
                                               char *suffix, char ***names);
@@ -913,5 +917,18 @@ static pmix_status_t pmix_regex_extract_ppn(char *regexp, char ***procs)
     }
 
     pmix_argv_free(nds);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t release(char *regexp)
+{
+    if (NULL == regexp) {
+        return PMIX_SUCCESS;
+    }
+
+    if (0 != strncmp(regexp, "pmix", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    free(regexp);
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,6 +83,8 @@ typedef pmix_status_t (*pmix_preg_base_module_pack_fn_t)(pmix_buffer_t *buffer, 
 
 typedef pmix_status_t (*pmix_preg_base_module_unpack_fn_t)(pmix_buffer_t *buffer, char **regex);
 
+typedef pmix_status_t (*pmix_preg_base_module_release_fn_t)(char *regexp);
+
 /**
  * Base structure for a PREG module
  */
@@ -95,6 +97,7 @@ typedef struct {
     pmix_preg_base_module_copy_fn_t copy;
     pmix_preg_base_module_pack_fn_t pack;
     pmix_preg_base_module_unpack_fn_t unpack;
+    pmix_preg_base_module_release_fn_t release;
 } pmix_preg_module_t;
 
 /* we just use the standard component definition */

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -44,15 +44,19 @@ static pmix_status_t parse_procs(const char *regexp, char ***procs);
 static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+static pmix_status_t release(char *regexp);
 
-pmix_preg_module_t pmix_preg_raw_module = {.name = "raw",
-                                           .generate_node_regex = generate_node_regex,
-                                           .generate_ppn = generate_ppn,
-                                           .parse_nodes = parse_nodes,
-                                           .parse_procs = parse_procs,
-                                           .copy = copy,
-                                           .pack = pack,
-                                           .unpack = unpack};
+pmix_preg_module_t pmix_preg_raw_module = {
+    .name = "raw",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack,
+    .release = release
+};
 
 static pmix_status_t generate_node_regex(const char *input, char **regexp)
 {
@@ -148,5 +152,17 @@ static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex)
     if (NULL == *regex) {
         return PMIX_ERR_NOMEM;
     }
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t release(char *regexp)
+{
+    if (NULL == regexp) {
+        return PMIX_SUCCESS;
+    }
+    if (0 != strncmp(regexp, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    free(regexp);
     return PMIX_SUCCESS;
 }

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -44,6 +44,7 @@
 #include "src/mca/psec/base/base.h"
 #include "src/mca/psquash/base/base.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/threads/pmix_tsd.h"
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
@@ -62,11 +63,7 @@ void pmix_rte_finalize(void)
     pmix_iof_req_t *req;
     pmix_regattr_input_t *p;
 
-    if (--pmix_initialized != 0) {
-        if (pmix_initialized < 0) {
-            fprintf(stderr, "PMIx Finalize called too many times\n");
-            return;
-        }
+    if (!pmix_init_called) {
         return;
     }
 
@@ -163,4 +160,5 @@ void pmix_rte_finalize(void)
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_stop(NULL);
+    pmix_tsd_keys_destruct();
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -73,7 +73,6 @@ const char* pmix_tool_version = PMIX_VERSION;
 const char* pmix_tool_org = "PMIx";
 const char* pmix_tool_msg = PMIX_PROXY_BUGREPORT_STRING;
 
-PMIX_EXPORT int pmix_initialized = 0;
 PMIX_EXPORT bool pmix_init_called = false;
 /* we have to export the pmix_globals object so
  * all plugins can access it. */
@@ -211,13 +210,6 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_info_t *iptr;
     size_t minfo;
     bool keepfqdn = false;
-
-    if (++pmix_initialized != 1) {
-        if (pmix_initialized < 1) {
-            return PMIX_ERROR;
-        }
-        return PMIX_SUCCESS;
-    }
 
 #if PMIX_NO_LIB_DESTRUCTOR
     if (pmix_init_called) {

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -45,7 +45,6 @@ PMIX_EXPORT extern char *pmix_timing_output;
 PMIX_EXPORT extern bool pmix_timing_overhead;
 #endif
 
-PMIX_EXPORT extern int pmix_initialized;
 PMIX_EXPORT extern char *pmix_net_private_ipv4;
 PMIX_EXPORT extern int pmix_event_caching_window;
 PMIX_EXPORT extern bool pmix_suppress_missing_data_warning;

--- a/src/threads/pmix_tsd.h
+++ b/src/threads/pmix_tsd.h
@@ -81,7 +81,8 @@ static inline int pmix_tsd_getspecific(pmix_tsd_key_t key, void **valuep)
  *                       create another thread specific data key
  * @retval ENOMEM        Insufficient memory exists to create the key
  */
-PMIX_EXPORT int pmix_tsd_key_create(pmix_tsd_key_t *key, pmix_tsd_destructor_t destructor);
+PMIX_EXPORT int pmix_tsd_key_create(pmix_tsd_key_t *key,
+                                    pmix_tsd_destructor_t destructor);
 
 /**
  * Destruct all thread-specific data keys


### PR DESCRIPTION
Finalize the MCA param subsystem to cleanup the
parameter storage. Provide a way to release the
pmix_value_t and pmix_data_array_t storage. Ensure
we release the pmix_job_t tracker in the gds/hash
component when the nspace is deleted.

Resolve memory corruption problem associated with passing
the HWLOC topology into the PMIx server from the host. This
was being copied during the "info_list" processing, and then
being deleted when the resulting data array was released - leaving
the server to continue accessing the free'd topology tree.

Remove an unnecessary "retain" - thanks to Artem Polyakov for
spotting it. Cleanup around that to avoid segfault of double
release while avoiding leak.

Add some missing utility finalize calls

Signed-off-by: Ralph Castain <rhc@pmix.org>
