### PR TITLE
Silence gcc12 warnings

### DIFF
--- a/examples/alloc.c
+++ b/examples/alloc.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,6 +160,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_status_t code;
     myrel_t myrel;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -171,17 +172,18 @@ int main(int argc, char **argv)
     }
     fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
-    /* get our universe size */
+    /* get our job size */
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     if (0 == myproc.rank) {
         /* try to get an allocation */

--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
     pmix_info_t *results;
     size_t nresults;
     char hostname[1024];
-
+    pmix_key_t cache;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     gethostname(hostname, sizeof(hostname));
@@ -150,7 +150,8 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/examples/client.c
+++ b/examples/client.c
@@ -136,6 +136,7 @@ int main(int argc, char **argv)
     pmix_topology_t mytopo;
     char **peers;
     pmix_rank_t *locals = NULL;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -182,7 +183,8 @@ int main(int argc, char **argv)
      * directive is provided so that something like an MPI implementation
      * can do some initial setup in MPI_Init prior to pausing for the
      * debugger */
-    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_STOP_IN_APP, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_DEBUG_STOP_IN_APP);
+    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         /* register for debugger release */
         DEBUG_CONSTRUCT_LOCK(&mylock);
         PMIX_INFO_CREATE(info, 1);
@@ -217,7 +219,8 @@ int main(int argc, char **argv)
     fprintf(stderr, "Client %s:%d topology loaded\n", myproc.nspace, myproc.rank);
 
     /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_UNIV_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
@@ -228,7 +231,8 @@ int main(int argc, char **argv)
 
     /* get the number of procs in our job - univ size is the total number of allocated
      * slots, not the number of procs in the job */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
@@ -299,7 +303,8 @@ int main(int argc, char **argv)
     PMIX_INFO_FREE(info, 1);
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get local peers failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -338,7 +343,8 @@ int main(int argc, char **argv)
             if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, proc.rank)) {
                 exit(1);
             }
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace,
                         myproc.rank, tmp, rc);
                 free(tmp);
@@ -366,7 +372,8 @@ int main(int argc, char **argv)
             if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, proc.rank)) {
                 exit(1);
             }
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace,
                         myproc.rank, tmp, rc);
                 free(tmp);

--- a/examples/client2.c
+++ b/examples/client2.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,6 +83,7 @@ int main(int argc, char **argv)
     bool flag;
     mylock_t mylock;
     pmix_data_array_t da, *dptr;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -120,7 +121,8 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
@@ -171,7 +173,8 @@ int main(int argc, char **argv)
     /* check the returned data */
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "test-key", NULL, 0, &val))) {
+        PMIX_LOAD_KEY(cache, "test-key");
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get on rank %u failed: %d\n", myproc.nspace,
                     myproc.rank, proc.rank, rc);
             goto done;

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
     uint8_t j;
     pmix_info_t timeout;
     int tlimit = 10;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -62,7 +63,8 @@ int main(int argc, char **argv)
 
     /* get our job size */
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -124,7 +126,8 @@ int main(int argc, char **argv)
     }
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get local peers failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -167,7 +170,8 @@ int main(int argc, char **argv)
         proc.rank = n;
         if (local) {
             (void)snprintf(tmp, 1024, "%s-%d-local", proc.nspace, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, &timeout, 1, &val))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, &timeout, 1, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace, myproc.rank,
                         tmp, PMIx_Error_string(rc));
                 goto done;
@@ -187,7 +191,8 @@ int main(int argc, char **argv)
             PMIX_VALUE_RELEASE(val);
         } else {
             (void)snprintf(tmp, 1024, "%s-%d-remote", myproc.nspace, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, &timeout, 1, &val))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, &timeout, 1, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace, myproc.rank,
                         tmp, PMIx_Error_string(rc));
                 goto done;
@@ -208,7 +213,8 @@ int main(int argc, char **argv)
         }
         /* if this isn't us, then get the ghex key */
         if (n != myproc.rank) {
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "ghex", &timeout, 1, &val))) {
+            PMIX_LOAD_KEY(cache, "ghex");
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, &timeout, 1, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get ghex failed: %s\n", myproc.nspace,
                         myproc.rank, PMIx_Error_string(rc));
                 goto done;

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,6 +51,7 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     char hostname[1024], dir[1024];
     size_t ntmp = 0;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -73,7 +74,8 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
@@ -117,7 +119,8 @@ int main(int argc, char **argv)
         /* get their universe size */
         val = NULL;
         PMIX_LOAD_PROCID(&proc, nsp2, PMIX_RANK_WILDCARD);
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val)) || NULL == val) {
+        PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val)) || NULL == val) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                     myproc.rank, rc);
             goto done;
@@ -130,7 +133,8 @@ int main(int argc, char **argv)
         /* get a proc-specific value */
         val = NULL;
         proc.rank = 1;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_RANK, NULL, 0, &val)) || NULL == val) {
+        PMIX_LOAD_KEY(cache, PMIX_LOCAL_RANK);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val)) || NULL == val) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %d\n", myproc.nspace,
                     myproc.rank, rc);
             goto done;

--- a/examples/fault.c
+++ b/examples/fault.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,6 +118,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     myrel_t myrel;
     pmix_status_t code[2] = {PMIX_ERR_PROC_ABORTED, PMIX_ERR_JOB_TERMINATED};
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -132,15 +133,16 @@ int main(int argc, char **argv)
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
-    /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
+    /* get our job size */
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* register another handler specifically for when the target
      * job completes */

--- a/examples/group.c
+++ b/examples/group.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
     mylock_t lock;
     pmix_info_t *results, info;
     size_t nresults, cid;
-
+    pmix_key_t cache;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -93,9 +93,10 @@ int main(int argc, char **argv)
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
-    /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %s\n", myproc.nspace,
+    /* get our job size */
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
@@ -107,7 +108,7 @@ int main(int argc, char **argv)
         }
         goto done;
     }
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* register our default errhandler */
     DEBUG_CONSTRUCT_LOCK(&lock);

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
     size_t nresults, cid, lcid, ninfo;
     pmix_data_array_t darray;
     void *grpinfo, *list;
