### PR TITLE
Ensure tools relay events to their server

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -217,6 +217,10 @@ PMIX_EXPORT pmix_status_t pmix_server_notify_client_of_event(pmix_status_t statu
                                                              pmix_data_range_t range,
                                                              const pmix_info_t info[], size_t ninfo,
                                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t pmix_notify_server_of_event(pmix_status_t status, const pmix_proc_t *source,
+                                                      pmix_data_range_t range, const pmix_info_t info[],
+                                                      size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata,
+                                                      bool dolocal);
 
 PMIX_EXPORT void pmix_event_timeout_cb(int fd, short flags, void *arg);
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -157,6 +157,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     pmix_cmd_t cmd;
     pmix_event_chain_t *chain;
     size_t ninfo;
+    pmix_data_range_t range;
     PMIX_HIDE_UNUSED_PARAMS(peer, hdr, cbdata);
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
@@ -226,14 +227,33 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
             goto error;
         }
     }
+    /* unpack the range, if provided */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &range, &cnt, PMIX_DATA_RANGE);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(chain);
+        goto error;
+    }
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        range = PMIX_RANGE_LOCAL;
+    }
+    if (PMIX_RANGE_LOCAL != range && pmix_globals.connected &&
+        !(PMIX_CHECK_NSPACE(peer->nptr->nspace, pmix_client_globals.myserver->nptr->nspace) &&
+          peer->info->pname.rank == pmix_client_globals.myserver->info->pname.rank)) {
+        pmix_output_verbose(2, pmix_client_globals.event_output,
+                            "[%s:%d] pmix:tool_notify_recv - relaying to server",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank);
+        rc = pmix_notify_server_of_event(chain->status, &chain->source, range,
+                                         chain->info, chain->ninfo, NULL, NULL, false);
+    }
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
         "[%s:%d] pmix:tool_notify_recv - processing event %s from source %s:%d, calling errhandler",
         pmix_globals.myid.nspace, pmix_globals.myid.rank, PMIx_Error_string(chain->status),
         chain->source.nspace, chain->source.rank);
 
-    rc = pmix_server_notify_client_of_event(chain->status, &chain->source,
-                                            PMIX_RANGE_LOCAL, // will be ignored
+    rc = pmix_server_notify_client_of_event(chain->status, &chain->source, range,
                                             chain->info, chain->ninfo, _notify_complete, chain);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
Tools can be chained from one tool to another, eventually connecting to a server. Events passed to a tool must be propagated along the chain to ensure all targets receive them.

Thanks to @david-edwards-arm for the report.

Signed-off-by: Ralph Castain <rhc@pmix.org>