### PR TITLE
llvm/oneapi: fixes to bring pmix up to iso c99

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -63,10 +63,10 @@ int pmix_bfrops_base_output = 0;
 
 static int pmix_bfrop_register(pmix_mca_base_register_flag_t flags)
 {
+    PMIX_HIDE_UNUSED_PARAMS(flags);
+
     if (PMIX_MCA_BASE_REGISTER_DEFAULT == flags) {
         /* do something to silence warning */
-        int count = 0;
-        ++count;
     }
     pmix_bfrops_globals.initial_size = PMIX_BFROP_DEFAULT_INITIAL_SIZE;
     pmix_mca_base_var_register("pmix", "bfrops", "base", "initial_size", "Initial size of a buffer",

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -106,7 +106,7 @@ int pmix_tsd_key_create(pmix_tsd_key_t *key, pmix_tsd_destructor_t destructor)
     return rc;
 }
 
-int pmix_tsd_keys_destruct()
+int pmix_tsd_keys_destruct(void)
 {
     int i;
     void *ptr;
@@ -125,7 +125,7 @@ int pmix_tsd_keys_destruct()
     return PMIX_SUCCESS;
 }
 
-void pmix_thread_set_main()
+void pmix_thread_set_main(void)
 {
     pmix_main_thread = pthread_self();
 }

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -674,12 +674,12 @@ void pmix_info_show_mca_params(const char *type, const char *component)
     }
 }
 
-void pmix_info_do_arch()
+void pmix_info_do_arch(void)
 {
     pmix_info_out("Configured architecture", "config:arch", PMIX_ARCH);
 }
 
-void pmix_info_do_hostname()
+void pmix_info_do_hostname(void)
 {
     pmix_info_out("Configure host", "config:host", PMIX_CONFIGURE_HOST);
 }

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -165,7 +165,7 @@ do_local_init:
     return pmix_tsd_key_create(&hostname_tsd_key, hostname_cleanup);
 }
 
-int pmix_net_finalize()
+int pmix_net_finalize(void)
 {
     free(private_ipv4);
     private_ipv4 = NULL;
@@ -400,12 +400,12 @@ int pmix_net_get_port(const struct sockaddr *addr)
 
 #else /* HAVE_STRUCT_SOCKADDR_IN */
 
-int pmix_net_init()
+int pmix_net_init(void)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_net_finalize()
+int pmix_net_finalize(void)
 {
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
compliance at least as far as the LLVM on which the Intel OneAPI 2022 release is based (14).  LLVM is getting pickier about what it lets through in terms of ISO C99 compliance when using -Werror, etc.

Related to https://reviews.llvm.org/D122983

Without this patch and without disabling developer flags (which is very difficult when building within spack without adding yet another variant) one gets these sorts of errors at compile time.

pmix_net.c:168:22: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]

threads/thread.c:109:27: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes] int pmix_tsd_keys_destruct()
                          ^
                           void

base/bfrop_base_frame.c:68:13: error: variable 'count' set but not used [-Werror,-Wunused-but-set-variable]
        int count = 0;

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>