### PR TITLE
Fix bashism in oac_check_package.m4

### DIFF
--- a/config/oac_check_package.m4
+++ b/config/oac_check_package.m4
@@ -421,7 +421,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_COMPILER], [
     m4_ifdef([$1_wrapper_compiler],
              [m4_define([wrapper_compiler_name], [$1_wrapper_compiler])],
              [m4_define([wrapper_compiler_name], [$1cc])])
-    AS_IF([test "${$1_USE_WRAPPER_COMPILER}" == "1"],
+    AS_IF([test "${$1_USE_WRAPPER_COMPILER}" = "1"],
           [# search for the package using wrapper compilers.  If the user
            # provided a --with-$1 argument, be explicit about where we look
            # for the compiler, so we don't find the wrong one.


### PR DESCRIPTION
Backport of https://github.com/open-mpi/oac/commit/9a9be81ba63a50e5b0c997e95358298b85400600

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick