### PR TITLE
Multiple commits

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -783,6 +783,28 @@ PMIX_EXPORT void pmix_hide_unused_params(int x, ...);
 #define PMIX_HIDE_UNUSED_PARAMS(...)
 #endif
 
+#define PMIX_TRACE_KEY_ACTUAL(s, k, v)                  \
+do {                                                    \
+    if (0 == strcmp(s, k)) {                            \
+        char *_v = PMIx_Value_string(v);                \
+        pmix_output(0, "[%s:%s:%d] %s\n%s\n",           \
+                    __FILE__, __func__, __LINE__,       \
+                    PMIx_Get_attribute_name(k), _v);    \
+        free(_v);                                       \
+    }                                                   \
+} while(0)
+
+#define PMIX_TRACE_KEY(c, s, k, v)                          \
+do {                                                        \
+    if (0 == strcasecmp(c, "SERVER") &&                     \
+        PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {         \
+        PMIX_TRACE_KEY_ACTUAL(s, k, v);                     \
+    } else if (0 == strcasecmp(c, "CLIENT") &&              \
+           !PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {     \
+           PMIX_TRACE_KEY_ACTUAL(s, k, v);                  \
+    }                                                       \
+} while (0)
+
 END_C_DECLS
 
 #endif /* PMIX_GLOBALS_H */

--- a/src/util/help-cli.txt
+++ b/src/util/help-cli.txt
@@ -80,3 +80,12 @@ but included an argument while the option does not support one:
   Given argument: %s
 
 Please correct the command line and try again.
+#
+[missing-argument]
+An option was included on the %s command line that requires
+an argument, but no argument was given:
+
+  Option: %s
+
+Please use the "%s --help %s" command to learn more about
+this option.

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -325,6 +325,26 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 if (found) {
                     break;
                 }
+                /* see if the option is in the list - if it is, then it is a
+                 * "recognized" option but may be missing an argument. The
+                 * getopt_long function declares these as "unrecognized", but
+                 * we would like to provide a more user-friendly error message */
+                for (n=0; NULL != myoptions[n].name; n++) {
+                    /* skip the "--" prefix */
+                    if (0 == strcmp(&argv[optind-1][2], myoptions[n].name)) {
+                        /* the option is recognized - probably misssing
+                         * an argument */
+                        str = pmix_show_help_string("help-cli.txt", "missing-argument", true,
+                                                    pmix_tool_basename, argv[optind-1],
+                                                    pmix_tool_basename, &argv[optind-1][2]);
+                        if (NULL != str) {
+                            printf("%s", str);
+                            free(str);
+                        }
+                        pmix_argv_free(argv);
+                        return PMIX_ERR_SILENT;
+                    }
+                }
                 str = pmix_show_help_string("help-cli.txt", "unregistered-option", true,
                                             pmix_tool_basename, argv[optind-1], pmix_tool_basename);
                 if (NULL != str) {

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -254,7 +254,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
                               pmix_info_t *qualifiers, size_t nquals,
                               pmix_list_t *kvals)
 {
-    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_status_t rc;
     pmix_proc_data_t *proc_data;
     pmix_dstor_t *hv;
     uint32_t id, kid=UINT32_MAX;
@@ -306,13 +306,14 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
         kid = p->index;
     }
 
+    rc = PMIX_SUCCESS;
     while (PMIX_SUCCESS == rc) {
         proc_data = lookup_proc(table, id, false);
         if (NULL == proc_data) {
             pmix_output_verbose(10, pmix_globals.debug_output,
-                        "HASH:FETCH[%s:%d] proc data for rank %s not found",
+                        "HASH:FETCH[%s:%d] proc data for rank %s not found - key %s",
                         __func__, __LINE__,
-                        PMIX_RANK_PRINT(rank));
+                        PMIX_RANK_PRINT(rank), key);
             return PMIX_ERR_NOT_FOUND;
         }
 


### PR DESCRIPTION
[Add some debug macros for tracking key values](https://github.com/openpmix/openpmix/commit/c4274b8d121154d19bc9d14053c49e1768b08526)

Add a global one for tracking keys, and another specifically
for use in the pmix_hash.c functions.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6469b2418224eb09b9329bf24e02869f1d7c89bb)

[Provide a little more useful error output](https://github.com/openpmix/openpmix/commit/c3272086b615836f6018fd749933ac6e46a5bb85)

If you provide a cmd line directive that requires
an argument, but forget to include the argument, then
output a better error message.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c685c17e145bba6ad53e7d36d0445339a87cf6ea)
