### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2006-2022 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2022 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
@@ -831,29 +831,25 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     #
 
     AC_MSG_CHECKING([for default value of mca_base_component_show_load_errors])
-    AC_ARG_ENABLE([show-load-errors-by-default],
-                  [AS_HELP_STRING([--enable-show-load-errors-by-default],
-                                  [Set the default value for the MCA parameter
-                                   mca_base_component_show_load_errors (but can be
-                                   overridden at run time by the usual
-                                   MCA-variable-setting mechansism).  This MCA variable
-                                   controls whether warnings are displayed when an MCA
-                                   component fails to load at run time due to an error.
-                                   (default: enabled in --enable-debug builds, meaning that
-                                   mca_base_component_show_load_errors is enabled
-                                   by default when configured with --enable-debug])])
-    if test "$enable_show_load_errors_by_default" = "no" ; then
-        PMIX_SHOW_LOAD_ERRORS_DEFAULT=0
-        AC_MSG_RESULT([disabled by default])
-    else
-        PMIX_SHOW_LOAD_ERRORS_DEFAULT=$WANT_DEBUG
-        if test "$WANT_DEBUG" = "1"; then
-            AC_MSG_RESULT([enabled by default])
-        else
-            AC_MSG_RESULT([disabled by default])
-        fi
+    AC_ARG_WITH([show-load-errors],
+                [AS_HELP_STRING([--with-show-load-errors],
+                                [Set the default value for the MCA
+                                parameter
+                                mca_base_component_show_load_errors (but
+                                can be overridden at run time by the usual
+                                MCA-variable-setting mechansism).
+                                (default: "all")])])
+
+    if test -z "$with_show_load_errors" || \
+       test "$with_show_load_errors" = "yes"; then
+        with_show_load_errors=all
+        AC_MSG_RESULT([enabled for all (by default)])
+    elif test "$with_show_load_errors" = "no"; then
+        with_show_load_errors=none
+        AC_MSG_RESULT([disabled for all (by default)])
     fi
-    AC_DEFINE_UNQUOTED(PMIX_SHOW_LOAD_ERRORS_DEFAULT, $PMIX_SHOW_LOAD_ERRORS_DEFAULT,
+
+    AC_DEFINE_UNQUOTED(PMIX_SHOW_LOAD_ERRORS_DEFAULT, ["$with_show_load_errors"],
                        [Default value for mca_base_component_show_load_errors MCA variable])
 
     AC_MSG_CHECKING([for subdir args])

--- a/examples/client.c
+++ b/examples/client.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      ParTec AG.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -148,8 +149,8 @@ int main(int argc, char **argv)
      * is included, then the process will be stopped in this call until
      * the "debugger release" notification arrives */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
-                rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
         exit(0);
     }
     fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
@@ -218,8 +219,8 @@ int main(int argc, char **argv)
 
     /* get our universe size */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank,
@@ -229,8 +230,8 @@ int main(int argc, char **argv)
     /* get the number of procs in our job - univ size is the total number of allocated
      * slots, not the number of procs in the job */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     nprocs = val->data.uint32;
@@ -245,8 +246,8 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Store_internal failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Store_internal failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     free(tmp);
@@ -257,8 +258,8 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     free(tmp);
@@ -269,16 +270,16 @@ int main(int argc, char **argv)
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     free(tmp);
 
     /* push the data to our PMIx server */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     if (0 == myproc.rank) {
@@ -292,8 +293,8 @@ int main(int argc, char **argv)
     flag = true;
     PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank,
-                rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
         goto done;
     }
     PMIX_INFO_FREE(info, 1);
@@ -339,8 +340,8 @@ int main(int argc, char **argv)
                 exit(1);
             }
             if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace,
-                        myproc.rank, tmp, rc);
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace,
+                        myproc.rank, tmp, PMIx_Error_string(rc));
                 free(tmp);
                 goto done;
             }
