### PR TITLE
Release GIL before registering event handler

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1360,7 +1360,8 @@ cdef class PMIxClient:
             ninfo = 0
 
         # pass our hdlr switchyard to the API
-        rc = PMIx_Register_event_handler(codes, ncodes, info, ninfo, pyeventhandler, NULL, NULL)
+        with nogil:
+             rc = PMIx_Register_event_handler(codes, ncodes, info, ninfo, pyeventhandler, NULL, NULL)
 
         # cleanup
         if 0 < ninfo:


### PR DESCRIPTION
Newfound bug can result in deadlocks in the Python bindings when calling `PMIx_Register_event_handler()`. Add change to drop GIL before registering a new event handler.