### PR TITLE
Fix retrieval of node/app/session-realm info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ examples/showkeys
 examples/abi_no_init
 examples/abi_with_init
 examples/group_lcl_cid
+examples/nodeinfo
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -23,7 +23,7 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello nodeinfo
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -91,6 +91,14 @@ server_SOURCES = server.c examples.h examples.c
 server_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_LDADD = $(top_builddir)/src/libpmix.la
 endif
+
+hello_SOURCES = hello.c examples.h
+hello_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+hello_LDADD =  $(top_builddir)/src/libpmix.la
+
+nodeinfo_SOURCES = nodeinfo.c examples.h
+nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o client debugger debuggerd dmodex dynamic fault pub server

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -96,7 +96,7 @@ hello_SOURCES = hello.c examples.h
 hello_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hello_LDADD =  $(top_builddir)/src/libpmix.la
 
-nodeinfo_SOURCES = nodeinfo.c examples.h
+nodeinfo_SOURCES = nodeinfo.c examples.h examples.c
 nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
 

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,7 +94,6 @@ int main(int argc, char **argv)
     char hostname[1024];
     pmix_value_t *val;
     uint16_t localrank;
-    size_t n;
     pmix_query_t query;
     mylock_t mylock;
     bool refresh = false;
@@ -131,7 +130,6 @@ int main(int argc, char **argv)
             myproc.nspace, myproc.rank, (unsigned long) pid, hostname, (int) localrank);
 
 #if PMIX_VERSION_MAJOR >= 4
-    n = 1;
     PMIX_QUERY_CONSTRUCT(&query);
     PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NUM_PSETS);
     PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_PSET_NAMES);

--- a/examples/nodeinfo.c
+++ b/examples/nodeinfo.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    char *nodelist, **nodes, *hostname;
+    pmix_info_t info[2];
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* get the list of nodes being used */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get node list failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nodelist = strdup(val->data.string);
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: Host list %s\n",
+                myproc.nspace, myproc.rank, val->data.string);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_ARGV_SPLIT(nodes, nodelist, ',');
+    free(nodelist);
+    if (NULL == nodes) {
+        goto done;
+    }
+    /* get some node-specific info */
+    if (1 < nprocs) {
+        proc.rank = myproc.rank + 1;
+        if (nprocs == proc.rank) {
+            proc.rank = 0;
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_HOSTNAME, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Rank %u is on host %s\n",
+                myproc.nspace, myproc.rank, proc.rank, val->data.string);
+        hostname = strdup(val->data.string);
+        PMIX_VALUE_RELEASE(val);
+
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: Rank %u has coordinates\n    %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Value_string(val));
+            PMIX_VALUE_RELEASE(val);
+        }
+
+        // try with directive
+        proc.rank = PMIX_RANK_WILDCARD;
+        PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, hostname, PMIX_STRING);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates with directive for host %s failed: %s\n",
+                    myproc.nspace, myproc.rank, hostname, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Host %s has coordinates\n    %s\n",
+                myproc.nspace, myproc.rank, hostname, PMIx_Value_string(val));
+        PMIX_VALUE_RELEASE(val);
+    }
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -130,7 +130,9 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
+                                   const char key[],
+                                   pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
@@ -1085,6 +1087,8 @@ PMIX_EXPORT pmix_status_t PMIx_Parse_cpuset_string(const char *cpuset_string,
 
 PMIX_EXPORT pmix_status_t PMIx_Get_cpuset(pmix_cpuset_t *cpuset, pmix_bind_envelope_t ref);
 
+PMIX_EXPORT void PMIx_Cpuset_destruct(pmix_cpuset_t *cpuset);
+
 /* Get the relative locality of two local processes given their locality strings.
  *
  * locality1 - String returned by the PMIx_server_generate_locality_string API
@@ -1125,7 +1129,6 @@ PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
 PMIX_EXPORT const char* PMIx_Scope_string(pmix_scope_t scope);
 PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist);
 PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
-PMIX_EXPORT const char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
@@ -1134,11 +1137,13 @@ PMIX_EXPORT const char* PMIx_Get_attribute_string(char *attribute);
 PMIX_EXPORT const char* PMIx_Get_attribute_name(char *attrstring);
 PMIX_EXPORT const char* PMIx_Link_state_string(pmix_link_state_t state);
 PMIX_EXPORT const char* PMIx_Device_type_string(pmix_device_type_t type);
+PMIX_EXPORT const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp);
 
 /* the following print statements return ALLOCATED strings
  * that the user must release when done */
 PMIX_EXPORT char* PMIx_Info_string(pmix_info_t *info);
 PMIX_EXPORT char* PMIx_Value_string(pmix_value_t *value);
+PMIX_EXPORT char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */
@@ -1577,11 +1582,19 @@ PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
 
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
+
 /* Transfer data from one pmix_value_t to another - this is actually
  * executed as a COPY operation, so the original data is not altered.
  */
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src);
+
+/* Compre the contents of two pmix_value_t structures */
+PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
+                                                pmix_value_t *v2);
+
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
 
 /* Load key/value data into a pmix_info_t struct. Note that this
  * effectively is a PMIX_LOAD_KEY operation to copy the key,
@@ -1615,6 +1628,8 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const char *key,
                                              const void *value,
                                              pmix_data_type_t type);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 /* Transfer the data in an existing pmix_info_t struct to a list. This
  * is executed as a COPY operation, so the original data is not altered.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -462,10 +462,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"         // (bool) spawned app consists of debugger daemons
 #define PMIX_COSPAWN_APP                    "pmix.cospawn"          // (bool) designated app is to be spawned as a disconnected
                                                                     //        job - i.e., not part of the "comm_world" of the job
-#define PMIX_COLOCATE_PROC                  "pmix.colproc"          // (pmix_data_array_t*) Array of pmix_proc_t identifying the procs
+#define PMIX_COLOCATE_PROCS                 "pmix.colproc"          // (pmix_data_array_t*) Array of pmix_proc_t identifying the procs
                                                                     //        with which the new job's procs are to be colocated
-#define PMIX_COLOCATE_NUM_PROC              "pmix.colnum.proc"      // (uint16_t) Number of procs to colocate with each identified proc
-#define PMIX_COLOCATE_NUM_NODE              "pmix.colnum.node"      // (uint16_t) Number of procs to colocate on the node of each identified proc
+#define PMIX_COLOCATE_NPERPROC              "pmix.colnum.proc"      // (uint16_t) Number of procs to colocate with each identified proc
+#define PMIX_COLOCATE_NPERNODE              "pmix.colnum.node"      // (uint16_t) Number of procs to colocate on the node of each identified proc
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
 #define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc
@@ -1478,6 +1478,7 @@ typedef uint32_t pmix_info_directives_t;
 #define PMIX_INFO_ARRAY_END         0x00000002      // mark the end of an array created by PMIX_INFO_CREATE
 #define PMIX_INFO_REQD_PROCESSED    0x00000004      // reqd attribute has been processed
 #define PMIX_INFO_QUALIFIER         0x00000008      // info is a qualifier to the primary value
+#define PMIX_INFO_PERSISTENT        0x00000010      // do not release included value
 /* the top 16-bits are reserved for internal use by
  * implementers - these may be changed inside the
  * PMIx library */
@@ -1844,10 +1845,10 @@ static inline void pmix_argv_free(char **argv)
         return;
 
     for (p = argv; NULL != *p; ++p) {
-        free(*p);
+        pmix_free(*p);
     }
 
-    free(argv);
+    pmix_free(argv);
 }
 
 #define PMIX_ARGV_FREE(a)  pmix_argv_free(a)
@@ -2336,7 +2337,7 @@ typedef struct pmix_geometry {
             for (_i=0; _i < (n); _i++) {            \
                 PMIX_GEOMETRY_DESTRUCT(&(m)[_i]);   \
             }                                       \
-            free((m));                              \
+            pmix_free((m));                         \
             (m) = NULL;                             \
         }                                           \
     } while(0)
@@ -2380,10 +2381,10 @@ typedef struct pmix_device_distance {
 #define PMIX_DEVICE_DIST_DESTRUCT(m)    \
     do {                                \
         if (NULL != ((m)->uuid)) {      \
-            free((m)->uuid);            \
+            pmix_free((m)->uuid);       \
         }                               \
         if (NULL != ((m)->osname)) {    \
-            free((m)->osname);          \
+            pmix_free((m)->osname);     \
         }                               \
     } while(0)
 
@@ -2408,7 +2409,7 @@ typedef struct pmix_device_distance {
             for (_i=0; _i < (n); _i++) {                \
                 PMIX_DEVICE_DIST_DESTRUCT(&(m)[_i]);    \
             }                                           \
-            free((m));                                  \
+            pmix_free((m));                             \
             (m) = NULL;                                 \
         }                                               \
     } while(0)
@@ -2671,7 +2672,7 @@ typedef struct pmix_proc {
 #define PMIX_PROC_FREE(m, n)                    \
     do {                                        \
         if (NULL != (m)) {                      \
-            pmix_free((m));                          \
+            pmix_free((m));                     \
             (m) = NULL;                         \
         }                                       \
     } while (0)
@@ -2888,16 +2889,23 @@ typedef struct pmix_proc_stats {
         }                               \
     } while(0)
 
-#define PMIX_PROC_STATS_FREE(m, n)                  \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_PROC_STATS_DESTRUCT(&(m)[_k]); \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_proc_stats_free(pmix_proc_stats_t *ps, size_t n)
+{
+    size_t k;
+
+    if (NULL != ps) {
+        for (k=0; k < n; k++) {
+            PMIX_PROC_STATS_DESTRUCT(&ps[k]);
+        }
+    }
+}
+
+#define PMIX_PROC_STATS_FREE(m, n)  \
+do {                                \
+    pmix_proc_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *disk;
@@ -2953,16 +2961,23 @@ typedef struct {
         }                               \
     } while(0)
 
-#define PMIX_DISK_STATS_FREE(m, n)                  \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_DISK_STATS_DESTRUCT(&(m)[_k]); \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_disk_stats_free(pmix_disk_stats_t *d, size_t n)
+{
+    size_t k;
+
+    if (NULL != d) {
+        for (k=0; k < n; k++) {
+            PMIX_DISK_STATS_DESTRUCT(&d[k]);
+        }
+    }
+}
+
+#define PMIX_DISK_STATS_FREE(m, n)  \
+do {                                \
+    pmix_disk_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *net_interface;
@@ -3008,16 +3023,23 @@ typedef struct {
         }                                   \
     } while(0)
 
