### PR TITLE
Add some debug macros for tracking key values

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -808,6 +808,28 @@ PMIX_EXPORT void pmix_hide_unused_params(int x, ...);
 #define PMIX_HIDE_UNUSED_PARAMS(...)
 #endif
 
+#define PMIX_TRACE_KEY_ACTUAL(s, k, v)                  \
+do {                                                    \
+    if (0 == strcmp(s, k)) {                            \
+        char *_v = PMIx_Value_string(v);                \
+        pmix_output(0, "[%s:%s:%d] %s\n%s\n",           \
+                    __FILE__, __func__, __LINE__,       \
+                    PMIx_Get_attribute_name(k), _v);    \
+        free(_v);                                       \
+    }                                                   \
+} while(0)
+
+#define PMIX_TRACE_KEY(c, s, k, v)                          \
+do {                                                        \
+    if (0 == strcasecmp(c, "SERVER") &&                     \
+        PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {         \
+        PMIX_TRACE_KEY_ACTUAL(s, k, v);                     \
+    } else if (0 == strcasecmp(c, "CLIENT") &&              \
+           !PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {     \
+           PMIX_TRACE_KEY_ACTUAL(s, k, v);                  \
+    }                                                       \
+} while (0)
+
 END_C_DECLS
 
 #endif /* PMIX_GLOBALS_H */

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -254,7 +254,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
                               pmix_info_t *qualifiers, size_t nquals,
                               pmix_list_t *kvals)
 {
-    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_status_t rc;
     pmix_proc_data_t *proc_data;
     pmix_dstor_t *hv;
     uint32_t id, kid=UINT32_MAX;
@@ -306,13 +306,14 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
         kid = p->index;
     }
 
+    rc = PMIX_SUCCESS;
     while (PMIX_SUCCESS == rc) {
         proc_data = lookup_proc(table, id, false);
         if (NULL == proc_data) {
             pmix_output_verbose(10, pmix_globals.debug_output,
-                        "HASH:FETCH[%s:%d] proc data for rank %s not found",
+                        "HASH:FETCH[%s:%d] proc data for rank %s not found - key %s",
                         __func__, __LINE__,
-                        PMIX_RANK_PRINT(rank));
+                        PMIX_RANK_PRINT(rank), key);
             return PMIX_ERR_NOT_FOUND;
         }
 


### PR DESCRIPTION
Add a global one for tracking keys, and another specifically for use in the pmix_hash.c functions.

Signed-off-by: Ralph Castain <rhc@pmix.org>