### PR TITLE
Fix make_tarball and remove unused variable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ multiple release branches.
 
 4.2.0 -- TBD
 ----------------------
+ - PR #2672 Fix make_tarball and remove unused variable
  - PR #2670 Support broader range of output formats
  - PR #2668 Multiple commits
     - Sort proc arrays to remove order sensitivity

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -14,6 +14,7 @@
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -109,7 +110,7 @@ if test "$LIBEVENT" != ""; then
     echo "*** Adding --with-libevent=$LIBEVENT to config_args"
     config_args="--with-libevent=$LIBEVENT $config_args"
 fi
-
+config_args="$config_args --enable-devel-check"
 export DISTCHECK_CONFIGURE_FLAGS=$config_args
 
 #

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -301,7 +301,6 @@ int pmix_mca_base_var_enum_create_flag(const char *name,
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    int all_flags = 0;
     for (i = 0; i < new_enum->super.enum_value_count; ++i) {
         new_enum->enum_flags[i].flag = flags[i].flag;
         new_enum->enum_flags[i].string = strdup(flags[i].string);
@@ -312,7 +311,6 @@ int pmix_mca_base_var_enum_create_flag(const char *name,
         assert(!(flags[i].flag & flags[i].conflicting_flag));
         assert(!(all_flags & flags[i].flag));
         assert(flags[i].flag);
-        all_flags |= flags[i].flag;
     }
 
     *enumerator = new_enum;


### PR DESCRIPTION
make_tarball needs to explicitly --enable-devel-check as it
otherwise enables picky compiler settings without the "hide"
macro and fails.

Signed-off-by: Ralph Castain <rhc@pmix.org>