### PR TITLE
Cleanup some store/retrieve issues

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -747,7 +747,7 @@ static inline bool pmix_check_app_info(const char *key)
 {
     char *keys[] = {
         PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
-        PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX,
+        PMIX_PSET_NAME, PMIX_PSET_MEMBERS, PMIX_APP_MAP_TYPE,  PMIX_APP_MAP_REGEX,
         NULL
     };
     size_t n;

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -249,7 +249,8 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
 
     for (j = 0; j < size; j++) {
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
-                            "%s gds:hash:app_array for key %s", PMIX_NAME_PRINT(&pmix_globals.myid),
+                            "%s gds:hash:app_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
                             iptr[j].key);
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);


### PR DESCRIPTION
Store my appnum and other values in the pmix_globals struct as they arrive. Define PMIX_PSET_MEMBERSHIP as an app-level info for retrieval purposes.

Signed-off-by: Ralph Castain <rhc@pmix.org>