### PR TITLE
Fix Coverity CID #378400

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -732,8 +732,12 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        lg->hostname = strdup(kv->value->data.string);
-                        PMIX_RELEASE(kv);
+                        if (NULL != kv) {  // will never be NULL
+                            lg->hostname = strdup(kv->value->data.string);
+                            PMIX_RELEASE(kv);
+                        } else {
+                            lg->hostname = strdup("unknown");
+                        }
                     } else {
                         /* try for the nodeid */
                         cb2.key = PMIX_NODEID;
@@ -741,8 +745,12 @@ static void get_data(int sd, short args, void *cbdata)
                         if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                             kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                             PMIX_DESTRUCT(&cb2);
-                            PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
-                            PMIX_RELEASE(kv);
+                            if (NULL != kv) {  // will never be NULL
+                                PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
+                                PMIX_RELEASE(kv);
+                            } else {
+                                rc = PMIX_ERROR;
+                            }
                             if (PMIX_SUCCESS != rc) {
                                 cb->status = rc;
                                 goto done;

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -643,14 +643,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                 PMIX_DESTRUCT(&cb2);
-                PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
-                PMIX_RELEASE(kv);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_RELEASE(cb);
-                    PMIX_DESTRUCT(&cb2);
-                    return PMIX_ERR_BAD_PARAM;
+                if (NULL != kv) {  // should never be NULL
+                    PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
+                    PMIX_RELEASE(kv);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_RELEASE(cb);
+                        PMIX_DESTRUCT(&cb2);
+                        return PMIX_ERR_BAD_PARAM;
+                    }
+                    cb->nmembers += jsize;
                 }
-                cb->nmembers += jsize;
             } else {
                 PMIX_RELEASE(cb);
                 PMIX_DESTRUCT(&cb2);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1172,8 +1172,12 @@ static pmix_status_t write_output_line(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                cptr = strdup(kv->value->data.string);
-                PMIX_RELEASE(kv);
+                if (NULL != kv) {  // should never be NULL
+                    cptr = strdup(kv->value->data.string);
+                    PMIX_RELEASE(kv);
+                } else {
+                    cptr = strdup("unknown");
+                }
             } else {
                 cptr = strdup("unknown");
             }
@@ -1187,12 +1191,16 @@ static pmix_status_t write_output_line(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
-                PMIX_RELEASE(kv);
-                if (PMIX_SUCCESS != rc) {
-                    pidstring = strdup("unknown");
+                if (NULL != kv) { // should never be NULL
+                    PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
+                    PMIX_RELEASE(kv);
+                    if (PMIX_SUCCESS != rc) {
+                        pidstring = strdup("unknown");
+                    } else {
+                        pmix_asprintf(&pidstring, "%u", pid);
+                    }
                 } else {
-                    pmix_asprintf(&pidstring, "%u", pid);
+                    pidstring = strdup("unknown");
                 }
             } else {
                 pidstring = strdup("unknown");

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -127,6 +127,7 @@ do {                                    \
     if (NULL != (d)->value) {           \
         PMIX_VALUE_RELEASE((d)->value); \
     }                                   \
+    free(d);                            \
 } while(0)
 
 /* define a struct for passing topology objects */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4120,7 +4120,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
     char *grpid;
     pmix_proc_t *procs;
     pmix_group_t *grp, *pgrp;
-    pmix_info_t *info = NULL, *iptr, *grpinfoptr = NULL;
+    pmix_info_t *info = NULL, *iptr = NULL, *grpinfoptr = NULL;
     size_t n, ninfo, ninf, nprocs, n2, ngrpinfo = 0;
     pmix_server_trkr_t *trk;
     struct timeval tv = {0, 0};
@@ -4445,6 +4445,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
                 PMIX_INFO_FREE(trk->info, trk->ninfo);
                 trk->info = iptr;
                 trk->ninfo = n2;
+                iptr = NULL;
             }
         }
         rc = pmix_host_server.group(PMIX_GROUP_CONSTRUCT, grp->grpid, trk->pcs, trk->npcs,
@@ -4470,6 +4471,9 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
 error:
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
+    }
+    if (NULL != iptr) {
+        PMIX_INFO_FREE(iptr, n2);
     }
     return rc;
 }

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -235,12 +235,15 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
         PMIX_DSTOR_RELEASE(hv);
         return rc;
     }
-    pmix_output_verbose(10, pmix_globals.debug_output,
-                        "%s ADDING KEY %s VALUE %s FOR RANK %s WITH %u QUALS TO TABLE %s",
-                        PMIX_NAME_PRINT(&pmix_globals.myid),
-                        kin->key, PMIx_Value_string(kin->value),
-                        PMIX_RANK_PRINT(rank), (unsigned)m,
-                        table->ht_label);
+    if (9 < pmix_output_get_verbosity(pmix_globals.debug_output)) {
+        char *v = PMIx_Value_string(kin->value);
+        pmix_output(0, "%s ADDING KEY %s VALUE %s FOR RANK %s WITH %u QUALS TO TABLE %s",
+                    PMIX_NAME_PRINT(&pmix_globals.myid),
+                    kin->key, v,
+                    PMIX_RANK_PRINT(rank), (unsigned)m,
+                    table->ht_label);
+        free(v);
+    }
     pmix_pointer_array_add(&proc_data->data, hv);
     return PMIX_SUCCESS;
 }

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -551,7 +551,7 @@ static pmix_status_t read_topic(FILE *fp, char ***array)
         if (0 == strncmp(line, "#include#", strlen("#include#"))) {
             /* keyword "include" found - check for file/topic */
             file = &line[strlen("#include#")];
-            if (NULL == file) {
+            if (0 == strlen(file)) {
                 /* missing filename */
                 free(line);
                 return PMIX_ERR_BAD_PARAM;


### PR DESCRIPTION
Ensure we release the pmix_dstor_t object itself

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fix Coverity CID #380553

It is just debug output, but ensure we free the character
string returned by PMIx_Value_string

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fix Coverity CID #380367

Protect against possible NULL list item

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID #379775

The list item removed from the list should never be NULL,
but silence Coverity anyway.

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes CID #379495

Protect against possible NULL pointer, even though that
pointer really can never be NULL

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID #379233

Fix check for zero-length string

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID 378450

Fix resource leak in error path

Signed-off-by: Ralph Castain <rhc@pmix.org>