### PR TITLE
Do not set the buffer type in construct

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -138,8 +138,9 @@ PMIX_CLASS_INSTANCE(pmix_bfrops_base_active_module_t, pmix_list_item_t, NULL, mo
 /** Value **/
 static void pmix_buffer_construct(pmix_buffer_t *buffer)
 {
-    /** set the default buffer type */
-    buffer->type = pmix_bfrops_globals.default_type;
+    /** set the buffer type  to UNDEF so the first pack operation
+     * can correctly set it */
+    buffer->type = PMIX_BFROP_BUFFER_UNDEF;
 
     /* Make everything NULL to begin with */
     buffer->base_ptr = buffer->pack_ptr = buffer->unpack_ptr = NULL;


### PR DESCRIPTION
Need to let the first pack command set the buffer type
so it gets set to that of the remote side. Otherwise,
you get an error if the other side is different than that
of the sender.

Thanks to @david-edwards-arm for reporting the problem

Signed-off-by: Ralph Castain <rhc@pmix.org>