### PR TITLE
Catch v4.2 up with changes from master branch

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -451,7 +451,11 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to use for starting spawned procs
 #define PMIX_WDIR                           "pmix.wdir"             // (char*) working directory for spawned procs
 #define PMIX_WDIR_USER_SPECIFIED            "pmix.wdir.user"        // (bool) User specified the working directory
-#define PMIX_DISPLAY_MAP                    "pmix.dispmap"          // (bool) display process map upon spawn
+#define PMIX_DISPLAY_MAP                    "pmix.dispmap"          // (bool) display placement map upon spawn
+#define PMIX_DISPLAY_MAP_DETAILED           "pmix.dispmapdet"       // (bool) display a highly detailed placement map upon spawn
+#define PMIX_DISPLAY_ALLOCATION             "pmix.dispalloc"        // (bool) display the resource allocation
+#define PMIX_DISPLAY_TOPOLOGY               "pmix.disptopo"         // (char*) comma-delimited list of hosts whose topology is
+                                                                    //         to be displayed
 #define PMIX_PPR                            "pmix.ppr"              // (char*) #procs to spawn on each identified resource
 #define PMIX_MAPBY                          "pmix.mapby"            // (char*) mapping policy
 #define PMIX_RANKBY                         "pmix.rankby"           // (char*) ranking policy

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -610,8 +610,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
          * rank should be known. So return them here if
          * requested */
         if (NULL != proc) {
-            pmix_strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
-            proc->rank = pmix_globals.myid.rank;
+            PMIX_LOAD_PROCID(proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
         }
         ++pmix_globals.init_cntr;
         /* we also need to check the info keys to see if something need
@@ -736,7 +735,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
         PMIX_CONSTRUCT(&pmix_server_globals.iof_residuals, pmix_list_t);
     } else {
         if (NULL != proc) {
-            pmix_strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
+            PMIX_LOAD_NSPACE(proc->nspace, evar);
         }
         PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, evar);
         /* set the global pmix_namespace_t object for our peer */
@@ -763,10 +762,10 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;
     }
-    pmix_globals.mypeer->info->pname.nspace = strdup(proc->nspace);
-    pmix_globals.mypeer->info->pname.rank = proc->rank;
-    PMIX_LOAD_PROCID(pmix_globals.myidval.data.proc, proc->nspace, proc->rank);
-    pmix_globals.myrankval.data.rank = proc->rank;
+    pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+    pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
+    PMIX_LOAD_PROCID(pmix_globals.myidval.data.proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
+    pmix_globals.myrankval.data.rank = pmix_globals.myid.rank;
 
     /* select our psec compat module - the selection will be based
      * on the corresponding envars that should have been passed

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1543,7 +1543,8 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t 
                 /* see if we already have one - we reuse the same sink for
                  * all streams */
                 PMIX_LIST_FOREACH(sink, &nptr->sinks, pmix_iof_sink_t) {
-                    if (sink->name.rank == name->rank) {
+                    if (sink->name.rank == name->rank &&
+                        ((stream & sink->tag) || nptr->iof_flags.merge)) {
                         channel = &sink->wev;
                         break;
                     }
@@ -1579,7 +1580,12 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t 
         if (PMIX_FWD_STDOUT_CHANNEL & stream) {
             channel = &pmix_client_globals.iof_stdout.wev;
         } else {
-            channel = &pmix_client_globals.iof_stderr.wev;
+            if(!myflags.merge) {
+                channel = &pmix_client_globals.iof_stderr.wev;
+            }
+            else {
+                channel = &pmix_client_globals.iof_stdout.wev;
+            }
         }
     }
 

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -596,6 +596,10 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
     }
 
     sptr = pmix_gds_hash_check_session(trk, sid);
+    if (NULL == sptr) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
     PMIX_CONSTRUCT(&ncache, pmix_list_t);
 
     for (j = 1; j < size; j++) {


### PR DESCRIPTION
[iof: Fix merging of stderr to stdout.](https://github.com/openpmix/openpmix/commit/f799291e2ac274e5a7ccc56d32c26776d3a764f5)

Also, make sure stderr/stdout are seperated when writing
to files.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/1491f3e92d803dbd039f8c61a25c282964895753)

[Fix bad dereferences when passed a NULL parameter to PMIx_Init](https://github.com/openpmix/openpmix/commit/45a540285d70611618ada328e869c7479c708586)

Missed a couple of spots that reference the "proc" parameter in
PMIx_Init, which is allowed to be NULL. Use a different place
to get the desired data and avoid the issue.

Thanks to @krempel-pt for the report.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/65df29a746ece16e282e9170f73f024d13eba0c3)

[Add new attribute definitions to support display options](https://github.com/openpmix/openpmix/commit/065c1f184f25a0bfa6940d2b5a3f40ef9b083231)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/195e36f1d6bb711ee5a4b4e03f78c37f593944ab)

Thanks to @krempel-pt for the report

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/ac7abc6e432cd3fe2d5a72809a987f180133d668)