-
+    pmix_key_t cache;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -103,7 +103,8 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -213,7 +214,8 @@ int main(int argc, char **argv)
 
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, tinfo, 2, &val))) {
+        PMIX_LOAD_KEY(cache, PMIX_GROUP_LOCAL_CID);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, tinfo, 2, &val))) {
                 fprintf(stderr, "Client ns %s rank %d: PMIx_Get of LOCAL CID for rank %d failed: %s\n",
                         myproc.nspace, myproc.rank, n, PMIx_Error_string(rc));
             continue;

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
     pmix_query_t query;
     mylock_t mylock;
     bool refresh = false;
+    pmix_key_t cache;
 
     if (1 < argc) {
         if (NULL != strstr(argv[1], "true")) {
@@ -118,7 +119,8 @@ int main(int argc, char **argv)
         exit(0);
     }
     /* get our local rank */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_RANK);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/examples/jctrl.c
+++ b/examples/jctrl.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,6 +100,7 @@ int main(int argc, char **argv)
     bool flag;
     mylock_t mylock;
     pmix_data_array_t *dptr;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -133,15 +134,16 @@ int main(int argc, char **argv)
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
-    /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
+    /* get our job size */
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* inform the RM that we are preemptible, and that our checkpoint methods are
      * "signal" on SIGUSR2 and event on PMIX_JCTRL_CHECKPOINT */

--- a/examples/nodeinfo.c
+++ b/examples/nodeinfo.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     char *nodelist, **nodes, *hostname;
     pmix_info_t info[2];
-
+    pmix_key_t cache;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us - note that the call to "init" includes the return of
@@ -66,7 +66,8 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get our job size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n",
                 myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -76,7 +77,8 @@ int main(int argc, char **argv)
     fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* get the list of nodes being used */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_NODE_LIST);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get node list failed: %s\n",
                 myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -98,7 +100,8 @@ int main(int argc, char **argv)
         if (nprocs == proc.rank) {
             proc.rank = 0;
         }
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_HOSTNAME, NULL, 0, &val))) {
+        PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname for rank %u failed: %s\n",
                     myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
             goto done;
@@ -108,7 +111,8 @@ int main(int argc, char **argv)
         hostname = strdup(val->data.string);
         PMIX_VALUE_RELEASE(val);
 
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val))) {
+        PMIX_LOAD_KEY(cache, PMIX_FABRIC_COORDINATES);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates for rank %u failed: %s\n",
                     myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
         } else {
@@ -121,7 +125,7 @@ int main(int argc, char **argv)
         proc.rank = PMIX_RANK_WILDCARD;
         PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
         PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, hostname, PMIX_STRING);
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, info, 2, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates with directive for host %s failed: %s\n",
                     myproc.nspace, myproc.rank, hostname, PMIx_Error_string(rc));
             goto done;

--- a/examples/pub.c
+++ b/examples/pub.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     pmix_info_t *info;
     pmix_pdata_t *pdata;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -55,17 +56,18 @@ int main(int argc, char **argv)
     }
     fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
-    /* get our universe size */
+    /* get our job size */
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* call fence to ensure the data is received */
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {

--- a/examples/pubi.c
+++ b/examples/pubi.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,6 +45,7 @@ int main(int argc, char **argv)
     pmix_info_t *info;
     pmix_pdata_t *pdata;
     size_t n;
+    pmix_key_t cache;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -56,17 +57,18 @@ int main(int argc, char **argv)
     }
     fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
-    /* get our universe size */
+    /* get our job size */
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* publish something */
     if (0 == myproc.rank) {

--- a/examples/server.c
+++ b/examples/server.c
@@ -200,6 +200,7 @@ int main(int argc, char **argv)
     uid_t uid = geteuid();
     pmix_info_t *info;
     struct stat buf;
+    pmix_nspace_t ncache;
 
     /* define and pass a personal tmpdir to protect the system */
     if (NULL == (tdir = getenv("TMPDIR"))) {
@@ -291,7 +292,8 @@ int main(int argc, char **argv)
 
     /* prep the local node for launch */
     x = PMIX_NEW(myxfer_t);
-    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support("foobar", NULL, 0, opcbfunc, x))) {
+    PMIX_LOAD_NSPACE(ncache, "foobar");
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support(ncache, NULL, 0, opcbfunc, x))) {
         fprintf(stderr, "Setup local support failed: %d\n", rc);
         PMIx_server_finalize();
         system(cleanup);

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -203,7 +203,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
  *     an error. The timeout parameter can help avoid "hangs" due to programming
  *     errors that prevent the target proc from ever exposing its data.
  */
-PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
+                                   const pmix_key_t key,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_value_t **val);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -599,6 +599,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
     pid_t pid;
     pmix_kval_t *kptr;
     pmix_iof_req_t *iofreq;
+    pmix_key_t cache;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -901,7 +902,8 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
     pmix_strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
     PMIX_INFO_LOAD(&ginfo, PMIX_OPTIONAL, NULL, PMIX_BOOL);
-    if (PMIX_SUCCESS == PMIx_Get(&wildcard, PMIX_DEBUG_STOP_IN_INIT, &ginfo, 1, &val)) {
+    PMIX_LOAD_KEY(cache, PMIX_DEBUG_STOP_IN_INIT);
+    if (PMIX_SUCCESS == PMIx_Get(&wildcard, cache, &ginfo, 1, &val)) {
         pmix_output_verbose(2, pmix_client_globals.base_output,
                             "[%s:%d] RECEIVED STOP IN INIT FOR RANK %s",
                             pmix_globals.myid.nspace,
@@ -1516,6 +1518,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     pmix_proc_t *pa;
     size_t m, n, np, ninfo;
     pmix_namespace_t *ns;
+    pmix_key_t cache;
 
     /* set default response */
     *procs = NULL;
@@ -1550,7 +1553,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
-            rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, iptr, ninfo, &val);
+            PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+            rc = PMIx_Get(&proc, cache, iptr, ninfo, &val);
             if (PMIX_SUCCESS != rc) {
                 continue;
             }
@@ -1628,7 +1632,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     /* get the list of local peers for this nspace and node */
     PMIX_LOAD_NSPACE(proc.nspace, nspace);
 
-    rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, iptr, ninfo, &val);
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    rc = PMIx_Get(&proc, cache, iptr, ninfo, &val);
     if (PMIX_SUCCESS != rc) {
         goto done;
     }
@@ -1681,6 +1686,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     char **tmp = NULL, **p;
     size_t n;
     pmix_namespace_t *ns;
+    pmix_key_t cache;
 
     /* set default response */
     *nodelist = NULL;
@@ -1700,7 +1706,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
-            rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val);
+            PMIX_LOAD_KEY(cache, PMIX_NODE_LIST);
+            rc = PMIx_Get(&proc, cache, NULL, 0, &val);
             if (PMIX_SUCCESS != rc) {
                 continue;
             }
