### PR TITLE
Silence complaint about enum vs int

### DIFF
--- a/src/util/keyval/keyval_lex.h
+++ b/src/util/keyval/keyval_lex.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,21 +36,16 @@
 
 #include <stdio.h>
 
-enum pmix_keyval_parse_state_t {
-    PMIX_UTIL_KEYVAL_PARSE_DONE,
-    PMIX_UTIL_KEYVAL_PARSE_ERROR,
-
-    PMIX_UTIL_KEYVAL_PARSE_NEWLINE,
-    PMIX_UTIL_KEYVAL_PARSE_EQUAL,
-    PMIX_UTIL_KEYVAL_PARSE_SINGLE_WORD,
-    PMIX_UTIL_KEYVAL_PARSE_VALUE,
-    PMIX_UTIL_KEYVAL_PARSE_MCAVAR,
-    PMIX_UTIL_KEYVAL_PARSE_ENVVAR,
-    PMIX_UTIL_KEYVAL_PARSE_ENVEQL,
-
-    PMIX_UTIL_KEYVAL_PARSE_MAX
-};
-typedef enum pmix_keyval_parse_state_t pmix_keyval_parse_state_t;
+#define PMIX_UTIL_KEYVAL_PARSE_DONE         0
+#define PMIX_UTIL_KEYVAL_PARSE_ERROR        1
+#define PMIX_UTIL_KEYVAL_PARSE_NEWLINE      2
+#define PMIX_UTIL_KEYVAL_PARSE_EQUAL        3
+#define PMIX_UTIL_KEYVAL_PARSE_SINGLE_WORD  4
+#define PMIX_UTIL_KEYVAL_PARSE_VALUE        5
+#define PMIX_UTIL_KEYVAL_PARSE_MCAVAR       6
+#define PMIX_UTIL_KEYVAL_PARSE_ENVVAR       7
+#define PMIX_UTIL_KEYVAL_PARSE_ENVEQL       8
+#define PMIX_UTIL_KEYVAL_PARSE_MAX          9
 
 int pmix_util_keyval_yylex(void);
 int pmix_util_keyval_init_buffer(FILE *file);

--- a/src/util/pmix_keyval_parse.c
+++ b/src/util/pmix_keyval_parse.c
@@ -40,7 +40,7 @@ static size_t key_buffer_len = 0;
 static pmix_mutex_t keyval_mutex;
 
 static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback);
-static int parse_line_new(const char *filename, pmix_keyval_parse_state_t first_val,
+static int parse_line_new(const char *filename, int first_val,
                           pmix_keyval_parse_fn_t callback);
 static void parse_error(int num, const char *filename);
 
@@ -307,10 +307,10 @@ static int add_to_env_str(char *var, char *val)
     return PMIX_SUCCESS;
 }
 
-static int parse_line_new(const char *filename, pmix_keyval_parse_state_t first_val,
+static int parse_line_new(const char *filename, int first_val,
                           pmix_keyval_parse_fn_t callback)
 {
-    pmix_keyval_parse_state_t val;
+    int val;
     char *tmp;
     int rc;
 


### PR DESCRIPTION
The icc compiler seems to believe that an enum is not an integer, thus generating a warning. Go figure.

Signed-off-by: Ralph Castain <rhc@pmix.org>