### PR TITLE
Output IO as singleton, support background commands

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -85,6 +85,7 @@ static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 #include "src/util/pmix_show_help.h"
 
 #include "pmix_client_ops.h"
+#include "src/server/pmix_server_ops.h"
 
 #define PMIX_MAX_RETRIES 10
 
@@ -512,7 +513,8 @@ static void client_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     pmix_iof_req_t *req;
     pmix_info_t *info = NULL;
 
-    pmix_output_verbose(2, pmix_client_globals.iof_output, "recvd IOF with %d bytes",
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "recvd IOF with %d bytes",
                         (int) buf->bytes_used);
 
     PMIX_HIDE_UNUSED_PARAMS(hdr, cbdata);
@@ -728,6 +730,10 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
             PMIX_LOAD_PROCID(proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
         }
         pmix_globals.mypeer->nptr->nspace = strdup(pmix_globals.myid.nspace);
+        /* define us as an IOF endpoint so any output will be printed */
+        pmix_globals.iof_flags.local_output = true;
+        PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_list_t);
+        PMIX_CONSTRUCT(&pmix_server_globals.iof_residuals, pmix_list_t);
     } else {
         if (NULL != proc) {
             pmix_strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -336,7 +336,11 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
         }
     }
     if (optind < argc) {
-        results->tail = pmix_argv_copy(&argv[optind]);
+        /* if this is an '&', it simply indicates that the executable
+         * was being pushed into the background - ignore it */
+        if (0 != strcmp(argv[optind], "&")) {
+            results->tail = pmix_argv_copy(&argv[optind]);
+        }
     }
     pmix_argv_free(argv);
     return PMIX_SUCCESS;


### PR DESCRIPTION
When running as a singleton, setup to handle any IO from spawned
children. Do not identify an ampersand as a cmd line "tail" as
this falsely implies it is an application.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 1c1d4e1707f5ce7a586461189222611c1d75976d)