@@ -1737,7 +1744,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     }
 
     PMIX_LOAD_NSPACE(proc.nspace, nspace);
-    rc = PMIx_Get(&proc, PMIX_NODE_LIST, NULL, 0, &val);
+    PMIX_LOAD_KEY(cache, PMIX_NODE_LIST);
+    rc = PMIx_Get(&proc, cache, NULL, 0, &val);
     if (PMIX_SUCCESS != rc) {
         return rc;
     }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -178,6 +178,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
     bool qval = false;
     pmix_value_t *ival = NULL;
     pmix_info_t optional;
+    pmix_key_t cache;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -361,7 +362,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
                     /* lookup the node where that proc is running - if all we
                      * have is the hash component, then we have to threadshift
                      * to make that request */
-                    rc = _getfn_fastpath(&p, PMIX_HOSTNAME, &optional, 1, &ival);
+                    PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+                    rc = _getfn_fastpath(&p, cache, &optional, 1, &ival);
                     if (PMIX_ERR_NOT_SUPPORTED == rc) {
                         /* all we have is hash */
                         PMIX_CONSTRUCT(&cb2, pmix_cb_t);
@@ -488,7 +490,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
                 if (UINT32_MAX != appnum) {
                     /* they provided an appnum - if it
                      * isn't our appnum, then we need to redirect */
-                    rc = _getfn_fastpath(&pmix_globals.myid, PMIX_APPNUM, &optional, 1, &ival);
+                    PMIX_LOAD_KEY(cache, PMIX_APPNUM);
+                    rc = _getfn_fastpath(&pmix_globals.myid, cache, &optional, 1, &ival);
                     if (PMIX_SUCCESS == rc) {
                         PMIX_VALUE_GET_NUMBER(rc, ival, app, uint32_t);
                         if (PMIX_SUCCESS != rc) {
@@ -520,7 +523,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
                  * the appnum - if the ID is other than us, then we just need to
                  * flag it as "app-info" and mark it for the undefined rank so
                  * the GDS will know where to look */
-                rc = _getfn_fastpath(&pmix_globals.myid, PMIX_APPNUM, &optional, 1, &ival);
+                PMIX_LOAD_KEY(cache, PMIX_APPNUM);
+                rc = _getfn_fastpath(&pmix_globals.myid, cache, &optional, 1, &ival);
                 if (PMIX_SUCCESS == rc) {
                     PMIX_VALUE_GET_NUMBER(rc, ival, app, uint32_t);
                     if (PMIX_SUCCESS != rc) {

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -74,6 +74,7 @@ static pmix_peer_t *find_peer(const pmix_proc_t *proc)
     pmix_proc_t wildcard;
     pmix_value_t *value;
     int i;
+    pmix_key_t cache;
 
     if (NULL == proc) {
         return pmix_globals.mypeer;
@@ -101,7 +102,8 @@ static pmix_peer_t *find_peer(const pmix_proc_t *proc)
          * to retrieve it once */
         pmix_strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
         wildcard.rank = PMIX_RANK_WILDCARD;
-        if (PMIX_SUCCESS != PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value)) {
+        PMIX_LOAD_KEY(cache, PMIX_BFROPS_MODULE);
+        if (PMIX_SUCCESS != PMIx_Get(&wildcard, cache, NULL, 0, &value)) {
             /* couldn't get it - nothing we can do */
             return NULL;
         }
@@ -134,9 +136,9 @@ static pmix_peer_t *find_peer(const pmix_proc_t *proc)
 
     /* If the target is for the server, then
      * pack it using that peer. */
-    if (0
-        == strncmp(proc->nspace, pmix_client_globals.myserver->info->pname.nspace,
-                   PMIX_MAX_NSLEN)) {
+    if (0 == strncmp(proc->nspace,
+                     pmix_client_globals.myserver->info->pname.nspace,
+                     PMIX_MAX_NSLEN)) {
         return pmix_client_globals.myserver;
     }
 
@@ -144,7 +146,8 @@ static pmix_peer_t *find_peer(const pmix_proc_t *proc)
      * cached, so we will only have to retrieve it once */
     pmix_strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value)) {
+    PMIX_LOAD_KEY(cache, PMIX_BFROPS_MODULE);
+    if (PMIX_SUCCESS != PMIx_Get(&wildcard, cache, NULL, 0, &value)) {
         /* couldn't get it - nothing we can do */
         return NULL;
     }

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
     test_params params;
     INIT_TEST_PARAMS(params);
     pmix_proc_t myproc, proc;
+    pmix_key_t cache;
 
     parse_cmd(argc, argv, &params);
 
@@ -89,7 +90,8 @@ int main(int argc, char **argv)
     TEST_VERBOSE((" Client ns %s rank %d: PMIx_Init success", myproc.nspace, myproc.rank));
 
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_UNIV_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         TEST_ERROR(
             ("rank %d: PMIx_Get universe size failed: %s", myproc.rank, PMIx_Error_string(rc)));
         FREE_TEST_PARAMS(params);
@@ -110,7 +112,8 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("rank %d: Universe size check: PASSED", myproc.rank));
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         TEST_ERROR(("rank %d: PMIx_Get hostname failed: %s", myproc.rank, PMIx_Error_string(rc)));
         FREE_TEST_PARAMS(params);
         exit(rc);
@@ -129,7 +132,8 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("rank %d: Hostname check: PASSED", myproc.rank));
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NODEID, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_NODEID);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         TEST_ERROR(("rank %d: PMIx_Get nodeid failed: %s", myproc.rank, PMIx_Error_string(rc)));
         FREE_TEST_PARAMS(params);
         exit(rc);

--- a/test/simple/doubleget.c
+++ b/test/simple/doubleget.c
@@ -37,7 +37,9 @@ static int pmi_set_string(const char *key, void *data, size_t size)
     return 0;
 }
 
-static int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out,
+static int pmi_get_string(uint32_t peer_rank,
+                          const pmix_key_t key,
+                          void **data_out,
                           size_t *data_size_out)
 {
     int rc;
@@ -107,6 +109,7 @@ int main(int argc, char *argv[])
     size_t size_out;
     int rc;
     pmix_value_t *pvalue;
+    pmix_key_t cache;
 
     /* check the args */
     if (1 < argc) {
@@ -147,7 +150,8 @@ int main(int argc, char *argv[])
     PMIX_LOAD_PROCID(&allproc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get the number of procs in our job */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&allproc, PMIX_JOB_SIZE, NULL, 0, &pvalue))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&allproc, cache, NULL, 0, &pvalue))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
         exit(1);
@@ -175,9 +179,11 @@ int main(int argc, char *argv[])
     }
 
     if (0 == myproc.rank) {
-        pmi_get_string(1, "test-key-3", (void **) &data_out, &size_out);
+        PMIX_LOAD_KEY(cache, "test-key-3");
+        pmi_get_string(1, cache, (void **) &data_out, &size_out);
     } else {
-        pmi_get_string(0, "test-key-2", (void **) &data_out, &size_out);
+        PMIX_LOAD_KEY(cache, "test-key-2");
+        pmi_get_string(0, cache, (void **) &data_out, &size_out);
     }
     printf("%d: obtained data \"%s\"\n", myproc.rank, data_out);
 

--- a/test/simple/get_put_example.c
+++ b/test/simple/get_put_example.c
@@ -24,6 +24,7 @@ int main(int argc, char **argv)
     pmix_value_t pvalue;
     pmix_proc_t myproc, rootproc;
     pmix_info_t info;
+    pmix_key_t cache;
     hide_unused_params(rc, argc, argv);
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -52,7 +53,8 @@ int main(int argc, char **argv)
     rootproc = myproc;
     rootproc.rank = 0;
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&rootproc, "my.foo", NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, "my.foo");
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&rootproc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Get of root's my.foo failed\n");
         exit(1);
     }

