### PR TITLE
Fix retrieval of node/app/session-realm info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ examples/showkeys
 examples/abi_no_init
 examples/abi_with_init
 examples/group_lcl_cid
+examples/nodeinfo
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -24,7 +24,7 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init group_lcl_cid
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello nodeinfo  abi_no_init abi_with_init group_lcl_cid
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -109,6 +109,10 @@ abi_with_init_LDADD =  $(top_builddir)/src/libpmix.la
 group_lcl_cid_SOURCES = group_lcl_cid.c examples.h
 group_lcl_cid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_lcl_cid_LDADD =  $(top_builddir)/src/libpmix.la
+
+nodeinfo_SOURCES = nodeinfo.c examples.h
+nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/examples/nodeinfo.c
+++ b/examples/nodeinfo.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    char *nodelist, **nodes, *hostname;
+    pmix_info_t info[2];
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* get the list of nodes being used */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get node list failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nodelist = strdup(val->data.string);
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: Host list %s\n",
+                myproc.nspace, myproc.rank, val->data.string);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_ARGV_SPLIT(nodes, nodelist, ',');
+    free(nodelist);
+    if (NULL == nodes) {
+        goto done;
+    }
+    /* get some node-specific info */
+    if (1 < nprocs) {
+        proc.rank = myproc.rank + 1;
+        if (nprocs == proc.rank) {
+            proc.rank = 0;
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_HOSTNAME, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Rank %u is on host %s\n",
+                myproc.nspace, myproc.rank, proc.rank, val->data.string);
+        hostname = strdup(val->data.string);
+        PMIX_VALUE_RELEASE(val);
+
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates for rank %u failed: %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: Rank %u has coordinates\n    %s\n",
+                    myproc.nspace, myproc.rank, proc.rank, PMIx_Value_string(val));
+            PMIX_VALUE_RELEASE(val);
+        }
+
+        // try with directive
+        proc.rank = PMIX_RANK_WILDCARD;
+        PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, hostname, PMIX_STRING);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates with directive for host %s failed: %s\n",
+                    myproc.nspace, myproc.rank, hostname, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client ns %s rank %d: Host %s has coordinates\n    %s\n",
+                myproc.nspace, myproc.rank, hostname, PMIx_Value_string(val));
+        PMIX_VALUE_RELEASE(val);
+    }
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -78,6 +78,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
                                      const pmix_info_t info[], size_t ninfo,
                                      pmix_get_logic_t *lg, pmix_value_t **val)
 {
+    pmix_status_t rc;
     pmix_value_t *ival;
     size_t n;
 
@@ -106,17 +107,26 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* see if they want a static response (i.e., they provided the storage),
-     * a pointer to the answer, or an allocated storage object */
+    if (NULL != key) {
+        /* see if they are asking about a specific type of info */
+        if (pmix_check_node_info(key)) {
+            lg->nodeinfo = true;
+        } else if (pmix_check_app_info(key)) {
+            lg->appinfo = true;
+        } else if (pmix_check_session_info(key)) {
+            lg->sessioninfo = true;
+        }
+    }
+
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_GET_POINTER_VALUES)) {
-            /* they want the pointer */
+            /* they want a pointer to the answer */
             if (NULL == val) {
                 return PMIX_ERR_BAD_PARAM;
             }
             lg->pntrval = PMIX_INFO_TRUE(&info[n]);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GET_STATIC_VALUES)) {
-            /* they provided the storage */
+            /* they want a static response (i.e., they provided the storage) */
             if (NULL == val || NULL == *val) {
                 return PMIX_ERR_BAD_PARAM;
             }
@@ -130,6 +140,55 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GET_REFRESH_CACHE)) {
             /* immediately query the server */
             lg->refresh_cache = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_JOB_INFO)) {
+            /* regardless of the default setting, they want us
+             * to get it from the job realm */
+            lg->nodeinfo = false;
+            lg->appinfo = false;
+            lg->sessioninfo = false;
+            /* have to let the loop continue in case there are
+             * other relevant directives - e.g., refresh_cache */
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_INFO)) {
+            /* regardless of the default setting, they want us
+             * to get it from the node realm */
+            lg->nodedirective = true;
+            lg->nodeinfo = true;
+            lg->appinfo = false;
+            lg->sessioninfo = false;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_APP_INFO)) {
+            /* regardless of the default setting, they want us
+             * to get it from the app realm */
+            lg->appdirective = true;
+            lg->appinfo = true;
+            lg->nodeinfo = false;
+            lg->sessioninfo = false;
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
+            /* regardless of the default setting, they want us
+             * to get it from the session realm */
+            lg->sessiondirective = true;
+            lg->sessioninfo = true;
+            lg->nodeinfo = false;
+            lg->appinfo = false;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+            lg->hostname = info[n].value.data.string;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->nodeid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->appnum, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->sessionid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
         }
     }
 
@@ -173,8 +232,9 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
 
     /* if they passed our nspace and an INVALID rank, and are asking
      * for PMIX_RANK, then they are asking for our process rank */
