### PR TITLE
Enable show_help output on tools

### DIFF
--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -66,7 +66,8 @@ static void localcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE_THREAD(&mycount->lock);
 }
 
-pmix_status_t pmix_plog_base_log(const pmix_proc_t *source, const pmix_info_t data[], size_t ndata,
+pmix_status_t pmix_plog_base_log(const pmix_proc_t *source,
+                                 const pmix_info_t data[], size_t ndata,
                                  const pmix_info_t directives[], size_t ndirs,
                                  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -95,7 +96,8 @@ pmix_status_t pmix_plog_base_log(const pmix_proc_t *source, const pmix_info_t da
      * can only be on one list at a time */
     PMIX_ACQUIRE_THREAD(&pmix_plog_globals.lock);
 
-    pmix_output_verbose(2, pmix_plog_base_framework.framework_output, "plog:log called");
+    pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                        "plog:log called");
 
     /* initialize the tracker */
     mycount = PMIX_NEW(pmix_mycount_t);

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -111,8 +111,9 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-    /* if we are not a gateway, then we don't handle this */
-    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
+    /* if we are not a gateway or tool, then we don't handle this */
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -191,7 +191,9 @@ static pmix_status_t match(const char *a, const char *b)
 }
 
 
-static pmix_status_t pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
+static pmix_status_t pmix_get_tli(const char *filename,
+                                  const char *topic,
+                                  tuple_list_item_t **tli_)
 {
     tuple_list_item_t *tli = *tli_;
 


### PR DESCRIPTION
Don't restrict the plog/stdfd component to only work
on gateways - it needs to also support tools.

Refs https://github.com/openpmix/prrte/issues/1442
Signed-off-by: Ralph Castain <rhc@pmix.org>