### PR TITLE
Fix dmodex operations

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -951,7 +951,7 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
     pmix_dmdx_reply_caddy_t *caddy = (pmix_dmdx_reply_caddy_t *) cbdata;
     pmix_server_caddy_t *cd;
     pmix_peer_t *peer;
-    pmix_rank_info_t *rinfo;
+    pmix_rank_info_t *rinfo, *rptr;
     int32_t cnt;
     pmix_kval_t *kv;
     pmix_namespace_t *ns, *nptr;
@@ -966,8 +966,10 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(caddy);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_output_verbose(2, pmix_server_globals.get_output, "[%s:%d] process dmdx reply from %s:%u",
-                        __FILE__, __LINE__, caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "[%s:%d] process dmdx reply from %s:%u",
+                        __FILE__, __LINE__,
+                        caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
 
     /* find the nspace object for the proc whose data is being received */
     nptr = NULL;
@@ -1033,7 +1035,13 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                 peer = pmix_globals.mypeer;
             } else {
                 /* there must be at least one local proc */
-                rinfo = (pmix_rank_info_t *) pmix_list_get_first(&nm->ns->ranks);
+                rinfo = NULL;
+                PMIX_LIST_FOREACH(rptr, &nm->ns->ranks, pmix_rank_info_t) {
+                    if (0 <= rptr->peerid) {
+                        rinfo = rptr;
+                        break;
+                    }
+                }
                 if (NULL == rinfo) {
                     PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
                     goto complete;


### PR DESCRIPTION
Local clients are added to the namespace tracking list upon
registration, but they are not added to the array of local
clients until they actually connect. Thus, the refid of the
first client on the tracking list won't necessarily be set
if it wasn't the first to actually connect.

We know that at least one local client must exist since
someone asked for the direct modex info, so search the
list until we find one that has connected. We have to look
for someone who connected as that is the only way we know
which GDS component to use for that namespace.

Fixes PRRTE [#1243](https://github.com/openpmix/prrte/issues/1243)

Signed-off-by: Ralph Castain <rhc@pmix.org>