### PR TITLE
Complete implementation of group info exchange

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -24,7 +24,7 @@ headers = examples.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init nodeinfo
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup hello abi_no_init abi_with_init nodeinfo group_lcl_cid
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -110,8 +110,12 @@ abi_with_init_SOURCES = abi_with_init.c
 abi_with_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 abi_with_init_LDADD =  $(top_builddir)/src/libpmix.la
 
+group_lcl_cid_SOURCES = group_lcl_cid.c
+group_lcl_cid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_lcl_cid_LDADD =  $(top_builddir)/src/libpmix.la
+
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
         hello jctrl launcher log pub pubi server tool \
-        abi_no_init abi_with_init nodeinfo
+        abi_no_init abi_with_init nodeinfo group_lcl_cid

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * This test simulates the way Open MPI uses the PMIx_Group_construct to
+ * implement MPI4 functions:
+ * - MPI_Comm_create_from_group
+ * - MPI_Intercomm_create_from_groups
+ */
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+static uint32_t get_timeout = 600; /* default 600 secs to get remote data */
+
+static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source,
+                                info, ninfo, results, nresults,
+                                cbfunc, cbdata);
+
+    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
+}
+
+static void op_callbk(pmix_status_t status, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+    
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    mylock_t lock;
+    pmix_info_t *results, *info, tinfo[2];
+    size_t nresults, cid, lcid, ninfo;
+    pmix_data_array_t darray;
+    void *grpinfo, *list;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)getpid());
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+
+    /* register our default errhandler */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, errhandler_reg_callbk,
+                                (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        goto done;
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    grpinfo = PMIx_Info_list_start();
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    list = PMIx_Info_list_start();
+    lcid = 1234UL + (unsigned long) myproc.rank;
+    rc = PMIx_Info_list_add(list, PMIX_GROUP_LOCAL_CID, &lcid, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_convert(list, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_convert failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_INFO, &darray, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_add failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIx_Info_list_release(list);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_Info_list_convert(grpinfo, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Info_list_convert failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    info = (pmix_info_t*)darray.array;
+    ninfo = darray.size;
+    PMIx_Info_list_release(grpinfo);
+
+    rc = PMIx_Group_construct("ourgroup", procs, nprocs, info, ninfo, &results, &nresults);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    /* we should have a single results object */
+    if (NULL != results) {
+        cid = 0;
+        PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
+        fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
+                myproc.rank, PMIx_Error_string(rc), results[0].key, (unsigned long) cid);
+    } else {
+        fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
+    }
+    PMIX_PROC_FREE(procs, nprocs);
+
+    /*
+     * destruct the group
+     */
+    rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+    }
+
+    PMIX_INFO_CONSTRUCT(&tinfo[0]);
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_SIZE);
+    PMIX_INFO_SET_QUALIFIER(&tinfo[0]);
+    PMIX_INFO_CONSTRUCT(&tinfo[1]);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TIMEOUT, &get_timeout, PMIX_UINT32);
+
+    for (n = 0; n < nprocs; n++) {
+        proc.rank = n;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, tinfo, 2, &val))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get of LOCAL CID for rank %d failed: %s\n",
+                        myproc.nspace, myproc.rank, n, PMIx_Error_string(rc));
+            continue;
+        }
+        if (PMIX_SIZE != val->type) {
+           fprintf(stderr, "%s:%d: PMIx_Get LOCAL CID for rank %d returned wrong type: %s\n", myproc.nspace,
+                    myproc.rank, n, PMIx_Data_type_string(val->type));
+            PMIX_VALUE_RELEASE(val);
+            continue;
+        }
+        if ((1234UL + (unsigned long)n) != val->data.size) {
+            fprintf(stderr, "%s:%d: PMIx_Get LOCAL CID for rank %d returned wrong value: %s\n",
+                    myproc.nspace, myproc.rank, n, PMIx_Value_string(val));
+            PMIX_VALUE_RELEASE(val);
+            continue;
+        }
+        fprintf(stderr, "%s:%d: PMIx_Get LOCAL CID for rank %u SUCCESS value: %s\n",
+                myproc.nspace, myproc.rank, n, PMIx_Value_string(val));
+        PMIX_VALUE_RELEASE(val);
+    }
+
+done:
+    /* finalize us */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Deregister_event_handler(1, op_callbk, &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    DEBUG_DESTRUCT_LOCK(&lock);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    fprintf(stderr, "%s:%d COMPLETE\n", myproc.nspace, myproc.rank);
+    fflush(stderr);
+    return (0);
+}
+

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -20,7 +20,7 @@
 
 #include "src/include/pmix_stdint.h"
 
-#include "pmix.h"
+#include "include/pmix.h"
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"
@@ -169,9 +169,6 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     pmix_cmd_t cmd = PMIX_GROUP_CONSTRUCT_CMD;
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
-    size_t n, num;
-    bool embed = true;
-    pmix_info_t *iptr = NULL;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -192,27 +189,6 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     /* check for bozo input */
     if (NULL == procs || 0 >= nprocs) {
         return PMIX_ERR_BAD_PARAM;
-    }
-
-    /* need to add the fence request to the provided info
-     * structs as this is a blocking operation - only add
-     * it if the user didn't specify this themselves */
-    for (n = 0; n < ninfo; n++) {
-        if (PMIX_CHECK_KEY(&info[n], PMIX_EMBED_BARRIER)) {
-            embed = PMIX_INFO_TRUE(&info[n]);
-            break;
-        }
-    }
-    if (embed) {
-        PMIX_INFO_CREATE(iptr, ninfo + 1);
-        num = ninfo + 1;
-        for (n = 0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&iptr[n], &info[n]);
-        }
-        PMIX_INFO_LOAD(&iptr[ninfo], PMIX_EMBED_BARRIER, &embed, PMIX_BOOL);
-    } else {
-        iptr = (pmix_info_t *) info;
-        num = ninfo;
     }
 
     msg = PMIX_NEW(pmix_buffer_t);
