### PR TITLE
Allow gds function fallback to hash.

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,7 +49,7 @@
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
-#include "src/mca/gds/gds.h"
+#include "src/mca/gds/base/base.h"
 #include "src/mca/pcompress/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/threads/pmix_threads.h"

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -27,6 +27,7 @@
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/pstrg/pstrg.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/mca/gds/base/base.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -46,6 +46,7 @@
 #include "src/client/pmix_client_ops.h"
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/base/base.h"
+#include "src/mca/gds/base/base.h"
 #include "src/mca/pnet/pnet.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,12 +86,16 @@ typedef pmix_status_t (*pmix_gds_base_module_assemb_kvs_req_fn_t)(const pmix_pro
 /* define a macro for server keys answer based on peer */
 #define PMIX_GDS_ASSEMB_KVS_REQ(s, p, r, k, b, c)                                            \
     do {                                                                                     \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                  \
-        (s) = PMIX_SUCCESS;                                                                  \
-        if (NULL != _g->assemb_kvs_req) {                                                    \
-            pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS ASSEMBLE REQ WITH %s", \
-                                __FILE__, __LINE__, _g->name);                               \
-            (s) = _g->assemb_kvs_req(r, k, b, (void *) c);                                   \
+        (s) = PMIX_ERROR;                                                                    \
+        pmix_gds_base_active_module_t*_gi;                                                   \
+        PMIX_LIST_FOREACH (_gi, &pmix_gds_globals.actives, pmix_gds_base_active_module_t) {  \
+            if (NULL != _gi->module->assemb_kvs_req) {                                       \
+                pmix_output_verbose(1, pmix_gds_base_output,                                 \
+                                    "[%s:%d] GDS ASSEMBLE REQ WITH %s",                      \
+                                    __FILE__, __LINE__, _gi->module->name);                  \
+                (s) = _gi->module->assemb_kvs_req(r, k, b, (void *) c);                      \
+                break;                                                                       \
+            }                                                                                \
         }                                                                                    \
     } while (0)
 
@@ -100,12 +105,16 @@ typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t
 /* define a macro for client key processing from a server response based on peer */
 #define PMIX_GDS_ACCEPT_KVS_RESP(s, p, b)                                                   \
     do {                                                                                    \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                 \
-        (s) = PMIX_SUCCESS;                                                                 \
-        if (NULL != _g->accept_kvs_resp) {                                                  \
-            pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS ACCEPT RESP WITH %s", \
-                                __FILE__, __LINE__, _g->name);                              \
-            (s) = _g->accept_kvs_resp(b);                                                   \
+        (s) = PMIX_ERROR;                                                                   \
+        pmix_gds_base_active_module_t*_gi;                                                  \
+        PMIX_LIST_FOREACH (_gi, &pmix_gds_globals.actives, pmix_gds_base_active_module_t) { \
+            if (NULL != _gi->module->accept_kvs_resp) {                                     \
+                pmix_output_verbose(1, pmix_gds_base_output,                                \
+                                    "[%s:%d] GDS ACCEPT RESP WITH %s",                      \
+                                    __FILE__, __LINE__, _gi->module->name);                 \
+                (s) = _gi->module->accept_kvs_resp(b);                                      \
+                break;                                                                      \
+            }                                                                               \
         }                                                                                   \
     } while (0)
 
@@ -208,10 +217,17 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
 /* define a convenience macro for storing key-val pairs based on peer */
 #define PMIX_GDS_STORE_KV(s, p, pc, sc, k)                                                     \
     do {                                                                                       \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                    \
-        pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS STORE KV WITH %s", __FILE__, \
-                            __LINE__, _g->name);                                               \
-        (s) = _g->store(pc, sc, k);                                                            \
+        (s) = PMIX_ERROR;                                                                      \
+        pmix_gds_base_active_module_t*_gi;                                                     \
+        PMIX_LIST_FOREACH (_gi, &pmix_gds_globals.actives, pmix_gds_base_active_module_t) {    \
+            if (NULL != _gi->module->store) {                                                  \
+                pmix_output_verbose(1, pmix_gds_base_output,                                   \
+                                    "[%s:%d] GDS STORE KV WITH %s",                            \
+                                    __FILE__, __LINE__, _gi->module->name);                    \
+                (s) = _gi->module->store(pc, sc, k);                                           \
+                break;                                                                         \
+            }                                                                                  \
+        }                                                                                      \
     } while (0)
 
 /**

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +35,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_socket_errno.h"
 #include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/gds/base/base.h"
 #include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"
 #include "src/util/pmix_alfg.h"

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +49,7 @@
 
 #include "src/mca/ptl/base/base.h"
 #include "src/mca/ptl/base/ptl_base_handshake.h"
+#include "src/mca/gds/base/base.h"
 
 /****    SUPPORTING FUNCTIONS    ****/
 static void timeout(int sd, short args, void *cbdata);

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +63,7 @@
 #include "src/util/pmix_show_help.h"
 
 #include "src/mca/ptl/base/base.h"
+#include "src/mca/gds/base/base.h"
 
 // local functions for connection support
 static void *listen_thread(void *obj);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +48,7 @@
 
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
-#include "src/mca/gds/gds.h"
+#include "src/mca/gds/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"


### PR DESCRIPTION
For a strict subset of gds module function pointers, allow for the use of NULL to indicate that another module should be used instead, namely hash.

The impacted functions here are: store, assemb_kvs_req, and accept_kvs_resp.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>