### PR TITLE
Update from master branch

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1024,25 +1024,6 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
                       [Whether we want to enable dlopen support])
 
 #
-# Is this a developer copy?
-#
-
-if test -e $PMIX_TOP_SRCDIR/.git; then
-    PMIX_DEVEL=1
-    # check for Flex
-    AC_PROG_LEX(yywrap)
-    if test "x$LEX" != xflex; then
-        AC_MSG_WARN([PMIx requires Flex to build from non-tarball sources,])
-        AC_MSG_WARN([but Flex was not found. Please install Flex into])
-        AC_MSG_WARN([your path and try again])
-        AC_MSG_ERROR([Cannot continue])
-    fi
-else
-    PMIX_DEVEL=0
-fi
-
-
-#
 # Developer picky compiler options
 #
 

--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,25 @@ PMIX_SETUP_WRAPPER_INIT
 # This did not exist pre AM 1.11.x (where x is somewhere >0 and <3),
 # but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AC_PROG_LEX(yywrap)
+
+#
+# Is this a developer copy?
+#
+
+if test -e $PMIX_TOP_SRCDIR/.git; then
+    PMIX_DEVEL=1
+else
+    PMIX_DEVEL=0
+fi
+# check for Flex
+AC_PROG_LEX(noyywrap)
+if test "x$LEX" != xflex && test ! -e $PMIX_TOP_SRCDIR/util/keyval/keyval_lex.c; then
+    AC_MSG_WARN([PMIx requires Flex to build from sources that were not])
+    AC_MSG_WARN([fully pre-processed (e.g., an official release tarball),])
+    AC_MSG_WARN([but Flex was not found. Please install Flex into])
+    AC_MSG_WARN([your path and try again])
+    AC_MSG_ERROR([Cannot continue])
+fi
 
 ############################################################################
 # Configuration options

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -462,10 +462,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"         // (bool) spawned app consists of debugger daemons
 #define PMIX_COSPAWN_APP                    "pmix.cospawn"          // (bool) designated app is to be spawned as a disconnected
                                                                     //        job - i.e., not part of the "comm_world" of the job
-#define PMIX_COLOCATE_PROC                  "pmix.colproc"          // (pmix_data_array_t*) Array of pmix_proc_t identifying the procs
+#define PMIX_COLOCATE_PROCS                 "pmix.colproc"          // (pmix_data_array_t*) Array of pmix_proc_t identifying the procs
                                                                     //        with which the new job's procs are to be colocated
-#define PMIX_COLOCATE_NUM_PROC              "pmix.colnum.proc"      // (uint16_t) Number of procs to colocate with each identified proc
-#define PMIX_COLOCATE_NUM_NODE              "pmix.colnum.node"      // (uint16_t) Number of procs to colocate on the node of each identified proc
+#define PMIX_COLOCATE_NPERPROC              "pmix.colnum.proc"      // (uint16_t) Number of procs to colocate with each identified proc
+#define PMIX_COLOCATE_NPERNODE              "pmix.colnum.node"      // (uint16_t) Number of procs to colocate on the node of each identified proc
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
 #define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -108,8 +108,8 @@ pmix_status_t pmix_hwloc_register(void)
                                       &pmix_hwloc_verbose);
     if (0 < pmix_hwloc_verbose) {
         /* set default output */
-        pmix_hwloc_verbose = pmix_output_open(NULL);
-        pmix_output_set_verbosity(pmix_hwloc_verbose, pmix_hwloc_verbose);
+        pmix_hwloc_output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(pmix_hwloc_output, pmix_hwloc_verbose);
     }
 
     vmhole = "biggest";

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -5,8 +5,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -638,12 +638,6 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
         } else if (pmix_check_app_info(key)) {
             appinfo = true;
         }
-    }
-
-    /* find the hash table for this nspace */
-    trk = pmix_gds_hash_get_tracker(proc->nspace, false);
-    if (NULL == trk) {
-        return PMIX_ERR_INVALID_NAMESPACE;
     }
 
     if (!PMIX_RANK_IS_VALID(proc->rank)) {

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -301,7 +301,11 @@ static void send_error_show_help(int fd, int exit_status, const char *file, cons
    the pipe up to the parent, and the keepalive pipe. */
 static int close_open_file_descriptors(int write_fd, int keepalive)
 {
+#if defined(__OSX__)
+    DIR *dir = opendir("/dev/fd");
+#else  /* Linux */
     DIR *dir = opendir("/proc/self/fd");
+#endif  /* defined(__OSX__) */
     if (NULL == dir) {
         return PMIX_ERR_FILE_OPEN_FAILURE;
     }

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -316,8 +316,9 @@ pmix_status_t pmix_register_params(void)
 
     (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "maxfd",
                                       "In non-Linux environments, use this value as a maximum number of file descriptors to close when forking a new child process",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &pmix_maxfd);
+                                      PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0,
+                                      PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_9,
+                                      PMIX_MCA_BASE_VAR_SCOPE_ALL, &pmix_maxfd);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -51,6 +51,7 @@ int pmix_event_caching_window = 1;
 bool pmix_suppress_missing_data_warning = false;
 char *pmix_progress_thread_cpus = NULL;
 bool pmix_bind_progress_thread_reqd = false;
+int pmix_maxfd = 1024;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -312,6 +313,11 @@ pmix_status_t pmix_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                       PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_9,
                                       PMIX_MCA_BASE_VAR_SCOPE_ALL, &pmix_bind_progress_thread_reqd);
+
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "maxfd",
+                                      "In non-Linux environments, use this value as a maximum number of file descriptors to close when forking a new child process",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_maxfd);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
@@ -51,6 +51,7 @@ PMIX_EXPORT extern int pmix_event_caching_window;
 PMIX_EXPORT extern bool pmix_suppress_missing_data_warning;
 PMIX_EXPORT extern char *pmix_progress_thread_cpus;
 PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
