### PR TITLE
Add some detail to warning output by flex detector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,10 +222,12 @@ fi
 # check for Flex
 AC_PROG_LEX(noyywrap)
 if test "x$LEX" != xflex && test ! -e $PMIX_TOP_SRCDIR/src/util/keyval/keyval_lex.c; then
-    AC_MSG_WARN([PMIx requires Flex to build from sources that were not])
-    AC_MSG_WARN([fully pre-processed (e.g., an official release tarball),])
-    AC_MSG_WARN([but Flex was not found. Please install Flex into])
-    AC_MSG_WARN([your path and try again])
+    AC_MSG_WARN([*** Could not find Flex on your system.])
+    AC_MSG_WARN([*** Flex is required for developer builds of PMIx.])
+    AC_MSG_WARN([*** Other versions of Lex are not supported.])
+    AC_MSG_WARN([*** NOTE: If you are building from an official tarball])
+    AC_MSG_WARN([*** (not the ones made by GitHub!) downloaded from the])
+    AC_MSG_WARN([*** OpenPMIx web site, you do not need Flex.])
     AC_MSG_ERROR([Cannot continue])
 fi
 


### PR DESCRIPTION
Ensure they know they need flex for GitHub-generated
tarballs (but not our offical ones).

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 1f0b53f482a659e3a19e20983fc1b0637b52bb14)