### PR TITLE
pmix_list: fix a bug in pmix_list_insert()

### DIFF
--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -138,9 +138,9 @@ bool pmix_list_insert(pmix_list_t *list, pmix_list_item_t *item, long long idx)
         assert(1 == item->pmix_list_item_refcount);
         item->pmix_list_item_belong_to = list;
 #endif
+        list->pmix_list_length++;
     }
 
-    list->pmix_list_length++;
     return true;
 }
 


### PR DESCRIPTION
Fix the bug that calls to pmix_list_insert() with idx=0 will make list->pmix_list_length increase twice.

Port of https://github.com/open-mpi/ompi/pull/11059

Signed-off-by: Ralph Castain <rhc@pmix.org>