### PR TITLE
Multiple commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,6 @@ src/include/pmix_dictionary.h
 src/mca/pinstalldirs/config/pinstall_dirs.h
 src/mca/pdl/base/static-components.h
 src/mca/pinstalldirs/base/static-components.h
-src/mca/common/sse/sse_lex.c
 
 src/tools/pattrs/pattrs
 src/tools/pevent/pevent

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -3525,6 +3525,9 @@ static inline pmix_boolean_t pmix_check_true(const pmix_value_t *value)
 #define PMIX_CHECK_TRUE(a) \
     (PMIX_BOOL_TRUE == pmix_check_true(a) ? true : false)
 
+#define PMIX_CHECK_BOOL(a) \
+    (PMIX_NON_BOOL == pmix_check_true(a) ? false : true)
+
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
  * type of PMIX_UNDEF is taken to imply a boolean "true"

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -643,14 +643,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                 PMIX_DESTRUCT(&cb2);
-                PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
-                PMIX_RELEASE(kv);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_RELEASE(cb);
-                    PMIX_DESTRUCT(&cb2);
-                    return PMIX_ERR_BAD_PARAM;
+                if (NULL != kv) {  // should never be NULL
+                    PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
+                    PMIX_RELEASE(kv);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_RELEASE(cb);
+                        PMIX_DESTRUCT(&cb2);
+                        return PMIX_ERR_BAD_PARAM;
+                    }
+                    cb->nmembers += jsize;
                 }
-                cb->nmembers += jsize;
             } else {
                 PMIX_RELEASE(cb);
                 PMIX_DESTRUCT(&cb2);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1172,8 +1172,12 @@ static pmix_status_t write_output_line(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                cptr = strdup(kv->value->data.string);
-                PMIX_RELEASE(kv);
+                if (NULL != kv) {  // should never be NULL
+                    cptr = strdup(kv->value->data.string);
+                    PMIX_RELEASE(kv);
+                } else {
+                    cptr = strdup("unknown");
+                }
             } else {
                 cptr = strdup("unknown");
             }
@@ -1187,12 +1191,16 @@ static pmix_status_t write_output_line(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
-                PMIX_RELEASE(kv);
-                if (PMIX_SUCCESS != rc) {
-                    pidstring = strdup("unknown");
+                if (NULL != kv) { // should never be NULL
+                    PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
+                    PMIX_RELEASE(kv);
+                    if (PMIX_SUCCESS != rc) {
+                        pidstring = strdup("unknown");
+                    } else {
+                        pmix_asprintf(&pidstring, "%u", pid);
+                    }
                 } else {
-                    pmix_asprintf(&pidstring, "%u", pid);
+                    pidstring = strdup("unknown");
                 }
             } else {
                 pidstring = strdup("unknown");

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -127,6 +127,7 @@ do {                                    \
     if (NULL != (d)->value) {           \
         PMIX_VALUE_RELEASE((d)->value); \
     }                                   \
+    free(d);                            \
 } while(0)
 
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4114,7 +4114,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
     char *grpid;
     pmix_proc_t *procs;
     pmix_group_t *grp, *pgrp;
-    pmix_info_t *info = NULL, *iptr, *grpinfoptr = NULL;
+    pmix_info_t *info = NULL, *iptr = NULL, *grpinfoptr = NULL;
     size_t n, ninfo, ninf, nprocs, n2, ngrpinfo = 0;
     pmix_server_trkr_t *trk;
     struct timeval tv = {0, 0};
@@ -4439,6 +4439,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
                 PMIX_INFO_FREE(trk->info, trk->ninfo);
                 trk->info = iptr;
                 trk->ninfo = n2;
+                iptr = NULL;
             }
         }
         rc = pmix_host_server.group(PMIX_GROUP_CONSTRUCT, grp->grpid, trk->pcs, trk->npcs,
@@ -4464,6 +4465,9 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
 error:
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
+    }
+    if (NULL != iptr) {
+        PMIX_INFO_FREE(iptr, n2);
     }
     return rc;
 }

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -235,6 +235,33 @@ static inline bool pmix_check_cli_option(char *a, char *b)
 #define PMIX_CHECK_CLI_OPTION(a, b) \
     pmix_check_cli_option(a, b)
 
