### PR TITLE
Allow printing of info and value structs prior to init

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -44,6 +44,14 @@ char* PMIx_Info_string(const pmix_info_t *info)
     pmix_status_t rc;
     char *output = NULL;
 
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        pmix_bfrops_base_print_info(&output, NULL, (void*)info, PMIX_INFO);
+        return output;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
     PMIX_BFROPS_PRINT(rc, pmix_globals.mypeer,
                       &output, NULL,
                       (void*)info, PMIX_INFO);
@@ -57,6 +65,14 @@ char* PMIx_Value_string(const pmix_value_t *value)
 {
     pmix_status_t rc;
     char *output = NULL;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        pmix_bfrops_base_print_value(&output, NULL, (void*)value, PMIX_VALUE);
+        return output;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     PMIX_BFROPS_PRINT(rc, pmix_globals.mypeer,
                       &output, NULL,

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -44,13 +44,10 @@ char* PMIx_Info_string(const pmix_info_t *info)
     pmix_status_t rc;
     char *output = NULL;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         pmix_bfrops_base_print_info(&output, NULL, (void*)info, PMIX_INFO);
         return output;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     PMIX_BFROPS_PRINT(rc, pmix_globals.mypeer,
                       &output, NULL,
@@ -66,13 +63,10 @@ char* PMIx_Value_string(const pmix_value_t *value)
     pmix_status_t rc;
     char *output = NULL;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         pmix_bfrops_base_print_value(&output, NULL, (void*)value, PMIX_VALUE);
         return output;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     PMIX_BFROPS_PRINT(rc, pmix_globals.mypeer,
                       &output, NULL,


### PR DESCRIPTION
Allow the PMIx_Info_string and PMIx_Value_string functions to
successfully complete prior to calling PMIx_Init (in whatever
form).

Fixes https://github.com/openpmix/openpmix/issues/2723
Signed-off-by: Ralph Castain <rhc@pmix.org>