### PR TITLE
Multiple commits

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1209,8 +1209,11 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         pynsptr = <const char *>(pyns)
         value[0].data.envar.value = strdup(pynsptr)
         # TODO: way/function to verify char type
-        pyseparator = <char>ord(val['value']['separator'])
-        value[0].data.envar.separator = pyseparator
+        enval = val['value']['separator']
+        if isinstance(enval, pmix_int_types):
+            value[0].data.envar.separator = enval
+        else:
+            value[0].data.envar.separator = ord(enval)
     elif val['val_type'] == PMIX_REGEX:
         regex = val['value']
         ba = pmix_convert_regex(regex)

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -92,11 +92,10 @@ def pyevhdlr(stop):
     return
 
 
-# create a progress thread for processing events
-progressThread = threading.Thread(target = pyevhdlr, args =(lambda : stop_progress, ))
-# ensure the thread dies at termination of main so we can exit
+# create a progress thread for processing events - ensure the
+# thread dies at termination of main so we can exit
 # if we should terminate without finalizing
-progressThread.setDaemon(True)
+progressThread = threading.Thread(target = pyevhdlr, daemon = True, args =(lambda : stop_progress, ))
 
 cdef void dmodx_cbfunc(pmix_status_t status,
                        char *data, size_t sz,
@@ -3226,6 +3225,10 @@ cdef class PMIxTool(PMIxServer):
         # finalize
         rc = PMIx_tool_finalize()
         return rc
+
+    # see if the tool is connected
+    def is_connected(self):
+        return PMIx_tool_is_connected()
 
     # Disconnect from a server
     def disconnect(server:dict):

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -200,6 +200,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CONNECT_TO_SYSTEM              "pmix.cnct.sys"         // (bool) The requestor requires that a connection be made only to
                                                                     //        a local system-level PMIx server
 #define PMIX_CONNECT_SYSTEM_FIRST           "pmix.cnct.sys.first"   // (bool) Preferentially look for a system-level PMIx server first
+#define PMIX_CONNECT_TO_SCHEDULER           "pmix.cnct.sched"       // (bool) Connect to the system scheduler
 #define PMIX_SERVER_URI                     "pmix.srvr.uri"         // (char*) URI of server to be contacted
 #define PMIX_MYSERVER_URI                   "pmix.mysrvr.uri"       // (char*) URI of this proc's listener socket
 #define PMIX_SERVER_HOSTNAME                "pmix.srvr.host"        // (char*) node where target server is located
@@ -1519,7 +1520,7 @@ typedef uint8_t pmix_alloc_directive_t;
 #define PMIX_ALLOC_NEW          1  // new allocation is being requested. The resulting allocation will be
                                    // disjoint (i.e., not connected in a job sense) from the requesting allocation
 #define PMIX_ALLOC_EXTEND       2  // extend the existing allocation, either in time or as additional resources
-#define PMIX_ALLOC_RELEASE      3  // release part of the existing allocation. Attributes in the accompanying
+#define PMIX_ALLOC_RELEASE      3  // release part or all of the existing allocation. Attributes in the accompanying
                                    // pmix\_info\_t array may be used to specify permanent release of the
                                    // identified resources, or "lending" of those resources for some period
                                    // of time.

--- a/include/pmix_tool.h
+++ b/include/pmix_tool.h
@@ -98,6 +98,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
  * operation. */
 PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void);
 
+/* Check if the tool is connected to a PMIx server */
+PMIX_EXPORT bool PMIx_tool_is_connected(void);
+
 /* Establish a connection to a PMIx server. The target server can
  * be given as:
  *

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -200,35 +200,9 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
 
     /* if I am a scheduler server, then I should be able
      * to support this myself */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
-        /* see if we can do it ourselves */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
         rc = pmix_pnet.register_fabric(fabric, directives, ndirs, cbfunc, cbdata);