--- a/test/simple/gwclient.c
+++ b/test/simple/gwclient.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +48,7 @@ int main(int argc, char **argv)
     pmix_proc_t proc;
     pmix_info_t *info;
     size_t n, ninfo;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -63,7 +64,8 @@ int main(int argc, char **argv)
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "my.net.key", NULL, 0, &val))
+    PMIX_LOAD_KEY(cache, "my.net.key");
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))
         || PMIX_DATA_ARRAY != val->type || NULL == val->data.darray
         || NULL == val->data.darray->array) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get my.net.key failed: %s", myproc.nspace,

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -273,6 +273,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_data_array_t *darray;
     pmix_info_t *iarray;
+    pmix_nspace_t cache;
 
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
@@ -412,8 +413,9 @@ int main(int argc, char **argv)
     /* now load the array */
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NETWORK, darray, PMIX_DATA_ARRAY);
 
+    PMIX_LOAD_NSPACE(cache, "foobar");
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("foobar", info, ninfo, sacbfunc, (void *) x))) {
+        != (rc = PMIx_server_setup_application(cache, info, ninfo, sacbfunc, (void *) x))) {
         return rc;
     }
     DEBUG_WAIT_THREAD(&x->lock);
@@ -423,14 +425,14 @@ int main(int argc, char **argv)
     /* pass any returned data down */
     DEBUG_CONSTRUCT_LOCK(&x->lock);
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("foobar", x->info, x->ninfo, opcbfunc, x))) {
+        != (rc = PMIx_server_setup_local_support(cache, x->info, x->ninfo, opcbfunc, x))) {
         return rc;
     }
     DEBUG_WAIT_THREAD(&x->lock);
     PMIX_RELEASE(x);
 
     /* fork/exec the test */
-    pmix_strncpy(proc.nspace, "foobar", PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(proc.nspace, "foobar");
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
         x = PMIX_NEW(myxfer_t);
@@ -489,7 +491,7 @@ int main(int argc, char **argv)
 
     /* deregister the nspace */
     x = PMIX_NEW(myxfer_t);
-    PMIx_server_deregister_nspace("foobar", opcbfunc, (void *) x);
+    PMIx_server_deregister_nspace(cache, opcbfunc, (void *) x);
     DEBUG_WAIT_THREAD(&x->lock);
     PMIX_RELEASE(x);
 

--- a/test/simple/quietclient.c
+++ b/test/simple/quietclient.c
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
     char **peers;
     bool all_local, local;
     pmix_rank_t *locals = NULL;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us and declare we are a test programming model */
@@ -139,7 +140,8 @@ int main(int argc, char **argv)
     /* test something */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s", myproc.nspace, myproc.rank,
                     PMIx_Error_string(rc));
         exit(rc);
