### PR TITLE
Multiple commits

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1237,7 +1237,10 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         return {'value':value[0].data.byte, 'val_type':PMIX_BYTE}
     elif PMIX_STRING == value[0].type:
         pyb = value[0].data.string
-        pystr = pyb.decode("ascii")
+        try:
+            pystr = pyb.decode("ascii")
+        except:
+            pystr = pyb
         return {'value':pystr, 'val_type':PMIX_STRING}
     elif PMIX_SIZE == value[0].type:
         return {'value':value[0].data.size, 'val_type':PMIX_SIZE}
@@ -1398,12 +1401,12 @@ cdef int pmix_unload_info(const pmix_info_t *info, size_t ninfo, ilist:list):
     cdef size_t n
     n = 0
     while n < ninfo:
+        kystr = strdup(info[n].key)
         # pmix_unload_value returns a python dict of val, val_type
         val = pmix_unload_value(&info[n].value)
         if val['val_type'] == PMIX_UNDEF:
             return PMIX_ERR_NOT_SUPPORTED
         d     = {}
-        kystr = strdup(info[n].key)
         pykey = str(kystr.decode("ascii"))
         free(kystr)
         d['key']      = pykey

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -7,7 +7,7 @@ from libc.string cimport memcpy
 from libc.stdio cimport printf
 from ctypes import addressof, c_int
 from cython.operator import address
-import signal, time
+import signal, time, sys
 import threading, ctypes
 import queue
 import array
@@ -640,14 +640,15 @@ cdef class PMIxClient:
                     PyMem_Free(keys[n])
                     n += 1
                 return rc
-            else:
-                keys = NULL
         else:
             keys = NULL
 
         # allocate and load pmix info structs from python list of dictionaries
-        info_ptr = &info
-        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if dicts is not None:
+            info_ptr = &info
+            rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        else:
+            info = NULL
 
         # pass it into the unpublish API
         rc = PMIx_Unpublish(keys, info, ninfo)
@@ -2648,7 +2649,7 @@ cdef int query(pmix_proc_t *source,
         args['queries'] = pyqueries
         pmix_unload_procs(source, 1, myproc)
         args['source'] = myproc[0]
-        rc,results = pmixservermodule['query'](args, pyqueries)
+        rc,results = pmixservermodule['query'](args)
     else:
         rc = PMIX_ERR_NOT_SUPPORTED
         results = []

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1725,6 +1725,23 @@ cdef class PMIxServer(PMIxClient):
             rc = PMIx_server_init(&self.myserver, NULL, 0)
         return rc
 
+    # Allow a tool to set server module callback functions
+    # when it needs to also act as a server
+    def set_server_module(self, map:dict):
+        # setup server module
+        if map is None or 0 == len(map):
+            print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
+            return PMIX_ERR_INIT
+        kvkeys = list(map.keys())
+        for key in kvkeys:
+            try:
+                print("ASSIGNED FN", key)
+                setmodulefn(key, map[key])
+            except KeyError:
+                print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
+                return PMIX_ERR_INIT
+        return PMIX_SUCCESS
+
     def finalize(self):
         global stop_progress
         global progressThread

--- a/bindings/python/tests/python/sched.py
+++ b/bindings/python/tests/python/sched.py
@@ -28,23 +28,23 @@ def main():
     print("Version: ", vers)
 
     # Register a fabric
-    rc = foo.register_fabric(None)
+    rc = foo.fabric_register(None)
     print("Fabric registered: ", rc)
 
     # setup the application
-    (rc, regex) = foo.generate_regex("test000,test001,test002")
+    (rc, regex) = foo.generate_regex(["test000","test001","test002"])
     print("Node regex, rc: ", regex, rc)
-    (rc, ppn) = foo.generate_ppn("0,1,2;3,4,5;6,7")
+    (rc, ppn) = foo.generate_ppn(["0,1,2", "3,4,5", "6,7"])
     print("PPN, rc: ", ppn, rc)
-    darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_NETWORK_ID,
+    darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_FABRIC_ID,
                             'value':'SIMPSCHED.net', 'val_type':PMIX_STRING},
