### PR TITLE
Allow Python tool to set server module functions

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1725,6 +1725,23 @@ cdef class PMIxServer(PMIxClient):
             rc = PMIx_server_init(&self.myserver, NULL, 0)
         return rc
 
+    # Allow a tool to set server module callback functions
+    # when it needs to also act as a server
+    def set_server_module(self, map:dict):
+        # setup server module
+        if map is None or 0 == len(map):
+            print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
+            return PMIX_ERR_INIT
+        kvkeys = list(map.keys())
+        for key in kvkeys:
+            try:
+                print("ASSIGNED FN", key)
+                setmodulefn(key, map[key])
+            except KeyError:
+                print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
+                return PMIX_ERR_INIT
+        return PMIX_SUCCESS
+
     def finalize(self):
         global stop_progress
         global progressThread

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2114,7 +2114,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:server setup_fork for nspace %s rank %u", proc->nspace, proc->rank);
+                        "pmix:server setup_fork for nspace %s rank %u",
+                        proc->nspace, proc->rank);
 
     /* pass the nspace */
     pmix_setenv("PMIX_NAMESPACE", proc->nspace, true, env);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -286,7 +286,8 @@ static void tool_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_info_t *info = NULL;
     PMIX_HIDE_UNUSED_PARAMS(hdr, cbdata);
 
-    pmix_output_verbose(2, pmix_client_globals.iof_output, "recvd IOF with %d bytes",
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "recvd IOF with %d bytes",
                         (int) buf->bytes_used);
 
     /* if the buffer is empty, they are simply closing the socket */
@@ -400,7 +401,8 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
     size_t n;
     PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
 
-    pmix_output_verbose(2, pmix_client_globals.base_output, "[%s:%d] DEBUGGER RELEASE RECVD",
+    pmix_output_verbose(2, pmix_client_globals.base_output,
+                        "[%s:%d] DEBUGGER RELEASE RECVD",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
     if (NULL != info) {
         lock = NULL;
@@ -777,6 +779,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
             pmix_client_globals.myserver->info->gid = pmix_globals.gid;
+            /* mark us as not connecting to avoid asking for our job info */
+            do_not_connect = true;
         }
     }
     /* setup the wildcard ID */
@@ -811,9 +815,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
 
     /* open the pmdl framework and select the active modules for this environment
      * as we might need them if we are asking a server to launch something for us */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
+    rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
@@ -965,9 +969,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     /* if we are acting as a server, then start listening */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* setup the fork/exec framework */
-        if (PMIX_SUCCESS
-            != (rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework,
-                                                  PMIX_MCA_BASE_OPEN_DEFAULT))) {
+        rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework,
+                                          PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
             return rc;
         }
         if (PMIX_SUCCESS != (rc = pmix_pfexec_base_select())) {
@@ -982,9 +986,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         }
 
         /* open the pnet framework and select the active modules for this environment */
-        if (PMIX_SUCCESS
-            != (rc = pmix_mca_base_framework_open(&pmix_pnet_base_framework,
-                                                  PMIX_MCA_BASE_OPEN_DEFAULT))) {
+        rc = pmix_mca_base_framework_open(&pmix_pnet_base_framework,
+                                          PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
             return rc;
         }
         if (PMIX_SUCCESS != (rc = pmix_pnet_base_select())) {


### PR DESCRIPTION
Provide a server entry point for passing callback functions. If connection is optional, then don't ask for job info as that causes the tool to hang. Fix some indenting.

Signed-off-by: Ralph Castain <rhc@pmix.org>