### PR TITLE
Provide more detailed process failure codes and fix CLI parsing

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1331,15 +1331,21 @@ typedef int pmix_status_t;
 #define PMIX_ERR_JOB_INSUFFICIENT_RESOURCES         -234
 #define PMIX_ERR_JOB_SYS_OP_FAILED                  -235
 
-/* job-related non-error events */
+/* job/session-related non-error events */
 #define PMIX_EVENT_JOB_START                        -191
 #define PMIX_EVENT_JOB_END                          -145
 #define PMIX_EVENT_SESSION_START                    -192
 #define PMIX_EVENT_SESSION_END                      -193
 
 /* process-related events */
+#define PMIX_ERR_PROC_REQUESTED_ABORT               -8
 #define PMIX_ERR_PROC_TERM_WO_SYNC                  -200
 #define PMIX_EVENT_PROC_TERMINATED                  -201
+#define PMIX_ERR_PROC_KILLED_BY_CMD                 -400
+#define PMIX_ERR_PROC_FAILED_TO_START               -401
+#define PMIX_ERR_PROC_ABORTED_BY_SIG                -402
+#define PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED         -403
+#define PMIX_ERR_EXIT_NONZERO_TERM                  -404
 
 /* system failures */
 #define PMIX_EVENT_SYS_BASE                         -230

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -76,7 +76,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 #define PMIX_ERR_SILENT                             -2
 #define PMIX_ERR_DEBUGGER_RELEASE                   -3
 #define PMIX_ERR_PROC_ABORTED                       -7
-#define PMIX_ERR_PROC_REQUESTED_ABORT               -8
 #define PMIX_ERR_PROC_ABORTING                      -9
 #define PMIX_ERR_SERVER_FAILED_REQUEST              -10
 #define PMIX_EXISTS                                 -11

--- a/src/util/pmix_error.c
+++ b/src/util/pmix_error.c
@@ -64,6 +64,16 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
         return "PROC-ABORT-REQUESTED";
     case PMIX_ERR_PROC_ABORTING:
         return "PROC-ABORTING";
+    case PMIX_ERR_PROC_KILLED_BY_CMD:
+        return"PROC-KILLED-BY-CMD";
+    case PMIX_ERR_PROC_FAILED_TO_START:
+        return "PROC-FAILED-TO-START";
+    case PMIX_ERR_PROC_ABORTED_BY_SIG:
+        return "PROC-ABORTED-BY-SIG";
+    case PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED:
+        return "PROC-SENSOR-BOUND-EXCEEDED";
+    case PMIX_ERR_EXIT_NONZERO_TERM:
+        return "PROC-EXIT-NONZERO-TERM";
 
     case PMIX_ERR_SERVER_FAILED_REQUEST:
         return "SERVER FAILED REQUEST";


### PR DESCRIPTION
Restore a couple of deprecated status codes and add a few relevant to process fault reporting.

Fix the cmd line option parser to better support multi-word directives.

Signed-off-by: Ralph Castain <rhc@pmix.org>