### PR TITLE
TMA: Integrate more custom memory allocator infrastructure.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -750,8 +750,9 @@ tma_construct(
     tma->tma_realloc = NULL;
     tma->tma_strdup = tma_strdup;
     tma->tma_memmove = tma_memmove;
+    // TODO(skg) Add free()
+    tma->tma_free = NULL;
     tma->arena = NULL;
-    tma->dontfree = 1;
 }
 
 static void


### PR DESCRIPTION
This commit further integrates TMA infrastructure into the base object
system. Some key memory allocations there were outside a provided TMA's
purview; now they are captured.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>