### PR TITLE
Checkpoint gds/shmem work.

### DIFF
--- a/src/class/pmix_object.c
+++ b/src/class/pmix_object.c
@@ -66,13 +66,13 @@ static const int increment = 10;
 /*
  * Local functions
  */
-static void save_class(pmix_class_t *cls, pmix_tma_t *tma);
-static void expand_array(pmix_tma_t *tma);
+static void save_class(pmix_class_t *cls);
+static void expand_array(void);
 
 /*
  * Lazy initialization of class descriptor.
  */
-void pmix_class_initialize(pmix_class_t *cls, pmix_tma_t *tma)
+void pmix_class_initialize(pmix_class_t *cls)
 {
     pmix_class_t *c;
     pmix_construct_t *cls_construct_array;
@@ -123,7 +123,7 @@ void pmix_class_initialize(pmix_class_t *cls, pmix_tma_t *tma)
      * plus for each a NULL-sentinel
      */
 
-    cls->cls_construct_array = (void (**)(pmix_object_t *)) pmix_tma_malloc(tma,
+    cls->cls_construct_array = (void (**)(pmix_object_t *)) malloc(
         (cls_construct_array_count + cls_destruct_array_count + 2) * sizeof(pmix_construct_t));
     if (NULL == cls->cls_construct_array) {
         perror("Out of memory");
@@ -154,7 +154,7 @@ void pmix_class_initialize(pmix_class_t *cls, pmix_tma_t *tma)
     *cls_destruct_array = NULL; /* end marker for the destructors */
 
     cls->cls_initialized = pmix_class_init_epoch;
-    save_class(cls, tma);
+    save_class(cls);
 
     /* All done */
 
@@ -189,25 +189,25 @@ int pmix_class_finalize(void)
     return 0;
 }
 
-static void save_class(pmix_class_t *cls, pmix_tma_t *tma)
+static void save_class(pmix_class_t *cls)
 {
     if (num_classes >= max_classes) {
-        expand_array(tma);
+        expand_array();
     }
 
     classes[num_classes] = cls->cls_construct_array;
     ++num_classes;
 }
 
-static void expand_array(pmix_tma_t *tma)
+static void expand_array(void)
 {
     int i;
 
     max_classes += increment;
     if (NULL == classes) {
-        classes = (void **) pmix_tma_calloc(tma, max_classes, sizeof(void *));
+        classes = (void **) calloc(max_classes, sizeof(void *));
     } else {
-        classes = (void **) pmix_tma_realloc(tma, classes, sizeof(void *) * max_classes);
+        classes = (void **) realloc(classes, sizeof(void *) * max_classes);
     }
     if (NULL == classes) {
         perror("class malloc failed");

--- a/src/mca/gds/shmem/Makefile.am
+++ b/src/mca/gds/shmem/Makefile.am
@@ -25,9 +25,13 @@
 
 AM_CPPFLAGS = $(gds_shmem_CPPFLAGS)
 
-# TODO(skg) Eventually incorporate pmix_hash2.
+# TODO(skg) Eventually reincorporate pmix_hash2.
+# TODO(skg) Eventually reincorporate pmix_hash_table2.
+# TODO(skg) Eventually reincorporate pmix_pointer_array2.
 
 headers = \
+        pmix_pointer_array2.h \
+        pmix_hash_table2.h \
         pmix_hash2.h \
         gds_shmem.h \
         gds_shmem_utils.h \
@@ -35,6 +39,8 @@ headers = \
         gds_shmem_fetch.h
 
 sources = \
+        pmix_pointer_array2.c \
+        pmix_hash_table2.c \
         pmix_hash2.c \
         gds_shmem_component.c \
         gds_shmem.c \

--- a/src/mca/gds/shmem/gds_shmem_component.c
+++ b/src/mca/gds/shmem/gds_shmem_component.c
@@ -37,8 +37,6 @@ component_query(
 ) {
     // See if the required system file is present.
     // See pmix_vmem_find_hole() for more information.
-    // TODO(skg) Add some parameters to disable shared-memory support. If sm
-    // support is disabled, then we do not have to look for this file.
     if (access("/proc/self/maps", F_OK) == -1) {
         *priority = 0;
         *module = NULL;
@@ -62,7 +60,7 @@ component_query(
 pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
     .super = {
         PMIX_GDS_BASE_VERSION_1_0_0,
-        /** Component name and version */
+        /** Component name and version. */
         .pmix_mca_component_name = PMIX_GDS_SHMEM_NAME,
         PMIX_MCA_BASE_MAKE_VERSION(
             component,
@@ -70,11 +68,10 @@ pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
             PMIX_MINOR_VERSION,
             PMIX_RELEASE_VERSION
         ),
-        /** Component query function */
+        /** Component query function. */
         .pmix_mca_query_component = component_query,
         .reserved = {0}
     },
-    .sessions = PMIX_LIST_STATIC_INIT,
     .jobs = PMIX_LIST_STATIC_INIT
 };
 

--- a/src/mca/gds/shmem/gds_shmem_store.c
+++ b/src/mca/gds/shmem/gds_shmem_store.c
@@ -25,6 +25,90 @@
 
 #include "src/mca/pmdl/pmdl.h"
 
+/**
+ * Populates the provided with the elements present in the given comma-delimited
+ * string. If the list is not empty, it is first cleared and then set.
+ */
+static pmix_status_t
+set_host_aliases_from_cds(
+    pmix_list_t *list,
+    const char *cds
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_tma_t *tma = pmix_obj_get_tma(&list->super);
+    // If the list isn't empty, release remove and release its items.
+    if (!pmix_list_is_empty(list)) {
+        pmix_list_item_t *it;
+        while (NULL != (it = pmix_list_remove_first(list))) {
+            PMIX_RELEASE(it);
+        }
+    }
+    // Now, add each element present in the comma-delimited string list.
+    char **tmp = pmix_argv_split(cds, ',');
+    if (!tmp) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
+    for (size_t i = 0; NULL != tmp[i]; i++) {
+        pmix_gds_shmem_host_alias_t *alias;
+        alias = PMIX_NEW(pmix_gds_shmem_host_alias_t, tma);
+        if (!alias) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+
+        alias->name = pmix_tma_strdup(tma, tmp[i]);
+        if (!alias->name) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+
+        pmix_list_append(list, &alias->super);
+    }
+out:
+    pmix_argv_free(tmp);
+    return rc;
+}
+
+/**
+ * Adds the given host name to the provided list. If the host name already
+ * exists, then it is not added.
+ */
+#if 0
+static pmix_status_t
+add_unique_hostname(
+    pmix_list_t *list,
+    const char *hostname
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_tma_t *tma = pmix_obj_get_tma(&list->super);
+    bool add_host_name = true;
+
+    pmix_gds_shmem_host_alias_t *ai;
+    PMIX_LIST_FOREACH (ai, list, pmix_gds_shmem_host_alias_t) {
+        // The host name is already present in the list.
+        if (0 == strcmp(hostname, ai->name)) {
+            add_host_name = false;
+            break;
+        }
+    }
+    if (add_host_name) {
+        pmix_gds_shmem_host_alias_t *alias;
+        alias = PMIX_NEW(pmix_gds_shmem_host_alias_t, tma);
+        if (!alias) {
+            rc = PMIX_ERR_NOMEM;
+            goto out;
+        }
+        alias->name = pmix_tma_strdup(tma, hostname);
+        if (!alias->name) {
+            rc = PMIX_ERR_NOMEM;
+        }
+    }
+out:
+    return rc;
+}
+#endif
+
 static pmix_status_t
 cache_node_info(
     pmix_info_t *info,
@@ -33,9 +117,15 @@ cache_node_info(
     pmix_gds_shmem_nodeinfo_t **nodeinfo
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
-    // Construct the cache. We'll cleanup after ourselves if something fails.
-    PMIX_CONSTRUCT(cache, pmix_list_t);
+    pmix_tma_t *tma = pmix_obj_get_tma(&cache->super);
+    bool have_node_id_info = false;
+
     pmix_gds_shmem_nodeinfo_t *inodeinfo = NULL;
+    inodeinfo = PMIX_NEW(pmix_gds_shmem_nodeinfo_t, tma);
+    if (!inodeinfo) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
     // Cache the values while searching for the nodeid and/or hostname.
     for (size_t j = 0; j < ninfo; j++) {
         PMIX_GDS_SHMEM_VOUT(
@@ -43,9 +133,7 @@ cache_node_info(
             PMIX_NAME_PRINT(&pmix_globals.myid), info[j].key
         );
         if (PMIX_CHECK_KEY(&info[j], PMIX_NODEID)) {
-            if (!inodeinfo) {
-                inodeinfo = PMIX_NEW(pmix_gds_shmem_nodeinfo_t);
-            }
+            have_node_id_info = true;
             PMIX_VALUE_GET_NUMBER(
                 rc, &info[j].value, inodeinfo->nodeid, uint32_t
             );
@@ -55,21 +143,28 @@ cache_node_info(
             }
         }
         else if (PMIX_CHECK_KEY(&info[j], PMIX_HOSTNAME)) {
-            if (!inodeinfo) {
-                inodeinfo = PMIX_NEW(pmix_gds_shmem_nodeinfo_t);
-            }
-            inodeinfo->hostname = strdup(info[j].value.data.string);
+            have_node_id_info = true;
+            inodeinfo->hostname = pmix_tma_strdup(
+                tma, info[j].value.data.string
+            );
         }
         else if (PMIX_CHECK_KEY(&info[j], PMIX_HOSTNAME_ALIASES)) {
-            if (!inodeinfo) {
-                inodeinfo = PMIX_NEW(pmix_gds_shmem_nodeinfo_t);
+            have_node_id_info = true;
+            // info[j].value.data.string is a
+            // comma-delimited string of hostnames.
+            rc = set_host_aliases_from_cds(
+                inodeinfo->aliases,
+                info[j].value.data.string
+            );
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                break;
             }
-            inodeinfo->aliases = pmix_argv_split(info[j].value.data.string, ',');
             // Need to cache this value as well.
-            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(info[j].key);
+            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t, tma);
+            kv->key = pmix_tma_strdup(tma, info[j].key);
             kv->value = NULL;
-            PMIX_VALUE_XFER(rc, kv->value, &info[j].value);
+            PMIX_GDS_SHMEM_VALUE_XFER(rc, kv->value, &info[j].value, tma);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kv);
@@ -78,10 +173,10 @@ cache_node_info(
             pmix_list_append(cache, &kv->super);
         }
         else {
-            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(info[j].key);
+            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t, tma);
+            kv->key = pmix_tma_strdup(tma, info[j].key);
             kv->value = NULL;
-            PMIX_VALUE_XFER(rc, kv->value, &info[j].value);
+            PMIX_GDS_SHMEM_VALUE_XFER(rc, kv->value, &info[j].value, tma);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kv);
@@ -90,8 +185,12 @@ cache_node_info(
             pmix_list_append(cache, &kv->super);
         }
     }
+    // Make sure that the caller passed us node identifier info.
+    if (!have_node_id_info) {
+        rc = PMIX_ERR_BAD_PARAM;
+    }
+out:
     if (PMIX_SUCCESS != rc) {
-        PMIX_LIST_DESTRUCT(cache);
         PMIX_RELEASE(inodeinfo);
         inodeinfo = NULL;
     }
@@ -101,137 +200,78 @@ cache_node_info(
 
 pmix_status_t
 pmix_gds_shmem_store_node_array(
+    pmix_gds_shmem_job_t *job,
     pmix_value_t *val,
     pmix_list_t *target
 ) {
+    PMIX_GDS_SHMEM_VOUT_HERE();
+
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_gds_shmem_nodeinfo_t *nodeinfo = NULL;
-    bool update = false;
-
-    PMIX_GDS_SHMEM_VOUT(
-        "%s: STORING NODE ARRAY",
-        PMIX_NAME_PRINT(&pmix_globals.myid)
-    );
-    // We are expecting an array of node-level info for a
-    // specific node. Make sure we were given the correct type.
+    pmix_tma_t *tma = pmix_gds_shmem_get_job_tma(job);
+    // We expect an array of node-level info for a specific
+    // node. Make sure we were given the correct type.
     if (PMIX_DATA_ARRAY != val->type) {
         rc = PMIX_ERR_TYPE_MISMATCH;
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    pmix_info_t *info = (pmix_info_t *)val->data.darray->array;
+    const size_t ninfo = val->data.darray->size;
     // Construct node info cache from provided data.
-    pmix_list_t cache;
-    rc = cache_node_info(
-        (pmix_info_t *)val->data.darray->array,
-        val->data.darray->size, &cache, &nodeinfo
-    );
+    pmix_list_t *cache = PMIX_NEW(pmix_list_t, tma);
+    if (!cache) {
+        return PMIX_ERR_NOMEM;
+    }
+
+    rc = cache_node_info(info, ninfo, cache, &nodeinfo);
     if (PMIX_SUCCESS != rc) {
         goto out;
     }
-    // Make sure that the caller passed us node identifier info.
-    if (!nodeinfo) {
-        rc = PMIX_ERR_BAD_PARAM;
-        goto out;
-    }
-    // See if we already have this node on the provided list.
-    pmix_gds_shmem_nodeinfo_t *ni;
-    PMIX_LIST_FOREACH (ni, target, pmix_gds_shmem_nodeinfo_t) {
-        if (UINT32_MAX != ni->nodeid && UINT32_MAX != nodeinfo->nodeid) {
-            if (ni->nodeid == nodeinfo->nodeid) {
-                if (NULL == ni->hostname && NULL != nodeinfo->hostname) {
-                    ni->hostname = strdup(nodeinfo->hostname);
-                }
-                if (NULL != nodeinfo->aliases) {
-                    for (size_t n = 0; NULL != nodeinfo->aliases[n]; n++) {
-                        pmix_argv_append_unique_nosize(
-                            &ni->aliases, nodeinfo->aliases[n]
-                        );
-                    }
-                }
-                PMIX_RELEASE(nodeinfo);
-                nodeinfo = ni;
-                update = true;
-                break;
-            }
-        }
-        else if (NULL != ni->hostname && NULL != nodeinfo->hostname) {
-            if (0 == strcmp(ni->hostname, nodeinfo->hostname)) {
-                if (UINT32_MAX == ni->nodeid && UINT32_MAX != nodeinfo->nodeid) {
-                    ni->nodeid = nodeinfo->nodeid;
-                }
-                if (NULL != nodeinfo->aliases) {
-                    for (size_t n = 0; NULL != nodeinfo->aliases[n]; n++) {
-                        pmix_argv_append_unique_nosize(
-                            &ni->aliases, nodeinfo->aliases[n]
-                        );
-                    }
-                }
-                PMIX_RELEASE(nodeinfo);
-                nodeinfo = ni;
-                update = true;
-                break;
-            }
-        }
-    }
-    // If the target didn't have the info, then add it.
-    if (!update) {
-        pmix_list_append(target, &nodeinfo->super);
-    }
-    // TODO(skg) I think this is wasted work in the not updated case: nodeinfo
-    // will not be updated to point to an item in the target's list, so
-    // processing this might not make sense. Ask Ralph.
-    // Transfer the cached items to the nodeinfo list.
+
     pmix_kval_t *cache_kv;
-    cache_kv = (pmix_kval_t *)pmix_list_remove_first(&cache);
+    cache_kv = (pmix_kval_t *)pmix_list_remove_first(cache);
     while (NULL != cache_kv) {
-        // If this is an update, we have to ensure each
-        // data item only appears once on the list.
-        if (update) {
-            pmix_kval_t *kv;
-            PMIX_LIST_FOREACH (kv, &nodeinfo->info, pmix_kval_t) {
-                if (PMIX_CHECK_KEY(kv, cache_kv->key)) {
-                    pmix_list_remove_item(&nodeinfo->info, &kv->super);
-                    PMIX_RELEASE(kv);
-                    break;
-                }
-            }
-        }
-        pmix_list_append(&nodeinfo->info, &cache_kv->super);
-        cache_kv = (pmix_kval_t *)pmix_list_remove_first(&cache);
+        pmix_list_append(nodeinfo->info, &cache_kv->super);
+        cache_kv = (pmix_kval_t *)pmix_list_remove_first(cache);
     }
+
+    pmix_list_append(target, &nodeinfo->super);
 out:
-    PMIX_LIST_DESTRUCT(&cache);
+    PMIX_LIST_DESTRUCT(cache);
     return rc;
 }
 
 pmix_status_t
 pmix_gds_shmem_store_app_array(
-    pmix_value_t *val,
-    pmix_gds_shmem_job_t *job
+    pmix_gds_shmem_job_t *job,
+    pmix_value_t *val
 ) {
+    PMIX_GDS_SHMEM_VOUT_HERE();
+
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_gds_shmem_app_t *app = NULL;
-    bool update = false;
-
-    PMIX_GDS_SHMEM_VOUT(
-        "%s: PROCESSING APP ARRAY",
-        PMIX_NAME_PRINT(&pmix_globals.myid)
-    );
+    pmix_tma_t *tma = pmix_gds_shmem_get_job_tma(job);
     // Apps must belong to a job.
     if (!job) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return PMIX_ERR_BAD_PARAM;
     }
-    // We are expecting an array of app-level info.
-    // Make sure we were given the correct type.
+    // We expect an array of node-level info for a specific
+    // node. Make sure we were given the correct type.
     if (PMIX_DATA_ARRAY != val->type) {
         PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
         return PMIX_ERR_TYPE_MISMATCH;
     }
-    // setup arrays and lists.
-    pmix_list_t app_cache, node_cache;
-    PMIX_CONSTRUCT(&app_cache, pmix_list_t);
-    PMIX_CONSTRUCT(&node_cache, pmix_list_t);
+    // Setup arrays and lists.
+    pmix_list_t *app_cache = PMIX_NEW(pmix_list_t, tma);
+    if (!app_cache) {
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_list_t *node_cache = PMIX_NEW(pmix_list_t, tma);
+    if (!node_cache) {
+        return PMIX_ERR_NOMEM;
+    }
 
     const size_t size = val->data.darray->size;
     pmix_info_t *info = (pmix_info_t *)val->data.darray->array;
@@ -255,35 +295,36 @@ pmix_gds_shmem_store_app_array(
                 PMIX_ERROR_LOG(rc);
                 goto out;
             }
-            app = PMIX_NEW(pmix_gds_shmem_app_t);
+            app = PMIX_NEW(pmix_gds_shmem_app_t, tma);
             app->appnum = appnum;
         }
         else if (PMIX_CHECK_KEY(&info[j], PMIX_NODE_INFO_ARRAY)) {
-            rc = pmix_gds_shmem_store_node_array(&info[j].value, &node_cache);
+            rc = pmix_gds_shmem_store_node_array(
+                job, &info[j].value, node_cache
+            );
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 goto out;
             }
         }
         else {
-            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(info[j].key);
-            kv->value = NULL;
-            PMIX_VALUE_XFER(rc, kv->value, &info[j].value);
+            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t, tma);
+            kv->key = pmix_tma_strdup(tma, info[j].key);
+            PMIX_GDS_SHMEM_VALUE_XFER(rc, kv->value, &info[j].value, tma);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kv);
                 goto out;
             }
-            pmix_list_append(&app_cache, &kv->super);
+            pmix_list_append(app_cache, &kv->super);
         }
     }
 
     if (NULL == app) {
         // Per the standard, they don't have to provide us with
         // an appnum so long as only one app is in the job.
-        if (0 == pmix_list_get_size(&job->apps)) {
-            app = PMIX_NEW(pmix_gds_shmem_app_t);
+        if (0 == pmix_list_get_size(job->smdata->apps)) {
+            app = PMIX_NEW(pmix_gds_shmem_app_t, tma);
             app->appnum = 0;
         }
         else {
@@ -294,21 +335,8 @@ pmix_gds_shmem_store_app_array(
             goto out;
         }
     }
-    // See if we already have this app on the provided list.
-    pmix_gds_shmem_app_t *appi;
-    PMIX_LIST_FOREACH (appi, &job->apps, pmix_gds_shmem_app_t) {
-        if (appi->appnum == app->appnum) {
-            // We assume that the data is updating the current values.
-            PMIX_RELEASE(app);
-            app = appi;
-            update = true;
-            break;
-        }
-    }
-    // We didn't already have it, so add it now.
-    if (!update) {
-        pmix_list_append(&job->apps, &app->super);
-    }
+    // Add it to our list of apps.
+    pmix_list_append(job->smdata->apps, &app->super);
     // Point the app at its job.
     if (NULL == app->job) {
         // Do NOT retain the tracker. We will not release it in the app
@@ -318,151 +346,28 @@ pmix_gds_shmem_store_app_array(
     }
     // Transfer the app-level data across.
     pmix_kval_t *akv;
-    akv = (pmix_kval_t *)pmix_list_remove_first(&app_cache);
+    akv = (pmix_kval_t *)pmix_list_remove_first(app_cache);
     while (NULL != akv) {
-        // If this is an update, we have to ensure each
-        // data item only appears once on the list.
-        if (update) {
-            pmix_kval_t *kv;
-            PMIX_LIST_FOREACH (kv, &app->appinfo, pmix_kval_t) {
-                if (PMIX_CHECK_KEY(kv, akv->key)) {
-                    pmix_list_remove_item(&app->appinfo, &kv->super);
-                    PMIX_RELEASE(kv);
-                    break;
-                }
-            }
-        }
-        if (PMIX_CHECK_KEY(akv, PMIX_MODEL_LIBRARY_NAME) ||
-            PMIX_CHECK_KEY(akv, PMIX_PROGRAMMING_MODEL) ||
-            PMIX_CHECK_KEY(akv, PMIX_MODEL_LIBRARY_VERSION) ||
-            PMIX_CHECK_KEY(akv, PMIX_PERSONALITY)) {
-            // Pass this info to the pmdl framework
-            pmix_pmdl.setup_nspace_kv(job->nspace, akv);
-        }
-        pmix_list_append(&app->appinfo, &akv->super);
-        akv = (pmix_kval_t *)pmix_list_remove_first(&app_cache);
+        pmix_list_append(app->appinfo, &akv->super);
+        akv = (pmix_kval_t *)pmix_list_remove_first(app_cache);
     }
     // Transfer the associated node-level data across.
     pmix_gds_shmem_nodeinfo_t *nd;
-    nd = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(&node_cache);
+    nd = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(node_cache);
     while (NULL != nd) {
-        pmix_list_append(&app->nodeinfo, &nd->super);
-        nd = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(&node_cache);
+        pmix_list_append(app->nodeinfo, &nd->super);
+        nd = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(node_cache);
     }
 out:
-    PMIX_LIST_DESTRUCT(&app_cache);
-    PMIX_LIST_DESTRUCT(&node_cache);
+    PMIX_LIST_DESTRUCT(app_cache);
+    PMIX_LIST_DESTRUCT(node_cache);
     return rc;
 }
 
 pmix_status_t
-pmix_gds_shmem_store_session_array(
-    pmix_value_t *val,
-    pmix_gds_shmem_job_t *job
-) {
-    pmix_status_t rc = PMIX_SUCCESS;
-    pmix_gds_shmem_session_t *session = NULL;
-
-    PMIX_GDS_SHMEM_VOUT(
-        "%s: PROCESSING SESSION ARRAY",
-        PMIX_NAME_PRINT(&pmix_globals.myid)
-    );
-    // We are expecting an array of session-level info.
-    // Make sure we were given the correct type.
-    if (PMIX_DATA_ARRAY != val->type) {
-        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-        return PMIX_ERR_TYPE_MISMATCH;
-    }
-    // Construct the node and session caches.
-    pmix_list_t sesh_cache, node_cache;
-    PMIX_CONSTRUCT(&sesh_cache, pmix_list_t);
-    PMIX_CONSTRUCT(&node_cache, pmix_list_t);
-
-    const size_t size = val->data.darray->size;
-    pmix_info_t *info = (pmix_info_t *)val->data.darray->array;
-    for (size_t j = 0; j < size; j++) {
-        if (PMIX_CHECK_KEY(&info[j], PMIX_SESSION_ID)) {
-            uint32_t sid;
-            PMIX_VALUE_GET_NUMBER(rc, &info[j].value, sid, uint32_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                goto out;
-            }
-            // See if we already have this session - it could have
-            // been defined by a separate PMIX_SESSION_ID key.
-            pmix_gds_shmem_component_t *comp = &pmix_mca_gds_shmem_component;
-            pmix_gds_shmem_session_t *si;
-            PMIX_LIST_FOREACH (si, &comp->sessions, pmix_gds_shmem_session_t) {
-                if (si->id == sid) {
-                    session = si;
-                    break;
-                }
-            }
-            if (NULL == session) {
-                /* wasn't found, so create one */
-                session = PMIX_NEW(pmix_gds_shmem_session_t);
-                session->id = sid;
-                pmix_list_append(&comp->sessions, &session->super);
-            }
-        }
-        else if (PMIX_CHECK_KEY(&info[j], PMIX_NODE_INFO_ARRAY)) {
-            rc = pmix_gds_shmem_store_node_array(&info[j].value, &node_cache);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                goto out;
-            }
-        }
-        else {
-            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(info[j].key);
-            kv->value = NULL;
-            PMIX_VALUE_XFER(rc, kv->value, &info[j].value);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(kv);
-                goto out;
-            }
-            pmix_list_append(&sesh_cache, &kv->super);
-        }
-    }
-    // This is not allowed to happen: they are required
-    // to provide us with a session ID per the standard.
-    if (NULL == session) {
-        rc = PMIX_ERR_BAD_PARAM;
-        PMIX_ERROR_LOG(rc);
-        goto out;
-    }
-    // Point the job at it.
-    if (NULL != job->session) {
-        PMIX_RELEASE(job->session);
-    }
-    PMIX_RETAIN(session);
-    job->session = session;
-    // Transfer the session data across.
-    pmix_kval_t *skv;
-    skv = (pmix_kval_t *)pmix_list_remove_first(&sesh_cache);
-    while (NULL != skv) {
-        pmix_list_append(&session->sessioninfo, &skv->super);
-        skv = (pmix_kval_t *)pmix_list_remove_first(&sesh_cache);
-    }
-    // Transfer the node info data across.
-    pmix_gds_shmem_nodeinfo_t *ni;
-    ni = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(&node_cache);
-    while (NULL != ni) {
-        pmix_list_append(&session->nodeinfo, &ni->super);
-        ni = (pmix_gds_shmem_nodeinfo_t *)pmix_list_remove_first(&node_cache);
-    }
-out:
-    PMIX_LIST_DESTRUCT(&sesh_cache);
-    PMIX_LIST_DESTRUCT(&node_cache);
-    return rc;
-}
-
-pmix_status_t
-pmix_gds_shmem_store_proc_data_in_hashtab(
-    const pmix_kval_t *kval,
-    const char *namespace_id,
-    pmix_hash_table_t *target_ht
+pmix_gds_shmem_store_proc_data(
+    pmix_gds_shmem_job_t *job,
+    const pmix_kval_t *kval
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
     // First, make sure this is proc data.
@@ -489,26 +394,17 @@ pmix_gds_shmem_store_proc_data_in_hashtab(
     const pmix_rank_t rank = iptr[0].value.data.rank;
     // Cycle through the values for this rank and store them.
     for (size_t j = 1; j < size; j++) {
-        pmix_kval_t kv;
-        if (PMIX_CHECK_KEY(&iptr[j], PMIX_QUALIFIED_VALUE)) {
-            rc = pmix_gds_shmem_store_qualified(
-                target_ht, rank, &iptr[j].value
-            );
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                return rc;
-            }
-            continue;
-        }
-        kv.key = iptr[j].key;
-        kv.value = &iptr[j].value;
+        pmix_kval_t kv = {
+            .key = iptr[j].key,
+            .value = &iptr[j].value
+        };
         PMIX_GDS_SHMEM_VOUT(
-            "%s: %s for nspace=%s rank=%u key=%s",
+            "%s:%s for nspace=%s rank=%u key=%s",
             __func__, PMIX_NAME_PRINT(&pmix_globals.myid),
-            namespace_id, rank, kv.key
+            job->nspace_id, rank, kv.key
         );
         // Store it in the hash_table.
-        rc = pmix_hash2_store(target_ht, rank, &kv, NULL, 0);
+        rc = pmix_hash2_store(job->smdata->local_hashtab, rank, &kv, NULL, 0);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
@@ -517,69 +413,39 @@ pmix_gds_shmem_store_proc_data_in_hashtab(
     return rc;
 }
 
-pmix_status_t
-pmix_gds_shmem_store_qualified(
-    pmix_hash_table_t *ht,
-    pmix_rank_t rank,
-    pmix_value_t *value
-) {
-    pmix_status_t rc = PMIX_SUCCESS;
-
-    // The value contains a pmix_data_array_t whose first position contains the
-    // key-value being stored, followed by one or more qualifiers.
-    pmix_info_t *info = (pmix_info_t *)value->data.darray->array;
-    const size_t sz = value->data.darray->size;
-    // Extract the primary value.
-    pmix_kval_t kv;
-    PMIX_CONSTRUCT(&kv, pmix_kval_t);
-    kv.key = info[0].key;
-    kv.value = &info[0].value;
-
-    const size_t nquals = sz - 1;
-    pmix_info_t *quals;
-    PMIX_INFO_CREATE(quals, nquals);
-    for (size_t n = 1; n < sz; n++) {
-        PMIX_INFO_SET_QUALIFIER(&quals[n - 1]);
-        PMIX_INFO_XFER(&quals[n - 1], &info[n]);
-    }
-    // Store the result.
-    rc = pmix_hash2_store(ht, rank, &kv, quals, nquals);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-    }
-    PMIX_INFO_FREE(quals, nquals);
-    return rc;
-}
-
+// TODO(skg) Maybe we can use this to store data for register_job_info().
 pmix_status_t
 pmix_gds_shmem_store_job_array(
     pmix_info_t *info,
     pmix_gds_shmem_job_t *job,
     uint32_t *flags,
+    // TODO(skg) Do we need to populate these?
     char ***procs,
     char ***nodes
 ) {
+    PMIX_HIDE_UNUSED_PARAMS(procs, nodes);
+    PMIX_GDS_SHMEM_VOUT_HERE();
+
     pmix_status_t rc = PMIX_SUCCESS;
-
-    PMIX_GDS_SHMEM_VOUT(
-        "%s:%s STORING JOB ARRAY", __func__,
-        PMIX_NAME_PRINT(&pmix_globals.myid)
-    );
-
-    // We are expecting an array of job-level info.
+    pmix_tma_t *tma = pmix_gds_shmem_get_job_tma(job);
+    // We expect an array of job-level info.
     if (PMIX_DATA_ARRAY != info->value.type) {
         PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
         return PMIX_ERR_TYPE_MISMATCH;
     }
 
-    pmix_list_t cache;
-    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    pmix_list_t *cache = PMIX_NEW(pmix_list_t, tma);
+    if (!cache) {
+        return PMIX_ERR_NOMEM;
+    }
 
     const size_t size = info->value.data.darray->size;
     pmix_info_t *iptr = (pmix_info_t *)info->value.data.darray->array;
     for (size_t j = 0; j < size; j++) {
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APP_INFO_ARRAY)) {
-            rc = pmix_gds_shmem_store_app_array(&iptr[j].value, job);
+            rc = pmix_gds_shmem_store_app_array(
+                job, &iptr[j].value
+            );
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
@@ -587,66 +453,24 @@ pmix_gds_shmem_store_job_array(
         }
         else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
             rc = pmix_gds_shmem_store_node_array(
-                &iptr[j].value, &job->nodeinfo
+                job, &iptr[j].value, job->smdata->nodeinfo
             );
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
         }
-        else if (PMIX_CHECK_KEY(&iptr[j], PMIX_PROC_MAP)) {
-            // TODO(skg) A candidate for shared-memory?
-            // Not allowed to get this more than once.
-            if (*flags & PMIX_GDS_SHMEM_PROC_MAP) {
-                rc = PMIX_ERR_BAD_PARAM;
-                PMIX_ERROR_LOG(rc);
-                return rc;
-            }
-            // Parse the regex to get the argv array
-            // containing proc ranks on each node.
-            rc = pmix_preg.parse_procs(iptr[j].value.data.bo.bytes, procs);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                return rc;
-            }
-            // Mark that we got the map.
-            *flags |= PMIX_GDS_SHMEM_PROC_MAP;
-        }
-        else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_MAP)) {
-            // TODO(skg) A candidate for shared-memory?
-            // Not allowed to get this more than once.
-            if (*flags & PMIX_GDS_SHMEM_NODE_MAP) {
-                rc = PMIX_ERR_BAD_PARAM;
-                PMIX_ERROR_LOG(rc);
-                return rc;
-            }
-            // Parse the regex to get the argv array of node names.
-            rc = pmix_preg.parse_nodes(iptr[j].value.data.bo.bytes, nodes);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                return rc;
-            }
-            /* mark that we got the map */
-            *flags |= PMIX_GDS_SHMEM_NODE_MAP;
-        }
-        else if (PMIX_CHECK_KEY(&iptr[j], PMIX_MODEL_LIBRARY_NAME) ||
-                 PMIX_CHECK_KEY(&iptr[j], PMIX_PROGRAMMING_MODEL) ||
-                 PMIX_CHECK_KEY(&iptr[j], PMIX_MODEL_LIBRARY_VERSION) ||
-                 PMIX_CHECK_KEY(&iptr[j], PMIX_PERSONALITY)) {
-            // Pass this info to the pmdl framework.
-            pmix_pmdl.setup_nspace(job->nspace, &iptr[j]);
-        }
         else {
-            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(iptr[j].key);
+            pmix_kval_t *kv = PMIX_NEW(pmix_kval_t, tma);
+            kv->key = pmix_tma_strdup(tma, iptr[j].key);
             kv->value = NULL;
-            PMIX_VALUE_XFER(rc, kv->value, &iptr[j].value);
+            PMIX_GDS_SHMEM_VALUE_XFER(rc, kv->value, &iptr[j].value, tma);
             if (PMIX_SUCCESS != rc) {
                 PMIX_RELEASE(kv);
-                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_LIST_DESTRUCT(cache);
                 return rc;
             }
-            pmix_list_append(&job->jobinfo, &kv->super);
+            pmix_list_append(job->smdata->jobinfo, &kv->super);
             // Check for job size.
             if (PMIX_CHECK_KEY(&iptr[j], PMIX_JOB_SIZE)) {
                 if (!(PMIX_GDS_SHMEM_JOB_SIZE & *flags)) {
@@ -665,307 +489,7 @@ pmix_gds_shmem_store_job_array(
                     job->nspace->num_waiting = 1;
                 }
             }
-            else {
-                pmix_iof_check_flags(&iptr[j], &job->nspace->iof_flags);
-            }
         }
-    }
-    return rc;
-}
-
-pmix_status_t
-pmix_gds_shmem_store_map(
-    pmix_gds_shmem_job_t *job,
-    char **nodes,
-    char **ppn,
-    uint32_t flags
-) {
-    pmix_status_t rc = PMIX_SUCCESS;
-    uint32_t totalprocs = 0;
-    pmix_hash_table_t *ht = &job->hashtab_internal;
-
-    PMIX_GDS_SHMEM_VOUT(
-        "%s:%s STORING MAP", __func__, PMIX_NAME_PRINT(&pmix_globals.myid)
-    );
-    // If the list sizes don't match, then that's an error.
-    if (pmix_argv_count(nodes) != pmix_argv_count(ppn)) {
-        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-        return PMIX_ERR_BAD_PARAM;
-    }
-    // If they didn't provide the number of nodes,
-    // then compute it from the list of nodes.
-    if (!(PMIX_GDS_SHMEM_NUM_NODES & flags)) {
-        pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_NUM_NODES);
-        kv->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-        kv->value->type = PMIX_UINT32;
-        kv->value->data.uint32 = pmix_argv_count(nodes);
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s adding key=%s to job info", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid), kv->key
-        );
-        rc = pmix_hash2_store(ht, PMIX_RANK_WILDCARD, kv, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kv);
-            return rc;
-        }
-        PMIX_RELEASE(kv); // Maintain accounting.
-    }
-
-    for (size_t n = 0; NULL != nodes[n]; n++) {
-        pmix_gds_shmem_nodeinfo_t *nd = NULL;
-        pmix_kval_t *kvi = NULL;
-        // Check and see if we already have this node.
-        nd = pmix_gds_shmem_get_nodeinfo_by_nodename(&job->nodeinfo, nodes[n]);
-        if (NULL == nd) {
-            nd = PMIX_NEW(pmix_gds_shmem_nodeinfo_t);
-            nd->hostname = strdup(nodes[n]);
-            nd->nodeid = n;
-            pmix_list_append(&job->nodeinfo, &nd->super);
-        }
-        // Store the proc list as-is.
-        pmix_kval_t *kval = PMIX_NEW(pmix_kval_t);
-        if (NULL == kval) {
-            return PMIX_ERR_NOMEM;
-        }
-        kval->key = strdup(PMIX_LOCAL_PEERS);
-        kval->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-        if (NULL == kval->value) {
-            PMIX_RELEASE(kval);
-            return PMIX_ERR_NOMEM;
-        }
-        kval->value->type = PMIX_STRING;
-        kval->value->data.string = strdup(ppn[n]);
-
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s adding key=%s to node=%s info", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid), kval->key, nodes[n]
-        );
-        // Ensure this item only appears once on the list.
-        PMIX_LIST_FOREACH (kvi, &nd->info, pmix_kval_t) {
-            if (PMIX_CHECK_KEY(kvi, kval->key)) {
-                pmix_list_remove_item(&nd->info, &kvi->super);
-                PMIX_RELEASE(kvi);
-                break;
-            }
-        }
-        pmix_list_append(&nd->info, &kval->super);
-
-        // Save the local leader.
-        pmix_rank_t rank = strtoul(ppn[n], NULL, 10);
-        kval = PMIX_NEW(pmix_kval_t);
-        if (NULL == kval) {
-            return PMIX_ERR_NOMEM;
-        }
-        kval->key = strdup(PMIX_LOCALLDR);
-        kval->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-        if (NULL == kval->value) {
-            PMIX_RELEASE(kval);
-            return PMIX_ERR_NOMEM;
-        }
-        kval->value->type = PMIX_PROC_RANK;
-        kval->value->data.rank = rank;
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s adding key=%s to node=%s info", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid), kval->key, nodes[n]
-        );
-        // Ensure this item only appears once on the list.
-        PMIX_LIST_FOREACH (kvi, &nd->info, pmix_kval_t) {
-            if (PMIX_CHECK_KEY(kvi, kval->key)) {
-                pmix_list_remove_item(&nd->info, &kvi->super);
-                PMIX_RELEASE(kvi);
-                break;
-            }
-        }
-        pmix_list_append(&nd->info, &kval->super);
-
-        // Split the list of procs so we can
-        // store their individual location data.
-        char **procs = pmix_argv_split(ppn[n], ',');
-        // Save the local size in case they don't give it to us.
-        kval = PMIX_NEW(pmix_kval_t);
-        if (NULL == kval) {
-            pmix_argv_free(procs);
-            return PMIX_ERR_NOMEM;
-        }
-        kval->key = strdup(PMIX_LOCAL_SIZE);
-        kval->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-        if (NULL == kval->value) {
-            PMIX_RELEASE(kval);
-            pmix_argv_free(procs);
-            return PMIX_ERR_NOMEM;
-        }
-        kval->value->type = PMIX_UINT32;
-        kval->value->data.uint32 = pmix_argv_count(procs);
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s adding key=%s to node=%s info", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid), kval->key, nodes[n]
-        );
-        // Ensure this item only appears once on the list.
-        PMIX_LIST_FOREACH (kvi, &nd->info, pmix_kval_t) {
-            if (PMIX_CHECK_KEY(kvi, kval->key)) {
-                pmix_list_remove_item(&nd->info, &kvi->super);
-                PMIX_RELEASE(kvi);
-                break;
-            }
-        }
-        pmix_list_append(&nd->info, &kval->super);
-
-        // Track total procs in job in case they didn't give it to us.
-        totalprocs += pmix_argv_count(procs);
-        for (size_t m = 0; NULL != procs[m]; m++) {
-            // Store the hostname for each proc.
-            kval = PMIX_NEW(pmix_kval_t);
-            kval->key = strdup(PMIX_HOSTNAME);
-            kval->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-            kval->value->type = PMIX_STRING;
-            kval->value->data.string = strdup(nodes[n]);
-            rank = strtol(procs[m], NULL, 10);
-            PMIX_GDS_SHMEM_VOUT(
-                "%s:%s for [%s:%u]: key=%s", __func__,
-                PMIX_NAME_PRINT(&pmix_globals.myid),
-                job->nspace_id, rank, kval->key
-            );
-            rc = pmix_hash2_store(ht, rank, kval, NULL, 0);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(kval);
-                pmix_argv_free(procs);
-                return rc;
-            }
-            PMIX_RELEASE(kval); // Maintain accounting.
-            if (!(PMIX_GDS_SHMEM_PROC_DATA & flags)) {
-                // Add an entry for the nodeid.
-                kval = PMIX_NEW(pmix_kval_t);
-                kval->key = strdup(PMIX_NODEID);
-                kval->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                kval->value->type = PMIX_UINT32;
-                PMIX_GDS_SHMEM_VOUT(
-                    "%s:%s for [%s:%u]: key=%s", __func__,
-                    PMIX_NAME_PRINT(&pmix_globals.myid),
-                    job->nspace_id, rank, kval->key
-                );
-                kval->value->data.uint32 = n;
-                rc = pmix_hash2_store(ht, rank, kval, NULL, 0);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kval);
-                    pmix_argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kval); // Maintain accounting.
-                // Add an entry for the local rank.
-                kval = PMIX_NEW(pmix_kval_t);
-                kval->key = strdup(PMIX_LOCAL_RANK);
-                kval->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-                kval->value->type = PMIX_UINT16;
-                kval->value->data.uint16 = m;
-                PMIX_GDS_SHMEM_VOUT(
-                    "%s:%s for [%s:%u]: key=%s", __func__,
-                    PMIX_NAME_PRINT(&pmix_globals.myid),
-                    job->nspace_id, rank, kval->key
-                );
-                rc = pmix_hash2_store(ht, rank, kval, NULL, 0);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kval);
-                    pmix_argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kval); // Maintain accounting.
-                // Add an entry for the node rank. For now
-                // we assume only the one job is running.
-                kval = PMIX_NEW(pmix_kval_t);
-                kval->key = strdup(PMIX_NODE_RANK);
-                kval->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-                kval->value->type = PMIX_UINT16;
-                kval->value->data.uint16 = m;
-                PMIX_GDS_SHMEM_VOUT(
-                    "%s:%s for [%s:%u]: key=%s", __func__,
-                    PMIX_NAME_PRINT(&pmix_globals.myid),
-                    job->nspace_id, rank, kval->key
-                );
-                rc = pmix_hash2_store(ht, rank, kval, NULL, 0);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kval);
-                    pmix_argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kval); // Maintain accounting.
-            }
-        }
-        pmix_argv_free(procs);
-    }
-    // Store the comma-delimited list of nodes hosting
-    // procs in this nspace in case someone using PMIx v2
-    // requests it.
-    pmix_kval_t *kval = PMIX_NEW(pmix_kval_t);
-    kval->key = strdup(PMIX_NODE_LIST);
-    kval->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-    kval->value->type = PMIX_STRING;
-    kval->value->data.string = pmix_argv_join(nodes, ',');
-    PMIX_GDS_SHMEM_VOUT(
-        "%s:%s for nspace=%s: key=%s", __func__,
-        PMIX_NAME_PRINT(&pmix_globals.myid),
-        job->nspace_id, kval->key
-    );
-
-    rc = pmix_hash2_store(ht, PMIX_RANK_WILDCARD, kval, NULL, 0);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(kval);
-        return rc;
-    }
-    PMIX_RELEASE(kval); // Maintain accounting.
-
-    // If they didn't provide the job size, compute it as being the number of
-    // provided procs (i.e., size of ppn list).
-    if (!(PMIX_GDS_SHMEM_JOB_SIZE & flags)) {
-        pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_JOB_SIZE);
-        kv->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-        kv->value->type = PMIX_UINT32;
-        kv->value->data.uint32 = totalprocs;
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s for nspace=%s: key=%s", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid),
-            job->nspace_id, kv->key
-        );
-        rc = pmix_hash2_store(ht, PMIX_RANK_WILDCARD, kv, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kv);
-            return rc;
-        }
-        PMIX_RELEASE(kv); // Maintain accounting.
-        flags |= PMIX_GDS_SHMEM_JOB_SIZE;
-        job->nspace->nprocs = totalprocs;
-    }
-
-    // If they didn't provide a value for max procs, just assume it is the same
-    // as the number of procs in the job and store it.
-    if (!(PMIX_GDS_SHMEM_MAX_PROCS & flags)) {
-        pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-        kv->key = strdup(PMIX_MAX_PROCS);
-        kv->value = (pmix_value_t *)malloc(sizeof(pmix_value_t));
-        kv->value->type = PMIX_UINT32;
-        kv->value->data.uint32 = totalprocs;
-        PMIX_GDS_SHMEM_VOUT(
-            "%s:%s for nspace=%s: key=%s", __func__,
-            PMIX_NAME_PRINT(&pmix_globals.myid),
-            job->nspace_id, kv->key
-        );
-
-        rc = pmix_hash2_store(ht, PMIX_RANK_WILDCARD, kv, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kv);
-            return rc;
-        }
-        PMIX_RELEASE(kv); // Maintain accounting.
-        flags |= PMIX_GDS_SHMEM_MAX_PROCS;
     }
     return rc;
 }

