### PR TITLE
Updates from master branch

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -85,7 +85,7 @@ installation using the --with-libevent=<dir> option if it is in
 a non-standard location. Similarly, non-standard locations for
 the HWLOC package must be specified using the --with-hwloc=<dir>
 option. In both cases, PMIx will automatically detect these
-packages in standard locations and build-in support for them
+packages in standard locations and built-in support for them
 unless otherwise specified using the respective configure option.
 
 

--- a/INSTALL
+++ b/INSTALL
@@ -71,7 +71,7 @@ using the --with-libevent=<dir> option if it is in a non-standard
 location. Similarly, non-standard locations for the HWLOC package
 must be specified using the --with-hwloc=<dir> option. In both
 cases, PMIx will automatically detect these packages in standard
-locations and build-in support for them unless otherwise specified
+locations and built-in support for them unless otherwise specified
 using the respective configure option.
 
 If you need special access to install, then you can execute "make

--- a/VERSION
+++ b/VERSION
@@ -45,16 +45,16 @@ std_major=4
 std_minor=1
 std_extension=2
 
-# PMIx Standard ABI Compliance Level
-# The major and minor numbers indicate the version
+# PMIx Standard ABI Compliance Level(s)
+# The major and minor numbers (MAJOR.MINOR) indicate the version
 # of the official PMIx Standard ABI that is supported
-# by this release. Generally, the PMIx Standard ABI
-# should match the PMIx Standard Compliance Level
-# major/minor levels. However, they are listed separately
-# for maximal flexibility.
+# by this release. This may be a comma separated list (no spaces)
+# if more than one PMIx Standard ABI level is supported.
+# The PMIx Standard defines a 'stable' and a 'provisional' ABI.
+# Therefore, there are two sets of major/minor values.
 # Since no PMIx Standard ABI exists at the moment, set to "0.0"
-std_abi_major=0
-std_abi_minor=0
+std_abi_stable=0.0
+std_abi_provisional=0.0
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/VERSION
+++ b/VERSION
@@ -4,6 +4,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2022      IBM Corporation. All rights reserved.
 
 # This is the VERSION file for PMIx, describing the precise
 # version of PMIx in this distribution.  The various components of
@@ -43,6 +44,17 @@ greek=a1
 std_major=4
 std_minor=1
 std_extension=2
+
+# PMIx Standard ABI Compliance Level
+# The major and minor numbers indicate the version
+# of the official PMIx Standard ABI that is supported
+# by this release. Generally, the PMIx Standard ABI
+# should match the PMIx Standard Compliance Level
+# major/minor levels. However, they are listed separately
+# for maximal flexibility.
+# Since no PMIx Standard ABI exists at the moment, set to "0.0"
+std_abi_major=0
+std_abi_minor=0
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2710,7 +2710,7 @@ cdef void toolconnected(pmix_info_t *info, size_t ninfo,
     # we cannot execute a callback function here as
     # that would cause PMIx to lockup. So we start
     # a new thread on a timer that should execute a
-    # callback after the funciton returns
+    # callback after the function returns
     cdef pmix_proc_t *proc
     proc = NULL
     pmix_copy_nspace(proc[0].nspace, ret_proc['nspace'])
@@ -2795,7 +2795,7 @@ cdef int allocate(const pmix_proc_t *client,
     # we cannot execute a callback function here as
     # that would cause PMIx to lockup. So we start
     # a new thread on a timer that should execute a
-    # callback after the funciton returns
+    # callback after the function returns
     cdef pmix_info_t *info
     cdef pmix_info_t **info_ptr
     cdef size_t ninfo = 0

--- a/config/oac_check_package.m4
+++ b/config/oac_check_package.m4
@@ -53,7 +53,7 @@ dnl      in the specified path.
 dnl   4. We try to find the specified header and function with no change
 dnl      in CPPFLAGS or LDFLAGS and adding the specified libraries to LIBS.
 dnl
-dnl It is the resposibility of the caller to register arguments of the form
+dnl It is the responsibility of the caller to register arguments of the form
 dnl with-<package name>, with-<package name>-libdir, and with-package name>-incdir.
 dnl All three are optional, nothing will break if the caller doesn't specify them
 dnl (and indeed, if the package being searched for isn't libnl3, it's likely the
@@ -63,7 +63,7 @@ dnl By default, OAC_CHECK_PACKAGE will use <package name> for the module name to
 dnl to pkg-config, meaning there is a <package name>.pc in the filesystem.  If a
 dnl different module name should be used, add a macro to the M4 environment named
 dnl <package name>_pkgconfig_module with the value of the pkgconfig module name
-dnl to use.  For exmaple, if the libevent module name is libevent_core, you could
+dnl to use.  For example, if the libevent module name is libevent_core, you could
 dnl specify:
 dnl
 dnl    m4_define([libevent_pkgconfig_module], [libevent_core])

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -157,15 +157,25 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_STD_VERSION], ["$PMIX_STD_VERSION"],
                        [The PMIx Standard compliance level])
 
-    AC_MSG_CHECKING([for pmix standard ABI version])
-    PMIX_STD_ABI_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-version`"
+    AC_MSG_CHECKING([for pmix standard stable ABI version(s)])
+    PMIX_STD_ABI_STABLE_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-stable-version`"
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_STD_ABI_VERSION])
-    AC_SUBST(PMIX_STD_ABI_VERSION)
-    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_VERSION], ["$PMIX_STD_ABI_VERSION"],
-                       [The PMIx Standard ABI compliance level])
+    AC_MSG_RESULT([$PMIX_STD_ABI_STABLE_VERSION])
+    AC_SUBST(PMIX_STD_ABI_STABLE_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_STABLE_VERSION], ["$PMIX_STD_ABI_STABLE_VERSION"],
+                       [The PMIx Standard Stable ABI compliance level(s)])
+
+    AC_MSG_CHECKING([for pmix standard provisional ABI version(s)])
+    PMIX_STD_ABI_PROVISIONAL_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-provisional-version`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_MSG_RESULT([$PMIX_STD_ABI_PROVISIONAL_VERSION])
+    AC_SUBST(PMIX_STD_ABI_PROVISIONAL_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_PROVISIONAL_VERSION], ["$PMIX_STD_ABI_PROVISIONAL_VERSION"],
+                       [The PMIx Standard Provisional ABI compliance level(s)])
 
     PMIX_REPO_REV="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --repo-rev`"
     if test "$?" != "0"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -70,7 +70,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_top_builddir)
 
     # Get pmix's absolute top srcdir (which may not be the same as the
-    # real $top_srcdir.  First, go back to the startdir incase the
+    # real $top_srcdir.  First, go back to the startdir in case the
     # $srcdir is relative.
 
     cd "$PMIX_startdir"
@@ -1145,7 +1145,7 @@ AS_IF([test "$pmix_install_primary_headers" = "no"],
 #
 AC_ARG_ENABLE([per-user-config-files],
    [AS_HELP_STRING([--enable-per-user-config-files],
-      [Disable per-user configuration files, to save disk accesses during job start-up.  This is likely desirable for large jobs.  Note that this can also be acheived by environment variables at run-time.  (default: enabled)])])
+      [Disable per-user configuration files, to save disk accesses during job start-up.  This is likely desirable for large jobs.  Note that this can also be achieved by environment variables at run-time.  (default: enabled)])])
 if test "$enable_per_user_config_files" = "no" ; then
   result=0
 else

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2009-2021 IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2009-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
@@ -156,6 +156,16 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_STD_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_STD_VERSION], ["$PMIX_STD_VERSION"],
                        [The PMIx Standard compliance level])
+
+    AC_MSG_CHECKING([for pmix standard ABI version])
+    PMIX_STD_ABI_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --std-abi-version`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_MSG_RESULT([$PMIX_STD_ABI_VERSION])
+    AC_SUBST(PMIX_STD_ABI_VERSION)
+    AC_DEFINE_UNQUOTED([PMIX_STD_ABI_VERSION], ["$PMIX_STD_ABI_VERSION"],
+                       [The PMIx Standard ABI compliance level])
 
     PMIX_REPO_REV="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --repo-rev`"
     if test "$?" != "0"; then

