### PR TITLE
Add "const" qualifiers to some string print APIs

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1133,16 +1133,16 @@ PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
 PMIX_EXPORT const char* PMIx_Job_state_string(pmix_job_state_t state);
-PMIX_EXPORT const char* PMIx_Get_attribute_string(char *attribute);
-PMIX_EXPORT const char* PMIx_Get_attribute_name(char *attrstring);
+PMIX_EXPORT const char* PMIx_Get_attribute_string(const char *attribute);
+PMIX_EXPORT const char* PMIx_Get_attribute_name(const char *attrstring);
 PMIX_EXPORT const char* PMIx_Link_state_string(pmix_link_state_t state);
 PMIX_EXPORT const char* PMIx_Device_type_string(pmix_device_type_t type);
 PMIX_EXPORT const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp);
 
 /* the following print statements return ALLOCATED strings
  * that the user must release when done */
-PMIX_EXPORT char* PMIx_Info_string(pmix_info_t *info);
-PMIX_EXPORT char* PMIx_Value_string(pmix_value_t *value);
+PMIX_EXPORT char* PMIx_Info_string(const pmix_info_t *info);
+PMIX_EXPORT char* PMIx_Value_string(const pmix_value_t *value);
 PMIX_EXPORT char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 
 /* Get the PMIx version string. Note that the provided string is

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -847,7 +847,7 @@ release:
 }
 
 /*****   LOCATE A GIVEN ATTRIBUTE    *****/
-PMIX_EXPORT const char *pmix_attributes_lookup(char *attr)
+PMIX_EXPORT const char *pmix_attributes_lookup(const char *attr)
 {
     size_t n;
 
@@ -859,7 +859,7 @@ PMIX_EXPORT const char *pmix_attributes_lookup(char *attr)
     return NULL;
 }
 
-PMIX_EXPORT const char *pmix_attributes_reverse_lookup(char *attrstring)
+PMIX_EXPORT const char *pmix_attributes_reverse_lookup(const char *attrstring)
 {
     size_t n;
 

--- a/src/common/pmix_attributes.h
+++ b/src/common/pmix_attributes.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +67,8 @@ PMIX_EXPORT void pmix_attributes_print_attrs(char ***ans, char *function, pmix_r
 PMIX_EXPORT void pmix_attributes_print_headers(char ***ans, char *level);
 
 PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata);
-PMIX_EXPORT const char *pmix_attributes_lookup(char *name);
-PMIX_EXPORT const char *pmix_attributes_reverse_lookup(char *name);
+PMIX_EXPORT const char *pmix_attributes_lookup(const char *name);
+PMIX_EXPORT const char *pmix_attributes_reverse_lookup(const char *name);
 PMIX_EXPORT const pmix_regattr_input_t *pmix_attributes_lookup_term(char *attr);
 
 END_C_DECLS

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -329,12 +329,12 @@ PMIX_EXPORT const char *PMIx_Job_state_string(pmix_job_state_t state)
     }
 }
 
-PMIX_EXPORT const char *PMIx_Get_attribute_string(char *attribute)
+PMIX_EXPORT const char *PMIx_Get_attribute_string(const char *attribute)
 {
     return pmix_attributes_lookup(attribute);
 }
 
-PMIX_EXPORT const char *PMIx_Get_attribute_name(char *attrstring)
+PMIX_EXPORT const char *PMIx_Get_attribute_name(const char *attrstring)
 {
     return pmix_attributes_reverse_lookup(attrstring);
 }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -39,7 +39,7 @@
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_printf.h"
 
-char* PMIx_Info_string(pmix_info_t *info)
+char* PMIx_Info_string(const pmix_info_t *info)
 {
     pmix_status_t rc;
     char *output = NULL;
@@ -53,7 +53,7 @@ char* PMIx_Info_string(pmix_info_t *info)
     return output;
 }
 
-char* PMIx_Value_string(pmix_value_t *value)
+char* PMIx_Value_string(const pmix_value_t *value)
 {
     pmix_status_t rc;
     char *output = NULL;


### PR DESCRIPTION
We frequently pass "const" values to functions, and this
generates warnings when passing those values to print
them. No need for that, nor for having to cast the "const"
away - the print functions never alter the provided value.

Signed-off-by: Ralph Castain <rhc@pmix.org>