### PR TITLE
Multiple commits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,10 +23,18 @@ other, a single NEWS-worthy item might apply to different series. For
 example, a bug might be fixed in the master, and then moved to
 multiple release branches.
 
-4.2.1 -- 09 Sept 2022
+4.2.1 -- 13 Sept 2022
 ----------------------
+ - PR #2754 Multiple commits
+    - Export the output_stream_t class declaration
+    - Update NEWS for release
+ - PR #2752 Catch missing library renames
+ - PR #2751 Multiple commits
+    - Remove stale m4 and unimplemented function declaration
+    - Mark that proc arrays being passed have been sorted
+    - Add improved debug and correct param passing to pmix_init_util
  - PR #2747 Final prep for release
- = PR #2746 Ensure tools relay events to their server
+ - PR #2746 Ensure tools relay events to their server
  - PR #2744 Multiple commits
     - Clean up leftover .gitignore entry
     - Fix a number of Coverity issues

--- a/src/util/pmix_output.h
+++ b/src/util/pmix_output.h
@@ -536,7 +536,7 @@ PMIX_EXPORT void pmix_output_hexdump(int verbose_level, int output_id, void *ptr
  * The intended usage is to invoke the constructor and then enable
  * the output fields that you want.
  */
-PMIX_CLASS_DECLARATION(pmix_output_stream_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_output_stream_t);
 
 END_C_DECLS
 


### PR DESCRIPTION
[Export the output_stream_t class declaration](https://github.com/openpmix/openpmix/commit/43129256059df203db17b1464e83b0e50a6e1997)

Needs to be visible so PRRTE can use it

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7aed475954d7b4d3fe5786cde7f4e33fd6c58954)

[Update NEWS for release](https://github.com/openpmix/openpmix/commit/460998e9a4ccfd87de73d35d06810956332c62f7)

Signed-off-by: Ralph Castain <rhc@pmix.org>