-#define PMIX_NET_STATS_FREE(m, n)                   \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_NET_STATS_DESTRUCT(&(m)[_k]);  \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_net_stats_free(pmix_net_stats_t *nst, size_t n)
+{
+    size_t k;
+
+    if (NULL != nst) {
+        for (k=0; k < n; k++) {
+            PMIX_NET_STATS_DESTRUCT(&nst[k]);
+        }
+    }
+}
+
+#define PMIX_NET_STATS_FREE(m, n)   \
+do {                                \
+    pmix_net_stats_free(m, n);      \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
 
 typedef struct {
     char *node;
@@ -3070,11 +3092,6 @@ typedef struct {
         (m) = (pmix_node_stats_t*)pmix_calloc((n) , sizeof(pmix_node_stats_t)); \
     } while (0)
 
-#define PMIX_NODE_STATS_RELEASE(m)      \
-    do {                                \
-        PMIX_NODE_STATS_FREE((m), 1);   \
-    } while (0)
-
 #define PMIX_NODE_STATS_CONSTRUCT(m)                \
     do {                                            \
         memset((m), 0, sizeof(pmix_node_stats_t));  \
@@ -3094,16 +3111,27 @@ typedef struct {
         }                                                           \
     } while(0)
 
-#define PMIX_NET_STATS_FREE(m, n)                   \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_NET_STATS_DESTRUCT(&(m)[_k]);  \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
+static inline void pmix_node_stats_free(pmix_node_stats_t *nd, size_t n)
+{
+    size_t k;
+
+    if (NULL != nd) {
+        for (k=0; k < n; k++) {
+            PMIX_NODE_STATS_DESTRUCT(&nd[k]);
+        }
+    }
+}
+
+#define PMIX_NODE_STATS_FREE(m, n)  \
+do {                                \
+    pmix_node_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
+
+#define PMIX_NODE_STATS_RELEASE(m)  \
+    pmix_node_stats_free(m, 1)
+
 
 /****    PMIX VALUE STRUCT    ****/
 
@@ -3186,34 +3214,11 @@ typedef struct pmix_value {
         }                                                       \
     } while (0)
 
-/* release a single pmix_value_t struct, including its data */
-#define PMIX_VALUE_RELEASE(m)       \
-    do {                            \
-        PMIX_VALUE_DESTRUCT((m));   \
-        pmix_free((m));                  \
-        (m) = NULL;                 \
-    } while (0)
-
 /* initialize a single value struct */
 #define PMIX_VALUE_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_value_t));   \
         (m)->type = PMIX_UNDEF;                 \
-    } while (0)
-
-/* release the memory in the value struct data field */
-#define PMIX_VALUE_DESTRUCT(m) pmix_value_destruct(m)
-
-#define PMIX_VALUE_FREE(m, n)                           \
-    do {                                                \
-        size_t _vv;                                     \
-        if (NULL != (m)) {                              \
-            for (_vv=0; _vv < (n); _vv++) {             \
-                PMIX_VALUE_DESTRUCT(&((m)[_vv]));       \
-            }                                           \
-            pmix_free((m));                                  \
-            (m) = NULL;                                 \
-        }                                               \
     } while (0)
 
 #define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
@@ -3285,23 +3290,6 @@ typedef struct pmix_info {
         (m)->value.type = PMIX_UNDEF;           \
     } while (0)
 
-#define PMIX_INFO_DESTRUCT(m) \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while (0)
-
-#define PMIX_INFO_FREE(m, n)                        \
-    do {                                            \
-        size_t _is;                                 \
-        if (NULL != (m)) {                          \
-            for (_is=0; _is < (n); _is++) {         \
-                PMIX_INFO_DESTRUCT(&((m)[_is]));    \
-            }                                       \
-            pmix_free((m));                         \
-            (m) = NULL;                             \
-        }                                           \
-    } while (0)
-
 /* macros for setting and unsetting the "reqd" flag
  * in a pmix_info_t */
 #define PMIX_INFO_REQUIRED(m)       \
@@ -3333,6 +3321,11 @@ typedef struct pmix_info {
 #define PMIX_INFO_IS_QUALIFIER(i)    \
     ((i)->flags & PMIX_INFO_QUALIFIER)
 
+/* macro for setting and testing the "donot release" flag */
+#define PMIX_INFO_SET_PERSISTENT(ii) \
+    ((ii)->flags |= PMIX_INFO_PERSISTENT)
+#define PMIX_INFO_IS_PERSISTENT(ii)  \
+    ((ii)->flags & PMIX_INFO_PERSISTENT)
 
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
@@ -3363,35 +3356,10 @@ typedef struct pmix_pdata {
         (m) = (pmix_pdata_t*)pmix_calloc((n), sizeof(pmix_pdata_t)); \
     } while (0)
 
-#define PMIX_PDATA_RELEASE(m)                   \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-        pmix_free((m));                              \
-        (m) = NULL;                             \
-    } while (0)
-
 #define PMIX_PDATA_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_pdata_t));   \
         (m)->value.type = PMIX_UNDEF;           \
-    } while (0)
-
-#define PMIX_PDATA_DESTRUCT(m)                  \
-    do {                                        \
-        PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while (0)
-
-#define PMIX_PDATA_FREE(m, n)                           \
-    do {                                                \
-        size_t _ps;                                     \
-        pmix_pdata_t *_pdf = (pmix_pdata_t*)(m);        \
-        if (NULL != _pdf) {                             \
-            for (_ps=0; _ps < (n); _ps++) {             \
-                PMIX_PDATA_DESTRUCT(&(_pdf[_ps]));      \
-            }                                           \
-            pmix_free((m));                                  \
-            (m) = NULL;                                 \
-        }                                               \
     } while (0)
 
 
@@ -3439,50 +3407,6 @@ typedef struct pmix_app {
 #define PMIX_APP_CONSTRUCT(m)                   \
     do {                                        \
         memset((m), 0, sizeof(pmix_app_t));     \
-    } while (0)
-
-#define PMIX_APP_DESTRUCT(m)                                    \
-    do {                                                        \
-        size_t _aii;                                            \
-        if (NULL != (m)->cmd) {                                 \
-            pmix_free((m)->cmd);                                     \
-            (m)->cmd = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->argv) {                                \
-            for (_aii=0; NULL != (m)->argv[_aii]; _aii++) {     \
-                pmix_free((m)->argv[_aii]);                          \
-            }                                                   \
-            pmix_free((m)->argv);                                    \
-            (m)->argv = NULL;                                   \
-        }                                                       \
-        if (NULL != (m)->env) {                                 \
-            for (_aii=0; NULL != (m)->env[_aii]; _aii++) {      \
-                pmix_free((m)->env[_aii]);                           \
-            }                                                   \
-            pmix_free((m)->env);                                     \
-            (m)->env = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->cwd) {                                 \
-            pmix_free((m)->cwd);                                     \
-            (m)->cwd = NULL;                                    \
-        }                                                       \
-        if (NULL != (m)->info) {                                \
-            PMIX_INFO_FREE((m)->info, (m)->ninfo);              \
-            (m)->info = NULL;                                   \
-            (m)->ninfo = 0;                                     \
-        }                                                       \
-    } while (0)
-
-#define PMIX_APP_FREE(m, n)                     \
-    do {                                        \
-        size_t _as;                             \
-        if (NULL != (m)) {                      \
-            for (_as=0; _as < (n); _as++) {     \
-                PMIX_APP_DESTRUCT(&((m)[_as])); \
-            }                                   \
-            pmix_free((m));                          \
-            (m) = NULL;                         \
-        }                                       \
     } while (0)
 
 
@@ -3906,80 +3830,6 @@ typedef void (*pmix_device_dist_cbfunc_t)(pmix_status_t status,
                                           void *release_cbdata);
 
 
-/********    STANDARD MACROS FOR DARRAY AND VALUE SUPPORT     ********/
-static inline void pmix_darray_destruct(pmix_data_array_t *m);
-
-static inline void pmix_value_destruct(pmix_value_t * m)
-{
-    if (PMIX_STRING == (m)->type) {
-        if (NULL != (m)->data.string) {
-            pmix_free((m)->data.string);
-            (m)->data.string = NULL;
-        }
-    } else if ((PMIX_BYTE_OBJECT == (m)->type) ||
-               (PMIX_COMPRESSED_STRING == (m)->type)) {
-        if (NULL != (m)->data.bo.bytes) {
-            pmix_free((m)->data.bo.bytes);
-            (m)->data.bo.bytes = NULL;
-            (m)->data.bo.size = 0;
-        }
-    } else if (PMIX_DATA_ARRAY == (m)->type) {
-        if (NULL != (m)->data.darray) {
-            pmix_darray_destruct((m)->data.darray);
-            pmix_free((m)->data.darray);
-            (m)->data.darray = NULL;
-        }
-    } else if (PMIX_ENVAR == (m)->type) {
-        PMIX_ENVAR_DESTRUCT(&(m)->data.envar);
-    } else if (PMIX_PROC == (m)->type) {
-        PMIX_PROC_RELEASE((m)->data.proc);
-    }
-}
-
-static inline void pmix_darray_destruct(pmix_data_array_t *m)
-{
-    if (NULL != m) {
-        if (PMIX_INFO == m->type) {
-            pmix_info_t *_info = (pmix_info_t*)m->array;
-            PMIX_INFO_FREE(_info, m->size);
-        } else if (PMIX_PROC == m->type) {
-            pmix_proc_t *_p = (pmix_proc_t*)m->array;
-            PMIX_PROC_FREE(_p, m->size);
-        } else if (PMIX_PROC_INFO == m->type) {
-            pmix_proc_info_t *_pi = (pmix_proc_info_t*)m->array;
-            PMIX_PROC_INFO_FREE(_pi, m->size);
-        } else if (PMIX_ENVAR == m->type) {
-            pmix_envar_t *_e = (pmix_envar_t*)m->array;
-            PMIX_ENVAR_FREE(_e, m->size);
-        } else if (PMIX_VALUE == m->type) {
-            pmix_value_t *_v = (pmix_value_t*)m->array;
-            PMIX_VALUE_FREE(_v, m->size);
-        } else if (PMIX_PDATA == m->type) {
-            pmix_pdata_t *_pd = (pmix_pdata_t*)m->array;
-            PMIX_PDATA_FREE(_pd, m->size);
-        } else if (PMIX_QUERY == m->type) {
-            pmix_query_t *_q = (pmix_query_t*)m->array;
-            PMIX_QUERY_FREE(_q, m->size);
-        } else if (PMIX_APP == m->type) {
-            pmix_app_t *_a = (pmix_app_t*)m->array;
-            PMIX_APP_FREE(_a, m->size);
-        } else if (PMIX_BYTE_OBJECT == m->type ||
-                   PMIX_COMPRESSED_STRING == m->type) {
-            pmix_byte_object_t *_b = (pmix_byte_object_t*)m->array;
-            PMIX_BYTE_OBJECT_FREE(_b, m->size);
-        } else if (PMIX_STRING == m->type) {
-            char **_s = (char**)m->array;
-            size_t _si;
-            for (_si=0; _si < m->size; _si++) {
-                pmix_free(_s[_si]);
-            }
-            pmix_free(m->array);
-            m->array = NULL;
-        } else {
-            pmix_free(m->array);
-        }
-    }
-}
 
 #define PMIX_DATA_ARRAY_INIT(m, t)      \
     do {                                \
@@ -4131,7 +3981,97 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         }                                                                       \
     } while(0)
 
-#define PMIX_DATA_ARRAY_DESTRUCT(m) pmix_darray_destruct(m)
+#include <pmix_deprecated.h>
+
+/********    STANDARD MACROS FOR DARRAY AND VALUE SUPPORT     ********/
+
+/* release the memory in the value struct data field */
+#define PMIX_VALUE_DESTRUCT(m) PMIx_Value_destruct(m)
+
+/* release a single pmix_value_t struct, including its data */
+#define PMIX_VALUE_RELEASE(m)       \
+    do {                            \
+        PMIX_VALUE_DESTRUCT((m));   \
+        pmix_free((m));                  \
+        (m) = NULL;                 \
+    } while (0)
+
+#define PMIX_VALUE_FREE(m, n)                           \
+    do {                                                \
+        size_t _vv;                                     \
+        if (NULL != (m)) {                              \
+            for (_vv=0; _vv < (n); _vv++) {             \
+                PMIX_VALUE_DESTRUCT(&((m)[_vv]));       \
+            }                                           \
+            pmix_free((m));                             \
+            (m) = NULL;                                 \
+        }                                               \
+    } while (0)
+
+#define PMIX_INFO_DESTRUCT(m)                   \
+    do {                                        \
+        if (!PMIX_INFO_IS_PERSISTENT((m))) {    \
+            PMIX_VALUE_DESTRUCT(&(m)->value);   \
+        }                                       \
+    } while (0)
+
+#define PMIX_INFO_FREE(m, n)                        \
+    do {                                            \
+        size_t _is;                                 \
+        if (NULL != (m)) {                          \
+            for (_is=0; _is < (n); _is++) {         \
+                PMIX_INFO_DESTRUCT(&((m)[_is]));    \
+            }                                       \
+            pmix_free((m));                         \
+            (m) = NULL;                             \
+        }                                           \
+    } while (0)
+
+#define PMIX_APP_DESTRUCT(m)                                    \
+    do {                                                        \
+        if (NULL != (m)->cmd) {                                 \
+            pmix_free((m)->cmd);                                \
+            (m)->cmd = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->argv) {                                \
+            pmix_argv_free((m)->argv);                          \
+            (m)->argv = NULL;                                   \
+        }                                                       \
+        if (NULL != (m)->env) {                                 \
+            pmix_argv_free((m)->env);                           \
+            (m)->env = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->cwd) {                                 \
+            pmix_free((m)->cwd);                                \
+            (m)->cwd = NULL;                                    \
+        }                                                       \
+        if (NULL != (m)->info) {                                \
+            PMIX_INFO_FREE((m)->info, (m)->ninfo);              \
+            (m)->info = NULL;                                   \
+            (m)->ninfo = 0;                                     \
+        }                                                       \
+    } while (0)
+
+static inline void pmix_app_free(pmix_app_t *ap, size_t n)
+{
+    size_t k;
+
+    if (NULL != ap) {
+        for (k=0; k < n; k++) {
+            PMIX_APP_DESTRUCT(&ap[k]);
+        }
+    }
+}
+
+#define PMIX_APP_FREE(m, n)     \
+    do {                        \
+        pmix_app_free(m, n);    \
+        pmix_free(m);           \
+        (m) = NULL;             \
+    } while (0)
+
+
+#define PMIX_DATA_ARRAY_DESTRUCT(m) PMIx_Data_array_destruct(m)
 
 #define PMIX_DATA_ARRAY_FREE(m)             \
     do {                                    \
@@ -4142,7 +4082,35 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         }                                   \
     } while(0)
 
