### PR TITLE
Enable pickyness by default in Git repo builds

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -185,13 +185,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_REPO_REV], ["$PMIX_REPO_REV"],
                        [The OpenPMIx Git Revision])
 
-    # A hint to tell us if we are working with a build from Git or a tarball.
-    # Helpful when preparing diagnostic output.
-    if test -e $PMIX_TOP_SRCDIR/.git; then
-        AC_DEFINE_UNQUOTED([PMIX_GIT_REPO_BUILD], ["1"],
-            [If built from a git repo])
-    fi
-
     PMIX_RELEASE_DATE="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --release-date`"
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
@@ -1017,6 +1010,15 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 ])dnl
 
 AC_DEFUN([PMIX_DEFINE_ARGS],[
+
+    # A hint to tell us if we are working with a build from Git or a tarball.
+    # Helpful when preparing diagnostic output.
+    if test -e $PMIX_TOP_SRCDIR/.git; then
+        AC_DEFINE_UNQUOTED([PMIX_GIT_REPO_BUILD], ["1"],
+            [If built from a git repo])
+        pmix_git_repo_build=yes
+    fi
+
     # do we want dlopen support ?
     AC_MSG_CHECKING([if want dlopen support])
     AC_ARG_ENABLE([dlopen],
@@ -1045,6 +1047,12 @@ AC_ARG_ENABLE(devel-check,
     AS_HELP_STRING([--enable-devel-check],
                    [enable developer-level compiler pickyness when building PMIx (default: disabled)]))
 if test "$enable_devel_check" = "yes"; then
+    AC_MSG_RESULT([yes])
+    WANT_PICKY_COMPILER=1
+elif test "$enable_devel_check" = "no"; then
+    AC_MSG_RESULT([no])
+    WANT_PICKY_COMPILER=0
+elif test "$pmix_git_repo_build" = "yes"; then
     AC_MSG_RESULT([yes])
     WANT_PICKY_COMPILER=1
 else

--- a/examples/server.c
+++ b/examples/server.c
@@ -301,7 +301,7 @@ int main(int argc, char **argv)
     PMIX_RELEASE(x);
 
     /* fork/exec the test */
-    (void) strncpy(proc.nspace, "foobar", PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(proc.nspace, "foobar");
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
         if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, &client_env))) { // n
@@ -419,39 +419,39 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
     }
     PMIX_DESTRUCT(&myxfer);
 
-    (void) strncpy(x->info[i].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_UNIV_SIZE);
     x->info[i].value.type = PMIX_UINT32;
     x->info[i].value.data.uint32 = nprocs;
 
     ++i;
-    (void) strncpy(x->info[i].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_SPAWNED);
     x->info[i].value.type = PMIX_UINT32;
     x->info[i].value.data.uint32 = 0;
 
     ++i;
-    (void) strncpy(x->info[i].key, PMIX_LOCAL_SIZE, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_LOCAL_SIZE);
     x->info[i].value.type = PMIX_UINT32;
     x->info[i].value.data.uint32 = nprocs;
 
     ++i;
-    (void) strncpy(x->info[i].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_LOCAL_PEERS);
     x->info[i].value.type = PMIX_STRING;
     x->info[i].value.data.string = strdup(ranks);
 
     ++i;
     PMIx_generate_regex(hostname, &regex);
-    (void) strncpy(x->info[i].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_NODE_MAP);
     x->info[i].value.type = PMIX_STRING;
     x->info[i].value.data.string = regex;
 
     ++i;
     PMIx_generate_ppn(ranks, &ppn);
-    (void) strncpy(x->info[i].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_PROC_MAP);
     x->info[i].value.type = PMIX_STRING;
     x->info[i].value.data.string = ppn;
 
     ++i;
-    (void) strncpy(x->info[i].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[i].key, PMIX_JOB_SIZE);
     x->info[i].value.type = PMIX_UINT32;
     x->info[i].value.data.uint32 = nprocs;
 
@@ -528,14 +528,14 @@ static pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object, int 
     /* use the myxfer_t object to ensure we release
      * the caller when notification has been queued */
     x = PMIX_NEW(myxfer_t);
-    (void) strncpy(x->caller.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(x->caller.nspace, proc->nspace);
     x->caller.rank = proc->rank;
 
     PMIX_INFO_CREATE(x->info, 2);
-    (void) strncpy(x->info[0].key, "DARTH", PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[0].key, "DARTH");
     x->info[0].value.type = PMIX_INT8;
     x->info[0].value.data.int8 = 12;
-    (void) strncpy(x->info[1].key, "VADER", PMIX_MAX_KEYLEN);
+    PMIX_LOAD_KEY(x->info[1].key, "VADER");
     x->info[1].value.type = PMIX_DOUBLE;
     x->info[1].value.data.dval = 12.34;
     x->cbfunc = cbfunc;
@@ -789,7 +789,7 @@ static pmix_status_t query_fn(pmix_proc_t *proct, pmix_query_t *queries, size_t 
     /* keep this simple */
     PMIX_INFO_CREATE(info, nqueries);
     for (n = 0; n < nqueries; n++) {
-        (void) strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
+        PMIX_LOAD_KEY(info[n].key, queries[n].keys[0]);
         info[n].value.type = PMIX_STRING;
         if (0 > asprintf(&info[n].value.data.string, "%d", (int) n)) {
             return PMIX_ERROR;
@@ -808,7 +808,7 @@ static void tool_connect_fn(pmix_info_t *info, size_t ninfo, pmix_tool_connectio
     pmix_output(0, "SERVER: TOOL CONNECT");
 
     /* just pass back an arbitrary nspace */
-    (void) strncpy(proc.nspace, "TOOL", PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(proc.nspace, "TOOL");
     proc.rank = 0;
 
     if (NULL != cbfunc) {

--- a/examples/server.c
+++ b/examples/server.c
@@ -589,9 +589,9 @@ static pmix_status_t publish_fn(const pmix_proc_t *proc, const pmix_info_t info[
 
     for (n = 0; n < ninfo; n++) {
         p = PMIX_NEW(pmix_locdat_t);
-        (void) strncpy(p->pdata.proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+        PMIX_LOAD_NSPACE(p->pdata.proc.nspace, proc->nspace);
         p->pdata.proc.rank = proc->rank;
-        (void) strncpy(p->pdata.key, info[n].key, PMIX_MAX_KEYLEN);
+        PMIX_LOAD_KEY(p->pdata.key, info[n].key);
         PMIx_Value_xfer(&p->pdata.value, (pmix_value_t *) &info[n].value);
         pmix_list_append(&pubdata, &p->super);
     }
@@ -619,9 +619,9 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_
         PMIX_LIST_FOREACH (p, &pubdata, pmix_locdat_t) {
             if (0 == strncmp(keys[n], p->pdata.key, PMIX_MAX_KEYLEN)) {
                 p2 = PMIX_NEW(pmix_locdat_t);
-                (void) strncpy(p2->pdata.proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(p2->pdata.proc.nspace, p->pdata.proc.nspace);
                 p2->pdata.proc.rank = p->pdata.proc.rank;
-                (void) strncpy(p2->pdata.key, p->pdata.key, PMIX_MAX_KEYLEN);
+                PMIX_LOAD_KEY(p2->pdata.key, p->pdata.key);
                 PMIx_Value_xfer(&p2->pdata.value, &p->pdata.value);
                 pmix_list_append(&results, &p2->super);
                 break;
@@ -634,9 +634,9 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_
         for (i = 0; i < n; i++) {
             p = (pmix_locdat_t *) pmix_list_remove_first(&results);
             if (p) {
-                (void) strncpy(pd[i].proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(pd[i].proc.nspace, p->pdata.proc.nspace);
                 pd[i].proc.rank = p->pdata.proc.rank;
-                (void) strncpy(pd[i].key, p->pdata.key, PMIX_MAX_KEYLEN);
+                PMIX_LOAD_KEY(pd[i].key, p->pdata.key);
                 PMIx_Value_xfer(&pd[i].value, &p->pdata.value);
             }
         }

--- a/src/include/pmix_stdint.h
+++ b/src/include/pmix_stdint.h
@@ -120,7 +120,7 @@ typedef unsigned long long uintptr_t;
 #        define PRIsize_t "zu"
 #    elif SIZEOF_SIZE_T == SIZEOF_LONG
 #        define PRIsize_t "lu"
-#    elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+#    elif defined(SIZEOF_LONG_LONG) && SIZEOF_SIZE_T == SIZEOF_LONG_LONG
 #        define PRIsize_t "llu"
 #    else
 #        define PRIsize_t "u"

--- a/src/include/pmix_stdint.h
+++ b/src/include/pmix_stdint.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,7 +97,7 @@ typedef signed long intptr_t;
 typedef unsigned long uintptr_t;
 #    endif
 
-#elif HAVE_LONG_LONG && SIZEOF_VOID_P == SIZEOF_LONG_LONG
+#elif HAVE_LONG_LONG && defined(SIZEOF_LONG_LONG) && SIZEOF_VOID_P == SIZEOF_LONG_LONG
 
 #    ifndef HAVE_INTPTR_T
 typedef signed long long intptr_t;

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -211,7 +211,6 @@ static int file_exists(const char *filename, const char *ext)
 int pmix_mca_base_component_repository_add(const char *project,
                                            const char *path)
 {
-    PMIX_HIDE_UNUSED_PARAMS(path);
 #if PMIX_HAVE_PDL_SUPPORT
     char *path_to_use = NULL, *dir, *ctx;
     const char sep[] = {PMIX_ENV_SEP, '\0'};
@@ -236,7 +235,8 @@ int pmix_mca_base_component_repository_add(const char *project,
     } while (NULL != (dir = strtok_r(NULL, sep, &ctx)));
 
     free(path_to_use);
-
+#else
+    PMIX_HIDE_UNUSED_PARAMS(project, path);
 #endif /* PMIX_HAVE_PDL_SUPPORT */
 
     return PMIX_SUCCESS;

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -68,7 +68,10 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds);
  */
 int pmix_mca_base_open(const char *add_path)
 {
-    char *value, **paths = NULL, *cptr;
+#if PMIX_WANT_HOME_CONFIG_FILES
+    char *value;
+#endif
+    char **paths = NULL, *cptr;
     pmix_output_stream_t lds;
     char hostname[PMIX_MAXHOSTNAMELEN] = {0};
     int var_id;

--- a/src/mca/gds/shmem/pmix_hash2.c
+++ b/src/mca/gds/shmem/pmix_hash2.c
@@ -320,7 +320,7 @@ pmix_status_t pmix_hash2_fetch(pmix_hash_table2_t *table,
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_data2_t *proc_data;
     pmix_dstor_t *hv;
-    uint32_t id, kid;
+    uint32_t id, kid=UINT32_MAX;
     char *node;
     pmix_regattr_input_t *p;
     pmix_info_t *iptr;
@@ -507,7 +507,7 @@ pmix_status_t pmix_hash2_remove_data(pmix_hash_table2_t *table,
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_data2_t *proc_data;
     pmix_dstor_t *d;
-    uint32_t id, kid;
+    uint32_t id, kid=UINT32_MAX;
     int n;
     char *node;
     pmix_regattr_input_t *p;

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -97,6 +97,7 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer, const pmix_info_t dir
     bool takeus;
     char **types;
     size_t n, m;
+    PMIX_HIDE_UNUSED_PARAMS(peer);
 
     PMIX_ACQUIRE_THREAD(&lock);
 

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -254,7 +254,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_data_t *proc_data;
     pmix_dstor_t *hv;
-    uint32_t id, kid;
+    uint32_t id, kid=UINT32_MAX;
     char *node;
     pmix_regattr_input_t *p;
     pmix_info_t *iptr;
@@ -411,7 +411,7 @@ pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_data_t *proc_data;
     pmix_dstor_t *d;
-    uint32_t id, kid;
+    uint32_t id, kid=UINT32_MAX;
     int n;
     char *node;
     pmix_regattr_input_t *p;

--- a/test/util/numa.c
+++ b/test/util/numa.c
@@ -9,7 +9,10 @@
 int main(int argc, char **argv)
 {
     hwloc_topology_t topo;
-    int ret, num, weight, N;
+#if HWLOC_API_VERSION >= 0x20000
+    int ret;
+#endif
+    int num, weight, N;
     hwloc_obj_t obj;
     unsigned width, w;
     hwloc_bitmap_t numas[100], result;


### PR DESCRIPTION
Just to avoid committing things that fail the
enable-devel-check builds

Signed-off-by: Ralph Castain <rhc@pmix.org>