### PR TITLE
Add some scheduler integration support

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -85,6 +85,7 @@ ctypedef struct pmix_pyshift_t:
     pmix_credential_cbfunc_t getcredential
     pmix_validation_cbfunc_t validationcredential
     pmix_info_cbfunc_t allocate
+    pmix_info_cbfunc_t sessioncontrol
     void *notification_cbdata
     void *cbdata
 

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -444,7 +444,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
                                       const pmix_info_t directives[], size_t ndirs,
                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-/* Request an allocation operation from the host resource manager.
+/* Request an allocation operation from the host scheduler.
  * Several broad categories are envisioned, including the ability to:
  *
  * - request allocation of additional resources, including memory,

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -841,6 +841,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_FABRIC_ENDPTS_NODE       "pmix.alloc.endpts.nd"  // (size_t) number of endpoints to allocate per node
 #define PMIX_ALLOC_FABRIC_SEC_KEY           "pmix.alloc.nsec"       // (pmix_byte_object_t) fabric security key
 #define PMIX_ALLOC_QUEUE                    "pmix.alloc.queue"      // (char*) name of queue being referenced
+#define PMIX_ALLOC_PREEMPTIBLE              "pmix.alloc.preempt"    // (bool) by default, all jobs in the resulting allocation are to be
+                                                                    //        considered preemptible (overridable at per-job level)
 
 
 /* job control attributes */
@@ -874,6 +876,47 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CLEANUP_LEAVE_TOPDIR           "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove
                                                                     //        the top-level directory (the one given in the
                                                                     //        cleanup request)
+/* session control attributes */
+#define PMIX_SESSION_CTRL_ID                "pmix.ssnctrl.id"       // (char*) provide a string identifier for this request
+
+/* session instantiation attributes - called by scheduler
+ * Schedulers calling to create a session are required to provide:
+ *  - the effective userID and groupID that the session should have
+ *    when instantiated.
+ *  - description of the resources that are to be included in the session
+ *  - if applicable, the image that should be provisioned on nodes
+ *    included in the session
+ *  - an array of applications (if any) that are to be started in the
+ *    session once instantiated
+ */
+#define PMIX_SESSION_APP                    "pmix.ssn.app"          // (pmix_data_array_t*) Array of pmix_app_t to be executed in the assigned
+                                                                    //        session upon session instantiation
+#define PMIX_SESSION_PROVISION              "pmix.ssn.pvn"          // (pmix_data_array_t*) description of nodes to be provisioned with
+                                                                    //       specified image
+#define PMIX_SESSION_PROVISION_NODES        "pmix.ssn.pvnnds"       // (char*) regex identifying nodes that are to be provisioned
+#define PMIX_SESSION_PROVISION_IMAGE        "pmix.ssn.pvnimg"       // (char*) name of the image that is to be provisioned
+
+/* session operational attributes - called by scheduler */
+#define PMIX_SESSION_PAUSE                  "pmix.ssn.pause"        // (bool) pause all jobs in the specified session
+#define PMIX_SESSION_RESUME                 "pmix.ssn.resume"       // (bool) "un-pause" all jobs in the specified session
+#define PMIX_SESSION_TERMINATE              "pmix.ssn.terminate"    // (bool) terminate all jobs in the specified session and recover all
+                                                                    //        resources included in the session.
+#define PMIX_SESSION_PREEMPT                "pmix.ssn.preempt"      // (bool) preempt indicated jobs (given in accompanying pmix_info_t via
+                                                                    //        the PMIX_NSPACE attribute) in the specified session and recover
+                                                                    //        all their resources. If no PMIX_NSPACE is specified, then preempt
+                                                                    //        all jobs in the session.
+#define PMIX_SESSION_RESTORE                "pmix.ssn.restore"      // (bool) restore indicated jobs (given in accompanying pmix_info_t via
+                                                                    //        the PMIX_NSPACE attribute) in the specified session, including
+                                                                    //        all their resources. If no PMIX_NSPACE is specified, then restore
+                                                                    //        all jobs in the session.
+#define PMIX_SESSION_SIGNAL                 "pmix.ssn.sig"          // (int) send given signal to all processes of every job in the session
+
+/* session operational attributes - called by RTE */
+#define PMIX_SESSION_COMPLETE               "pmix.ssn.complete"     // (bool) specified session has completed, all resources have been
+                                                                    //        recovered and are available for scheduling. Must include
+                                                                    //        pmix_info_t indicating ID and returned status of any jobs
+                                                                    //        executing in the session.
+
 
 /* monitoring attributes */
 #define PMIX_MONITOR_ID                     "pmix.monitor.id"       // (char*) provide a string identifier for this request
@@ -1525,14 +1568,15 @@ typedef uint32_t pmix_info_directives_t;
 
 /* define a set of directives for allocation requests */
 typedef uint8_t pmix_alloc_directive_t;
