### PR TITLE
Fix PMIX_INFO_*PROCESSED macros

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3306,9 +3306,9 @@ typedef struct pmix_info {
     !((m)->flags & PMIX_INFO_REQD)
 
 /* macros for setting and testing the "reqd processed" flag */
-#define PMIX_INFO_WAS_PROCESSED(m)  \
-    ((m)->flags |= PMIX_INFO_REQD_PROCESSED)
 #define PMIX_INFO_PROCESSED(m)  \
+    ((m)->flags |= PMIX_INFO_REQD_PROCESSED)
+#define PMIX_INFO_WAS_PROCESSED(m)  \
     ((m)->flags & PMIX_INFO_REQD_PROCESSED)
 
 /* macro for testing end of the array */


### PR DESCRIPTION
According to the standard, `PMIX_INFO_PROCESSED(info)` is meant to set and `PMIX_INFO_WAS_PROCESSED(info)` is meant to test the processed flag.

Signed-off-by: Stephan Krempel <krempel@par-tec.com>