### PR TITLE
Add improved debug and correct param passing to pmix_init_util

### DIFF
--- a/etc/pmix-mca-params.conf
+++ b/etc/pmix-mca-params.conf
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,28 +20,28 @@
 #
 
 # This is the default system-wide MCA parameters defaults file.
-# Specifically, the MCA parameter "mca_param_files" defaults to a
+# The MCA parameter "mca_param_files" defaults to a
 # value of
 # "$HOME/.pmix/mca-params.conf:$sysconf/pmix-mca-params.conf"
-# (this file is the latter of the two).  So if the default value of
-# mca_param_files is not changed, this file is used to set system-wide
-# MCA parameters.  This file can therefore be used to set system-wide
-# default MCA parameters for all users.  Of course, users can override
-# these values if they want, but this file is an excellent location
-# for setting system-specific MCA parameters for those users who don't
-# know / care enough to investigate the proper values for them.
+# (this file is the latter of the two).  The list of files are parsed
+# in a right-to-left manner so that the user-level default file values
+# naturally overwrite those from the default system file.  This file
+# can therefore be used to set system-wide default MCA parameters for
+# all users.
 
 # Note that this file is only applicable where it is visible (in a
-# filesystem sense).  Specifically, processes each read this file
-# during their call to PMIx_Init to determine what default values for MCA
-# parameters should be used.  Launchers generally do not bundle up the values in
-# this file from the node where they are run and send them to all nodes;
-# the default value decisions are effectively distributed.  Hence,
-# these values are typically only applicable on nodes that "see" this file.  If
-# $sysconf is a directory on a local disk, it is likely that changes
-# to this file will need to be propagated to other nodes.  If $sysconf
-# is a directory that is shared via a networked filesystem, changes to
-# this file will be visible to all nodes that share this $sysconf.
+# filesystem sense).  Launchers in some PMIx-enabled environments
+# (e.g., PRRTE) will read and forward the values to the backend
+# compute nodes, thus providing for a more scalable startup procedure.
+#
+# For launchers do not provide this service, processes each read this
+# file during their call to PMIx_Init to determine what default values
+# for MCA parameters should be used. This necessitates that the file be
+# visible on all nodes, and can result in significant startup procedure
+# delays as large numbers of processes attempt to simultaneously read/parse
+# the files. Also note that if $sysconf is a directory on a local disk
+# in this case, it is likely that changes to this file will need to be
+# propagated to other nodes prior to launching your job
 
 # The format is straightforward: one per line, mca_param_name =
 # rvalue.  Quoting is ignored (so if you use quotes or escape
@@ -55,5 +56,5 @@
 # Change component loading path
 #   mca_base_component_path = /usr/local/lib/pmix:~/my_pmix_components
 
-# See "pinfo --param all all --level 9" for a full listing of PMIx
+# See "pmix_info --param all all" for a full listing of PMIx
 # MCA parameters available and their default values.

--- a/src/mca/base/help-pmix-mca-var.txt
+++ b/src/mca/base/help-pmix-mca-var.txt
@@ -14,6 +14,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2018      Intel, Inc. All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -122,19 +123,3 @@ starting your job.
 
   Value:      %s
   Source:     %s
-#
-[incorrect-env-list-param]
-WARNING: The format of "pmix_mca_base_env_list" parameter is a delimited list of VAR=VAL or
-VAR instances. By default, the delimiter is a semicolon: VAR1=VAL1;VAR2;VAR3=VAL3;...
-You can set other via "pmix_mca_base_env_list_delimiter" parameter. If the delimiter is a
-semicolon, the value of "pmix_mca_base_env_list" variable should be quoted to not interfere
-with SHELL command line parsing. In the case where a value is not assigned to variable
-VAR, the value will be taken from the current environment.
-The following environment variable was not found in the environment:
-  Variable:             %s
-  MCA variable value:   %s
-#
-[incorrect-env-list-sep]
-An invalid value was supplied for an MCA variable "pmix_mca_base_env_list_delimiter".
-The "pmix_mca_base_env_list" variable will be ignored.
-  Value:     %s

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -106,7 +106,8 @@ int pmix_mca_base_component_find(const char *directory, pmix_mca_base_framework_
     PMIX_HIDE_UNUSED_PARAMS(open_dso_components);
 
     pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_COMPONENT, framework->framework_output,
-                        "mca: base: component_find: searching %s for %s components", directory,
+                        "mca: base: component_find: searching %s for %s components",
+                        (NULL == directory) ? "NULL" : directory,
                         framework->framework_name);
 
     if (!ignore_requested) {
@@ -139,10 +140,9 @@ int pmix_mca_base_component_find(const char *directory, pmix_mca_base_framework_
         find_dyn_components(directory, framework, (const char **) requested_component_names,
                             include_mode);
     } else {
-        pmix_output_verbose(
-            PMIX_MCA_BASE_VERBOSE_INFO, 0,
-            "pmix:mca: base: component_find: dso loading for %s MCA components disabled",
-            framework->framework_name);
+        pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_INFO, 0,
+                            "pmix:mca: base: component_find: dso loading for %s MCA components disabled",
+                            framework->framework_name);
     }
 #endif
 
