### PR TITLE
Export the output_stream_t class declaration

### DIFF
--- a/src/util/pmix_output.h
+++ b/src/util/pmix_output.h
@@ -536,7 +536,7 @@ PMIX_EXPORT void pmix_output_hexdump(int verbose_level, int output_id, void *ptr
  * The intended usage is to invoke the constructor and then enable
  * the output fields that you want.
  */
-PMIX_CLASS_DECLARATION(pmix_output_stream_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_output_stream_t);
 
 END_C_DECLS
 


### PR DESCRIPTION
Needs to be visible so PRRTE can use it

Signed-off-by: Ralph Castain <rhc@pmix.org>