### PR TITLE
Modify the pmix_output system

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1118,8 +1118,8 @@ static pmix_status_t write_output_line(const pmix_proc_t *name,
     } else {
         /* error - this should never happen */
         PMIX_ERROR_LOG(PMIX_ERR_VALUE_OUT_OF_BOUNDS);
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output, "%s stream %0x",
-                             PMIX_NAME_PRINT(&pmix_globals.myid), stream));
+        pmix_output_verbose(1, pmix_client_globals.iof_output, "%s stream %0x",
+                             PMIX_NAME_PRINT(&pmix_globals.myid), stream);
         return PMIX_ERR_VALUE_OUT_OF_BOUNDS;
     }
 
@@ -1469,9 +1469,9 @@ process:
     /* is the write event issued? */
     if (!channel->pending) {
         /* issue it */
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+        pmix_output_verbose(1, pmix_client_globals.iof_output,
                              "%s write:output adding write event",
-                             PMIX_NAME_PRINT(&pmix_globals.myid)));
+                             PMIX_NAME_PRINT(&pmix_globals.myid));
         PMIX_IOF_SINK_ACTIVATE(channel);
     }
 
@@ -1597,11 +1597,11 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t 
         }
     }
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+    pmix_output_verbose(1, pmix_client_globals.iof_output,
                          "%s write:output setting up to write %lu bytes to %s for %s on fd %d",
                          PMIX_NAME_PRINT(&pmix_globals.myid), (unsigned long) bo->size,
                          PMIx_IOF_channel_string(stream), PMIX_NAME_PRINT(name),
-                         (NULL == channel) ? -1 : channel->fd));
+                         (NULL == channel) ? -1 : channel->fd);
 
     /* zero bytes can just be passed along */
     if (0 == bo->size) {
@@ -1730,9 +1730,9 @@ void pmix_iof_write_handler(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(sink);
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+    pmix_output_verbose(1, pmix_client_globals.iof_output,
                          "%s write:handler writing data to %d",
-                         PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd));
+                         PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd);
 
     while (NULL != (item = pmix_list_remove_first(&wev->outputs))) {
         output = (pmix_iof_write_output_t *) item;
@@ -1924,10 +1924,10 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
             return;
         }
 
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+        pmix_output_verbose(1, pmix_client_globals.iof_output,
                              "%s iof:read handler Error on %s",
                              PMIX_NAME_PRINT(&pmix_globals.myid),
-                             PMIx_IOF_channel_string(rev->channel)));
+                             PMIx_IOF_channel_string(rev->channel));
         /* Un-recoverable error */
         bo.bytes = NULL;
         bo.size = 0;
@@ -2090,9 +2090,9 @@ static void iof_sink_construct(pmix_iof_sink_t *ptr)
 static void iof_sink_destruct(pmix_iof_sink_t *ptr)
 {
     if (0 <= ptr->wev.fd) {
-        PMIX_OUTPUT_VERBOSE(
+        pmix_output_verbose
             (20, pmix_client_globals.iof_output, "%s iof: closing sink for process %s on fd %d",
-             PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(&ptr->name), ptr->wev.fd));
+             PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(&ptr->name), ptr->wev.fd);
         PMIX_DESTRUCT(&ptr->wev);
     }
 }
@@ -2118,8 +2118,8 @@ static void iof_read_event_destruct(pmix_iof_read_event_t *rev)
         pmix_event_del(&rev->ev);
     }
     if (0 <= rev->fd) {
-        PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output, "%s iof: closing fd %d",
-                             PMIX_NAME_PRINT(&pmix_globals.myid), rev->fd));
+        pmix_output_verbose(20, pmix_client_globals.iof_output, "%s iof: closing fd %d",
+                             PMIX_NAME_PRINT(&pmix_globals.myid), rev->fd);
         close(rev->fd);
         rev->fd = -1;
     }
