### PR TITLE
Remove bad destruct call

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -693,7 +693,6 @@ static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd, pmix_bu
         if (rc != PMIX_SUCCESS) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&pkt);
-            PMIX_DESTRUCT(&pbkt);
             PMIX_DESTRUCT(&cb);
             return rc;
         }


### PR DESCRIPTION
The get_job_data function cannot destruct the buffer being
passed to it - the caller will do so in the event of a
returned error status.

Fixes https://github.com/openpmix/openpmix/issues/2632

Signed-off-by: Ralph Castain <rhc@pmix.org>