### PR TITLE
Try both peer and server storage for connect info

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3577,10 +3577,14 @@ static void _cnct(int sd, short args, void *cbdata)
                 cb.copy = false;
                 PMIX_GDS_FETCH_KV(rc, cd->peer, &cb);
                 if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(reply);
-                    PMIX_DESTRUCT(&cb);
-                    goto error;
+                    /* try getting it from our storage */
+                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(reply);
+                        PMIX_DESTRUCT(&cb);
+                        goto error;
+                    }
                 }
                 PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
                 /* pack the nspace name */


### PR DESCRIPTION
Give the local client's GDS module first chance to provide the connect info, but then try the server's module if that didn't work.

Signed-off-by: Ralph Castain <rhc@pmix.org>