### PR TITLE
Fix/implement the group invite support

### DIFF
--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -70,7 +70,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: executing fence");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: executing fence");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -107,7 +108,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     rc = cb->status;
     PMIX_RELEASE(cb);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence released");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: fence released");
 
     return rc;
 }
@@ -125,7 +127,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.fence_output, "pmix: fence_nb called");
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
+                        "pmix: fence_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -90,7 +90,9 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status, const pmix_pro
     return rc;
 }
 
-static void notify_event_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
+static void notify_event_cbfunc(struct pmix_peer_t *pr,
+                                pmix_ptl_hdr_t *hdr,
+                                pmix_buffer_t *buf,
                                 void *cbdata)
 {
     (void) hdr;
@@ -98,7 +100,7 @@ static void notify_event_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmi
     int32_t cnt = 1;
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
 
-    if (0 < hdr->nbytes) {
+    if (0 < buf->bytes_used) {
         /* unpack the status */
         PMIX_BFROPS_UNPACK(rc, pr, buf, &ret, &cnt, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
@@ -1200,7 +1202,8 @@ static void _notify_client_event(int sd, short args, void *cbdata)
             }
         }
         PMIX_LIST_DESTRUCT(&trk);
-        if (PMIX_RANGE_LOCAL != cd->range && PMIX_CHECK_PROCID(&cd->source, &pmix_globals.myid)) {
+        if (PMIX_RANGE_LOCAL != cd->range &&
+            PMIX_CHECK_PROCID(&cd->source, &pmix_globals.myid)) {
             /* if we are the source, then we need to post this upwards as
              * well so the host RM can broadcast it as necessary */
             if (NULL != pmix_host_server.notify_event) {

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -245,7 +245,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     pmix_active_code_t *active;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_client_globals.event_output, "pmix: _add_hdlr");
+    pmix_output_verbose(2, pmix_client_globals.event_output,
+                        "pmix: _add_hdlr");
 
     /* check to see if we have an active registration on these codes */
     if (NULL == cd->codes) {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -379,11 +379,10 @@ exit:
  */
 void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
 {
-    (void) sd;
-    (void) flags;
     pmix_peer_t *peer = (pmix_peer_t *) cbdata;
     pmix_ptl_send_t *msg = peer->send_msg;
     pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(peer);
@@ -453,13 +452,13 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
 
 void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
 {
-    (void) flags;
     pmix_status_t rc;
     pmix_peer_t *peer = (pmix_peer_t *) cbdata;
     pmix_ptl_recv_t *msg = NULL;
     pmix_ptl_hdr_t hdr;
     size_t nbytes;
     char *ptr;
+    PMIX_HIDE_UNUSED_PARAMS(flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(peer);
@@ -617,11 +616,10 @@ err_close:
 
 void pmix_ptl_base_send(int sd, short args, void *cbdata)
 {
-    (void) sd;
-    (void) args;
     pmix_ptl_queue_t *queue = (pmix_ptl_queue_t *) cbdata;
     pmix_ptl_send_t *snd;
     pmix_ptl_recv_t *msg;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(queue);
@@ -705,13 +703,12 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
 
 void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
 {
-    (void) fd;
-    (void) args;
     pmix_ptl_sr_t *ms = (pmix_ptl_sr_t *) cbdata;
     pmix_ptl_posted_recv_t *req;
     pmix_ptl_send_t *snd;
     uint32_t tag;
     pmix_ptl_recv_t *msg;
+    PMIX_HIDE_UNUSED_PARAMS(fd, args);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(ms);
@@ -805,11 +802,10 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
 
 void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
 {
-    (void) fd;
-    (void) flags;
     pmix_ptl_recv_t *msg = (pmix_ptl_recv_t *) cbdata;
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
+    PMIX_HIDE_UNUSED_PARAMS(fd, flags);
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(msg);
@@ -837,8 +833,9 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
                 }
                 msg->data = NULL; // protect the data region
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                                    "%s:%d EXECUTE CALLBACK for tag %u", pmix_globals.myid.nspace,
-                                    pmix_globals.myid.rank, msg->hdr.tag);
+                                    "%s:%d EXECUTE CALLBACK for tag %u with %d bytes",
+                                    pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                                    msg->hdr.tag, (int)msg->hdr.nbytes);
                 rcv->cbfunc(msg->peer, &msg->hdr, &buf, rcv->cbdata);
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
                                     "%s:%d CALLBACK COMPLETE", pmix_globals.myid.nspace,

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -644,7 +644,8 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk, pmix_buffer_t *buf)
     PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
 
     if (PMIX_COLLECT_YES == trk->collect_type) {
-        pmix_output_verbose(2, pmix_server_globals.fence_output, "fence - assembling data");
+       pmix_output_verbose(2, pmix_server_globals.fence_output,
+                           "fence - assembling data");
 
         /* Evaluate key names sizes and their count to select
          * a format to store key names:
@@ -869,7 +870,8 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     pmix_group_caddy_t *gcd;
     pmix_group_t *grp;
 
-    pmix_output_verbose(2, pmix_server_globals.fence_output, "recvd FENCE");
+    pmix_output_verbose(2, pmix_server_globals.fence_output,
+                        "recvd FENCE");
 
     /* unpack the number of procs */
     cnt = 1;
@@ -877,8 +879,9 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     if (PMIX_SUCCESS != rc) {
         return rc;
     }
-    pmix_output_verbose(2, pmix_server_globals.fence_output, "recvd fence from %s:%u with %d procs",
-                        cd->peer->info->pname.nspace, cd->peer->info->pname.rank, (int) nprocs);
+    pmix_output_verbose(2, pmix_server_globals.fence_output,
+                        "recvd fence from %s with %d procs",
+                        PMIX_PEER_PRINT(cd->peer), (int) nprocs);
     /* there must be at least one as the client has to at least provide
      * their own namespace */
     if (nprocs < 1) {
@@ -907,16 +910,25 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         for (n = 0; n < nprocs; n++) {
             if (PMIX_CHECK_NSPACE(procs[n].nspace, grp->grpid)) {
                 /* we need to replace this proc with grp members */
-                gcd = PMIX_NEW(pmix_group_caddy_t);
-                gcd->grp = grp;
-                gcd->idx = n;
-                gcd->rank = procs[n].rank;
-                pmix_list_append(&expand, &gcd->super);
-                /* see how many need to come across */
                 if (PMIX_RANK_WILDCARD == procs[n].rank) {
+                    gcd = PMIX_NEW(pmix_group_caddy_t);
+                    gcd->grp = grp;
+                    gcd->idx = n;
+                    gcd->rank = PMIX_RANK_WILDCARD;
+                    pmix_list_append(&expand, &gcd->super);
                     nmbrs += grp->nmbrs - 1; // account for replacing current proc
+                } else {
+                    /* find the matching rank */
+                    if (grp->nmbrs <= procs[n].rank) {
+                        /* the group rank is out of bounds */
+                        PMIX_LIST_DESTRUCT(&expand);
+                        rc = PMIX_ERR_BAD_PARAM;
+                        goto cleanup;
+                    }
+                    /* we own the procs array, so just replace the procs nspace
+                     * (which is the group ID) with that of the member */
+                    PMIX_LOAD_NSPACE(procs[n].nspace, grp->members[n].nspace);
                 }
-                break;
             }
         }
     }
@@ -931,15 +943,9 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
                 memcpy(&newprocs[n], &procs[idx], sizeof(pmix_proc_t));
                 ++n;
             } else {
-                /* if we are bringing over just one, then simply replace */
-                if (PMIX_RANK_WILDCARD != gcd->rank) {
-                    memcpy(&newprocs[n], &gcd->grp->members[gcd->rank], sizeof(pmix_proc_t));
-                    ++n;
-                } else {
-                    /* take them all */
-                    memcpy(&newprocs[n], gcd->grp->members, gcd->grp->nmbrs * sizeof(pmix_proc_t));
-                    n += gcd->grp->nmbrs;
-                }
+                /* take them all */
+                memcpy(&newprocs[n], gcd->grp->members, gcd->grp->nmbrs * sizeof(pmix_proc_t));
+                n += gcd->grp->nmbrs;
                 PMIX_RELEASE(gcd);
                 gcd = (pmix_group_caddy_t *) pmix_list_remove_first(&expand);
             }
@@ -2243,7 +2249,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_status_t *codes = NULL;
     pmix_info_t *info = NULL;
     size_t ninfo = 0, ncodes, n;
-    pmix_regevents_info_t *reginfo;
+    pmix_regevents_info_t *reginfo, *rptr;
     pmix_peer_events_info_t *prev = NULL;
     pmix_setup_caddy_t *scd;
     bool enviro_events = false;
@@ -2251,7 +2257,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_proc_t *affected = NULL;
     size_t naffected = 0;
 
-    pmix_output_verbose(2, pmix_server_globals.event_output, "recvd register events for peer %s:%d",
+    pmix_output_verbose(2, pmix_server_globals.event_output,
+                        "recvd register events for peer %s:%d",
                         peer->info->pname.nspace, peer->info->pname.rank);
 
     /* unpack the number of codes */
@@ -2394,13 +2401,13 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             pmix_list_append(&reginfo->peers, &prev->super);
         } else {
             /* if we get here, then we didn't find an existing registration for this code */
-            reginfo = PMIX_NEW(pmix_regevents_info_t);
-            if (NULL == reginfo) {
+            rptr = PMIX_NEW(pmix_regevents_info_t);
+            if (NULL == rptr) {
                 rc = PMIX_ERR_NOMEM;
                 goto cleanup;
             }
-            reginfo->code = codes[n];
-            pmix_list_append(&pmix_server_globals.events, &reginfo->super);
+            rptr->code = codes[n];
+            pmix_list_append(&pmix_server_globals.events, &rptr->super);
             prev = PMIX_NEW(pmix_peer_events_info_t);
             if (NULL == prev) {
                 rc = PMIX_ERR_NOMEM;
@@ -2414,7 +2421,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
                 memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
             }
             prev->enviro_events = enviro_events;
-            pmix_list_append(&reginfo->peers, &prev->super);
+            pmix_list_append(&rptr->peers, &prev->super);
         }
     }
 
@@ -2523,7 +2530,10 @@ void pmix_server_deregister_events(pmix_peer_t *peer, pmix_buffer_t *buf)
     pmix_regevents_info_t *reginfo_next;
     pmix_peer_events_info_t *prev;
 
-    pmix_output_verbose(2, pmix_server_globals.event_output, "recvd deregister events");
+    pmix_output_verbose(2, pmix_server_globals.event_output,
+                        "%s recvd deregister events from %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_PEER_PRINT(peer));
 
     /* unpack codes and process until done */
     cnt = 1;
@@ -2586,7 +2596,8 @@ static void intermed_step(pmix_status_t status, void *cbdata)
     }
 
     /* pass it to our host RM for distribution */
-    rc = pmix_prm.notify(cd->status, &cd->source, cd->range, cd->info, cd->ninfo, local_cbfunc, cd);
+    rc = pmix_prm.notify(cd->status, &cd->source, cd->range,
+                         cd->info, cd->ninfo, local_cbfunc, cd);
     if (PMIX_SUCCESS == rc) {
         /* let the callback function respond for us */
         return;
@@ -2682,9 +2693,9 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer, pmix_buffer
     PMIX_INFO_LOAD(&cd->info[cd->ninfo - 1], PMIX_SERVER_INTERNAL_NOTIFY, NULL, PMIX_BOOL);
 
     /* process it */
-    if (PMIX_SUCCESS
-        != (rc = pmix_server_notify_client_of_event(cd->status, &cd->source, cd->range, cd->info,
-                                                    cd->ninfo, intermed_step, cd))) {
+    rc = pmix_server_notify_client_of_event(cd->status, &cd->source, cd->range, cd->info,
+                                            cd->ninfo, intermed_step, cd);
+    if (PMIX_SUCCESS != rc) {
         goto exit;
     }
     return rc;


### PR DESCRIPTION
We had pushed this off as the only users were working with
the blocking forms of group construct...but now seems to be
the time! Uncovered a few bugs in the basic code paths, so
worth the effort.

Fix a check in event notification that was looking at the
wrong field for determining if a status had been included.

Fix a bunch of places in client group functions that were
using the wrong callback object or were simple errors.

Ensure that fence uses the right group participants.

Cleanup the asyncgroup example as the non-leader group
members were not waiting for the "group complete" event.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit d9aa3a016f2ae9e28aa6082c7f622d8882f468c1)