@@ -170,7 +172,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -189,7 +192,8 @@ int main(int argc, char **argv)
     }
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -263,7 +267,8 @@ int main(int argc, char **argv)
                 }
                 if (local) {
                     (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j);
-                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                    PMIX_LOAD_KEY(cache, tmp);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
                                     myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
                         continue;
@@ -296,7 +301,8 @@ int main(int argc, char **argv)
                      * always can get our own remote data as we published it */
                     if (proc.rank != myproc.rank) {
                         (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
-                        if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                        PMIX_LOAD_KEY(cache, tmp);
+                        if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                             /* this data should _not_ be found as we are on the same node
                              * and the data was "put" with a PMIX_REMOTE scope */
                             pmix_output(0,
@@ -309,7 +315,8 @@ int main(int argc, char **argv)
                     }
                 } else {
                     (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
-                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                    PMIX_LOAD_KEY(cache, tmp);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                         pmix_output(
                             0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed for remote proc",
                             myproc.nspace, myproc.rank, j, tmp);

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -117,6 +117,7 @@ int main(int argc, char **argv)
     bool all_local, local;
     pmix_rank_t *locals = NULL;
     pmix_topology_t topo;
+    pmix_key_t cache;
 
     if (1 < argc) {
         if (0 == strcmp("-abort", argv[1])) {
@@ -139,7 +140,8 @@ int main(int argc, char **argv)
 
     /* test something */
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -149,7 +151,8 @@ int main(int argc, char **argv)
     pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
 
     /* test something */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_SERVER_URI, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_SERVER_URI);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get server URI failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -157,7 +160,8 @@ int main(int argc, char **argv)
     pmix_output(0, "CLIENT SERVER URI: %s", val->data.string);
     PMIX_VALUE_RELEASE(val);
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_RANK);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get LOCAL RANK failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -165,7 +169,8 @@ int main(int argc, char **argv)
     pmix_output(0, "CLIENT LOCAL RANK: %u", val->data.uint16);
     PMIX_VALUE_RELEASE(val);
 
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get HOSTNAME failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -174,7 +179,8 @@ int main(int argc, char **argv)
     PMIX_VALUE_RELEASE(val);
 
     /* check if a security credential was given */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_CREDENTIAL, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_CREDENTIAL);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get CREDENTIAL failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
     } else {
@@ -215,7 +221,8 @@ int main(int argc, char **argv)
     }
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -290,7 +297,8 @@ int main(int argc, char **argv)
                 }
                 if (local) {
                     (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j);
-                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                    PMIX_LOAD_KEY(cache, tmp);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
                                     myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
                         continue;
@@ -325,7 +333,8 @@ int main(int argc, char **argv)
                      * always can get our own remote data as we published it */
                     if (proc.rank != myproc.rank) {
                         (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
-                        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                        PMIX_LOAD_KEY(cache, tmp);
+                        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                             /* this data should _not_ be found as we are on the same node
                              * and the data was "put" with a PMIX_REMOTE scope */
                             pmix_output(0,
@@ -346,7 +355,8 @@ int main(int argc, char **argv)
                 } else {
                     val = NULL;
                     (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
-                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                    PMIX_LOAD_KEY(cache, tmp);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct",
                                     myproc.nspace, myproc.rank, j, tmp);
                     } else {

--- a/test/simple/simpcoord.c
+++ b/test/simple/simpcoord.c
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
     pmix_coord_t *coords;
     char *hostname;
     pmix_byte_object_t *bptr;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -66,7 +67,8 @@ int main(int argc, char **argv)
     /* test something */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s", myproc.nspace, myproc.rank,
                     PMIx_Error_string(rc));
         exit(rc);
@@ -76,7 +78,8 @@ int main(int argc, char **argv)
     pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
 
     /* get our assumed hostname */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get hostname failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -86,7 +89,8 @@ int main(int argc, char **argv)
     pmix_output(0, "Client %s:%d hostname %s", myproc.nspace, myproc.rank, hostname);
 
     /* get our assigned fabric endpts */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_FABRIC_ENDPT, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_FABRIC_ENDPT);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get fabric endpt failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto nextstep;
@@ -112,7 +116,8 @@ int main(int argc, char **argv)
 
 nextstep:
     /* get our assigned fabric coordinates */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_FABRIC_COORDINATES, NULL, 0, &val))
+    PMIX_LOAD_KEY(cache, PMIX_FABRIC_COORDINATES);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, cache, NULL, 0, &val))
         || NULL == val) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get fabric coordinate failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,6 +103,7 @@ int main(int argc, char **argv)
     pmix_info_t *iptr;
     size_t ninfo;
     pmix_status_t code;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us and declare we are a test programming model */
@@ -121,7 +122,8 @@ int main(int argc, char **argv)
     /* test something */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
@@ -152,7 +154,8 @@ int main(int argc, char **argv)
     }
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);

--- a/test/simple/simpdie.c
+++ b/test/simple/simpdie.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,6 +92,7 @@ int main(int argc, char **argv)
     bool fail_early = false;
     bool fail_after_participate = false;
     int opt;
+    pmix_key_t cache;
 
     if (1 == argc) {
         fail_early = true;
@@ -121,7 +122,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -126,9 +126,10 @@ int main(int argc, char **argv)
     bool local, all_local;
     char **peers;
     pmix_rank_t *locals = NULL;
-    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
     pmix_info_t timeout, *iptr;
     size_t ninfo;
+    pmix_key_t cache;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     dofence = false;
     sleeptime = 2;
@@ -169,7 +170,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Rank %d[msg=%d]: PMIx_Get job size failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
         ++msgnum;
         exitstatus = 1;
@@ -242,7 +244,8 @@ int main(int argc, char **argv)
     }
 
     /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Rank %d[msg=%d]: PMIx_Get local peers failed: %s", myproc.rank, msgnum, PMIx_Error_string(rc));
         ++msgnum;
         exitstatus = 1;
@@ -283,7 +286,8 @@ int main(int argc, char **argv)
             pmix_output(0, "Rank %u[msg=%d]: retrieving %s from local proc %u", myproc.rank, msgnum, tmp, n);
             ++msgnum;
             proc.rank = n;
-            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, iptr, ninfo, valcbfunc, tmp))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, cache, iptr, ninfo, valcbfunc, tmp))) {
                 pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
                 ++msgnum;
                 exitstatus = 1;
@@ -293,7 +297,8 @@ int main(int argc, char **argv)
         } else {
             (void) asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
             pmix_output(0, "Rank %u[msg=%d]: retrieving %s from remote proc %u", myproc.rank, msgnum, tmp, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, iptr, ninfo, valcbfunc, tmp))) {
+            PMIX_LOAD_KEY(cache, tmp);
+            if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, cache, iptr, ninfo, valcbfunc, tmp))) {
                 pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);
                 ++msgnum;
                 exitstatus = 1;

--- a/test/simple/simpdyn.c
+++ b/test/simple/simpdyn.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
     pmix_proc_t *peers;
     size_t npeers, ntmp = 0;
     char *nodelist;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     gethostname(hostname, sizeof(hostname));
