### PR TITLE
Have python bindings properly setup the env

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1649,14 +1649,12 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
         try:
             if p['env'] is not None:
                 m = len(p['env']) + 1
-            else:
-                m = 1
-            env = <char**> malloc(m * sizeof(char*))
-            if not argv:
-                return PMIX_ERR_NOMEM
-            memset(env, 0, m)
-            if p['env'] is not None:
+                env = <char**> malloc(m * sizeof(char*))
+                if not env:
+                    return PMIX_ERR_NOMEM
+                memset(env, 0, m)
                 pmix_load_argv(env, p['env'])
+                apps[n].env = env
         except:
             pass
 


### PR DESCRIPTION
The PMIx Python bindings doesn't set the pmix_app_t env parameter correctly. Bug fix to properly set this up. 

Signed-off-by: Matthew Baker <matthew@voltrondata.com>