### PR TITLE
Fix retrieval of node/app/session-realm info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ examples/showkeys
 examples/abi_no_init
 examples/abi_with_init
 examples/group_lcl_cid
+examples/nodeinfo
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -23,7 +23,7 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello nodeinfo
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -95,6 +95,10 @@ endif
 hello_SOURCES = hello.c examples.h
 hello_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hello_LDADD =  $(top_builddir)/src/libpmix.la
+
+nodeinfo_SOURCES = nodeinfo.c examples.h
+nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/examples/nodeinfo.c
+++ b/examples/nodeinfo.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    char *nodelist, **nodes, *hostname;
+    pmix_info_t info[2];
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* get the list of nodes being used */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get node list failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nodelist = strdup(val->data.string);
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: Host list %s\n",
+                myproc.nspace, myproc.rank, val->data.string);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_ARGV_SPLIT(nodes, nodelist, ',');
+    free(nodelist);
+    if (NULL == nodes) {
+        goto done;
+    }
+    /* get some node-specific info */
+    if (1 < nprocs) {
+        proc.rank = myproc.rank + 1;
+        if (nprocs == proc.rank) {
+            proc.rank = 0;
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_HOSTNAME, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Rank %u is on host %s\n",
+                myproc.nspace, myproc.rank, proc.rank, val->data.string);
+        hostname = strdup(val->data.string);
+        PMIX_VALUE_RELEASE(val);
+
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: Rank %u has coordinates\n    %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Value_string(val));
+            PMIX_VALUE_RELEASE(val);
+        }
+
+        // try with directive
+        proc.rank = PMIX_RANK_WILDCARD;
+        PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, hostname, PMIX_STRING);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates with directive for host %s failed: %s\n",
+                    myproc.nspace, myproc.rank, hostname, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Host %s has coordinates\n    %s\n",
+                myproc.nspace, myproc.rank, hostname, PMIx_Value_string(val));
+        PMIX_VALUE_RELEASE(val);
+    }
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -630,18 +630,23 @@ PMIX_EXPORT void pmix_log_local_op(int sd, short args, void *cbdata_);
 
 static inline bool pmix_check_node_info(const char *key)
 {
-    char *keys[] = {PMIX_HOSTNAME,
-                    PMIX_HOSTNAME_ALIASES,
-                    PMIX_NODEID,
-                    PMIX_AVAIL_PHYS_MEMORY,
-                    PMIX_LOCAL_PEERS,
-                    PMIX_LOCAL_PROCS,
-                    PMIX_LOCAL_CPUSETS,
-                    PMIX_LOCAL_SIZE,
-                    PMIX_NODE_SIZE,
-                    PMIX_LOCALLDR,
-                    PMIX_NODE_OVERSUBSCRIBED,
-                    NULL};
+    char *keys[] = {
+        PMIX_HOSTNAME,                  PMIX_HOSTNAME_ALIASES,
+        PMIX_NODEID,                    PMIX_AVAIL_PHYS_MEMORY,
+        PMIX_LOCAL_PEERS,               PMIX_LOCAL_PROCS,
+        PMIX_LOCAL_CPUSETS,             PMIX_LOCAL_SIZE,
+        PMIX_NODE_SIZE,                 PMIX_LOCALLDR,
+        PMIX_NODE_OVERSUBSCRIBED,       PMIX_FABRIC_DEVICES,
+        PMIX_FABRIC_COORDINATES,        PMIX_FABRIC_DEVICE,
+        PMIX_FABRIC_DEVICE_INDEX,       PMIX_FABRIC_DEVICE_NAME,
+        PMIX_FABRIC_DEVICE_VENDOR,      PMIX_FABRIC_DEVICE_BUS_TYPE,
+        PMIX_FABRIC_DEVICE_VENDORID,    PMIX_FABRIC_DEVICE_DRIVER,
+        PMIX_FABRIC_DEVICE_FIRMWARE,    PMIX_FABRIC_DEVICE_ADDRESS,
+        PMIX_FABRIC_DEVICE_MTU,         PMIX_FABRIC_DEVICE_COORDINATES,
+        PMIX_FABRIC_DEVICE_SPEED,       PMIX_FABRIC_DEVICE_STATE,
+        PMIX_FABRIC_DEVICE_TYPE,        PMIX_FABRIC_DEVICE_PCI_DEVID,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -654,8 +659,11 @@ static inline bool pmix_check_node_info(const char *key)
 
 static inline bool pmix_check_app_info(const char *key)
 {
-    char *keys[] = {PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
-                    PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX, NULL};
+    char *keys[] = {
+        PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
+        PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -668,9 +676,12 @@ static inline bool pmix_check_app_info(const char *key)
 
 static inline bool pmix_check_session_info(const char *key)
 {
-    char *keys[] = {PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
-                    PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
-                    PMIX_RM_NAME,    PMIX_RM_VERSION,   NULL};
+    char *keys[] = {
+        PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
+        PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
+        PMIX_RM_NAME,    PMIX_RM_VERSION,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -408,11 +408,23 @@ typedef pmix_status_t (*pmix_gds_base_module_del_nspace_fn_t)(const char* nspace
         } else {                                            \
             (s) = PMIX_ERR_NOT_SUPPORTED;                   \
         }                                                   \
-} while(0)
+    } while(0)
 
-/**
-* structure for gds modules
-*/
+typedef pmix_status_t (*pmix_gds_base_module_fetch_array_fn_t)(struct pmix_peer_t *pr,
+                                                               pmix_buffer_t *reply);
+/* define a convenience macro for fetching array info for
+ * a given peer */
+#define PMIX_GDS_FETCH_INFO_ARRAYS(s, p, b)                                 \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS FETCH ARRAYS WITH %s",             \
+                            __FILE__, __LINE__, _g->name);                  \
+        (s) = _g->fetch_arrays((struct pmix_peer_t*)(p), b);                \
+    } while(0)
+
+
+/* structure for gds modules */
 typedef struct {
     const char *name;
     const bool is_tsafe;
@@ -430,6 +442,7 @@ typedef struct {
     pmix_gds_base_module_del_nspace_fn_t            del_nspace;
     pmix_gds_base_module_assemb_kvs_req_fn_t        assemb_kvs_req;
     pmix_gds_base_module_accept_kvs_resp_fn_t       accept_kvs_resp;
+    pmix_gds_base_module_fetch_array_fn_t           fetch_arrays;
 
 } pmix_gds_base_module_t;
 

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -51,8 +51,11 @@
 #include "gds_hash.h"
 #include "src/mca/gds/base/base.h"
 
-static pmix_status_t dohash(pmix_hash_table_t *ht, const char *key, pmix_rank_t rank,
-                            int skip_genvals, pmix_list_t *kvs)
+static pmix_status_t dohash(pmix_hash_table_t *ht,
+                            const char *key,
+                            pmix_rank_t rank,
+                            int skip_genvals,
+                            pmix_list_t *kvs)
 {
     pmix_status_t rc;
     pmix_value_t *val;
@@ -152,7 +155,8 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
     pmix_data_array_t *darray;
     pmix_info_t *iptr;
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output, "FETCHING NODE INFO");
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING NODE INFO");
 
     /* scan for the nodeID or hostname to identify
      * which node they are asking about */
@@ -663,10 +667,13 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     /* fetch from the corresponding hash table - note that
      * we always provide a copy as we don't support
      * shared memory */
-    if (PMIX_INTERNAL == scope || PMIX_SCOPE_UNDEF == scope || PMIX_GLOBAL == scope
-        || PMIX_RANK_WILDCARD == proc->rank) {
+    if (PMIX_INTERNAL == scope ||
+        PMIX_SCOPE_UNDEF == scope ||
+        PMIX_GLOBAL == scope ||
+        PMIX_RANK_WILDCARD == proc->rank) {
         ht = &trk->internal;
-    } else if (PMIX_LOCAL == scope || PMIX_GLOBAL == scope) {
+    } else if (PMIX_LOCAL == scope ||
+               PMIX_GLOBAL == scope) {
         ht = &trk->local;
     } else if (PMIX_REMOTE == scope) {
         ht = &trk->remote;
@@ -776,5 +783,63 @@ doover:
         }
     }
 
+    return rc;
+}
+
+pmix_status_t pmix_gds_hash_fetch_arrays(struct pmix_peer_t *pr, pmix_buffer_t *reply)
+{
+    pmix_peer_t *peer = (pmix_peer_t *) pr;
+    pmix_namespace_t *ns = peer->nptr;
+    pmix_job_t *trk;
+    pmix_list_t kvs;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        /* this function is only available on servers */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                "%s pmix:gds:hash fetch arrays for proc [%s:%u]",
+                PMIX_NAME_PRINT(&pmix_globals.myid),
+                peer->info->pname.nspace, peer->info->pname.rank);
+
+    /* see if we have a tracker for this nspace - we will
+     * if we already cached the job info for it. If we
+     * didn't then we'll have no idea how to answer any
+     * questions */
+    trk = pmix_gds_hash_get_tracker(ns->nspace, false);
+    if (NULL == trk) {
+        /* let the caller know */
+        return PMIX_ERR_INVALID_NAMESPACE;
+    }
+    PMIX_CONSTRUCT(&kvs, pmix_list_t);
+
+    rc = pmix_gds_hash_fetch_nodeinfo(NULL, trk, &trk->nodeinfo, NULL, 0, &kvs);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&kvs);
+        return rc;
+    }
+
+    rc = pmix_gds_hash_fetch_appinfo(NULL, trk, &trk->apps, NULL, 0, &kvs);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&kvs);
+        return rc;
+    }
+
+    /* pack the results */
+    while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&kvs))) {
+        PMIX_BFROPS_PACK(rc, peer, reply, kv, 1, PMIX_KVAL);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+    }
+    PMIX_LIST_DESTRUCT(&kvs);
     return rc;
 }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -82,22 +82,25 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, p
 
 static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
 