@@ -69,7 +70,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -110,7 +112,8 @@ int main(int argc, char **argv)
         pmix_strncpy(proc.nspace, nsp2, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         val = NULL;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val)) || NULL == val) {
+        PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val)) || NULL == val) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Get job %s size failed: %d", myproc.nspace,
                         myproc.rank, nsp2, rc);
             goto done;

--- a/test/simple/simpfabric.c
+++ b/test/simple/simpfabric.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,6 +110,8 @@ int main(int argc, char **argv)
     size_t ndist;
     pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS | PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_COPROC
                               | PMIX_DEVTYPE_GPU;
+    pmix_key_t cache;
+    pmix_nspace_t ncache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* smoke test */
@@ -131,7 +133,8 @@ int main(int argc, char **argv)
 
     /* get my procID */
     fprintf(stderr, "Getting procID\n");
-    rc = PMIx_Get(NULL, PMIX_PROCID, NULL, 0, &val);
+    PMIX_LOAD_KEY(cache, PMIX_PROCID);
+    rc = PMIx_Get(NULL, cache, NULL, 0, &val);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Get of my procID failed: %s\n", PMIx_Error_string(rc));
         goto cleanup;
@@ -141,7 +144,8 @@ int main(int argc, char **argv)
 
     /* get my topology */
     fprintf(stderr, "GETTING TOPOLOGY\n");
-    rc = PMIx_Get(&myproc, PMIX_TOPOLOGY2, NULL, 0, &val);
+    PMIX_LOAD_KEY(cache, PMIX_TOPOLOGY2);
+    rc = PMIx_Get(&myproc, cache, NULL, 0, &val);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Get of my topology failed: %s\n", PMIx_Error_string(rc));
         goto cleanup;
@@ -202,8 +206,9 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&iptr[3], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
 
     DEBUG_CONSTRUCT_LOCK(&cd.lock);
+    PMIX_LOAD_NSPACE(ncache, "SIMPSCHED");
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("SIMPSCHED", iptr, 4, setup_cbfunc, &cd))) {
+        != (rc = PMIx_server_setup_application(ncache, iptr, 4, setup_cbfunc, &cd))) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&cd.lock);
@@ -215,7 +220,7 @@ int main(int argc, char **argv)
     /* setup the local subsystem */
     DEBUG_CONSTRUCT_LOCK(&lock);
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("SIMPSCHED", cd.info, cd.ninfo, local_cbfunc,
+        != (rc = PMIx_server_setup_local_support(ncache, cd.info, cd.ninfo, local_cbfunc,
                                                  &lock))) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));

--- a/test/simple/simpft.c
+++ b/test/simple/simpft.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -87,7 +88,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -112,6 +112,7 @@ int main(int argc, char **argv)
     bool flag;
     mylock_t mylock;
     pmix_data_array_t *dptr;
+    pmix_key_t cache;
     hide_unused_params(rc, argc, argv);
 
     /* init us - note that the call to "init" includes the return of
@@ -146,7 +147,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/test/simple/simppub.c
+++ b/test/simple/simppub.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +48,7 @@ int main(int argc, char **argv)
     pmix_info_t *info;
     pmix_pdata_t *pdata;
     pmix_proc_t myproc;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -61,7 +62,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;

--- a/test/simple/simpsched.c
+++ b/test/simple/simpsched.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,6 +104,8 @@ int main(int argc, char **argv)
     mylock_t lock;
     mycaddy_t cd;
     pmix_value_t *val;
+    pmix_nspace_t ncache;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* smoke test */
@@ -143,7 +145,8 @@ int main(int argc, char **argv)
             }
         }
 
-        rc = PMIx_Get(NULL, PMIX_FABRIC_DEVICES, NULL, 0, &val);
+        PMIX_LOAD_KEY(cache, PMIX_FABRIC_DEVICES);
+        rc = PMIx_Get(NULL, cache, NULL, 0, &val);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Fabric get devices failed with error: %s\n", PMIx_Error_string(rc));
             goto cleanup;
@@ -180,8 +183,9 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&iptr[3], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
 
     DEBUG_CONSTRUCT_LOCK(&cd.lock);
+    PMIX_LOAD_NSPACE(ncache, "SIMPSCHED");
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("SIMPSCHED", iptr, 4, setup_cbfunc, &cd))) {
+        != (rc = PMIx_server_setup_application(ncache, iptr, 4, setup_cbfunc, &cd))) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&cd.lock);
@@ -193,7 +197,7 @@ int main(int argc, char **argv)
     /* setup the local subsystem */
     DEBUG_CONSTRUCT_LOCK(&lock);
     if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("SIMPSCHED", cd.info, cd.ninfo, local_cbfunc,
+        != (rc = PMIx_server_setup_local_support(ncache, cd.info, cd.ninfo, local_cbfunc,
                                                  &lock))) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
     uint32_t nprocs, n;
     volatile bool active;
     pmix_info_t info;
+    pmix_key_t cache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* init us */
@@ -87,7 +88,8 @@ int main(int argc, char **argv)
     /* test something */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s", myproc.nspace, myproc.rank,
                     PMIx_Error_string(rc));
         exit(rc);
@@ -105,7 +107,8 @@ int main(int argc, char **argv)
     /* get our job size */
     pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
         goto done;
@@ -142,7 +145,8 @@ int main(int argc, char **argv)
         /* check timeout on Get */
         proc.rank = 1;
         pmix_output(0, "TEST GET TIMEOUT");