+PMIX_EXPORT extern int pmix_maxfd;
 
 /** version string of pmix */
 extern const char pmix_version_string[];

--- a/src/util/pmix_fd.c
+++ b/src/util/pmix_fd.c
@@ -5,6 +5,9 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -201,7 +204,11 @@ static int fdmax = -1;
  and the pipe up to the parent. */
 void pmix_close_open_file_descriptors(int protected_fd)
 {
+#if defined(__OSX__)
+    DIR *dir = opendir("/dev/fd");
+#else  /* Linux */
     DIR *dir = opendir("/proc/self/fd");
+#endif  /* defined(__OSX__) */
     struct dirent *files;
     int dir_scan_fd = -1;
 


### PR DESCRIPTION
[Remove unnecessary function call in pmix_gds_hash_fetch().](https://github.com/openpmix/openpmix/commit/78488f61a196634830b9abfc1428b16667740204)

Remove an unnecessary call to pmix_gds_hash_get_tracker() in
pmix_gds_hash_fetch(). The job tracker had already been acquired
beforehand.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/69e6965c0660d3e8da15d217728df91cd551e832)

[pmix_fd: cap the max FD to try to close](https://github.com/openpmix/openpmix/commit/fdecf3074ae7c24bc46527434e5d89608de2218b)

On some OS's (e.g., macOS), the value returned by
sysconf(_SC_OPEN_MAX) can be set by the user via "ulimit -n X", where
X can be -1 (unlimited) or a positive integer. On macOS in particular,
if the user does not set this value, it's unclear how the default
value is chosen.  Some users have reported seeing arbitrarily large
default values (in the billions), resulting in a very large loop over
close() that can take minutes/hours to complete, leading the user to
think that the app has hung.  To avoid this, ensure that we cap the
max FD that we'll try to close.  This is not a perfect scheme, and
there's uncertainty on how the macOS default value works, so we
provide the pmix_maxfd MCA var to allow the user to set the max FD
value if needed.

This commit is inspired by https://github.com/open-mpi/ompi/pull/10360
and https://github.com/open-mpi/ompi/issues/10358.

Thanks to Scott Sayres for raising the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7c72657494d90df6eb3484910008103d7aaf139e)

[Support colocation of processes](https://github.com/openpmix/openpmix/commit/5f683044357369292a4886de90d56097371d969c)

When spawning a new job, support the case where the user
wants to spawn the new procs at locations where current
procs are executing. Provide for both specification of
the number of new procs to start on each node where the
current procs are executing, or the number of new procs
to start for each current proc that is executing.

Note that these are not required to be daemons - they can
be any application code, and can have any desired ranking
and/or binding policy. Mapping policy, however, will be
ignored as it is overridden by the "colocate" directive.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/137cc3d6b3c99065bb55633f6cf0568aecdc34d4)

[Optimize the file descriptor cleanup on OSX](https://github.com/openpmix/openpmix/commit/17c01cf73dc206cacddaea0e125c643ac388d345)

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/af5dd4902ded507469b0bbd16bf6e13dbf98fada)

[Require flex only when keyval_lex.c is not provided](https://github.com/openpmix/openpmix/commit/f31ce6aa7e127660a4b8a4b879c63df2950dc077)

We currently require flex whenever we are in a Git clone, but that
really isn't the requirement. We need flex whenever the flex output
files are not present - otherwise, you can build just fine. So open
things up a bit by tying the flex requirement to the actual one
(i.e., that the flex output file exist).

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/1286709db150ea2540f8a1d20f286a858c7a07df)

[Fix hwloc verbose output](https://github.com/openpmix/openpmix/commit/e1469bfd229073154a5ec31e0de3b6a46d5675bc)

Fix a typo in setting the verbosity

Signed-off-by: Ralph Castain <rhc@pmix.org>