--- a/config/pmix_check_pthread_pids.m4
+++ b/config/pmix_check_pthread_pids.m4
@@ -70,7 +70,7 @@ void *checkpid(void *arg) {
 [tpids_MSG=no PMIX_THREADS_HAVE_DIFFERENT_PIDS=0],
 [tpids_MSG=yes PMIX_THREADS_HAVE_DIFFERENT_PIDS=1],
 [
- # If we're cross compiling, we can't do another AC_* function here beause
+ # If we're cross compiling, we can't do another AC_* function here because
  # it we haven't displayed the result from the last one yet.  So defer
  # another test until below.
  PMIX_THREADS_HAVE_DIFFERENT_PIDS=

--- a/config/pmix_check_tm.m4
+++ b/config/pmix_check_tm.m4
@@ -26,7 +26,7 @@ dnl
 dnl $HEADER$
 dnl
 
-# PMIX_CHECK_TM_PBS_CONFIG_RUN([pbs-config args], [assigmnent variable],
+# PMIX_CHECK_TM_PBS_CONFIG_RUN([pbs-config args], [assignment variable],
 #                              [action-if-successful], [action-if-not-successful])
 # --------------------------------------------------------------------------------
 AC_DEFUN([PMIX_CHECK_TM_PBS_CONFIG_RUN], [

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -45,7 +45,7 @@ dnl
 AC_DEFUN([PMIX_CONFIGURE_SETUP],[
 
 # Some helper script functions.  Unfortunately, we cannot use $1 kinds
-# of arugments here because of the m4 substitution.  So we have to set
+# of arguments here because of the m4 substitution.  So we have to set
 # special variable names before invoking the function.  :-\
 
 pmix_show_title() {
@@ -350,7 +350,7 @@ dnl #######################################################################
 # PMIX_APPEND_UNIQ(variable, new_argument)
 # ----------------------------------------
 # Append new_argument to variable if not already in variable.  This assumes a
-# space seperated list.
+# space separated list.
 #
 # This could probably be made more efficient :(.
 AC_DEFUN([PMIX_APPEND_UNIQ], [
@@ -380,7 +380,7 @@ dnl #######################################################################
 # - the argument does not begin with -I, -L, or -l, or
 # - the argument begins with -I, -L, or -l, and it's not already in variable
 #
-# This macro assumes a space seperated list.
+# This macro assumes a space separated list.
 AC_DEFUN([PMIX_FLAGS_APPEND_UNIQ], [
     PMIX_VAR_SCOPE_PUSH([pmix_tmp pmix_append])
 
@@ -409,7 +409,7 @@ dnl #######################################################################
 # - the argument does not begin with -I, -L, or -l, or
 # - the argument begins with -I, -L, or -l, and it's not already in variable
 #
-# This macro assumes a space seperated list.
+# This macro assumes a space separated list.
 AC_DEFUN([PMIX_FLAGS_PREPEND_UNIQ], [
     PMIX_VAR_SCOPE_PUSH([pmix_tmp pmix_prepend])
 
@@ -440,7 +440,7 @@ dnl #######################################################################
 # variable, it is appended to variable.
 #
 # If an argument in new_argument begins with a -l and is already in
-# variable, the existing occurances of the argument are removed from
+# variable, the existing occurrences of the argument are removed from
 # variable and the argument is appended to variable.  This behavior
 # is most useful in LIBS, where ordering matters and being rightmost
 # is usually the right behavior.
@@ -649,7 +649,7 @@ AC_DEFUN([PMIX_COMPUTE_MAX_VALUE], [
                     overflow=1
                 fi
             else
-                # stil negative.  Time to give up.
+                # still negative.  Time to give up.
                 overflow=1
             fi
             pmix_num_bits=0

--- a/config/pmix_get_version.sh
+++ b/config/pmix_get_version.sh
@@ -57,8 +57,8 @@ else
     s/^greek/PMIX_GREEK_VERSION/
     s/^std_major/PMIX_STD_MAJOR_VERSION/
     s/^std_minor/PMIX_STD_MINOR_VERSION/
-    s/^std_abi_major/PMIX_STD_ABI_MAJOR_VERSION/
-    s/^std_abi_minor/PMIX_STD_ABI_MINOR_VERSION/
+    s/^std_abi_stable/PMIX_STD_ABI_STABLE_VERSION/
+    s/^std_abi_provisional/PMIX_STD_ABI_PROVISIONAL_VERSION/
     s/^repo_rev/PMIX_REPO_REV/
     s/^tarball_version/PMIX_TARBALL_VERSION/
     s/^date/PMIX_RELEASE_DATE/
@@ -72,7 +72,8 @@ else
         PMIX_VERSION="${PMIX_VERSION}${PMIX_GREEK_VERSION}"
 
         PMIX_STD_VERSION="$PMIX_STD_MAJOR_VERSION.$PMIX_STD_MINOR_VERSION"
-        PMIX_STD_ABI_VERSION="$PMIX_STD_ABI_MAJOR_VERSION.$PMIX_STD_ABI_MINOR_VERSION"
+        PMIX_STD_ABI_STABLE_VERSION="$PMIX_STD_ABI_STABLE_VERSION"
+        PMIX_STD_ABI_PROVISIONAL_VERSION="$PMIX_STD_ABI_PROVISIONAL_VERSION"
 
         if test "$PMIX_TARBALL_VERSION" = ""; then
             PMIX_TARBALL_VERSION=$PMIX_VERSION
@@ -132,8 +133,11 @@ case "$option" in
     --std-version)
     echo $PMIX_STD_VERSION
     ;;
-    --std-abi-version)
-    echo $PMIX_STD_ABI_VERSION
+    --std-abi-stable-version)
+    echo $PMIX_STD_ABI_STABLE_VERSION
+    ;;
+    --std-abi-provisional-version)
+    echo $PMIX_STD_ABI_PROVISIONAL_VERSION
     ;;
     --repo-rev)
     echo $PMIX_REPO_REV

--- a/config/pmix_get_version.sh
+++ b/config/pmix_get_version.sh
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -57,6 +57,8 @@ else
     s/^greek/PMIX_GREEK_VERSION/
     s/^std_major/PMIX_STD_MAJOR_VERSION/
     s/^std_minor/PMIX_STD_MINOR_VERSION/
+    s/^std_abi_major/PMIX_STD_ABI_MAJOR_VERSION/
+    s/^std_abi_minor/PMIX_STD_ABI_MINOR_VERSION/
     s/^repo_rev/PMIX_REPO_REV/
     s/^tarball_version/PMIX_TARBALL_VERSION/
     s/^date/PMIX_RELEASE_DATE/
@@ -70,6 +72,7 @@ else
         PMIX_VERSION="${PMIX_VERSION}${PMIX_GREEK_VERSION}"
 
         PMIX_STD_VERSION="$PMIX_STD_MAJOR_VERSION.$PMIX_STD_MINOR_VERSION"
+        PMIX_STD_ABI_VERSION="$PMIX_STD_ABI_MAJOR_VERSION.$PMIX_STD_ABI_MINOR_VERSION"
 
         if test "$PMIX_TARBALL_VERSION" = ""; then
             PMIX_TARBALL_VERSION=$PMIX_VERSION
@@ -128,6 +131,9 @@ case "$option" in
     ;;
     --std-version)
     echo $PMIX_STD_VERSION
+    ;;
+    --std-abi-version)
+    echo $PMIX_STD_ABI_VERSION
     ;;
     --repo-rev)
     echo $PMIX_REPO_REV

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -181,7 +181,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         # following lines and update the warning when we require a C11 compiler.
         # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
         # AC_MSG_ERROR([Aborting.])
-        # From Open MPI 1.7 on we require a C99 compiant compiler
+        # From Open MPI 1.7 on we require a C99 compliant compiler
         # with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
         m4_version_prereq([2.70],
             [],
@@ -205,7 +205,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
     PMIX_CC_HELPER([if $CC $1 supports C11 _Thread_local], [pmix_prog_cc_c11_helper__Thread_local_available],
                    [],[[static _Thread_local int  foo = 1;++foo;]])
 
-    dnl At this time, PMIx only needs thread local and the atomic convenience tyes for C11 suport. These
+    dnl At this time, PMIx only needs thread local and the atomic convenience types for C11 support. These
     dnl will likely be required in the future.
     AC_DEFINE_UNQUOTED([PMIX_C_HAVE__THREAD_LOCAL], [$pmix_prog_cc_c11_helper__Thread_local_available],
                        [Whether C compiler supports __Thread_local])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -113,7 +113,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
           ]])],
           [AC_MSG_RESULT([yes])],
           [AC_MSG_RESULT([no])
-           AC_MSG_WARN([PMIX rquires libevent to be compiled with thread support enabled])
+           AC_MSG_WARN([PMIX requires libevent to be compiled with thread support enabled])
            pmix_libevent_support=0])
     fi
 

--- a/config/pmix_setup_wrappers.m4
+++ b/config/pmix_setup_wrappers.m4
@@ -244,7 +244,7 @@ AC_DEFUN([RPATHIFY_LDFLAGS],[RPATHIFY_LDFLAGS_INTERNAL([$1], [rpath_args])])
 # and pkg-config files:
 #
 # 1) --enable-shared --disable-static (today's default): Any
-#    application linking against libpmix will be a dynamicly linked
+#    application linking against libpmix will be a dynamically linked
 #    application
 # 2) --enable-shared --enable-static: An application linking against
 #    libpmix will dynamically link against libpmix unless -static (or

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -97,7 +97,8 @@ PMIx configuration:
 -----------------------
 Version: $PMIX_MAJOR_VERSION.$PMIX_MINOR_VERSION.$PMIX_RELEASE_VERSION$PMIX_GREEK_VERSION
 PMIx Standard Version: $PMIX_STD_VERSION
-PMIx Standard ABI Version: $PMIX_STD_ABI_VERSION
+PMIx Standard Stable ABI Version(s): $PMIX_STD_ABI_STABLE_VERSION
+PMIx Standard Provisional ABI Version(s): $PMIX_STD_ABI_PROVISIONAL_VERSION
 EOF
 
     if test $WANT_DEBUG = 0 ; then

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -6,7 +6,7 @@ dnl Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
@@ -97,6 +97,7 @@ PMIx configuration:
 -----------------------
 Version: $PMIX_MAJOR_VERSION.$PMIX_MINOR_VERSION.$PMIX_RELEASE_VERSION$PMIX_GREEK_VERSION
 PMIx Standard Version: $PMIX_STD_VERSION
+PMIx Standard ABI Version: $PMIX_STD_ABI_VERSION
 EOF
 
     if test $WANT_DEBUG = 0 ; then

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -43,7 +43,7 @@ dnl
 # PMIX_SUMMARY_ADD([Resource Type], [Component Name], [], [$results])
 # and then unset $results to avoid namespace pollution.  This will
 # work properly with the current behavior, but would result in odd
-# errors if we delayed evaulation.
+# errors if we delayed evaluation.
 #
 # As a historical note, the third argument has never been used in
 # PMIX_SUMMARY_ADD and its meaning is unclear.  Preferred behavior is

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ PMIX_DEFINE_ARGS
 # Define some basic useful values
 PMIX_BASIC_SETUP
 
-# compatability for oac_check_package
+# compatibility for oac_check_package
 m4_copy([PMIX_LOG_COMMAND], [OAC_LOG_COMMAND])
 m4_copy([PMIX_LOG_MSG], [OAC_LOG_MSG])
 m4_copy([PMIX_APPEND], [OAC_APPEND])

--- a/contrib/perf_tools/README
+++ b/contrib/perf_tools/README
@@ -7,7 +7,7 @@ Building instructions:
     If you don't want to test PMI2 - remove pmi2 from the list of "all" targets.
 * run `make`.
 
-The follwoing files (or one of them) will be built as the result:
+The following files (or one of them) will be built as the result:
 * pmix_intra_perf - that is for testing pmix performance
 - pmi2_intra_perf - for testing pmi2 performance
 
@@ -28,7 +28,7 @@ for all environments). To use it open it and fix:
 - OMPI_BASE to point to your MPI installation
 - PMIX_LIB to point to your PMIx installation
 
-If you are running inside the supported batch system you shoud be fine to
+If you are running inside the supported batch system you should be fine to
 just run fixed `run.sh` with the first argument defining how many processes
 needs to be launched and all other parameters will be passed to the performance
 tool. For example:

--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -244,7 +244,7 @@ and link against PMIx.
 
 #############################################################################
 #
-# Prepatory Section
+# Preparatory Section
 #
 #############################################################################
 %prep
@@ -373,7 +373,7 @@ proc ModulesHelp { } {
    puts stderr "This module adds PMIx v%{version} to various paths"
 }
 
-module-whatis   "Sets up PMIx v%{version} in your enviornment"
+module-whatis   "Sets up PMIx v%{version} in your environment"
 
 prepend-path PATH "%{_prefix}/bin/"
 prepend-path LD_LIBRARY_PATH %{_libdir}

--- a/contrib/update-my-copyright.pl
+++ b/contrib/update-my-copyright.pl
@@ -9,7 +9,7 @@
 #
 # This script automates the tedious task of updating copyright notices
 # in the tops of PMIX source files before committing back to
-# the respository.  Set the environment variable
+# the repository.  Set the environment variable
 # PMIX_COPYRIGHT_SEARCH_NAME to a short (case-insensitive) name that
 # indicates your copyright line (e.g., "cisco"), and set the env
 # variable PMIX_COPYRIGHT_FORMAL_NAME with your organization's formal
@@ -53,7 +53,7 @@ use Getopt::Long;
 # Will exit with status 111 if there are out of date copyrights which this
 # script can correct.
 my $CHECK_ONLY = 0;
-# used by $CHECK_ONLY logic for bookeeping
+# used by $CHECK_ONLY logic for bookkeeping
 my $would_replace = 0;
 
 # Set to true to suppress most informational messages.  Only out of date files

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -55,7 +55,7 @@ install-data-local:
 
 # Only remove if exactly the same as what in our tree
 # NOTE TO READER: Bourne shell if ... fi evaluates the body if
-#    the return of the evaluted command is 0 (as opposed to non-zero
+#    the return of the evaluated command is 0 (as opposed to non-zero
 #    as used by everyone else)
 uninstall-local:
 	@ p="$(pmix_config_files)"; \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,7 +24,8 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello nodeinfo
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init nodeinfo
+
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -100,7 +102,16 @@ nodeinfo_SOURCES = nodeinfo.c examples.h
 nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
 
+abi_no_init_SOURCES = abi_no_init.c
+abi_no_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+abi_no_init_LDADD =  $(top_builddir)/src/libpmix.la
+
+abi_with_init_SOURCES = abi_with_init.c
+abi_with_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+abi_with_init_LDADD =  $(top_builddir)/src/libpmix.la
+
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
-        hello jctrl launcher log pub pubi server tool
+        hello jctrl launcher log pub pubi server tool \
+        abi_no_init abi_with_init nodeinfo

--- a/examples/abi_no_init.c
+++ b/examples/abi_no_init.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Test PMIx_Query_info outside of init/finalize by asking for a
+ * key (PMIX_QUERY_ABI_VERSION) that is allowed to be accessed
+ * outside of the init/finalize region.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <pmix.h>
+
+int main(int argc, char **argv) {
+    int rc, i;
+    size_t ninfo, nqueries;
+    pmix_info_t *info = NULL;
+    pmix_query_t *query = NULL;
+
+    nqueries = 1;
+
+    PMIX_QUERY_CREATE(query, nqueries);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+
+    rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
+    if (PMIX_SUCCESS != rc ) {
+        fprintf(stderr, "Error: PMIx_Query_info failed: %d (%s)\n", rc, PMIx_Error_string(rc));
+        return rc;
+    }
+
+    printf("--> Query returned (ninfo %d)\n", ninfo);
+    for(i = 0; i < ninfo; ++i) {
+        printf("--> KEY: %s\n", info[i].key);
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
+            printf("----> ABI: String: %s\n",
+                   info[i].value.data.string);
+        }
+    }
+
+    /*
+     * Cleanup
+     */
+    PMIX_INFO_FREE(info, ninfo);
+    PMIX_QUERY_FREE(query, nqueries);
+
+    return 0;
+}

--- a/examples/abi_no_init.c
+++ b/examples/abi_no_init.c
@@ -22,10 +22,11 @@ int main(int argc, char **argv) {
     pmix_info_t *info = NULL;
     pmix_query_t *query = NULL;
 
-    nqueries = 1;
+    nqueries = 2;
 
     PMIX_QUERY_CREATE(query, nqueries);
-    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_PROVISIONAL_ABI_VERSION);
 
     rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
     if (PMIX_SUCCESS != rc ) {
@@ -36,8 +37,12 @@ int main(int argc, char **argv) {
     printf("--> Query returned (ninfo %d)\n", ninfo);
     for(i = 0; i < ninfo; ++i) {
         printf("--> KEY: %s\n", info[i].key);
-        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
-            printf("----> ABI: String: %s\n",
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_STABLE_ABI_VERSION)) {
+            printf("----> ABI (Stable): String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+            printf("----> ABI (Provisional): String: %s\n",
                    info[i].value.data.string);
         }
     }

--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Test PMIx_Query_info with a locally resolved key (PMIX_QUERY_ABI_VERSION)
+ * and a key that the server will need to resolve.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <pmix.h>
+
+int main(int argc, char **argv) {
+    int rc, i;
+    size_t ninfo, nqueries;
+    pmix_info_t *info = NULL;
+    pmix_query_t *query = NULL;
+    static pmix_proc_t myproc;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "PMIx_Init failed: %d\n", rc);
+        exit(rc);
+    }
+
+    nqueries = 2;
+
+    PMIX_QUERY_CREATE(query, nqueries);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_NAMESPACES);
+
+    rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
+    if (PMIX_SUCCESS != rc ) {
+        fprintf(stderr, "Error: PMIx_Query_info failed: %d (%s)\n", rc, PMIx_Error_string(rc));
+        return rc;
+    }
+
+    printf("--> Query returned (ninfo %d)\n", ninfo);
+    for(i = 0; i < ninfo; ++i) {
+        printf("--> KEY: %s\n", info[i].key);
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
+            printf("----> ABI: String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_NAMESPACES)) {
+            printf("----> Namespaces: String: %s\n",
+                   info[i].value.data.string);
+        }
+    }
+
+    /*
+     * Cleanup
+     */
+    PMIX_INFO_FREE(info, ninfo);
+    PMIX_QUERY_FREE(query, nqueries);
+
+    PMIx_Finalize(NULL, 0);
+
+    return 0;
+}

