### PR TITLE
Sort proc arrays to remove order sensitivity and fix multi-node grp info

### DIFF
--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -188,10 +188,10 @@ int main(int argc, char **argv)
     if (NULL != results) {
         cid = 0;
         PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
-        fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
+        fprintf(stderr, "Rank %d Group construct complete with status %s KEY %s CID %lu\n",
                 myproc.rank, PMIx_Error_string(rc), results[0].key, (unsigned long) cid);
     } else {
-        fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
+        fprintf(stderr, "Rank %d Group construct complete, but no CID returned\n", myproc.rank);
     }
     PMIX_PROC_FREE(procs, nprocs);
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -116,8 +116,8 @@ pmix_server_module_t pmix_host_server = {
     .client_connected2 = NULL
 };
 
-pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
-                                void *cbdata)
+pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int32_t cnt;
     pmix_status_t rc;
@@ -172,7 +172,8 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_c
     if (NULL != pmix_host_server.abort) {
         pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
         proc.rank = peer->info->pname.rank;
-        rc = pmix_host_server.abort(&proc, peer->info->server_object, status, msg, procs, nprocs,
+        rc = pmix_host_server.abort(&proc, peer->info->server_object, status,
+                                    msg, procs, nprocs,
                                     cbfunc, cbdata);
     } else {
         rc = PMIX_ERR_NOT_SUPPORTED;
@@ -341,7 +342,8 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
  *         regardless of location
  * nprocs - the number of procs in the array
  */
-static pmix_server_trkr_t *get_tracker(char *id, pmix_proc_t *procs, size_t nprocs, pmix_cmd_t type)
+static pmix_server_trkr_t *get_tracker(char *id, pmix_proc_t *procs,
+                                       size_t nprocs, pmix_cmd_t type)
 {
     pmix_server_trkr_t *trk;
     size_t i, j;
@@ -416,7 +418,8 @@ static pmix_server_trkr_t *get_tracker(char *id, pmix_proc_t *procs, size_t npro
  *         regardless of location
  * nprocs - the number of procs in the array
  */
-static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs, size_t nprocs, pmix_cmd_t type)
+static pmix_server_trkr_t *new_tracker(char *id, pmix_proc_t *procs,
+                                       size_t nprocs, pmix_cmd_t type)
 {
     pmix_server_trkr_t *trk;
     size_t i;
@@ -947,6 +950,8 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         nprocs = nmbrs;
     }
     PMIX_LIST_DESTRUCT(&expand);
+    /* sort the array */
+    qsort(procs, nprocs, sizeof(pmix_proc_t), pmix_util_compare_proc);
 
     /* unpack the number of provided info structs */
     cnt = 1;
@@ -1178,7 +1183,8 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
+pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                  pmix_op_cbfunc_t cbfunc,
                                   void *cbdata)
 {
     pmix_setup_caddy_t *cd;
@@ -1249,7 +1255,8 @@ cleanup:
     return rc;
 }
 
-static void lkcbfunc(pmix_status_t status, pmix_pdata_t data[], size_t ndata, void *cbdata)
+static void lkcbfunc(pmix_status_t status, pmix_pdata_t data[],
+                     size_t ndata, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
 
@@ -1267,7 +1274,8 @@ static void lkcbfunc(pmix_status_t status, pmix_pdata_t data[], size_t ndata, vo
     }
     PMIX_RELEASE(cd);
 }
-pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_lookup_cbfunc_t cbfunc,
+pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                 pmix_lookup_cbfunc_t cbfunc,
                                  void *cbdata)
 {
     pmix_setup_caddy_t *cd;
@@ -1362,7 +1370,8 @@ cleanup:
     return rc;
 }
 
-pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
+pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                    pmix_op_cbfunc_t cbfunc,
                                     void *cbdata)
 {
     pmix_setup_caddy_t *cd;
@@ -1756,6 +1765,8 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
+    /* sort the procs */
+    qsort(procs, nprocs, sizeof(pmix_proc_t), pmix_util_compare_proc);
 
     /* unpack the number of provided info structs */
     cnt = 1;
@@ -1923,6 +1934,8 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
+    /* sort the procs */
+    qsort(procs, nprocs, sizeof(pmix_proc_t), pmix_util_compare_proc);
 
     /* unpack the number of provided info structs */
     cnt = 1;
@@ -2740,7 +2753,8 @@ static void logcbfn(pmix_status_t status, void *cbdata)
     }
     PMIX_RELEASE(cd);
 }
-pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
+pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
+                              pmix_op_cbfunc_t cbfunc,
                               void *cbdata)
 {
     int32_t cnt;
@@ -2835,7 +2849,8 @@ exit:
     return rc;
 }
 
