### PR TITLE
Add hooks for GDS components to handshake modex complete

### DIFF
--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -197,6 +197,11 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
     }
     pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "client:unpack fence received status %d", ret);
+    
+    /* provide an opportunity to store any data (or at least how to access
+     * any data) that was included in the fence */
+    PMIX_GDS_RECV_MODEX_COMPLETE(data);
+
     return ret;
 }
 

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -277,6 +277,28 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_names
         (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t *) n, b, t);                  \
     } while (0)
 
+typedef void (*pmix_gds_base_module_mark_modex_complete_fn_t)(struct pmix_peer_t *peer,
+                                                              pmix_list_t *nslist,
+                                                              pmix_buffer_t *buff);
+#define PMIX_GDS_MARK_MODEX_COMPLETE(p, l, b)                               \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                 \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS MARK MODEX COMPLETE WITH %s",      \
+                            __FILE__, __LINE__, _g->name);                  \
+        _g->mark_modex_complete(p, l, b);                                   \
+    } while (0)
+
+typedef void (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buffer_t *buff);
+#define PMIX_GDS_RECV_MODEX_COMPLETE(b)                                     \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS RECV MODEX COMPLETE WITH %s",      \
+                            __FILE__, __LINE__, _g->name);                  \
+        _g->recv_modex_complete(b);                                         \
+    } while (0)
+
 /**
  * fetch value corresponding to provided key from within the defined
  * scope. A NULL key returns all values committed by the given peer
@@ -447,7 +469,8 @@ typedef struct {
     pmix_gds_base_module_assemb_kvs_req_fn_t        assemb_kvs_req;
     pmix_gds_base_module_accept_kvs_resp_fn_t       accept_kvs_resp;
     pmix_gds_base_module_fetch_array_fn_t           fetch_arrays;
-
+    pmix_gds_base_module_mark_modex_complete_fn_t   mark_modex_complete;
+    pmix_gds_base_module_recv_modex_complete_fn_t   recv_modex_complete;
 } pmix_gds_base_module_t;
 
 /* NOTE: there is no public GDS interface structure - all access is

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -82,6 +82,12 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, p
 
 static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
 
+static void mark_modex_complete(struct pmix_peer_t *peer,
+                                pmix_list_t *nslist,
+                                pmix_buffer_t *buff);
+
+static void recv_modex_complete(pmix_buffer_t *buff);
+
 pmix_gds_base_module_t pmix_hash_module = {
     .name = "hash",
     .is_tsafe = false,
@@ -99,7 +105,9 @@ pmix_gds_base_module_t pmix_hash_module = {
     .del_nspace = nspace_del,
     .assemb_kvs_req = assemb_kvs_req,
     .accept_kvs_resp = accept_kvs_resp,
-    .fetch_arrays = pmix_gds_hash_fetch_arrays
+    .fetch_arrays = pmix_gds_hash_fetch_arrays,
+    .mark_modex_complete = mark_modex_complete,
+    .recv_modex_complete = recv_modex_complete
 };
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
@@ -1568,4 +1576,18 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
         return rc;
     }
     return rc;
+}
+
+static void mark_modex_complete(struct pmix_peer_t *peer,
+                                pmix_list_t *nslist,
+                                pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(peer, nslist, buff);
+    return;
+}
+
+static void recv_modex_complete(pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(buff);
+    return;
 }

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -1259,6 +1259,20 @@ del_nspace(
     return PMIX_SUCCESS;
 }
 
+static void mark_modex_complete(struct pmix_peer_t *peer,
+                                pmix_list_t *nslist,
+                                pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(peer, nslist, buff);
+    return;
+}
+
+static void recv_modex_complete(pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(buff);
+    return;
+}
+
 pmix_gds_base_module_t pmix_shmem_module = {
     .name = PMIX_GDS_SHMEM_NAME,
     .is_tsafe = false,
@@ -1275,7 +1289,9 @@ pmix_gds_base_module_t pmix_shmem_module = {
     .add_nspace = server_add_nspace,
     .del_nspace = del_nspace,
     .assemb_kvs_req = NULL,
-    .accept_kvs_resp = NULL
+    .accept_kvs_resp = NULL,
+    .mark_modex_complete = mark_modex_complete,
+    .recv_modex_complete = recv_modex_complete
 };
 
 /*

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3366,6 +3366,9 @@ finish_collective:
             PMIX_ERROR_LOG(ret);
             goto cleanup;
         }
+        /* let the gds have a chance to add any data it needs
+         * for providing access to any collected data */
+        PMIX_GDS_MARK_MODEX_COMPLETE(cd->peer, &nslist, reply);
         pmix_output_verbose(2, pmix_server_globals.base_output,
                             "server:modex_cbfunc reply being sent to %s:%u",
                             cd->peer->info->pname.nspace, cd->peer->info->pname.rank);


### PR DESCRIPTION
Give the relevant GDS component an opportunity to add info (e.g., attachment points) to the modex complete message that is sent to the client. Allow the client to pass that info into its active GDS component.

Signed-off-by: Ralph Castain <rhc@pmix.org>