### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=2
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=rc1
+greek=rc2
 
 # PMIx Standard Compliance Level
 # The major and minor numbers indicate the version

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -301,13 +301,15 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.tma_malloc = NULL,             \
-            .obj_tma.tma_calloc = NULL,             \
-            .obj_tma.tma_realloc = NULL,            \
-            .obj_tma.tma_strdup = NULL,             \
-            .obj_tma.tma_memmove = NULL,            \
-            .obj_tma.arena = NULL,                  \
-            .obj_tma.dontfree = false,              \
+            .obj_tma = {                            \
+                .tma_malloc = NULL,                 \
+                .tma_calloc = NULL,                 \
+                .tma_realloc = NULL,                \
+                .tma_strdup = NULL,                 \
+                .tma_memmove = NULL,                \
+                .arena = NULL,                      \
+                .dontfree = false                   \
+            },                                      \
             .cls_init_file_name = __FILE__,         \
             .cls_init_lineno = __LINE__             \
         }
@@ -317,13 +319,15 @@ PMIX_EXPORT extern int pmix_class_init_epoch;
             .obj_class = PMIX_CLASS(BASE_CLASS),    \
             .obj_lock = PTHREAD_MUTEX_INITIALIZER,  \
             .obj_reference_count = 1,               \
-            .obj_tma.tma_malloc = NULL,             \
-            .obj_tma.tma_calloc = NULL,             \
-            .obj_tma.tma_realloc = NULL,            \
-            .obj_tma.tma_strdup = NULL,             \
-            .obj_tma.tma_memmove = NULL,            \
-            .obj_tma.arena = NULL,                  \
-            .obj_tma.dontfree = false               \
+            .obj_tma = {                            \
+                .tma_malloc = NULL,                 \
+                .tma_calloc = NULL,                 \
+                .tma_realloc = NULL,                \
+                .tma_strdup = NULL,                 \
+                .tma_memmove = NULL,                \
+                .arena = NULL,                      \
+                .dontfree = false                   \
+            }                                       \
         }
 #endif
 

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -63,10 +63,10 @@ int pmix_bfrops_base_output = 0;
 
 static int pmix_bfrop_register(pmix_mca_base_register_flag_t flags)
 {
+    PMIX_HIDE_UNUSED_PARAMS(flags);
+
     if (PMIX_MCA_BASE_REGISTER_DEFAULT == flags) {
         /* do something to silence warning */
-        int count = 0;
-        ++count;
     }
     pmix_bfrops_globals.initial_size = PMIX_BFROP_DEFAULT_INITIAL_SIZE;
     pmix_mca_base_var_register("pmix", "bfrops", "base", "initial_size", "Initial size of a buffer",

--- a/src/mca/pnet/nvd/configure.m4
+++ b/src/mca/pnet/nvd/configure.m4
@@ -20,6 +20,8 @@
 # MCA_pmix_pnet_nvd_CONFIG(prefix, [action-if-found], [action-if-not-found])
 # --------------------------------------------------------
 AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
+    PMIX_VAR_SCOPE_PUSH([pmix_nvd_happy])
+
     AC_CONFIG_FILES([src/mca/pnet/nvd/Makefile])
 
     AS_IF([test "yes" = "no"],
@@ -28,7 +30,7 @@ AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
           [$2
            pmix_nvd_happy=no])
 
-    PMIX_SUMMARY_ADD([Transports], [NVIDIA], [], [$pmix_nvd_happy])])])
+    PMIX_SUMMARY_ADD([Transports], [NVIDIA], [], [$pmix_nvd_happy])
 
     PMIX_VAR_SCOPE_POP
 ])

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -106,7 +106,7 @@ int pmix_tsd_key_create(pmix_tsd_key_t *key, pmix_tsd_destructor_t destructor)
     return rc;
 }
 
-int pmix_tsd_keys_destruct()
+int pmix_tsd_keys_destruct(void)
 {
     int i;
     void *ptr;
@@ -125,7 +125,7 @@ int pmix_tsd_keys_destruct()
     return PMIX_SUCCESS;
 }
 
