### PR TITLE
Revert deletion of common Makefile.am required by autogen.pl

### DIFF
--- a/src/mca/common/Makefile.am
+++ b/src/mca/common/Makefile.am
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2022 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Note that this file must exist, even though it is empty (there is no
+# "base" directory for the common framework).  autogen.pl and
+# opal_mca.m4 assume that every framework has a top-level Makefile.am.
+# We *could* adjust the framework glue code to exclude "common" from
+# this requirement, but it's just a lot easier to have an empty
+# Makefile.am here.


### PR DESCRIPTION
The missing common Makefile.am resulted in the following error from autogen.pl:
> Missing src/mca/common/Makefile.am at ./autogen.pl line 96.