@@ -367,8 +368,8 @@ int main(int argc, char **argv)
                 exit(1);
             }
             if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace,
-                        myproc.rank, tmp, rc);
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace,
+                        myproc.rank, tmp, PMIx_Error_string(rc));
                 free(tmp);
                 goto done;
             }
@@ -397,8 +398,8 @@ done:
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
     } else {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
                 myproc.nspace, myproc.rank);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -63,6 +63,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <ctype.h>
 #include <sys/time.h> /* for struct timeval */
 #include <unistd.h> /* for uid_t and gid_t */
 #include <sys/types.h> /* for uid_t and gid_t */
@@ -3462,13 +3463,76 @@ typedef struct pmix_info {
 #define PMIX_INFO_IS_PERSISTENT(ii)  \
     ((ii)->flags & PMIX_INFO_PERSISTENT)
 
+typedef enum {
+    PMIX_BOOL_TRUE,
+    PMIX_BOOL_FALSE,
+    PMIX_NON_BOOL
+} pmix_boolean_t;
+
+/**
+ * Provide a check to see if a value is "true" or
+ * "false", whether given as a string or boolean
+ * input.
+ */
+static inline pmix_boolean_t pmix_check_true(const pmix_value_t *value)
+{
+    char *ptr;
+
+    if (PMIX_UNDEF == value->type) {
+        return PMIX_BOOL_TRUE; // default to true
+    }
+    if (PMIX_BOOL == value->type) {
+        if (value->data.flag) {
+            return PMIX_BOOL_TRUE;
+        } else {
+            return PMIX_BOOL_FALSE;
+        }
+    }
+    if (PMIX_STRING == value->type) {
+        if (NULL == value->data.string) {
+            return PMIX_BOOL_TRUE;
+        }
+        ptr = value->data.string;
+        /* Trim leading whitespace */
+        while (isspace(*ptr)) {
+            ++ptr;
+        }
+        if ('\0' == *ptr) {
+            return PMIX_BOOL_TRUE;
+        }
+        if (isdigit(*ptr)) {
+            if (0 == atoi(ptr)) {
+                return PMIX_BOOL_FALSE;
+            } else {
+                return PMIX_BOOL_TRUE;
+            }
+        } else if (0 == strncasecmp(ptr, "yes", 3) ||
+                   0 == strncasecmp(ptr, "true", 4)) {
+            return PMIX_BOOL_TRUE;
+        } else if (0 == strncasecmp(ptr, "no", 2) ||
+                   0 == strncasecmp(ptr, "false", 5)) {
+            return PMIX_BOOL_FALSE;
+        }
+    }
+
+    return PMIX_NON_BOOL;
+}
+
+/* provide a macro version of it for those preferring
+ * that syntax in their codes where they know the
+ * value being checked IS a boolean of some form
+ */
+#define PMIX_CHECK_TRUE(a) \
+    (PMIX_BOOL_TRUE == pmix_check_true(a) ? true : false)
+
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
  * type of PMIX_UNDEF is taken to imply a boolean "true"
  * as the presence of the key defaults to indicating
- * "true" */
+ * "true". Also supports passing of string representations
+ * such as "t" or "f" */
 #define PMIX_INFO_TRUE(m)   \
-    (PMIX_UNDEF == (m)->value.type || (PMIX_BOOL == (m)->value.type && (m)->value.data.flag)) ? true : false
+    (PMIX_BOOL_TRUE == pmix_check_true(&(m)->value) ? true : false)
 
 
 /****    PMIX LOOKUP RETURN STRUCT    ****/

--- a/src/mca/base/help-pmix-mca-base.txt
+++ b/src/mca/base/help-pmix-mca-base.txt
@@ -10,8 +10,9 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2019 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -60,6 +61,25 @@ all components *except* a and b", while "c,d" specifies the inclusive
 behavior and means "use *only* components c and d."
 
 You cannot mix inclusive and exclusive behavior.
+#
+[internal error during init]
+An internal error has occurred during the startup of PMIx.  This
+is highly unusual and shouldn't happen.
+
+The following message may provide additional insight into the error:
+
+  Failure at:      %s (%s:%d)
+  Error:           %d (%s)
+#
+[show_load_errors: too many /]
+The pmix_mca_base_component_show_load_errors MCA variable cannot
+contain a token that has more than one "/" character in it.
+
+The pmix_mca_base_component_show_load_errors MCA variable can only
+contain the values: all, none, or a comma-delimited list of tokens in
+the form of "framework" or "framework/component".
+
+  Erroneous value: %s
 #
 [failed to add component dir]
 The pmix_mca_base_component_path MCA variable was used to add paths to

--- a/src/mca/base/pmix_base.h
+++ b/src/mca/base/pmix_base.h
@@ -69,7 +69,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_component_priority_list_item_t)
  * Public variables
  */
 PMIX_EXPORT extern char *pmix_mca_base_component_path;
