### PR TITLE
Multiple commits

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -912,37 +912,34 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
                             pmix_globals.myid.nspace,
                             pmix_globals.myid.rank,
                             PMIX_RANK_PRINT(val->data.rank));
-        /* are we one of the procs to stop? */
-        if (PMIX_CHECK_RANK(val->data.rank, pmix_globals.myid.rank)) {
-            /* if the value was found, then we need to wait for debugger attach here */
-            /* register for the debugger release notification */
-            PMIX_CONSTRUCT_LOCK(&reglock);
-            PMIX_CONSTRUCT_LOCK(&releaselock);
-            PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
-            PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-DEBUGGER", PMIX_STRING);
-            PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_ONESHOT, NULL, PMIX_BOOL);
-            pmix_output_verbose(2, pmix_client_globals.event_output,
-                                "[%s:%d] REGISTERING WAIT FOR DEBUGGER", pmix_globals.myid.nspace,
-                                pmix_globals.myid.rank);
-            code = PMIX_DEBUGGER_RELEASE;
-            PMIx_Register_event_handler(&code, 1, evinfo, 3, notification_fn, evhandler_reg_callbk,
-                                        (void *) &reglock);
-            /* wait for registration to complete */
-            PMIX_WAIT_THREAD(&reglock);
-            PMIX_DESTRUCT_LOCK(&reglock);
-            PMIX_INFO_DESTRUCT(&evinfo[0]);
-            PMIX_INFO_DESTRUCT(&evinfo[1]);
-            /* notify the host that we are waiting */
-            PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-            PMIX_INFO_LOAD(&evinfo[1], PMIX_BREAKPOINT, "pmix-init", PMIX_STRING);
-            PMIx_Notify_event(PMIX_READY_FOR_DEBUG, &pmix_globals.myid, PMIX_RANGE_RM,
-                              evinfo, 2, NULL, NULL);
-            PMIX_INFO_DESTRUCT(&evinfo[0]);
-            PMIX_INFO_DESTRUCT(&evinfo[1]);
-            /* wait for release to arrive */
-            PMIX_WAIT_THREAD(&releaselock);
-            PMIX_DESTRUCT_LOCK(&releaselock);
-        }
+        /* if the value was found, then we need to wait for debugger attach here */
+        /* register for the debugger release notification */
+        PMIX_CONSTRUCT_LOCK(&reglock);
+        PMIX_CONSTRUCT_LOCK(&releaselock);
+        PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
+        PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-DEBUGGER", PMIX_STRING);
+        PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_ONESHOT, NULL, PMIX_BOOL);
+        pmix_output_verbose(2, pmix_client_globals.event_output,
+                            "[%s:%d] REGISTERING WAIT FOR DEBUGGER", pmix_globals.myid.nspace,
+                            pmix_globals.myid.rank);
+        code = PMIX_DEBUGGER_RELEASE;
+        PMIx_Register_event_handler(&code, 1, evinfo, 3, notification_fn, evhandler_reg_callbk,
+                                    (void *) &reglock);
+        /* wait for registration to complete */
+        PMIX_WAIT_THREAD(&reglock);
+        PMIX_DESTRUCT_LOCK(&reglock);
+        PMIX_INFO_DESTRUCT(&evinfo[0]);
+        PMIX_INFO_DESTRUCT(&evinfo[1]);
+        /* notify the host that we are waiting */
+        PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&evinfo[1], PMIX_BREAKPOINT, "pmix-init", PMIX_STRING);
+        PMIx_Notify_event(PMIX_READY_FOR_DEBUG, &pmix_globals.myid, PMIX_RANGE_RM,
+                          evinfo, 2, NULL, NULL);
+        PMIX_INFO_DESTRUCT(&evinfo[0]);
+        PMIX_INFO_DESTRUCT(&evinfo[1]);
+        /* wait for release to arrive */
+        PMIX_WAIT_THREAD(&releaselock);
+        PMIX_DESTRUCT_LOCK(&releaselock);
         PMIX_VALUE_FREE(val, 1); // cleanup memory
     } else {
         pmix_output_verbose(2, pmix_client_globals.base_output,

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -739,7 +739,7 @@ static inline bool pmix_check_app_info(const char *key)
 {
     char *keys[] = {
         PMIX_APP_SIZE,  PMIX_APPLDR,       PMIX_APP_ARGV,      PMIX_WDIR,
-        PMIX_PSET_NAME, PMIX_APP_MAP_TYPE, PMIX_APP_MAP_REGEX,
+        PMIX_PSET_NAME, PMIX_PSET_MEMBERS, PMIX_APP_MAP_TYPE,  PMIX_APP_MAP_REGEX,
         NULL
     };
     size_t n;

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -249,7 +249,8 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
 
     for (j = 0; j < size; j++) {
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
-                            "%s gds:hash:app_array for key %s", PMIX_NAME_PRINT(&pmix_globals.myid),
+                            "%s gds:hash:app_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
                             iptr[j].key);
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -89,7 +89,8 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
 static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, pmix_info_t info[],
                                           size_t ninfo, pmix_modex_cbfunc_t cbfunc, void *cbdata,
                                           pmix_dmdx_local_t **lcd, pmix_dmdx_request_t **rq);
-static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd, pmix_buffer_t *pbkt);
+static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd,
+                                  char *key, pmix_buffer_t *pbkt);
 static void get_timeout(int sd, short args, void *cbdata);
 
 /* declare a function whose sole purpose is to
@@ -285,12 +286,12 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         goto request;
     }
 
-    /* the target nspace is known, so we can process the request.
-     * if the rank is wildcard, then they are asking for the job-level
-     * info for this nspace - provide it */
+    /* the target nspace is known, so we can process the request */
     if (PMIX_RANK_WILDCARD == rank) {
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-        rc = get_job_data(nptr->nspace, cd, &pbkt);
+        /* they are asking for the job-level info for (or at least a
+         * reserved key from) this nspace */
+        rc = get_job_data(nptr->nspace, cd, key, &pbkt);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&pbkt);
             return rc;
