### PR TITLE
Some cleanup of the Python bindings build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ bindings/python/build/
 bindings/python/pmix_constants.pxd
 bindings/python/pmix_constants.pxi
 bindings/python/tests/__pycache__/
+bindings/python/dist/
+bindings/python/pypmix.egg-info/
 
 examples/alloc
 examples/client

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -15,12 +15,17 @@
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2021      IBM Corporation.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+# we do NOT want picky compilers down here
+CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
+PYTHONPATH=$PYTHONPATH:$(DESTDIR)$(prefix)/lib/python$(PYTHON_VERSION)/site-packages
 
 helpers = setup.py pmix.pyx pmix.pxi construct.py
 
@@ -30,9 +35,9 @@ if WANT_PYTHON_BINDINGS
 
 install-exec-local: $(helpers)
 	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include" --include-dir="$(top_srcdir)/include"
-	PMIX_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
 		$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --library-dirs="$(DESTDIR)$(libdir)" --user
-	PMIX_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
 		$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --prefix="$(DESTDIR)$(prefix)"
 
 uninstall-hook:
@@ -42,6 +47,6 @@ uninstall-hook:
 CLEANFILES += pmix.c
 
 clean-local:
-	rm -rf build
+	rm -rf build pypmix.egg-info dist
 
 endif

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -10,8 +10,8 @@ from subprocess import check_output, CalledProcessError
 def get_include():
     dirs = []
     try:
-        dirs.append(os.environ['PMIX_TOP_BUILDDIR'] + "/include")
-        dirs.append(os.environ['PMIX_TOP_SRCDIR'] + "/include")
+        dirs.append(os.environ['PMIX_BINDINGS_TOP_BUILDDIR'] + "/include")
+        dirs.append(os.environ['PMIX_BINDINGS_TOP_SRCDIR'] + "/include")
     except:
         return dirs
     return dirs
@@ -54,20 +54,26 @@ setup(
     url = 'https://pmix.org',
     license = '3-clause BSD',
     author = 'Ralph H. Castain',
-    author_email = 'ralph.h.castain@intel.com',
+    author_email = 'rhc@pmix.org',
     description = 'Python bindings for PMIx',
     classifiers = [
-            'Development Status :: 1 - Under Construction',
+            'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',
             'Topic :: HPC :: Parallel Programming :: System Management',
-            'License :: 3-clause BSD',
+            'License :: OSI Approved :: BSD License',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6'],
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12'],
     keywords = 'PMI PMIx HPC MPI SHMEM',
     platforms = 'any',
     ext_modules = cythonize([Extension("pmix",
-                                       [os.environ['PMIX_TOP_SRCDIR']+"/bindings/python/pmix.pyx"],
+                                       [os.environ['PMIX_BINDINGS_TOP_SRCDIR']+"/bindings/python/pmix.pyx"],
                                        libraries=["pmix"]) ],
                             compiler_directives={'language_level': 3}),
     include_dirs = get_include()


### PR DESCRIPTION
No picky compilers down there as Cython isn't prepared to handle them. Ensure we include the target destination in PYTHONPATH as it gets tested during install to ensure the target is present. Update install classifiers.

Update ignores

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit e9aea139fe92d14fb3bdc685ac7fb6106b19b5e8)