### PR TITLE
Stop multiple invocations of debugger-release

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -432,7 +432,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_TEXT_MESSAGE             "pmix.evtext"           // (char*) text message suitable for output by recipient - e.g., describing
                                                                     //         the cause of the event
 #define PMIX_EVENT_TIMESTAMP                "pmix.evtstamp"         // (time_t) System time when the associated event occurred.
-
+#define PMIX_EVENT_ONESHOT                  "pmix.evone"            // (bool) when registering, indicate that this event handler is to be deleted
+                                                                    //        after being invoked
 
 /* fault tolerance-related events */
 #define PMIX_EVENT_TERMINATE_SESSION        "pmix.evterm.sess"      // (bool) RM intends to terminate session

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -559,7 +559,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
     pmix_cmd_t cmd = PMIX_REQ_CMD;
     pmix_status_t code;
     pmix_proc_t wildcard;
-    pmix_info_t ginfo, evinfo[2];
+    pmix_info_t ginfo, evinfo[3];
     pmix_value_t *val = NULL;
     pmix_lock_t reglock, releaselock;
     size_t n;
@@ -884,11 +884,12 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
             PMIX_CONSTRUCT_LOCK(&releaselock);
             PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
             PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-DEBUGGER", PMIX_STRING);
+            PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_ONESHOT, NULL, PMIX_BOOL);
             pmix_output_verbose(2, pmix_client_globals.event_output,
                                 "[%s:%d] REGISTERING WAIT FOR DEBUGGER", pmix_globals.myid.nspace,
                                 pmix_globals.myid.rank);
             code = PMIX_DEBUGGER_RELEASE;