-pmix_status_t pmix_server_alloc(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_info_cbfunc_t cbfunc,
+pmix_status_t pmix_server_alloc(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                pmix_info_cbfunc_t cbfunc,
                                 void *cbdata)
 {
     int32_t cnt;
@@ -2904,7 +2919,8 @@ typedef struct {
 } pmix_srvr_epi_caddy_t;
 static PMIX_CLASS_INSTANCE(pmix_srvr_epi_caddy_t, pmix_list_item_t, NULL, NULL);
 
-pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_info_cbfunc_t cbfunc,
+pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                   pmix_info_cbfunc_t cbfunc,
                                    void *cbdata)
 {
     int32_t cnt, m;
@@ -3200,7 +3216,8 @@ exit:
     return rc;
 }
 
-pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_info_cbfunc_t cbfunc,
+pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                  pmix_info_cbfunc_t cbfunc,
                                   void *cbdata)
 {
     int32_t cnt;
@@ -3275,9 +3292,10 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_in
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
-    if (PMIX_SUCCESS
-        != (rc = pmix_host_server.monitor(&proc, &monitor, error, cd->info, cd->ninfo, cbfunc,
-                                          cd))) {
+    rc = pmix_host_server.monitor(&proc, &monitor, error,
+                                  cd->info, cd->ninfo,
+                                  cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
         goto exit;
     }
     return PMIX_SUCCESS;
@@ -3406,7 +3424,8 @@ exit:
     return rc;
 }
 
-pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
+pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                 pmix_op_cbfunc_t cbfunc,
                                  void *cbdata)
 {
     int32_t cnt;
@@ -3498,8 +3517,9 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_
     cd->ncodes = req->local_id;
 
     /* ask the host to execute the request */
-    rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs, cd->info, cd->ninfo, cd->channels, cbfunc,
-                                   cd);
+    rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
+                                   cd->info, cd->ninfo,
+                                   cd->channels, cbfunc, cd);
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         /* the host did it atomically - send the response. In
          * this particular case, we can just use the cbfunc
@@ -3517,7 +3537,8 @@ exit:
     return rc;
 }
 
-pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_op_cbfunc_t cbfunc,
+pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf,
+                                   pmix_op_cbfunc_t cbfunc,
                                    void *cbdata)
 {
     int32_t cnt;
@@ -3579,8 +3600,9 @@ pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf, pmix_o
     PMIX_RELEASE(req);
 
     /* tell the server to stop */
-    rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs, cd->info, cd->ninfo, cd->channels, cbfunc,
-                                   cd);
+    rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
+                                   cd->info, cd->ninfo,
+                                   cd->channels, cbfunc, cd);
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         /* the host did it atomically - send the response. In
          * this particular case, we can just use the cbfunc
@@ -3959,7 +3981,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                             /* add it to the kval */
                             val.data.darray = &darray;
                             /* store it */
-                            PMIX_GDS_STORE_KV(ret, pmix_globals.mypeer, &procid, PMIX_LOCAL, &kp);
+                            PMIX_GDS_STORE_KV(ret, pmix_globals.mypeer, &procid, PMIX_GLOBAL, &kp);
                             PMIX_DATA_ARRAY_DESTRUCT(&darray);
                             if (PMIX_SUCCESS != ret) {
                                 PMIX_ERROR_LOG(ret);
@@ -4031,7 +4053,8 @@ release:
     PMIX_RELEASE(scd);
 }
 
-static void grpcbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+static void grpcbfunc(pmix_status_t status,
+                      pmix_info_t *info, size_t ninfo, void *cbdata,
                       pmix_release_cbfunc_t relfn, void *relcbd)
 {
     pmix_server_trkr_t *tracker = (pmix_server_trkr_t *) cbdata;
@@ -4151,6 +4174,8 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
         goto error;
     }
     if (NULL == grp->members) {
+        /* sort the procs */
+        qsort(procs, nprocs, sizeof(pmix_proc_t), pmix_util_compare_proc);
         grp->members = procs;
         grp->nmbrs = nprocs;
     } else {

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -175,3 +175,15 @@ char *pmix_util_print_rank(const pmix_rank_t vpid)
     }
     return ptr->buffers[index];
 }
+
+int pmix_util_compare_proc(const void *a, const void *b)
+{
+    const pmix_proc_t *proc_a = (pmix_proc_t *)a;
+    const pmix_proc_t *proc_b = (pmix_proc_t *)b;
+
+    int nspace_dif = strncmp(proc_a->nspace, proc_b->nspace, PMIX_MAX_NSLEN);
+    if (nspace_dif != 0)
+        return nspace_dif;
+
+    return proc_a->rank - proc_b->rank;
+}

--- a/src/util/pmix_name_fns.h
+++ b/src/util/pmix_name_fns.h
@@ -52,5 +52,8 @@ PMIX_EXPORT char *pmix_util_print_rank(const pmix_rank_t vpid);
 #define PMIX_RANK_PRINT(n) pmix_util_print_rank(n)
 
 #define PMIX_PEER_PRINT(p) pmix_util_print_pname_args(&(p)->info->pname)
+
+PMIX_EXPORT int pmix_util_compare_proc(const void *a, const void *b);
+
 END_C_DECLS
 #endif


### PR DESCRIPTION
Remove the ordering sensitivity when doing collective operations
across arrays of procs as this is causing problems for users.
Indeed, backends are sorting the arrays given to them precisely
for this reason - so let's do it as a service to avoid future
complications.

Group info needs to be stored as "global" scope so it can be
properly retrieved.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit caf1f4336112f41f7eb0fe046714fd2b81c0ae60)