### PR TITLE
pmix reinit: a fix to allow pmix to be reinitable

### DIFF
--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -48,6 +48,7 @@
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
+#include "src/runtime/pmix_init_util.h"
 #include <event.h>
 
 #include "src/runtime/pmix_progress_threads.h"
@@ -161,4 +162,6 @@ void pmix_rte_finalize(void)
     /* now safe to release the event base */
     (void) pmix_progress_thread_stop(NULL);
     pmix_tsd_keys_destruct();
+
+    pmix_finalize_util();
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -558,3 +558,9 @@ return_error:
     }
     return ret;
 }
+
+int pmix_finalize_util(void)
+{
+    util_initialized = false;
+    return PMIX_SUCCESS;
+}

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -36,6 +36,7 @@ PMIX_EXPORT extern const char* pmix_tool_org;
 PMIX_EXPORT extern const char* pmix_tool_msg;
 
 PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
+PMIX_EXPORT int pmix_finalize_util(void);
 
 END_C_DECLS
 


### PR DESCRIPTION
I thought we had a CI test to check this but apparently it didn't detect this break. This is work using OMPI main at 14bc2ed496

Anway, without this patch, if one uses MPI Sessions with this sequence:

MPI_Session_init
MPI_Session_finalize
MPI_Session_init

the app will flame out with this type of traceback:

Starting second init
sessions_init_twice: pmix_pointer_array.c:234: pmix_pointer_array_add: Assertion `(table->addr != NULL) && (table->size > 0)' failed. [er-head:1794920] *** Process received signal ***
[er-head:1794920] Signal: Aborted (6)
[er-head:1794920] Signal code:  (-6)
[er-head:1794920] [ 0] /lib64/libpthread.so.0(+0x12c20)[0x7ffff7476c20] [er-head:1794920] [ 1] /lib64/libc.so.6(gsignal+0x10f)[0x7ffff70d637f] [er-head:1794920] [ 2] /lib64/libc.so.6(abort+0x127)[0x7ffff70c0db5] [er-head:1794920] [ 3] /lib64/libc.so.6(+0x21c89)[0x7ffff70c0c89] [er-head:1794920] [ 4] /lib64/libc.so.6(+0x2fa76)[0x7ffff70cea76] [er-head:1794920] [ 5] XXXXX/install/lib/libpmix.so.0(pmix_pointer_array_add+0x8d)[0x7ffff53f82a9] [er-head:1794920] [ 6] XXXXX/install/lib/libpmix.so.0(+0x15fd80)[0x7ffff53f2d80] [er-head:1794920] [ 7] XXXXX/install/lib/libpmix.so.0(pmix_mca_base_var_group_register+0x64)[0x7ffff53f3044] [er-head:1794920] [ 8] XXXXX/install/lib/libpmix.so.0(pmix_mca_base_framework_register+0x207)[0x7ffff53f48fc] [er-head:1794920] [ 9] XXXXX/install/lib/libpmix.so.0(pmix_mca_base_framework_open+0x46)[0x7ffff53f4ad0] [er-head:1794920] [10] XXXXX/install/lib/libpmix.so.0(pmix_rte_init+0x1d84)[0x7ffff539a3fb] [er-head:1794920] [11] XXXXX/install/lib/libpmix.so.0(PMIx_Init+0x5a2)[0x7ffff52f6ddd] [er-head:1794920] [12] XXXXX/install/lib/libmpi.so.0(ompi_rte_init+0x12e)[0x7ffff772c7e7] [er-head:1794920] [13] XXXXX/install/lib/libmpi.so.0(+0xb450b)[0x7ffff773850b] [er-head:1794920] [14] XXXXX/install/lib/libmpi.so.0(ompi_mpi_instance_init+0x72)[0x7ffff77396f7] [er-head:1794920] [15] XXXXX/install/lib/libmpi.so.0(PMPI_Session_init+0x1dd)[0x7ffff77b4e35] [er-head:1794920] [16] ./sessions_init_twice[0x401174] [er-head:1794920] [17] /lib64/libc.so.6(__libc_start_main+0xf3)[0x7ffff70c2493] [er-head:1794920] [18] ./sessions_init_twice[0x400c4e] [er-head:1794920] *** End of error message ***
-------------------------------------------------------------------------- prterun noticed that process rank 0 with PID 0 on node er-head exited on signal 6 (Aborted).

Signed-off-by: Howard Pritchard <howardp@lanl.gov>