### PR TITLE
Do not error out if lib is symlinked to lib64

### DIFF
--- a/config/oac_check_package.m4
+++ b/config/oac_check_package.m4
@@ -2,6 +2,7 @@ dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
+dnl Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -315,9 +316,12 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG], [
                       [test -z "${check_package_prefix}"],
                       [check_package_cv_$1_pcfilename="pcname"],
                       [test -r "${check_package_prefix}/lib/pkgconfig/pcname.pc" -a -r "${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
-                      [AC_MSG_ERROR([Found pcname in both ${check_package_prefix}/lib/pkgconfig and
+                      [AS_IF([test ! -L "${check_package_prefix}/lib" &&
+                              test ! -L "${check_package_prefix}/lib64"],
+                             [AC_MSG_ERROR([Found pcname in both ${check_package_prefix}/lib/pkgconfig and
 ${check_package_prefix}/lib64/pkgconfig.  This is confusing.  Please add --with-$1-libdir=PATH
 to configure to help disambiguate.])],
+                             [check_package_cv_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])],
                       [test -r "${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
                       [check_package_cv_$1_pcfilename="${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
                       [check_package_cv_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])])
@@ -603,9 +607,14 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC_PREFIX], [
 
                   AC_MSG_CHECKING([for $1 library (${check_package_generic_search_lib}) in ${check_package_prefix}])
                   AS_IF([test ${check_package_generic_prefix_lib} -eq 1 -a ${check_package_generic_prefix_lib64} -eq 1],
-                        [AC_MSG_ERROR([Found library $check_package_generic_search_lib in both ${check_package_prefix}/lib and
+                        [AS_IF([test ! -L "${check_package_prefix}/lib" &&
+                                test ! -L "${check_package_prefix}/lib64"],
+                               [AC_MSG_ERROR([Found library $check_package_generic_search_lib in both ${check_package_prefix}/lib and
 ${check_package_prefix}/lib64.  This has confused configure.  Please add --with-$1-libdir=PATH to configure to help
 disambiguate.])],
+                               [check_package_generic_prefix_happy=1
+                                $2_LDFLAGS=-L${check_package_prefix}/lib
+                                AC_MSG_RESULT([found -- lib])])],
                         [test ${check_package_generic_prefix_lib} -eq 1],
                         [check_package_generic_prefix_happy=1
                          $2_LDFLAGS=-L${check_package_prefix}/lib

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -28,7 +28,7 @@
 #
 # Adds the following to the wrapper compilers:
 #  * CPPFLAGS: none
-#  * LDLFGAS: add pmix_libevent_LDFLAGS
+#  * LDFLAGS: add pmix_libevent_LDFLAGS
 #  * LIBS: add pmix_libevent_LIBS
 AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir pmix_check_libevent_save_CPPFLAGS pmix_check_libevent_save_LDFLAGS pmix_check_libevent_save_LIBS])


### PR DESCRIPTION
Distros are now creating a symlink between /lib and /lib64, and
between /usr/lib and /usr/lib64, in accordance with recent
agreements on file system conventions. Thus, if we detect that
the package file exists in both places, check that the two
locations are not symlinks before declaring ambiguity and
exiting with an error.

Fixes https://github.com/openpmix/openpmix/issues/2676
Signed-off-by: Ralph Castain <rhc@pmix.org>