-                           {'key':PMIX_ALLOC_NETWORK_SEC_KEY, 'value':'T',
+                           {'key':PMIX_ALLOC_FABRIC_SEC_KEY, 'value':'T',
                             'val_type':PMIX_BOOL},
                            {'key':PMIX_SETUP_APP_ENVARS, 'value':'T',
                             'val_type':PMIX_BOOL}]}
     kyvals = [{'key':PMIX_NODE_MAP, 'value':regex, 'val_type':PMIX_STRING},
               {'key':PMIX_PROC_MAP, 'value':ppn, 'val_type':PMIX_STRING},
-              {'key':PMIX_ALLOC_NETWORK, 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
+              {'key':PMIX_ALLOC_FABRIC, 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
 
     appinfo = []
     rc, appinfo = foo.setup_application("SIMPSCHED", kyvals)

--- a/bindings/python/tests/python/server_upcalls.py
+++ b/bindings/python/tests/python/server_upcalls.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pmix import *
 import signal, time
 global killer
@@ -40,6 +42,8 @@ def clientfence(args:dict is not None):
                     except:
                         #it can be ignored
                         pass
+    except:
+        pass
     print("COMPLETE")
     return PMIX_SUCCESS, output
 
@@ -58,7 +62,7 @@ def clientunpublish(args:dict is not None):
     print("SERVER: UNPUBLISH")
     for k in args['keys']:
         for d in pmix_locdata:
-            if k.decode('ascii') == d['key']:
+            if k == d['key']:
                 pmix_locdata.remove(d)
     return PMIX_OPERATION_SUCCEEDED
 

--- a/config/pmix_check_os_flavors.m4
+++ b/config/pmix_check_os_flavors.m4
@@ -5,7 +5,7 @@ dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -23,7 +23,7 @@ AC_DEFUN([PMIX_CHECK_OS_FLAVOR_SPECIFIC],
     AC_MSG_CHECKING([$1])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
      [[#ifndef $1
-      error: this isnt $1
+      #this is not $1, error
       #endif
      ]])],
                       [pmix_found_$2=yes],

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2113,7 +2113,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:server setup_fork for nspace %s rank %u", proc->nspace, proc->rank);
+                        "pmix:server setup_fork for nspace %s rank %u",
+                        proc->nspace, proc->rank);
 
     /* pass the nspace */
     pmix_setenv("PMIX_NAMESPACE", proc->nspace, true, env);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -287,7 +287,8 @@ static void tool_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_info_t *info = NULL;
     PMIX_HIDE_UNUSED_PARAMS(hdr, cbdata);
 
-    pmix_output_verbose(2, pmix_client_globals.iof_output, "recvd IOF with %d bytes",
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "recvd IOF with %d bytes",
                         (int) buf->bytes_used);
 
     /* if the buffer is empty, they are simply closing the socket */
@@ -401,7 +402,8 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
     size_t n;
     PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
 
-    pmix_output_verbose(2, pmix_client_globals.base_output, "[%s:%d] DEBUGGER RELEASE RECVD",
+    pmix_output_verbose(2, pmix_client_globals.base_output,
+                        "[%s:%d] DEBUGGER RELEASE RECVD",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
     if (NULL != info) {
         lock = NULL;
@@ -778,6 +780,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
             pmix_client_globals.myserver->info->gid = pmix_globals.gid;
+            /* mark us as not connecting to avoid asking for our job info */
+            do_not_connect = true;
         }
     }
     /* setup the wildcard ID */
@@ -812,9 +816,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
 
     /* open the pmdl framework and select the active modules for this environment
      * as we might need them if we are asking a server to launch something for us */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
+    rc = pmix_mca_base_framework_open(&pmix_pmdl_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
@@ -966,9 +970,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     /* if we are acting as a server, then start listening */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* setup the fork/exec framework */
-        if (PMIX_SUCCESS
-            != (rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework,
-                                                  PMIX_MCA_BASE_OPEN_DEFAULT))) {
+        rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework,
+                                          PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
             return rc;
         }
         if (PMIX_SUCCESS != (rc = pmix_pfexec_base_select())) {
@@ -983,9 +987,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         }
 
         /* open the pnet framework and select the active modules for this environment */
-        if (PMIX_SUCCESS
-            != (rc = pmix_mca_base_framework_open(&pmix_pnet_base_framework,
-                                                  PMIX_MCA_BASE_OPEN_DEFAULT))) {
+        rc = pmix_mca_base_framework_open(&pmix_pnet_base_framework,
+                                          PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
             return rc;
         }
         if (PMIX_SUCCESS != (rc = pmix_pnet_base_select())) {


### PR DESCRIPTION
[Some repairs to the Python bindings](https://github.com/openpmix/openpmix/commit/f1f7513be3ad333486983d680e9bfe4c0b3eb9c9)

Correct the function signature for the Python "query" call. Add
some protection in a couple of places for data types.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/678e64f0883536f72aec02849c7525b15a27eacf)

[Fix the Python tests](https://github.com/openpmix/openpmix/commit/82a904b9f2049c6d454122620ace613cda259f9f)

Correct a couple of function signatures. Properly initialize the
"flags" field of a couple of pmix_info_t dicts.

Update the sched.py test

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/e112b827cf49d88be739b4467deedab0424ec11f)

[Minor correction to check_os_flavors](https://github.com/openpmix/openpmix/commit/1850385236ff2330e148526735fb2cd0d98e00c0)

Backport of https://github.com/open-mpi/ompi/pull/11081

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/71940e1300f2794efb3b167eeb30ac9a26f172ba)

[Allow Python tool to set server module functions](https://github.com/openpmix/openpmix/commit/dca1d1ed2f451d462d643e98518fd9d95167e132)

Provide a server entry point for passing callback functions.
If connection is optional, then don't ask for job info as
that causes the tool to hang. Fix some indenting.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/5fe57aae91b01da006f820abd36d1e6a682f85c3)