-        if (PMIX_OPERATION_SUCCEEDED == rc) {
-            /* did it atomically */
-            return rc;
-        } else if (PMIX_SUCCESS == rc) {
-            /* in progress - the pnet component will callback
-             * when it is complete */
-            return rc;
-        }
-        /* otherwise, see if we can pass
-         * it up to our host so they can send it to the scheduler */
-        if (NULL == pmix_host_server.fabric) {
-            return PMIX_ERR_NOT_SUPPORTED;
-        }
-        if (NULL != cbfunc) {
-            cb = PMIX_NEW(pmix_cb_t);
-            cb->fabric = fabric;
-            cb->cbfunc.opfn = cbfunc;
-            cb->cbdata = cbdata;
-        } else {
-            cb = (pmix_cb_t *) cbdata;
-        }
-        rc = pmix_host_server.fabric(&pmix_globals.myid, PMIX_FABRIC_REQUEST_INFO, directives,
-                                     ndirs, fcb, (void *) cb);
-        if (PMIX_SUCCESS != rc && NULL != cbfunc) {
-            PMIX_RELEASE(cb);
-        }
         return rc;
     }
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,6 +73,7 @@ struct pmix_ptl_base_t {
     char *report_uri;
     char *uri;
     char *urifile;
+    char *scheduler_filename;
     char *system_filename;
     char *session_filename;
     char *nspace_filename;
@@ -81,6 +82,7 @@ struct pmix_ptl_base_t {
     bool created_rendezvous_file;
     bool created_session_tmpdir;
     bool created_system_tmpdir;
+    bool created_scheduler_filename;
     bool created_system_filename;
     bool created_session_filename;
     bool created_nspace_filename;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -78,6 +78,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .report_uri = NULL,
     .uri = NULL,
     .urifile = NULL,
+    .scheduler_filename = NULL,
     .system_filename = NULL,
     .session_filename = NULL,
     .nspace_filename = NULL,
@@ -86,6 +87,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .created_rendezvous_file = false,
     .created_session_tmpdir = false,
     .created_system_tmpdir = false,
+    .created_scheduler_filename = false,
     .created_system_filename = false,
     .created_session_filename = false,
     .created_nspace_filename = false,
@@ -254,6 +256,17 @@ static pmix_status_t pmix_ptl_close(void)
     PMIX_LIST_DESTRUCT(&pmix_ptl_base.unexpected_msgs);
     PMIX_DESTRUCT(&pmix_ptl_base.listener);
 
+    if (NULL != pmix_ptl_base.scheduler_filename) {
+        if (pmix_ptl_base.created_scheduler_filename) {
+            rc = remove(pmix_ptl_base.scheduler_filename);
+            if (0 != rc) {
+                pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                                    "Remove of %s failed: %s",
+                                    pmix_ptl_base.scheduler_filename, strerror(errno));
+            }
+        }
+        free(pmix_ptl_base.scheduler_filename);
+    }
     if (NULL != pmix_ptl_base.system_filename) {
         if (pmix_ptl_base.created_system_filename) {
             rc = remove(pmix_ptl_base.system_filename);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -525,6 +525,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
                 if (PMIX_INFO_TRUE(&info[n])) {
                     PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_LAUNCHER);
                 }
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SCHEDULER)) {
+                if (PMIX_INFO_TRUE(&info[n])) {
+                    PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_SCHEDULER);
+                }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
@@ -967,7 +971,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* if we are acting as a server, then start listening */
-    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) ||
+        PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
         /* setup the fork/exec framework */
         rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework,
                                           PMIX_MCA_BASE_OPEN_DEFAULT);
@@ -1550,6 +1555,11 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     pmix_class_finalize();
 
     return PMIX_SUCCESS;
+}
+
+bool PMIx_tool_is_connected(void)
+{
+    return pmix_globals.connected;
 }
 
 pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc, pmix_info_t info[], size_t ninfo)


### PR DESCRIPTION
[Avoid infinite loop in fabric registration](https://github.com/openpmix/openpmix/commit/90cf81a5be41af632f77fca8b699f3c5c1905f11)

If a server or scheduler attempts to register a fabric,
do not call back into the host if we don't find the
requested fabric support. The host is the one that just
called down, so this can lead to an infinite loop.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Add an API and attribute](https://github.com/openpmix/openpmix/commit/686996edd425d2d4cd116642cd45ae7652e37353)

Add an API to report if the tool is connected

Also add a new attribute for connecting to a scheduler

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Cleanup a couple of warnings in Python bindings](https://github.com/openpmix/openpmix/commit/ebbf7e897b2171c0e7b6cd3e2e9ba6f0b155e4c0)

Some minor cleanups. Add support for the "tool is connected" API

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Add support for scheduler connections](https://github.com/openpmix/openpmix/commit/4bc926e13536c6beabf0fb4b9ba9fb9f828cf1b3)

Drop scheduler rendezvous files, allow specification
of connect to scheduler.

Signed-off-by: Ralph Castain <rhc@pmix.org>
