### PR TITLE
Update the PMIx ABI Query attributes to match the standard

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -45,16 +45,16 @@ std_major=4
 std_minor=1
 std_extension=2
 
-# PMIx Standard ABI Compliance Level
-# The major and minor numbers indicate the version
+# PMIx Standard ABI Compliance Level(s)
+# The major and minor numbers (MAJOR.MINOR) indicate the version
 # of the official PMIx Standard ABI that is supported
-# by this release. Generally, the PMIx Standard ABI
-# should match the PMIx Standard Compliance Level
-# major/minor levels. However, they are listed separately
-# for maximal flexibility.
+# by this release. This may be a comma separated list (no spaces)
+# if more than one PMIx Standard ABI level is supported.
+# The PMIx Standard defines a 'stable' and a 'provisional' ABI.
+# Therefore, there are two sets of major/minor values.
 # Since no PMIx Standard ABI exists at the moment, set to "0.0"
-std_abi_major=0
-std_abi_minor=0
+std_abi_stable=0.0
+std_abi_provisional=0.0
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -157,15 +157,25 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_STD_VERSION], ["$PMIX_STD_VERSION"],
                        [The PMIx Standard compliance level])
 
-    AC_MSG_CHECKING([for pmix standard ABI version])
-    PMIX_STD_ABI_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-version`"
+    AC_MSG_CHECKING([for pmix standard stable ABI version(s)])
+    PMIX_STD_ABI_STABLE_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-stable-version`"
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_STD_ABI_VERSION])
-    AC_SUBST(PMIX_STD_ABI_VERSION)
-    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_VERSION], ["$PMIX_STD_ABI_VERSION"],
-                       [The PMIx Standard ABI compliance level])
+    AC_MSG_RESULT([$PMIX_STD_ABI_STABLE_VERSION])
+    AC_SUBST(PMIX_STD_ABI_STABLE_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_STABLE_VERSION], ["$PMIX_STD_ABI_STABLE_VERSION"],
+                       [The PMIx Standard Stable ABI compliance level(s)])
+
+    AC_MSG_CHECKING([for pmix standard provisional ABI version(s)])
+    PMIX_STD_ABI_PROVISIONAL_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-provisional-version`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_MSG_RESULT([$PMIX_STD_ABI_PROVISIONAL_VERSION])
+    AC_SUBST(PMIX_STD_ABI_PROVISIONAL_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_PROVISIONAL_VERSION], ["$PMIX_STD_ABI_PROVISIONAL_VERSION"],
+                       [The PMIx Standard Provisional ABI compliance level(s)])
 
     PMIX_REPO_REV="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --repo-rev`"
     if test "$?" != "0"; then

--- a/config/pmix_get_version.sh
+++ b/config/pmix_get_version.sh
@@ -57,8 +57,8 @@ else
     s/^greek/PMIX_GREEK_VERSION/
     s/^std_major/PMIX_STD_MAJOR_VERSION/
     s/^std_minor/PMIX_STD_MINOR_VERSION/
-    s/^std_abi_major/PMIX_STD_ABI_MAJOR_VERSION/
-    s/^std_abi_minor/PMIX_STD_ABI_MINOR_VERSION/
+    s/^std_abi_stable/PMIX_STD_ABI_STABLE_VERSION/
+    s/^std_abi_provisional/PMIX_STD_ABI_PROVISIONAL_VERSION/
     s/^repo_rev/PMIX_REPO_REV/
     s/^tarball_version/PMIX_TARBALL_VERSION/
     s/^date/PMIX_RELEASE_DATE/
@@ -72,7 +72,8 @@ else
         PMIX_VERSION="${PMIX_VERSION}${PMIX_GREEK_VERSION}"
 
         PMIX_STD_VERSION="$PMIX_STD_MAJOR_VERSION.$PMIX_STD_MINOR_VERSION"
-        PMIX_STD_ABI_VERSION="$PMIX_STD_ABI_MAJOR_VERSION.$PMIX_STD_ABI_MINOR_VERSION"
+        PMIX_STD_ABI_STABLE_VERSION="$PMIX_STD_ABI_STABLE_VERSION"
+        PMIX_STD_ABI_PROVISIONAL_VERSION="$PMIX_STD_ABI_PROVISIONAL_VERSION"
 
         if test "$PMIX_TARBALL_VERSION" = ""; then
             PMIX_TARBALL_VERSION=$PMIX_VERSION
@@ -132,8 +133,11 @@ case "$option" in
     --std-version)
     echo $PMIX_STD_VERSION
     ;;