--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -27,11 +27,12 @@ int main(int argc, char **argv) {
         exit(rc);
     }
 
-    nqueries = 2;
+    nqueries = 3;
 
     PMIX_QUERY_CREATE(query, nqueries);
-    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_ABI_VERSION);
-    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_NAMESPACES);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[1].keys, PMIX_QUERY_PROVISIONAL_ABI_VERSION);
+    PMIX_ARGV_APPEND(rc, query[2].keys, PMIX_QUERY_NAMESPACES);
 
     rc = PMIx_Query_info(query, nqueries, &info, &ninfo);
     if (PMIX_SUCCESS != rc ) {
@@ -42,8 +43,12 @@ int main(int argc, char **argv) {
     printf("--> Query returned (ninfo %d)\n", ninfo);
     for(i = 0; i < ninfo; ++i) {
         printf("--> KEY: %s\n", info[i].key);
-        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_ABI_VERSION)) {
-            printf("----> ABI: String: %s\n",
+        if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_STABLE_ABI_VERSION)) {
+            printf("----> ABI (Stable): String: %s\n",
+                   info[i].value.data.string);
+        }
+        else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+            printf("----> ABI (Provisional): String: %s\n",
                    info[i].value.data.string);
         }
         else if (PMIX_CHECK_KEY(&info[i], PMIX_QUERY_NAMESPACES)) {

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1402,7 +1402,7 @@ PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
  * @param payload The address of a pmix_byte_object_t into which
  * the buffer is to be unloaded
  *
- * @retval PMIX_SUCCESS The request was succesfully completed.
+ * @retval PMIX_SUCCESS The request was successfully completed.
  *
  * @retval PMIX_ERROR(s) An appropriate error code indicating the
  * problem will be returned. This should be handled appropriately by
@@ -1590,7 +1590,7 @@ PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src);
 
-/* Compre the contents of two pmix_value_t structures */
+/* Compare the contents of two pmix_value_t structures */
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -640,7 +640,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        either or both of them may be included.
 #define PMIX_APP_INFO_ARRAY                 "pmix.app.arr"          // (pmix_data_array_t*) Provide an array of pmix_info_t containing app-level
                                                                     //        information. The PMIX_NSPACE or PMIX_JOBID attributes of the job containing
-                                                                    //        the appplication, plus its PMIX_APPNUM attribute, are required to be
+                                                                    //        the application, plus its PMIX_APPNUM attribute, are required to be
                                                                     //        included in the array.
 #define PMIX_PROC_INFO_ARRAY                "pmix.pdata"            // (pmix_data_array_t*) Provide an array of pmix_info_t containing process-realm
                                                                     //        information. The PMIX_RANK and PMIX_NSPACE attributes, or the
@@ -986,7 +986,7 @@ typedef uint32_t pmix_rank_t;
                                                                    //       storage system's atomic unit of transfer (e.g., block size)
 #define PMIX_STORAGE_OBJECTS_USED           "pmix.strg.objuse"     // (uint64_t) Overall used number of objects (e.g., inodes) for the storage system
 #define PMIX_STORAGE_PERSISTENCE            "pmix.strg.persist"    // (pmix_storage_persistence_t) Persistence level of the storage system
-                                                                   //       (e.g., sratch storage or achive storage)
+                                                                   //       (e.g., sratch storage or archive storage)
 #define PMIX_STORAGE_SUGGESTED_XFER_SIZE    "pmix.strg.sxfer"      // (double) Suggested transfer size (in bytes) for the storage system
 #define PMIX_STORAGE_VERSION                "pmix.strg.ver"        // (char*) Version string for the storage system
 
@@ -1199,7 +1199,7 @@ typedef uint8_t pmix_job_state_t;
 typedef int pmix_status_t;
 
 /* v1.x error values - must be fixed in place for backward
- * compatability. Note that some number of these have been
+ * compatibility. Note that some number of these have been
  * deprecated and may not be returned by v2.x and above
  * clients or servers. However, they must always be
  * at least defined to ensure older codes will compile */
@@ -2060,7 +2060,7 @@ char **pmix_argv_copy(char **argv)
  *
  * The \em env array will be grown if necessary.
  *
- * It is permissable to invoke this function with the
+ * It is permissible to invoke this function with the
  * system-defined \em environ variable.  For example:
  *
  * \code
@@ -2073,7 +2073,7 @@ char **pmix_argv_copy(char **argv)
  * environment.  This may very well lead to a memory leak, so its
  * use is strongly discouraged.
  *
- * It is also permissable to call this function with an empty \em
+ * It is also permissible to call this function with an empty \em
  * env, as long as it is pre-initialized with NULL:
  *
  * \code

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1124,7 +1124,9 @@ typedef uint32_t pmix_rank_t;
                                                                    //         Named values (i.e., values defined by constant names via a
                                                                    //         typical C-language enum declaration) must be provided as
                                                                    //         their numerical equivalent.