-void pmix_thread_set_main()
+void pmix_thread_set_main(void)
 {
     pmix_main_thread = pthread_self();
 }

--- a/src/tools/pmix_info/support.c
+++ b/src/tools/pmix_info/support.c
@@ -674,12 +674,12 @@ void pmix_info_show_mca_params(const char *type, const char *component)
     }
 }
 
-void pmix_info_do_arch()
+void pmix_info_do_arch(void)
 {
     pmix_info_out("Configured architecture", "config:arch", PMIX_ARCH);
 }
 
-void pmix_info_do_hostname()
+void pmix_info_do_hostname(void)
 {
     pmix_info_out("Configure host", "config:host", PMIX_CONFIGURE_HOST);
 }

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -165,7 +165,7 @@ do_local_init:
     return pmix_tsd_key_create(&hostname_tsd_key, hostname_cleanup);
 }
 
-int pmix_net_finalize()
+int pmix_net_finalize(void)
 {
     free(private_ipv4);
     private_ipv4 = NULL;
@@ -400,12 +400,12 @@ int pmix_net_get_port(const struct sockaddr *addr)
 
 #else /* HAVE_STRUCT_SOCKADDR_IN */
 
-int pmix_net_init()
+int pmix_net_init(void)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_net_finalize()
+int pmix_net_finalize(void)
 {
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
[llvm/oneapi: fixes to bring pmix up to iso c99](https://github.com/openpmix/openpmix/commit/70b891a13c27a2445a874a1054ff43cad8d8f4a4)

compliance at least as far as the LLVM on which the Intel OneAPI 2022
release is based (14).  LLVM is getting pickier about what it lets
through in terms of ISO C99 compliance when using -Werror, etc.

Related to https://reviews.llvm.org/D122983

Without this patch and without disabling developer flags (which is very
difficult when building within spack without adding yet another variant)
one gets these sorts of errors at compile time.

pmix_net.c:168:22: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]

threads/thread.c:109:27: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int pmix_tsd_keys_destruct()
                          ^
                           void

base/bfrop_base_frame.c:68:13: error: variable 'count' set but not used [-Werror,-Wunused-but-set-variable]
        int count = 0;

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/03d9d092d4876d411706fc0ddbdb5db2bb6bd39c)

[pnet/nvd: Fix macro escaping issue](https://github.com/openpmix/openpmix/commit/2aaabebab5c2ca6188244680c060f1b69790945a)

Add an OAC_VAR_SCOPE_PUSH to protect the temp variable and fix
escaping that was causing confusion on Autoconf's part (the
VAR_SCOPE_POP was outside the macro body, so screwed up
any AC_REQUIREs in OAC_VAR_SCOPE_POP).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/cfe12e8b67070162251f3a5566eddab859adbdad)

[Enhance the performance of the var_scope_push/pop script](https://github.com/openpmix/openpmix/commit/fec4e219ed01635d217355893337987b582e0e86)

Change to utilize shell scripts - ported from https://github.com/open-mpi/ompi/pull/10785

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/bd679b021a8804861608c96c337d4c474dd3057a)

[Roll to rc2](https://github.com/openpmix/openpmix/commit/38e2f460f915990840d8978a0daed86823c3642c)

Signed-off-by: Ralph Castain <rhc@pmix.org>

[PMIX_OBJ_STATIC_INIT: fixed initialization](https://github.com/openpmix/openpmix/commit/57284296f8dad47b9b2d018198bb7a76fa266873)

- there is potential issue in PMIX object: GCC v4.8.5 may
  fail to compile static initializer used in PMIX
  (it seems compiler issue)
- minor redesign of initializer to better fit C99 standard
  allows to workaround issue

Signed-off-by: Sergey Oblomov <sergeyo@nvidia.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/0d8d330380632b25b52dbf535c516bdac1640302)

Not technically true, but required for the commit checker as we have one non-cherrypick commit in this sequence.
bot:notacherrypick
