### PR TITLE
Coordinate psec modules across pfexec child

### DIFF
--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -143,6 +143,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
     pmix_rank_t rank = 0;
     char tmp[2048];
     bool nohup = false;
+    char *security_mode;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output,
@@ -301,6 +302,16 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             pmix_setenv("PMIX_RANK", tmp, true, &env);
             pmix_setenv("PMIX_SERVER_RANK", tmp, true, &env);
 
+            /* pass our active security modules */
+            security_mode = pmix_psec_base_get_available_modules();
+            pmix_setenv("PMIX_SECURITY_MODE", security_mode, true, &env);
+            free(security_mode);
+            /* pass the type of buffer we are using */
+            if (PMIX_BFROP_BUFFER_FULLY_DESC == pmix_globals.mypeer->nptr->compat.type) {
+                pmix_setenv("PMIX_BFROP_BUFFER_TYPE", "PMIX_BFROP_BUFFER_FULLY_DESC", true, &env);
+            } else {
+                pmix_setenv("PMIX_BFROP_BUFFER_TYPE", "PMIX_BFROP_BUFFER_NON_DESC", true, &env);
+            }
             /* get any PTL contribution such as tmpdir settings for session files */
             if (PMIX_SUCCESS != (rc = pmix_ptl.setup_fork(&child->proc, &env))) {
                 PMIX_ERROR_LOG(rc);

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -580,8 +580,9 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     }
     reply = ntohl(u32);
 
-    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)
-        && !PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
         rc = pmix_ptl_base_client_handshake(peer, reply);
     } else { // we are a tool
         rc = pmix_ptl_base_tool_handshake(peer, reply);
@@ -1013,8 +1014,8 @@ pmix_status_t pmix_ptl_base_tool_handshake(pmix_peer_t *peer, pmix_status_t rp)
     }
 
     /* if we need an identifier, it comes next */
-    if (PMIX_TOOL_NEEDS_ID == peer->proc_type.flag
-        || PMIX_LAUNCHER_NEEDS_ID == peer->proc_type.flag) {
+    if (PMIX_TOOL_NEEDS_ID == peer->proc_type.flag ||
+        PMIX_LAUNCHER_NEEDS_ID == peer->proc_type.flag) {
         PMIX_PTL_RECV_NSPACE(peer->sd, pmix_globals.myid.nspace);
         PMIX_PTL_RECV_U32(peer->sd, pmix_globals.myid.rank);
     }


### PR DESCRIPTION
When a tool pfexec's a server, it needs to ensure
that the server is using the same psec module as
the tool in order for the server to connect back
to its parent.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit e595f9304d2c43342108e8b08ba608c3114db808)