### PR TITLE
Forward stdin to apps directly fork/exec'd by PMIx

### DIFF
--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -261,6 +261,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     /* if we are a server, then process this ourselves */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+
+        if (NULL == pmix_host_server.spawn) {
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+
         cd = PMIX_NEW(pmix_setup_caddy_t);
         if (NULL == cd) {
             return PMIX_ERR_NOMEM;

--- a/src/mca/pfexec/base/base.h
+++ b/src/mca/pfexec/base/base.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,7 @@ typedef struct {
     int exitcode;
     int keepalive[2];
     pmix_pfexec_base_io_conf_t opts;
+    pmix_iof_sink_t stdinsink;
     pmix_iof_read_event_t *stdoutev;
     pmix_iof_read_event_t *stderrev;
 } pmix_pfexec_child_t;

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -145,7 +145,8 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
     bool nohup = false;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output, "%s pfexec:base spawn proc",
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output,
+                        "%s pfexec:base spawn proc",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
     /* establish our baseline working directory - we will be potentially
@@ -465,18 +466,21 @@ static pmix_status_t setup_prefork(pmix_pfexec_child_t *child)
             return PMIX_ERR_SYS_OTHER;
         }
     }
-    if (opts->connect_stdin) {
-        if (pipe(opts->p_stdin) < 0) {
-            PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
-            return PMIX_ERR_SYS_OTHER;
-        }
+    /* always leave stdin available in case we forward to it */
+    if (pipe(opts->p_stdin) < 0) {
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+        return PMIX_ERR_SYS_OTHER;
     }
+
     if (pipe(opts->p_stderr) < 0) {
         PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
         return PMIX_ERR_SYS_OTHER;
     }
 
-    /* connect read ends to IOF */
+    /* connect read/write ends to IOF */
+    PMIX_IOF_SINK_DEFINE(&child->stdinsink, &child->proc, opts->p_stdin[1],
+                         PMIX_FWD_STDIN_CHANNEL, pmix_iof_write_handler);
+
     PMIX_IOF_READ_EVENT_LOCAL(&child->stdoutev, opts->p_stdout[0],
                               pmix_iof_read_local_handler, false);
     PMIX_LOAD_PROCID(&child->stdoutev->name, child->proc.nspace, child->proc.rank);
@@ -496,7 +500,7 @@ pmix_status_t pmix_pfexec_base_setup_child(pmix_pfexec_child_t *child)
     int ret;
     pmix_pfexec_base_io_conf_t *opts = &child->opts;
 
-    if (opts->connect_stdin && 0 <= opts->p_stdin[1]) {
+    if (0 <= opts->p_stdin[1]) {
         close(opts->p_stdin[1]);
         opts->p_stdin[1] = -1;
     }
@@ -541,33 +545,15 @@ pmix_status_t pmix_pfexec_base_setup_child(pmix_pfexec_child_t *child)
             }
         }
     }
-    if (opts->connect_stdin) {
-        if (opts->p_stdin[0] != fileno(stdin)) {
-            ret = dup2(opts->p_stdin[0], fileno(stdin));
-            if (ret < 0) {
-                return PMIX_ERR_SYS_OTHER;
-            }
-            if (0 <= opts->p_stdin[0]) {
-                close(opts->p_stdin[0]);
-                opts->p_stdin[0] = -1;
-            }
+    if (opts->p_stdin[0] != fileno(stdin)) {
+        ret = dup2(opts->p_stdin[0], fileno(stdin));
+        if (ret < 0) {
+            return PMIX_ERR_SYS_OTHER;
         }
-    } else {
-        int fd;
-
-        /* connect input to /dev/null */
-        fd = open("/dev/null", O_RDONLY, 0);
-        if (0 > fd) {
-            return PMIX_ERROR;
+        if (0 <= opts->p_stdin[0]) {
+            close(opts->p_stdin[0]);
+            opts->p_stdin[0] = -1;
         }
-        if (fd != fileno(stdin)) {
-            ret = dup2(fd, fileno(stdin));
-            if (ret < 0) {
-                close(fd);
-                return PMIX_ERR_SYS_OTHER;
-            }
-        }
-        close(fd);
     }
 
     if (opts->p_stderr[1] != fileno(stderr)) {

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -245,11 +245,13 @@ static void chcon(pmix_pfexec_child_t *p)
     p->opts.p_stdout[1] = -1;
     p->opts.p_stderr[0] = -1;
     p->opts.p_stderr[1] = -1;
+    PMIX_CONSTRUCT(&p->stdinsink, pmix_iof_sink_t);
     p->stdoutev = NULL;
     p->stderrev = NULL;
 }
 static void chdes(pmix_pfexec_child_t *p)
 {
+    PMIX_DESTRUCT(&p->stdinsink);
     if (NULL != p->stdoutev) {
         PMIX_RELEASE(p->stdoutev);
     }
@@ -263,7 +265,9 @@ static void chdes(pmix_pfexec_child_t *p)
         close(p->keepalive[1]);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_pfexec_child_t, pmix_list_item_t, chcon, chdes);
+PMIX_CLASS_INSTANCE(pmix_pfexec_child_t,
+                    pmix_list_item_t,
+                    chcon, chdes);
 
 static void fccon(pmix_pfexec_fork_caddy_t *p)
 {
@@ -275,8 +279,11 @@ static void fccon(pmix_pfexec_fork_caddy_t *p)
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }
-PMIX_CLASS_INSTANCE(pmix_pfexec_fork_caddy_t, pmix_object_t, fccon, NULL);
+PMIX_CLASS_INSTANCE(pmix_pfexec_fork_caddy_t,
+                    pmix_object_t, fccon, NULL);
 
-PMIX_CLASS_INSTANCE(pmix_pfexec_signal_caddy_t, pmix_object_t, NULL, NULL);
+PMIX_CLASS_INSTANCE(pmix_pfexec_signal_caddy_t,
+                    pmix_object_t, NULL, NULL);
 
-PMIX_CLASS_INSTANCE(pmix_pfexec_cmpl_caddy_t, pmix_object_t, NULL, NULL);
+PMIX_CLASS_INSTANCE(pmix_pfexec_cmpl_caddy_t,
+                    pmix_object_t, NULL, NULL);


### PR DESCRIPTION
We allow tools to directly fork/exec intermediate
launchers via the PMIx library, so we need to support
forwarding of any stdin for those tools to the spawned
children.

Signed-off-by: Ralph Castain <rhc@pmix.org>