### PR TITLE
Clean up left over .gitignore entry after mca/common/* removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,6 @@ src/include/pmix_dictionary.h
 src/mca/pinstalldirs/config/pinstall_dirs.h
 src/mca/pdl/base/static-components.h
 src/mca/pinstalldirs/base/static-components.h
-src/mca/common/sse/sse_lex.c
 
 src/tools/pattrs/pattrs
 src/tools/pevent/pevent


### PR DESCRIPTION
Clean up left over .gitignore entry after mca/common/* removal in 4f8a4bdc