### PR TITLE
intel oneapi: fix a munge code error

### DIFF
--- a/src/mca/psec/munge/psec_munge_component.c
+++ b/src/mca/psec/munge/psec_munge_component.c
@@ -60,7 +60,8 @@ pmix_psec_base_component_t pmix_mca_psec_munge_component = {
     },
     .data = {
         /* The component is checkpoint ready */
-        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT,
+        .reserved = {0}
     },
     .assign_module = assign_module
 };


### PR DESCRIPTION
that the intel oneapi will not compile.

This patch allows the file to successfully compile using intel oneapi 2022 series (and probabably llvm/clang 14 or newer).

bot:notacherrypick

Signed-off-by: Howard Pritchard <howardp@lanl.gov>