-PMIX_EXPORT extern bool pmix_mca_base_component_show_load_errors;
+PMIX_EXPORT extern char *pmix_mca_base_component_show_load_errors;
 PMIX_EXPORT extern bool pmix_mca_base_component_track_load_errors;
 PMIX_EXPORT extern bool pmix_mca_base_component_disable_dlopen;
 PMIX_EXPORT extern char *pmix_mca_base_system_default_path;
@@ -210,6 +210,10 @@ pmix_mca_base_framework_components_register(struct pmix_mca_base_framework_t *fr
                                             pmix_mca_base_register_flag_t flags);
 
 /* pmix_mca_base_components_open.c */
+PMIX_EXPORT int pmix_mca_base_show_load_errors_init(void);
+PMIX_EXPORT int pmix_mca_base_show_load_errors_finalize(void);
+PMIX_EXPORT bool pmix_mca_base_show_load_errors(const char *framework_name,
+                                                const char *component_name);
 PMIX_EXPORT int pmix_mca_base_framework_components_open(struct pmix_mca_base_framework_t *framework,
                                                         pmix_mca_base_open_flag_t flags);
 

--- a/src/mca/base/pmix_mca_base_close.c
+++ b/src/mca/base/pmix_mca_base_close.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
@@ -59,6 +59,9 @@ int pmix_mca_base_close(void)
 
         /* Shut down the dynamic component finder */
         pmix_mca_base_component_find_finalize();
+
+        /* Shut down the show_load_errors processing */
+        pmix_mca_base_show_load_errors_finalize();
 
         /* Close pmix output stream 0 */
         pmix_output_close(0);

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2019 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -390,8 +390,8 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
                         "%s MCA component \"%s\" at path %s",
                         ri->ri_type, ri->ri_name, ri->ri_path);
 