-#define PMIX_QUERY_ABI_VERSION              "pmix.qry.abiversion"  // (char*) The PMIx Standard ABI version supported returned in the form "MAJOR.MINOR"
+#define PMIX_QUERY_STABLE_ABI_VERSION       "pmix.qry.stabiver"    // (char*) The PMIx Standard Stable ABI version supported returned in the form of a comma separated list of "MAJOR.MINOR"
+                                                                   //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
+#define PMIX_QUERY_PROVISIONAL_ABI_VERSION  "pmix.qry.prabiver"    // (char*) The PMIx Standard Provisional ABI version supported returned in the form of a comma separated "MAJOR.MINOR"
                                                                    //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
 
 /****    PROCESS STATE DEFINITIONS    ****/

--- a/src/class/pmix_bitmap.h
+++ b/src/class/pmix_bitmap.h
@@ -85,7 +85,7 @@ PMIX_EXPORT int pmix_bitmap_init(pmix_bitmap_t *bm, int size);
 
 /**
  * Set a bit of the bitmap. If the bit asked for is beyond the current
- * size of the bitmap, then the bitmap is extended to accomodate the
+ * size of the bitmap, then the bitmap is extended to accommodate the
  * bit
  *
  * @param  bitmap The input bitmap (IN)
@@ -224,7 +224,7 @@ PMIX_EXPORT bool pmix_bitmap_are_different(pmix_bitmap_t *left, pmix_bitmap_t *r
 PMIX_EXPORT char *pmix_bitmap_get_string(pmix_bitmap_t *bitmap);
 
 /**
- * Return the number of 'unset' bits, upto the specified length
+ * Return the number of 'unset' bits, up to the specified length
  *
  * @param bitmap Pointer to the bitmap
  * @param len Number of bits to check
@@ -233,7 +233,7 @@ PMIX_EXPORT char *pmix_bitmap_get_string(pmix_bitmap_t *bitmap);
 PMIX_EXPORT int pmix_bitmap_num_unset_bits(pmix_bitmap_t *bm, int len);
 
 /**
- * Return the number of 'set' bits, upto the specified length
+ * Return the number of 'set' bits, up to the specified length
  *
  * @param bitmap Pointer to the bitmap
  * @param len Number of bits to check

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -172,7 +172,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hotel_t);
  * already been ("forcibly") checked out *before* the
  * eviction_callback_fn is invoked.
  *
- * @return PMIX_SUCCESS if all initializations were succesful. Otherwise,
+ * @return PMIX_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 PMIX_EXPORT pmix_status_t pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -381,7 +381,7 @@ static inline pmix_list_item_t *pmix_list_get_last(pmix_list_t *list)
  * Similar to the STL, this is a special invalid list item -- it
  * should \em not be used for storage.  It is only suitable for
  * comparison to other items in the list to see if they are valid or
- * not; it's ususally used when iterating through the items in a list.
+ * not; it's usually used when iterating through the items in a list.
  *
  * This is an inlined function in compilers that support inlining, so
  * it's usually a cheap operation.
@@ -403,7 +403,7 @@ static inline pmix_list_item_t *pmix_list_get_begin(pmix_list_t *list)
  * Similar to the STL, this is a special invalid list item -- it
  * should \em not be used for storage.  It is only suitable for
  * comparison to other items in the list to see if they are valid or
- * not; it's ususally used when iterating through the items in a list.
+ * not; it's usually used when iterating through the items in a list.
  *
  * This is an inlined function in compilers that support inlining, so
  * it's usually a cheap operation.
@@ -614,7 +614,7 @@ static inline void pmix_list_prepend(pmix_list_t *list, pmix_list_item_t *item)
     /* reset item's previous pointer */
     item->pmix_list_prev = sentinel;
 
-    /* reset previous first element's previous poiner */
+    /* reset previous first element's previous pointer */
     sentinel->pmix_list_next->pmix_list_prev = item;
 
     /* reset head's next pointer */
@@ -854,7 +854,7 @@ PMIX_EXPORT void pmix_list_join(pmix_list_t *thislist,
  * last) elements of \c xlist are moved into \c thislist,
  * inserting them before \c pos.  \c pos must be a valid iterator
  * in \c thislist and \c [first, last) must be a valid range in \c
- * xlist.  \c postition must not be in the range \c [first, last).
+ * xlist.  \c position must not be in the range \c [first, last).
  * It is, however, valid for \c xlist and \c thislist to be the
  * same list.
  *

--- a/src/class/pmix_pointer_array.h
+++ b/src/class/pmix_pointer_array.h
@@ -95,7 +95,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pointer_array_t);
  * @param max_size The maximum size of the array (IN)
  * @param block_size The size for all subsequent grows of the array (IN).
  *