--- a/src/mca/gds/shmem/gds_shmem_store.h
+++ b/src/mca/gds/shmem/gds_shmem_store.h
@@ -28,6 +28,7 @@ BEGIN_C_DECLS
  */
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem_store_node_array(
+    pmix_gds_shmem_job_t *job,
     pmix_value_t *val,
     pmix_list_t *target
 );
@@ -39,34 +40,17 @@ pmix_gds_shmem_store_node_array(
  */
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem_store_app_array(
-    pmix_value_t *val,
-    pmix_gds_shmem_job_t *job
+    pmix_gds_shmem_job_t *job,
+    pmix_value_t *val
 );
 
 /**
  *
  */
 PMIX_EXPORT pmix_status_t
-pmix_gds_shmem_store_session_array(
-    pmix_value_t *val,
-    pmix_gds_shmem_job_t *job
-);
-
-/**
- *
- */
-PMIX_EXPORT pmix_status_t
-pmix_gds_shmem_store_proc_data_in_hashtab(
-    const pmix_kval_t *kval,
-    const char *namespace_id,
-    pmix_hash_table_t *target_ht
-);
-
-PMIX_EXPORT pmix_status_t
-pmix_gds_shmem_store_qualified(
-    pmix_hash_table_t *ht,
-    pmix_rank_t rank,
-    pmix_value_t *value
+pmix_gds_shmem_store_proc_data(
+    pmix_gds_shmem_job_t *job,
+    const pmix_kval_t *kval
 );
 
 PMIX_EXPORT pmix_status_t
@@ -76,14 +60,6 @@ pmix_gds_shmem_store_job_array(
     uint32_t *flags,
     char ***procs,
     char ***nodes
-);
-
-PMIX_EXPORT pmix_status_t
-pmix_gds_shmem_store_map(
-    pmix_gds_shmem_job_t *job,
-    char **nodes,
-    char **ppn,
-    uint32_t flags
 );
 
 END_C_DECLS

--- a/src/mca/gds/shmem/gds_shmem_utils.c
+++ b/src/mca/gds/shmem/gds_shmem_utils.c
@@ -18,6 +18,30 @@
 
 #include "src/mca/pcompress/base/base.h"
 
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_CREATE() for our needs.
+#define PMIX_GDS_SHMEM_INFO_CREATE(m, n, tma)                                  \
+do {                                                                           \
+    pmix_info_t *i;                                                            \
+    (m) = (pmix_info_t *)pmix_tma_calloc((tma), (n), sizeof(pmix_info_t));     \
+    if (NULL != (m)) {                                                         \
+        i = (pmix_info_t *)(m);                                                \
+        i[(n) - 1].flags = PMIX_INFO_ARRAY_END;                                \
+    }                                                                          \
+} while (0)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_XFER() for our needs.
+#define PMIX_GDS_SHMEM_INFO_XFER(d, s, tma)                                    \
+    (void)pmix_gds_shmem_info_xfer(d, s, tma)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_PROC_CREATE() for our needs.
+#define PMIX_GDS_SHMEM_PROC_CREATE(m, n, tma)                                  \
+do {                                                                           \
+    (m) = (pmix_proc_t *)pmix_tma_calloc((tma), (n), sizeof(pmix_proc_t));     \
+} while (0)
+
 pmix_status_t
 pmix_gds_shmem_get_job_tracker(
     const pmix_nspace_t nspace,
@@ -28,7 +52,6 @@ pmix_gds_shmem_get_job_tracker(
     pmix_gds_shmem_job_t *target_tracker = NULL, *tracker = NULL;
     pmix_gds_shmem_component_t *component = &pmix_mca_gds_shmem_component;
     // Try to find the tracker for this job.
-    // TODO(skg) Consider using a hash table here for lookup.
     PMIX_LIST_FOREACH (tracker, &component->jobs, pmix_gds_shmem_job_t) {
         if (0 == strcmp(nspace, tracker->nspace_id)) {
             target_tracker = tracker;
@@ -96,18 +119,18 @@ pmix_gds_shmem_get_nodeinfo_by_nodename(
     pmix_list_t *nodes,
     const char *hostname
 ) {
-    pmix_gds_shmem_nodeinfo_t *ni;
     bool aliases_exist = false;
 
     if (NULL == hostname) {
         return NULL;
     }
     // First, just check all the node names as this is the most likely match.
+    pmix_gds_shmem_nodeinfo_t *ni;
     PMIX_LIST_FOREACH (ni, nodes, pmix_gds_shmem_nodeinfo_t) {
         if (0 == strcmp(ni->hostname, hostname)) {
             return ni;
         }
-        if (NULL != ni->aliases) {
+        if (!pmix_list_is_empty(ni->aliases)) {
             aliases_exist = true;
         }
     }
@@ -117,11 +140,10 @@ pmix_gds_shmem_get_nodeinfo_by_nodename(
     }
     // If a match wasn't found, then we have to try the aliases.
     PMIX_LIST_FOREACH (ni, nodes, pmix_gds_shmem_nodeinfo_t) {
-        if (NULL != ni->aliases) {
-            for (int i = 0; NULL != ni->aliases[i]; i++) {
-                if (0 == strcmp(ni->aliases[i], hostname)) {
-                    return ni;
-                }
+        pmix_gds_shmem_host_alias_t *nai = NULL;
+        PMIX_LIST_FOREACH (nai, ni->aliases, pmix_gds_shmem_host_alias_t) {
+            if (0 == strcmp(nai->name, hostname)) {
+                return ni;
             }
         }
     }
@@ -139,3 +161,869 @@ pmix_gds_shmem_check_hostname(
     }
     return false;
 }
+
+/**
+ * Error function for catching unhandled data types.
+ */
+static inline pmix_status_t
+unhandled_type(
+    pmix_data_type_t val_type
+) {
+    static const pmix_status_t rc = PMIX_ERR_FATAL;
+    PMIX_GDS_SHMEM_VOUT(
+        "%s: %s", __func__, PMIx_Data_type_string(val_type)
+    );
+    PMIX_ERROR_LOG(rc);
+    return rc;
+}
+
+/**
+ * Returns the size required to store the given type.
+ */
+// TODO(skg) This probably shouldn't live here. Figure out a way to get this in
+// an appropriate place.
+pmix_status_t
+pmix_gds_shmem_get_value_size(
+    const pmix_value_t *value,
+    size_t *result
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t total = 0;
+
+    const pmix_data_type_t type = value->type;
+    // NOTE(skg) This follows the size conventions set in include/pmix_common.h.
+    switch (type) {
+        case PMIX_ALLOC_DIRECTIVE:
+        case PMIX_BYTE:
+        case PMIX_DATA_RANGE:
+        case PMIX_INT8:
+        case PMIX_PERSIST:
+        case PMIX_POINTER:
+        case PMIX_PROC_STATE:
+        case PMIX_SCOPE:
+        case PMIX_UINT8:
+            total += sizeof(int8_t);
+            break;
+        case PMIX_BOOL:
+            total += sizeof(bool);
+            break;
+        // TODO(skg) This needs more work. For example, we can potentially miss
+        // the storage requirements of scaffolding around things like
+        // PMIX_STRINGs, for example. See pmix_gds_shmem_copy_darray().
+        case PMIX_DATA_ARRAY: {
+            total += sizeof(pmix_data_array_t);
+            const size_t n = value->data.darray->size;
+            PMIX_GDS_SHMEM_VOUT(
+                "%s: %s of type=%s has size=%zd",
+                __func__, PMIx_Data_type_string(type),
+                PMIx_Data_type_string(value->data.darray->type), n
+            );
+            // We don't construct or destruct tmp_value because we are only
+            // interested in inspecting its values for the purposes of
+            // estimating its size using this function.
+            pmix_value_t tmp_value = {
+                .type = value->data.darray->type
+            };
+            size_t sizeofn = 0;
+            rc = pmix_gds_shmem_get_value_size(&tmp_value, &sizeofn);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            total += n * sizeofn;
+            break;
+        }
+        case PMIX_DOUBLE:
+            total += sizeof(double);
+            break;
+        case PMIX_ENVAR: {
+            const pmix_envar_t *val = &value->data.envar;
+            total += sizeof(*val);
+            total += strlen(val->envar) + 1;
+            total += strlen(val->value) + 1;
+            break;
+        }
+        case PMIX_FLOAT:
+            total += sizeof(float);
+            break;
+        case PMIX_INFO:
+            total += sizeof(pmix_info_t);
+            break;
+        case PMIX_INT:
+        case PMIX_UINT:
+        case PMIX_STATUS:
+            total += sizeof(int);
+            break;
+        case PMIX_INT16:
+            total += sizeof(int16_t);
+            break;
+        case PMIX_INT32:
+            total += sizeof(int32_t);
+            break;
+        case PMIX_INT64:
+            total += sizeof(int64_t);
+            break;
+        case PMIX_PID:
+            total += sizeof(pid_t);
+            break;
+        case PMIX_PROC:
+            total += sizeof(pmix_proc_t);
+            break;
+        case PMIX_PROC_RANK:
+            total += sizeof(pmix_rank_t);
+            break;
+        case PMIX_REGEX:
+            total += sizeof(pmix_byte_object_t);
+            total += value->data.bo.size;
+            break;
+        case PMIX_STRING:
+            total += strlen(value->data.string) + 1;
+            break;
+        case PMIX_SIZE:
+            total += sizeof(size_t);
+            break;
+        case PMIX_UINT16:
+            total += sizeof(uint16_t);
+            break;
+        case PMIX_UINT32:
+            total += sizeof(uint32_t);
+            break;
+        case PMIX_UINT64:
+            total += sizeof(uint64_t);
+            break;
+        case PMIX_APP:
+        case PMIX_BUFFER:
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMMAND:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_COORD:
+        case PMIX_DATA_BUFFER:
+        case PMIX_DATA_TYPE:
+        case PMIX_DEVICE_DIST:
+        case PMIX_DEVTYPE:
+        case PMIX_DISK_STATS:
+        case PMIX_ENDPOINT:
+        case PMIX_GEOMETRY:
+        case PMIX_INFO_DIRECTIVES:
+        case PMIX_IOF_CHANNEL:
+        case PMIX_JOB_STATE:
+        case PMIX_KVAL:
+        case PMIX_LINK_STATE:
+        case PMIX_NET_STATS:
+        case PMIX_NODE_STATS:
+        case PMIX_PDATA:
+        case PMIX_PROC_CPUSET:
+        case PMIX_PROC_INFO:
+        case PMIX_PROC_NSPACE:
+        case PMIX_PROC_STATS:
+        case PMIX_QUERY:
+        case PMIX_REGATTR:
+        case PMIX_TIME:
+        case PMIX_TIMEVAL:
+        case PMIX_TOPO:
+        case PMIX_VALUE:
+        default:
+            return unhandled_type(type);
+    }
+    *result = total;
+    return rc;
+}
+
+/**
+ * Returns page size.
+ */
+static inline size_t
+get_page_size(void)
+{
+    const long i = sysconf(_SC_PAGE_SIZE);
+    if (-1 == i) {
+        PMIX_ERROR_LOG(PMIX_ERROR);
+        return 0;
+    }
+    return i;
+}
+
+/**
+ * Returns amount needed to pad to page boundary.
+ */
+size_t
+pmix_gds_shmem_pad_amount_to_page(
+    size_t size
+) {
+    const size_t page_size = get_page_size();
+    return ((~size) + page_size + 1) & (page_size - 1);
+}
+
+/**
+ * Returns a valid path or NULL on error.
+ */
+static const char *
+get_shmem_backing_path(
+    const char *id
+) {
+    static char path[PMIX_PATH_MAX] = {'\0'};
+    const char *basedir = NULL;
+    // TODO(skg) Fix
+#if 0
+    for (size_t i = 0; i < ninfo; ++i) {
+        if (PMIX_CHECK_KEY(&info[i], PMIX_NSDIR)) {
+            basedir = info[i].value.data.string;
+            break;
+        }
+        if (PMIX_CHECK_KEY(&info[i], PMIX_TMPDIR)) {
+            basedir = info[i].value.data.string;
+            break;
+        }
+    }
+#endif
+    if (!basedir) {
+        if (NULL == (basedir = getenv("TMPDIR"))) {
+            basedir = "/tmp";
+        }
+    }
+    // Now that we have the base dir, append file name.
+    size_t nw = snprintf(
+        path, PMIX_PATH_MAX, "%s/gds-%s.%s.%d",
+        basedir, PMIX_GDS_SHMEM_NAME, id, getpid()
+    );
+    if (nw >= PMIX_PATH_MAX) {
+        return NULL;
+    }
+    return path;
+}
+
+// TODO(skg) Add pmix_vmem_hole_kind_t paremeter. We may not want to use the
+// largest available hole all the time.
+/**
+ * Create and attach to a shared-memory segment.
+ */
+pmix_status_t
+pmix_gds_shmem_segment_create_and_attach(
+    pmix_gds_shmem_job_t *job,
+    const char *segment_id,
+    size_t segment_size
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    const char *segment_path = NULL;
+    uintptr_t mmap_addr = 0;
+    // Find a hole in virtual memory that meets our size requirements.
+    size_t base_addr = 0;
+    rc = pmix_vmem_find_hole(
+        VMEM_HOLE_BIGGEST, &base_addr, segment_size
+    );
+    if (PMIX_SUCCESS != rc) {
+        goto out;
+    }
+    PMIX_GDS_SHMEM_VOUT(
+        "%s: found vmhole at address=0x%zx",
+        __func__, base_addr
+    );
+    // Find a unique path for the shared-memory backing file.
+    segment_path = get_shmem_backing_path(segment_id);
+    if (!segment_path) {
+        rc = PMIX_ERROR;
+        goto out;
+    }
+    PMIX_GDS_SHMEM_VOUT(
+        "%s: segment backing file path is %s (size=%zd B)",
+        __func__, segment_path, segment_size
+    );
+    // Create a shared-memory segment backing store at the given path.
+    rc = pmix_shmem_segment_create(
+        job->shmem, segment_size, segment_path
+    );
+    if (PMIX_SUCCESS != rc) {
+        goto out;
+    }
+    // Attach to the shared-memory segment with the given address.
+    rc = pmix_shmem_segment_attach(
+        job->shmem, (void *)base_addr, &mmap_addr
+    );
+    if (PMIX_SUCCESS != rc) {
+        goto out;
+    }
+    // Make sure that we mapped to the requested address.
+    if (mmap_addr != (uintptr_t)job->shmem->base_address) {
+        // TODO(skg) Add a nice error message.
+        rc = PMIX_ERROR;
+        goto out;
+    }
+    PMIX_GDS_SHMEM_VOUT(
+        "%s: mmapd at address=0x%zx", __func__, (size_t)mmap_addr
+    );
+out:
+    if (PMIX_SUCCESS != rc) {
+        (void)pmix_shmem_segment_detach(job->shmem);
+        PMIX_ERROR_LOG(rc);
+    }
+    return rc;
+}
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies pmix_bfrops_base_copy_value() for our needs.
+pmix_status_t
+pmix_gds_shmem_bfrops_base_copy_value(
+    pmix_value_t **dest,
+    pmix_value_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+) {
+    pmix_value_t *p;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    /* create the new object */
+    *dest = (pmix_value_t *)pmix_tma_malloc(tma, sizeof(pmix_value_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    p = *dest;
+
+    /* copy the type */
+    p->type = src->type;
+    /* copy the data */
+    return pmix_gds_shmem_value_xfer(p, src, tma);
+}
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_INFO_XFER() for our needs.
+static pmix_status_t
+pmix_gds_shmem_info_xfer(
+    pmix_info_t *dest,
+    const pmix_info_t *src,
+    pmix_tma_t *tma
+) {
+    if (NULL == dest || NULL == src) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_LOAD_KEY(dest->key, src->key);
+    return pmix_gds_shmem_value_xfer(&dest->value, &src->value, tma);
+}
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies pmix_bfrops_base_copy_darray() for our needs.
+pmix_status_t
+pmix_gds_shmem_copy_darray(
+    pmix_data_array_t **dest,
+    pmix_data_array_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_data_array_t *p = NULL;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    p = (pmix_data_array_t *)pmix_tma_calloc(tma, 1, sizeof(pmix_data_array_t));
+    if (NULL == p) {
+        rc = PMIX_ERR_NOMEM;
+        goto out;
+    }
+
+    p->type = src->type;
+    p->size = src->size;
+
+    if (0 == p->size || NULL == src->array) {
+        // Done!
+        goto out;
+    }
+
+    // Process based on type of array element.
+    switch (src->type) {
+        case PMIX_UINT8:
+        case PMIX_INT8:
+        case PMIX_BYTE:
+            p->array = (char *)pmix_tma_malloc(tma, src->size);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size);
+            break;
+        case PMIX_UINT16:
+        case PMIX_INT16:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(uint16_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint16_t));
+            break;
+        case PMIX_UINT32:
+        case PMIX_INT32:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(uint32_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint32_t));
+            break;
+        case PMIX_UINT64:
+        case PMIX_INT64:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(uint64_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint64_t));
+            break;
+        case PMIX_BOOL:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(bool));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(bool));
+            break;
+        case PMIX_SIZE:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(size_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(size_t));
+            break;
+        case PMIX_PID:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(pid_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pid_t));
+            break;
+        case PMIX_STRING: {
+            char **prarray, **strarray;
+            p->array = (char **)pmix_tma_malloc(tma, src->size * sizeof(char *));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            prarray = (char **)p->array;
+            strarray = (char **)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                if (NULL != strarray[n]) {
+                    prarray[n] = pmix_tma_strdup(tma, strarray[n]);
+                    if (NULL == prarray[n]) {
+                        rc = PMIX_ERR_NOMEM;
+                        goto out;
+                    }
+                }
+            }
+            break;
+        }
+        case PMIX_INT:
+        case PMIX_UINT:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(int));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(int));
+            break;
+        case PMIX_FLOAT:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(float));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(float));
+            break;
+        case PMIX_DOUBLE:
+            p->array = (char *)pmix_tma_malloc(tma, src->size * sizeof(double));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(double));
+            break;
+        case PMIX_TIMEVAL:
+            p->array = (struct timeval *)pmix_tma_malloc(
+                tma, src->size * sizeof(struct timeval)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            p->array = (time_t *)pmix_tma_malloc(tma, src->size * sizeof(time_t));
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            p->array = (pmix_status_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_status_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC:
+            PMIX_GDS_SHMEM_PROC_CREATE(p->array, src->size, tma);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_proc_t));
+            break;
+        case PMIX_PROC_RANK:
+            p->array = (pmix_rank_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_rank_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_rank_t));
+            break;
+        case PMIX_INFO: {
+            pmix_info_t *p1, *s1;
+            PMIX_GDS_SHMEM_INFO_CREATE(p->array, src->size, tma);
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            p1 = (pmix_info_t *)p->array;
+            s1 = (pmix_info_t *)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                PMIX_GDS_SHMEM_INFO_XFER(&p1[n], &s1[n], tma);
+            }
+            break;
+        }
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING: {
+            pmix_byte_object_t *pbo, *sbo;
+            p->array = (pmix_byte_object_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_byte_object_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            pbo = (pmix_byte_object_t *)p->array;
+            sbo = (pmix_byte_object_t *)src->array;
+            for (size_t n = 0; n < src->size; n++) {
+                if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
+                    pbo[n].size = sbo[n].size;
+                    pbo[n].bytes = (char *)pmix_tma_malloc(tma, pbo[n].size);
+                    memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
+                } else {
+                    pbo[n].bytes = NULL;
+                    pbo[n].size = 0;
+                }
+            }
+            break;
+        }
+        case PMIX_PERSIST:
+            p->array = (pmix_persistence_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_persistence_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_persistence_t));
+            break;
+        case PMIX_SCOPE:
+            p->array = (pmix_scope_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_scope_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            p->array = (pmix_data_range_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_data_range_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_data_range_t));
+            break;
+        case PMIX_COMMAND:
+            p->array = (pmix_cmd_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_cmd_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_cmd_t));
+            break;
+        case PMIX_INFO_DIRECTIVES:
+            p->array = (pmix_info_directives_t *)pmix_tma_malloc(
+                tma, src->size * sizeof(pmix_info_directives_t)
+            );
+            if (NULL == p->array) {
+                rc = PMIX_ERR_NOMEM;
+                goto out;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_info_directives_t));
+            break;
+        case PMIX_DATA_ARRAY:
+            // We don't support nested arrays.
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            break;
+        case PMIX_VALUE:
+        case PMIX_APP:
+        case PMIX_PDATA:
+        case PMIX_BUFFER:
+        case PMIX_KVAL:
+        // TODO(skg) How are we going to handle this case? My guess is that
+        // since these are pointers then the assumption is that they are only
+        // valid within the process that asked to store them.
+        case PMIX_POINTER:
+        case PMIX_PROC_INFO:
+        case PMIX_QUERY:
+        case PMIX_ENVAR:
+        case PMIX_COORD:
+        case PMIX_REGATTR:
+        case PMIX_PROC_CPUSET:
+        case PMIX_GEOMETRY:
+        case PMIX_DEVICE_DIST:
+        case PMIX_ENDPOINT:
+        case PMIX_PROC_NSPACE:
+        case PMIX_PROC_STATS:
+        case PMIX_DISK_STATS:
+        case PMIX_NET_STATS:
+        case PMIX_NODE_STATS:
+        default:
+            pmix_output(
+                0, "%s: UNSUPPORTED TYPE: %s",
+                __func__, PMIx_Data_type_string(src->type)
+            );
+            rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+out:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        pmix_tma_free(tma, p);
+        p = NULL;
+    }
+    *dest = p;
+    return rc;
+}
+
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies pmix_bfrops_base_value_xfer() for our needs.
+pmix_status_t
+pmix_gds_shmem_value_xfer(
+    pmix_value_t *p,
+    const pmix_value_t *src,
+    pmix_tma_t *tma
+) {
+    p->type = src->type;
+
+    switch (src->type) {
+        case PMIX_UNDEF:
+            break;
+        case PMIX_BOOL:
+            p->data.flag = src->data.flag;
+            break;
+        case PMIX_BYTE:
+            p->data.byte = src->data.byte;
+            break;
+        case PMIX_STRING:
+            if (NULL != src->data.string) {
+                p->data.string = pmix_tma_strdup(tma, src->data.string);
+            } else {
+                p->data.string = NULL;
+            }
+            break;
+        case PMIX_SIZE:
+            p->data.size = src->data.size;
+            break;
+        case PMIX_PID:
+            p->data.pid = src->data.pid;
+            break;
+        case PMIX_INT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.integer, &src->data.integer, sizeof(int));
+            break;
+        case PMIX_INT8:
+            p->data.int8 = src->data.int8;
+            break;
+        case PMIX_INT16:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int16, &src->data.int16, 2);
+            break;
+        case PMIX_INT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int32, &src->data.int32, 4);
+            break;
+        case PMIX_INT64:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int64, &src->data.int64, 8);
+            break;
+        case PMIX_UINT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint, &src->data.uint, sizeof(unsigned int));
+            break;
+        case PMIX_UINT8:
+            p->data.uint8 = src->data.uint8;
+            break;
+        case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint16, &src->data.uint16, 2);
+            break;
+        case PMIX_UINT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint32, &src->data.uint32, 4);
+            break;
+        case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
+           /* to avoid alignment issues */
+            memcpy(&p->data.uint64, &src->data.uint64, 8);
+            break;
+        case PMIX_FLOAT:
+            p->data.fval = src->data.fval;
+            break;
+        case PMIX_DOUBLE:
+            p->data.dval = src->data.dval;
+            break;
+        case PMIX_TIMEVAL:
+            memcpy(&p->data.tv, &src->data.tv, sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            memcpy(&p->data.time, &src->data.time, sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC_RANK:
+            memcpy(&p->data.rank, &src->data.rank, sizeof(pmix_rank_t));
+            break;
+        case PMIX_PROC:
+            PMIX_GDS_SHMEM_PROC_CREATE(p->data.proc, 1, tma);
+            if (NULL == p->data.proc) {
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->data.proc, src->data.proc, sizeof(pmix_proc_t));
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+        case PMIX_REGEX:
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
+            if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
+                p->data.bo.bytes = pmix_tma_malloc(tma, src->data.bo.size);
+                memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
+                p->data.bo.size = src->data.bo.size;
+            } else {
+                p->data.bo.bytes = NULL;
+                p->data.bo.size = 0;
+            }
+            break;
+        case PMIX_PERSIST:
+            memcpy(
+                &p->data.persist,
+                &src->data.persist,
+                sizeof(pmix_persistence_t)
+            );
+            break;
+        case PMIX_SCOPE:
+            memcpy(&p->data.scope, &src->data.scope, sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            memcpy(&p->data.range, &src->data.range, sizeof(pmix_data_range_t));
+            break;
+        case PMIX_PROC_STATE:
+            memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
+            break;
+        case PMIX_DATA_ARRAY:
+            return pmix_gds_shmem_copy_darray(
+                &p->data.darray,
+                src->data.darray,
+                PMIX_DATA_ARRAY,
+                tma
+            );
+        case PMIX_POINTER:
+            p->data.ptr = src->data.ptr;
+            break;
+        case PMIX_ALLOC_DIRECTIVE:
+            memcpy(
+                &p->data.adir,
+                &src->data.adir,
+                sizeof(pmix_alloc_directive_t)
+            );
+            break;
+        case PMIX_ENVAR:
+            // NOTE(skg) This one is okay because all it does is set members.
+            PMIX_ENVAR_CONSTRUCT(&p->data.envar);
+            if (NULL != src->data.envar.envar) {
+                p->data.envar.envar = pmix_tma_strdup(tma, src->data.envar.envar);
+            }
+            if (NULL != src->data.envar.value) {
+                p->data.envar.value = pmix_tma_strdup(tma, src->data.envar.value);
+            }
+            p->data.envar.separator = src->data.envar.separator;
+            break;
+        case PMIX_LINK_STATE:
+            memcpy(
+                &p->data.linkstate,
+                &src->data.linkstate,
+                sizeof(pmix_link_state_t)
+            );
+            break;
+        case PMIX_JOB_STATE:
+            memcpy(
+                &p->data.jstate,
+                &src->data.jstate,
+                sizeof(pmix_job_state_t)
+            );
+            break;
+        case PMIX_LOCTYPE:
+            memcpy(
+                &p->data.locality,
+                &src->data.locality,
+                sizeof(pmix_locality_t)
+            );
+            break;
+        case PMIX_DEVTYPE:
+            memcpy(
+                &p->data.devtype,
+                &src->data.devtype,
+                sizeof(pmix_device_type_t)
+            );
+            break;
+        // TODO(skg) Implement currently unsupported types.
+        case PMIX_PROC_NSPACE:
+        case PMIX_PROC_INFO:
+        case PMIX_COORD:
+        case PMIX_TOPO:
+        case PMIX_PROC_CPUSET:
+        case PMIX_GEOMETRY:
+        case PMIX_DEVICE_DIST:
+        case PMIX_ENDPOINT:
+        case PMIX_REGATTR:
+        case PMIX_DATA_BUFFER:
+        case PMIX_PROC_STATS:
+        case PMIX_DISK_STATS:
+        case PMIX_NET_STATS:
+        case PMIX_NODE_STATS:
+        default:
+            pmix_output(
+                0, "%s: UNSUPPORTED TYPE: %s",
+                __func__, PMIx_Data_type_string(src->type)
+            );
+            return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+/*
+ * vim: ft=cpp ts=4 sts=4 sw=4 expandtab
+ */

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -33,6 +33,27 @@ do {                                                                           \
                         "gds:" PMIX_GDS_SHMEM_NAME ":" __VA_ARGS__);           \
 } while (0)
 
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_VALUE_XFER() for our needs.
+#define PMIX_GDS_SHMEM_VALUE_XFER(r, v, s, tma)                                \
+do {                                                                           \
+    if (NULL == (v)) {                                                         \
+        (v) = (pmix_value_t *)pmix_tma_malloc((tma), sizeof(pmix_value_t));    \
+        if (NULL == (v)) {                                                     \
+            (r) = PMIX_ERR_NOMEM;                                              \
+        } else {                                                               \
+            (r) = pmix_gds_shmem_value_xfer((v), (s), (tma));                  \
+        }                                                                      \
+    } else {                                                                   \
+        (r) = pmix_gds_shmem_value_xfer((v), (s), (tma));                      \
+    }                                                                          \
+} while(0)
+
+// TODO(skg) This shouldn't live here. Figure out a way to get this in an
+// appropriate place. This modifies PMIX_BFROPS_COPY() for our needs.
+#define PMIX_GDS_SHMEM_BFROPS_COPY_TMA(r, d, s, t, tma)                        \
+(r) = pmix_gds_shmem_bfrops_base_copy_value(d, s, t, tma)
+
 BEGIN_C_DECLS
 
 PMIX_EXPORT pmix_status_t
@@ -53,6 +74,84 @@ pmix_gds_shmem_check_hostname(
     const char *h1,
     const char *h2
 );
+
+PMIX_EXPORT pmix_status_t
+pmix_gds_shmem_get_value_size(
+    const pmix_value_t *value,
+    size_t *result
+);
+
+PMIX_EXPORT size_t
+pmix_gds_shmem_pad_amount_to_page(
+    size_t size
+);
+
+PMIX_EXPORT pmix_status_t
+pmix_gds_shmem_segment_create_and_attach(
+    pmix_gds_shmem_job_t *job,
+    const char *segment_id,
+    size_t segment_size
+);
+
+PMIX_EXPORT pmix_status_t
+pmix_gds_shmem_value_xfer(
+    pmix_value_t *p,
+    const pmix_value_t *src,
+    pmix_tma_t *tma
+);
+
+PMIX_EXPORT pmix_status_t
+pmix_gds_shmem_bfrops_base_copy_value(
+    pmix_value_t **dest,
+    pmix_value_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+);
+
+PMIX_EXPORT pmix_status_t
+pmix_gds_shmem_copy_darray(
+    pmix_data_array_t **dest,
+    pmix_data_array_t *src,
+    pmix_data_type_t type,
+    pmix_tma_t *tma
+);
+
+static inline pmix_tma_t *
+pmix_gds_shmem_get_job_tma(
+    pmix_gds_shmem_job_t *job
+) {
+    return &job->smdata->tma;
+}
+
+static inline bool
+pmix_gds_shmem_keys_eq(
+    const char *k1,
+    const char *k2
+) {
+    return 0 == strcmp(k1, k2);
+}
+
+static inline void
+pmix_gds_shmem_vout_smdata(
+    pmix_gds_shmem_job_t *job
+) {
+    PMIX_GDS_SHMEM_VOUT(
+        "shmem@%p, "
+        "jobinfo@%p, "
+        "apps@%p, "
+        "nodeinfo@%p, "
+        "local_hashtab@%p, "
+        "tma@%p, "
+        "tma.data_ptr=%p",
+        (void *)job->shmem->base_address,
+        (void *)job->smdata->jobinfo,
+        (void *)job->smdata->apps,
+        (void *)job->smdata->nodeinfo,
+        (void *)job->smdata->local_hashtab,
+        (void *)&job->smdata->tma,
+        (void *)job->smdata->tma.data_ptr
+    );
+}
 
 END_C_DECLS
 

--- a/src/mca/gds/shmem/pmix_hash2.h
+++ b/src/mca/gds/shmem/pmix_hash2.h
@@ -19,7 +19,11 @@
 #include "src/include/pmix_config.h"
 
 #include "src/include/pmix_globals.h"
+#if 0 // TODO(skg)
 #include "src/class/pmix_hash_table.h"
+#else
+#include "pmix_hash_table2.h"
+#endif
 #include "src/mca/bfrops/bfrops_types.h"
 
 BEGIN_C_DECLS
@@ -29,7 +33,7 @@ BEGIN_C_DECLS
  */
 PMIX_EXPORT pmix_status_t
 pmix_hash2_store(
-    pmix_hash_table_t *table,
+    pmix_hash_table2_t *table,
     pmix_rank_t rank, pmix_kval_t *kin,
     pmix_info_t *qualifiers,
     size_t nquals
@@ -41,7 +45,7 @@ pmix_hash2_store(
  */
 PMIX_EXPORT pmix_status_t
 pmix_hash2_fetch(
-    pmix_hash_table_t *table,
+    pmix_hash_table2_t *table,
     pmix_rank_t rank,
     const char *key,
     pmix_info_t *qualifiers,
@@ -59,7 +63,7 @@ pmix_hash2_fetch(
  */
 PMIX_EXPORT pmix_status_t
 pmix_hash2_remove_data(
-    pmix_hash_table_t *table,
+    pmix_hash_table2_t *table,
     pmix_rank_t rank,
     const char *key
 );

--- a/src/mca/gds/shmem/pmix_hash_table2.c
+++ b/src/mca/gds/shmem/pmix_hash_table2.c
@@ -1,0 +1,802 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2015 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// Please note that structures here potentially use a custom memory allocator.
+// This means that memory management calls should go through calls like
+// pmix_tma_calloc(), not calloc().
+// See src/class/pmix_object.h for more information about TMA.
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+#include "src/include/pmix_config.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#if 0 // TODO(skg)
+#include "src/class/pmix_hash_table.h"
+#else
+#include "pmix_hash_table2.h"
+#endif
+#include "src/class/pmix_list.h"
+#include "src/util/pmix_output.h"
+
+#include "pmix_common.h"
+
+/*
+ * pmix_hash_table2_t
+ */
+
+#define HASH_MULTIPLIER 31
+
+/*
+ * Define the structs that are opaque in the .h
+ */
+
+struct pmix_hash_element_t {
+    pmix_tma_t *tma; /* The memory allocator used for this element. */
+    int valid; /* whether this element is valid */
+    union {    /* the key, in its various forms */
+        uint32_t u32;
+        uint64_t u64;
+        struct {
+            const void *key;
+            size_t key_size;
+        } ptr;
+    } key;
+    void *value; /* the value */
+};
+typedef struct pmix_hash_element_t pmix_hash_element_t;
+
+struct pmix_hash_type_methods_t {
+    /* Frees any storage associated with the element
+     * The value is not owned by the hash table
+     * The key,key_size of pointer keys is
+     */
+    void (*elt_destructor)(pmix_hash_element_t *elt);
+    /* Hash the key of the element -- for growing and adjusting-after-removal */
+    uint64_t (*hash_elt)(pmix_hash_element_t *elt);
+};
+
+/* interact with the class-like mechanism */
+
+static void pmix_hash_table2_construct(pmix_hash_table2_t *ht);
+static void pmix_hash_table2_destruct(pmix_hash_table2_t *ht);
+
+PMIX_CLASS_INSTANCE(pmix_hash_table2_t, pmix_object_t, pmix_hash_table2_construct,
+                    pmix_hash_table2_destruct);
+
+static void pmix_hash_table2_construct(pmix_hash_table2_t *ht)
+{
+    ht->ht_table = NULL;
+    ht->ht_capacity = ht->ht_size = ht->ht_growth_trigger = 0;
+    ht->ht_density_numer = ht->ht_density_denom = 0;
+    ht->ht_growth_numer = ht->ht_growth_denom = 0;
+    ht->ht_type_methods = NULL;
+}
+
+static void pmix_hash_table2_destruct(pmix_hash_table2_t *ht)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+    pmix_hash_table2_remove_all(ht);
+    pmix_tma_free(tma, ht->ht_table);
+}
+
+/*
+ * Init, etc
+ */
+
+static size_t pmix_hash_round_capacity_up(size_t capacity)
+{
+    /* round up to (1 mod 30) */
+    return ((capacity + 29) / 30 * 30 + 1);
+}
+
+/* this could be the new init if people wanted a more general API */
+/* (that's why it isn't static) */
+int /* PMIX_ return code */
+pmix_hash_table2_init2(pmix_hash_table2_t *ht, size_t estimated_max_size, int density_numer,
+                      int density_denom, int growth_numer, int growth_denom)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+    size_t est_capacity = estimated_max_size * density_denom / density_numer;
+    size_t capacity = pmix_hash_round_capacity_up(est_capacity);
+    ht->ht_table = (pmix_hash_element_t *)pmix_tma_calloc(tma, capacity, sizeof(pmix_hash_element_t));
+    if (NULL == ht->ht_table) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    ht->ht_capacity = capacity;
+    ht->ht_density_numer = density_numer;
+    ht->ht_density_denom = density_denom;
+    ht->ht_growth_numer = growth_numer;
+    ht->ht_growth_denom = growth_denom;
+    ht->ht_growth_trigger = capacity * density_numer / density_denom;
+    ht->ht_type_methods = NULL;
+    return PMIX_SUCCESS;
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_init(pmix_hash_table2_t *ht, size_t table_size)
+{
+    /* default to density of 1/2 and growth of 2/1 */
+    return pmix_hash_table2_init2(ht, table_size, 1, 2, 2, 1);
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_remove_all(pmix_hash_table2_t *ht)
+{
+    size_t ii;
+    for (ii = 0; ii < ht->ht_capacity; ii += 1) {
+        pmix_hash_element_t *elt = &ht->ht_table[ii];
+        if (elt->valid && ht->ht_type_methods && ht->ht_type_methods->elt_destructor) {
+            ht->ht_type_methods->elt_destructor(elt);
+        }
+        elt->valid = 0;
+        elt->value = NULL;
+    }
+    ht->ht_size = 0;
+    /* the tests reuse the hash table for different types after removing all */
+    /* so we should allow that by forgetting what type it used to be */
+    ht->ht_type_methods = NULL;
+    return PMIX_SUCCESS;
+}
+
+static int /* PMIX_ return code */
+pmix_hash_grow(pmix_hash_table2_t *ht)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+    size_t jj, ii;
+    pmix_hash_element_t *old_table;
+    pmix_hash_element_t *new_table;
+    size_t old_capacity;
+    size_t new_capacity;
+
+    old_table = ht->ht_table;
+    old_capacity = ht->ht_capacity;
+
+    new_capacity = old_capacity * ht->ht_growth_numer / ht->ht_growth_denom;
+    new_capacity = pmix_hash_round_capacity_up(new_capacity);
+
+    new_table = (pmix_hash_element_t *)pmix_tma_calloc(tma, new_capacity, sizeof(new_table[0]));
+    if (NULL == new_table) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* for each element of the old table (indexed by jj), insert it
+       into the new table (indexed by ii), using the hash_elt method
+       to generically hash an element, then modulo the new capacity,
+       and using struct-assignment to copy an old element into its
+       place int he new table.  The hash table never owns the value,
+       and in the case of ptr keys the old dlements will be blindly
+       deleted, so we still own the ptr key storage, just in the new
+       table now */
+    for (jj = 0; jj < old_capacity; jj += 1) {
+        pmix_hash_element_t *old_elt;
+        pmix_hash_element_t *new_elt;
+        old_elt = &old_table[jj];
+        if (old_elt->valid) {
+            for (ii = (ht->ht_type_methods->hash_elt(old_elt) % new_capacity);; ii += 1) {
+                if (ii == new_capacity) {
+                    ii = 0;
+                }
+                new_elt = &new_table[ii];
+                if (!new_elt->valid) {
+                    *new_elt = *old_elt;
+                    break;
+                }
+            }
+        }
+    }
+    /* update with the new, free the old, return */
+    ht->ht_table = new_table;
+    ht->ht_capacity = new_capacity;
+    ht->ht_growth_trigger = new_capacity * ht->ht_density_numer / ht->ht_density_denom;
+    pmix_tma_free(tma, old_table);
+    return PMIX_SUCCESS;
+}
+
+/* one of the removal functions has determined which element should be
+   removed.  With the help of the type methods this can be generic.
+   The important thing is to rehash any valid elements immediately
+   following the element-being-removed */
+static int /* PMIX_ return code */
+pmix_hash_table2_remove_elt_at(pmix_hash_table2_t *ht, size_t ii)
+{
+    size_t jj, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elts = ht->ht_table;
+    pmix_hash_element_t *elt;
+
+    elt = &elts[ii];
+
+    if (!elt->valid) {
+        /* huh?  removing a not-valid element? */
+        return PMIX_ERROR;
+    }
+
+    elt->valid = 0;
+    if (ht->ht_type_methods->elt_destructor) {
+        ht->ht_type_methods->elt_destructor(elt);
+    }
+
+    /* need to possibly re-insert followers because of the now-gap */
+    /* E.g., XYyAaCbz.  (where upper is ideal, lower is not)
+     * remove A
+     * leaving XYy.aCbz. and we need to reconsider aCbz
+     * first a gets reinserted where it wants to be: XYya.Cbz.
+     * next  C doesn't move:                         XYya.Cbz.
+     * then  b gets put where it wants to be:        XYyabC.z.
+     * then  z moves down a little:                  XYyabCz..
+     * then  . means we're done
+     */
+    for (ii = ii + 1;; ii += 1) { /* scan immediately following elements */
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &elts[ii];
+        if (!elt->valid) {
+            break; /* done */
+        }
+        /* rehash it and move it if necessary */
+        for (jj = ht->ht_type_methods->hash_elt(elt) % capacity;; jj += 1) {
+            if (jj == capacity) {
+                jj = 0;
+            }
+            if (jj == ii) {
+                /* already in place, either ideal or best-for-now */
+                break;
+            } else if (!elts[jj].valid) {
+                /* move it down, and invaildate where it came from */
+                elts[jj] = elts[ii];
+                elts[ii].valid = 0;
+                break;
+            } else {
+                /* still need to find its place */
+            }
+        }
+    }
+    ht->ht_size -= 1;
+    return PMIX_SUCCESS;
+}
+
+/***************************************************************************/
+
+static uint64_t pmix_hash_hash_elt_uint32(pmix_hash_element_t *elt)
+{
+    return elt->key.u32;
+}
+
+static const struct pmix_hash_type_methods_t pmix_hash_type_methods_uint32
+    = {NULL, pmix_hash_hash_elt_uint32};
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_value_uint32(pmix_hash_table2_t *ht, uint32_t key, void **value)
+{
+    size_t ii, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+
+//TODO(skg) This triggers an error. Figure out why.
+#if 0
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint32:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint32:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint32;
+    for (ii = key % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.u32 == key) {
+            *value = elt->value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_set_value_uint32(pmix_hash_table2_t *ht, uint32_t key, void *value)
+{
+    int rc;
+    size_t ii, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_set_value_uint32:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_set_value_uint32:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint32;
+    for (ii = key % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            /* new entry */
+            elt->key.u32 = key;
+            elt->value = value;
+            elt->valid = 1;
+            elt->tma = tma;
+            ht->ht_size += 1;
+            if (ht->ht_size >= ht->ht_growth_trigger) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_grow(ht))) {
+                    return rc;
+                }
+            }
+            return PMIX_SUCCESS;
+        } else if (elt->key.u32 == key) {
+            /* replace existing element */
+            elt->value = value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+int pmix_hash_table2_remove_value_uint32(pmix_hash_table2_t *ht, uint32_t key)
+{
+    size_t ii, capacity = ht->ht_capacity;
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint32:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_remove_value_uint32:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint32;
+    for (ii = key % capacity;; ii += 1) {
+        pmix_hash_element_t *elt;
+        if (ii == capacity)
+            ii = 0;
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.u32 == key) {
+            return pmix_hash_table2_remove_elt_at(ht, ii);
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+/***************************************************************************/
+
+static uint64_t pmix_hash_hash_elt_uint64(pmix_hash_element_t *elt)
+{
+    return elt->key.u64;
+}
+
+static const struct pmix_hash_type_methods_t pmix_hash_type_methods_uint64
+    = {NULL, pmix_hash_hash_elt_uint64};
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_value_uint64(pmix_hash_table2_t *ht, uint64_t key, void **value)
+{
+    size_t ii;
+    size_t capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint64:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint64:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint64;
+    for (ii = key % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.u64 == key) {
+            *value = elt->value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_set_value_uint64(pmix_hash_table2_t *ht, uint64_t key, void *value)
+{
+    int rc;
+    size_t ii, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_set_value_uint64:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_set_value_uint64:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint64;
+    for (ii = key % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            /* new entry */
+            elt->key.u64 = key;
+            elt->value = value;
+            elt->valid = 1;
+            elt->tma = tma;
+            ht->ht_size += 1;
+            if (ht->ht_size >= ht->ht_growth_trigger) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_grow(ht))) {
+                    return rc;
+                }
+            }
+            return PMIX_SUCCESS;
+        } else if (elt->key.u64 == key) {
+            elt->value = value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_remove_value_uint64(pmix_hash_table2_t *ht, uint64_t key)
+{
+    size_t ii, capacity = ht->ht_capacity;
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_uint64:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_remove_value_uint64:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_uint64;
+    for (ii = key % capacity;; ii += 1) {
+        pmix_hash_element_t *elt;
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.u64 == key) {
+            return pmix_hash_table2_remove_elt_at(ht, ii);
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+/***************************************************************************/
+
+/* helper function used in several places */
+static uint64_t pmix_hash_hash_key_ptr(const void *key, size_t key_size)
+{
+    uint64_t hash;
+    const unsigned char *scanner;
+    size_t ii;
+
+    hash = 0;
+    scanner = (const unsigned char *) key;
+    for (ii = 0; ii < key_size; ii += 1) {
+        hash = HASH_MULTIPLIER * hash + *scanner++;
+    }
+    return hash;
+}
+
+/* ptr methods */
+
+static void pmix_hash_destruct_elt_ptr(pmix_hash_element_t *elt)
+{
+    elt->key.ptr.key_size = 0;
+    void *key = (void *) elt->key.ptr.key; /* cast away const so we can free it */
+    if (NULL != key) {
+        elt->key.ptr.key = NULL;
+        pmix_tma_free(elt->tma, key);
+    }
+}
+
+static uint64_t pmix_hash_hash_elt_ptr(pmix_hash_element_t *elt)
+{
+    return pmix_hash_hash_key_ptr(elt->key.ptr.key, elt->key.ptr.key_size);
+}
+
+static const struct pmix_hash_type_methods_t pmix_hash_type_methods_ptr
+    = {pmix_hash_destruct_elt_ptr, pmix_hash_hash_elt_ptr};
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_value_ptr(pmix_hash_table2_t *ht, const void *key, size_t key_size, void **value)
+{
+    size_t ii, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_ptr:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_get_value_ptr:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_ptr;
+    for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.ptr.key_size == key_size
+                   && 0 == memcmp(elt->key.ptr.key, key, key_size)) {
+            *value = elt->value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep going */
+        }
+    }
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_set_value_ptr(pmix_hash_table2_t *ht, const void *key, size_t key_size, void *value)
+{
+    int rc;
+    size_t ii, capacity = ht->ht_capacity;
+    pmix_hash_element_t *elt;
+    pmix_tma_t *tma = pmix_obj_get_tma(&ht->super);
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_set_value_ptr:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_set_value_ptr:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_ptr;
+    for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            /* new entry */
+            void *key_local = malloc(key_size);
+            memcpy(key_local, key, key_size);
+            elt->key.ptr.key = key_local;
+            elt->key.ptr.key_size = key_size;
+            elt->value = value;
+            elt->valid = 1;
+            elt->tma = tma;
+            ht->ht_size += 1;
+            if (ht->ht_size >= ht->ht_growth_trigger) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_grow(ht))) {
+                    return rc;
+                }
+            }
+            return PMIX_SUCCESS;
+        } else if (elt->key.ptr.key_size == key_size
+                   && 0 == memcmp(elt->key.ptr.key, key, key_size)) {
+            /* replace existing value */
+            elt->value = value;
+            return PMIX_SUCCESS;
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_remove_value_ptr(pmix_hash_table2_t *ht, const void *key, size_t key_size)
+{
+    size_t ii, capacity = ht->ht_capacity;
+
+#if PMIX_ENABLE_DEBUG
+    if (capacity == 0) {
+        pmix_output(0, "pmix_hash_table2_get_value_ptr:"
+                       "pmix_hash_table2_init() has not been called");
+        return PMIX_ERROR;
+    }
+    if (NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
+        pmix_output(0, "pmix_hash_table2_remove_value_ptr:"
+                       "hash table is for a different key type");
+        return PMIX_ERROR;
+    }
+#endif
+
+    ht->ht_type_methods = &pmix_hash_type_methods_ptr;
+    for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {
+        pmix_hash_element_t *elt;
+        if (ii == capacity) {
+            ii = 0;
+        }
+        elt = &ht->ht_table[ii];
+        if (!elt->valid) {
+            return PMIX_ERR_NOT_FOUND;
+        } else if (elt->key.ptr.key_size == key_size
+                   && 0 == memcmp(elt->key.ptr.key, key, key_size)) {
+            return pmix_hash_table2_remove_elt_at(ht, ii);
+        } else {
+            /* keep looking */
+        }
+    }
+}
+
+/***************************************************************************/
+/* Traversals */
+
+static int /* PMIX_ return code */
+pmix_hash_table2_get_next_elt(pmix_hash_table2_t *ht,
+                             pmix_hash_element_t *prev_elt, /* NULL means find first */
+                             pmix_hash_element_t **next_elt)
+{
+    pmix_hash_element_t *elts = ht->ht_table;
+    size_t ii, capacity = ht->ht_capacity;
+
+    for (ii = (NULL == prev_elt ? 0 : (prev_elt - elts) + 1); ii < capacity; ii += 1) {
+        pmix_hash_element_t *elt = &elts[ii];
+        if (elt->valid) {
+            *next_elt = elt;
+            return PMIX_SUCCESS;
+        }
+    }
+    return PMIX_ERROR;
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_first_key_uint32(pmix_hash_table2_t *ht, uint32_t *key, void **value,
+                                     void **node)
+{
+    return pmix_hash_table2_get_next_key_uint32(ht, key, value, NULL, node);
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_next_key_uint32(pmix_hash_table2_t *ht, uint32_t *key, void **value,
+                                    void *in_node, void **out_node)
+{
+    pmix_hash_element_t *elt;
+    if (PMIX_SUCCESS == pmix_hash_table2_get_next_elt(ht, (pmix_hash_element_t *) in_node, &elt)) {
+        *key = elt->key.u32;
+        *value = elt->value;
+        *out_node = elt;
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_first_key_ptr(pmix_hash_table2_t *ht, void **key, size_t *key_size, void **value,
+                                  void **node)
+{
+    return pmix_hash_table2_get_next_key_ptr(ht, key, key_size, value, NULL, node);
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_next_key_ptr(pmix_hash_table2_t *ht, void **key, size_t *key_size, void **value,
+                                 void *in_node, void **out_node)
+{
+    pmix_hash_element_t *elt;
+    if (PMIX_SUCCESS == pmix_hash_table2_get_next_elt(ht, (pmix_hash_element_t *) in_node, &elt)) {
+        *key = (void *) elt->key.ptr.key;
+        *key_size = elt->key.ptr.key_size;
+        *value = elt->value;
+        *out_node = elt;
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_first_key_uint64(pmix_hash_table2_t *ht, uint64_t *key, void **value,
+                                     void **node)
+{
+    return pmix_hash_table2_get_next_key_uint64(ht, key, value, NULL, node);
+}
+
+int /* PMIX_ return code */
+pmix_hash_table2_get_next_key_uint64(pmix_hash_table2_t *ht, uint64_t *key, void **value,
+                                    void *in_node, void **out_node)
+{
+    pmix_hash_element_t *elt;
+    if (PMIX_SUCCESS == pmix_hash_table2_get_next_elt(ht, (pmix_hash_element_t *) in_node, &elt)) {
+        *key = elt->key.u64;
+        *value = elt->value;
+        *out_node = elt;
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+size_t
+pmix_hash_table2_t_sizeof_hash_element(void)
+{
+    return sizeof(pmix_hash_element_t);
+}
+
+/* there was/is no traversal for the ptr case; it would go here */
+/* interact with the class-like mechanism */

--- a/src/mca/gds/shmem/pmix_hash_table2.h
+++ b/src/mca/gds/shmem/pmix_hash_table2.h
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/** @file
+ *
+ *  A hash table that may be indexed with either fixed length
+ *  (e.g. uint32_t/uint64_t) or arbitrary size binary key
+ *  values. However, only one key type may be used in a given table
+ *  concurrently.
+ */
+
+#ifndef PMIX_HASH_TABLE2_H
+#define PMIX_HASH_TABLE2_H
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_prefetch.h"
+
+#ifdef HAVE_STDINT_H
+#    include <stdint.h>
+#endif
+
+#include "src/class/pmix_list.h"
+
+#include "pmix_common.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hash_table2_t);
+
+struct pmix_hash_table2_t {
+    pmix_object_t super;                    /**< subclass of pmix_object_t */
+    const char *ht_label;                   /**< label for debugging */
+    struct pmix_hash_element_t *ht_table;   /**< table of elements (opaque to users) */
+    size_t ht_capacity;                     /**< allocated size (capacity) of table */
+    size_t ht_size;                         /**< number of extant entries */
+    size_t ht_growth_trigger;               /**< size hits this and table is grown  */
+    int ht_density_numer, ht_density_denom; /**< max allowed density of table */
+    int ht_growth_numer, ht_growth_denom;   /**< growth factor when grown  */
+    const struct pmix_hash_type_methods_t *ht_type_methods;
+};
+typedef struct pmix_hash_table2_t pmix_hash_table2_t;
+
+#define PMIX_HASH_TABLE2_STATIC_INIT                 \
+{                                                   \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .ht_label = NULL,                               \
+    .ht_table = NULL,                               \
+    .ht_capacity = 0,                               \
+    .ht_size = 0,                                   \
+    .ht_growth_trigger = 0,                         \
+    .ht_density_numer = 0,                          \
+    .ht_density_denom = 0,                          \
+    .ht_growth_numer = 0,                           \
+    .ht_growth_denom = 0,                           \
+    .ht_type_methods = NULL                         \
+}
+/**
+ *  Initializes the table size, must be called before using
+ *  the table.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   size    The size of the table, which will be rounded up
+ *                   (if required) to the next highest power of two (IN).
+ *  @return  PMIX error code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_init(pmix_hash_table2_t *ht, size_t table_size);
+
+/* this could be the new init if people wanted a more general API */
+PMIX_EXPORT int pmix_hash_table2_init2(pmix_hash_table2_t *ht, size_t estimated_max_size,
+                                      int density_numer, int density_denom, int growth_numer,
+                                      int growth_denom);
+
+/**
+ *  Returns the number of elements currently stored in the table.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @return  The number of elements in the table.
+ *
+ */
+
+static inline size_t pmix_hash_table2_get_size(pmix_hash_table2_t *ht)
+{
+    return ht->ht_size;
+}
+
+/**
+ *  Remove all elements from the table.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_remove_all(pmix_hash_table2_t *ht);
+
+/**
+ *  Retrieve value via uint32_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   ptr     The value associated with the key
+ *  @return  integer return code:
+ *           - PMIX_SUCCESS       if key was found
+ *           - PMIX_ERR_NOT_FOUND if key was not found
+ *           - PMIX_ERROR         other error
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_value_uint32(pmix_hash_table2_t *table, uint32_t key,
+                                                 void **ptr);
+
+/**
+ *  Set value based on uint32_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   value   The value to be associated with the key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_set_value_uint32(pmix_hash_table2_t *table, uint32_t key,
+                                                 void *value);
+
+/**
+ *  Remove value based on uint32_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_remove_value_uint32(pmix_hash_table2_t *table, uint32_t key);
+
+/**
+ *  Retrieve value via uint64_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   ptr     The value associated with the key
+ *  @return  integer return code:
+ *           - PMIX_SUCCESS       if key was found
+ *           - PMIX_ERR_NOT_FOUND if key was not found
+ *           - PMIX_ERROR         other error
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_value_uint64(pmix_hash_table2_t *table, uint64_t key,
+                                                 void **ptr);
+
+/**
+ *  Set value based on uint64_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   value   The value to be associated with the key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_set_value_uint64(pmix_hash_table2_t *table, uint64_t key,
+                                                 void *value);
+
+/**
+ *  Remove value based on uint64_t key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_remove_value_uint64(pmix_hash_table2_t *table, uint64_t key);
+
+/**
+ *  Retrieve value via arbitrary length binary key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   ptr     The value associated with the key
+ *  @return  integer return code:
+ *           - PMIX_SUCCESS       if key was found
+ *           - PMIX_ERR_NOT_FOUND if key was not found
+ *           - PMIX_ERROR         other error
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_value_ptr(pmix_hash_table2_t *table, const void *key,
+                                              size_t keylen, void **ptr);
+
+/**
+ *  Set value based on arbitrary length binary key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @param   value   The value to be associated with the key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_set_value_ptr(pmix_hash_table2_t *table, const void *key,
+                                              size_t keylen, void *value);
+
+/**
+ *  Remove value based on arbitrary length binary key.
+ *
+ *  @param   table   The input hash table (IN).
+ *  @param   key     The input key (IN).
+ *  @return  PMIX return code.
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_remove_value_ptr(pmix_hash_table2_t *table, const void *key,
+                                                 size_t keylen);
+
+/** The following functions are only for allowing iterating through
+    the hash table. The calls return along with a key, a pointer to
+    the hash node with the current key, so that subsequent calls do
+    not have to traverse all over again to the key (although it may
+    just be a simple thing - to go to the array element and then
+    traverse through the individual list). But lets take out this
+    inefficiency too. This is similar to having an STL iterator in
+    functionality */
+
+/**
+ *  Get the first 32 bit key from the hash table, which can be used later to
+ *  get the next key
+ *  @param  table   The hash table pointer (IN)
+ *  @param  key     The first key (OUT)
+ *  @param  value   The value corresponding to this key (OUT)
+ *  @param  node    The pointer to the hash table internal node which stores
+ *                  the key-value pair (this is required for subsequent calls
+ *                  to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_first_key_uint32(pmix_hash_table2_t *table, uint32_t *key,
+                                                     void **value, void **node);
+
+/**
+ *  Get the next 32 bit key from the hash table, knowing the current key
+ *  @param  table    The hash table pointer (IN)
+ *  @param  key      The key (OUT)
+ *  @param  value    The value corresponding to this key (OUT)
+ *  @param  in_node  The node pointer from previous call to either get_first
+                     or get_next (IN)
+ *  @param  out_node The pointer to the hash table internal node which stores
+ *                   the key-value pair (this is required for subsequent calls
+ *                   to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_next_key_uint32(pmix_hash_table2_t *table, uint32_t *key,
+                                                    void **value, void *in_node, void **out_node);
+
+/**
+ *  Get the first 64 key from the hash table, which can be used later to
+ *  get the next key
+ *  @param  table   The hash table pointer (IN)
+ *  @param  key     The first key (OUT)
+ *  @param  value   The value corresponding to this key (OUT)
+ *  @param  node    The pointer to the hash table internal node which stores
+ *                  the key-value pair (this is required for subsequent calls
+ *                  to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_first_key_uint64(pmix_hash_table2_t *table, uint64_t *key,
+                                                     void **value, void **node);
+
+/**
+ *  Get the next 64 bit key from the hash table, knowing the current key
+ *  @param  table    The hash table pointer (IN)
+ *  @param  key      The key (OUT)
+ *  @param  value    The value corresponding to this key (OUT)
+ *  @param  in_node  The node pointer from previous call to either get_first
+                     or get_next (IN)
+ *  @param  out_node The pointer to the hash table internal node which stores
+ *                   the key-value pair (this is required for subsequent calls
+ *                   to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_next_key_uint64(pmix_hash_table2_t *table, uint64_t *key,
+                                                    void **value, void *in_node, void **out_node);
+
+/**
+ *  Get the first ptr bit key from the hash table, which can be used later to
+ *  get the next key
+ *  @param  table    The hash table pointer (IN)
+ *  @param  key      The first key (OUT)
+ *  @param  key_size The first key size (OUT)
+ *  @param  value    The value corresponding to this key (OUT)
+ *  @param  node     The pointer to the hash table internal node which stores
+ *                   the key-value pair (this is required for subsequent calls
+ *                   to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_first_key_ptr(pmix_hash_table2_t *table, void **key,
+                                                  size_t *key_size, void **value, void **node);
+
+/**
+ *  Get the next ptr bit key from the hash table, knowing the current key
+ *  @param  table    The hash table pointer (IN)
+ *  @param  key      The key (OUT)
+ *  @param  key_size The key size (OUT)
+ *  @param  value    The value corresponding to this key (OUT)
+ *  @param  in_node  The node pointer from previous call to either get_first
+                     or get_next (IN)
+ *  @param  out_node The pointer to the hash table internal node which stores
+ *                   the key-value pair (this is required for subsequent calls
+ *                   to get_next_key) (OUT)
+ *  @return PMIX error code
+ *
+ */
+
+PMIX_EXPORT int pmix_hash_table2_get_next_key_ptr(pmix_hash_table2_t *table, void **key,
+                                                 size_t *key_size, void **value, void *in_node,
+                                                 void **out_node);
+
+/**
+ * Returns the size of the opaque pmix_hash_element_t structure. Note that this
+ * only returns the size of the structure itself and does not capture the size
+ * of data that are stored within an element.
+ */
+PMIX_EXPORT size_t
+pmix_hash_table2_t_sizeof_hash_element(void);
+
+/**
+ * @brief Returns next power-of-two of the given value.
+ *
+ * @param value The integer value to return power of 2
+ *
+ * @returns The next power of two
+ *
+ * WARNING: *NO* error checking is performed.  This is meant to be a
+ * fast inline function.
+ * Using __builtin_clz (count-leading-zeros) uses 4 cycles instead of 77
+ * compared to the loop-version (on Intel Nehalem -- with icc-12.1.0 -O2).
+ */
+#if 0 // TODO(skg) Uncomment when reincorporating.
+static inline int pmix_next_poweroftwo(int value)
+{
+    int power2;
+
+#if PMIX_C_HAVE_BUILTIN_CLZ
+    if (PMIX_UNLIKELY(0 == value)) {
+        return 1;
+    }
+    power2 = 1 << (8 * sizeof(int) - __builtin_clz(value));
+#else
+    for (power2 = 1; value > 0; value >>= 1, power2 <<= 1) /* empty */
+        ;
+#endif
+
+    return power2;
+}
+#endif
+
+/**
+ * Loop over a hash table.
+ *
+ * @param[in] key Key for each item
+ * @param[in] type Type of key (ui32|ui64|ptr)
+ * @param[in] value Storage for each item
+ * @param[in] ht Hash table to iterate over
+ *
+ * This macro provides a simple way to loop over the items in a pmix_hash_table2_t. It
+ * is not safe to call pmix_hash_table2_remove* from within the loop.
+ *
+ * Example Usage:
+ *
+ * uint64_t key;
+ * void * value;
+ * PMIX_HASH_TABLE2_FOREACH(key, uint64, value, ht) {
+ *    do_something(key, value);
+ * }
+ */
+#define PMIX_HASH_TABLE2_FOREACH(key, type, value, ht) \
+    for (void *_nptr = NULL;                          \
+         PMIX_SUCCESS                                 \
+         == pmix_hash_table2_get_next_key_##type(ht, &key, (void **) &value, _nptr, &_nptr);)
+
+#define PMIX_HASH_TABLE2_FOREACH_PTR(key, value, ht, body)                                       \
+    {                                                                                           \
+        size_t key_size_;                                                                       \
+        for (void *_nptr = NULL;                                                                \
+            PMIX_SUCCESS                                                                        \
+            == pmix_hash_table2_get_next_key_ptr(ht, &key, &key_size_, (void **) &value, _nptr,  \
+                                                &_nptr);)                                       \
+            body                                                                                \
+    }
+
+END_C_DECLS
+
+#endif /* PMIX_HASH_TABLE2_H */

--- a/src/mca/gds/shmem/pmix_pointer_array2.c
+++ b/src/mca/gds/shmem/pmix_pointer_array2.c
@@ -1,0 +1,457 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// Please note that structures here potentially use a custom memory allocator.
+// This means that memory management calls should go through calls like
+// pmix_tma_calloc(), not calloc().
+// See src/class/pmix_object.h for more information about TMA.
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if 0 // TODO(skg)
+#include "src/class/pmix_pointer_array.h"
+#else
+#include "pmix_pointer_array2.h"
+#endif
+#include "src/util/pmix_output.h"
+
+static void pmix_pointer_array2_construct(pmix_pointer_array2_t *);
+static void pmix_pointer_array2_destruct(pmix_pointer_array2_t *);
+static bool grow_table(pmix_pointer_array2_t *table, int at_least);
+
+PMIX_CLASS_INSTANCE(pmix_pointer_array2_t, pmix_object_t, pmix_pointer_array2_construct,
+                    pmix_pointer_array2_destruct);
+
+/*
+ * pmix_pointer_array constructor
+ */
+static void pmix_pointer_array2_construct(pmix_pointer_array2_t *array)
+{
+    array->lowest_free = 0;
+    array->number_free = 0;
+    array->size = 0;
+    array->max_size = INT_MAX;
+    array->block_size = 8;
+    array->free_bits = NULL;
+    array->addr = NULL;
+}
+
+/*
+ * pmix_pointer_array destructor
+ */
+static void pmix_pointer_array2_destruct(pmix_pointer_array2_t *array)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&array->super);
+    /* free table */
+    if (NULL != array->free_bits) {
+        pmix_tma_free(tma, array->free_bits);
+        array->free_bits = NULL;
+    }
+    if (NULL != array->addr) {
+        pmix_tma_free(tma, array->addr);
+        array->addr = NULL;
+    }
+
+    array->size = 0;
+}
+
+#define TYPE_ELEM_COUNT(TYPE, CAP) (((CAP) + 8 * sizeof(TYPE) - 1) / (8 * sizeof(TYPE)))
+
+/**
+ * Translate an index position into the free bits array into 2 values, the
+ * index of the element and the index of the bit position.
+ */
+#define GET_BIT_POS(IDX, BIDX, PIDX)               \
+    do {                                           \
+        uint32_t __idx = (uint32_t)(IDX);          \
+        (BIDX) = (__idx / (8 * sizeof(uint64_t))); \
+        (PIDX) = (__idx % (8 * sizeof(uint64_t))); \
+    } while (0)
+
+/**
+ * A classical find first zero bit (ffs) on a large array. It checks starting
+ * from the indicated position until it finds a zero bit. If SET is true,
+ * the bit is set. The position of the bit is returned in store.
+ *
+ * According to Section 6.4.4.1 of the C standard we don't need to prepend a type
+ * indicator to constants (the type is inferred by the compiler according to
+ * the number of bits necessary to represent it).
+ */
+#define FIND_FIRST_ZERO(START_IDX, STORE)                                   \
+    do {                                                                    \
+        uint32_t __b_idx, __b_pos;                                          \
+        if (0 == table->number_free) {                                      \
+            (STORE) = table->size;                                          \
+            break;                                                          \
+        }                                                                   \
+        GET_BIT_POS((START_IDX), __b_idx, __b_pos);                         \
+        for (; table->free_bits[__b_idx] == 0xFFFFFFFFFFFFFFFFu; __b_idx++) \
+            ;                                                               \
+        assert(__b_idx < (uint32_t) table->size);                           \
+        uint64_t __check_value = table->free_bits[__b_idx];                 \
+        __b_pos = 0;                                                        \
+                                                                            \
+        if (0x00000000FFFFFFFFu == (__check_value & 0x00000000FFFFFFFFu)) { \
+            __check_value >>= 32;                                           \
+            __b_pos += 32;                                                  \
+        }                                                                   \
+        if (0x000000000000FFFFu == (__check_value & 0x000000000000FFFFu)) { \
+            __check_value >>= 16;                                           \
+            __b_pos += 16;                                                  \
+        }                                                                   \
+        if (0x00000000000000FFu == (__check_value & 0x00000000000000FFu)) { \
+            __check_value >>= 8;                                            \
+            __b_pos += 8;                                                   \
+        }                                                                   \
+        if (0x000000000000000Fu == (__check_value & 0x000000000000000Fu)) { \
+            __check_value >>= 4;                                            \
+            __b_pos += 4;                                                   \
+        }                                                                   \
+        if (0x0000000000000003u == (__check_value & 0x0000000000000003u)) { \
+            __check_value >>= 2;                                            \
+            __b_pos += 2;                                                   \
+        }                                                                   \
+        if (0x0000000000000001u == (__check_value & 0x0000000000000001u)) { \
+            __b_pos += 1;                                                   \
+        }                                                                   \
+        (STORE) = (__b_idx * 8 * sizeof(uint64_t)) + __b_pos;               \
+    } while (0)
+
+/**
+ * Set the IDX bit in the free_bits array. The bit should be previously unset.
+ */
+#define SET_BIT(IDX)                                                            \
+    do {                                                                        \
+        uint32_t __b_idx, __b_pos;                                              \
+        GET_BIT_POS((IDX), __b_idx, __b_pos);                                   \
+        assert(0 == (table->free_bits[__b_idx] & (((uint64_t) 1) << __b_pos))); \
+        table->free_bits[__b_idx] |= (((uint64_t) 1) << __b_pos);               \
+    } while (0)
+
+/**
+ * Unset the IDX bit in the free_bits array. The bit should be previously set.
+ */
+#define UNSET_BIT(IDX)                                                     \
+    do {                                                                   \
+        uint32_t __b_idx, __b_pos;                                         \
+        GET_BIT_POS((IDX), __b_idx, __b_pos);                              \
+        assert((table->free_bits[__b_idx] & (((uint64_t) 1) << __b_pos))); \
+        table->free_bits[__b_idx] ^= (((uint64_t) 1) << __b_pos);          \
+    } while (0)
+
+#if 0
+/**
+ * Validate the pointer array by making sure that the elements and
+ * the free bits array are in sync. It also check that the number
+ * of remaining free element is consistent.
+ */
+static void pmix_pointer_array2_validate(pmix_pointer_array2_t *array)
+{
+    int i, cnt = 0;
+    uint32_t b_idx, p_idx;
+
+    for( i = 0; i < array->size; i++ ) {
+        GET_BIT_POS(i, b_idx, p_idx);
+        if( NULL == array->addr[i] ) {
+            cnt++;
+            assert( 0 == (array->free_bits[b_idx] & (((uint64_t)1) << p_idx)) );
+        } else {
+            assert( 0 != (array->free_bits[b_idx] & (((uint64_t)1) << p_idx)) );
+        }
+    }
+    assert(cnt == array->number_free);
+}
+#endif
+
+/**
+ * initialize an array object
+ */
+int pmix_pointer_array2_init(pmix_pointer_array2_t *array, int initial_allocation, int max_size,
+                            int block_size)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&array->super);
+    size_t num_bytes;
+
+    /* check for errors */
+    if (NULL == array || max_size < block_size) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    array->max_size = max_size;
+    array->block_size = (0 == block_size ? 8 : block_size);
+    array->lowest_free = 0;
+
+    num_bytes = (0 < initial_allocation ? initial_allocation : block_size);
+
+    /* Allocate and set the array to NULL */
+    array->addr = (void **) pmix_tma_calloc(tma, num_bytes, sizeof(void *));
+    if (NULL == array->addr) { /* out of memory */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    array->free_bits = (uint64_t *) pmix_tma_calloc(tma, TYPE_ELEM_COUNT(uint64_t, num_bytes), sizeof(uint64_t));
+    if (NULL == array->free_bits) { /* out of memory */
+        pmix_tma_free(tma, array->addr);
+        array->addr = NULL;
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    array->number_free = num_bytes;
+    array->size = num_bytes;
+
+    return PMIX_SUCCESS;
+}
+
+/**
+ * add a pointer to dynamic pointer table
+ *
+ * @param table Pointer to pmix_pointer_array2_t object (IN)
+ * @param ptr Pointer to be added to table    (IN)
+ *
+ * @return Array index where ptr is inserted or PMIX_ERROR if it fails
+ */
+int pmix_pointer_array2_add(pmix_pointer_array2_t *table, void *ptr)
+{
+    int index = table->size + 1;
+
+    if (table->number_free == 0) {
+        /* need to grow table */
+        if (!grow_table(table, index)) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    assert((table->addr != NULL) && (table->size > 0));
+    assert((table->lowest_free >= 0) && (table->lowest_free < table->size));
+    assert((table->number_free > 0) && (table->number_free <= table->size));
+
+    /*
+     * add pointer to table, and return the index
+     */
+
+    index = table->lowest_free;
+    assert(NULL == table->addr[index]);
+    table->addr[index] = ptr;
+    table->number_free--;
+    SET_BIT(index);
+    if (table->number_free > 0) {
+        FIND_FIRST_ZERO(index, table->lowest_free);
+    } else {
+        table->lowest_free = table->size;
+    }
+
+#if 0
+    pmix_pointer_array2_validate(table);
+#endif
+    return index;
+}
+
+/**
+ * Set the value of the dynamic array at a specified location.
+ *
+ *
+ * @param table Pointer to pmix_pointer_array2_t object (IN)
+ * @param ptr Pointer to be added to table    (IN)
+ *
+ * @return Error code
+ *
+ * Assumption: NULL element is free element.
+ */
+int pmix_pointer_array2_set_item(pmix_pointer_array2_t *table, int index, void *value)
+{
+    assert(table != NULL);
+
+    if (PMIX_UNLIKELY(0 > index)) {
+        return PMIX_ERROR;
+    }
+
+    /* expand table if required to set a specific index */
+
+    if (table->size <= index) {
+        if (!grow_table(table, index)) {
+            return PMIX_ERROR;
+        }
+    }
+    assert(table->size > index);
+    /* mark element as free, if NULL element */
+    if (NULL == value) {
+        if (NULL != table->addr[index]) {
+            if (index < table->lowest_free) {
+                table->lowest_free = index;
+            }
+            table->number_free++;
+            UNSET_BIT(index);
+        }
+    } else {
+        if (NULL == table->addr[index]) {
+            table->number_free--;
+            SET_BIT(index);
+            /* Reset lowest_free if required */
+            if (index == table->lowest_free) {
+                FIND_FIRST_ZERO(index, table->lowest_free);
+            }
+        } else {
+            assert(index != table->lowest_free);
+        }
+    }
+    table->addr[index] = value;
+
+#if 0
+    pmix_pointer_array2_validate(table);
+    pmix_output(0,"pmix_pointer_array2_set_item: OUT: "
+                " table %p (size %ld, lowest free %ld, number free %ld)"
+                " addr[%d] = %p\n",
+                table, table->size, table->lowest_free, table->number_free,
+                index, table->addr[index]);
+#endif
+
+    return PMIX_SUCCESS;
+}
+
+/**
+ * Test whether a certain element is already in use. If not yet
+ * in use, reserve it.
+ *
+ * @param array Pointer to array (IN)
+ * @param index Index of element to be tested (IN)
+ * @param value New value to be set at element index (IN)
+ *
+ * @return true/false True if element could be reserved
+ *                    False if element could not be reserved (e.g.in use).
+ *
+ * In contrary to array_set, this function does not allow to overwrite
+ * a value, unless the previous value is NULL ( equiv. to free ).
+ */
+bool pmix_pointer_array2_test_and_set_item(pmix_pointer_array2_t *table, int index, void *value)
+{
+    assert(table != NULL);
+    assert(index >= 0);
+
+#if 0
+    pmix_output(0,"pmix_pointer_array2_test_and_set_item: IN:  "
+               " table %p (size %ld, lowest free %ld, number free %ld)"
+               " addr[%d] = %p\n",
+               table, table->size, table->lowest_free, table->number_free,
+               index, table->addr[index]);
+#endif
+
+    /* expand table if required to set a specific index */
+    if (index < table->size && table->addr[index] != NULL) {
+        /* This element is already in use */
+        return false;
+    }
+
+    /* Do we need to grow the table? */
+
+    if (table->size <= index) {
+        if (!grow_table(table, index)) {
+            return false;
+        }
+    }
+
+    /*
+     * allow a specific index to be changed.
+     */
+    assert(NULL == table->addr[index]);
+    table->addr[index] = value;
+    table->number_free--;
+    SET_BIT(index);
+    /* Reset lowest_free if required */
+    if (table->number_free > 0) {
+        if (index == table->lowest_free) {
+            FIND_FIRST_ZERO(index, table->lowest_free);
+        }
+    } else {
+        table->lowest_free = table->size;
+    }
+
+#if 0
+    pmix_pointer_array2_validate(table);
+    pmix_output(0,"pmix_pointer_array2_test_and_set_item: OUT: "
+               " table %p (size %ld, lowest free %ld, number free %ld)"
+               " addr[%d] = %p\n",
+               table, table->size, table->lowest_free, table->number_free,
+               index, table->addr[index]);
+#endif
+
+    return true;
+}
+
+int pmix_pointer_array2_set_size(pmix_pointer_array2_t *array, int new_size)
+{
+    if (new_size > array->size) {
+        if (!grow_table(array, new_size)) {
+            return PMIX_ERROR;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static bool grow_table(pmix_pointer_array2_t *table, int at_least)
+{
+    pmix_tma_t *tma = pmix_obj_get_tma(&table->super);
+    int i, new_size, new_size_int;
+    void *p;
+
+    new_size = table->block_size * ((at_least + 1 + table->block_size - 1) / table->block_size);
+    if (new_size >= table->max_size) {
+        new_size = table->max_size;
+        if (at_least >= table->max_size) {
+            return false;
+        }
+    }
+
+    p = (void **) pmix_tma_realloc(tma, table->addr, new_size * sizeof(void *));
+    if (NULL == p) {
+        return false;
+    }
+
+    table->number_free += (new_size - table->size);
+    table->addr = (void **) p;
+    for (i = table->size; i < new_size; ++i) {
+        table->addr[i] = NULL;
+    }
+    new_size_int = TYPE_ELEM_COUNT(uint64_t, new_size);
+    if ((int) (TYPE_ELEM_COUNT(uint64_t, table->size)) != new_size_int) {
+        p = (uint64_t *) pmix_tma_realloc(tma, table->free_bits, new_size_int * sizeof(uint64_t));
+        if (NULL == p) {
+            return false;
+        }
+        table->free_bits = (uint64_t *) p;
+        for (i = TYPE_ELEM_COUNT(uint64_t, table->size); i < new_size_int; i++) {
+            table->free_bits[i] = 0;
+        }
+    }
+    table->size = new_size;
+#if 0
+    pmix_output(0, "grow_table %p to %d (max_size %d, block %d, number_free %d)\n",
+                (void*)table, table->size, table->max_size, table->block_size, table->number_free);
+#endif
+    return true;
+}

--- a/src/mca/gds/shmem/pmix_pointer_array2.h
+++ b/src/mca/gds/shmem/pmix_pointer_array2.h
@@ -1,0 +1,216 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file
+ *
+ * Utility functions to manage fortran <-> c opaque object
+ * translation.  Note that since MPI defines fortran handles as
+ * [signed] int's, we use int everywhere in here where you would
+ * normally expect size_t.  There's some code that makes sure indices
+ * don't go above FORTRAN_HANDLE_MAX (which is min(INT_MAX, fortran
+ * INTEGER max)), just to be sure.
+ */
+
+#ifndef PMIX_POINTER_ARRAY2_H
+#define PMIX_POINTER_ARRAY2_H
+
+#include "src/include/pmix_config.h"
+
+#include "src/class/pmix_object.h"
+#include "src/include/pmix_prefetch.h"
+
+BEGIN_C_DECLS
+
+/**
+ * dynamic pointer array
+ */
+struct pmix_pointer_array2_t {
+    /** base class */
+    pmix_object_t super;
+    /** Index of lowest free element.  NOTE: This is only an
+        optimization to know where to search for the first free slot.
+        It does \em not necessarily imply indices all above this index
+        are not taken! */
+    int lowest_free;
+    /** number of free elements in the list */
+    int number_free;
+    /** size of list, i.e. number of elements in addr */
+    int size;
+    /** maximum size of the array */
+    int max_size;
+    /** block size for each allocation */
+    int block_size;
+    /** pointer to an array of bits to speed up the research for an empty position. */
+    uint64_t *free_bits;
+    /** pointer to array of pointers */
+    void **addr;
+};
+
+#define PMIX_POINTER_ARRAY_STATIC_INIT              \
+{                                                   \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .lowest_free = 0,                               \
+    .number_free = 0,                               \
+    .size = 0,                                      \
+    .max_size = 0,                                  \
+    .block_size = 0,                                \
+    .free_bits = NULL,                              \
+    .addr = NULL                                    \
+}
+
+/**
+ * Convenience typedef
+ */
+typedef struct pmix_pointer_array2_t pmix_pointer_array2_t;
+/**
+ * Class declaration
+ */
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pointer_array2_t);
+
+/**
+ * Initialize the pointer array with an initial size of initial_allocation.
+ * Set the maximum size of the array, as well as the size of the allocation
+ * block for all subsequent growing operations. Remarque: The pointer array
+ * has to be created bfore calling this function.
+ *
+ * @param array Pointer to pointer of an array (IN/OUT)
+ * @param initial_allocation The number of elements in the initial array (IN)
+ * @param max_size The maximum size of the array (IN)
+ * @param block_size The size for all subsequent grows of the array (IN).
+ *
+ * @return PMIX_SUCCESS if all initializations were succesfull. Otherwise,
+ *  the error indicate what went wrong in the function.
+ */
+PMIX_EXPORT int pmix_pointer_array2_init(pmix_pointer_array2_t *array, int initial_allocation,
+                                        int max_size, int block_size);
+
+/**
+ * Add a pointer to the array (Grow the array, if need be)
+ *
+ * @param array Pointer to array (IN)
+ * @param ptr Pointer value (IN)
+ *
+ * @return Index of inserted array element.  Return value of
+ *  (-1) indicates an error.
+ */
+PMIX_EXPORT int pmix_pointer_array2_add(pmix_pointer_array2_t *array, void *ptr);
+
+/**
+ * Set the value of an element in array
+ *
+ * @param array Pointer to array (IN)
+ * @param index Index of element to be reset (IN)
+ * @param value New value to be set at element index (IN)
+ *
+ * @return Error code.  (-1) indicates an error.
+ */
+PMIX_EXPORT int pmix_pointer_array2_set_item(pmix_pointer_array2_t *array, int index, void *value);
+
+/**
+ * Get the value of an element in array
+ *
+ * @param array          Pointer to array (IN)
+ * @param element_index  Index of element to be returned (IN)
+ *
+ * @return Error code.  NULL indicates an error.
+ */
+
+static inline void *pmix_pointer_array2_get_item(pmix_pointer_array2_t *table, int element_index)
+{
+    void *p;
+
+    if (PMIX_UNLIKELY(0 > element_index || table->size <= element_index)) {
+        return NULL;
+    }
+    p = table->addr[element_index];
+    return p;
+}
+
+/**
+ * Get the size of the pointer array
+ *
+ * @param array Pointer to array (IN)
+ *
+ * @returns size Size of the array
+ *
+ * Simple inline function to return the size of the array in order to
+ * hide the member field from external users.
+ */
+static inline int pmix_pointer_array2_get_size(pmix_pointer_array2_t *array)
+{
+    return array->size;
+}
+
+/**
+ * Set the size of the pointer array
+ *
+ * @param array Pointer to array (IN)
+ *
+ * @param size Desired size of the array
+ *
+ * Simple function to set the size of the array in order to
+ * hide the member field from external users.
+ */
+PMIX_EXPORT int pmix_pointer_array2_set_size(pmix_pointer_array2_t *array, int size);
+
+/**
+ * Test whether a certain element is already in use. If not yet
+ * in use, reserve it.
+ *
+ * @param array Pointer to array (IN)
+ * @param index Index of element to be tested (IN)
+ * @param value New value to be set at element index (IN)
+ *
+ * @return true/false True if element could be reserved
+ *                    False if element could not be reserved (e.g., in use).
+ *
+ * In contrary to array_set, this function does not allow to overwrite
+ * a value, unless the previous value is NULL ( equiv. to free ).
+ */
+PMIX_EXPORT bool pmix_pointer_array2_test_and_set_item(pmix_pointer_array2_t *table, int index,
+                                                      void *value);
+
+/**
+ * Empty the array.
+ *
+ * @param array Pointer to array (IN)
+ *
+ */
+static inline void pmix_pointer_array2_remove_all(pmix_pointer_array2_t *array)
+{
+    int i;
+    if (array->number_free == array->size)
+        return; /* nothing to do here this time (the array is already empty) */
+
+    array->lowest_free = 0;
+    array->number_free = array->size;
+    for (i = 0; i < array->size; i++) {
+        array->addr[i] = NULL;
+    }
+    for (i = 0; i < (int) ((array->size + 8 * sizeof(uint64_t) - 1) / (8 * sizeof(uint64_t)));
+         i++) {
+        array->free_bits[i] = 0;
+    }
+}
+
+END_C_DECLS
+
+#endif /* PMIX_POINTER_ARRAY2_H */


### PR DESCRIPTION
For a single client it appears that the sharing of hash tables and lists
works. pmix_gds_shmem_fetch() requires work to accommodate multiple
clients.

Other notable changes include:
* Revert changes introduced in 'TMA: Integrate more custom memory allocator
  infrastructure'. The base object system doesn't appear to require the
  changes introduced in that commit.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>