-    if (PMIX_RANK_INVALID == lg->p.rank && PMIX_CHECK_NSPACE(lg->p.nspace, pmix_globals.myid.nspace)
-        && NULL != key && 0 == strncmp(key, PMIX_RANK, PMIX_MAX_KEYLEN)) {
+    if (PMIX_RANK_INVALID == lg->p.rank &&
+        PMIX_CHECK_NSPACE(lg->p.nspace, pmix_globals.myid.nspace) &&
+        NULL != key && 0 == strncmp(key, PMIX_RANK, PMIX_MAX_KEYLEN)) {
         if (lg->stval) {
             ival = *val;
             ival->type = PMIX_PROC_RANK;
@@ -624,17 +684,22 @@ static pmix_status_t process_values(pmix_cb_t *cb)
 
 static void get_data(int sd, short args, void *cbdata)
 {
-    pmix_cb_t *cb;
+    pmix_cb_t *cb, cb2;
     pmix_cb_t *cbret;
     pmix_buffer_t *msg;
     pmix_status_t rc;
     pmix_proc_t proc;
     pmix_get_logic_t *lg;
+    pmix_info_t optional, *iptr;
+    size_t nfo, n;
+    pmix_kval_t *kv;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cb);
     cb = (pmix_cb_t*)cbdata;
     lg = cb->lg;
+    iptr = cb->info;
+    nfo = cb->ninfo;
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix:client:get_data value for proc %s key %s",
@@ -643,7 +708,272 @@ static void get_data(int sd, short args, void *cbdata)
     /* check the data provided to us by the server first */
     cb->proc = &lg->p;
     cb->scope = lg->scope;
+    PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
 
+    if (lg->nodeinfo) {
+        pmix_output_verbose(2, pmix_client_globals.get_output,
+                            "pmix:client:get_data value requesting node-level info for proc %s key %s",
+                            PMIX_NAME_PRINT(&lg->p), (NULL == cb->key) ? "NULL" : cb->key);
+        if (NULL == lg->hostname && UINT32_MAX == lg->nodeid) {
+            /* if they didn't specify the target node, then see if they
+             * specified a proc */
+            if (PMIX_RANK_IS_VALID(cb->proc->rank)) {
+                /* if this is us, then we know our info */
+                if (PMIX_CHECK_PROCID(cb->proc, &pmix_globals.myid)) {
+                    lg->hostname = strdup(pmix_globals.hostname);
+                    lg->nodeid = pmix_globals.nodeid;
+                } else {
+                    PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+                    cb2.proc = cb->proc;
+                    cb2.key = PMIX_HOSTNAME;
+                    cb2.info = &optional;
+                    cb2.ninfo = 1;
+                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+                        kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                        PMIX_DESTRUCT(&cb2);
+                        lg->hostname = strdup(kv->value->data.string);
+                        PMIX_RELEASE(kv);
+                    } else {
+                        /* try for the nodeid */
+                        cb2.key = PMIX_NODEID;
+                        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                        if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+                            kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                            PMIX_DESTRUCT(&cb2);
+                            PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
+                            PMIX_RELEASE(kv);
+                            if (PMIX_SUCCESS != rc) {
+                                cb->status = rc;
+                                goto done;
+                            }
+                        } else {
+                            /* could not find hostname or nodeid, so we cannot do anything */
+                            cb->status = PMIX_ERR_NOT_FOUND;
+                            goto done;
+                        }
+                    }
+                }
+            } else {
+                /* it's an invalid rank - if it is our nspace, then we assume they are
+                 * asking about us */
+                if (PMIX_CHECK_NSPACE(cb->proc->nspace, pmix_globals.myid.nspace)) {
+                    lg->hostname = strdup(pmix_globals.hostname);
+                    lg->nodeid = pmix_globals.nodeid;
+                } else {
+                    /* an invalid rank and not our nspace, with nothing else specified,
+                     * leaves us with no way to look this up */
+                    cb->status = PMIX_ERR_NOT_FOUND;
+                    goto done;
+                }
+            }
+        }
+        /* if we have a hostname and that is what they were
+         * asking for, then we are done */
+        if (NULL != lg->hostname && 0 == strcmp(cb->key, PMIX_HOSTNAME)) {
+            cb->status = PMIX_SUCCESS;
+            PMIX_VALUE_CREATE(cb->value, 1);
+            PMIX_VALUE_LOAD(cb->value, lg->hostname, PMIX_STRING);
+            goto done;
+        }
+        /* if we have a nodeid and that is what they were
+         * asking for, then we are done */
+        if (UINT32_MAX != lg->nodeid && 0 == strcmp(cb->key, PMIX_NODEID)) {
+            cb->status = PMIX_SUCCESS;
+            PMIX_VALUE_CREATE(cb->value, 1);
+            PMIX_VALUE_LOAD(cb->value, &lg->nodeid, PMIX_UINT32);
+            goto done;
+        }
+        /* we have to look for the info, so we need to tell the GDS
+         * that this is a nodeinfo request and pass the
+         * nodename or nodeid */
+        if (lg->nodedirective) {
+            /* just need to add the hostname/nodeid */
+            nfo = cb->ninfo + 2;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            if (NULL != lg->hostname) {
+                PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_HOSTNAME, lg->hostname, PMIX_STRING);
+            } else {
+                PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_HOSTNAME, &lg->nodeid, PMIX_UINT32);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        } else {
+            /* need to add directive and hostname/nodeid */
+            nfo = cb->ninfo + 3;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_NODE_INFO, NULL, PMIX_BOOL);
+            if (NULL != lg->hostname) {
+                PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_HOSTNAME, lg->hostname, PMIX_STRING);
+            } else {
+                PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_HOSTNAME, &lg->nodeid, PMIX_UINT32);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+2], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        }
+        goto doget;
+    }
+
+    if (lg->appinfo) {
+        /* if they didn't provide an appnum, then we have to look it up */
+        if (UINT32_MAX == lg->appnum) {
+            /* if they didn't specify the target app, then see if they
+             * specified a proc */
+            if (PMIX_RANK_IS_VALID(cb->proc->rank)) {
+                /* if this is us, then we know our appnum */
+                if (PMIX_CHECK_PROCID(cb->proc, &pmix_globals.myid)) {
+                    lg->appnum = pmix_globals.appnum;
+                } else {
+                    PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+                    cb2.proc = cb->proc;
+                    cb2.key = PMIX_APPNUM;
+                    cb2.info = &optional;
+                    cb2.ninfo = 1;
+                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+                        kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                        PMIX_DESTRUCT(&cb2);
+                        PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->appnum, uint32_t);
+                        PMIX_RELEASE(kv);
+                        if (PMIX_SUCCESS != rc) {
+                            cb->status = rc;
+                            goto done;
+                        }
+                    } else {
+                        /* couldn't find this proc's appnum - nothing we can do */
+                        cb->status = PMIX_ERR_NOT_FOUND;
+                        goto done;
+                    }
+                }
+            } else {
+                /* rank is invalid - if the nspace is ours, then we assume
+                 * they want info about our app */
+                if (PMIX_CHECK_NSPACE(cb->proc->nspace, pmix_globals.myid.nspace)) {
+                    lg->appnum = pmix_globals.appnum;
+                } else {
+                    /* an invalid rank and not our nspace, with nothing else specified,
+                     * leaves us with no way to look this up */
+                    cb->status = PMIX_ERR_NOT_FOUND;
+                    goto done;
+                }
+            }
+        }
+        /* we get here with a valid appnum - if that is what they were
+         * asking for, then we are done */
+        if (0 == strcmp(cb->key, PMIX_APPNUM)) {
+            cb->status = PMIX_SUCCESS;
+            PMIX_VALUE_CREATE(cb->value, 1);
+            PMIX_VALUE_LOAD(cb->value, &lg->appnum, PMIX_UINT32);
+            goto done;
+        }
+        /* setup the request */
+        if (lg->appdirective) {
+            /* just need to add the appnum */
+            nfo = cb->ninfo + 2;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_APPNUM, &lg->appnum, PMIX_UINT32);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        } else {
+            /* need to add directive and appnum */
+            nfo = cb->ninfo + 3;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_APP_INFO, NULL, PMIX_BOOL);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_APPNUM, &lg->appnum, PMIX_UINT32);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+2], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        }
+        goto doget;
+    }
+
+    if (lg->sessioninfo) {
+        /* if they didn't provide a sessionid, then we have to look it up */
+        if (UINT32_MAX == lg->sessionid) {
+            /* if they didn't specify the target session, then see if they
+             * specified a proc */
+            if (PMIX_RANK_IS_VALID(cb->proc->rank)) {
+                /* if this is us, then we know our info */
+                if (PMIX_CHECK_PROCID(cb->proc, &pmix_globals.myid)) {
+                    lg->sessionid = pmix_globals.sessionid;
+                } else {
+                    PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+                    cb2.proc = cb->proc;
+                    cb2.key = PMIX_SESSION_ID;
+                    cb2.info = &optional;
+                    cb2.ninfo = 1;
+                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+                        kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                        PMIX_DESTRUCT(&cb2);
+                        PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->sessionid, uint32_t);
+                        PMIX_RELEASE(kv);
+                        if (PMIX_SUCCESS != rc) {
+                            cb->status = rc;
+                            goto done;
+                        }
+                    }
+                }
+            } else {
+                /* rank is invalid - if the nspace is ours, then we assume
+                 * they want info about our session */
+                if (PMIX_CHECK_NSPACE(cb->proc->nspace, pmix_globals.myid.nspace)) {
+                    lg->sessionid = pmix_globals.sessionid;
+                } else {
+                    /* an invalid rank and not our nspace, with nothing else specified,
+                     * leaves us with no way to look this up */
+                    cb->status = PMIX_ERR_NOT_FOUND;
+                    goto done;
+                }
+            }
+        }
+        /* if they were asking for sessionid, then we are done */
+        if (0 == strcmp(cb->key, PMIX_SESSION_ID)) {
+            cb->status = PMIX_SUCCESS;
+            PMIX_VALUE_CREATE(cb->value, 1);
+            PMIX_VALUE_LOAD(cb->value, &lg->sessionid, PMIX_UINT32);
+            goto done;
+        }
+        /* setup the request */
+        if (lg->sessiondirective) {
+            /* just need to add the sessionid */
+            nfo = cb->ninfo + 2;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_SESSION_ID, &lg->sessionid, PMIX_UINT32);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        } else {
+            /* need to add directive and sessionid */
+            nfo = cb->ninfo + 3;
+            PMIX_INFO_CREATE(iptr, nfo);
+            for (n=0; n < cb->ninfo; n++) {
+                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
+            }
+            PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_SESSION_INFO, NULL, PMIX_BOOL);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_SESSION_ID, &lg->sessionid, PMIX_UINT32);
+            PMIX_INFO_LOAD(&iptr[cb->ninfo+2], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            cb->infocopy = true;
+        }
+        goto doget;
+    }
+
+doget:
+    cb->info = iptr;
+    cb->ninfo = nfo;
     PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
     if (PMIX_SUCCESS == rc) {
         pmix_output_verbose(5, pmix_client_globals.get_output,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -341,6 +341,16 @@ static void lgcon(pmix_get_logic_t *p)
     p->add_immediate = false;
     p->refresh_cache = false;
     p->scope = PMIX_SCOPE_UNDEF;
+    p->sessioninfo = false;
+    p->sessiondirective = false;
+    p->sessionid = UINT32_MAX;
+    p->nodeinfo = false;
+    p->nodedirective = false;
+    p->hostname = NULL;
+    p->nodeid = UINT32_MAX;
+    p->appinfo = false;
+    p->appdirective = false;
+    p->appnum = UINT32_MAX;
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_get_logic_t, pmix_object_t, lgcon, NULL);
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -534,6 +534,16 @@ typedef struct {
     bool add_immediate;
     bool refresh_cache;
     pmix_scope_t scope;
+    bool sessioninfo;
+    bool sessiondirective;
+    uint32_t sessionid;
+    bool nodeinfo;
+    bool nodedirective;
+    char *hostname;
+    uint32_t nodeid;
+    bool appinfo;
+    bool appdirective;
+    uint32_t appnum;
 } pmix_get_logic_t;
 PMIX_CLASS_DECLARATION(pmix_get_logic_t);
 
@@ -657,6 +667,7 @@ typedef struct {
     uint32_t appnum;     // my appnum
     pid_t pid;           // my local pid
     uint32_t nodeid;     // my nodeid, if given
+    uint32_t sessionid;  // my sessionid, if given
     int pindex;
     pmix_event_base_t *evbase;
     int debug_output;
@@ -700,18 +711,23 @@ PMIX_EXPORT void pmix_log_local_op(int sd, short args, void *cbdata_);
 
 static inline bool pmix_check_node_info(const char *key)
 {
-    char *keys[] = {PMIX_HOSTNAME,
-                    PMIX_HOSTNAME_ALIASES,
-                    PMIX_NODEID,
-                    PMIX_AVAIL_PHYS_MEMORY,
-                    PMIX_LOCAL_PEERS,
-                    PMIX_LOCAL_PROCS,
-                    PMIX_LOCAL_CPUSETS,
-                    PMIX_LOCAL_SIZE,
-                    PMIX_NODE_SIZE,
-                    PMIX_LOCALLDR,
-                    PMIX_NODE_OVERSUBSCRIBED,
-                    NULL};
+    char *keys[] = {
+        PMIX_HOSTNAME,                  PMIX_HOSTNAME_ALIASES,
+        PMIX_NODEID,                    PMIX_AVAIL_PHYS_MEMORY,
+        PMIX_LOCAL_PEERS,               PMIX_LOCAL_PROCS,
+        PMIX_LOCAL_CPUSETS,             PMIX_LOCAL_SIZE,
+        PMIX_NODE_SIZE,                 PMIX_LOCALLDR,
+        PMIX_NODE_OVERSUBSCRIBED,       PMIX_FABRIC_DEVICES,
+        PMIX_FABRIC_COORDINATES,        PMIX_FABRIC_DEVICE,
+        PMIX_FABRIC_DEVICE_INDEX,       PMIX_FABRIC_DEVICE_NAME,
+        PMIX_FABRIC_DEVICE_VENDOR,      PMIX_FABRIC_DEVICE_BUS_TYPE,
+        PMIX_FABRIC_DEVICE_VENDORID,    PMIX_FABRIC_DEVICE_DRIVER,
+        PMIX_FABRIC_DEVICE_FIRMWARE,    PMIX_FABRIC_DEVICE_ADDRESS,
+        PMIX_FABRIC_DEVICE_MTU,         PMIX_FABRIC_DEVICE_COORDINATES,
+        PMIX_FABRIC_DEVICE_SPEED,       PMIX_FABRIC_DEVICE_STATE,
+        PMIX_FABRIC_DEVICE_TYPE,        PMIX_FABRIC_DEVICE_PCI_DEVID,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -724,8 +740,11 @@ static inline bool pmix_check_node_info(const char *key)
 
 static inline bool pmix_check_app_info(const char *key)
 {
-    char *keys[] = {PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
-                    PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX, NULL};
+    char *keys[] = {
+        PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
+        PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {
@@ -738,9 +757,12 @@ static inline bool pmix_check_app_info(const char *key)
 
 static inline bool pmix_check_session_info(const char *key)
 {
-    char *keys[] = {PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
-                    PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
-                    PMIX_RM_NAME,    PMIX_RM_VERSION,   NULL};
+    char *keys[] = {
+        PMIX_SESSION_ID, PMIX_CLUSTER_ID,   PMIX_UNIV_SIZE,
+        PMIX_TMPDIR,     PMIX_TDIR_RMCLEAN, PMIX_HOSTNAME_KEEP_FQDN,
+        PMIX_RM_NAME,    PMIX_RM_VERSION,
+        NULL
+    };
     size_t n;
 
     for (n = 0; NULL != keys[n]; n++) {

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -371,38 +371,52 @@ typedef pmix_status_t (*pmix_gds_base_module_del_nspace_fn_t)(const char *nspace
     } while (0)
 
 /* define a convenience macro for is_tsafe for fetch operation */
-#define PMIX_GDS_FETCH_IS_TSAFE(s, p)                                                            \
-    do {                                                                                         \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                      \
-        pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS FETCH IS THREAD SAFE WITH %s", \
-                            __FILE__, __LINE__, _g->name);                                       \
-        if (true == _g->is_tsafe) {                                                              \
-            (s) = PMIX_SUCCESS;                                                                  \
-        } else {                                                                                 \
-            (s) = PMIX_ERR_NOT_SUPPORTED;                                                        \
-        }                                                                                        \
-    } while (0)
+#define PMIX_GDS_FETCH_IS_TSAFE(s, p)                       \
+    do {                                                    \
+        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,        \
+                "[%s:%d] GDS FETCH IS THREAD SAFE WITH %s", \
+                            __FILE__, __LINE__, _g->name);  \
+        if (true == _g->is_tsafe) {                         \
+            (s) = PMIX_SUCCESS;                             \
+        } else {                                            \
+            (s) = PMIX_ERR_NOT_SUPPORTED;                   \
+        }                                                   \
+    } while(0)
 
-/**
- * structure for gds modules
- */
+typedef pmix_status_t (*pmix_gds_base_module_fetch_array_fn_t)(struct pmix_peer_t *pr,
+                                                               pmix_buffer_t *reply);
+/* define a convenience macro for fetching array info for
+ * a given peer */
+#define PMIX_GDS_FETCH_INFO_ARRAYS(s, p, b)                                 \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS FETCH ARRAYS WITH %s",             \
+                            __FILE__, __LINE__, _g->name);                  \
+        (s) = _g->fetch_arrays((struct pmix_peer_t*)(p), b);                \
+    } while(0)
+
+
+/* structure for gds modules */
 typedef struct {
     const char *name;
     const bool is_tsafe;
-    pmix_gds_base_module_init_fn_t init;
-    pmix_gds_base_module_fini_fn_t finalize;
-    pmix_gds_base_assign_module_fn_t assign_module;
-    pmix_gds_base_module_cache_job_info_fn_t cache_job_info;
-    pmix_gds_base_module_register_job_info_fn_t register_job_info;
-    pmix_gds_base_module_store_job_info_fn_t store_job_info;
-    pmix_gds_base_module_store_fn_t store;
-    pmix_gds_base_module_store_modex_fn_t store_modex;
-    pmix_gds_base_module_fetch_fn_t fetch;
-    pmix_gds_base_module_setup_fork_fn_t setup_fork;
-    pmix_gds_base_module_add_nspace_fn_t add_nspace;
-    pmix_gds_base_module_del_nspace_fn_t del_nspace;
-    pmix_gds_base_module_assemb_kvs_req_fn_t assemb_kvs_req;
-    pmix_gds_base_module_accept_kvs_resp_fn_t accept_kvs_resp;
+    pmix_gds_base_module_init_fn_t                  init;
+    pmix_gds_base_module_fini_fn_t                  finalize;
+    pmix_gds_base_assign_module_fn_t                assign_module;
+    pmix_gds_base_module_cache_job_info_fn_t        cache_job_info;
+    pmix_gds_base_module_register_job_info_fn_t     register_job_info;
+    pmix_gds_base_module_store_job_info_fn_t        store_job_info;
+    pmix_gds_base_module_store_fn_t                 store;
+    pmix_gds_base_module_store_modex_fn_t           store_modex;
+    pmix_gds_base_module_fetch_fn_t                 fetch;
+    pmix_gds_base_module_setup_fork_fn_t            setup_fork;
+    pmix_gds_base_module_add_nspace_fn_t            add_nspace;
+    pmix_gds_base_module_del_nspace_fn_t            del_nspace;
+    pmix_gds_base_module_assemb_kvs_req_fn_t        assemb_kvs_req;
+    pmix_gds_base_module_accept_kvs_resp_fn_t       accept_kvs_resp;
+    pmix_gds_base_module_fetch_array_fn_t           fetch_arrays;
 
 } pmix_gds_base_module_t;
 

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -102,9 +102,9 @@ pmix_status_t pmix_gds_hash_fetch_sessioninfo(const char *key,
     }
 
     if (NULL == key) {
-        if (trk->nptr->version.major < 3 ||
-            (3 == trk->nptr->version.major &&
-             0 == trk->nptr->version.minor)) {
+        if (trk->nptr->version.major < 4 ||
+            (4 == trk->nptr->version.major &&
+             1 == trk->nptr->version.minor)) {
             /* we can only transfer the data as independent values */
             PMIX_LIST_FOREACH(kv, sessionlist, pmix_kval_t) {
                 kp2 = PMIX_NEW(pmix_kval_t);

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -51,6 +51,116 @@
 #include "gds_hash.h"
 #include "src/mca/gds/base/base.h"
 
+pmix_status_t pmix_gds_hash_fetch_sessioninfo(const char *key,
+                                              pmix_job_t *trk,
+                                              pmix_info_t *info, size_t ninfo,
+                                              pmix_list_t *kvs)
+{
+    size_t n, nds;
+    pmix_status_t rc;
+    pmix_list_t *sessionlist = NULL;
+    uint32_t sid = UINT32_MAX;
+    pmix_session_t *sptr;
+    pmix_kval_t *kv, *kp2;
+    pmix_info_t *iptr;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING SESSION INFO");
+
+    /* scan for the nodeID or hostname to identify
+     * which node they are asking about */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, sid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            break;
+        }
+    }
+
+    if (UINT32_MAX == sid) {
+        /* they just want the session info from this job. */
+        if (NULL == trk->session) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            return PMIX_ERR_NOT_FOUND;
+        }
+        sessionlist = &trk->session->sessioninfo;
+    } else {
+        /* we cannot use the "check_session" function as we don't want
+         * to create a session that doesn't yet exist */
+        PMIX_LIST_FOREACH(sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
+            if (sptr->session == sid) {
+                sessionlist = &sptr->sessioninfo;
+                break;
+            }
+        }
+    }
+    if (NULL == sessionlist) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == key) {
+        if (trk->nptr->version.major < 3 ||
+            (3 == trk->nptr->version.major &&
+             0 == trk->nptr->version.minor)) {
+            /* we can only transfer the data as independent values */
+            PMIX_LIST_FOREACH(kv, sessionlist, pmix_kval_t) {
+                kp2 = PMIX_NEW(pmix_kval_t);
+                kp2->key = strdup(kv->key);
+                PMIX_VALUE_XFER(rc, kp2->value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_RELEASE(kp2);
+                    return rc;
+                }
+                pmix_list_append(kvs, &kp2->super);
+            }
+        } else {
+            /* we return it as an info array */
+            PMIX_KVAL_NEW(kp2, PMIX_SESSION_INFO_ARRAY);
+            kp2->value->type = PMIX_DATA_ARRAY;
+            nds = pmix_list_get_size(sessionlist) + 1;
+            PMIX_DATA_ARRAY_CREATE(kp2->value->data.darray, nds, PMIX_INFO);
+            iptr = (pmix_info_t*)kp2->value->data.darray->array;
+            /* first element has to be the session id */
+            PMIX_INFO_LOAD(&iptr[0], PMIX_SESSION_ID, &sid, PMIX_UINT32);
+            /* populate the rest of the array */
+            n = 1;
+            PMIX_LIST_FOREACH(kv, sessionlist, pmix_kval_t) {
+                PMIX_LOAD_KEY(iptr[n].key, kv->key);
+                rc = PMIx_Value_xfer(&iptr[n].value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_RELEASE(kp2);
+                    return rc;
+                }
+                ++n;
+            }
+            pmix_list_append(kvs, &kp2->super);
+        }
+        return PMIX_SUCCESS;
+    } else {
+        /* find the specific key */
+        PMIX_LIST_FOREACH(kv, sessionlist, pmix_kval_t) {
+            if (PMIX_CHECK_KEY(kv, key)) {
+                kp2 = PMIX_NEW(pmix_kval_t);
+                kp2->key = strdup(kv->key);
+                PMIX_VALUE_XFER(rc, kp2->value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_RELEASE(kp2);
+                    return rc;
+                }
+                char *tmp = PMIx_Value_string(kp2->value);
+                free(tmp);
+                pmix_list_append(kvs, &kp2->super);
+                return PMIX_SUCCESS;
+            }
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}
+
 pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmix_list_t *tgt,
                                            pmix_info_t *info, size_t ninfo, pmix_list_t *kvs)
 {
@@ -64,7 +174,8 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
     pmix_data_array_t *darray;
     pmix_info_t *iptr;
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output, "FETCHING NODE INFO");
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING NODE INFO");
 
     /* scan for the nodeID or hostname to identify
      * which node they are asking about */
@@ -92,8 +203,9 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
                  * info must be provided as a data_array with a key
                  * of the node's name as earlier versions don't understand
                  * node_info arrays */
-                if (trk->nptr->version.major < 3
-                    || (3 == trk->nptr->version.major && 0 == trk->nptr->version.minor)) {
+                if (trk->nptr->version.major < 3 ||
+                    (3 == trk->nptr->version.major &&
+                     0 == trk->nptr->version.minor)) {
                     if (NULL == nd->hostname) {
                         /* skip this one */
                         continue;
@@ -182,8 +294,9 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk, pmi
          * info must be provided as a data_array with a key
          * of the node's name as earlier versions don't understand
          * node_info arrays */
-        if (trk->nptr->version.major < 3
-            || (3 == trk->nptr->version.major && 0 == trk->nptr->version.minor)) {
+        if (trk->nptr->version.major < 3 ||
+            (3 == trk->nptr->version.major &&
+             0 == trk->nptr->version.minor)) {
             if (NULL == nd->hostname) {
                 kv->key = strdup(pmix_globals.hostname);
             } else {
@@ -280,7 +393,8 @@ pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *trk, pmix
     pmix_data_array_t *darray;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "FETCHING APP INFO WITH %d APPS", (int) pmix_list_get_size(tgt));
+                        "FETCHING APP INFO WITH %d APPS",
+                        (int) pmix_list_get_size(tgt));
 
     /* scan for the appnum to identify
      * which app they are asking about */
@@ -389,14 +503,14 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     pmix_status_t rc;
     pmix_kval_t *kv, *kvptr;
     pmix_info_t *iptr;
-    size_t m, n, ninfo, niptr;
+    size_t n, ninfo, niptr;
     pmix_hash_table_t *ht;
-    pmix_session_t *sptr;
-    uint32_t sid;
     pmix_rank_t rnk;
     pmix_list_t rkvs;
+    bool sessioninfo = false;
     bool nodeinfo = false;
     bool appinfo = false;
+    bool sidgiven = false;
     bool nigiven = false;
     bool apigiven = false;
 
@@ -438,6 +552,11 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
                 return rc;
             }
             pmix_list_append(kvs, &kv->super);
+        }
+        /* collect all the relevant session-level info */
+        rc = pmix_gds_hash_fetch_sessioninfo(NULL, trk, qualifiers, nqual, kvs);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
         }
         /* collect the relevant node-level info */
         rc = pmix_gds_hash_fetch_nodeinfo(NULL, trk, &trk->nodeinfo, qualifiers, nqual, kvs);
@@ -488,49 +607,8 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     /* see if they are asking for session, node, or app-level info */
     for (n = 0; n < nqual; n++) {
         if (PMIX_CHECK_KEY(&qualifiers[n], PMIX_SESSION_INFO)) {
-            /* they must have provided a session ID */
-            for (m = 0; m < nqual; m++) {
-                if (PMIX_CHECK_KEY(&qualifiers[m], PMIX_SESSION_ID)) {
-                    /* see if we have this session */
-                    PMIX_VALUE_GET_NUMBER(rc, &qualifiers[m].value, sid, uint32_t);
-                    if (PMIX_SUCCESS != rc) {
-                        /* didn't provide a correct value */
-                        PMIX_ERROR_LOG(rc);
-                        return rc;
-                    }
-                    PMIX_LIST_FOREACH (sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
-                        if (sptr->session == sid) {
-                            /* see if they want info for a specific node */
-                            rc = pmix_gds_hash_fetch_nodeinfo(key, trk, &sptr->nodeinfo, qualifiers,
-                                                              nqual, kvs);
-                            /* if they did, then we are done */
-                            if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
-                                return rc;
-                            }
-                            /* check the session info */
-                            PMIX_LIST_FOREACH (kvptr, &sptr->sessioninfo, pmix_kval_t) {
-                                if (NULL == key || PMIX_CHECK_KEY(kvptr, key)) {
-                                    kv = PMIX_NEW(pmix_kval_t);
-                                    kv->key = strdup(kvptr->key);
-                                    kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                                    PMIX_VALUE_XFER(rc, kv->value, kvptr->value);
-                                    if (PMIX_SUCCESS != rc) {
-                                        PMIX_RELEASE(kv);
-                                        return rc;
-                                    }
-                                    pmix_list_append(kvs, &kv->super);
-                                    if (NULL != key) {
-                                        /* we are done */
-                                        return PMIX_SUCCESS;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            /* if we get here, then the session wasn't found */
-            return PMIX_ERR_NOT_FOUND;
+            sessioninfo = PMIX_INFO_TRUE(&qualifiers[n]);
+            sidgiven = true;
         } else if (PMIX_CHECK_KEY(&qualifiers[n], PMIX_NODE_INFO)) {
             nodeinfo = PMIX_INFO_TRUE(&qualifiers[n]);
             nigiven = true;
@@ -540,13 +618,20 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
         }
     }
 
-    /* check for node/app keys in the absence of corresponding qualifier */
-    if (NULL != key && !nigiven && !apigiven) {
-        if (pmix_check_node_info(key)) {
+    /* check for session/node/app keys in the absence of corresponding qualifier */
+    if (NULL != key && !sidgiven && !nigiven && !apigiven) {
+        if (pmix_check_session_info(key)) {
+            sessioninfo = true;
+        } else if (pmix_check_node_info(key)) {
             nodeinfo = true;
         } else if (pmix_check_app_info(key)) {
             appinfo = true;
         }
+    }
+
+    if (sessioninfo) {
+        rc = pmix_gds_hash_fetch_sessioninfo(key, trk, qualifiers, nqual, kvs);
+        return rc;
     }
 
     if (!PMIX_RANK_IS_VALID(proc->rank)) {
@@ -572,10 +657,13 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
     /* fetch from the corresponding hash table - note that
      * we always provide a copy as we don't support
      * shared memory */
-    if (PMIX_INTERNAL == scope || PMIX_SCOPE_UNDEF == scope ||
-        PMIX_GLOBAL == scope || PMIX_RANK_WILDCARD == proc->rank) {
+    if (PMIX_INTERNAL == scope ||
+        PMIX_SCOPE_UNDEF == scope ||
+        PMIX_GLOBAL == scope ||
+        PMIX_RANK_WILDCARD == proc->rank) {
         ht = &trk->internal;
-    } else if (PMIX_LOCAL == scope || PMIX_GLOBAL == scope) {
+    } else if (PMIX_LOCAL == scope ||
+               PMIX_GLOBAL == scope) {
         ht = &trk->local;
     } else if (PMIX_REMOTE == scope) {
         ht = &trk->remote;
@@ -685,5 +773,70 @@ doover:
         }
     }
 
+    return rc;
+}
+
+pmix_status_t pmix_gds_hash_fetch_arrays(struct pmix_peer_t *pr, pmix_buffer_t *reply)
+{
+    pmix_peer_t *peer = (pmix_peer_t *) pr;
+    pmix_namespace_t *ns = peer->nptr;
+    pmix_job_t *trk;
+    pmix_list_t kvs;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        /* this function is only available on servers */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                "%s pmix:gds:hash fetch arrays for proc [%s:%u]",
+                PMIX_NAME_PRINT(&pmix_globals.myid),
+                peer->info->pname.nspace, peer->info->pname.rank);
+
+    /* see if we have a tracker for this nspace - we will
+     * if we already cached the job info for it. If we
+     * didn't then we'll have no idea how to answer any
+     * questions */
+    trk = pmix_gds_hash_get_tracker(ns->nspace, false);
+    if (NULL == trk) {
+        /* let the caller know */
+        return PMIX_ERR_INVALID_NAMESPACE;
+    }
+    PMIX_CONSTRUCT(&kvs, pmix_list_t);
+
+    rc = pmix_gds_hash_fetch_sessioninfo(NULL, trk, NULL, 0, &kvs);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&kvs);
+        return rc;
+    }
+
+    rc = pmix_gds_hash_fetch_nodeinfo(NULL, trk, &trk->nodeinfo, NULL, 0, &kvs);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&kvs);
+        return rc;
+    }
+
+    rc = pmix_gds_hash_fetch_appinfo(NULL, trk, &trk->apps, NULL, 0, &kvs);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&kvs);
+        return rc;
+    }
+
+    /* pack the results */
+    while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&kvs))) {
+        PMIX_BFROPS_PACK(rc, peer, reply, kv, 1, PMIX_KVAL);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+    }
+    PMIX_LIST_DESTRUCT(&kvs);
     return rc;
 }

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -98,6 +98,9 @@ extern pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix
 
 extern pmix_job_t *pmix_gds_hash_get_tracker(const pmix_nspace_t nspace, bool create);
 
+extern pmix_session_t* pmix_gds_hash_check_session(pmix_job_t *trk,
+                                                   uint32_t sid);
+
 extern bool pmix_gds_hash_check_hostname(char *h1, char *h2);
 
 extern bool pmix_gds_hash_check_node(pmix_nodeinfo_t *n1, pmix_nodeinfo_t *n2);
@@ -110,6 +113,11 @@ extern pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char
 extern pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
                                          const char *key, pmix_info_t qualifiers[], size_t nqual,
                                          pmix_list_t *kvs);
+
+extern pmix_status_t pmix_gds_hash_fetch_sessioninfo(const char *key,
+                                                     pmix_job_t *trk,
+                                                     pmix_info_t *info, size_t ninfo,
+                                                     pmix_list_t *kvs);
 
 extern pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk,
                                                   pmix_list_t *tgt, pmix_info_t *info, size_t ninfo,
@@ -124,6 +132,8 @@ extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t s
 extern pmix_status_t pmix_gds_hash_store_qualified(pmix_hash_table_t *ht,
                                                    pmix_rank_t rank,
                                                    pmix_value_t *value);
+
+extern pmix_status_t pmix_gds_hash_fetch_arrays(struct pmix_peer_t *pr, pmix_buffer_t *reply);
 
 END_C_DECLS
 

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -212,7 +212,7 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
 /* process an app array - contains an array of
  * app-level info for a single app. If the
  * appnum is not included in the array, then
- * it is assumed that only app is in the job.
+ * it is assumed that only one app is in the job.
  * This assumption is checked and generates
  * an error if violated */
 pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk)
@@ -227,7 +227,8 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
     pmix_nodeinfo_t *nd;
     bool update;
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output, "PROCESSING APP ARRAY");
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "PROCESSING APP ARRAY");
 
     /* apps have to belong to a job */
     if (NULL == trk) {
@@ -460,10 +461,10 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
 
 pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t *trk)
 {
-    pmix_session_t *s = NULL, *sptr;
+    pmix_session_t *sptr;
     size_t j, size;
     pmix_info_t *iptr;
-    pmix_list_t cache, ncache;
+    pmix_list_t ncache;
     pmix_status_t rc;
     pmix_kval_t *kp2;
     pmix_nodeinfo_t *nd;
@@ -477,79 +478,52 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
     size = val->data.darray->size;
     iptr = (pmix_info_t *) val->data.darray->array;
 
-    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    /* the first value is required to be the session ID */
+    if (!PMIX_CHECK_KEY(&iptr[0], PMIX_SESSION_ID)) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_VALUE_GET_NUMBER(rc, &iptr[0].value, sid, uint32_t);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    sptr = pmix_gds_hash_check_session(trk, sid);
     PMIX_CONSTRUCT(&ncache, pmix_list_t);
-    for (j = 0; j < size; j++) {
-        if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_LIST_DESTRUCT(&cache);
-                PMIX_LIST_DESTRUCT(&ncache);
-                return rc;
-            }
-            /* see if we already have this session - it could have
-             * been defined by a separate PMIX_SESSION_ID key */
-            PMIX_LIST_FOREACH (sptr, &pmix_mca_gds_hash_component.mysessions, pmix_session_t) {
-                if (sptr->session == sid) {
-                    s = sptr;
-                    break;
-                }
-            }
-            if (NULL == s) {
-                /* wasn't found, so create one */
-                s = PMIX_NEW(pmix_session_t);
-                s->session = sid;
-                pmix_list_append(&pmix_mca_gds_hash_component.mysessions, &s->super);
-            }
-        } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
+
+    for (j = 1; j < size; j++) {
+         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
+                    "%s gds:hash:session_array for key %s",
+                    PMIX_NAME_PRINT(&pmix_globals.myid),
+                    iptr[j].key);
+        if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
             if (PMIX_SUCCESS != (rc = pmix_gds_hash_process_node_array(&iptr[j].value, &ncache))) {
                 PMIX_ERROR_LOG(rc);
-                PMIX_LIST_DESTRUCT(&cache);
                 PMIX_LIST_DESTRUCT(&ncache);
                 return rc;
             }
         } else {
             kp2 = PMIX_NEW(pmix_kval_t);
             kp2->key = strdup(iptr[j].key);
-            kp2->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
             PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kp2);
-                PMIX_LIST_DESTRUCT(&cache);
                 PMIX_LIST_DESTRUCT(&ncache);
                 return rc;
             }
-            pmix_list_append(&cache, &kp2->super);
+            char *tmp = PMIx_Value_string(kp2->value);
+            free(tmp);
+            pmix_list_append(&sptr->sessioninfo, &kp2->super);
         }
     }