- * @return PMIX_SUCCESS if all initializations were succesfull. Otherwise,
+ * @return PMIX_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 PMIX_EXPORT int pmix_pointer_array_init(pmix_pointer_array_t *array, int initial_allocation,

--- a/src/class/pmix_ring_buffer.h
+++ b/src/class/pmix_ring_buffer.h
@@ -62,7 +62,7 @@ PMIX_CLASS_DECLARATION(pmix_ring_buffer_t);
  * @param ring Pointer to a ring buffer (IN/OUT)
  * @param size The number of elements in the ring (IN)
  *
- * @return PMIX_SUCCESS if all initializations were succesful. Otherwise,
+ * @return PMIX_SUCCESS if all initializations were successful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
 PMIX_EXPORT int pmix_ring_buffer_init(pmix_ring_buffer_t *ring, int size);

--- a/src/class/pmix_value_array.h
+++ b/src/class/pmix_value_array.h
@@ -98,7 +98,7 @@ static inline int pmix_value_array_reserve(pmix_value_array_t *array, size_t siz
 }
 
 /**
- *  Retreives the number of elements in the array.
+ *  Retrieves the number of elements in the array.
  *
  *  @param   array   The input array (IN).
  *  @return  The number of elements currently in use.

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -52,10 +52,14 @@
 
 #ifdef PMIX_GIT_REPO_BUILD
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION ", repo rev: " PMIX_REPO_REV
-                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ","
+                                          " Stable ABI: " PMIX_STD_ABI_STABLE_VERSION ","
+                                          " Provisional ABI: " PMIX_STD_ABI_PROVISIONAL_VERSION ")";
 #else
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION
-                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ","
+                                          " Stable ABI: " PMIX_STD_ABI_STABLE_VERSION ","
+                                          " Provisional ABI: " PMIX_STD_ABI_PROVISIONAL_VERSION ")";
 #endif
 static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -52,10 +52,10 @@
 
 #ifdef PMIX_GIT_REPO_BUILD
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION ", repo rev: " PMIX_REPO_REV
-                                          " (PMIx Standard: " PMIX_STD_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
 #else
 static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION
-                                          " (PMIx Standard: " PMIX_STD_VERSION ")";
+                                          " (PMIx Standard: " PMIX_STD_VERSION ", ABI: " PMIX_STD_ABI_VERSION ")";
 #endif
 static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -471,10 +471,14 @@ static void localquery(int sd, short args, void *cbdata)
         for (p = 0; NULL != queries[n].keys[p]; p++) {
             cb.key = queries[n].keys[p];
             // Locally resolvable keys
-            if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_ABI_VERSION)) {
-                pmix_kval_t *kv = NULL;
+            if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
                 PMIX_KVAL_NEW(kv, cb.key);
-                PMIx_Value_load(kv->value, PMIX_STD_ABI_VERSION, PMIX_STRING);
+                PMIx_Value_load(kv->value, PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
+                pmix_list_append(&cb.kvs, &kv->super);
+                rc = PMIX_SUCCESS;
+            } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+                PMIX_KVAL_NEW(kv, cb.key);
+                PMIx_Value_load(kv->value, PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
                 pmix_list_append(&cb.kvs, &kv->super);
                 rc = PMIX_SUCCESS;
             } else {
@@ -860,7 +864,10 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
  */
 static bool pmix_query_check_is_local_resolve(const char *key)
 {
-    if (0 == strcmp(key, PMIX_QUERY_ABI_VERSION)) {
+    if (0 == strcmp(key, PMIX_QUERY_STABLE_ABI_VERSION)) {
+        return true;
+    }
+    else if (0 == strcmp(key, PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
         return true;
     }
     return false;
@@ -910,12 +917,16 @@ static int pmix_query_resolve_all_pre_init(pmix_query_t queries[], size_t nqueri
 
     // If it does qualify then fill in the results
     *nresults = num_info;
-    PMIX_INFO_CREATE(*results, *nresults);
+    PMIX_INFO_CREATE((*results), (*nresults));
     cur_info = 0;
     for (n = 0; n < nqueries; n++) {
         for (p = 0; NULL != queries[n].keys[p]; p++) {
-            if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_ABI_VERSION)) {
-                PMIx_Info_load(results[cur_info], PMIX_QUERY_ABI_VERSION, PMIX_STD_ABI_VERSION, PMIX_STRING);
+            if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
+                PMIx_Info_load(&((*results)[cur_info]), PMIX_QUERY_STABLE_ABI_VERSION, PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
+                ++cur_info;
+            }
+            else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+                PMIx_Info_load(&((*results)[cur_info]), PMIX_QUERY_PROVISIONAL_ABI_VERSION, PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
                 ++cur_info;
             }
         }
@@ -961,9 +972,14 @@ void pmix_query_local_resolve_cbfunc(pmix_status_t status,
     for (n = 0; n < local_cd->orig_nqueries; n++) {
         p_idx = 0;
         for (p = 0; NULL != local_cd->orig_queries[n].keys[p]; p++) {
-            if (0 == strcmp(local_cd->orig_queries[n].keys[p], PMIX_QUERY_ABI_VERSION)) {
+            if (0 == strcmp(local_cd->orig_queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
                 PMIx_Info_load(&local_cd->info[n_idx], local_cd->orig_queries[n].keys[p],
-                               PMIX_STD_ABI_VERSION, PMIX_STRING);
+                               PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
+                ++p_idx;
+            }
+            else if (0 == strcmp(local_cd->orig_queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
+                PMIx_Info_load(&local_cd->info[n_idx], local_cd->orig_queries[n].keys[p],
+                               PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
                 ++p_idx;
             }
         }

--- a/src/include/pmix_atomic.h
+++ b/src/include/pmix_atomic.h
@@ -44,8 +44,8 @@
  *
  *  - \c PMIX_HAVE_ATOMIC_MEM_BARRIER atomic memory barriers
  *  - \c PMIX_HAVE_ATOMIC_SPINLOCKS atomic spinlocks
- *  - \c PMIX_HAVE_ATOMIC_MATH_32 if 32 bit add/sub/compare-exchange can be done "atomicly"
- *  - \c PMIX_HAVE_ATOMIC_MATH_64 if 64 bit add/sub/compare-exchange can be done "atomicly"
+ *  - \c PMIX_HAVE_ATOMIC_MATH_32 if 32 bit add/sub/compare-exchange can be done "atomically"
+ *  - \c PMIX_HAVE_ATOMIC_MATH_64 if 64 bit add/sub/compare-exchange can be done "atomically"
  *
  * Note that for the Atomic math, atomic add/sub may be implemented as
  * C code using pmix_atomic_compare_exchange.  The appearance of atomic

--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -486,7 +486,7 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 /* Prior to Mac OS X 10.3, the length modifier "ll" wasn't
    supported, but "q" was for long long.  This isn't ANSI
    C and causes a warning when using PRI?64 macros.  We
-   don't support versions prior to OS X 10.3, so we dont'
+   don't support versions prior to OS X 10.3, so we don't
    need such backward compatibility.  Instead, redefine
    the macros to be "ll", which is ANSI C and doesn't
    cause a compiler warning. */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -633,7 +633,7 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *e
         }
 
         /*
-         * If not recursively decending, then if we find a directory then fail
+         * If not recursively descending, then if we find a directory then fail
          * since we were not told to remove it.
          */
         if (is_dir && !cd->recurse) {

--- a/src/include/pmix_portable_platform_real.h
+++ b/src/include/pmix_portable_platform_real.h
@@ -330,7 +330,7 @@
       /* Include below might fail for ancient versions lacking this header, but testing shows it
          works back to at least 5.1-3 (Nov 2003), and based on docs probably back to 3.2 (Sep 2000) */
         #define PLATFORM_COMPILER_VERSION 0       
-    #elif defined(__x86_64__) /* bug 1753 - 64-bit omp.h upgrade happenned in <6.0-8,6.1-1] */
+    #elif defined(__x86_64__) /* bug 1753 - 64-bit omp.h upgrade happened in <6.0-8,6.1-1] */
       #include "omp.h"
       #if defined(_PGOMP_H)
         /* 6.1.1 or newer */
@@ -341,7 +341,7 @@
         #define PLATFORM_COMPILER_VERSION 0
         #define PLATFORM_COMPILER_VERSION_STR "<=6.0-8"
       #endif
-    #else /* 32-bit omp.h upgrade happenned in <5.2-4,6.0-8] */
+    #else /* 32-bit omp.h upgrade happened in <5.2-4,6.0-8] */
       #include "omp.h"
       #if defined(_PGOMP_H)
         /* 6.0-8 or newer */
@@ -590,7 +590,7 @@
     #define PLATFORM_COMPILER_VERSION_STR __clang_version__
   #endif
 
-// NOTE: PLATFORM_COMPILER_FAMILYID "20" is allocted to NVHPC, appearing earlier
+// NOTE: PLATFORM_COMPILER_FAMILYID "20" is allocated to NVHPC, appearing earlier
 
 #else /* unknown compiler */
   #define PLATFORM_COMPILER_UNKNOWN  1

--- a/src/mca/base/help-pmix-mca-var.txt
+++ b/src/mca/base/help-pmix-mca-var.txt
@@ -75,7 +75,7 @@ variables are supposed to affect.
 [re-register-with-different-type]
 An MCA variable was re-registered with a different type (i.e., it was
 either originally registered as an INT and re-registered as a STRING,
-or it was originially registered as a STRING and re-registered as an
+or it was originally registered as a STRING and re-registered as an
 INT).  This a developer error; your job may abort.
 
   MCA variable name: %s

--- a/src/mca/base/pmix_base.h
+++ b/src/mca/base/pmix_base.h
@@ -126,7 +126,7 @@ PMIX_EXPORT int pmix_mca_base_open(void);
  * @return PMIX_ERROR Upon failure
  *
  * This function closes down the entire MCA.  It clears all MCA
- * parameters and closes down the MCA component respository.
+ * parameters and closes down the MCA component repository.
  *
  * It must be the last MCA function invoked.  It is normally invoked
  * during the finalize stage.

--- a/src/mca/base/pmix_mca_base_component_compare.c
+++ b/src/mca/base/pmix_mca_base_component_compare.c
@@ -31,7 +31,7 @@
  * the types of the modules are the same.  Sort first by priority,
  * second by module name, third by module version.
  *
- * Note that we acutally want a *reverse* ordering here -- the al_*
+ * Note that we actually want a *reverse* ordering here -- the al_*
  * functions will put "smaller" items at the head, and "larger" items
  * at the tail.  Since we want the highest priority at the head, it
  * may help the gentle reader to consider this an inverse comparison.

--- a/src/mca/base/pmix_mca_base_list.c
+++ b/src/mca/base/pmix_mca_base_list.c
@@ -41,7 +41,7 @@ PMIX_CLASS_INSTANCE(pmix_mca_base_component_priority_list_item_t,
                     pmix_mca_base_component_list_item_t, cpl_constructor, NULL);
 
 /*
- * Just do basic sentinel intialization
+ * Just do basic sentinel initialization
  */
 static void cl_constructor(pmix_object_t *obj)
 {
@@ -50,7 +50,7 @@ static void cl_constructor(pmix_object_t *obj)
 }
 
 /*
- * Just do basic sentinel intialization
+ * Just do basic sentinel initialization
  */
 static void cpl_constructor(pmix_object_t *obj)
 {

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -607,7 +607,7 @@ int pmix_mca_base_var_get_value(int vari, void *value, pmix_mca_base_var_source_
     }
 
     if (NULL != value) {
-        /* Return a poiner to our backing store (either a char **, int *,
+        /* Return a pointer to our backing store (either a char **, int *,
            or bool *) */
         *tmp = var->mbv_storage;
     }

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -53,7 +53,7 @@
  * - If nothing else was found, use the variable's default value.
  *
  * Note that there is a second header file (pmix_mca_base_vari.h)
- * that contains several internal type delcarations for the variable
+ * that contains several internal type declarations for the variable
  * system.  The internal file is only used within the variable system
  * itself; it should not be required by any other PMIX entities.
  */
@@ -305,7 +305,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
  *
  * @retval PMIX_SUCCESS
  *
- * This function initalizes the MCA variable system.  It is
+ * This function initializes the MCA variable system.  It is
  * invoked internally (by pmix_mca_base_open()) and is only documented
  * here for completeness.
  */
@@ -458,7 +458,7 @@ PMIX_EXPORT int pmix_mca_base_framework_var_register(
  * creates a new name that by which the same variable value is
  * accessible.
  *
- * Note that the original variable name has precendence over all
+ * Note that the original variable name has precedence over all
  * synonyms.  For example, consider the case if variable is
  * originally registered under the name "A" and is later
  * registered with synonyms "B" and "C".  If the user sets values
@@ -481,7 +481,7 @@ PMIX_EXPORT int pmix_mca_base_var_register_synonym(int synonym_for, const char *
  * @param vari Index returned from pmix_mca_base_var_register() or
  * pmix_mca_base_var_register_synonym().
  *
- * Deregistering a variable does not free the variable or any memory assoicated
+ * Deregistering a variable does not free the variable or any memory associated
  * with it. All memory will be freed and the variable index released when
  * pmix_mca_base_var_finalize() is called.
  *
@@ -657,7 +657,7 @@ PMIX_EXPORT int pmix_mca_base_var_get(int vari, const pmix_mca_base_var_t **var)
 PMIX_EXPORT int pmix_mca_base_var_get_count(void);
 
 /**
- * Obtain a list of enironment variables describing the all
+ * Obtain a list of environment variables describing the all
  * valid (non-default) MCA variables and their sources.
  *
  * @param[out] env A pointer to an argv-style array of key=value

--- a/src/mca/base/pmix_mca_base_var_enum.h
+++ b/src/mca/base/pmix_mca_base_var_enum.h
@@ -85,7 +85,7 @@ typedef int (*pmix_mca_base_var_enum_dump_fn_t)(pmix_mca_base_var_enum_t *self, 
  * @retval PMIX_SUCCESS on success
  * @retval PMIX_ERR_VALUE_OUT_OF_BOUNDS if not found
  *
- * @long This function returns the string value for a given interger value in the
+ * @long This function returns the string value for a given integer value in the
  * {string_value} parameter. The {string_value} parameter may be NULL in which case
  * no string is returned. If a string is returned in {string_value} the caller
  * must free the string with free().

--- a/src/mca/base/pmix_mca_base_var_group.h
+++ b/src/mca/base/pmix_mca_base_var_group.h
@@ -66,7 +66,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_group_t);
  * @param[in] project_name Project name for this group.
  * @param[in] framework_name Framework name for this group.
  * @param[in] component_name Component name for this group.
- * @param[in] descrition Description of this group.
+ * @param[in] description Description of this group.
  *
  * @retval index Unique group index
  * @return pmix error code on Error

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -1332,7 +1332,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr,
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
     }
-    /* we want to preserve any pointes in the provided
+    /* we want to preserve any pointers in the provided
      * info struct so the result points to the same
      * memory location */
     memcpy(&iptr->info, info, sizeof(pmix_info_t));

--- a/src/mca/mca.h
+++ b/src/mca/mca.h
@@ -84,7 +84,7 @@ typedef struct pmix_mca_base_module_2_0_0_t pmix_mca_base_module_2_0_0_t;
  *
  * If the component a) has no MCA parameters to register, b) no
  * resources to allocate, and c) can always be used in a process
- * (albiet perhaps not selected), it may provide NULL for this
+ * (albeit perhaps not selected), it may provide NULL for this
  * function.  In this cause, the MCA will act as if it called the open
  * function and it returned PMIX_SUCCESS.
  */
@@ -127,7 +127,7 @@ typedef int (*pmix_mca_base_close_component_1_0_0_fn_t)(void);
  *
  * This function is used by the mca_base_select function to find the
  * highest priority component to select. Frameworks are free to
- * implement their own query function, but must also implment their
+ * implement their own query function, but must also implement their
  * own select function as a result.
  */
 typedef int (*pmix_mca_base_query_component_2_0_0_fn_t)(pmix_mca_base_module_2_0_0_t **module,
@@ -176,7 +176,7 @@ typedef int (*pmix_mca_base_query_component_2_0_0_fn_t)(pmix_mca_base_module_2_0
  *
  * If the component a) has no MCA parameters to register, b) no
  * resources to allocate, and c) can always be used in a process
- * (albiet perhaps not selected), it may provide NULL for this
+ * (albeit perhaps not selected), it may provide NULL for this
  * function.  In this cause, the MCA will act as if it called the
  * registration function and it returned PMIX_SUCCESS.
  */

--- a/src/mca/pcompress/pcompress.h
+++ b/src/mca/pcompress/pcompress.h
@@ -22,7 +22,7 @@
  * General Description:
  *
  * The PMIX Compress framework has been created to provide an abstract interface
- * to the compression agent library on the host machine. This fromework is useful
+ * to the compression agent library on the host machine. This framework is useful
  * when distributing files that can be compressed before sending to dimish the
  * load on the network.
  *

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -60,15 +60,17 @@ static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbyt
     z_stream strm;
     size_t len, len2;
     uint8_t *tmp, *ptr;
+    uint32_t len3;
     int rc;
 
     /* set default output */
     *outbytes = NULL;
     *outlen = 0;
 
-    if (inlen < pmix_compress_base.compress_limit) {
+    if (inlen < pmix_compress_base.compress_limit || inlen >= UINT32_MAX) {
         return false;
     }
+    len3 = inlen;
 
     /* setup the stream */
     memset(&strm, 0, sizeof(strm));
@@ -99,7 +101,7 @@ static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbyt
 
     rc = deflate(&strm, Z_FINISH);
     (void) deflateEnd(&strm);
-    if (Z_OK != rc && Z_STREAM_END != rc) {
+    if (Z_STREAM_END != rc) {
         free(tmp);
         return false;
     }
@@ -117,7 +119,7 @@ static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbyt
     *outlen = len2;
 
     /* fold the uncompressed length into the buffer */
-    memcpy(ptr, &inlen, sizeof(uint32_t));
+    memcpy(ptr, &len3, sizeof(uint32_t));
     ptr += sizeof(uint32_t);
     /* bring over the compressed data */
     memcpy(ptr, tmp, len2 - sizeof(uint32_t));
@@ -167,7 +169,7 @@ static bool doit(uint8_t **outbytes, size_t len2, const uint8_t *inbytes, size_t
 
     rc = inflate(&strm, Z_FINISH);
     inflateEnd(&strm);
-    if (Z_OK == rc) {
+    if (Z_STREAM_END == rc) {
         *outbytes = dest;
         return true;
     }
@@ -176,7 +178,7 @@ static bool doit(uint8_t **outbytes, size_t len2, const uint8_t *inbytes, size_t
 }
 static bool zlib_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *inbytes, size_t inlen)
 {
-    int32_t len2;
+    uint32_t len2;
     bool rc;
     uint8_t *input;
 
@@ -187,7 +189,7 @@ static bool zlib_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *i
     memcpy(&len2, inbytes, sizeof(uint32_t));
 
     pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
-                        "DECOMPRESSING INPUT OF LEN %" PRIsize_t " OUTPUT %d", inlen, len2);
+                        "DECOMPRESSING INPUT OF LEN %" PRIsize_t " OUTPUT %u", inlen, len2);
 
     input = (uint8_t *) (inbytes + sizeof(uint32_t)); // step over the size
     rc = doit(outbytes, len2, input, inlen);
@@ -200,13 +202,18 @@ static bool zlib_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *i
 
 static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
 {
-    int32_t len2;
+    uint32_t len2;
     bool rc;
     uint8_t *input;
 
     /* the first 4 bytes contains the uncompressed size */
     memcpy(&len2, inbytes, sizeof(uint32_t));
-    /* add one to hold the NULL terminator */
+    if (len2 == UINT32_MAX) {
+        /* set the default error answer */
+        *outstring = NULL;
+        return false;
+    }
+    /* add one to hold the NUL terminator */
     ++len2;
 
     /* decompress the bytes */
@@ -214,8 +221,8 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     rc = doit((uint8_t **) outstring, len2, input, len);
 
     if (rc) {
-        /* ensure this is NULL terminated! */
-        outstring[len2 - 1] = NULL;
+        /* ensure this is NUL terminated! */
+        *outstring[len2 - 1] = '\0';
         return true;
     }
 

--- a/src/mca/pdl/base/pdl_base_open.c
+++ b/src/mca/pdl/base/pdl_base_open.c
@@ -42,7 +42,7 @@ int pmix_pdl_base_open(pmix_mca_base_open_flag_t flags)
 }
 
 /* VERY IMPORTANT: This framework is static, and is opened before any
-   other dyanmic frameworks are opened (which makes sense, of course).
+   other dynamic frameworks are opened (which makes sense, of course).
    But we must mark this framework is NO_DSO so that the MCA framework
    base doesn't try to open any dynamic components in this
    framework. */

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -38,7 +38,7 @@
  * to set the affinity of that new child process according to a
  * complex series of rules.  This binding may fail in a myriad of
  * different ways.  A lot of this code deals with reporting that error
- * occurately to the end user.  This is a complex task in itself
+ * accurately to the end user.  This is a complex task in itself
  * because the child process is not "really" an PMIX process -- all
  * error reporting must be proxied up to the parent who can use normal
  * PMIX error reporting mechanisms.
@@ -397,7 +397,7 @@ static void do_child(pmix_app_t *app, char **env, pmix_pfexec_child_t *child, in
     set_handler_linux(SIGCHLD);
 
     /* Unblock all signals, for many of the same reasons that we
-       set the default handlers, above.  This is noticable on
+       set the default handlers, above.  This is noticeable on
        Linux where the event library blocks SIGTERM, but we don't
        want that blocked by the launched process. */
     sigprocmask(0, 0, &sigs);

--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -224,7 +224,7 @@ pmix_status_t pmix_plog_base_log(const pmix_proc_t *source, const pmix_info_t da
              * fails - that error would be returned in the callback function.
              * In this case, the error indicates that the request contained
              * an incorrect/invalid element that prevents the plugin from
-             * executing it. The first such retured error will be cached and
+             * executing it. The first such returned error will be cached and
              * returned to the caller upon completion of all pending operations.
              * No callback from failed plugins shall be executed.
              */

--- a/src/mca/plog/smtp/plog_smtp.c
+++ b/src/mca/plog/smtp/plog_smtp.c
@@ -191,7 +191,7 @@ static int send_email(char *msg)
     set_oldsig = true;
 
     /* Try to get a libesmtp session.  If so, assume that libesmtp is
-       happy and proceeed */
+       happy and proceed */
     session = smtp_create_session();
     if (NULL == session) {
         err = PMIX_ERR_NOT_SUPPORTED;

--- a/src/mca/psquash/flex128/psquash_flex128.c
+++ b/src/mca/psquash/flex128/psquash_flex128.c
@@ -303,7 +303,7 @@ static pmix_status_t flex128_decode_int(pmix_data_type_t type, void *src, size_t
  *
  * This encoding changes the default representation by introducing an additional
  * bit per each byte to store a "continuation flag". So integers are now encoded
- * with the same representation, but the base B = 128 and the remaning bit is
+ * with the same representation, but the base B = 128 and the remaining bit is
  * used to indicate whether or not the next byte contains more bits of this value.
  */
 static size_t flex_pack_integer(size_t val, uint8_t out_buf[FLEX_BASE7_MAX_BUF_SIZE])

--- a/src/mca/pstat/linux/pstat_linux_module.c
+++ b/src/mca/pstat/linux/pstat_linux_module.c
@@ -574,7 +574,7 @@ static void local_getfields(char *dptr, char ***fields)
     }
 
     /* working from this point, find the end of each
-     * alpha-numeric field and store it on the stack.
+     * alphanumeric field and store it on the stack.
      * Then shift across the white space to the start
      * of the next one
      */

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -74,7 +74,7 @@ An attempt was made to make a TCP connection between two hosts:
   Receiving host:   %s
 
 Unfortunately, the connection was refused due to a failure to
-authenticate. This is usually caused by a mis-match between
+authenticate. This is usually caused by a mismatch between
 the security domains of the two hosts - e.g., one might be
 using Munge while the other is not. This can typically be
 resolved by specifying the desired security method. For

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -174,7 +174,7 @@ pmix_status_t pmix_ptl_base_recv_blocking(int sd, char *data, size_t size)
                    in that case is a RST packet, which receive
                    will turn into a connection reset by peer
                    errno.  In that case, leave the socket in
-                   CONNECT_ACK and propogate the error up to
+                   CONNECT_ACK and propagate the error up to
                    recv_connect_ack, who will try to establish the
                    connection again */
                 pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -754,7 +754,7 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     }
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "QUEING MSG TO SERVER %s ON SOCKET %d OF SIZE %d",
+                        "QUEUEING MSG TO SERVER %s ON SOCKET %d OF SIZE %d",
                         PMIX_PNAME_PRINT(&ms->peer->info->pname), ms->peer->sd,
                         (int) ms->bfr->bytes_used);
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -405,7 +405,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
          * request. In this case, we create a local tracker for
          * possibly existing keys that are added with the completed
          * commit request. Thus, the get request will be pended in
-         * tracker and will be deffered. This scenario is possible
+         * tracker and will be deferred. This scenario is possible
          * when the non-fence commit-get scheme is used and when
          * the peer GDS component is `dstore`.
          * Checking the peer storage for local keys to avoid creating

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2011-2012 University of Houston. All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
@@ -1217,6 +1217,14 @@ void pmix_info_show_pmix_version(const char *scope)
         return;
     }
     pmix_info_out("PMIX release date", tmp, PMIX_RELEASE_DATE);
+    free(tmp);
+
+    // PMIx Standard Compliance levels
+    pmix_info_out("PMIX Standard", "pmix:std:version", PMIX_STD_VERSION);
+    if (0 > asprintf(&tmp, "Stable (%s), Provisional (%s)", PMIX_STD_ABI_STABLE_VERSION, PMIX_STD_ABI_PROVISIONAL_VERSION)) {
+        return;
+    }
+    pmix_info_out("PMIX Standard ABI", "pmix:std:abi:version", tmp);
     free(tmp);
 }
 

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -376,7 +376,7 @@ static int pretty_print_nodes(pmix_node_t **nodes, pmix_std_cntr_t num_nodes) {
     pmix_std_cntr_t i;
 
     /*
-     * Caculate segment lengths
+     * Calculate segment lengths
      */
     len_name    = (int) strlen("Node Name");
     len_state   = (int) strlen("State");
@@ -457,7 +457,7 @@ static int pretty_print_jobs(pmix_job_t **jobs, pmix_std_cntr_t num_jobs) {
         jobstr = PMIX_JOBID_PRINT(job->jobid);
 
         /*
-         * Caculate segment lengths
+         * Calculate segment lengths
          */
         len_jobid  = strlen(jobstr);;
         len_state  = (int) (strlen(pmix_job_state_to_str(job->state)) < strlen("State") ?
@@ -529,7 +529,7 @@ static int pretty_print_vpids(pmix_job_t *job) {
     }
 
     /*
-     * Caculate segment lengths
+     * Calculate segment lengths
      */
     len_o_proc_name = (int)strlen("PMIX Name");
     len_proc_name   = (int)strlen("Process Name");

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -153,7 +153,7 @@ struct options_data_t {
      * language-binding specific file (for example, a C++ header file)
      * when invoking an optional language binding. */
     char *req_file;
-    /* Default includedir, before variable expansion.  Almost alwyas
+    /* Default includedir, before variable expansion.  Almost always
      * set as ${includedir} outside of multilib situations. */
     char *path_includedir;
     /* Default libdir, before variable expansion.  Almost always set
@@ -619,7 +619,7 @@ int main(int argc, char *argv[])
             old_match = temp;
             temp = strstr(temp + 1, extension);
         }
-        /* Only if there was a match of .exe, erase the last occurence of .exe */
+        /* Only if there was a match of .exe, erase the last occurrence of .exe */
         if (NULL != old_match) {
             *old_match = '\0';
         }

--- a/src/util/pmix_argv.h
+++ b/src/util/pmix_argv.h
@@ -58,7 +58,7 @@ BEGIN_C_DECLS
  * @retval PMIX_ERROR On failure
  *
  * This function adds a string to an argv array of strings by value;
- * it is permissable to pass a string on the stack as the str
+ * it is permissible to pass a string on the stack as the str
  * argument to this function.
  *
  * To add the first entry to an argv array, call this function with
@@ -149,7 +149,7 @@ PMIX_EXPORT pmix_status_t pmix_argv_delete(int *argc, char ***argv, int start, i
  * another.  The first token in source will be inserted at index
  * start in the target argv; all other tokens will follow it.
  * Similar to pmix_argv_append(), the target may be realloc()'ed
- * to accomodate the new storage requirements.
+ * to accommodate the new storage requirements.
  *
  * The source array is left unaffected -- its contents are copied
  * by value over to the target array (i.e., the strings that
@@ -172,7 +172,7 @@ PMIX_EXPORT pmix_status_t pmix_argv_insert(char ***target, int start, char **sou
  * another.  The token will be inserted at the specified index
  * in the target argv; all other tokens will be shifted down.
  * Similar to pmix_argv_append(), the target may be realloc()'ed
- * to accomodate the new storage requirements.
+ * to accommodate the new storage requirements.
  *
  * The source token is left unaffected -- its contents are copied
  * by value over to the target array (i.e., the string that

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -164,7 +164,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         pmix_argv_free(argv);
-                        return PMIX_ERR_SILENT;
+                        return PMIX_OPERATION_SUCCEEDED;
                     }
                     if (0 == strcmp(ptr, "verbose") || 0 == strcmp(ptr, "v")) {
                         str = pmix_show_help_string("help-cli.txt", "verbose", false);
@@ -173,7 +173,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         pmix_argv_free(argv);
-                        return PMIX_ERR_SILENT;
+                        return PMIX_OPERATION_SUCCEEDED;
                     }
                     if (0 == strcmp(ptr, "help") || 0 == strcmp(ptr, "h")) {
                         // they requested help on the "help" option itself
@@ -187,7 +187,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         pmix_argv_free(argv);
-                        return PMIX_ERR_SILENT;
+                        return PMIX_OPERATION_SUCCEEDED;
                     }
                     /* see if the argument is one of our options */
                     found = false;
@@ -200,7 +200,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                 free(str);
                             }
                             pmix_argv_free(argv);
-                            return PMIX_ERR_SILENT;
+                            return PMIX_OPERATION_SUCCEEDED;
                         }
                     }
                     if (!found) {
@@ -223,6 +223,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         printf("%s", str);
                         free(str);
                     }
+                    pmix_argv_free(argv);
+                    return PMIX_OPERATION_SUCCEEDED;
                 } else {  // unrecognized option
                     str = pmix_show_help_string("help-cli.txt", "unrecognized-option", true,
                                                 pmix_tool_basename, optarg);
@@ -244,7 +246,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 }
                 // if they ask for the version, that is all we do
                 pmix_argv_free(argv);
-                return PMIX_ERR_SILENT;
+                return PMIX_OPERATION_SUCCEEDED;
             default:
                 /* this could be one of the short options other than 'h' or 'V', so
                  * we have to check */

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -47,7 +47,7 @@
 
 /*
  * Merge two environ-like char arrays, ensuring that there are no
- * duplicate entires
+ * duplicate entries
  */
 char **pmix_environ_merge(char **minor, char **major)
 {

--- a/src/util/pmix_environ.h
+++ b/src/util/pmix_environ.h
@@ -54,7 +54,7 @@ BEGIN_C_DECLS
  * @retval New array of environ
  *
  * Merge two environ-like arrays into a single, new array,
- * ensuring that there are no duplicate entires.  If there are
+ * ensuring that there are no duplicate entries.  If there are
  * duplicates, entries in the \em major array are favored over
  * those in the \em minor array.
  *

--- a/src/util/pmix_if.c
+++ b/src/util/pmix_if.c
@@ -156,7 +156,7 @@ int pmix_ifindextokindex(int if_index)
 }
 
 /*
- *  Attempt to resolve the adddress (given as either IPv4/IPv6 string
+ *  Attempt to resolve the address (given as either IPv4/IPv6 string
  *  or hostname) and lookup corresponding interface.
  */
 

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -257,7 +257,7 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
         if (64 == prefixlen) {
             /* prefixlen is always /64, any other case would be routing.
                Compare the first eight bytes (64 bits) and hope that
-               endianess is not an issue on any system as long as
+               endianness is not an issue on any system as long as
                addresses are always stored in network byte order.
             */
             if (((const uint32_t *) (a6_1))[0] == ((const uint32_t *) (a6_2))[0]
@@ -353,7 +353,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     case AF_INET6:
 #    if defined(__NetBSD__)
         /* hotfix for netbsd: on my netbsd machine, getnameinfo
-           returns an unkown error code. */
+           returns an unknown error code. */
         if (NULL
             == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
             pmix_output(0, "pmix_sockaddr2str failed with error code %d", errno);

--- a/src/util/pmix_net.h
+++ b/src/util/pmix_net.h
@@ -42,7 +42,7 @@
 BEGIN_C_DECLS
 
 /**
- * Intiailize the network helper subsystem
+ * Initialize the network helper subsystem
  *
  * Initialize the network helper subsystem.  Should be called exactly
  * once for any process that will use any function in the network

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -76,7 +76,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
         return (PMIX_SUCCESS);
     }
 
-    /* didnt work, so now have to build our way down the tree */
+    /* didn't work, so now have to build our way down the tree */
     /* Split the requested path up into its individual parts */
 
     parts = pmix_argv_split(path, path_sep[0]);
@@ -104,7 +104,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
         }
 
         /* If it's not the first part, ensure that there's a
-           preceeding path_sep and then append this part */
+           preceding path_sep and then append this part */
 
         else {
             if (path_sep[0] != tmp[strlen(tmp) - 1]) {
@@ -164,7 +164,7 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
     }
 
     /*
-     * Make sure we have access to the the base directory
+     * Make sure we have access to the base directory
      */
     if (PMIX_SUCCESS != (rc = pmix_os_dirpath_access(path, 0))) {
         exit_status = rc;
@@ -210,7 +210,7 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
         }
 
         /*
-         * If not recursively decending, then if we find a directory then fail
+         * If not recursively descending, then if we find a directory then fail
          * since we were not told to remove it.
          */
         if (is_dir && !recursive) {

--- a/src/util/pmix_os_dirpath.h
+++ b/src/util/pmix_os_dirpath.h
@@ -110,7 +110,7 @@ typedef bool (*pmix_os_dirpath_destroy_callback_fn_t)(const char *root, const ch
  * @retval PMIX_SUCCESS If the directory was successfully removed or removed to the
  *                      specification of the user (i.e., obeyed the callback function).
  * @retval PMIX_ERR_NOT_FOUND If directory does not exist.
- * @retval PMIX_ERROR If the directory cannnot be removed, accessed properly, or contains
+ * @retval PMIX_ERROR If the directory cannot be removed, accessed properly, or contains
  *                    directories that could not be removed..
  */
 PMIX_EXPORT int pmix_os_dirpath_destroy(const char *path, bool recursive,

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -214,7 +214,7 @@ char *pmix_path_findv(char *fname, int mode, char **envv, char *wrkdir)
 }
 
 /**
- *  Forms a complete pathname and checks it for existance and
+ *  Forms a complete pathname and checks it for existence and
  *  permissions
  *
  *  Accepts:
@@ -490,7 +490,7 @@ static char *pmix_check_mtab(char *dev_path)
 #    define PAN_KERNEL_FS_CLIENT_SUPER_MAGIC 0xAAD7AAEA /* Panasas FS */
 #endif
 #ifndef GPFS_SUPER_MAGIC
-#    define GPFS_SUPER_MAGIC 0x47504653 /* Thats GPFS in ASCII */
+#    define GPFS_SUPER_MAGIC 0x47504653 /* That's GPFS in ASCII */
 #endif
 #ifndef AUTOFS_SUPER_MAGIC
 #    define AUTOFS_SUPER_MAGIC 0x0187

--- a/src/util/pmix_path.h
+++ b/src/util/pmix_path.h
@@ -112,7 +112,7 @@ PMIX_EXPORT bool pmix_path_is_absolute(const char *path);
 PMIX_EXPORT char *pmix_find_absolute_path(char *app_name) __pmix_attribute_warn_unused_result__;
 
 /**
- * Forms a complete pathname and checks it for existance and
+ * Forms a complete pathname and checks it for existence and
  * permissions
  *
  * @param fname File name

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -201,7 +201,7 @@ static int ptym_open(char *pts_name)
                     continue; /* try next pty device */
                 }
             }
-            pts_name[5] = 't'; /* chage "pty" to "tty" */
+            pts_name[5] = 't'; /* change "pty" to "tty" */
             return fdm;        /* got it, return fd of master */
         }
     }

--- a/src/util/pmix_show_help.h
+++ b/src/util/pmix_show_help.h
@@ -48,7 +48,7 @@
  * appropriate help message to display.  It looks for the message name
  * in the file, reads in the message, and displays it.  printf()-like
  * substitutions are performed (e.g., %d, %s, etc.) --
- * pmix_show_help() takes a variable legnth argument list that are
+ * pmix_show_help() takes a variable length argument list that are
  * used for these substitutions.
  *
  * The format of the help file is simplistic:
@@ -173,7 +173,7 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename,
  * of the show_help functionality. OMPI defines the show_help directory
  * based on where OMPI was installed. However, if the library wants to
  * use show_help to provide error output specific to itself, then it
- * nees to tell pmix_show_help.how to find its own show_help files - without
+ * needs to tell pmix_show_help.how to find its own show_help files - without
  * interfering with the linked ORTE libs when they need to do show_help.
  */
 PMIX_EXPORT pmix_status_t pmix_show_help_add_dir(const char *directory);

--- a/src/util/pmix_string_copy.c
+++ b/src/util/pmix_string_copy.c
@@ -21,7 +21,7 @@ void pmix_string_copy(char *dest, const char *src, size_t dest_len)
     char *new_dest = dest;
 
     // PMIx does not do *giant* string copies.  Hence, we use the
-    // hueristic: if "dest_len" is too large, this is a programmer
+    // heuristic: if "dest_len" is too large, this is a programmer
     // error.  We pseudo-arbitrarily pick a large value to be the max
     // allowable dest_len: 128K.  If we ever need to increase this
     // value someday (because something has a legit reason to

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -489,7 +489,7 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
             continue;
         }
 
-        /* id's assigned auomatically. Ther shouldn't be any gaps in descr[] */
+        /* id's assigned auomatically. There shouldn't be any gaps in descr[] */
         assert(NULL != descr[id].descr_ev);
 
         if (ev->type == PMIX_TIMING_INTBEGIN) {
@@ -517,7 +517,7 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
             if (NULL == descr[id].begin_ev) {
                 /* the measurement on this interval wasn't started! */
                 char *file = pmix_basename(ev->file);
-                pmix_output(0, "pmix_timing_deltas: inteval end without start at %s:%d:%s", file,
+                pmix_output(0, "pmix_timing_deltas: interval end without start at %s:%d:%s", file,
                             ev->line, ev->func);
                 free(file);
             } else {

--- a/src/util/pmix_timings.h
+++ b/src/util/pmix_timings.h
@@ -199,7 +199,7 @@ PMIX_EXPORT void pmix_timing_end_prep(pmix_timing_prep_t p, const char *func, co
  *
  * @param t timing handler
  * @param account_overhead consider malloc overhead introduced by timing code
- * @param prefix prefix to use when no fname was specifyed to ease grep'ing
+ * @param prefix prefix to use when no fname was specified to ease grep'ing
  * @param fname name of the output file (may be NULL)
  *
  * @retval PMIX_SUCCESS On success
@@ -304,7 +304,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
 /**
  * MSTART: Measurement START
  * Introduce new timing measurement conjuncted with its start
- * on the specifyed timing handler;
+ * on the specified timing handler;
  * will be "compiled out" when PMIX is configured without
  * --enable-timing.
  *
@@ -315,7 +315,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
 
 /**
  * MSTOP: STOP Measurement
- * Finishes the most recent measurement on the specifyed timing handler;
+ * Finishes the most recent measurement on the specified timing handler;
  * will be "compiled out" when PMIX is configured without
  * --enable-timing.
  *
@@ -325,7 +325,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
 
 /**
  * MSTOP_ID: STOP Measurement with ID=id.
- * Finishes the measurement with give ID on the specifyed timing handler;
+ * Finishes the measurement with give ID on the specified timing handler;
  * will be "compiled out" when PMIX is configured without
  * --enable-timing.
  *
@@ -335,12 +335,12 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
 
 /**
  * MNEXT: start NEXT Measurement
- * Convinient macro, may be implemented with the sequence of three previously
- * defined macroses:
+ * Convenient macro, may be implemented with the sequence of three previously
+ * defined macros:
  * - finish current measurement (PMIX_TIMING_MSTOP);
  * - introduce new timing measurement (PMIX_TIMING_MDESCR);
  * - starts next measurement (PMIX_TIMING_MSTART_ID)
- * on the specifyed timing handler;
+ * on the specified timing handler;
  * will be "compiled out" when PMIX is configured without
  * --enable-timing.
  *

--- a/test/test_cd.c
+++ b/test/test_cd.c
@@ -48,14 +48,14 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
         TEST_ERROR(("%s:%d: Connect blocking test failed.", my_nspace, my_rank));
         exit(PMIX_ERROR);
     }
-    TEST_VERBOSE(("%s:%d: Connect blocking test succeded", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Connect blocking test succeeded", my_nspace, my_rank));
 
     rc = PMIx_Disconnect(&proc, 1, NULL, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Disconnect blocking test failed.", my_nspace, my_rank));
         exit(PMIX_ERROR);
     }
-    TEST_VERBOSE(("%s:%d: Disconnect blocking test succeded.", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Disconnect blocking test succeeded.", my_nspace, my_rank));
 
     cbdata.in_progress = 1;
     rc = PMIx_Connect_nb(&proc, 1, NULL, 0, cnct_cb, &cbdata);
@@ -67,7 +67,7 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
         TEST_ERROR(("%s:%d: Connect non-blocking test failed.", my_nspace, my_rank));
         exit(PMIX_ERROR);
     }
-    TEST_VERBOSE(("%s:%d: Connect non-blocking test succeded.", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Connect non-blocking test succeeded.", my_nspace, my_rank));
 
     cbdata.in_progress = 1;
     rc = PMIx_Disconnect_nb(&proc, 1, NULL, 0, cd_cb, &cbdata);
@@ -79,6 +79,6 @@ int test_connect_disconnect(char *my_nspace, int my_rank)
         TEST_ERROR(("%s:%d: Disconnect non-blocking test failed.", my_nspace, my_rank));
         exit(PMIX_ERROR);
     }
-    TEST_VERBOSE(("%s:%d: Disconnect non-blocking test succeded.", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Disconnect non-blocking test succeeded.", my_nspace, my_rank));
     return PMIX_SUCCESS;
 }

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -72,7 +72,7 @@ int test_error(char *my_nspace, int my_rank, test_params params)
 
     TEST_VERBOSE(("test-error: running  error handling test cases"));
     /* register specific client error handlers and test their invocation
-     * by  trigerring events  from server side*/
+     * by  triggering events  from server side*/
     status = PMIX_ERR_TIMEOUT;
     PMIx_Register_event_handler(&status, 1, NULL, 0, timeout_errhandler, errhandler_reg_callbk1,
                                 &errhandler_refs[0]);

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -41,7 +41,7 @@ static int resolve_nspace(char *nspace, test_params params, char *my_nspace, int
     }
     if (nprocs != nranks) {
         TEST_ERROR(
-            ("%s:%d: Resolve peers returned incorect result: returned %lu processes, expected %lu",
+            ("%s:%d: Resolve peers returned incorrect result: returned %lu processes, expected %lu",
              my_nspace, my_rank, nprocs, nranks));
         PMIX_PROC_FREE(procs, nprocs);
         PMIX_PROC_FREE(ranks, nranks);

--- a/test/test_spawn.c
+++ b/test/test_spawn.c
@@ -74,12 +74,12 @@ int test_spawn(char *my_nspace, int my_rank)
         TEST_ERROR(("%s:%d: Spawn blocking test failed.", my_nspace, my_rank));
         exit(rc);
     }
-    TEST_VERBOSE(("%s:%d: Spawn blocking test succeded.", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Spawn blocking test succeeded.", my_nspace, my_rank));
     rc = test_spawn_common(my_nspace, my_rank, 0);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: Spawn non-blocking test failed.", my_nspace, my_rank));
         exit(rc);
     }
-    TEST_VERBOSE(("%s:%d: Spawn non-blocking test succeded.", my_nspace, my_rank));
+    TEST_VERBOSE(("%s:%d: Spawn non-blocking test succeeded.", my_nspace, my_rank));
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
[Setup PMIX_STD_ABI_VERSION in the VERSION file](https://github.com/openpmix/openpmix/commit/4ff7c8eb7da698f2cb53306f056365efbe18a75f)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d41b236ef1de75c3d19dc824050ea928d7e41163)

[Define the PMIX_QUERY_ABI_VERSION attribute](https://github.com/openpmix/openpmix/commit/ac8a9969c9894d021abb1bbf725980f1968da0e9)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/16ffea621554fe1e07f7771b69e8135a6f07dd79)

[Backend query support for PMIX_QUERY_ABI_VERSION and local keys](https://github.com/openpmix/openpmix/commit/b7ae9413c5d75e02fbaa62ad03d34e869cf3dc90)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/265f1dc79c24a0c9bb4f4d388ae57f846683c16a)

[Add examples for using PMIx_Query_info with PMIX_QUERY_ABI_VERSION](https://github.com/openpmix/openpmix/commit/ca15b8040c509aed366ffa7b1ce0b2671980457d)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/4c455027697459eea9e58b3936968284033dcfbe)

* `PMIX_QUERY_STABLE_ABI_VERSION` : Stable ABI version(s)
 * `PMIX_QUERY_PROVISIONAL_ABI_VERSION` : Provisional ABI version(s)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/fa15e0dce95f5280579c635adf9cd59abc13f7c4)

[Add PMIx Standard version info to pmix_info](https://github.com/openpmix/openpmix/commit/419fbabdeeddeaf333e51e831b75f0452fa4f959)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3f7b1d007b804c05dd0d2f18a4c6c08275354c7a)

[Fix typos.](https://github.com/openpmix/openpmix/commit/560bfb462be9d581d06c1510750088ac98c47229)

Typos found with codespell.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/ac0654a318a71bab4ef533e910cd8059c6911d80)

[Fix pcompress/zlib implementation (](https://github.com/openpmix/openpmix/commit/fdbe1f75d5ff0558cf19f2b199096514fe704941)https://github.com/openpmix/openpmix/pull/2625[)](https://github.com/openpmix/openpmix/commit/fdbe1f75d5ff0558cf19f2b199096514fe704941)

* pcompress/zlib: Check for correct return values.

deflate and inflate with Z_FINISH return Z_STREAM_END on success.
All other cases imply that an error occurred or that not enough
output space was available. These cases should be treated as
errors because:

- deflateBound specifies max amount of output bytes to expect
- inflate takes length from message into account

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>

* pcompress/zlib: Use correct data types.

On 64 bit systems size_t is larger than uint32_t. This means that
performing a memcpy() with sizeof(uint32_t) truncates the value.

Also avoid signed data types when unsigned types are better suited.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>

* pcompress/zlib: Correctly terminate string.

Right now each successful operation leads to out of boundary heap
access by not dereferencing the double pointer outstring.

This is supposed to terminate the string with a '\0', not setting
a char pointer to NULL.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>

* pcompress/zlib: Validate input length.

Check that input length is not UINT32_MAX to avoid integer overflow.
If such an overflow occurs, a malicious peer could trigger an out of
boundary heap access when terminating the string with a nul byte.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6c9d3dde370cfb61739ba312f7631cd0f44eac3d)

[Return "succeeded" status when outputting help/version info](https://github.com/openpmix/openpmix/commit/bacc8676a17e3dec1a1ca517e237684416fc5e33)

Any time we ask for help or version info, we should
return an "operation succeeded" status when done so the
caller knows we did it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/b83c97fdd789102c443d83e71ec123cfa1173f85)
