### PR TITLE
Silence the gcc12 complaints

### DIFF
--- a/examples/server.c
+++ b/examples/server.c
@@ -200,6 +200,7 @@ int main(int argc, char **argv)
     uid_t uid = geteuid();
     pmix_info_t *info;
     struct stat buf;
+    pmix_nspace_t ncache;
 
     /* define and pass a personal tmpdir to protect the system */
     if (NULL == (tdir = getenv("TMPDIR"))) {
@@ -290,8 +291,9 @@ int main(int argc, char **argv)
     PMIX_RELEASE(x);
 
     /* prep the local node for launch */
+    PMIX_LOAD_NSPACE(ncache, "foobar");
     x = PMIX_NEW(myxfer_t);
-    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support("foobar", NULL, 0, opcbfunc, x))) {
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support(ncache, NULL, 0, opcbfunc, x))) {
         fprintf(stderr, "Setup local support failed: %d\n", rc);
         PMIx_server_finalize();
         system(cleanup);
@@ -301,7 +303,7 @@ int main(int argc, char **argv)
     PMIX_RELEASE(x);
 
     /* fork/exec the test */
-    PMIX_LOAD_NSPACE(proc.nspace, "foobar");
+    PMIX_LOAD_NSPACE(proc.nspace, ncache);
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
         if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, &client_env))) { // n

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -273,6 +273,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_data_array_t *darray;
     pmix_info_t *iarray;
+    pmix_nspace_t ncache;
 
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
@@ -411,9 +412,10 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&iarray[3], PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);
     /* now load the array */
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NETWORK, darray, PMIX_DATA_ARRAY);
+    PMIX_LOAD_NSPACE(ncache, "foobar");
 
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("foobar", info, ninfo, sacbfunc, (void *) x))) {
+    rc = PMIx_server_setup_application(ncache, info, ninfo, sacbfunc, (void *) x);
+    if (PMIX_SUCCESS != rc) {
         return rc;
     }
     DEBUG_WAIT_THREAD(&x->lock);
@@ -422,8 +424,8 @@ int main(int argc, char **argv)
 
     /* pass any returned data down */
     DEBUG_CONSTRUCT_LOCK(&x->lock);
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("foobar", x->info, x->ninfo, opcbfunc, x))) {
+    rc = PMIx_server_setup_local_support(ncache, x->info, x->ninfo, opcbfunc, x);
+    if (PMIX_SUCCESS != rc) {
         return rc;
     }
     DEBUG_WAIT_THREAD(&x->lock);
@@ -489,7 +491,7 @@ int main(int argc, char **argv)
 
     /* deregister the nspace */
     x = PMIX_NEW(myxfer_t);
-    PMIx_server_deregister_nspace("foobar", opcbfunc, (void *) x);
+    PMIx_server_deregister_nspace(ncache, opcbfunc, (void *) x);
     DEBUG_WAIT_THREAD(&x->lock);
     PMIX_RELEASE(x);
 

--- a/test/simple/simpfabric.c
+++ b/test/simple/simpfabric.c
@@ -108,8 +108,11 @@ int main(int argc, char **argv)
     pmix_cpuset_t mycpuset;
     pmix_device_distance_t *distances;
     size_t ndist;
-    pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS | PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_COPROC
-                              | PMIX_DEVTYPE_GPU;
+    pmix_device_type_t type = PMIX_DEVTYPE_OPENFABRICS |
+                              PMIX_DEVTYPE_NETWORK |
+                              PMIX_DEVTYPE_COPROC |
+                              PMIX_DEVTYPE_GPU;
+    pmix_nspace_t ncache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* smoke test */
@@ -200,10 +203,10 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);
 
     PMIX_INFO_LOAD(&iptr[3], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
-
+    PMIX_LOAD_NSPACE(ncache, "SIMPSCHED");
     DEBUG_CONSTRUCT_LOCK(&cd.lock);
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("SIMPSCHED", iptr, 4, setup_cbfunc, &cd))) {
+    rc = PMIx_server_setup_application(ncache, iptr, 4, setup_cbfunc, &cd);
+    if (PMIX_SUCCESS != rc) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&cd.lock);
@@ -214,9 +217,8 @@ int main(int argc, char **argv)
 
     /* setup the local subsystem */
     DEBUG_CONSTRUCT_LOCK(&lock);
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("SIMPSCHED", cd.info, cd.ninfo, local_cbfunc,
-                                                 &lock))) {
+    rc = PMIx_server_setup_local_support(ncache, cd.info, cd.ninfo, local_cbfunc, &lock);
+    if (PMIX_SUCCESS != rc) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&lock);

--- a/test/simple/simpsched.c
+++ b/test/simple/simpsched.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv)
     mylock_t lock;
     mycaddy_t cd;
     pmix_value_t *val;
+    pmix_nspace_t ncache;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* smoke test */
@@ -178,10 +179,10 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);
 
     PMIX_INFO_LOAD(&iptr[3], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
-
+    PMIX_LOAD_NSPACE(ncache, "SIMPSCHED");
     DEBUG_CONSTRUCT_LOCK(&cd.lock);
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_application("SIMPSCHED", iptr, 4, setup_cbfunc, &cd))) {
+    rc = PMIx_server_setup_application(ncache, iptr, 4, setup_cbfunc, &cd);
+    if (PMIX_SUCCESS != rc) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&cd.lock);
@@ -192,9 +193,8 @@ int main(int argc, char **argv)
 
     /* setup the local subsystem */
     DEBUG_CONSTRUCT_LOCK(&lock);
-    if (PMIX_SUCCESS
-        != (rc = PMIx_server_setup_local_support("SIMPSCHED", cd.info, cd.ninfo, local_cbfunc,
-                                                 &lock))) {
+    rc = PMIx_server_setup_local_support(ncache, cd.info, cd.ninfo, local_cbfunc, &lock);
+    if (PMIX_SUCCESS != rc) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(rc));
         DEBUG_DESTRUCT_LOCK(&lock);


### PR DESCRIPTION
Just need to encapsulate nspace names in pmix_nspace_t. We
already were consistent in use of char* for keys.

Signed-off-by: Ralph Castain <rhc@pmix.org>