### PR TITLE
Ensure tools relay events to their server

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -192,6 +192,10 @@ PMIX_EXPORT pmix_status_t pmix_server_notify_client_of_event(pmix_status_t statu
                                                              pmix_data_range_t range,
                                                              const pmix_info_t info[], size_t ninfo,
                                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t pmix_notify_server_of_event(pmix_status_t status, const pmix_proc_t *source,
+                                                      pmix_data_range_t range, const pmix_info_t info[],
+                                                      size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata,
+                                                      bool dolocal);
 
 PMIX_EXPORT void pmix_event_timeout_cb(int fd, short flags, void *arg);
 


### PR DESCRIPTION
Tools can be chained from one tool to another, eventually connecting to a server. Events passed to a tool must be propagated along the chain to ensure all targets receive them.

Thanks to @david-edwards-arm for the report.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit db800a63eb2c2aeac982a39313d32f644c8e2f22)