### PR TITLE
Add attribute to report index of topology in storage array

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -345,6 +345,7 @@ typedef uint32_t pmix_rank_t;
 /* topology info */
 #define PMIX_TOPOLOGY2                      "pmix.topo2"            // (pmix_topology_t*) pointer to a PMIx topology object
 #define PMIX_LOCALITY_STRING                "pmix.locstr"           // (char*) string describing a proc's location
+#define PMIX_TOPOLOGY_INDEX                 "pmix.topo.index"       // (int)  index of a topology in a storage array
 
 
 /* request-related info */


### PR DESCRIPTION
When reporting the allocation, the RTE must include topology information for each node. Rather than passing the topology itself repeatedly, pass an index for the topology in an array of topologies and then include that array in the report.

Signed-off-by: Ralph Castain <rhc@pmix.org>