### PR TITLE
Multiple commits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,9 @@ multiple release branches.
 ----------------------
 **** NOTE: This is the minimum version required to support PRRTE v3.0.
 
+ - PR #2799: Multiple commits
+    - Add const qualifier to pset_name
+    - Fix one place that complained about lost qualifier
  - PR #2797 Silence complaint about enum vs int
  - PR #2793 Update NEWS
  - PR #2792 Multiple commits

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -849,7 +849,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_generate_cpuset_string(const pmix_cpuset_t
  * Provide a function by which the host environment can define a new process set.
  */
 PMIX_EXPORT pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members,
-                                                         size_t nmembers, char *pset_name);
+                                                         size_t nmembers, const char *pset_name);
 
 /* Delete a process set
  * Provide a function by which the host environment can delete a new process set.

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2986,7 +2986,7 @@ pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t 
 
     /* need to threadshift this request */
     PMIX_CONSTRUCT(&cd, pmix_setup_caddy_t);
-    cd.nspace = pset_name;
+    cd.nspace = (char*)pset_name;
     cd.procs = (pmix_proc_t *) members;
     cd.nprocs = nmembers;
     cd.opcbfunc = opcbfunc;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2972,7 +2972,7 @@ static void psetdef(int sd, short args, void *cbdata)
 }
 
 pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t nmembers,
-                                             char *pset_name)
+                                             const char *pset_name)
 {
     pmix_setup_caddy_t cd;
     pmix_status_t rc;


### PR DESCRIPTION
[Add const qualifier to pset_name](https://github.com/openpmix/openpmix/commit/d45eeace6b228d2162584843335e03a0de04bd6b)

Since pset_name in PMIx_server_define_process_set() is not
to be modified by the function, it should be declared as
const, especially to avoid compiler warnings about
discarded qualifiers.

Signed-off-by: Stephan Krempel <krempel@par-tec.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/1f16aec285303c521348b3c6770d881baa0cde95)

[Fix one place that complained about lost qualifier](https://github.com/openpmix/openpmix/commit/8e821e5ec1c266699e8c832b58f5a77e12572ab0)

It's a bit of a hack, but good enough for now.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/1dbf8e7b5d1f1eafd0ad824bbb76ec502fd30ee9)
