### PR TITLE
PMIX_OBJ_STATIC_INIT: fixed initialization

### DIFF
--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -319,13 +319,15 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.tma_malloc = NULL,             \
-            .obj_tma.tma_calloc = NULL,             \
-            .obj_tma.tma_realloc = NULL,            \
-            .obj_tma.tma_strdup = NULL,             \
-            .obj_tma.tma_memmove = NULL,            \
-            .obj_tma.tma_free = NULL,               \
-            .obj_tma.data_ptr = NULL,               \
+            .obj_tma = {                            \
+                .tma_malloc = NULL,                 \
+                .tma_calloc = NULL,                 \
+                .tma_realloc = NULL,                \
+                .tma_strdup = NULL,                 \
+                .tma_memmove = NULL,                \
+                .tma_free = NULL,                   \
+                .data_ptr = NULL                    \
+            },                                      \
             .cls_init_file_name = __FILE__,         \
             .cls_init_lineno = __LINE__             \
         }
@@ -335,13 +337,15 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.tma_malloc = NULL,             \
-            .obj_tma.tma_calloc = NULL,             \
-            .obj_tma.tma_realloc = NULL,            \
-            .obj_tma.tma_strdup = NULL,             \
-            .obj_tma.tma_memmove = NULL,            \
-            .obj_tma.tma_free = NULL,               \
-            .obj_tma.data_ptr = NULL                \
+            .obj_tma = {                            \
+                .tma_malloc = NULL,                 \
+                .tma_calloc = NULL,                 \
+                .tma_realloc = NULL,                \
+                .tma_strdup = NULL,                 \
+                .tma_memmove = NULL,                \
+                .tma_free = NULL,                   \
+                .data_ptr = NULL                    \
+            }                                       \
         }
 #endif
 


### PR DESCRIPTION
- there is potential issue in PMIX object: GCC v4.8.5 may fail to compile static initializer used in PMIX (it seems compiler issue)
- minor redesign of initializer to better fit C99 standard allows to workaround issue

compiler reports issue:
```
make[3]: Entering directory `ompi/3rd-party/openpmix/src/include'
  CC       pmix_globals.lo
pmix_globals.c:65:1: error: missing initializer for field ‘tma_realloc’ of ‘pmix_tma_t’ [-Werror=missing-field-initializers]
PMIX_EXPORT pmix_lock_t pmix_global_lock = {.mutex = PMIX_MUTEX_STATIC_INIT,
^
In file included from ompi/3rd-party/openpmix/src/util/pmix_output.h:76:0,
                 from ompi/3rd-party/openpmix/src/include/pmix_types.h:55,
                 from pmix_globals.c:26:
ompi/3rd-party/openpmix/src/class/pmix_object.h:221:13: note: ‘tma_realloc’ declared here
     void *(*tma_realloc)(struct pmix_tma *, void *, size_t);
             ^
pmix_globals.c:65:1: error: missing initializer for field ‘tma_strdup’ of ‘pmix_tma_t’ [-Werror=missing-field-initializers]
```

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>