### PR TITLE
Plug a memory leak

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -635,6 +635,9 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
         cb->cbfunc.valuefn = cbfunc;
         cb->cbdata = cbdata;
         PMIX_THREADSHIFT(cb, gcbfn);
+        if (copy) {
+            PMIX_INFO_FREE(iptr, nfo);
+        }
         return PMIX_SUCCESS;
     }
 


### PR DESCRIPTION
Ensure we release the created info array if we successfully traverse the "fastpath" in pmix_client_get

Fixes https://github.com/openpmix/openpmix/issues/2572
Signed-off-by: Ralph Castain <rhc@pmix.org>

bot:notacherrypick