-#include <pmix_deprecated.h>
+#define PMIX_PDATA_RELEASE(m)                   \
+    do {                                        \
+        PMIX_VALUE_DESTRUCT(&(m)->value);       \
+        pmix_free((m));                         \
+        (m) = NULL;                             \
+    } while (0)
+
+#define PMIX_PDATA_DESTRUCT(m)                  \
+    do {                                        \
+        PMIX_VALUE_DESTRUCT(&(m)->value);       \
+    } while (0)
+
+static inline void pmix_pdata_free(pmix_pdata_t *pd, size_t n)
+{
+    size_t k;
+
+    if (NULL != pd) {
+        for (k=0; k < n; k++) {
+            PMIX_PDATA_DESTRUCT(&pd[k]);
+        }
+    }
+}
+
+#define PMIX_PDATA_FREE(m, n)   \
+do {                            \
+    pmix_pdata_free(m, n);      \
+    pmix_free(m);               \
+    (m) = NULL;                 \
+} while(0)
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -214,10 +214,12 @@ PMIX_EXPORT pmix_status_t PMIx_Value_load(pmix_value_t *val,
 PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src);
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
                                          const char *key,
@@ -233,6 +235,8 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const char *key,
                                              const void *value,
                                              pmix_data_type_t type);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr,
                                               const pmix_info_t *info);
@@ -297,6 +301,9 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 
 #define PMIX_INFO_LIST_ADD(r, p, a, v, t)     \
     (r) = PMIx_Info_list_add((p), (a), (v), (t))
+
+#define PMIX_INFO_LIST_INSERT(r, p, i)     \
+    (r) = PMIx_Info_list_insert((p), (i))
 
 #define PMIX_INFO_LIST_XFER(r, p, a)     \
     (r) = PMIx_Info_list_xfer((p), (a))

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -17,7 +17,7 @@
  */
 
 #include "src/include/pmix_config.h"
-#include "pmix.h"
+#include "include/pmix.h"
 
 #include "src/client/pmix_client_ops.h"
 #include "src/hwloc/pmix_hwloc.h"
@@ -69,6 +69,19 @@ void PMIx_Topology_destruct(pmix_topology_t *topo)
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_hwloc_destruct_topology(topo);
+}
+
+void PMIx_Cpuset_destruct(pmix_cpuset_t *cpuset)
+{
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    pmix_hwloc_destruct_cpuset(cpuset);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Parse_cpuset_string(const char *cpuset_string, pmix_cpuset_t *cpuset)

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -156,14 +156,33 @@ PMIX_EXPORT const char *PMIx_Data_range_string(pmix_data_range_t range)
     }
 }
 
-PMIX_EXPORT const char *PMIx_Info_directives_string(pmix_info_directives_t directives)
+PMIX_EXPORT char *PMIx_Info_directives_string(pmix_info_directives_t directives)
 {
-    switch (directives) {
-    case PMIX_INFO_REQD:
-        return "REQUIRED";
-    default:
-        return "UNSPECIFIED";
+    char **tmp = NULL;
+    char *ret;
+
+    if (PMIX_INFO_QUALIFIER & directives) {
+        pmix_argv_append_nosize(&tmp, "QUALIFIER");
+    } else {
+        if (PMIX_INFO_REQD & directives) {
+            pmix_argv_append_nosize(&tmp, "REQUIRED");
+        } else {
+            pmix_argv_append_nosize(&tmp, "OPTIONAL");
+        }
+        if (PMIX_INFO_REQD_PROCESSED & directives) {
+            pmix_argv_append_nosize(&tmp, "PROCESSED");
+        }
+        if (PMIX_INFO_ARRAY_END & directives) {
+            pmix_argv_append_nosize(&tmp, "END");
+        }
     }
+    if (NULL != tmp) {
+        ret = pmix_argv_join(tmp, ':');
+        pmix_argv_free(tmp);
+    } else {
+        ret = strdup("UNSPECIFIED");
+    }
+    return ret;
 }
 
 PMIX_EXPORT const char *PMIx_Alloc_directive_string(pmix_alloc_directive_t directive)
@@ -239,6 +258,14 @@ PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
         return "GROUP LEAVE";
     case PMIX_GROUP_DESTRUCT_CMD:
         return "GROUP DESTRUCT";
+    case PMIX_IOF_DEREG_CMD:
+        return "IOF DEREG";
+    case PMIX_FABRIC_REGISTER_CMD:
+        return "FABRIC REGISTER";
+    case PMIX_FABRIC_UPDATE_CMD:
+        return "FABRIC UPDATE";
+    case PMIX_COMPUTE_DEVICE_DISTANCES_CMD:
+        return "COMPUTE DEVICE DIST";
     default:
         return "UNKNOWN";
     }
@@ -343,5 +370,25 @@ const char *PMIx_Device_type_string(pmix_device_type_t type)
         return "COPROCESSOR";
     default:
         return "UNKNOWN";