@@ -2151,9 +2151,9 @@ static void iof_write_event_destruct(pmix_iof_write_event_t *wev)
     }
     free(wev->ev);
     if (2 < wev->fd) {
-        PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
+        pmix_output_verbose(20, pmix_client_globals.iof_output,
                              "%s iof: closing fd %d for write event",
-                             PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd));
+                             PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd);
         close(wev->fd);
     }
     PMIX_LIST_DESTRUCT(&wev->outputs);

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -171,8 +171,8 @@ static inline bool pmix_iof_fd_always_ready(int fd)
  * endpoint list for this proc */
 #define PMIX_IOF_SINK_DEFINE(snk, nm, fid, tg, wrthndlr)                                           \
     do {                                                                                           \
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,                                    \
-                             "defining endpt: file %s line %d fd %d", __FILE__, __LINE__, (fid))); \
+        pmix_output_verbose(1, pmix_client_globals.iof_output,                                     \
+                             "defining endpt: file %s line %d fd %d", __FILE__, __LINE__, (fid));  \
         PMIX_CONSTRUCT((snk), pmix_iof_sink_t);                                                    \
         pmix_strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);                            \
         (snk)->name.rank = (nm)->rank;                                                             \
@@ -213,8 +213,8 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     do {                                                                                         \
         size_t _ii;                                                                              \
         pmix_iof_read_event_t *rev;                                                              \
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output, "defining read event at: %s %d", \
-                             __FILE__, __LINE__));                                               \
+        pmix_output_verbose(1, pmix_client_globals.iof_output, "defining read event at: %s %d", \
+                             __FILE__, __LINE__);                                                \
         rev = PMIX_NEW(pmix_iof_read_event_t);                                                   \
         if (NULL != (p)) {                                                                       \
             (rev)->ntargets = (np);                                                              \
@@ -244,8 +244,8 @@ static inline bool pmix_iof_fd_always_ready(int fd)
 #define PMIX_IOF_READ_EVENT_LOCAL(rv, fid, cbfunc, actv)                                         \
     do {                                                                                         \
         pmix_iof_read_event_t *rev;                                                              \
-        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output, "defining read event at: %s %d", \
-                             __FILE__, __LINE__));                                               \
+        pmix_output_verbose(1, pmix_client_globals.iof_output, "defining read event at: %s %d", \
+                             __FILE__, __LINE__);                                                \
         rev = PMIX_NEW(pmix_iof_read_event_t);                                                   \
         rev->fd = (fid);                                                                         \
         rev->always_readable = pmix_iof_fd_always_ready(fid);                                    \

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -399,23 +399,23 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
        If it is in a stopped state and we do not first change it to
        running, then SIGTERM will not get delivered.  Ignore return
        value. */
-    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGCONT",
-                         PMIX_NAME_PRINT(&pmix_globals.myid)));
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGCONT",
+                         PMIX_NAME_PRINT(&pmix_globals.myid));
     scd->sigfn(child->pid, SIGCONT);
 
     /* wait a little to give the proc a chance to wakeup */
     sleep(pmix_pfexec_globals.timeout_before_sigkill);
     /* issue a SIGTERM */
-    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGTERM",
-                         PMIX_NAME_PRINT(&pmix_globals.myid)));
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGTERM",
+                         PMIX_NAME_PRINT(&pmix_globals.myid));
     scd->lock->status = scd->sigfn(child->pid, SIGTERM);
 
     if (0 != scd->lock->status) {
         /* wait a little again */
         sleep(pmix_pfexec_globals.timeout_before_sigkill);
         /* issue a SIGKILL */
-        PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGKILL",
-                             PMIX_NAME_PRINT(&pmix_globals.myid)));
+        pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output, "%s SENDING SIGKILL",
+                             PMIX_NAME_PRINT(&pmix_globals.myid));
         scd->lock->status = scd->sigfn(child->pid, SIGKILL);
     }
 
@@ -446,8 +446,8 @@ void pmix_pfexec_base_signal_proc(int sd, short args, void *cbdata)
         return;
     }
 
-    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output, "%s SIGNALING %d",
-                         PMIX_NAME_PRINT(&pmix_globals.myid), scd->signal));
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output, "%s SIGNALING %d",
+                         PMIX_NAME_PRINT(&pmix_globals.myid), scd->signal);
     scd->lock->status = scd->sigfn(child->pid, scd->signal);
 
     PMIX_WAKEUP_THREAD(scd->lock);

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -175,15 +175,15 @@ static pmix_status_t sigproc(pid_t pd, int signum)
 
     if (0 != kill(pid, signum)) {
         if (ESRCH != errno) {
-            PMIX_OUTPUT_VERBOSE((2, pmix_pfexec_base_framework.framework_output,
+            pmix_output_verbose(2, pmix_pfexec_base_framework.framework_output,
                                  "%s pfexec:linux:SENT SIGNAL %d TO PID %d GOT ERRNO %d",
-                                 PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int) pid, errno));
+                                 PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int) pid, errno);
             return errno;
         }
     }
