### PR TITLE
Ensure the ptl connection handler includes the provided info

### DIFF
--- a/src/mca/ptl/base/ptl_base_handshake.h
+++ b/src/mca/ptl/base/ptl_base_handshake.h
@@ -31,29 +31,32 @@ BEGIN_C_DECLS
 
 /* define flag values that indicate the type of process attempting
  * to connect to a server:
- * 0 => simple client process
- * 1 => legacy tool - may or may not have an identifier
- * 2 => legacy launcher - may or may not have an identifier
+ *  0 => simple client process
+ *  1 => legacy tool - may or may not have an identifier
+ *  2 => legacy launcher - may or may not have an identifier
  * ------------------------------------------
- * 3 => self-started tool process that needs an identifier
- * 4 => self-started tool process that was given an identifier by caller
- * 5 => tool that was started by a PMIx server - identifier specified by server
- * 6 => self-started launcher that needs an identifier
- * 7 => self-started launcher that was given an identifier by caller
- * 8 => launcher that was started by a PMIx server - identifier specified by server
- * 9 => singleton client - treated like a tool that has an identifier
+ *  3 => self-started tool process that needs an identifier
+ *  4 => self-started tool process that was given an identifier by caller
+ *  5 => tool that was started by a PMIx server - identifier specified by server
+ *  6 => self-started launcher that needs an identifier
+ *  7 => self-started launcher that was given an identifier by caller
+ *  8 => launcher that was started by a PMIx server - identifier specified by server
+ *  9 => singleton client - treated like a tool that has an identifier
+ * ------------------------------------------
+ * 10 => scheduler
  */
 typedef uint8_t pmix_rnd_flag_t;
-#define PMIX_SIMPLE_CLIENT     0
-#define PMIX_LEGACY_TOOL       1
-#define PMIX_LEGACY_LAUNCHER   2
-#define PMIX_TOOL_NEEDS_ID     3
-#define PMIX_TOOL_GIVEN_ID     4
-#define PMIX_TOOL_CLIENT       5
-#define PMIX_LAUNCHER_NEEDS_ID 6
-#define PMIX_LAUNCHER_GIVEN_ID 7
-#define PMIX_LAUNCHER_CLIENT   8
-#define PMIX_SINGLETON_CLIENT  9
+#define PMIX_SIMPLE_CLIENT      0
+#define PMIX_LEGACY_TOOL        1
+#define PMIX_LEGACY_LAUNCHER    2
+#define PMIX_TOOL_NEEDS_ID      3
+#define PMIX_TOOL_GIVEN_ID      4
+#define PMIX_TOOL_CLIENT        5
+#define PMIX_LAUNCHER_NEEDS_ID  6
+#define PMIX_LAUNCHER_GIVEN_ID  7
+#define PMIX_LAUNCHER_CLIENT    8
+#define PMIX_SINGLETON_CLIENT   9
+#define PMIX_SCHEDULER_WITH_ID 10
 
 /* The following macros are used in the ptl_base_connection_hdlr.c
  * file to parse the handshake message and extract its fields */

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -77,10 +77,13 @@ typedef struct {
 #define PMIX_RELEASE_WILDCARD 255
 
 /* use 255 as WILDCARD for the release triplet values */
-#define PMIX_PROC_TYPE_STATIC_INIT                                                           \
-    {                                                                                        \
-        .type = PMIX_PROC_UNDEF, .major = PMIX_MAJOR_WILDCARD, .minor = PMIX_MINOR_WILDCARD, \
-        .release = PMIX_RELEASE_WILDCARD, .flag = 0                                          \
+#define PMIX_PROC_TYPE_STATIC_INIT          \
+    {                                       \
+        .type = PMIX_PROC_UNDEF,            \
+        .major = PMIX_MAJOR_WILDCARD,       \
+        .minor = PMIX_MINOR_WILDCARD,       \
+        .release = PMIX_RELEASE_WILDCARD,   \
+        .flag = 0                           \
     }
 
 /* Define process types - we use a bit-mask as procs can


### PR DESCRIPTION
The ptl connection handler wasn't unpacking any provided info keys, which led to loss of info about the type of "tool" connecting to the server. Add support for the "scheduler" proc type.

Signed-off-by: Ralph Castain <rhc@pmix.org>