+    }
+}
+
+const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp)
+{
+    switch (cmp) {
+    case PMIX_EQUAL:
+        return "EQUAL";
+    case PMIX_VALUE1_GREATER:
+        return "VALUE1 GREATER";
+    case PMIX_VALUE2_GREATER:
+        return "VALUE2 GREATER";
+    case PMIX_VALUE_TYPE_DIFFERENT:
+        return "DIFFERENT TYPES";
+    case PMIX_VALUE_COMPARISON_NOT_AVAIL:
+        return "COMPARISON NOT AVAILABLE";
+    case PMIX_VALUE_INCOMPATIBLE_OBJECTS:
+        return "INCOMPATIBLE OBJECTS";
+    default:
+        return "UNKNOWN VALUE";
     }
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -630,18 +630,23 @@ PMIX_EXPORT void pmix_log_local_op(int sd, short args, void *cbdata_);
 
 static inline bool pmix_check_node_info(const char *key)
 {
-    char *keys[] = {PMIX_HOSTNAME,
-                    PMIX_HOSTNAME_ALIASES,
-                    PMIX_NODEID,
-                    PMIX_AVAIL_PHYS_MEMORY,
-                    PMIX_LOCAL_PEERS,
-                    PMIX_LOCAL_PROCS,
-                    PMIX_LOCAL_CPUSETS,
-                    PMIX_LOCAL_SIZE,
-                    PMIX_NODE_SIZE,
-                    PMIX_LOCALLDR,
-                    PMIX_NODE_OVERSUBSCRIBED,
-                    NULL};
+    char *keys[] = {
+        PMIX_HOSTNAME,                  PMIX_HOSTNAME_ALIASES,
+        PMIX_NODEID,                    PMIX_AVAIL_PHYS_MEMORY,
+        PMIX_LOCAL_PEERS,               PMIX_LOCAL_PROCS,
+        PMIX_LOCAL_CPUSETS,             PMIX_LOCAL_SIZE,
+        PMIX_NODE_SIZE,                 PMIX_LOCALLDR,
+        PMIX_NODE_OVERSUBSCRIBED,       PMIX_FABRIC_DEVICES,
+        PMIX_FABRIC_COORDINATES,        PMIX_FABRIC_DEVICE,
+        PMIX_FABRIC_DEVICE_INDEX,       PMIX_FABRIC_DEVICE_NAME,
+        PMIX_FABRIC_DEVICE_VENDOR,      PMIX_FABRIC_DEVICE_BUS_TYPE,
+        PMIX_FABRIC_DEVICE_VENDORID,    PMIX_FABRIC_DEVICE_DRIVER,
+        PMIX_FABRIC_DEVICE_FIRMWARE,    PMIX_FABRIC_DEVICE_ADDRESS,
+        PMIX_FABRIC_DEVICE_MTU,         PMIX_FABRIC_DEVICE_COORDINATES,
+        PMIX_FABRIC_DEVICE_SPEED,       PMIX_FABRIC_DEVICE_STATE,
+        PMIX_FABRIC_DEVICE_TYPE,        PMIX_FABRIC_DEVICE_PCI_DEVID,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -654,8 +659,11 @@ static inline bool pmix_check_node_info(const char *key)
 
 static inline bool pmix_check_app_info(const char *key)
 {
-    char *keys[] = {PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
-                    PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX, NULL};
+    char *keys[] = {
+        PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
+        PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -668,9 +676,12 @@ static inline bool pmix_check_app_info(const char *key)
 
 static inline bool pmix_check_session_info(const char *key)
 {
-    char *keys[] = {PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
-                    PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
-                    PMIX_RM_NAME,    PMIX_RM_VERSION,   NULL};
+    char *keys[] = {
+        PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
+        PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
+        PMIX_RM_NAME,    PMIX_RM_VERSION,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {

--- a/src/mca/bfrops/base/Makefile.include
+++ b/src/mca/bfrops/base/Makefile.include
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,4 +35,5 @@ sources += \
         base/bfrop_base_pack.c \
         base/bfrop_base_print.c \
         base/bfrop_base_unpack.c \
-        base/bfrop_base_stubs.c
+        base/bfrop_base_stubs.c \
+        base/bfrop_base_cmp.c

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1001,6 +1001,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void *
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p, const pmix_value_t *src);
 
 PMIX_EXPORT pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p, pmix_value_t *p1);
+
+PMIX_EXPORT void pmix_bfrops_base_value_destruct(pmix_value_t *v);
+
+PMIX_EXPORT void pmix_bfrops_base_darray_destruct(pmix_data_array_t *d);
 
 END_C_DECLS
 

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -1,0 +1,1558 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include "pmix.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_error.h"
+#include "src/hwloc/pmix_hwloc.h"
+
+#include "src/mca/bfrops/base/base.h"
+
+#define PMIX_CHECK_SIMPLE(r)        \
+do {                                \
+    if (r < 0) {                    \
+        return PMIX_VALUE2_GREATER; \
+    } else if (0 < r) {             \
+        return PMIX_VALUE1_GREATER; \
+    } else {                        \
+        return PMIX_EQUAL;          \
+    }                               \
+} while(0)
+
+PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
+                                                pmix_value_t *v2)
+{
+    return pmix_bfrops_base_value_cmp(v1, v2);
+}
+
+static pmix_value_cmp_t cmp_string(char *s1, char *s2)
+{
+    int ret;
+
+    if (NULL == s1 && NULL == s2) {
+        return PMIX_EQUAL;
+    } else if (NULL != s1 && NULL == s2) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == s1 && NULL != s2) {
+        return PMIX_VALUE2_GREATER;
+    } else {
+        /* both are non-NULL */
+        ret = strcmp(s1, s2);
+        PMIX_CHECK_SIMPLE(ret);
+    }
+}
+
+static pmix_value_cmp_t cmp_byte_object(pmix_byte_object_t *bo1,
+                                        pmix_byte_object_t *bo2)
+{
+    int ret;
+
+    if (bo1->size == bo2->size) {
+        if (0 == bo1->size) {
+            return PMIX_EQUAL;
+        }
+        ret = memcmp(bo1->bytes, bo2->bytes, bo1->size);
+        PMIX_CHECK_SIMPLE(ret);
+    } else if (bo1->size > bo2->size) {
+        return PMIX_VALUE1_GREATER;
+    } else {
+        return PMIX_VALUE2_GREATER;
+    }
+}
+
+static pmix_value_cmp_t cmp_proc_info(pmix_proc_info_t *pi1,
+                                      pmix_proc_info_t *pi2)
+{
+    int ret;
+
+    ret = memcmp(&pi1->proc, &pi2->proc, sizeof(pmix_proc_t));
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (ret > 0) {
+        return PMIX_VALUE1_GREATER;
+    }
+    /* proc fields are the same - check further */
+    if (NULL == pi1->hostname && NULL != pi2->hostname) {
+        return PMIX_VALUE2_GREATER;
+    } else if (NULL != pi1->hostname && NULL == pi2->hostname) {
+        return PMIX_VALUE1_GREATER;
+    }
+    ret = strcmp(pi1->hostname, pi2->hostname);
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+    /* hostnames match */
+
+    if (NULL == pi1->executable_name && NULL != pi2->executable_name) {
+        return PMIX_VALUE2_GREATER;
+    } else if (NULL != pi1->executable_name && NULL == pi2->executable_name) {
+        return PMIX_VALUE1_GREATER;
+    }
+    ret = strcmp(pi1->executable_name, pi2->executable_name);
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+    /* executables match */
+
+    if (pi1->pid > pi2->pid) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pi2->pid > pi1->pid) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* pids match */
+
+    if (pi1->exit_code > pi2->exit_code) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pi2->exit_code > pi1->exit_code) {
+        return PMIX_VALUE2_GREATER;
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_envar(pmix_envar_t *e1,
+                                  pmix_envar_t *e2)
+{
+    int ret;
+
+    if (NULL != e1) {
+        if (NULL == e2) {
+            return PMIX_VALUE1_GREATER;
+        }
+        if (NULL == e1->envar && NULL == e2->envar) {
+            goto checkvalue;
+        } else if (NULL == e1->envar) {
+            return PMIX_VALUE2_GREATER;
+        } else if (NULL == e2->envar) {
+            return PMIX_VALUE1_GREATER;
+        }
+        /* both must not be NULL */
+        ret = strcmp(e1->envar, e2->envar);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else {
+        /* if e1 is NULL and e2 is not, then e2 is greater */
+        if (NULL != e2) {
+            return PMIX_VALUE2_GREATER;
+        } else {
+            /* if both are NULL, then they are equal */
+            return PMIX_EQUAL;
+        }
+    }
+
+checkvalue:
+    /* if both envar strings are NULL or are equal, then check value */
+    if (NULL != e1->value) {
+        if (NULL == e2->value) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(e1->value, e2->value);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != e2->value) {
+        /* we know e1->value had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+
+    /* finally, check separator */
+    if (e1->separator < e2->separator) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (e1->separator < e2->separator) {
+        return PMIX_VALUE1_GREATER;
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_coord(pmix_coord_t *c1,
+                                  pmix_coord_t *c2)
+{
+    int ret;
+
+    if (c1->view != c2->view) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+    if (0 == c1->dims && 0 != c2->dims) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 != c1->dims && 0 == c2->dims) {
+        return PMIX_VALUE1_GREATER;
+    }
+    ret = memcmp(c1->coord, c2->coord, c1->dims * sizeof(uint32_t));
+    PMIX_CHECK_SIMPLE(ret);
+}
+
+static pmix_value_cmp_t cmp_geometry(pmix_geometry_t *g1,
+                                     pmix_geometry_t *g2)
+{
+    int ret;
+    pmix_value_cmp_t rc;
+    size_t n;
+
+    if (g1->fabric != g2->fabric) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+
+    if (NULL != g1->uuid) {
+        if (NULL == g2->uuid) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(g1->uuid, g2->uuid);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != g2->uuid) {
+        /* we know g1->uuid had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* uuids match or are both NULL */
+
+    if (NULL != g1->osname) {
+        if (NULL == g2->osname) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(g1->osname, g2->osname);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != g2->osname) {
+        /* we know g1->osname had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* osnames match or are both NULL */
+
+    if (NULL == g1->coordinates && NULL == g2->coordinates) {
+        return PMIX_EQUAL;
+    } else if (NULL != g1->coordinates && NULL == g2->coordinates) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == g1->coordinates && NULL != g2->coordinates) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are not NULL */
+    if (g1->ncoords > g2->ncoords) {
+        return PMIX_VALUE1_GREATER;
+    } else if (g1->ncoords < g2->ncoords) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both have same number of coords */
+    if (0 == g1->ncoords) {
+        return PMIX_EQUAL;
+    }
+    for (n=0; n < g1->ncoords; n++) {
+        rc = cmp_coord(&g1->coordinates[n], &g2->coordinates[n]);
+        if (PMIX_EQUAL != rc) {
+            return rc;
+        }
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_topo(pmix_topology_t *t1,
+                                 pmix_topology_t *t2)
+{
+    int ret;
+    char *p1, *p2;
+
+    if (NULL == t1->source && NULL == t2->source) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != t1->source && NULL == t2->source) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    } else if (NULL == t1->source && NULL != t2->source) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+    /* both are not NULL */
+    ret = strcmp(t1->source, t2->source);
+    if (0 != ret) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+    /* sources match */
+
+    if (NULL == t1->topology && NULL == t2->topology) {
+        return PMIX_EQUAL;
+    } else if (NULL != t1->topology && NULL == t2->topology) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == t1->topology && NULL != t2->topology) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are not NULL */
+
+    /* stringify the topologies */
+    p1 = pmix_hwloc_print_topology(t1->topology);
+    if (NULL == p1) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    p2 = pmix_hwloc_print_topology(t2->topology);
+    if (NULL == p2) {
+        free(p1);
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    ret = strcmp(p1, p2);
+    free(p1);
+    free(p2);
+    PMIX_CHECK_SIMPLE(ret);
+}
+
+static pmix_value_cmp_t cmp_cpuset(pmix_cpuset_t *cs1,
+                                   pmix_cpuset_t *cs2)
+{
+    int ret;
+    char *p1, *p2;
+
+    if (NULL == cs1->source && NULL == cs2->source) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != cs1->source && NULL == cs2->source) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    } else if (NULL == cs1->source && NULL != cs2->source) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+    /* both are not NULL */
+    ret = strcmp(cs1->source, cs2->source);
+    if (0 != ret) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+    /* sources match */
+
+    /* stringify the cpusets */
+    p1 = pmix_hwloc_print_cpuset(cs1->bitmap);
+    if (NULL == p1) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    p2 = pmix_hwloc_print_cpuset(cs2->bitmap);
+    if (NULL == p2) {
+        free(p1);
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    ret = strcmp(p1, p2);
+    free(p1);
+    free(p2);
+    PMIX_CHECK_SIMPLE(ret);
+}
+
+static pmix_value_cmp_t cmp_devdist(pmix_device_distance_t *dd1,
+                                    pmix_device_distance_t *dd2)
+{
+    int ret;
+
+    if (dd1->type != dd2->type) {
+        return PMIX_VALUE_INCOMPATIBLE_OBJECTS;
+    }
+
+    if (NULL != dd1->uuid) {
+        if (NULL == dd2->uuid) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(dd1->uuid, dd2->uuid);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != dd2->uuid) {
+        /* we know g1->uuid had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* uuids match or are both NULL */
+
+    if (NULL != dd1->osname) {
+        if (NULL == dd2->osname) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(dd1->osname, dd2->osname);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != dd2->osname) {
+        /* we know g1->osname had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* osnames match or are both NULL */
+
+    if (dd1->mindist > dd2->mindist) {
+        return PMIX_VALUE1_GREATER;
+    } else if (dd1->mindist < dd2->mindist) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    if (dd1->maxdist > dd2->maxdist) {
+        return PMIX_VALUE1_GREATER;
+    } else if (dd1->maxdist < dd2->maxdist) {
+        return PMIX_VALUE2_GREATER;
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_endpoint(pmix_endpoint_t *e1,
+                                     pmix_endpoint_t *e2)
+{
+    pmix_value_cmp_t rc;
+    int ret;
+
+    if (NULL != e1->uuid) {
+        if (NULL == e2->uuid) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(e1->uuid, e2->uuid);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != e2->uuid) {
+        /* we know e1->uuid had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* uuids match or are both NULL */
+
+    if (NULL != e1->osname) {
+        if (NULL == e2->osname) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(e1->osname, e2->osname);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != e2->osname) {
+        /* we know e1->osname had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* osnames match or are both NULL */
+
+    rc = cmp_byte_object(&e1->endpt, &e2->endpt);
+    return rc;
+}
+
+static pmix_value_cmp_t cmp_procstats(pmix_proc_stats_t *pcs1,
+                                      pmix_proc_stats_t *pcs2)
+{
+    int ret;
+
+    if (NULL == pcs1->node && NULL == pcs2->node) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != pcs1->node) {
+        if (NULL == pcs2->node) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(pcs1->node, pcs2->node);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != pcs2->node) {
+        /* we know pcs1->node had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    ret = memcmp(&pcs1->proc, &pcs2->proc, sizeof(pmix_proc_t));
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+    if (pcs1->pid > pcs2->pid) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->pid < pcs2->pid) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    if (NULL != pcs1->cmd) {
+        if (NULL == pcs2->cmd) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(pcs1->cmd, pcs2->cmd);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != pcs2->cmd) {
+        /* we know pcs1->cmd had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* cmds match or are both NULL */
+
+    if (pcs1->state > pcs2->state) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->state < pcs2->state) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    ret = memcmp(&pcs1->time, &pcs2->time, sizeof(struct timeval));
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+
+    if (pcs1->percent_cpu > pcs2->percent_cpu) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->percent_cpu < pcs2->percent_cpu) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->priority > pcs2->priority) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->priority < pcs2->priority) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->num_threads > pcs2->num_threads) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->num_threads < pcs2->num_threads) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->pss > pcs2->pss) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->pss < pcs2->pss) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->vsize > pcs2->vsize) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->vsize < pcs2->vsize) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->rss > pcs2->rss) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->rss < pcs2->rss) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->peak_vsize > pcs2->peak_vsize) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->peak_vsize < pcs2->peak_vsize) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (pcs1->processor > pcs2->processor) {
+        return PMIX_VALUE1_GREATER;
+    } else if (pcs1->processor < pcs2->processor) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    ret = memcmp(&pcs1->sample_time, &pcs2->sample_time, sizeof(struct timeval));
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_diskstats(pmix_disk_stats_t *ds1,
+                                      pmix_disk_stats_t *ds2)
+{
+    int ret;
+
+    if (NULL == ds1->disk && NULL == ds2->disk) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != ds1->disk) {
+        if (NULL == ds2->disk) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(ds1->disk, ds2->disk);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != ds2->disk) {
+        /* we know ds1->disk had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    if (ds1->num_reads_completed > ds2->num_reads_completed) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_reads_completed < ds2->num_reads_completed) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_reads_merged > ds2->num_reads_merged) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_reads_merged < ds2->num_reads_merged) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_sectors_read > ds2->num_sectors_read) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_sectors_read < ds2->num_sectors_read) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->milliseconds_reading > ds2->milliseconds_reading) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->milliseconds_reading < ds2->milliseconds_reading) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_writes_completed > ds2->num_writes_completed) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_writes_completed < ds2->num_writes_completed) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_writes_merged > ds2->num_writes_merged) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_writes_merged < ds2->num_writes_merged) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_sectors_written > ds2->num_sectors_written) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_sectors_written < ds2->num_sectors_written) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->milliseconds_writing > ds2->milliseconds_writing) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->milliseconds_writing < ds2->milliseconds_writing) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->num_ios_in_progress > ds2->num_ios_in_progress) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->num_ios_in_progress < ds2->num_ios_in_progress) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->milliseconds_io > ds2->milliseconds_io) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->milliseconds_io < ds2->milliseconds_io) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ds1->weighted_milliseconds_io > ds2->weighted_milliseconds_io) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ds1->weighted_milliseconds_io < ds2->weighted_milliseconds_io) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_netstats(pmix_net_stats_t *ns1,
+                                     pmix_net_stats_t *ns2)
+{
+    int ret;
+
+    if (NULL == ns1->net_interface && NULL == ns2->net_interface) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != ns1->net_interface) {
+        if (NULL == ns2->net_interface) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(ns1->net_interface, ns2->net_interface);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != ns2->net_interface) {
+        /* we know ns1->disk had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    if (ns1->num_bytes_recvd > ns2->num_bytes_recvd) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_bytes_recvd < ns2->num_bytes_recvd) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ns1->num_packets_recvd > ns2->num_packets_recvd) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_packets_recvd < ns2->num_packets_recvd) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ns1->num_recv_errs > ns2->num_recv_errs) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_recv_errs < ns2->num_recv_errs) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ns1->num_bytes_sent > ns2->num_bytes_sent) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_bytes_sent < ns2->num_bytes_sent) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ns1->num_packets_sent > ns2->num_packets_sent) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_packets_sent < ns2->num_packets_sent) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (ns1->num_send_errs > ns2->num_send_errs) {
+        return PMIX_VALUE1_GREATER;
+    } else if (ns1->num_send_errs < ns2->num_send_errs) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_nodestats(pmix_node_stats_t *nds1,
+                                      pmix_node_stats_t *nds2)
+{
+    int ret;
+    pmix_value_cmp_t rc;
+    size_t n;
+
+    if (NULL == nds1->node && NULL == nds2->node) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != nds1->node) {
+        if (NULL == nds2->node) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(nds1->node, nds2->node);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != nds2->node) {
+        /* we know nds1->node had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    if (nds1->la > nds2->la) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->la < nds2->la) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->la5 > nds2->la5) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->la5 < nds2->la5) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->la15 > nds2->la15) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->la15 < nds2->la15) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->total_mem > nds2->total_mem) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->total_mem < nds2->total_mem) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->free_mem > nds2->free_mem) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->free_mem < nds2->free_mem) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->buffers > nds2->buffers) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->buffers < nds2->buffers) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->cached > nds2->cached) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->cached < nds2->cached) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->swap_cached > nds2->swap_cached) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->swap_cached < nds2->swap_cached) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->swap_total > nds2->swap_total) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->swap_total < nds2->swap_total) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->swap_free > nds2->swap_free) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->swap_free < nds2->swap_free) {
+        return PMIX_VALUE2_GREATER;
+    }
+    if (nds1->mapped > nds2->mapped) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->mapped < nds2->mapped) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    ret = memcmp(&nds1->sample_time, &nds2->sample_time, sizeof(struct timeval));
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+
+    if (NULL != nds1->diskstats && NULL == nds2->diskstats) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == nds1->diskstats && NULL == nds2->diskstats) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+    if (nds1->ndiskstats > nds2->ndiskstats) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->ndiskstats < nds2->ndiskstats) {
+        return PMIX_VALUE2_GREATER;
+    }
+    for (n=0; n < nds1->ndiskstats; n++) {
+        rc = cmp_diskstats(&nds1->diskstats[n], &nds2->diskstats[n]);
+        if (PMIX_EQUAL != rc) {
+            return rc;
+        }
+    }
+    if (NULL != nds1->netstats && NULL == nds2->netstats) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == nds1->netstats && NULL == nds2->netstats) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+    if (nds1->nnetstats > nds2->nnetstats) {
+        return PMIX_VALUE1_GREATER;
+    } else if (nds1->nnetstats < nds2->nnetstats) {
+        return PMIX_VALUE2_GREATER;
+    }
+    for (n=0; n < nds1->nnetstats; n++) {
+        rc = cmp_netstats(&nds1->netstats[n], &nds2->netstats[n]);
+        if (PMIX_EQUAL != rc) {
+            return rc;
+        }
+    }
+
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_regattr(pmix_regattr_t *r1,
+                                    pmix_regattr_t *r2)
+{
+    int ret, c1, c2, n;
+
+    if (NULL == r1->name && NULL == r2->name) {
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+    if (NULL != r1->name) {
+        if (NULL == r2->name) {
+            return PMIX_VALUE1_GREATER;
+        }
+        ret = strcmp(r1->name, r2->name);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != r2->name) {
+        /* we know r1->name had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL and equal */
+
+    ret = strcmp(r1->string, r2->string);
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+
+    if (r1->type > r2->type) {
+        return PMIX_VALUE1_GREATER;
+    } else if (r2->type > r1->type) {
+        return PMIX_VALUE2_GREATER;
+    }
+
+    if (NULL == r1->description && NULL == r2->description) {
+        return PMIX_EQUAL;
+    } else if (NULL != r1->description && NULL == r2->description) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == r1->description && NULL != r2->description) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+    c1 = pmix_argv_count(r1->description);
+    c2 = pmix_argv_count(r2->description);
+    if (c1 > c2) {
+        return PMIX_VALUE1_GREATER;
+    } else if (c2 > c1) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* same number of lines */
+    for (n=0; n < c1; n++) {
+        ret = strcmp(r1->description[n], r2->description[n]);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (ret > 0) {
+            return PMIX_VALUE1_GREATER;
+        }
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_info(pmix_info_t *i1,
+                                 pmix_info_t *i2)
+{
+    int ret;
+    pmix_value_cmp_t rc;
+
+    ret = strcmp(i1->key, i2->key);
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (ret > 0) {
+        return PMIX_VALUE1_GREATER;
+    }
+    rc = pmix_bfrops_base_value_cmp(&i1->value, &i2->value);
+    return rc;
+}
+
+static pmix_value_cmp_t cmp_dbuf(pmix_data_buffer_t *db1,
+                                 pmix_data_buffer_t *db2)
+{
+    int ret;
+
+    if (NULL == db1->base_ptr && NULL == db2->base_ptr) {
+        return PMIX_EQUAL;
+    }
+    if (NULL != db1->base_ptr) {
+        if (NULL == db2->base_ptr) {
+            return PMIX_VALUE1_GREATER;
+        }
+    } else if (NULL != db2->base_ptr) {
+        /* we know db1->base_ptr had to be NULL */
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+    if (db1->bytes_used > db2->bytes_used) {
+        return PMIX_VALUE1_GREATER;
+    } else if (db2->bytes_used > db1->bytes_used) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* same number of bytes used */
+    ret = memcmp(db1->base_ptr, db2->base_ptr, db1->bytes_used);
+    if (ret < 0) {
+        return PMIX_VALUE2_GREATER;
+    } else if (0 < ret) {
+        return PMIX_VALUE1_GREATER;
+    }
+    return PMIX_EQUAL;
+}
+
+static pmix_value_cmp_t cmp_darray(pmix_data_array_t *d1,
+                                   pmix_data_array_t *d2)
+{
+    size_t n;
+    int ret;
+    pmix_value_cmp_t rc;
+    char *st1, *st2;
+    pmix_byte_object_t *bo1, *bo2;
+    pmix_proc_info_t *pi1, *pi2;
+    pmix_coord_t *c1, *c2;
+    pmix_geometry_t *g1, *g2;
+    pmix_envar_t *e1, *e2;
+    pmix_topology_t *t1, *t2;
+    pmix_cpuset_t *cs1, *cs2;
+    pmix_device_distance_t *dd1, *dd2;
+    pmix_endpoint_t *end1, *end2;
+    pmix_proc_stats_t *pcs1, *pcs2;
+    pmix_disk_stats_t *ds1, *ds2;
+    pmix_net_stats_t *ns1, *ns2;
+    pmix_node_stats_t *nds1, *nds2;
+    pmix_regattr_t *ra1, *ra2;
+    pmix_info_t *i1, *i2;
+    pmix_data_buffer_t *db1, *db2;
+
+    if (NULL == d1 && NULL == d2) {
+        return PMIX_EQUAL;
+    } else if (NULL != d1 && NULL == d2) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == d1) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    if (d1->type != d2->type) {
+        return PMIX_VALUE_TYPE_DIFFERENT;
+    }
+
+    if (NULL == d1->array && NULL == d2->array) {
+        return PMIX_EQUAL;
+    } else if (NULL != d1->array && NULL == d2->array) {
+        return PMIX_VALUE1_GREATER;
+    } else if (NULL == d1->array) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* both are non-NULL */
+
+    if (d1->size > d2->size) {
+        return PMIX_VALUE1_GREATER;
+    } else if (d1->size < d2->size) {
+        return PMIX_VALUE2_GREATER;
+    }
+    /* they are the same size */
+    if (0 == d1->size) {
+        return PMIX_EQUAL;
+    }
+    /* the size is greater than zero */
+
+    switch (d1->type) {
+        case PMIX_UNDEF:
+            return PMIX_EQUAL;
+            break;
+        case PMIX_BOOL:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(bool));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_BYTE:
+            ret = memcmp(d1->array, d2->array, d1->size);
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_STRING:
+            st1 = (char*)d1->array;
+            st2 = (char*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_string(&st1[n], &st2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_SIZE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(size_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PID:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pid_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INT:
+        case PMIX_UINT:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(int));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INT8:
+        case PMIX_UINT8:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(int8_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INT16:
+        case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(int16_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INT32:
+        case PMIX_UINT32:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(int32_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INT64:
+        case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(int64_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_FLOAT:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(float));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_DOUBLE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(double));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_TIMEVAL:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(struct timeval));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_TIME:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(time_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_STATUS:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_status_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PROC_RANK:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_rank_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PROC_NSPACE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_nspace_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PROC:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_proc_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_INFO:
+            i1 = (pmix_info_t*)d1->array;
+            i2 = (pmix_info_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_info(&i1[n], &i2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+        case PMIX_REGEX:
+            bo1 = (pmix_byte_object_t*)d1->array;
+            bo2 = (pmix_byte_object_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_byte_object(&bo1[n], &bo2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_PERSIST:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_persistence_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_SCOPE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_scope_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_DATA_RANGE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_data_range_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PROC_STATE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_proc_state_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_PROC_INFO:
+            pi1 = (pmix_proc_info_t*)d1->array;
+            pi2 = (pmix_proc_info_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_proc_info(&pi1[n], &pi2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_DATA_ARRAY:
+            return cmp_darray(d1->array, d2->array);
+            break;
+        case PMIX_POINTER:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(void*));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_ALLOC_DIRECTIVE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_alloc_directive_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_ENVAR:
+            e1 = (pmix_envar_t*)d1->array;
+            e2 = (pmix_envar_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_envar(&e1[n], &e2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_COORD:
+            c1 = (pmix_coord_t*)d1->array;
+            c2 = (pmix_coord_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_coord(&c1[n], &c2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_LINK_STATE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_link_state_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_JOB_STATE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_job_state_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_TOPO:
+            t1 = (pmix_topology_t *)d1->array;
+            t2 = (pmix_topology_t *)d1->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_topo(&t1[n], &t2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_PROC_CPUSET:
+            cs1 = (pmix_cpuset_t *)d1->array;
+            cs2 = (pmix_cpuset_t *)d1->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_cpuset(&cs1[n], &cs2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_LOCTYPE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_locality_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_GEOMETRY:
+            g1 = (pmix_geometry_t*)d1->array;
+            g2 = (pmix_geometry_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_geometry(&g1[n], &g2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_DEVTYPE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_device_type_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
+        case PMIX_DEVICE_DIST:
+            dd1 = (pmix_device_distance_t*)d1->array;
+            dd2 = (pmix_device_distance_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_devdist(&dd1[n], &dd2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_ENDPOINT:
+            end1 = (pmix_endpoint_t*)d1->array;
+            end2 = (pmix_endpoint_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_endpoint(&end1[n], &end2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_DATA_BUFFER:
+            db1 = (pmix_data_buffer_t*)d1->array;
+            db2 = (pmix_data_buffer_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_dbuf(&db1[n], &db2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_PROC_STATS:
+            pcs1 = (pmix_proc_stats_t*)d1->array;
+            pcs2 = (pmix_proc_stats_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_procstats(&pcs1[n], &pcs2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_DISK_STATS:
+            ds1 = (pmix_disk_stats_t*)d1->array;
+            ds2 = (pmix_disk_stats_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_diskstats(&ds1[n], &ds2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_NET_STATS:
+            ns1 = (pmix_net_stats_t*)d1->array;
+            ns2 = (pmix_net_stats_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_netstats(&ns1[n], &ns2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        case PMIX_NODE_STATS:
+            nds1 = (pmix_node_stats_t*)d1->array;
+            nds2 = (pmix_node_stats_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_nodestats(&nds1[n], &nds2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+
+        case PMIX_REGATTR:
+            ra1 = (pmix_regattr_t*)d1->array;
+            ra2 = (pmix_regattr_t*)d2->array;
+            for (n=0; n < d1->size; n++) {
+                rc = cmp_regattr(&ra1[n], &ra2[n]);
+                if (PMIX_EQUAL != rc) {
+                    return rc;
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+
+        default:
+            pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %s (%d)",
+                        PMIx_Data_type_string(d1->type), (int) d1->type);
+    }
+    return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+
+}
+
+/* compare function for pmix_value_t */
+pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p1,
+                                            pmix_value_t *p2)
+{
+    pmix_value_cmp_t rc;
+    int ret;
+
+    if (p1->type != p2->type) {
+        return PMIX_VALUE_TYPE_DIFFERENT;
+    }
+
+    switch (p1->type) {
+    case PMIX_UNDEF:
+        return PMIX_EQUAL;
+        break;
+    case PMIX_BOOL:
+        ret = memcmp(&p1->data.flag, &p2->data.flag, sizeof(bool));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_BYTE:
+        ret = memcmp(&p1->data.byte, &p2->data.byte, 1);
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_STRING:
+        rc = cmp_string(p1->data.string, p2->data.string);
+        return rc;
+        break;
+    case PMIX_SIZE:
+        ret = memcmp(&p1->data.size, &p2->data.size, sizeof(size_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PID:
+        ret = memcmp(&p1->data.pid, &p2->data.pid, sizeof(pid_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_INT:
+    case PMIX_UINT:
+        ret = memcmp(&p1->data.integer, &p2->data.integer, sizeof(int));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_INT8:
+    case PMIX_UINT8:
+        ret = memcmp(&p1->data.int8, &p2->data.int8, sizeof(int8_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_INT16:
+    case PMIX_UINT16:
+    case PMIX_STOR_ACCESS_TYPE:
+        ret = memcmp(&p1->data.int16, &p2->data.int16, sizeof(int16_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_INT32:
+    case PMIX_UINT32:
+        ret = memcmp(&p1->data.int32, &p2->data.int32, sizeof(int32_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_INT64:
+    case PMIX_UINT64:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
+        ret = memcmp(&p1->data.int64, &p2->data.int64, sizeof(int64_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_FLOAT:
+        ret = memcmp(&p1->data.fval, &p2->data.fval, sizeof(float));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_DOUBLE:
+        ret = memcmp(&p1->data.dval, &p2->data.dval, sizeof(double));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_TIMEVAL:
+        ret = memcmp(&p1->data.tv, &p2->data.tv, sizeof(struct timeval));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_TIME:
+        ret = memcmp(&p1->data.time, &p2->data.time, sizeof(time_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_STATUS:
+        ret = memcmp(&p1->data.status, &p2->data.status, sizeof(pmix_status_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PROC_RANK:
+        ret = memcmp(&p1->data.rank, &p2->data.rank, sizeof(pmix_rank_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PROC_NSPACE:
+        ret = memcmp(p1->data.nspace, p2->data.nspace, sizeof(pmix_nspace_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PROC:
+        ret = memcmp(p1->data.proc, p2->data.proc, sizeof(pmix_proc_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_BYTE_OBJECT:
+    case PMIX_COMPRESSED_STRING:
+    case PMIX_COMPRESSED_BYTE_OBJECT:
+    case PMIX_REGEX:
+        rc = cmp_byte_object(&p1->data.bo, &p2->data.bo);
+        return rc;
+        break;
+    case PMIX_PERSIST:
+        ret = memcmp(&p1->data.persist, &p2->data.persist, sizeof(pmix_persistence_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_SCOPE:
+        ret = memcmp(&p1->data.scope, &p2->data.scope, sizeof(pmix_scope_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_DATA_RANGE:
+        ret = memcmp(&p1->data.range, &p2->data.range, sizeof(pmix_data_range_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PROC_STATE:
+        ret = memcmp(&p1->data.state, &p2->data.state, sizeof(pmix_proc_state_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_PROC_INFO:
+        rc = cmp_proc_info(p1->data.pinfo, p2->data.pinfo);
+        return rc;
+        break;
+    case PMIX_DATA_ARRAY:
+        return cmp_darray(p1->data.darray, p2->data.darray);
+        break;
+    case PMIX_POINTER:
+        ret = memcmp(p1->data.ptr, p2->data.ptr, sizeof(void*));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_ALLOC_DIRECTIVE:
+        ret = memcmp(&p1->data.adir, &p2->data.adir, sizeof(pmix_alloc_directive_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_ENVAR:
+        rc = cmp_envar(&p1->data.envar, &p2->data.envar);
+        return rc;
+        break;
+    case PMIX_COORD:
+        rc = cmp_coord(p1->data.coord, p2->data.coord);
+        return rc;
+        break;
+    case PMIX_LINK_STATE:
+        ret = memcmp(&p1->data.linkstate, &p2->data.linkstate, sizeof(pmix_link_state_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_JOB_STATE:
+        ret = memcmp(&p1->data.jstate, &p2->data.jstate, sizeof(pmix_job_state_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_TOPO:
+        rc = cmp_topo(p1->data.topo, p2->data.topo);
+        return rc;
+        break;
+    case PMIX_PROC_CPUSET:
+        rc = cmp_cpuset(p1->data.cpuset, p2->data.cpuset);
+        return rc;
+        break;
+        case PMIX_LOCTYPE:
+        ret = memcmp(&p1->data.locality, &p2->data.locality, sizeof(pmix_locality_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_GEOMETRY:
+        rc = cmp_geometry(p1->data.geometry, p2->data.geometry);
+        return rc;
+        break;
+        case PMIX_DEVTYPE:
+        ret = memcmp(&p1->data.devtype, &p2->data.devtype, sizeof(pmix_device_type_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_DEVICE_DIST:
+        rc = cmp_devdist(p1->data.devdist, p2->data.devdist);
+        return rc;
+        break;
+    case PMIX_ENDPOINT:
+        rc = cmp_endpoint(p1->data.endpoint, p2->data.endpoint);
+        return rc;
+        break;
+    case PMIX_DATA_BUFFER:
+        rc = cmp_dbuf(p1->data.dbuf, p2->data.dbuf);
+        return rc;
+        break;
+    case PMIX_PROC_STATS:
+        rc = cmp_procstats(p1->data.pstats, p2->data.pstats);
+        return rc;
+        break;
+    case PMIX_DISK_STATS:
+        rc = cmp_diskstats(p1->data.dkstats, p2->data.dkstats);
+        return rc;
+        break;
+    case PMIX_NET_STATS:
+        rc = cmp_netstats(p1->data.netstats, p2->data.netstats);
+        return rc;
+        break;
+    case PMIX_NODE_STATS:
+        rc = cmp_nodestats(p1->data.ndstats, p2->data.ndstats);
+        return rc;
+        break;
+
+    /* account for types that don't use a specific field
+     * in the union */
+    case PMIX_REGATTR:
+        rc = cmp_regattr(p1->data.ptr, p2->data.ptr);
+        return rc;
+        break;
+
+    default:
+        pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %s (%d)",
+                    PMIx_Data_type_string(p1->type), (int) p1->type);
+    }
+    return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+}

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -54,10 +54,20 @@ PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *kv,
     return pmix_bfrops_base_value_unload(kv, data, sz);
 }
 
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val)
+{
+    pmix_bfrops_base_value_destruct(val);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src)
 {
     return pmix_bfrops_base_value_xfer(dest, src);
+}
+
+PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d)
+{
+    pmix_bfrops_base_darray_destruct(d);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
@@ -76,11 +86,20 @@ PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
 PMIX_EXPORT pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
                                          const pmix_info_t *src)
 {
+    pmix_status_t rc;
+
     if (NULL == dest || NULL == src) {
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_LOAD_KEY(dest->key, src->key);
-    return PMIx_Value_xfer(&dest->value, &src->value);
+    dest->flags = src->flags;
+    if (PMIX_INFO_IS_PERSISTENT(src)) {
+        memcpy(&dest->value, &src->value, sizeof(pmix_value_t));
+        rc = PMIX_SUCCESS;
+    } else {
+        rc = PMIx_Value_xfer(&dest->value, &src->value);
+    }
+    return rc;
 }
 
 void pmix_bfrops_base_value_load(pmix_value_t *v,
@@ -678,169 +697,291 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
     return rc;
 }
 
-/* compare function for pmix_value_t */
-pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p, pmix_value_t *p1)
+void pmix_bfrops_base_darray_destruct(pmix_data_array_t *d)
 {
-    pmix_value_cmp_t rc = PMIX_VALUE1_GREATER;
-    int ret;
+    size_t n;
+    char **s;
+    pmix_value_t *vt;
+    pmix_app_t *ap;
+    pmix_info_t *info;
+    pmix_pdata_t *pd;
+    pmix_buffer_t *pb;
+    pmix_byte_object_t *bo;
+    pmix_kval_t *kv;
+    pmix_proc_info_t *pi;
+    pmix_data_array_t *darray;
+    pmix_query_t *q;
+    pmix_envar_t *ev;
+    pmix_coord_t *coord;
+    pmix_regattr_t *reg;
+    pmix_cpuset_t *cp;
+    pmix_topology_t *topo;
+    pmix_geometry_t *geo;
+    pmix_device_distance_t *dvd;
+    pmix_endpoint_t *endpt;
+    pmix_data_buffer_t *db;
+    pmix_proc_stats_t *pstats;
+    pmix_disk_stats_t *dkstats;
+    pmix_net_stats_t *netstats;
+    pmix_node_stats_t *ndstats;
 
-    if (p->type != p1->type) {
-        return rc;
+    switch (d->type) {
+        case PMIX_STRING:
+            s = (char**)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != s[n]) {
+                    pmix_free(s[n]);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_VALUE:
+            vt = (pmix_value_t*)d->array;
+            PMIX_VALUE_FREE(vt, d->size);
+            break;
+        case PMIX_APP:
+            ap = (pmix_app_t*)d->array;
+            PMIX_APP_FREE(ap, d->size);
+            break;
+        case PMIX_INFO:
+            info = (pmix_info_t*)d->array;
+            PMIX_INFO_FREE(info, d->size);
+            break;
+        case PMIX_PDATA:
+            pd = (pmix_pdata_t*)d->array;
+            PMIX_PDATA_FREE(pd, d->size);
+            break;
+        case PMIX_BUFFER:
+            pb = (pmix_buffer_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                PMIX_DESTRUCT(&pb[n]);
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            bo = (pmix_byte_object_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != bo[n].bytes) {
+                    pmix_free(bo[n].bytes);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_KVAL:
+            kv = (pmix_kval_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != kv[n].key) {
+                    pmix_free(kv[n].key);
+                }
+                if (NULL != kv[n].value) {
+                    PMIX_VALUE_FREE(kv[n].value, 1);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_PROC_INFO:
+            pi = (pmix_proc_info_t*)d->array;
+            PMIX_PROC_INFO_FREE(pi, d->size);
+            break;
+        case PMIX_DATA_ARRAY:
+            darray = (pmix_data_array_t *) d->array;
+            pmix_bfrops_base_darray_destruct(darray);
+            break;
+        case PMIX_QUERY:
+            q = (pmix_query_t*)d->array;
+            PMIX_QUERY_FREE(q, d->size);
+            break;
+        case PMIX_ENVAR:
+            ev = (pmix_envar_t*)d->array;
+            PMIX_ENVAR_FREE(ev, d->size);
+            break;
+        case PMIX_COORD:
+            coord = (pmix_coord_t*)d->array;
+            PMIX_COORD_FREE(coord, d->size);
+            break;
+        case PMIX_REGATTR:
+            reg = (pmix_regattr_t*)d->array;
+            PMIX_REGATTR_FREE(reg, d->size);
+            break;
+        case PMIX_PROC_CPUSET:
+            cp = (pmix_cpuset_t*)d->array;
+            pmix_hwloc_release_cpuset(cp, d->size);
+            break;
+        case PMIX_TOPO:
+            topo = (pmix_topology_t*)d->array;
+            pmix_hwloc_release_topology(topo, d->size);
+            break;
+        case PMIX_GEOMETRY:
+            geo = (pmix_geometry_t*)d->array;
+            PMIX_GEOMETRY_FREE(geo, d->size);
+            break;
+        case PMIX_DEVICE_DIST:
+            dvd = (pmix_device_distance_t*)d->array;
+            PMIX_DEVICE_DIST_FREE(dvd, d->size);
+            break;
+        case PMIX_ENDPOINT:
+            endpt = (pmix_endpoint_t*)d->array;
+            PMIX_ENDPOINT_FREE(endpt, d->size);
+            break;
+        case PMIX_REGEX:
+            bo = (pmix_byte_object_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                if (NULL != bo[n].bytes) {
+                    pmix_preg.release(bo[n].bytes);
+                }
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_DATA_BUFFER:
+            db = (pmix_data_buffer_t*)d->array;
+            for (n=0; n < d->size; n++) {
+                PMIX_DATA_BUFFER_DESTRUCT(&db[n]);
+            }
+            pmix_free(d->array);
+            break;
+        case PMIX_PROC_STATS:
+            pstats = (pmix_proc_stats_t*)d->array;
+            PMIX_PROC_STATS_FREE(pstats, d->size);
+            break;
+        case PMIX_DISK_STATS:
+            dkstats = (pmix_disk_stats_t*)d->array;
+            PMIX_DISK_STATS_FREE(dkstats, d->size);
+            break;
+        case PMIX_NET_STATS:
+            netstats = (pmix_net_stats_t*)d->array;
+            PMIX_NET_STATS_FREE(netstats, d->size);
+            break;
+        case PMIX_NODE_STATS:
+            ndstats = (pmix_node_stats_t*)d->array;
+            PMIX_NODE_STATS_FREE(ndstats, d->size);
+            break;
+
+        default:
+            if (NULL != d->array) {
+                pmix_free(d->array);
+            }
+            break;
     }
+    d->array = NULL;
+    d->type = PMIX_UNDEF;
+    d->size = 0;
+    return;
+}
 
-    switch (p->type) {
-    case PMIX_UNDEF:
-        rc = PMIX_EQUAL;
-        break;
-    case PMIX_BOOL:
-        if (p->data.flag == p1->data.flag) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_BYTE:
-        if (p->data.byte == p1->data.byte) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_SIZE:
-        if (p->data.size == p1->data.size) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_INT:
-        if (p->data.integer == p1->data.integer) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_INT8:
-        if (p->data.int8 == p1->data.int8) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_INT16:
-        if (p->data.int16 == p1->data.int16) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_INT32:
-        if (p->data.int32 == p1->data.int32) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_INT64:
-        if (p->data.int64 == p1->data.int64) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_UINT:
-        if (p->data.uint == p1->data.uint) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_UINT8:
-        if (p->data.uint8 == p1->data.int8) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_UINT16:
-    case PMIX_STOR_ACCESS_TYPE:
-        if (p->data.uint16 == p1->data.uint16) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_UINT32:
-        if (p->data.uint32 == p1->data.uint32) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_UINT64:
-    case PMIX_STOR_MEDIUM:
-    case PMIX_STOR_ACCESS:
-    case PMIX_STOR_PERSIST:
-        if (p->data.uint64 == p1->data.uint64) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_STRING:
-        if (0 == strcmp(p->data.string, p1->data.string)) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_COMPRESSED_STRING:
-        if (p->data.bo.size > p1->data.bo.size) {
-            return PMIX_VALUE2_GREATER;
-        } else {
-            return PMIX_VALUE1_GREATER;
-        }
-    case PMIX_STATUS:
-        if (p->data.status == p1->data.status) {
-            rc = PMIX_EQUAL;
-        }
-        break;
-    case PMIX_ENVAR:
-        if (NULL != p->data.envar.envar) {
-            if (NULL == p1->data.envar.envar) {
-                return PMIX_VALUE1_GREATER;
+void pmix_bfrops_base_value_destruct(pmix_value_t *v)
+{
+    switch (v->type) {
+        case PMIX_STRING:
+            if (NULL != v->data.string) {
+                free(v->data.string);
             }
-            ret = strcmp(p->data.envar.envar, p1->data.envar.envar);
-            if (ret < 0) {
-                return PMIX_VALUE2_GREATER;
-            } else if (0 < ret) {
-                return PMIX_VALUE1_GREATER;
+            break;
+        case PMIX_PROC:
+            if (NULL != v->data.proc) {
+                PMIX_PROC_FREE(v->data.proc, 1);
             }
-        } else if (NULL != p1->data.envar.envar) {
-            /* we know value1->envar had to be NULL */
-            return PMIX_VALUE2_GREATER;
-        }
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            if (NULL != v->data.bo.bytes) {
+                free(v->data.bo.bytes);
+            }
+            break;
+        case PMIX_PROC_INFO:
+            if (NULL != v->data.pinfo) {
+                PMIX_PROC_INFO_FREE(v->data.pinfo, 1);
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            if (NULL != v->data.darray) {
+                pmix_bfrops_base_darray_destruct(v->data.darray);
+            }
+            break;
+        case PMIX_ENVAR:
+            if (NULL != v->data.envar.envar) {
+                free(v->data.envar.envar);
+            }
+            if (NULL != v->data.envar.value) {
+                free(v->data.envar.value);
+            }
+            break;
+        case PMIX_COORD:
+            if (NULL != v->data.coord) {
+                PMIX_COORD_FREE(v->data.coord, 1);
+            }
+            break;
+        case PMIX_TOPO:
+            if (NULL != v->data.topo) {
+                pmix_hwloc_release_topology(v->data.topo, 1);
+            }
+            break;
+        case PMIX_PROC_CPUSET:
+            if (NULL != v->data.cpuset) {
+                pmix_hwloc_release_cpuset(v->data.cpuset, 1);
+            }
+            break;
+        case PMIX_GEOMETRY:
+            if (NULL != v->data.geometry) {
+                PMIX_GEOMETRY_FREE(v->data.geometry, 1);
+            }
+            break;
+        case PMIX_DEVICE_DIST:
+            if (NULL != v->data.devdist) {
+                PMIX_DEVICE_DIST_DESTRUCT(v->data.devdist);
+            }
+            break;
+        case PMIX_ENDPOINT:
+            if (NULL != v->data.endpoint) {
+                PMIX_ENDPOINT_DESTRUCT(v->data.endpoint);
+            }
+            break;
+        case PMIX_REGATTR:
+            if (NULL != v->data.ptr) {
+                PMIX_REGATTR_DESTRUCT((pmix_regattr_t*)v->data.ptr);
+            }
+            break;
+        case PMIX_REGEX:
+            if (NULL != v->data.bo.bytes) {
+                pmix_preg.release(v->data.bo.bytes);
+            }
+            break;
+        case PMIX_DATA_BUFFER:
+            if (NULL != v->data.dbuf) {
+                PMIX_DATA_BUFFER_RELEASE(v->data.dbuf);
+            }
+            break;
+        case PMIX_PROC_STATS:
+            if (NULL != v->data.pstats) {
+                PMIX_PROC_STATS_RELEASE(v->data.pstats);
+            }
+            break;
+        case PMIX_DISK_STATS:
+            if (NULL != v->data.dkstats) {
+                PMIX_DISK_STATS_RELEASE(v->data.dkstats);
+            }
+            break;
+        case PMIX_NET_STATS:
+            if (NULL != v->data.netstats) {
+                PMIX_NET_STATS_RELEASE(v->data.netstats);
+            }
+            break;
+        case PMIX_NODE_STATS:
+            if (NULL != v->data.ndstats) {
+                PMIX_NODE_STATS_RELEASE(v->data.ndstats);
+            }
+            break;
 
-        /* if both are NULL or are equal, then check value */
-        if (NULL != p->data.envar.value) {
-            if (NULL == p1->data.envar.value) {
-                return PMIX_VALUE1_GREATER;
-            }
-            ret = strcmp(p->data.envar.value, p1->data.envar.value);
-            if (ret < 0) {
-                return PMIX_VALUE2_GREATER;
-            } else if (0 < ret) {
-                return PMIX_VALUE1_GREATER;
-            }
-        } else if (NULL != p1->data.envar.value) {
-            /* we know value1->value had to be NULL */
-            return PMIX_VALUE2_GREATER;
-        }
-
-        /* finally, check separator */
-        if (p->data.envar.separator < p1->data.envar.separator) {
-            return PMIX_VALUE2_GREATER;
-        }
-        if (p1->data.envar.separator < p->data.envar.separator) {
-            return PMIX_VALUE1_GREATER;
-        }
-        rc = PMIX_EQUAL;
-        break;
-    case PMIX_COORD:
-        ret = memcmp(p->data.coord, p1->data.coord, sizeof(pmix_coord_t));
-        if (0 > ret) {
-            return PMIX_VALUE2_GREATER;
-        } else if (0 < ret) {
-            return PMIX_VALUE1_GREATER;
-        } else {
-            return PMIX_EQUAL;
-        }
-    case PMIX_REGATTR:
-        ret = memcmp(p->data.ptr, p1->data.ptr, sizeof(pmix_regattr_t));
-        if (0 > ret) {
-            return PMIX_VALUE2_GREATER;
-        } else if (0 < ret) {
-            return PMIX_VALUE1_GREATER;
-        } else {
-            return PMIX_EQUAL;
-        }
-
-    default:
-        pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int) p->type);
+        default:
+            /* silence warnings */
+            break;
     }
-    return rc;
+    // mark the value as no longer defined
+    memset(v, 0, sizeof(pmix_value_t));
+    v->type = PMIX_UNDEF;
+    return;
 }
 
 /* Xfer FUNCTIONS FOR GENERIC PMIX TYPES */
@@ -1181,6 +1322,26 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
     return PMIX_SUCCESS;
 }
 
+PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr,
+                                                pmix_info_t *info)
+{
+    pmix_list_t *p = (pmix_list_t *) ptr;
+    pmix_infolist_t *iptr;
+
+    iptr = PMIX_NEW(pmix_infolist_t);
+    if (NULL == iptr) {
+        return PMIX_ERR_NOMEM;
+    }
+    /* we want to preserve any pointes in the provided
+     * info struct so the result points to the same
+     * memory location */
+    memcpy(&iptr->info, info, sizeof(pmix_info_t));
+    // mark that this value should not be released
+    PMIX_INFO_SET_PERSISTENT(&iptr->info);
+    pmix_list_append(p, &iptr->super);
+    return PMIX_SUCCESS;
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr, const pmix_info_t *info)
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
@@ -1190,7 +1351,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr, const pmix_info_t *info
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
     }
-    PMIX_INFO_XFER(&iptr->info, info);
+    PMIx_Info_xfer(&iptr->info, info);
     pmix_list_append(p, &iptr->super);
     return PMIX_SUCCESS;
 }
@@ -1222,7 +1383,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
     /* transfer the elements across */
     n = 0;
     PMIX_LIST_FOREACH (iptr, p, pmix_infolist_t) {
-        PMIX_INFO_XFER(&array[n], &iptr->info);
+        PMIx_Info_xfer(&array[n], &iptr->info);
         ++n;
     }
 

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -696,7 +696,7 @@ pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src)
                 PMIX_LOAD_KEY(pd[n].key, sd[n].key);
                 rc = PMIx_Value_xfer(&pd[n].value, &sd[n].value);
                 if (PMIX_SUCCESS != rc) {
-                    PMIX_INFO_FREE(pd, src->data.darray->size);
+                    PMIX_PDATA_FREE(pd, src->data.darray->size);
                     return rc;
                 }
             }

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -408,11 +408,23 @@ typedef pmix_status_t (*pmix_gds_base_module_del_nspace_fn_t)(const char* nspace
         } else {                                            \
             (s) = PMIX_ERR_NOT_SUPPORTED;                   \
         }                                                   \
-} while(0)
+    } while(0)
 
-/**
-* structure for gds modules
-*/
+typedef pmix_status_t (*pmix_gds_base_module_fetch_array_fn_t)(struct pmix_peer_t *pr,
+                                                               pmix_buffer_t *reply);
+/* define a convenience macro for fetching array info for
+ * a given peer */
+#define PMIX_GDS_FETCH_INFO_ARRAYS(s, p, b)                                 \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS FETCH ARRAYS WITH %s",             \
+                            __FILE__, __LINE__, _g->name);                  \
+        (s) = _g->fetch_arrays((struct pmix_peer_t*)(p), b);                \
+    } while(0)
+
+
+/* structure for gds modules */
 typedef struct {
     const char *name;
     const bool is_tsafe;
@@ -430,6 +442,7 @@ typedef struct {
     pmix_gds_base_module_del_nspace_fn_t            del_nspace;
     pmix_gds_base_module_assemb_kvs_req_fn_t        assemb_kvs_req;
     pmix_gds_base_module_accept_kvs_resp_fn_t       accept_kvs_resp;
+    pmix_gds_base_module_fetch_array_fn_t           fetch_arrays;
 
 } pmix_gds_base_module_t;
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -82,22 +82,25 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, p
 
 static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
 
-pmix_gds_base_module_t pmix_hash_module = {.name = "hash",
-                                           .is_tsafe = false,
-                                           .init = hash_init,
-                                           .finalize = hash_finalize,
-                                           .assign_module = hash_assign_module,
-                                           .cache_job_info = hash_cache_job_info,
-                                           .register_job_info = hash_register_job_info,
-                                           .store_job_info = hash_store_job_info,
-                                           .store = pmix_gds_hash_store,
-                                           .store_modex = hash_store_modex,
-                                           .fetch = pmix_gds_hash_fetch,
-                                           .setup_fork = setup_fork,
-                                           .add_nspace = nspace_add,
-                                           .del_nspace = nspace_del,
-                                           .assemb_kvs_req = assemb_kvs_req,
-                                           .accept_kvs_resp = accept_kvs_resp};
+pmix_gds_base_module_t pmix_hash_module = {
+    .name = "hash",
+    .is_tsafe = false,
+    .init = hash_init,
+    .finalize = hash_finalize,
+    .assign_module = hash_assign_module,
+    .cache_job_info = hash_cache_job_info,
+    .register_job_info = hash_register_job_info,
+    .store_job_info = hash_store_job_info,
+    .store = pmix_gds_hash_store,
+    .store_modex = hash_store_modex,
+    .fetch = pmix_gds_hash_fetch,
+    .setup_fork = setup_fork,
+    .add_nspace = nspace_add,
+    .del_nspace = nspace_del,
+    .assemb_kvs_req = assemb_kvs_req,
+    .accept_kvs_resp = accept_kvs_resp,
+    .fetch_arrays = pmix_gds_hash_fetch_arrays
+};
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -107,11 +107,16 @@ static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 
     PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
 
+    PMIX_CONSTRUCT(&mca_gds_hash_component.mysessions, pmix_list_t);
+    PMIX_CONSTRUCT(&mca_gds_hash_component.myjobs, pmix_list_t);
+
     return PMIX_SUCCESS;
 }
 
 static void hash_finalize(void)
 {
+    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.mysessions);
+    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.myjobs);
     return;
 }
 

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -121,6 +121,8 @@ extern pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *tr
 extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t scope,
                                          pmix_kval_t *kv);
 
+extern pmix_status_t pmix_gds_hash_fetch_arrays(struct pmix_peer_t *pr, pmix_buffer_t *reply);
+
 END_C_DECLS
 
 #endif

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -33,8 +33,6 @@
 #include "gds_hash.h"
 #include "src/mca/gds/gds.h"
 
-static pmix_status_t component_open(void);
-static pmix_status_t component_close(void);
 static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
 
 /*
@@ -54,8 +52,6 @@ pmix_gds_hash_component_t mca_gds_hash_component = {
                                        PMIX_RELEASE_VERSION),
 
             /* Component open and close functions */
-            .pmix_mca_open_component = component_open,
-            .pmix_mca_close_component = component_close,
             .pmix_mca_query_component = component_query,
             .reserved = {0}
         },
@@ -70,26 +66,10 @@ pmix_gds_hash_component_t mca_gds_hash_component = {
     .myjobs = PMIX_LIST_STATIC_INIT
 };
 
-static int component_open(void)
-{
-    PMIX_CONSTRUCT(&mca_gds_hash_component.mysessions, pmix_list_t);
-    PMIX_CONSTRUCT(&mca_gds_hash_component.myjobs, pmix_list_t);
-
-    return PMIX_SUCCESS;
-}
-
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     *priority = 10;
     *module = (pmix_mca_base_module_t *) &pmix_hash_module;
-    return PMIX_SUCCESS;
-}
-
-static int component_close(void)
-{
-    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.mysessions);
-    PMIX_LIST_DESTRUCT(&mca_gds_hash_component.myjobs);
-
     return PMIX_SUCCESS;
 }
 
@@ -158,9 +138,6 @@ static void apdes(pmix_apptrkr_t *p)
 {
     PMIX_LIST_DESTRUCT(&p->appinfo);
     PMIX_LIST_DESTRUCT(&p->nodeinfo);
-    if (NULL != p->job) {
-        PMIX_RELEASE(p->job);
-    }
 }
 PMIX_CLASS_INSTANCE(pmix_apptrkr_t, pmix_list_item_t, apcon, apdes);
 

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -315,7 +315,10 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
     }
     /* point the app at its job */
     if (NULL == app->job) {
-        PMIX_RETAIN(trk);
+        /* do NOT retain the tracker - we will not release
+         * it in the app destructor. If we retain the tracker,
+         * then we won't release it later because the refcount
+         * is wrong */
         app->job = trk;
     }
 

--- a/src/mca/preg/Makefile.am
+++ b/src/mca/preg/Makefile.am
@@ -31,6 +31,7 @@ libmca_preg_la_SOURCES =
 headers = preg.h preg_types.h
 sources =
 
+# install the header files
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
 

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,6 +85,8 @@ PMIX_EXPORT pmix_status_t pmix_preg_base_copy(char **dest, size_t *len, const ch
 PMIX_EXPORT pmix_status_t pmix_preg_base_pack(pmix_buffer_t *buffer, const char *input);
 
 PMIX_EXPORT pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex);
+
+PMIX_EXPORT pmix_status_t pmix_preg_base_release(char *regexp);
 
 END_C_DECLS
 

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -59,7 +59,8 @@ pmix_preg_module_t pmix_preg = {
     .parse_procs = pmix_preg_base_parse_procs,
     .copy = pmix_preg_base_copy,
     .pack = pmix_preg_base_pack,
-    .unpack = pmix_preg_base_unpack
+    .unpack = pmix_preg_base_unpack,
+    .release = pmix_preg_base_release
 };
 
 static pmix_status_t pmix_preg_close(void)

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -154,3 +154,17 @@ pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex)
     PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buffer, regex, &cnt, PMIX_STRING);
     return rc;
 }
+
+pmix_status_t pmix_preg_base_release(char *regexp)
+{
+    pmix_preg_base_active_module_t *active;
+
+    PMIX_LIST_FOREACH (active, &pmix_preg_globals.actives, pmix_preg_base_active_module_t) {
+        if (NULL != active->module->release) {
+            if (PMIX_SUCCESS == active->module->release(regexp)) {
+                return PMIX_SUCCESS;
+            }
+        }
+    }
+    return PMIX_ERR_BAD_PARAM;
+}

--- a/src/mca/preg/compress/preg_compress.h
+++ b/src/mca/preg/compress/preg_compress.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -26,7 +26,7 @@
 #endif
 #include <ctype.h>
 
-#include "pmix.h"
+#include "include/pmix.h"
 #include "pmix_common.h"
 
 #include "src/class/pmix_list.h"
@@ -50,15 +50,19 @@ static pmix_status_t parse_procs(const char *regexp, char ***procs);
 static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+static pmix_status_t release(char *regexp);
 
-pmix_preg_module_t pmix_preg_native_module = {.name = "pmix",
-                                              .generate_node_regex = generate_node_regex,
-                                              .generate_ppn = generate_ppn,
-                                              .parse_nodes = parse_nodes,
-                                              .parse_procs = parse_procs,
-                                              .copy = copy,
-                                              .pack = pack,
-                                              .unpack = unpack};
+pmix_preg_module_t pmix_preg_native_module = {
+    .name = "pmix",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack,
+    .release = release
+};
 
 static pmix_status_t regex_parse_value_ranges(char *base, char *ranges, int num_digits,
                                               char *suffix, char ***names);
@@ -402,10 +406,12 @@ static pmix_status_t generate_ppn(const char *input, char **regexp)
         while (NULL != (rng = (pmix_regex_range_t *) pmix_list_remove_first(&vreg->ranges))) {
             if (1 == rng->cnt) {
                 if (0 > asprintf(&tmp2, "%s%d,", tmp, rng->start)) {
+                    free(tmp);
                     return PMIX_ERR_NOMEM;
                 }
             } else {
                 if (0 > asprintf(&tmp2, "%s%d-%d,", tmp, rng->start, rng->start + rng->cnt - 1)) {
+                    free(tmp);
                     return PMIX_ERR_NOMEM;
                 }
             }
@@ -911,5 +917,18 @@ static pmix_status_t pmix_regex_extract_ppn(char *regexp, char ***procs)
     }
 
     pmix_argv_free(nds);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t release(char *regexp)
+{
+    if (NULL == regexp) {
+        return PMIX_SUCCESS;
+    }
+
+    if (0 != strncmp(regexp, "pmix", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    free(regexp);
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/native/preg_native.h
+++ b/src/mca/preg/native/preg_native.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,6 +83,8 @@ typedef pmix_status_t (*pmix_preg_base_module_pack_fn_t)(pmix_buffer_t *buffer, 
 
 typedef pmix_status_t (*pmix_preg_base_module_unpack_fn_t)(pmix_buffer_t *buffer, char **regex);
 
+typedef pmix_status_t (*pmix_preg_base_module_release_fn_t)(char *regexp);
+
 /**
  * Base structure for a PREG module
  */
@@ -95,6 +97,7 @@ typedef struct {
     pmix_preg_base_module_copy_fn_t copy;
     pmix_preg_base_module_pack_fn_t pack;
     pmix_preg_base_module_unpack_fn_t unpack;
+    pmix_preg_base_module_release_fn_t release;
 } pmix_preg_module_t;
 
 /* we just use the standard component definition */

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -26,7 +26,7 @@
 #endif
 #include <ctype.h>
 
-#include "pmix.h"
+#include "include/pmix.h"
 #include "pmix_common.h"
 
 #include "src/mca/bfrops/base/base.h"
@@ -44,15 +44,19 @@ static pmix_status_t parse_procs(const char *regexp, char ***procs);
 static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
+static pmix_status_t release(char *regexp);
 
-pmix_preg_module_t pmix_preg_raw_module = {.name = "raw",
-                                           .generate_node_regex = generate_node_regex,
-                                           .generate_ppn = generate_ppn,
-                                           .parse_nodes = parse_nodes,
-                                           .parse_procs = parse_procs,
-                                           .copy = copy,
-                                           .pack = pack,
-                                           .unpack = unpack};
+pmix_preg_module_t pmix_preg_raw_module = {
+    .name = "raw",
+    .generate_node_regex = generate_node_regex,
+    .generate_ppn = generate_ppn,
+    .parse_nodes = parse_nodes,
+    .parse_procs = parse_procs,
+    .copy = copy,
+    .pack = pack,
+    .unpack = unpack,
+    .release = release
+};
 
 static pmix_status_t generate_node_regex(const char *input, char **regexp)
 {
@@ -148,5 +152,17 @@ static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex)
     if (NULL == *regex) {
         return PMIX_ERR_NOMEM;
     }
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t release(char *regexp)
+{
+    if (NULL == regexp) {
+        return PMIX_SUCCESS;
+    }
+    if (0 != strncmp(regexp, "raw:", 4)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    free(regexp);
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/raw/preg_raw.h
+++ b/src/mca/preg/raw/preg_raw.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -44,6 +44,7 @@
 #include "src/mca/psec/base/base.h"
 #include "src/mca/psquash/base/base.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/threads/pmix_tsd.h"
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
@@ -61,11 +62,7 @@ void pmix_rte_finalize(void)
     pmix_notify_caddy_t *cd;
     pmix_iof_req_t *req;
 
-    if (--pmix_initialized != 0) {
-        if (pmix_initialized < 0) {
-            fprintf(stderr, "PMIx Finalize called too many times\n");
-            return;
-        }
+    if (!pmix_init_called) {
         return;
     }
 
@@ -147,4 +144,5 @@ void pmix_rte_finalize(void)
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_stop(NULL);
+    pmix_tsd_keys_destruct();
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -71,7 +71,6 @@ const char* pmix_tool_version = PMIX_VERSION;
 const char* pmix_tool_org = "PMIx";
 const char* pmix_tool_msg = PMIX_PROXY_BUGREPORT_STRING;
 
-PMIX_EXPORT int pmix_initialized = 0;
 PMIX_EXPORT bool pmix_init_called = false;
 /* we have to export the pmix_globals object so
  * all plugins can access it. However, it is included
@@ -191,13 +190,6 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_info_t *iptr;
     size_t minfo;
     bool keepfqdn = false;
-
-    if (++pmix_initialized != 1) {
-        if (pmix_initialized < 1) {
-            return PMIX_ERROR;
-        }
-        return PMIX_SUCCESS;
-    }
 
 #if PMIX_NO_LIB_DESTRUCTOR
     if (pmix_init_called) {

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -45,7 +45,6 @@ PMIX_EXPORT extern char *pmix_timing_output;
 PMIX_EXPORT extern bool pmix_timing_overhead;
 #endif
 
-PMIX_EXPORT extern int pmix_initialized;
 PMIX_EXPORT extern char *pmix_net_private_ipv4;
 PMIX_EXPORT extern int pmix_event_caching_window;
 PMIX_EXPORT extern bool pmix_suppress_missing_data_warning;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4438,7 +4438,19 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         PMIX_GDS_REGISTER_JOB_INFO(rc, peer, reply);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(reply);
             return rc;
+        }
+        /* if the peer is using the "dstore" component, then
+         * we also have to send back any session/node/app-level
+         * info so it can be stored locally in their hash */
+        if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
+            PMIX_GDS_FETCH_INFO_ARRAYS(rc, peer, reply);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(reply);
+                return rc;
+            }
         }
         PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, reply);
         if (PMIX_SUCCESS != rc) {

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -55,7 +55,16 @@ static void pdcon(pmix_proc_data_t *p)
 }
 static void pddes(pmix_proc_data_t *p)
 {
-    PMIX_LIST_DESTRUCT(&p->data);
+    pmix_kval_t *kv;
+
+    while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&p->data))){
+        if (!PMIX_CHECK_KEY(kv, PMIX_TOPOLOGY2)) {
+            PMIX_RELEASE(kv);
+        } else {
+            free(kv->key);
+            free(kv);
+        }
+    }
 }
 static PMIX_CLASS_INSTANCE(pmix_proc_data_t, pmix_list_item_t, pdcon, pddes);
 
@@ -260,7 +269,8 @@ pmix_status_t pmix_hash_fetch_by_key(pmix_hash_table_t *table, const char *key, 
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table, pmix_rank_t rank, const char *key)
+pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
+                                    pmix_rank_t rank, const char *key)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_data_t *proc_data;


### PR DESCRIPTION
Per the Standard, one can retrieve information about a process
from the node/app/session realms in two ways:

(a) by passing the proc ID along with a key that belongs to
    one of those realms. The PMIx library is responsible
    for identifying such keys and retrieving the specified
    info from the corresponding default realm. If the user
    wishes the key to be retrieved from a non-default realm,
    then they must include the attribute specifying that realm.

(b) by passing an invalid proc rank (e.g., wildcard or undef)
    and including attributes that specify the realm from which
    the given key is to be retrieved along with whatever
    further identification is required - e.g., PMIX_NODE_INFO
    combined with the hostname of the node whose information
    is being fetched.

This commit fixes both methods and provides an example (nodeinfo)
in the examples directory for using this feature.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 77fc96c5a045060810d23ba8080c62fbc074aefe)