@@ -449,7 +450,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         /* we did find it, so go ahead and collect the payload */
     } else if (PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 4, 0, 0)) {
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-        rc = get_job_data(nspace, cd, &pbkt);
+        rc = get_job_data(nspace, cd, key, &pbkt);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&pbkt);
             return rc;
@@ -662,7 +663,10 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
     }
 }
 
-static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd, pmix_buffer_t *pbkt)
+static pmix_status_t get_job_data(char *nspace,
+                                  pmix_server_caddy_t *cd,
+                                  char *key,
+                                  pmix_buffer_t *pbkt)
 {
     pmix_status_t rc;
     pmix_buffer_t pkt;
@@ -676,6 +680,7 @@ static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd, pmix_bu
      * of returning a copy of the data, or a pointer to
      * local storage */
     cb.proc = &proc;
+    cb.key = key;
     cb.scope = PMIX_INTERNAL;
     cb.copy = false;
     cb.info = cd->info;
@@ -753,7 +758,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
     /* if the rank is WILDCARD or the target is in an nspace different
      * from the requester, include a copy of the job-level data */
     if (PMIX_RANK_WILDCARD == rank || diffnspace) {
-        rc = get_job_data(nptr->nspace, cd, &pbkt);
+        rc = get_job_data(nptr->nspace, cd, NULL, &pbkt);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&pbkt);
             return rc;


### PR DESCRIPTION
[Cleanup some store/retrieve issues](https://github.com/openpmix/openpmix/commit/d35861f652e6177ab412caa0f362deeabe4a9c38)

Store my appnum and other values in the pmix_globals struct
as they arrive. Define PMIX_PSET_MEMBERSHIP as an app-level
info for retrieval purposes.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/a72d9c7d728e793152b77c43a327891bbf9c390a)

[Stop-in-init applies to all procs in a job](https://github.com/openpmix/openpmix/commit/fddeb6e2ec1d4bbf4423ede41d91685b8c720760)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9f297ced5093868a4d3138ece0df1822348531dd)
