### PR TITLE
Fix/implement the group invite support

### DIFF
--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -69,7 +69,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: executing fence");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: executing fence");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -106,7 +107,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     rc = cb->status;
     PMIX_RELEASE(cb);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence released");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: fence released");
 
     return rc;
 }
@@ -124,7 +126,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence_nb called");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: fence_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -90,7 +90,9 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status, const pmix_pro
     return rc;
 }
 
-static void notify_event_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
+static void notify_event_cbfunc(struct pmix_peer_t *pr,
+                                pmix_ptl_hdr_t *hdr,
+                                pmix_buffer_t *buf,
                                 void *cbdata)
 {
     (void) hdr;
@@ -98,7 +100,7 @@ static void notify_event_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmi
     int32_t cnt = 1;
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
 
-    if (0 < hdr->nbytes) {
+    if (0 < buf->bytes_used) {
         /* unpack the status */
         PMIX_BFROPS_UNPACK(rc, pr, buf, &ret, &cnt, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
@@ -1200,7 +1202,8 @@ static void _notify_client_event(int sd, short args, void *cbdata)
             }
         }
         PMIX_LIST_DESTRUCT(&trk);
-        if (PMIX_RANGE_LOCAL != cd->range && PMIX_CHECK_PROCID(&cd->source, &pmix_globals.myid)) {
+        if (PMIX_RANGE_LOCAL != cd->range &&
+            PMIX_CHECK_PROCID(&cd->source, &pmix_globals.myid)) {
             /* if we are the source, then we need to post this upwards as
              * well so the host RM can broadcast it as necessary */
             if (NULL != pmix_host_server.notify_event) {

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -245,7 +245,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     pmix_active_code_t *active;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_client_globals.event_output, "pmix: _add_hdlr");
+    pmix_output_verbose(2, pmix_client_globals.event_output,
+                        "pmix: _add_hdlr");
 
     /* check to see if we have an active registration on these codes */
     if (NULL == cd->codes) {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -379,11 +379,10 @@ exit:
  */
 void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
 {
-    (void) sd;
-    (void) flags;
     pmix_peer_t *peer = (pmix_peer_t *) cbdata;
     pmix_ptl_send_t *msg = peer->send_msg;
     pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(peer);
@@ -453,13 +452,13 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
 
 void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
 {
-    (void) flags;
     pmix_status_t rc;
     pmix_peer_t *peer = (pmix_peer_t *) cbdata;
     pmix_ptl_recv_t *msg = NULL;
     pmix_ptl_hdr_t hdr;
     size_t nbytes;
     char *ptr;
+    PMIX_HIDE_UNUSED_PARAMS(flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(peer);
@@ -617,11 +616,10 @@ err_close:
 
 void pmix_ptl_base_send(int sd, short args, void *cbdata)
 {
-    (void) sd;
-    (void) args;
     pmix_ptl_queue_t *queue = (pmix_ptl_queue_t *) cbdata;
     pmix_ptl_send_t *snd;
     pmix_ptl_recv_t *msg;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(queue);
@@ -705,13 +703,12 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
 
 void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
 {
-    (void) fd;
-    (void) args;
     pmix_ptl_sr_t *ms = (pmix_ptl_sr_t *) cbdata;
     pmix_ptl_posted_recv_t *req;
     pmix_ptl_send_t *snd;
     uint32_t tag;
     pmix_ptl_recv_t *msg;
+    PMIX_HIDE_UNUSED_PARAMS(fd, args);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(ms);
@@ -805,11 +802,10 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
 
 void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
 {
-    (void) fd;
-    (void) flags;
     pmix_ptl_recv_t *msg = (pmix_ptl_recv_t *) cbdata;
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
+    PMIX_HIDE_UNUSED_PARAMS(fd, flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(msg);
@@ -837,8 +833,9 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
                 }
                 msg->data = NULL; // protect the data region
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                                    "%s:%d EXECUTE CALLBACK for tag %u", pmix_globals.myid.nspace,
-                                    pmix_globals.myid.rank, msg->hdr.tag);
+                                    "%s:%d EXECUTE CALLBACK for tag %u with %d bytes",
+                                    pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                    msg->hdr.tag, (int)msg->hdr.nbytes);
                 rcv->cbfunc(msg->peer, &msg->hdr, &buf, rcv->cbdata);
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
                                     "%s:%d CALLBACK COMPLETE", pmix_globals.myid.nspace,


### PR DESCRIPTION
We had pushed this off as the only users were working with
the blocking forms of group construct...but now seems to be
the time! Uncovered a few bugs in the basic code paths, so
worth the effort.

Fix a check in event notification that was looking at the
wrong field for determining if a status had been included.

Fix a bunch of places in client group functions that were
using the wrong callback object or were simple errors.

Ensure that fence uses the right group participants.

Cleanup the asyncgroup example as the non-leader group
members were not waiting for the "group complete" event.

Fixes https://github.com/openpmix/openpmix/issues/2683
Signed-off-by: Ralph Castain <rhc@pmix.org>