-        if (PMIX_ERR_TIMEOUT == (rc = PMIx_Get(&proc, "1234", &info, 1, &val))) {
+        PMIX_LOAD_KEY(cache, "1234");
+        if (PMIX_ERR_TIMEOUT == (rc = PMIx_Get(&proc, cache, &info, 1, &val))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Get did not timeout: %s", myproc.nspace,
                         myproc.rank, PMIx_Error_string(rc));
             goto done;

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -22,6 +22,7 @@ int main(int argc, char **argv)
     pmix_proc_t myproc;
     pmix_status_t rc=0;
     int rank;
+    pmix_key_t cache;
     hide_unused_params(rc, argc, argv);
 
     rc = PMIx_Init(&myproc, NULL, 0);
@@ -29,7 +30,8 @@ int main(int argc, char **argv)
 
     {
         pmix_value_t *value;
-        rc = PMIx_Get(&myproc, PMIX_RANK, NULL, 0, &value);
+        PMIX_LOAD_KEY(cache, PMIX_RANK);
+        rc = PMIx_Get(&myproc, cache, NULL, 0, &value);
         assert(PMIX_SUCCESS == rc);
         printf("%d\n", value->type);
         assert(value->type == PMIX_INT);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -274,12 +274,14 @@ typedef struct {
         get_cbdata _cbdata;                                                                       \
         _cbdata.status = PMIX_SUCCESS;                                                            \
         pmix_proc_t _foobar;                                                                      \
+        pmix_key_t __cache;                                                                       \
         SET_KEY(_key, fence_num, ind, use_same_keys);                                             \
+        PMIX_LOAD_KEY(__cache, _key);                                                             \
         PMIX_LOAD_PROCID(&_foobar, ns, r);                                                        \
         TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, _key));   \
         if (blocking) {                                                                           \
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&_foobar, _key, NULL, 0, &_val))) {                \
-                if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_NOT_FOUND)           \
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&_foobar, __cache, NULL, 0, &_val))) {             \
+                if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_NOT_FOUND)                      \
                       && ok_notfnd)) {                                                            \
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %s from %s:%d, key %s", my_nspace,       \
                                 my_rank, PMIx_Error_string(rc), ns, r, _key));                    \
@@ -291,7 +293,7 @@ typedef struct {
             PMIX_VALUE_CREATE(_val, 1);                                                           \
             _cbdata.kv = _val;                                                                    \
             if (PMIX_SUCCESS                                                                      \
-                != (rc = PMIx_Get_nb(&_foobar, _key, NULL, 0, get_cb, (void *) &_cbdata))) {      \
+                != (rc = PMIx_Get_nb(&_foobar, __cache, NULL, 0, get_cb, (void *) &_cbdata))) {   \
                 TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s", my_nspace,      \
                               my_rank, PMIx_Error_string(rc), ns, r, _key));                      \
             } else {                                                                              \

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -260,11 +260,13 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
     pmix_rank_t npeers;
     int rc;
     pmix_proc_t proc;
+    pmix_key_t cache;
 
     pmix_strncpy(proc.nspace, my_nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     /* get number of neighbors on this node */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_SIZE);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peer # failed: %d", my_nspace, my_rank, rc));
         exit(rc);
     }
@@ -283,7 +285,8 @@ static int get_local_peers(char *my_nspace, int my_rank, pmix_rank_t **_peers, p
     peers = malloc(sizeof(pmix_rank_t) * npeers);
 
     /* get ranks of neighbors on this node */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, cache, NULL, 0, &val))) {
         TEST_ERROR(("%s:%d: PMIx_Get local peers failed: %d", my_nspace, my_rank, rc));
         free(peers);
         exit(rc);
@@ -345,6 +348,7 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     pmix_info_t info;
+    pmix_key_t cache;
 
     pmix_strncpy(proc.nspace, my_nspace, PMIX_MAX_NSLEN);
     proc.rank = my_rank;
@@ -445,7 +449,8 @@ int test_job_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
         j = 1;
         PMIX_INFO_LOAD(&info, PMIX_TIMEOUT, &j, PMIX_INT);
         PMIX_INFO_REQUIRED(&info);
-        if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, "foobar", &info, 1, &val))) {
+        PMIX_LOAD_KEY(cache, "foobar");
+        if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, cache, &info, 1, &val))) {
             TEST_ERROR(("%s:%d: PMIx_Get returned success instead of failure", my_nspace, my_rank));
             exit(PMIX_ERROR);
         }

--- a/test/test_v2/test_fence_partial.c
+++ b/test/test_v2/test_fence_partial.c
@@ -77,6 +77,7 @@ int main(int argc, char *argv[]) {
     long usecs_elapsed;
     unsigned long sleep_time_ms;
     double secs_elapsed, fence_time, sleep_time, padded_fence_time;
+    pmix_key_t cache;
 
     // pass in function pointer for custom argument processing, if no custom processing, will be null
     pmixt_pre_init(argc, argv, &params, &v_params, &parse_fence_client);
@@ -90,11 +91,13 @@ int main(int argc, char *argv[]) {
     PMIX_LOAD_NSPACE(job_proc.nspace, this_proc.nspace);
     job_proc.rank = PMIX_RANK_WILDCARD;
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), params, v_params);
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), params, v_params);
     PMIX_VALUE_GET_NUMBER(rc, val, num_procs, uint32_t);
     free(val);
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_NUM_NODES, NULL, 0, &val), params, v_params);
+    PMIX_LOAD_KEY(cache, PMIX_NUM_NODES);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), params, v_params);
     PMIX_VALUE_GET_NUMBER(rc, val, num_nodes, uint32_t);
     free(val);
 

--- a/test/test_v2/test_get_basic.c
+++ b/test/test_v2/test_get_basic.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2021 Triad National Security, LLC.
  *                         All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +27,7 @@ int main(int argc, char *argv[])
     test_params l_params;
     validation_params v_params;
     pmix_proc_t job_proc;
+    pmix_key_t cache;
 
     pmixt_pre_init(argc, argv, &l_params, &v_params, NULL);
     TEST_VERBOSE(("v_params values: pmix_nspace %s; pmix_job_size %d; pmix_univ_size %d",
@@ -45,47 +46,55 @@ int main(int argc, char *argv[])
     job_proc = this_proc;
     job_proc.rank = PMIX_RANK_WILDCARD; // == UINT32_MAX-1
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), l_params, v_params);
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
     /* After using PMIx_Get to get a value, we need to compare it our validation parameters
        we've passed as an argument; this is the main purpose of pmixt_validate_predefined(). */
 
