### PR TITLE
Include deprecated definitions in Python bindings

### DIFF
--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -515,6 +515,10 @@ def main():
     definitions.write("\n\n")
     constants.write("\n\n")
     harvest_constants(options, "pmix_tool.h", constants, definitions)
+    # add some space
+    definitions.write("\n\n")
+    constants.write("\n\n")
+    harvest_constants(options, "pmix_deprecated.h", constants, definitions)
     # close the files to ensure all output is written
     constants.close()
     definitions.close()


### PR DESCRIPTION
Need the extended list of attributes

Signed-off-by: Ralph Castain <rhc@pmix.org>