-    PMIX_OUTPUT_VERBOSE((2, pmix_pfexec_base_framework.framework_output,
+    pmix_output_verbose(2, pmix_pfexec_base_framework.framework_output,
                          "%s pfexec:linux:SENT SIGNAL %d TO PID %d SUCCESS",
-                         PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int) pid));
+                         PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int) pid);
     return 0;
 }
 

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -598,8 +598,8 @@ static pmix_status_t pmix_regex_extract_nodes(char *regexp, char ***names)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
-                         "pmix:extract:nodes: checking list: %s", regexp));
+    pmix_output_verbose(1, pmix_preg_base_framework.framework_output,
+                         "pmix:extract:nodes: checking list: %s", regexp);
 
     do {
         /* Find the base */
@@ -675,9 +675,9 @@ static pmix_status_t pmix_regex_extract_nodes(char *regexp, char ***names)
             } else {
                 suffix = NULL;
             }
-            PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
+            pmix_output_verbose(1, pmix_preg_base_framework.framework_output,
                                  "regex:extract:nodes: parsing range %s %s %s", base, base + i,
-                                 suffix));
+                                 suffix);
 
             ret = regex_parse_value_ranges(base, base + i, num_digits, suffix, names);
             if (NULL != suffix) {
@@ -747,8 +747,8 @@ static pmix_status_t regex_parse_value_ranges(char *base, char *ranges, int num_
 
     if (start < orig + len) {
 
-        PMIX_OUTPUT_VERBOSE((1, pmix_preg_base_framework.framework_output,
-                             "regex:parse:ranges: parse range %s (2)", start));
+        pmix_output_verbose(1, pmix_preg_base_framework.framework_output,
+                             "regex:parse:ranges: parse range %s (2)", start);
 
         ret = regex_parse_value_range(base, start, num_digits, suffix, names);
         if (PMIX_SUCCESS != ret) {

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -176,10 +176,10 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
 
     PMIX_HIDE_UNUSED_PARAMS(error);
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking file monitoring for requestor %s:%d",
                          pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                         requestor->info->pname.nspace, requestor->info->pname.rank));
+                         requestor->info->pname.nspace, requestor->info->pname.rank);
 
     /* if they didn't ask to monitor a file, then nothing for us to do */
     if (0 != strcmp(monitor->key, PMIX_MONITOR_FILE)) {
@@ -284,26 +284,26 @@ static void file_sample(int sd, short args, void *cbdata)
 
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sampling file %s", pmix_globals.myid.nspace,
-                         pmix_globals.myid.rank, ft->file));
+                         pmix_globals.myid.rank, ft->file);
 
     /* stat the file and get its info */
     /* coverity[TOCTOU] */
     if (0 > stat(ft->file, &buf)) {
         /* cannot stat file */
-        PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+        pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                              "[%s:%d] could not stat %s", pmix_globals.myid.nspace,
-                             pmix_globals.myid.rank, ft->file));
+                             pmix_globals.myid.rank, ft->file);
         /* re-add the timer, in case this file shows up */
         pmix_event_evtimer_add(&ft->ev, &ft->tv);
         return;
     }
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] size %lu access %s\tmod %s", pmix_globals.myid.nspace,
                          pmix_globals.myid.rank, (unsigned long) buf.st_size, ctime(&buf.st_atime),
-                         ctime(&buf.st_mtime)));
+                         ctime(&buf.st_mtime));
 
     if (ft->file_size) {
         if (buf.st_size == (int64_t) ft->last_size) {
@@ -328,9 +328,9 @@ static void file_sample(int sd, short args, void *cbdata)
         }
     }
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sampled file %s misses %d", pmix_globals.myid.nspace,
-                         pmix_globals.myid.rank, ft->file, ft->nmisses));
+                         pmix_globals.myid.rank, ft->file, ft->nmisses);
 
     if (ft->nmisses == ft->ndrops) {
         if (4 < pmix_output_get_verbosity(pmix_psensor_base_framework.framework_output)) {

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -165,10 +165,10 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
     size_t n;
     pmix_ptl_posted_recv_t *rcv;
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking heartbeat monitoring for requestor %s:%d",
                          pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                         requestor->info->pname.nspace, requestor->info->pname.rank));
