### PR TITLE
Updates for upcoming v4.2.1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=4
 minor=2
-release=0
+release=1
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -24,7 +24,7 @@ release=0
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=rc2
+greek=a1
 
 # PMIx Standard Compliance Level
 # The major and minor numbers indicate the version
@@ -106,7 +106,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=8:0:6
+libpmix_so_version=8:1:6
 
 # "Common" components install standalone libraries that are run-time
 # # linked by one or more components.  So they need to be versioned as

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -94,7 +94,7 @@ echo "--> Found specfile: $specfile"
 # Find where the top RPM-building directory is
 #
 
-rpmtopdir=${rpmtopdir:-"`grep %_topdir $HOME/.rpmmacros | awk '{ print $2 }'`"}
+rpmtopdir=${rpmtopdir:-$HOME/RPMBUILD}
 if test "$rpmtopdir" != ""; then
 	rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then

--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -66,7 +66,8 @@ static void localcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE_THREAD(&mycount->lock);
 }
 
-pmix_status_t pmix_plog_base_log(const pmix_proc_t *source, const pmix_info_t data[], size_t ndata,
+pmix_status_t pmix_plog_base_log(const pmix_proc_t *source,
+                                 const pmix_info_t data[], size_t ndata,
                                  const pmix_info_t directives[], size_t ndirs,
                                  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -95,7 +96,8 @@ pmix_status_t pmix_plog_base_log(const pmix_proc_t *source, const pmix_info_t da
      * can only be on one list at a time */
     PMIX_ACQUIRE_THREAD(&pmix_plog_globals.lock);
 
-    pmix_output_verbose(2, pmix_plog_base_framework.framework_output, "plog:log called");
+    pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                        "plog:log called");
 
     /* initialize the tracker */
     mycount = PMIX_NEW(pmix_mycount_t);

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -111,8 +111,9 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-    /* if we are not a gateway, then we don't handle this */
-    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
+    /* if we are not a gateway or tool, then we don't handle this */
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -192,7 +192,9 @@ static pmix_status_t match(const char *a, const char *b)
 }
 
 
-static pmix_status_t pmix_get_tli(const char *filename, const char *topic, tuple_list_item_t **tli_)
+static pmix_status_t pmix_get_tli(const char *filename,
+                                  const char *topic,
+                                  tuple_list_item_t **tli_)
 {
     tuple_list_item_t *tli = *tli_;
 


### PR DESCRIPTION
[Fix the buildrpm script](https://github.com/openpmix/openpmix/commit/3f9ee9d3f7afa74d24a8e641de0bf8faffee3a55)

Current code never finds home directory RPMBUILD, so
simplify it so it works.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/df0280b1328eaa99f578c19c32bf2315cd6c57b8)

[Enable show_help output on tools](https://github.com/openpmix/openpmix/commit/2b561432c5f196d8b83fbfbebb868b901cf87784)

Don't restrict the plog/stdfd component to only work
on gateways - it needs to also support tools.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/e3b925f82d2a59f58c60c7d7a7b5a71eda7d41ae)

[Bump VERSION to v4.2.1](https://github.com/openpmix/openpmix/commit/edaf6866ea1d0a948b06aab87b7baa4408849c06)

Signed-off-by: Ralph Castain <rhc@pmix.org>