-            PMIx_Register_event_handler(&code, 1, evinfo, 2, notification_fn, evhandler_reg_callbk,
+            PMIx_Register_event_handler(&code, 1, evinfo, 3, notification_fn, evhandler_reg_callbk,
                                         (void *) &reglock);
             /* wait for registration to complete */
             PMIX_WAIT_THREAD(&reglock);

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -29,6 +29,7 @@
 
 #include "pmix_common.h"
 #include "src/class/pmix_list.h"
+#include "src/mca/bfrops/bfrops_types.h"
 #include "src/util/pmix_output.h"
 
 BEGIN_C_DECLS
@@ -70,6 +71,7 @@ typedef struct {
     char *name;
     size_t index;
     uint8_t precedence;
+    bool oneshot;
     char *locator;
     pmix_proc_t source; // who generated this event
     /* When registering for events, callers can specify
@@ -205,6 +207,9 @@ PMIX_EXPORT bool pmix_notify_check_range(pmix_range_trkr_t *rng, const pmix_proc
 
 PMIX_EXPORT bool pmix_notify_check_affected(pmix_proc_t *interested, size_t ninterested,
                                             pmix_proc_t *affected, size_t naffected);
+
+PMIX_EXPORT pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
+                                                     pmix_buffer_t *msg);
 
 /* invoke the server event notification handler */
 PMIX_EXPORT pmix_status_t pmix_server_notify_client_of_event(pmix_status_t status,

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -467,6 +467,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     char *name = NULL, *locator = NULL;
     bool firstoverall = false, lastoverall = false;
     bool found;
+    bool oneshot = false;
     pmix_list_t xfer;
     pmix_info_caddy_t *ixfer;
     void *cbobject = NULL;
@@ -488,49 +489,45 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     /* if directives were included */
     if (NULL != cd->info) {
         for (n = 0; n < cd->ninfo; n++) {
-            if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_FIRST, PMIX_MAX_KEYLEN)) {
+            if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_FIRST)) {
                 /* flag if they asked to put this one first overall */
                 firstoverall = PMIX_INFO_TRUE(&cd->info[n]);
                 location = PMIX_EVENT_ORDER_FIRST_OVERALL;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_LAST, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_LAST)) {
                 /* flag if they asked to put this one last overall */
                 lastoverall = PMIX_INFO_TRUE(&cd->info[n]);
                 location = PMIX_EVENT_ORDER_LAST_OVERALL;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_PREPEND, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_PREPEND)) {
                 /* flag if they asked to prepend this handler */
                 if (PMIX_INFO_TRUE(&cd->info[n])) {
                     location = PMIX_EVENT_ORDER_PREPEND;
                 }
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_APPEND, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_APPEND)) {
                 /* flag if they asked to append this handler */
                 if (PMIX_INFO_TRUE(&cd->info[n])) {
                     location = PMIX_EVENT_ORDER_APPEND;
                 }
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_NAME)) {
                 name = cd->info[n].value.data.string;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_RETURN_OBJECT)) {
                 cbobject = cd->info[n].value.data.ptr;
-            } else if (0
-                       == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_FIRST_IN_CATEGORY,
-                                  PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_FIRST_IN_CATEGORY)) {
                 if (PMIX_INFO_TRUE(&cd->info[n])) {
                     location = PMIX_EVENT_ORDER_FIRST;
                 }
-            } else if (0
-                       == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_LAST_IN_CATEGORY,
-                                  PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_LAST_IN_CATEGORY)) {
                 if (PMIX_INFO_TRUE(&cd->info[n])) {
                     location = PMIX_EVENT_ORDER_LAST;
                 }
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_BEFORE, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_BEFORE)) {
                 location = PMIX_EVENT_ORDER_BEFORE;
                 locator = cd->info[n].value.data.string;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_AFTER, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_HDLR_AFTER)) {
                 location = PMIX_EVENT_ORDER_AFTER;
                 locator = cd->info[n].value.data.string;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_RANGE, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_RANGE)) {
                 range = cd->info[n].value.data.range;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_CUSTOM_RANGE)) {
                 /* provides an array of pmix_proc_t identifying the procs
                  * that are to receive this notification, or a single pmix_proc_t  */
                 if (PMIX_DATA_ARRAY == cd->info[n].value.type
@@ -547,20 +544,22 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                     rc = PMIX_ERR_BAD_PARAM;
                     goto ack;
                 }
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_AFFECTED_PROC)) {
                 cd->affected = cd->info[n].value.data.proc;
                 cd->naffected = 1;
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
                 ixfer->ninfo = 1;
                 pmix_list_append(&xfer, &ixfer->super);
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_AFFECTED_PROCS)) {
                 cd->affected = (pmix_proc_t *) cd->info[n].value.data.darray->array;
                 cd->naffected = cd->info[n].value.data.darray->size;
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
                 ixfer->ninfo = 1;
                 pmix_list_append(&xfer, &ixfer->super);
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_ONESHOT)) {
+                oneshot = PMIX_INFO_TRUE(&cd->info[n]);
             } else {
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
@@ -582,8 +581,8 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
      * first check to ensure they didn't already direct some
      * other event into the same cherished position */
     if (firstoverall || lastoverall) {
-        if ((firstoverall && NULL != pmix_globals.events.first)
-            || (lastoverall && NULL != pmix_globals.events.last)) {
+        if ((firstoverall && NULL != pmix_globals.events.first) ||
+            (lastoverall && NULL != pmix_globals.events.last)) {
             /* oops - someone already took that position */
             index = UINT_MAX;
             rc = PMIX_ERR_EVENT_REGISTRATION;
@@ -598,6 +597,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
         if (NULL != name) {
             evhdlr->name = strdup(name);
         }
+        evhdlr->oneshot = oneshot;
         evhdlr->precedence = location;
         index = pmix_globals.events.nhdlrs;
         evhdlr->index = index;
@@ -664,6 +664,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     index = pmix_globals.events.nhdlrs;
     evhdlr->index = index;
     ++pmix_globals.events.nhdlrs;
+    evhdlr->oneshot = oneshot;
     evhdlr->precedence = location;
     if (NULL != locator) {
         evhdlr->locator = strdup(locator);
@@ -953,16 +954,158 @@ PMIX_EXPORT pmix_status_t PMIx_Register_event_handler(pmix_status_t codes[], siz
     return rc;
 }
 
+pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
+                                         pmix_buffer_t *msg)
+{
+    pmix_status_t rc;
+    pmix_event_hdlr_t *evhdlr, *ev;
+    size_t n;
+    pmix_active_code_t *active;
+    pmix_status_t wildcard = PMIX_MAX_ERR_CONSTANT;
+
+    /* check the first and last locations */
+    if ((NULL != pmix_globals.events.first && pmix_globals.events.first->index == event_hdlr_ref) ||
+        (NULL != pmix_globals.events.last && pmix_globals.events.last->index == event_hdlr_ref)) {
+        /* found it */
+        if (NULL != pmix_globals.events.first &&
+            pmix_globals.events.first->index == event_hdlr_ref) {
+            ev = pmix_globals.events.first;
+        } else {
+            ev = pmix_globals.events.last;
+        }
+        /* if this is a default handler, see if any other default
+         * handlers remain */
+        if (NULL == ev->codes) {
+            if (NULL != msg) {
+                if (0 == pmix_list_get_size(&pmix_globals.events.default_events)) {
+                    /* tell the server to dereg our default handler */
+                    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
+                                     &wildcard, 1, PMIX_STATUS);
+                    if (PMIX_SUCCESS != rc) {
+                        return rc;
+                    }
+                }
+            }
+        } else {
+            for (n = 0; n < ev->ncodes; n++) {
+                /* see if this is the last registration we have for this code */
+                PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
+                    if (active->code == ev->codes[n]) {
+                        --active->nregs;
+                        if (0 == active->nregs) {
+                            pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
+                            if (NULL != msg) {
+                                /* tell the server to dereg this code */
+                                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
+                                                 &active->code, 1, PMIX_STATUS);
+                                if (PMIX_SUCCESS != rc) {
+                                    PMIX_RELEASE(active);
+                                    return rc;
+                                }
+                            }
+                            PMIX_RELEASE(active);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        if (ev == pmix_globals.events.first) {
+            pmix_globals.events.first = NULL;
+        } else {
+            pmix_globals.events.last = NULL;
+        }
+        PMIX_RELEASE(ev);
+        return PMIX_SUCCESS;
+    }
+
+    /* the registration can be in any of three places, so check each of them */
+    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.default_events, pmix_event_hdlr_t) {
+        if (evhdlr->index == event_hdlr_ref) {
+            /* found it */
+            pmix_list_remove_item(&pmix_globals.events.default_events, &evhdlr->super);
+            if (NULL != msg) {
+                /* if there are no more default handlers registered, tell
+                 * the server to dereg the default handler */
+                if (0 == pmix_list_get_size(&pmix_globals.events.default_events)) {
+                    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &wildcard, 1,
+                                     PMIX_STATUS);
+                    if (PMIX_SUCCESS != rc) {
+                        return rc;
+                    }
+                }
+            }
+            PMIX_RELEASE(evhdlr);
+            return PMIX_SUCCESS;
+        }
+    }
+    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.single_events, pmix_event_hdlr_t) {
+        if (evhdlr->index == event_hdlr_ref) {
+            /* found it */
+            pmix_list_remove_item(&pmix_globals.events.single_events, &evhdlr->super);
+            /* see if this is the last registration we have for this code */
+            PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
+                if (active->code == evhdlr->codes[0]) {
+                    --active->nregs;
+                    if (0 == active->nregs) {
+                        pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
+                        if (NULL != msg) {
+                            /* tell the server to dereg this code */
+                            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
+                                             &active->code, 1, PMIX_STATUS);
+                            if (PMIX_SUCCESS != rc) {
+                                PMIX_RELEASE(active);
+                                return rc;
+                            }
+                        }
+                        PMIX_RELEASE(active);
+                    }
+                    break;
+                }
+            }
+            PMIX_RELEASE(evhdlr);
+            return PMIX_SUCCESS;
+        }
+    }
+    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.multi_events, pmix_event_hdlr_t) {
+        if (evhdlr->index == event_hdlr_ref) {
+            /* found it */
+            pmix_list_remove_item(&pmix_globals.events.multi_events, &evhdlr->super);
+            for (n = 0; n < evhdlr->ncodes; n++) {
+                /* see if this is the last registration we have for this code */
+                PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
+                    if (active->code == evhdlr->codes[n]) {
+                        --active->nregs;
+                        if (0 == active->nregs) {
+                            pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
+                            if (NULL != msg) {
+                                /* tell the server to dereg this code */
+                                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
+                                                 &active->code, 1, PMIX_STATUS);
+                                if (PMIX_SUCCESS != rc) {
+                                    PMIX_RELEASE(active);
+                                    return rc;
+                                }
+                            }
+                            PMIX_RELEASE(active);
+                        }
+                        break;
+                    }
+                }
+            }
+            PMIX_RELEASE(evhdlr);
+            return PMIX_SUCCESS;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
 static void dereg_event_hdlr(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
     pmix_buffer_t *msg = NULL;
-    pmix_event_hdlr_t *evhdlr, *ev;
     pmix_cmd_t cmd = PMIX_DEREGEVENTS_CMD;
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_status_t wildcard = PMIX_MAX_ERR_CONSTANT;
-    size_t n;
-    pmix_active_code_t *active;
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
@@ -980,157 +1123,14 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
             goto cleanup;
         }
     }