+                         requestor->info->pname.nspace, requestor->info->pname.rank);
 
     /* if they didn't ask for heartbeats, then nothing for us to do */
     if (0 != strcmp(monitor->key, PMIX_MONITOR_HEARTBEAT)) {
@@ -280,17 +280,17 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(fd, dummy);
 
 
-    PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+    pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sensor:check_heartbeat for proc %s:%d", pmix_globals.myid.nspace,
                          pmix_globals.myid.rank, ft->requestor->info->pname.nspace,
-                         ft->requestor->info->pname.rank));
+                         ft->requestor->info->pname.rank);
 
     if (0 == ft->nbeats && !ft->stopped) {
         /* no heartbeat recvd in last window */
-        PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+        pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                              "[%s:%d] sensor:check_heartbeat failed for proc %s:%d",
                              pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                             ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank));
+                             ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank);
         /* generate an event */
         pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         source.rank = ft->requestor->info->pname.rank;
@@ -305,10 +305,10 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
             PMIX_ERROR_LOG(rc);
         }
     } else {
-        PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
+        pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                              "[%s:%d] sensor:check_heartbeat detected %d beats for proc %s:%d",
                              pmix_globals.myid.nspace, pmix_globals.myid.rank, ft->nbeats,
-                             ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank));
+                             ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank);
     }
     /* reset for next period */
     ft->nbeats = 0;

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -555,9 +555,9 @@ again:
     if (-1 == fsrc && -1 == vfsrc) {
         char *last_sep;
 
-        PMIX_OUTPUT_VERBOSE((10, 0,
+        pmix_output_verbose(10, 0,
                              "pmix_path_nfs: stat(v)fs on file:%s failed errno:%d directory:%s\n",
-                             fname, errno, file));
+                             fname, errno, file);
         if (EPERM == errno) {
             free(file);
             if (NULL != ret_fstype) {
@@ -641,8 +641,8 @@ found:
                     continue;
                 }
                 if (0 == strcasecmp(fs_types[x].f_fsname, fs_type)) {
-                    PMIX_OUTPUT_VERBOSE(
-                        (10, 0, "pmix_path_nfs: file:%s on fs:%s\n", fname, fs_type));
+                    pmix_output_verbose
+                        (10, 0, "pmix_path_nfs: file:%s on fs:%s\n", fname, fs_type);
                     free(fs_type);
                     if (NULL != ret_fstype) {
                         *ret_fstype = strdup(fs_types[x].f_fsname);
@@ -658,7 +658,7 @@ found:
         }
     }
 
-    PMIX_OUTPUT_VERBOSE((10, 0, "pmix_path_nfs: file:%s on fs:%s\n", fname, fs_types[i].f_fsname));
+    pmix_output_verbose(10, 0, "pmix_path_nfs: file:%s on fs:%s\n", fname, fs_types[i].f_fsname);
     if (NULL != ret_fstype) {
         *ret_fstype = strdup(fs_types[i].f_fsname);
     }
@@ -693,10 +693,10 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     } while (-1 == rc && ESTALE == err && (--trials > 0));
 
     if (-1 == rc) {
-        PMIX_OUTPUT_VERBOSE((10, 2,
+        pmix_output_verbose(10, 2,
                              "pmix_path_df: stat(v)fs on "
                              "path: %s failed with errno: %d (%s)\n",
-                             path, err, strerror(err)));
+                             path, err, strerror(err));
         return PMIX_ERROR;
     }
 
@@ -704,10 +704,10 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     /* sometimes buf.f_bavail is negative */
     *out_avail = buf.f_bsize * ((int) buf.f_bavail < 0 ? 0 : buf.f_bavail);
 
-    PMIX_OUTPUT_VERBOSE((10, 2,
+    pmix_output_verbose(10, 2,
                          "pmix_path_df: stat(v)fs states "
                          "path: %s has %" PRIu64 " B of free space.",
-                         path, *out_avail));
+                         path, *out_avail);
 
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Replace the PMIX_OUTPUT_VERBOSE macro with direct
calls to pmix_output_verbose so it always compiles, even in non-debug configurations. Inline the "check_verbosity" function to minimize the performance impact of calling that function - requires changing the "info" array into a properly-prefixed global array.

Retain the PMIX_OUTPUT_VERBOSE definition so that
legacy users (e.g., PRRTE v3.0.0) are not impacted, but direct that it always be compiled "in".

Signed-off-by: Ralph Castain <rhc@pmix.org>