-    if (NULL == s) {
-        /* this is not allowed to happen - they are required
-         * to provide us with a session ID per the standard */
-        PMIX_LIST_DESTRUCT(&cache);
-        PMIX_LIST_DESTRUCT(&ncache);
-        rc = PMIX_ERR_BAD_PARAM;
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-    /* point the job at it */
-    if (NULL != trk->session) {
-        PMIX_RELEASE(trk->session);
-    }
-    PMIX_RETAIN(s);
-    trk->session = s;
-    /* transfer the data across */
-    kp2 = (pmix_kval_t *) pmix_list_remove_first(&cache);
-    while (NULL != kp2) {
-        pmix_list_append(&s->sessioninfo, &kp2->super);
-        kp2 = (pmix_kval_t *) pmix_list_remove_first(&cache);
-    }
-    PMIX_LIST_DESTRUCT(&cache);
-    nd = (pmix_nodeinfo_t *) pmix_list_remove_first(&ncache);
+
+    nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
     while (NULL != nd) {
-        pmix_list_append(&s->nodeinfo, &nd->super);
-        nd = (pmix_nodeinfo_t *) pmix_list_remove_first(&ncache);
+        pmix_list_append(&sptr->nodeinfo, &nd->super);
+        nd = (pmix_nodeinfo_t*)pmix_list_remove_first(&ncache);
     }
     PMIX_LIST_DESTRUCT(&ncache);
     return PMIX_SUCCESS;

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -478,6 +478,7 @@ fetch_job_level_info_for_namespace(
     return rc;
 }
 #endif
+
 pmix_status_t
 pmix_gds_shmem_fetch(
     const pmix_proc_t *proc,

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -88,6 +88,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .appnum = 0,
     .pid = 0,
     .nodeid = UINT32_MAX,
+    .sessionid = UINT32_MAX,
     .pindex = 0,
     .evbase = NULL,
     .debug_output = -1,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4441,7 +4441,19 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         PMIX_GDS_REGISTER_JOB_INFO(rc, peer, reply);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(reply);
             return rc;
+        }
+        /* if the peer is using the "dstore" component, then
+         * we also have to send back any session/node/app-level
+         * info so it can be stored locally in their hash */
+        if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
+            PMIX_GDS_FETCH_INFO_ARRAYS(rc, peer, reply);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(reply);
+                return rc;
+            }
         }
         PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, reply);
         if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
Per the Standard, one can retrieve information about a process
from the node/app/session realms in two ways:

(a) by passing the proc ID along with a key that belongs to
    one of those realms. The PMIx library is responsible
    for identifying such keys and retrieving the specified
    info from the corresponding default realm. If the user
    wishes the key to be retrieved from a non-default realm,
    then they must include the attribute specifying that realm.

(b) by passing an invalid proc rank (e.g., wildcard or undef)
    and including attributes that specify the realm from which
    the given key is to be retrieved along with whatever
    further identification is required - e.g., PMIX_NODE_INFO
    combined with the hostname of the node whose information
    is being fetched.

This commit fixes both methods and provides an example (nodeinfo)
in the examples directory for using this feature.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 77fc96c5a045060810d23ba8080c62fbc074aefe)