### PR TITLE
Support broader range of output formats

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -895,7 +895,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_PUSH_STDIN                 "pmix.iof.stdin"        // (bool) Used by a tool to request that the PMIx library collect
                                                                     //        the tool's stdin and forward it to the procs specified in
                                                                     //        the PMIx_IOF_push call
-#define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the [nspace,rank] and channel it comes from
+#define PMIX_IOF_TAG_OUTPUT                 "pmix.iof.tag"          // (bool) Tag output with the [local jobid,rank] and channel it comes from
+#define PMIX_IOF_TAG_DETAILED_OUTPUT        "pmix.iof.tagdet"       // (bool) Tag output with the [local jobid,rank][hostname:pid] and channel it comes from
+#define PMIX_IOF_TAG_FULLNAME_OUTPUT        "pmix.iof.tagfull"      // (bool) Tag output with the [nspace,rank] and channel it comes from
 #define PMIX_IOF_RANK_OUTPUT                "pmix.iof.rank"         // (bool) Tag output with the rank it came from
 #define PMIX_IOF_TIMESTAMP_OUTPUT           "pmix.iof.ts"           // (bool) Timestamp output
 #define PMIX_IOF_MERGE_STDERR_STDOUT        "pmix.iof.mrg"          // (bool) merge stdout and stderr streams from application procs

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -236,6 +236,8 @@ typedef struct {
     bool xml;
     bool timestamp;
     bool tag;
+    bool tag_detailed;
+    bool tag_fullname;
     bool rank;
     char *file;
     char *directory;
@@ -253,6 +255,8 @@ typedef struct {
     .xml = false,                   \
     .timestamp = false,             \
     .tag = false,                   \
+    .tag_detailed = false,          \
+    .tag_fullname = false,          \
     .rank = false,                  \
     .file = NULL,                   \
     .directory = NULL,              \


### PR DESCRIPTION
Formats include:

* tag => prepend `[jobid,rank]<stream>:` to output. The "jobid"
  is taken as the portion of the nspace after a `@` character.
  As this is not a universal standard, the "jobid" will be
  replaced by the full namespace if the `@` is not found.

* tag-fullname => prepend `[nspace,rank]<stream>:` to output

* tag-detailed => prepend `[jobid,rank][hostname:pid]<stream>:` to
  output. The hostname and pid will be reported as "unknown" if
  not found inside the PMIx local data of the server.
  Combining tag-fullname with tag-detailed is supported.

* rank => prepend `[rank]<stream>` to output

* xml => output in a pseudo-xml format. This can be combined
  with tag-fullname and/or tag-detailed

Signed-off-by: Ralph Castain <rhc@pmix.org>