-pmix_gds_base_module_t pmix_hash_module = {.name = "hash",
-                                           .is_tsafe = false,
-                                           .init = hash_init,
-                                           .finalize = hash_finalize,
-                                           .assign_module = hash_assign_module,
-                                           .cache_job_info = hash_cache_job_info,
-                                           .register_job_info = hash_register_job_info,
-                                           .store_job_info = hash_store_job_info,
-                                           .store = pmix_gds_hash_store,
-                                           .store_modex = hash_store_modex,
-                                           .fetch = pmix_gds_hash_fetch,
-                                           .setup_fork = setup_fork,
-                                           .add_nspace = nspace_add,
-                                           .del_nspace = nspace_del,
-                                           .assemb_kvs_req = assemb_kvs_req,
-                                           .accept_kvs_resp = accept_kvs_resp};
+pmix_gds_base_module_t pmix_hash_module = {
+    .name = "hash",
+    .is_tsafe = false,
+    .init = hash_init,
+    .finalize = hash_finalize,
+    .assign_module = hash_assign_module,
+    .cache_job_info = hash_cache_job_info,
+    .register_job_info = hash_register_job_info,
+    .store_job_info = hash_store_job_info,
+    .store = pmix_gds_hash_store,
+    .store_modex = hash_store_modex,
+    .fetch = pmix_gds_hash_fetch,
+    .setup_fork = setup_fork,
+    .add_nspace = nspace_add,
+    .del_nspace = nspace_del,
+    .assemb_kvs_req = assemb_kvs_req,
+    .accept_kvs_resp = accept_kvs_resp,
+    .fetch_arrays = pmix_gds_hash_fetch_arrays
+};
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 {

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -121,6 +121,8 @@ extern pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *tr
 extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t scope,
                                          pmix_kval_t *kv);
 
