### PR TITLE
Add const qualifier to pset_name

### DIFF
--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -849,7 +849,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_generate_cpuset_string(const pmix_cpuset_t
  * Provide a function by which the host environment can define a new process set.
  */
 PMIX_EXPORT pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members,
-                                                         size_t nmembers, char *pset_name);
+                                                         size_t nmembers, const char *pset_name);
 
 /* Delete a process set
  * Provide a function by which the host environment can delete a new process set.

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2973,7 +2973,7 @@ static void psetdef(int sd, short args, void *cbdata)
 }
 
 pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t nmembers,
-                                             char *pset_name)
+                                             const char *pset_name)
 {
     pmix_setup_caddy_t cd;
     pmix_status_t rc;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2987,7 +2987,7 @@ pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t 
 
     /* need to threadshift this request */
     PMIX_CONSTRUCT(&cd, pmix_setup_caddy_t);
-    cd.nspace = pset_name;
+    cd.nspace = (char*)pset_name;
     cd.procs = (pmix_proc_t *) members;
     cd.nprocs = nmembers;
     cd.opcbfunc = opcbfunc;


### PR DESCRIPTION
Since pset_name in PMIx_server_define_process_set() is not to be modified by the function, it should be declared as const, especially to avoid compiler warnings about discarded qualifiers.

Signed-off-by: Stephan Krempel <krempel@par-tec.com>