@@ -243,14 +219,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     }
 
     /* pack the info structs */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &num, 1, PMIX_SIZE);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         goto done;
     }
-    if (0 < num) {
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, iptr, num, PMIX_INFO);
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
@@ -272,9 +248,6 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     }
 
 done:
-    if (embed && NULL != iptr) {
-        PMIX_INFO_FREE(iptr, num);
-    }
     if (PMIX_SUCCESS != rc && NULL != msg) {
         PMIX_RELEASE(msg);
     }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -340,6 +340,8 @@ static void lgcon(pmix_get_logic_t *p)
     p->pntrval = false;
     p->stval = false;
     p->optional = false;
+    p->add_immediate = false;
+    p->qualified_value = false;
     p->refresh_cache = false;
     p->scope = PMIX_SCOPE_UNDEF;
 }
@@ -387,6 +389,9 @@ static void cbdes(pmix_cb_t *p)
         PMIX_DEVICE_DIST_FREE(p->dist, p->nvals);
     }
     PMIX_LIST_DESTRUCT(&p->kvs);
+    if (NULL != p->lg) {
+        free(p->lg);
+    }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cb_t, pmix_list_item_t, cbcon, cbdes);
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -432,6 +432,13 @@ typedef struct {
 } pmix_query_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
 
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t proc;
+    pmix_byte_object_t blob;  // packed blob of info provided by this proc
+} pmix_grpinfo_t;
+PMIX_CLASS_DECLARATION(pmix_grpinfo_t);
+
 /* define a tracker for collective operations
  * - instanced in pmix_server_ops.c */
 typedef struct {
@@ -457,6 +464,7 @@ typedef struct {
     uint32_t local_cnt; // number of local participants who have contributed
     pmix_info_t *info;  // array of info structs
     size_t ninfo;       // number of info structs in array
+    pmix_list_t grpinfo;    // list of group info to be distributed
     pmix_collect_t collect_type; // whether or not data is to be returned at completion
     pmix_modex_cbfunc_t modexcbfunc;
     pmix_op_cbfunc_t op_cbfunc;
@@ -524,6 +532,8 @@ typedef struct {
     bool pntrval;
     bool stval;
     bool optional;
+    bool add_immediate;
+    bool qualified_value;
     bool refresh_cache;
     pmix_scope_t scope;
 } pmix_get_logic_t;

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -115,8 +115,9 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace, pmix_bu
     PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buff, &bo, &cnt, PMIX_BYTE_OBJECT);
 
     /* If the collect flag is set, we should have some data for unpacking */
-    if ((PMIX_COLLECT_YES == trk->collect_type)
-        && (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc)) {
+    if ((PMIX_COLLECT_YES == trk->collect_type) &&
+        (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc)) {
+        PMIX_ERROR_LOG(rc);
         goto exit;
     }
 
@@ -129,6 +130,7 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace, pmix_bu
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
             /* no data was returned, so we are done with this blob */
             PMIX_DESTRUCT(&bkt);
+            PMIX_ERROR_LOG(rc);
             break;
         }
         if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -75,6 +75,10 @@ typedef pmix_status_t (*pmix_gds_base_assign_module_fn_t)(pmix_info_t *info,
                                                           size_t ninfo,
                                                           int *priority);
 
+#define PMIX_GDS_CHECK_COMPONENT(p, s) (0 == strcmp((p)->nptr->compat.gds->name, (s)))
+#define PMIX_GDS_CHECK_PEER_COMPONENT(p1, p2) \
+    (0 == strcmp((p1)->nptr->compat.gds->name, (p2)->nptr->compat.gds->name))
+
 /* SERVER FN: assemble the keys buffer for server answer */
 typedef pmix_status_t (*pmix_gds_base_module_assemb_kvs_req_fn_t)(const pmix_proc_t *proc,
                                                             pmix_list_t *kvs,

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1297,7 +1297,8 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx, pmix_proc_t *pro
     pmix_kval_t kv;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s:%d] gds:hash:store_modex for nspace %s", pmix_globals.myid.nspace,
+                        "[%s:%d] gds:hash:store_modex for nspace %s",
+                        pmix_globals.myid.nspace,
                         pmix_globals.myid.rank, proc->nspace);
 
     PMIX_HIDE_UNUSED_PARAMS(ctx);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -732,6 +732,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
 {
     pmix_status_t rc;
     bool found = false;
+    bool used_mypeer = true;
     pmix_buffer_t pbkt, pkt;
     pmix_proc_t proc;
     pmix_cb_t cb;
@@ -784,6 +785,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
         }
         if (NULL != peer) {
             PMIX_GDS_FETCH_KV(rc, peer, &cb);
+            used_mypeer = false;
         }
     }
     cb.info = NULL;
@@ -792,7 +794,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
         found = true;
         PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
         /* assemble the provided data into a byte object */
-        if (PMIX_RANK_UNDEF == rank || diffnspace) {
+        if (PMIX_RANK_UNDEF == rank || diffnspace || used_mypeer) {
             PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
         } else {
             PMIX_GDS_ASSEMB_KVS_REQ(rc, cd->peer, &proc, &cb.kvs, &pkt, cd);


### PR DESCRIPTION
Porting some logic requires significant changes from
current PMIx master, so modifications had to be made
to get things right. Include the group_lcl_cid.c
example that illustrates how to use it.

Signed-off-by: Ralph Castain <rhc@pmix.org>