### PR TITLE
pnet/nvd: Fix macro escaping issue

### DIFF
--- a/src/mca/pnet/nvd/configure.m4
+++ b/src/mca/pnet/nvd/configure.m4
@@ -20,6 +20,8 @@
 # MCA_pmix_pnet_nvd_CONFIG(prefix, [action-if-found], [action-if-not-found])
 # --------------------------------------------------------
 AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
+    PMIX_VAR_SCOPE_PUSH([pmix_nvd_happy])
+
     AC_CONFIG_FILES([src/mca/pnet/nvd/Makefile])
 
     AS_IF([test "yes" = "no"],
@@ -28,7 +30,7 @@ AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
           [$2
            pmix_nvd_happy=no])
 
-    PMIX_SUMMARY_ADD([Transports], [NVIDIA], [], [$pmix_nvd_happy])])])
+    PMIX_SUMMARY_ADD([Transports], [NVIDIA], [], [$pmix_nvd_happy])
 
     PMIX_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
Add an OAC_VAR_SCOPE_PUSH to protect the temp variable and fix escaping that was causing confusion on Autoconf's part (the VAR_SCOPE_POP was outside the macro body, so screwed up any AC_REQUIREs in OAC_VAR_SCOPE_POP).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>