-    pmixt_validate_predefined(&job_proc, PMIX_JOB_SIZE, val, PMIX_UINT32, &v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_UINT32, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_JOB_SIZE check"));
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_UNIV_SIZE, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_UNIV_SIZE, val, PMIX_UINT32, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_UNIV_SIZE);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_UINT32, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_UNIV_SIZE check"));
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_SIZE, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&this_proc, PMIX_LOCAL_SIZE, val, PMIX_UINT32, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_SIZE);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&this_proc, cache, val, PMIX_UINT32, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_LOCAL_SIZE check"));
 
-    PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_LOCAL_RANK, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&this_proc, PMIX_LOCAL_RANK, val, PMIX_UINT16, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_RANK);
+    PMIXT_CHECK(PMIx_Get(&this_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&this_proc, cache, val, PMIX_UINT16, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_LOCAL_RANK check"));
 
-    PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_NODEID, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&this_proc, PMIX_NODEID, val, PMIX_UINT32, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_NODEID);
+    PMIXT_CHECK(PMIx_Get(&this_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&this_proc, cache, val, PMIX_UINT32, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_NODEID check"));
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_PEERS, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_LOCAL_PEERS, val, PMIX_STRING, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_STRING, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_LOCAL_PEERS check"));
 
-    PMIXT_CHECK(PMIx_Get(&this_proc, PMIX_HOSTNAME, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&this_proc, PMIX_HOSTNAME, val, PMIX_STRING, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+    PMIXT_CHECK(PMIx_Get(&this_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&this_proc, cache, val, PMIX_STRING, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_HOSTNAME check"));
 
     job_proc.rank = PMIX_RANK_INVALID;
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_RANK, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_RANK, val, PMIX_PROC_RANK, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_RANK);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_PROC_RANK, &v_params);
     TEST_VERBOSE(("after PMIX_RANK check"));
 
     /* finalize */

--- a/test/test_v2/test_get_peers.c
+++ b/test/test_v2/test_get_peers.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2020      Triad National Security, LLC.
  *                         All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +34,7 @@ int main(int argc, char *argv[])
     validation_params v_params;
     pmix_proc_t job_proc, peer_proc;
     uint32_t i;
+    pmix_key_t cache;
 
     pmixt_pre_init(argc, argv, &l_params, &v_params, NULL);
     /* initialization */
@@ -45,13 +46,15 @@ int main(int argc, char *argv[])
     job_proc = this_proc;
     job_proc.rank = PMIX_RANK_WILDCARD;
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_JOB_SIZE, val, PMIX_UINT32, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_JOB_SIZE);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_UINT32, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_JOB_SIZE check"));
 
-    PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_LOCAL_PEERS, NULL, 0, &val), l_params, v_params);
-    pmixt_validate_predefined(&job_proc, PMIX_LOCAL_PEERS, val, PMIX_STRING, &v_params);
+    PMIX_LOAD_KEY(cache, PMIX_LOCAL_PEERS);
+    PMIXT_CHECK(PMIx_Get(&job_proc, cache, NULL, 0, &val), l_params, v_params);
+    pmixt_validate_predefined(&job_proc, cache, val, PMIX_STRING, &v_params);
     free(val);
     TEST_VERBOSE(("after PMIX_LOCAL_PEERS check"));
 
@@ -59,23 +62,27 @@ int main(int argc, char *argv[])
     peer_proc = this_proc;
     for (i = 0; i < v_params.pmix_job_size; i++) {
         peer_proc.rank = i;
-        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_LOCAL_RANK, NULL, 0, &val), l_params, v_params);
-        pmixt_validate_predefined(&peer_proc, PMIX_LOCAL_RANK, val, PMIX_UINT16, &v_params);
+        PMIX_LOAD_KEY(cache, PMIX_LOCAL_RANK);
+        PMIXT_CHECK(PMIx_Get(&peer_proc, cache, NULL, 0, &val), l_params, v_params);
+        pmixt_validate_predefined(&peer_proc, cache, val, PMIX_UINT16, &v_params);
         free(val);
         TEST_VERBOSE(("after PMIX_LOCAL_RANK check for rank = %d", peer_proc.rank));
 
-        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_NODEID, NULL, 0, &val), l_params, v_params);
-        pmixt_validate_predefined(&peer_proc, PMIX_NODEID, val, PMIX_UINT32, &v_params);
+        PMIX_LOAD_KEY(cache, PMIX_NODEID);
+        PMIXT_CHECK(PMIx_Get(&peer_proc, cache, NULL, 0, &val), l_params, v_params);
+        pmixt_validate_predefined(&peer_proc, cache, val, PMIX_UINT32, &v_params);
         free(val);
         TEST_VERBOSE(("after PMIX_NODEID check for rank = %d", peer_proc.rank));
 
-        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_NODE_RANK, NULL, 0, &val), l_params, v_params);
-        pmixt_validate_predefined(&peer_proc, PMIX_NODE_RANK, val, PMIX_UINT16, &v_params);
+        PMIX_LOAD_KEY(cache, PMIX_NODE_RANK);
+        PMIXT_CHECK(PMIx_Get(&peer_proc, cache, NULL, 0, &val), l_params, v_params);
+        pmixt_validate_predefined(&peer_proc, cache, val, PMIX_UINT16, &v_params);
         free(val);
         TEST_VERBOSE(("after PMIX_NODE_RANK check for rank = %d", peer_proc.rank));
 
-        PMIXT_CHECK(PMIx_Get(&peer_proc, PMIX_HOSTNAME, NULL, 0, &val), l_params, v_params);
-        pmixt_validate_predefined(&peer_proc, PMIX_HOSTNAME, val, PMIX_STRING, &v_params);
+        PMIX_LOAD_KEY(cache, PMIX_HOSTNAME);
+        PMIXT_CHECK(PMIx_Get(&peer_proc, cache, NULL, 0, &val), l_params, v_params);
+        pmixt_validate_predefined(&peer_proc, cache, val, PMIX_STRING, &v_params);
         free(val);
         TEST_VERBOSE(("after PMIX_HOSTNAME check for rank = %d", peer_proc.rank));
     }


### PR DESCRIPTION
Pretty much all about passing char* strings to
functions expecting pmix_key_t or pmix_nspace_t
structs.

Fixes https://github.com/openpmix/openpmix/issues/2684
Signed-off-by: Ralph Castain <rhc@pmix.org>