### PR TITLE
Fix the buildrpm script

### DIFF
--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -94,7 +94,7 @@ echo "--> Found specfile: $specfile"
 # Find where the top RPM-building directory is
 #
 
-rpmtopdir=${rpmtopdir:-"`grep %_topdir $HOME/.rpmmacros | awk '{ print $2 }'`"}
+rpmtopdir=${rpmtopdir:-$HOME/RPMBUILD}
 if test "$rpmtopdir" != ""; then
 	rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then


### PR DESCRIPTION
Current code never finds home directory RPMBUILD, so simplify it so it works.

Signed-off-by: Ralph Castain <rhc@pmix.org>