### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix_check_jansson.m4
+++ b/config/pmix_check_jansson.m4
@@ -51,7 +51,7 @@ AC_DEFUN([PMIX_CHECK_JANSSON],[
                       [pmix_check_jansson_happy="yes"],
 		      [pmix_check_jansson_happy="no"])
 
-    if test "$pmix_check_jansson_happy" == "yes"; then
+    if test "$pmix_check_jansson_happy" = "yes"; then
         AC_MSG_CHECKING([if libjansson version is 2.11 or greater])
         pmix_check_jansson_save_CPPFLAGS="${CPPFLAGS}"
         PMIX_FLAGS_APPEND_UNIQ([CPPFLAGS], [${pmix_check_jansson_CPPFLAGS}])

--- a/config/pmix_check_pthread_pids.m4
+++ b/config/pmix_check_pthread_pids.m4
@@ -49,7 +49,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([#include <pthread.h>
 #include <stdlib.h>
 
 void *checkpid(void *arg);
-int main() {
+int main(void) {
   pthread_t thr;
   int pid, *retval;
   pid = getpid();

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -35,7 +35,7 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
     pmix_have_topology_dup=0
 
-    if test "$with_hwloc" == "no"; then
+    if test "$with_hwloc" = "no"; then
         AC_MSG_WARN([PMIx requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])


### PR DESCRIPTION
[build: fix bashisms in configure](https://github.com/openpmix/openpmix/commit/f81e3280db4f4021a2f139261a970557c0bee45f)

configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors
like this aren't spotted. Notably Debian defaults to /bin/sh provided
by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2fbaa02c82532fc066b83ba3fb1cf7fa40ee012c)

[build: fix -Wstrict-prototypes](https://github.com/openpmix/openpmix/commit/5534c3535f9c235a48f5afe70489fc06d9260a94)

Follow up to https://github.com/openpmix/openpmix/commit/03d9d092d4876d411706fc0ddbdb5db2bb6bd39c.
Signed-off-by: Sam James <sam@gentoo.org>

(cherry picked from commit https://github.com/openpmix/openpmix/commit/53715742f3859b8e07da24471bc650e03cb4ad1a)