+extern pmix_status_t pmix_gds_hash_fetch_arrays(struct pmix_peer_t *pr, pmix_buffer_t *reply);
+
 END_C_DECLS
 
 #endif

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4438,7 +4438,19 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         PMIX_GDS_REGISTER_JOB_INFO(rc, peer, reply);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(reply);
             return rc;
+        }
+        /* if the peer is using the "dstore" component, then
+         * we also have to send back any session/node/app-level
+         * info so it can be stored locally in their hash */
+        if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
+            PMIX_GDS_FETCH_INFO_ARRAYS(rc, peer, reply);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(reply);
+                return rc;
+            }
         }
         PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, reply);
         if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
Per the Standard, one can retrieve information about a process
from the node/app/session realms in two ways:

(a) by passing the proc ID along with a key that belongs to
    one of those realms. The PMIx library is responsible
    for identifying such keys and retrieving the specified
    info from the corresponding default realm. If the user
    wishes the key to be retrieved from a non-default realm,
    then they must include the attribute specifying that realm.

(b) by passing an invalid proc rank (e.g., wildcard or undef)
    and including attributes that specify the realm from which
    the given key is to be retrieved along with whatever
    further identification is required - e.g., PMIX_NODE_INFO
    combined with the hostname of the node whose information
    is being fetched.

This commit fixes both methods and provides an example (nodeinfo)
in the examples directory for using this feature.

Thanks to Michael Raymond for the report and assistance in
triaging the problem.

Signed-off-by: Ralph Castain <rhc@pmix.org>