-    --std-abi-version)
-    echo $PMIX_STD_ABI_VERSION
+    --std-abi-stable-version)
+    echo $PMIX_STD_ABI_STABLE_VERSION
+    ;;
+    --std-abi-provisional-version)
+    echo $PMIX_STD_ABI_PROVISIONAL_VERSION
     ;;
     --repo-rev)
     echo $PMIX_REPO_REV

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -97,7 +97,8 @@ PMIx configuration:
 -----------------------
 Version: $PMIX_MAJOR_VERSION.$PMIX_MINOR_VERSION.$PMIX_RELEASE_VERSION$PMIX_GREEK_VERSION
 PMIx Standard Version: $PMIX_STD_VERSION
-PMIx Standard ABI Version: $PMIX_STD_ABI_VERSION
+PMIx Standard Stable ABI Version(s): $PMIX_STD_ABI_STABLE_VERSION
+PMIx Standard Provisional ABI Version(s): $PMIX_STD_ABI_PROVISIONAL_VERSION
 EOF
 
     if test $WANT_DEBUG = 0 ; then

--- a/examples/abi_no_init.c
+++ b/examples/abi_no_init.c
@@ -25,10 +25,11 @@ int main(int argc, char **argv) {
     pmix_query_t *query = NULL;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
-    nqueries = 1;
+    nqueries = 2;
 
     PMIX_QUERY_CREATE(query, nqueries);
-    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_PROVISIONAL_ABI_VERSION);
 
     rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
     if (PMIX_SUCCESS != rc ) {
@@ -39,8 +40,12 @@ int main(int argc, char **argv) {
     printf("--> Query returned (ninfo %d)\n", (int)ninfo);
     for(i = 0; i < ninfo; ++i) {
         printf("--> KEY: %s\n", info[i].key);
-        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
-            printf("----> ABI: String: %s\n",
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_STABLE_ABI_VERSION)) {
+            printf("----> ABI (Stable): String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+            printf("----> ABI (Provisional): String: %s\n",
                    info[i].value.data.string);
         }
     }

--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -30,11 +30,12 @@ int main(int argc, char **argv) {
         exit(rc);
     }
 
-    nqueries = 2;
+    nqueries = 3;
 
     PMIX_QUERY_CREATE(query, nqueries);
-    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
-    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_NAMESPACES);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_PROVISIONAL_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[2].keys, PMIX_QUERY_NAMESPACES);
 
     rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
     if (PMIX_SUCCESS != rc ) {
@@ -45,8 +46,12 @@ int main(int argc, char **argv) {
     printf("--> Query returned (ninfo %d)\n", (int)ninfo);
     for(i = 0; i < ninfo; ++i) {
         printf("--> KEY: %s\n", info[i].key);
-        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
-            printf("----> ABI: String: %s\n",
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_STABLE_ABI_VERSION)) {
+            printf("----> ABI (Stable): String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+            printf("----> ABI (Provisional): String: %s\n",
                    info[i].value.data.string);
         }
         else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_NAMESPACES)) {

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1124,7 +1124,9 @@ typedef uint32_t pmix_rank_t;
                                                                    //         Named values (i.e., values defined by constant names via a
                                                                    //         typical C-language enum declaration) must be provided as
                                                                    //         their numerical equivalent.
-#define PMIX_QUERY_ABI_VERSION              "pmix.qry.abiversion"  // (char*) The PMIx Standard ABI version supported returned in the form "MAJOR.MINOR"
+#define PMIX_QUERY_STABLE_ABI_VERSION       "pmix.qry.stabiver"    // (char*) The PMIx Standard Stable ABI version supported returned in the form of a comma separated list of "MAJOR.MINOR"
+                                                                   //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
+#define PMIX_QUERY_PROVISIONAL_ABI_VERSION  "pmix.qry.prabiver"    // (char*) The PMIx Standard Provisional ABI version supported returned in the form of a comma separated "MAJOR.MINOR"
                                                                    //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
 
 /****    PROCESS STATE DEFINITIONS    ****/

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -52,10 +52,14 @@
 
 #ifdef PMIX_GIT_REPO_BUILD
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION ", repo rev: " PMIX_REPO_REV
-                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ","
+                                          " Stable ABI: " PMIX_STD_ABI_STABLE_VERSION ","
+                                          " Provisional ABI: " PMIX_STD_ABI_PROVISIONAL_VERSION ")";
 #else
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION
-                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ","
+                                          " Stable ABI: " PMIX_STD_ABI_STABLE_VERSION ","
+                                          " Provisional ABI: " PMIX_STD_ABI_PROVISIONAL_VERSION ")";
 #endif
 static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 


### PR DESCRIPTION
 * `PMIX_QUERY_STABLE_ABI_VERSION` : Stable ABI version(s)
 * `PMIX_QUERY_PROVISIONAL_ABI_VERSION` : Provisional ABI version(s)