-    vl = pmix_mca_base_component_show_load_errors ? PMIX_MCA_BASE_VERBOSE_ERROR
-                                                  : PMIX_MCA_BASE_VERBOSE_INFO;
+    vl = pmix_mca_base_show_load_errors(ri->ri_type,
+                                        ri->ri_name) ? PMIX_MCA_BASE_VERBOSE_ERROR : PMIX_MCA_BASE_VERBOSE_INFO;;
 
     /* Ensure that this component is not already loaded (should only happen
        if it was statically loaded).  It's an error if it's already

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2022 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
@@ -36,6 +36,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_show_help.h"
 
 /*
  * Local functions
@@ -46,6 +47,223 @@ struct pmix_mca_base_dummy_framework_list_item_t {
     pmix_list_item_t super;
     pmix_mca_base_framework_t framework;
 };
+
+typedef struct fc_pair {
+    pmix_list_item_t li;
+    char *framework_name;
+    char *component_name;
+} fc_pair_t;
+
+PMIX_CLASS_DECLARATION(fc_pair_t);
+
+typedef enum {
+    SHOW_LOAD_ERRORS_ALL,
+    SHOW_LOAD_ERRORS_INCLUDE,
+    SHOW_LOAD_ERRORS_EXCLUDE,
+    SHOW_LOAD_ERRORS_NONE,
+} show_load_type_t;
+
+static show_load_type_t show_load_errors = SHOW_LOAD_ERRORS_ALL;
+static pmix_list_t show_load_errors_include = PMIX_LIST_STATIC_INIT;
+static pmix_list_t show_load_errors_exclude = PMIX_LIST_STATIC_INIT;
+
+
+static void fc_pair_constructor(struct fc_pair *obj)
+{
+    obj->framework_name = NULL;
+    obj->component_name = NULL;
+}
+
+static void fc_pair_destructor(struct fc_pair *obj)
+{
+    free(obj->framework_name);
+    obj->framework_name = NULL;
+    free(obj->component_name);
+    obj->component_name = NULL;
+}
+
+PMIX_CLASS_INSTANCE(fc_pair_t, pmix_list_item_t,
+                    fc_pair_constructor,
+                    fc_pair_destructor);
+
+/*
+ * Parse the content of the show_load_errors value
+ *
+ * Valid values:
+ * - "all"
+ * - "none"
+ * - comma-delimited list of items, each of which is
+ *   "framework[/component]"
+ *
+ * The comma-delimited list may be prefixed with a "^".
+ */
+int pmix_mca_base_show_load_errors_init(void)
+{
+    PMIX_CONSTRUCT(&show_load_errors_include, pmix_list_t);
+    PMIX_CONSTRUCT(&show_load_errors_exclude, pmix_list_t);
+
+    // Check to see if mca_base_component_show_load_errors is a
+    // boolean value
+    pmix_value_t value;
+    PMIX_VALUE_LOAD(&value, pmix_mca_base_component_show_load_errors, PMIX_STRING);
+    pmix_boolean_t ret = pmix_check_true(&value);
+
+    // Treat true values as a synonym for "all", and false values
+    // as a synonym for "none".
+    if (PMIX_BOOL_TRUE == ret) {
+        show_load_errors = SHOW_LOAD_ERRORS_ALL;
+    } else if (PMIX_BOOL_FALSE == ret) {
+        show_load_errors = SHOW_LOAD_ERRORS_NONE;
+    } else {
+        // must not be a bool, so treat as a string
+        if (0 == strcasecmp(pmix_mca_base_component_show_load_errors, "all")) {
+            show_load_errors = SHOW_LOAD_ERRORS_ALL;
+        } else if (0 == strcasecmp(pmix_mca_base_component_show_load_errors, "none")) {
+            show_load_errors = SHOW_LOAD_ERRORS_NONE;
+        } else {
+            // We have a comma-delimited list of values.  Is it
+            // "include"-style, or "exclude" style?
+            size_t pos = 0;
+            pmix_list_t *list = &show_load_errors_include;
+            show_load_errors = SHOW_LOAD_ERRORS_INCLUDE;
+            if ('^' == pmix_mca_base_component_show_load_errors[0]) {
+                pos = 1;
+                list = &show_load_errors_exclude;
+                show_load_errors = SHOW_LOAD_ERRORS_EXCLUDE;
+            }
+
+            // Examine each of the values in the comma-delimited list.
+            // Each value can be of the form "framework" or
+            // "framework/component".
+            char **values = pmix_argv_split(pmix_mca_base_component_show_load_errors + pos,
+                                            ',');
+            if (values == NULL) {
+                ret = PMIX_ERROR;
+                pmix_show_help("help-mca-base.txt",
+                               "internal error during init", true,
+                               __func__, __FILE__, __LINE__,
+                               ret,
+                               "Failed to argv split pmix_mca_base_component_show_load_errors");
+                return ret;
+            }
+
+            char **split;
+            int argc;
+            fc_pair_t *fcp;
+            for (int i = 0; values[i] != NULL; ++i) {
+                split = pmix_argv_split(values[i], '/');
+                if (NULL == split) {
+                    ret = PMIX_ERROR;
+                    pmix_show_help("help-mca-base.txt",
+                                   "internal error during init", true,
+                                   __func__, __FILE__, __LINE__,
+                                   ret,
+                                   "Failed to argv split pmix_mca_base_component_show_load_errors value");
+                    return ret;
+                }
+
+                argc = pmix_argv_count(split);
+                if (0 == argc) {
+                    // This should never happen
+                    ret = PMIX_ERROR;
+                    pmix_show_help("help-mca-base.txt",
+                                   "internal error during init", true,
+                                   __func__, __FILE__, __LINE__,
+                                   ret,
+                                   "Argv split resulted in 0 tokens");
+                    return ret;
+                }
+
+                if (0 == strlen(split[0])) {
+                    // Empty entry (e.g., consecutive commas); silently
+                    // skip it
+                    continue;
+                }
+
+                if (argc > 2) {
+                    ret = PMIX_ERR_BAD_PARAM;
+                    pmix_show_help("help-mca-base.txt",
+                                   "show_load_errors: too many /", true,
+                                   values[i]);
+                    return ret;
+                }
+
+                fcp = PMIX_NEW(fc_pair_t);
+                if (NULL == fcp) {
+                    ret = PMIX_ERR_OUT_OF_RESOURCE;
+                    pmix_show_help("help-mca-base.txt",
+                                   "internal error during init", true,
+                                   __func__, __FILE__, __LINE__,
+                                   ret,
+                                   "Failed to alloc new fc_pair_t");
+                    return ret;
+                }
+
+                fcp->framework_name = split[0];
+                if (2 == argc) {
+                    fcp->component_name = split[1];
+                }
+
+                pmix_list_append(list, &fcp->li);
+            }
+            pmix_argv_free(values);
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+bool pmix_mca_base_show_load_errors(const char *framework_name,
+                                    const char *component_name)
+{
+    if (SHOW_LOAD_ERRORS_ALL == show_load_errors) {
+        return true;
+    } else if (SHOW_LOAD_ERRORS_NONE == show_load_errors) {
+        return false;
+    }
+
+    // If we get here, it means we have an include or exclude list.
+    // Setup for what to do based on whether it's an include or
+    // exclude list.
+    pmix_list_t *list;
+    bool value_if_match_found;
+
+    if (SHOW_LOAD_ERRORS_INCLUDE == show_load_errors) {
+        list = &show_load_errors_include;
+        value_if_match_found = true;
+    } else {
+        list = &show_load_errors_exclude;
+        value_if_match_found = false;
+    }
+
+    // See if the framework_name/component_name pair is found in the
+    // active list.
+    fc_pair_t *item;
+    PMIX_LIST_FOREACH(item, list, fc_pair_t) {
+        if (0 == strcmp(framework_name, item->framework_name)) {
+            if (NULL == item->component_name) {
+                // If there's no component name, then we're matching
+                // all components in this framework.
+                return value_if_match_found;
+            } else if (0 == strcmp(component_name, item->component_name)) {
+                // We matched both the framework *and* component name.
+                return value_if_match_found;
+            }
+        }
+    }
+
+    // We didn't find a match.
+    return !value_if_match_found;
+}
+
+int pmix_mca_base_show_load_errors_finalize(void)
+{
+    PMIX_DESTRUCT(&show_load_errors_include);
+    PMIX_DESTRUCT(&show_load_errors_exclude);
+
+    return PMIX_SUCCESS;
+}
 
 /**
  * Function for finding and opening either all MCA components, or the
@@ -138,7 +356,8 @@ static int open_components(pmix_mca_base_framework_t *framework)
                        display the error in the stream where it was
                        expected. */
 
-                    if (pmix_mca_base_component_show_load_errors) {
+                    if (pmix_mca_base_show_load_errors(component->pmix_mca_type_name,
+                                                       component->pmix_mca_component_name)) {
                         pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_ERROR, output_id,
                                             "mca: base: components_open: component %s "
                                             "/ %s open function failed",

--- a/src/mca/base/pmix_mca_base_components_register.c
+++ b/src/mca/base/pmix_mca_base_components_register.c
@@ -118,7 +118,8 @@ static int register_components(pmix_mca_base_framework_t *framework)
                    display the error in the stream where it was
                    expected. */
 
-                if (pmix_mca_base_component_show_load_errors) {
+                if (pmix_mca_base_show_load_errors(component->pmix_mca_type_name,
+                                                   component->pmix_mca_component_name)) {
                     pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_ERROR, output_id,
                                         "pmix:mca: base: components_register: component %s "
                                         "/ %s register function failed",

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -50,7 +50,7 @@ char *pmix_mca_base_component_path = NULL;
 int pmix_mca_base_opened = 0;
 char *pmix_mca_base_system_default_path = NULL;
 char *pmix_mca_base_user_default_path = NULL;
-bool pmix_mca_base_component_show_load_errors = (bool) PMIX_SHOW_LOAD_ERRORS_DEFAULT;
+char *pmix_mca_base_component_show_load_errors = NULL;
 bool pmix_mca_base_component_track_load_errors = false;
 bool pmix_mca_base_component_disable_dlopen = false;
 
@@ -107,15 +107,29 @@ int pmix_mca_base_open(void)
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     free(value);
 
-    pmix_mca_base_component_show_load_errors = (bool) PMIX_SHOW_LOAD_ERRORS_DEFAULT;
+    pmix_mca_base_component_show_load_errors = PMIX_SHOW_LOAD_ERRORS_DEFAULT;
     var_id = pmix_mca_base_var_register(
-        "pmix", "mca", "base", "component_show_load_errors",
-        "Whether to show errors for components that failed to load or not",
-        PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_9,
-        PMIX_MCA_BASE_VAR_SCOPE_READONLY, &pmix_mca_base_component_show_load_errors);
+                                        "pmix", "mca", "base", "component_show_load_errors",
+                                        "Whether to show errors for components that failed to load or not. "
+                                        "Valid values are \"all\" (meaning: all load failures are reported), "
+                                        "\"none\" (no load failures are reported), or a comma-delimited list "
+                                        "of items, each of which can be a framework/component pair or a framework "
+                                        "name (only load failures from the specifically-listed items are reported). "
+                                        "If the comma-delimited list is prefixed with \"^\", then orientation of "
+                                        "the list is negated: warn about all load failures *except* for the listed items.",
+                                        PMIX_MCA_BASE_VAR_TYPE_STRING,  NULL, 0,
+                                        PMIX_MCA_BASE_VAR_FLAG_NONE, PMIX_INFO_LVL_9,
+                                        PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                        &pmix_mca_base_component_show_load_errors);
     (void) pmix_mca_base_var_register_synonym(var_id, "pmix", "mca", NULL,
                                               "component_show_load_errors",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
+    // Parse the mca_base_component_show_load_errors value
+    int ret = pmix_mca_base_show_load_errors_init();
+    if (PMIX_SUCCESS != ret) {
+        return ret;
+    }
 
     pmix_mca_base_component_track_load_errors = false;
     var_id = pmix_mca_base_var_register(


### PR DESCRIPTION
[Consistently use PMIx_Error_string in client example](https://github.com/openpmix/openpmix/commit/896c081deb696b505fbfc004dc38c5fdd2c94d06)

Signed-off-by: Stephan Krempel <krempel@par-tec.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/8465992fc88cd3e0e9315da488b2bafb0941d8ce)

[Convert the MCA parameter "pmix_mca_base_component_show_load_errors"](https://github.com/openpmix/openpmix/commit/a72c896be48ff5202f25cb75e5f1a27c051a8c4b)

to be a flexible mechanism to specify when (and when not) to emit
warnings about errors when trying to load DSO components.

Port of https://github.com/open-mpi/ompi/pull/10763

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6927bc40c97151163bb49c76d1f0a73318b2f6ec)
