### PR TITLE
Add action to check commits on pull requests

### DIFF
--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -1,0 +1,28 @@
+name: PR Checks CI
+
+# We're using pull_request_target here instead of just pull_request so that the
+# action runs in the context of the base of the pull request, rather than in the
+# context of the merge commit. For more detail about the differences, see:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+on:
+    pull_request_target:
+        # We don't need this to be run on all types of PR behavior
+        # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+        types:
+          - opened
+          - synchronize
+          - edited
+
+permissions: {} # none
+
+jobs:
+  check:
+    permissions:
+      pull-requests: write
+    name: Check Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Commit Checker
+        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        with:
+          token: "${{ secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
The action checks each commit in a pull request to see if

* the committer / author do not match bad patterns ("root@", "localhost", etc.)
* a "Signed-off-by:" line exists
* a "cherry picked from" message appears, if required by config inputs (not required by default)
  * if the message exists, ensure the referenced commit exists

If all commit checks pass, the action successfully completes and the action check for the PR passes. If any commit check fails, the action check fails as well. Additionally, a comment is posted to the pull request, describing which commits failed which test and suggesting the user fix them.

Signed-off-by: Joe Downs <joe@dwns.dev>

-------
### Comment Example:
![image](https://user-images.githubusercontent.com/48387830/191418194-a73cf4e7-c2f3-47fb-a3a6-e2db5afd7291.png)

-------

@rhc54 Finally got the ompi commit checker moved to [its own repo](https://github.com/open-mpi/pr-git-commit-checker) as [you requested](https://github.com/open-mpi/ompi/pull/10789). It should be ready to go right now, however, I'm not sure if you or anyone else wants to make some changes. For the most part, these don't affect the operation of the action, but maintainers may want to change for personal taste / project requirements.

1. Filename (`pr-target.yaml`)
2. Action name (`PR Checks CI`)
3. Tracking reference (`@v1.0.0`)

Any of these can be changed if needed. I just gave them names that I thought make sense. I think probably the biggest point of discussion is no. 3, and perhaps @jsquyres has some thoughts on it.

I set it up to track the [v1.0.0 release](https://github.com/open-mpi/pr-git-commit-checker/releases/tag/v1.0.0). Which is of course the most stable, but means the file needs to be updated if we ever add more to the action. To save that (admittedly minor) trouble, I think it would be best to instead track a `v1` branch. That way, the YAML file doesn't have to be updated to make use of any changes. Honestly, we may never add anything extra, but maybe there could be some QoL updates in the future, or other small additions.

Lastly, do you also want the labeler for this repo and PRRTE?  If so, I can easily add that to this YAML. (It is in [its own repo](https://github.com/open-mpi/pr-labeler) as well). However, it might need a minor tweak, due to this repo's difference in label names.