@@ -235,7 +235,8 @@ static void find_dyn_components(const char *path, pmix_mca_base_framework_t *fra
     int ret;
 
     pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_COMPONENT, framework->framework_output,
-                        "mca: base: find_dyn_components: checking %s for %s components", path,
+                        "mca: base: find_dyn_components: checking %s for %s components",
+                        (NULL == path) ? "NULL" : path,
                         framework->framework_name);
 
     if (NULL != path) {

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -111,6 +111,9 @@ static int process_repository_item(const char *filename, void *data)
     /* check if the plugin has the appropriate prefix */
     pmix_asprintf(&prefix, "%s_mca_", project);
     if (0 != strncmp(base, prefix, strlen(prefix))) {
+        if (pmix_mca_base_show_load_errors(NULL, NULL)) {
+            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected %s", filename, prefix);
+        }
         free(base);
         free(prefix);
         return PMIX_SUCCESS;
@@ -224,9 +227,9 @@ int pmix_mca_base_component_repository_add(const char *project,
 
     dir = strtok_r(path_to_use, sep, &ctx);
     do {
-        if (0 != pmix_pdl_foreachfile(dir, process_repository_item, (void*)project)
-            && !(0 == strcmp(dir, pmix_mca_base_system_default_path)
-                 || 0 == strcmp(dir, pmix_mca_base_user_default_path))) {
+        if (0 != pmix_pdl_foreachfile(dir, process_repository_item, (void*)project) &&
+            !(0 == strcmp(dir, pmix_mca_base_system_default_path) ||
+              0 == strcmp(dir, pmix_mca_base_user_default_path))) {
             // It is not an error if a directory fails to add (e.g.,
             // if it doesn't exist).  But we should warn about it as
             // it is something related to "show_load_errors"

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -222,6 +222,9 @@ bool pmix_mca_base_show_load_errors(const char *framework_name,
     } else if (SHOW_LOAD_ERRORS_NONE == show_load_errors) {
         return false;
     }
+    if (NULL == framework_name) {
+        return false;
+    }
 
     // If we get here, it means we have an include or exclude list.
     // Setup for what to do based on whether it's an include or
@@ -242,7 +245,7 @@ bool pmix_mca_base_show_load_errors(const char *framework_name,
     fc_pair_t *item;
     PMIX_LIST_FOREACH(item, list, fc_pair_t) {
         if (0 == strcmp(framework_name, item->framework_name)) {
-            if (NULL == item->component_name) {
+            if (NULL == component_name) {
                 // If there's no component name, then we're matching
                 // all components in this framework.
                 return value_if_match_found;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -127,7 +127,7 @@ static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel, int room_n
 
 static bool util_initialized = false;
 
-int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir)
+int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
 {
     pmix_status_t ret;
 
@@ -160,7 +160,7 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir)
     }
 
     /* initialize the help system */
-    pmix_show_help_init(helpdir);
+    pmix_show_help_init(NULL);
 
     /* keyval lex-based parser */
     if (PMIX_SUCCESS != (ret = pmix_util_keyval_parse_init())) {
@@ -181,7 +181,7 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir)
     }
 
     /* initialize the mca */
-    if (PMIX_SUCCESS != (ret = pmix_mca_base_open(NULL))) {
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_open(libdir))) {
         fprintf(stderr, "pmix_mca_base_open failed\n");
         return ret;
     }


### PR DESCRIPTION
The param passed to pmix_init_util is the libdir of the caller.

Signed-off-by: Ralph Castain <rhc@pmix.org>