+static inline unsigned int pmix_convert_string_to_time(const char *t)
+{
+    char **tmp = pmix_argv_split(t, ':');
+    int sz = pmix_argv_count(tmp);
+    unsigned int tm;
+
+    /* work upwards from the bottom, where the
+     * bottom represents seconds, then minutes,
+     * then hours, and then days */
+    tm = strtoul(tmp[sz-1], NULL, 10);
+    if (0 <= (sz-2) && NULL != tmp[sz-2]) {
+        tm += 60 * strtoul(tmp[sz-2], NULL, 10);
+    }
+    if (0 <= (sz-3) && NULL != tmp[sz-3]) {
+        tm += 60 * 60 * strtoul(tmp[sz-3], NULL, 10);
+    }
+    if (0 <= (sz-4) && NULL != tmp[sz-4]) {
+        tm += 24 * 60 * 60 * strtoul(tmp[sz-4], NULL, 10);
+    }
+    pmix_argv_free(tmp);
+    return tm;
+}
+
+#define PMIX_CONVERT_TIME(s)    \
+    pmix_convert_string_to_time(s)
+
+
 #define PMIX_CLI_DEBUG_LIST(r)  \
 do {                                                                    \
     pmix_cli_item_t *_c;                                                \

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -235,12 +235,15 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
         PMIX_DSTOR_RELEASE(hv);
         return rc;
     }
-    pmix_output_verbose(10, pmix_globals.debug_output,
-                        "%s ADDING KEY %s VALUE %s FOR RANK %s WITH %u QUALS TO TABLE %s",
-                        PMIX_NAME_PRINT(&pmix_globals.myid),
-                        kin->key, PMIx_Value_string(kin->value),
-                        PMIX_RANK_PRINT(rank), (unsigned)m,
-                        table->ht_label);
+    if (9 < pmix_output_get_verbosity(pmix_globals.debug_output)) {
+        char *v = PMIx_Value_string(kin->value);
+        pmix_output(0, "%s ADDING KEY %s VALUE %s FOR RANK %s WITH %u QUALS TO TABLE %s",
+                    PMIX_NAME_PRINT(&pmix_globals.myid),
+                    kin->key, v,
+                    PMIX_RANK_PRINT(rank), (unsigned)m,
+                    table->ht_label);
+        free(v);
+    }
     pmix_pointer_array_add(&proc_data->data, hv);
     return PMIX_SUCCESS;
 }

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -552,7 +552,7 @@ static pmix_status_t read_topic(FILE *fp, char ***array)
         if (0 == strncmp(line, "#include#", strlen("#include#"))) {
             /* keyword "include" found - check for file/topic */
             file = &line[strlen("#include#")];
-            if (NULL == file) {
+            if (0 == strlen(file)) {
                 /* missing filename */
                 free(line);
                 return PMIX_ERR_BAD_PARAM;


### PR DESCRIPTION
[Clean up left over .gitignore entry after mca/common/* removal in](https://github.com/openpmix/openpmix/commit/a54c92f846e820d62dca38387e0cb8b81d09000c) https://github.com/openpmix/openpmix/commit/4f8a4bdcd0bc6b5124a2cf8d683b75254a5beb8d

https://github.com/openpmix/openpmix/commit/4f8a4bdcd0bc6b5124a2cf8d683b75254a5beb8d

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/11925eee34111c8a9aaa3abbdc304723637b2860)

[Fix Coverity CID #378400](https://github.com/openpmix/openpmix/commit/6ef7ee523247b49a62743e04d81a3452290cf7c4)

Ensure we release the pmix_dstor_t object itself

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fix Coverity CID #380553

It is just debug output, but ensure we free the character
string returned by PMIx_Value_string

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fix Coverity CID #380367

Protect against possible NULL list item

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID #379775

The list item removed from the list should never be NULL,
but silence Coverity anyway.

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes CID #379495

Protect against possible NULL pointer, even though that
pointer really can never be NULL

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID #379233

Fix check for zero-length string

Signed-off-by: Ralph Castain <rhc@pmix.org>

Fixes Coverity CID 378450

Fix resource leak in error path

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/13377c57ba55d0971d986245ff7ad65fe2db6c42)

[Add a couple more definitions](https://github.com/openpmix/openpmix/commit/e37e89c037a2276e3ccd7bebe17a2aaed2aaa312)

Porting from PRRTE for more general use

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/073251a455c68503426f0629ad7703d9ecc9f749)