+    pmix_deregister_event_hdlr(cd->ref, msg);
 
-    /* check the first and last locations */
-    if ((NULL != pmix_globals.events.first && pmix_globals.events.first->index == cd->ref)
-        || (NULL != pmix_globals.events.last && pmix_globals.events.last->index == cd->ref)) {
-        /* found it */
-        if (NULL != pmix_globals.events.first && pmix_globals.events.first->index == cd->ref) {
-            ev = pmix_globals.events.first;
-        } else {
-            ev = pmix_globals.events.last;
-        }
-        if (NULL != msg) {
-            /* if this is a default handler, see if any other default
-             * handlers remain */
-            if (NULL == ev->codes) {
-                if (0 == pmix_list_get_size(&pmix_globals.events.default_events)) {
-                    /* tell the server to dereg our default handler */
-                    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &wildcard, 1,
-                                     PMIX_STATUS);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_RELEASE(msg);
-                        goto cleanup;
-                    }
-                }
-            } else {
-                for (n = 0; n < ev->ncodes; n++) {
-                    /* see if this is the last registration we have for this code */
-                    PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-                        if (active->code == ev->codes[n]) {
-                            --active->nregs;
-                            if (0 == active->nregs) {
-                                pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
-                                /* tell the server to dereg this code */
-                                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
-                                                 &active->code, 1, PMIX_STATUS);
-                                if (PMIX_SUCCESS != rc) {
-                                    PMIX_RELEASE(active);
-                                    PMIX_RELEASE(msg);
-                                    goto cleanup;
-                                }
-                                PMIX_RELEASE(active);
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        if (ev == pmix_globals.events.first) {
-            pmix_globals.events.first = NULL;
-        } else {
-            pmix_globals.events.last = NULL;
-        }
-        PMIX_RELEASE(ev);
-        goto cleanup;
-    }
-
-    /* the registration can be in any of three places, so check each of them */
-    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.default_events, pmix_event_hdlr_t) {
-        if (evhdlr->index == cd->ref) {
-            /* found it */
-            pmix_list_remove_item(&pmix_globals.events.default_events, &evhdlr->super);
-            if (NULL != msg) {
-                /* if there are no more default handlers registered, tell
-                 * the server to dereg the default handler */
-                if (0 == pmix_list_get_size(&pmix_globals.events.default_events)) {
-                    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &wildcard, 1,
-                                     PMIX_STATUS);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_RELEASE(msg);
-                        goto cleanup;
-                    }
-                }
-            }
-            PMIX_RELEASE(evhdlr);
-            goto report;
-        }
-    }
-    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.single_events, pmix_event_hdlr_t) {
-        if (evhdlr->index == cd->ref) {
-            /* found it */
-            pmix_list_remove_item(&pmix_globals.events.single_events, &evhdlr->super);
-            if (NULL != msg) {
-                /* see if this is the last registration we have for this code */
-                PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-                    if (active->code == evhdlr->codes[0]) {
-                        --active->nregs;
-                        if (0 == active->nregs) {
-                            pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
-                            if (NULL != msg) {
-                                /* tell the server to dereg this code */
-                                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
-                                                 &active->code, 1, PMIX_STATUS);
-                                if (PMIX_SUCCESS != rc) {
-                                    PMIX_RELEASE(active);
-                                    PMIX_RELEASE(msg);
-                                    goto cleanup;
-                                }
-                            }
-                            PMIX_RELEASE(active);
-                        }
-                        break;
-                    }
-                }
-            }
-            PMIX_RELEASE(evhdlr);
-            goto report;
-        }
-    }
-    PMIX_LIST_FOREACH (evhdlr, &pmix_globals.events.multi_events, pmix_event_hdlr_t) {
-        if (evhdlr->index == cd->ref) {
-            /* found it */
-            pmix_list_remove_item(&pmix_globals.events.multi_events, &evhdlr->super);
-            for (n = 0; n < evhdlr->ncodes; n++) {
-                /* see if this is the last registration we have for this code */
-                PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-                    if (active->code == evhdlr->codes[n]) {
-                        --active->nregs;
-                        if (0 == active->nregs) {
-                            pmix_list_remove_item(&pmix_globals.events.actives, &active->super);
-                            if (NULL != msg) {
-                                /* tell the server to dereg this code */
-                                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg,
-                                                 &active->code, 1, PMIX_STATUS);
-                                if (PMIX_SUCCESS != rc) {
-                                    PMIX_RELEASE(active);
-                                    PMIX_RELEASE(msg);
-                                    goto cleanup;
-                                }
-                            }
-                            PMIX_RELEASE(active);
-                        }
-                        break;
-                    }
-                }
-            }
-            PMIX_RELEASE(evhdlr);
-            goto report;
-        }
-    }
-    /* if we get here, then the registration could not be found */
-    if (NULL != msg) {
-        PMIX_RELEASE(msg);
-    }
-    goto cleanup;
-
-report:
     if (NULL != msg) {
         /* send to the server */
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, NULL, NULL);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
         }
     }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -522,7 +522,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     size_t n;
     bool nspace_given = false, rank_given = false;
     bool share_topo = false;