-#define PMIX_ALLOC_NEW          1  // new allocation is being requested. The resulting allocation will be
-                                   // disjoint (i.e., not connected in a job sense) from the requesting allocation
-#define PMIX_ALLOC_EXTEND       2  // extend the existing allocation, either in time or as additional resources
-#define PMIX_ALLOC_RELEASE      3  // release part or all of the existing allocation. Attributes in the accompanying
-                                   // pmix\_info\_t array may be used to specify permanent release of the
-                                   // identified resources, or "lending" of those resources for some period
-                                   // of time.
-#define PMIX_ALLOC_REAQUIRE     4  // reacquire resources that were previously "lent" back to the scheduler
+#define PMIX_ALLOC_NEW          1   // new allocation is being requested. The resulting allocation will be
+                                    // disjoint (i.e., not connected in a job sense) from the requesting allocation
+#define PMIX_ALLOC_EXTEND       2   // extend the existing allocation, either in time or as additional resources
+#define PMIX_ALLOC_RELEASE      3   // release part or all of the existing allocation. Attributes in the accompanying
+                                    // pmix\_info\_t array may be used to specify permanent release of the
+                                    // identified resources, or "lending" of those resources for some period
+                                    // of time.
+#define PMIX_ALLOC_REAQUIRE     4   // reacquire resources that were previously "lent" back to the scheduler
+#define PMIX_ALLOC_REQ_CANCEL   5   // Cancel the indicated allocation request
 
 /* define a value boundary beyond which implementers are free
  * to define their own directive values */

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Redistribution and use in source and binary forms, with or without
@@ -536,6 +536,12 @@ typedef pmix_status_t (*pmix_server_fabric_fn_t)(const pmix_proc_t *requestor,
                                                  const pmix_info_t directives[], size_t ndirs,
                                                  pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Execute a session control operation request */
+typedef pmix_status_t (*pmix_server_session_control_fn_t)(const pmix_proc_t *requestor,
+                                                          uint32_t sessionID,
+                                                          const pmix_info_t directives[], size_t ndirs,
+                                                          pmix_info_cbfunc_t cbfunc, void *cbdata);
+
 typedef struct pmix_server_module_4_0_0_t {
     /* v1x interfaces */
     pmix_server_client_connected_fn_t   client_connected;
@@ -569,6 +575,8 @@ typedef struct pmix_server_module_4_0_0_t {
     pmix_server_grp_fn_t                group;
     pmix_server_fabric_fn_t             fabric;
     pmix_server_client_connected2_fn_t  client_connected2;
+    /* v5x interfaces */
+    pmix_server_session_control_fn_t    session_control;
 } pmix_server_module_t;
 
 /****    HOST RM FUNCTIONS FOR INTERFACE TO PMIX SERVER    ****/
@@ -868,6 +876,26 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_resources(pmix_info_t info[], siz
 PMIX_EXPORT pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
                                                            pmix_op_cbfunc_t cbfunc,
                                                            void *cbdata);
+
+/* Request a session control action. The sessionID identifies the session
+ * to which the specified control action is to be applied. A UINT32_MAX
+ * value can be used to indicate all sessions under the caller's control.
+ *
+ * The directives are provided as pmix_info_t structs in the directives
+ * array. The callback function provides a status to indicate whether or
+ * not the request was granted, and to provide some information as to the
+ * reason for any denial in the pmix_info_cbfunc_t' array of pmix_info_t
+ * structures. If non-NULL, then the specified release_fn must be called
+ * when the callback function completes - this will be used to release any
+ * provided pmix_info_t array.
+
+ * Passing NULL as the cbfunc to this call indicates that it shall be treated
+ * as a blocking operation, with the return status indicative of the overall
+ * operation's completion.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Session_control(uint32_t sessionID,
+                                               const pmix_info_t directives[], size_t ndirs,
+                                               pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1458,7 +1458,8 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
     pmix_setup_caddy_t *cd;
     pmix_lock_t mylock;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server deregister nspace %s",
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server deregister nspace %s",
                         nspace);
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
@@ -1526,7 +1527,8 @@ pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
     pmix_lock_t mylock;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server register resources");
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server register resources");
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -1593,7 +1595,8 @@ pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
     pmix_lock_t mylock;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server deregister resources");
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server deregister resources");
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -1627,6 +1630,76 @@ pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
     /* we have to push this into our event library to avoid
      * potential threading issues */
     PMIX_THREADSHIFT(cd, _deregister_resources);
+    return PMIX_SUCCESS;
+}
+
+static void myinfocbfunc(pmix_status_t status,
+                         pmix_info_t *info, size_t ninfo,
+                         void *cbdata,
+                         pmix_release_cbfunc_t release_fn,
+                         void *release_cbdata)
+{
+    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, release_fn, release_cbdata);
+
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(lock);
+}
+
+static void _session_control(int sd, short args, void *cbdata)
+{
+    pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    cd->cbfunc.infocbfunc(PMIX_SUCCESS, NULL, 0, cd->cbdata, NULL, NULL);
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t PMIx_Session_control(uint32_t sessionID,
+                                   const pmix_info_t directives[], size_t ndirs,
+                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_shift_caddy_t *cd;
+    pmix_lock_t mylock;
+    pmix_status_t rc;
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server session control");
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    cd->ncodes = sessionID;
+    cd->directives = (pmix_info_t*)directives;
+    cd->ndirs = ndirs;
+    cd->cbfunc.infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+
+    /* if the provided callback is NULL, then substitute
+     * our own internal cbfunc and block here */
+    if (NULL == cbfunc) {
+        PMIX_CONSTRUCT_LOCK(&mylock);
+        cd->cbfunc.infocbfunc = myinfocbfunc;
+        cd->cbdata = &mylock;
+        PMIX_THREADSHIFT(cd, _session_control);
+        PMIX_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIX_OPERATION_SUCCEEDED;
+        }
+        PMIX_DESTRUCT_LOCK(&mylock);
+        return rc;
+    }
+
+    /* we have to push this into our event library to avoid
+     * potential threading issues */
+    PMIX_THREADSHIFT(cd, _session_control);
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
* PMIx_Session_control[_nb] provides an entry point for requesting session-related operations. Schedulers use it to direct the RTE to instantiate a session. RTE's use it to notify schedulers of session completion.

* Attributes to support the above API

* A new server module upcall function pointer for passing session control requests

* Python binding implementations for both API and upcall

Signed-off-by: Ralph Castain <rhc@pmix.org>