### PR TITLE
Some fixes to the Python bindings

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1237,7 +1237,10 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         return {'value':value[0].data.byte, 'val_type':PMIX_BYTE}
     elif PMIX_STRING == value[0].type:
         pyb = value[0].data.string
-        pystr = pyb.decode("ascii")
+        try:
+            pystr = pyb.decode("ascii")
+        except:
+            pystr = pyb
         return {'value':pystr, 'val_type':PMIX_STRING}
     elif PMIX_SIZE == value[0].type:
         return {'value':value[0].data.size, 'val_type':PMIX_SIZE}
@@ -1398,12 +1401,12 @@ cdef int pmix_unload_info(const pmix_info_t *info, size_t ninfo, ilist:list):
     cdef size_t n
     n = 0
     while n < ninfo:
+        kystr = strdup(info[n].key)
         # pmix_unload_value returns a python dict of val, val_type
         val = pmix_unload_value(&info[n].value)
         if val['val_type'] == PMIX_UNDEF:
             return PMIX_ERR_NOT_SUPPORTED
         d     = {}
-        kystr = strdup(info[n].key)
         pykey = str(kystr.decode("ascii"))
         free(kystr)
         d['key']      = pykey

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -7,7 +7,7 @@ from libc.string cimport memcpy
 from libc.stdio cimport printf
 from ctypes import addressof, c_int
 from cython.operator import address
-import signal, time
+import signal, time, sys
 import threading, ctypes
 import queue
 import array
@@ -640,14 +640,15 @@ cdef class PMIxClient:
                     PyMem_Free(keys[n])
                     n += 1
                 return rc
-            else:
-                keys = NULL
         else:
             keys = NULL
 
         # allocate and load pmix info structs from python list of dictionaries
-        info_ptr = &info
-        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if dicts is not None:
+            info_ptr = &info
+            rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        else:
+            info = NULL
 
         # pass it into the unpublish API
         rc = PMIx_Unpublish(keys, info, ninfo)
@@ -2648,7 +2649,7 @@ cdef int query(pmix_proc_t *source,
         args['queries'] = pyqueries
         pmix_unload_procs(source, 1, myproc)
         args['source'] = myproc[0]
-        rc,results = pmixservermodule['query'](args, pyqueries)
+        rc,results = pmixservermodule['query'](args)
     else:
         rc = PMIX_ERR_NOT_SUPPORTED
         results = []

--- a/bindings/python/tests/python/sched.py
+++ b/bindings/python/tests/python/sched.py
@@ -28,23 +28,23 @@ def main():
     print("Version: ", vers)
 
     # Register a fabric
-    rc = foo.register_fabric(None)
+    rc = foo.fabric_register(None)
     print("Fabric registered: ", rc)
 
     # setup the application
-    (rc, regex) = foo.generate_regex("test000,test001,test002")
+    (rc, regex) = foo.generate_regex(["test000","test001","test002"])
     print("Node regex, rc: ", regex, rc)
-    (rc, ppn) = foo.generate_ppn("0,1,2;3,4,5;6,7")
+    (rc, ppn) = foo.generate_ppn(["0,1,2", "3,4,5", "6,7"])
     print("PPN, rc: ", ppn, rc)
-    darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_NETWORK_ID,
+    darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_FABRIC_ID,
                             'value':'SIMPSCHED.net', 'val_type':PMIX_STRING},
-                           {'key':PMIX_ALLOC_NETWORK_SEC_KEY, 'value':'T',
+                           {'key':PMIX_ALLOC_FABRIC_SEC_KEY, 'value':'T',
                             'val_type':PMIX_BOOL},
                            {'key':PMIX_SETUP_APP_ENVARS, 'value':'T',
                             'val_type':PMIX_BOOL}]}
     kyvals = [{'key':PMIX_NODE_MAP, 'value':regex, 'val_type':PMIX_STRING},
               {'key':PMIX_PROC_MAP, 'value':ppn, 'val_type':PMIX_STRING},
-              {'key':PMIX_ALLOC_NETWORK, 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
+              {'key':PMIX_ALLOC_FABRIC, 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
 
     appinfo = []
     rc, appinfo = foo.setup_application("SIMPSCHED", kyvals)

--- a/bindings/python/tests/python/server_upcalls.py
+++ b/bindings/python/tests/python/server_upcalls.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pmix import *
 import signal, time
 global killer
@@ -40,6 +42,8 @@ def clientfence(args:dict is not None):
                     except:
                         #it can be ignored
                         pass
+    except:
+        pass
     print("COMPLETE")
     return PMIX_SUCCESS, output
 
@@ -58,7 +62,7 @@ def clientunpublish(args:dict is not None):
     print("SERVER: UNPUBLISH")
     for k in args['keys']:
         for d in pmix_locdata:
-            if k.decode('ascii') == d['key']:
+            if k == d['key']:
                 pmix_locdata.remove(d)
     return PMIX_OPERATION_SUCCEEDED
 


### PR DESCRIPTION
[Some repairs to the Python bindings](https://github.com/openpmix/openpmix/commit/892bd4a01de1dc1dcf2d66193355feb6dad17df6)

Correct the function signature for the Python "query" call. Add
some protection in a couple of places for data types.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Fix the Python tests](https://github.com/openpmix/openpmix/commit/e1693833ac4f38474630c099f3ee66ee0f0159ac)

Correct a couple of function signatures. Properly initialize the
"flags" field of a couple of pmix_info_t dicts.

Update the sched.py test

Signed-off-by: Ralph Castain <rhc@pmix.org>