-    pmix_info_t ginfo, *iptr, evinfo[2];
+    pmix_info_t ginfo, *iptr, evinfo[3];
     char *evar, *nspace = NULL;
     pmix_rank_t rank = PMIX_RANK_INVALID;
     pmix_rank_info_t *rinfo;
@@ -908,11 +908,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
         PMIX_CONSTRUCT_LOCK(&releaselock);
         PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
         PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-RELEASE", PMIX_STRING);
+        PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_ONESHOT, NULL, PMIX_BOOL);
         pmix_output_verbose(2, pmix_client_globals.event_output,
                             "[%s:%d] WAITING IN INIT FOR RELEASE", pmix_globals.myid.nspace,
                             pmix_globals.myid.rank);
         code = PMIX_DEBUGGER_RELEASE;
-        PMIx_Register_event_handler(&code, 1, evinfo, 2, notification_fn, evhandler_reg_callbk,
+        PMIx_Register_event_handler(&code, 1, evinfo, 3, notification_fn, evhandler_reg_callbk,
                                     (void *) &reglock);
         /* wait for registration to complete */
         PMIX_WAIT_THREAD(&reglock);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -423,7 +423,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     bool rank_given = false;
     bool fwd_stdin = false;
     bool connect_optional = false;
-    pmix_info_t ginfo, *iptr, evinfo[2];
+    pmix_info_t ginfo, *iptr, evinfo[3];
     size_t n;
     pmix_ptl_posted_recv_t *rcv;
     pmix_proc_t wildcard, myserver;
@@ -1032,11 +1032,12 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         PMIX_CONSTRUCT_LOCK(&releaselock);
         PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
         PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-RELEASE", PMIX_STRING);
+        PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_ONESHOT, NULL, PMIX_BOOL);
         pmix_output_verbose(2, pmix_client_globals.event_output,
                             "[%s:%d] WAITING IN INIT FOR RELEASE", pmix_globals.myid.nspace,
                             pmix_globals.myid.rank);
         code = PMIX_DEBUGGER_RELEASE;
-        PMIx_Register_event_handler(&code, 1, evinfo, 2, notification_fn, evhandler_reg_callbk,
+        PMIx_Register_event_handler(&code, 1, evinfo, 3, notification_fn, evhandler_reg_callbk,
                                     (void *) &reglock);
         /* wait for registration to complete */
         PMIX_WAIT_THREAD(&reglock);


### PR DESCRIPTION
It is possible for a tool to receive two copies
of a "debugger-release" event - one directly from
the source and another from the server to which it
is connected. This can create a race condition that
thread-locks the tool.

Add a new PMIX_EVENT_ONESHOT attribute by which a
process can request that an event handler be atomically
deregistered once handling of that event is complete.
Thus, even if a second event is received, the event
notification system will ignore it unless the process
re-registers a handler for it.

Signed-off-by: Ralph Castain <rhc@pmix.org>