### PR TITLE
gds/shmem: Fix crash in server_mark_modex_complete().

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -12,28 +12,16 @@
 #ifndef PMIX_GDS_SHMEM_H
 #define PMIX_GDS_SHMEM_H
 
-#include "src/include/pmix_config.h"
+#include "pmix_config.h"
+#include "include/pmix_common.h"
 #include "src/include/pmix_globals.h"
+
+#include "src/util/pmix_shmem.h"
 
 #include "src/mca/gds/base/base.h"
 
-#include "src/class/pmix_object.h"
-#include "src/class/pmix_list.h"
-
-#include "src/util/pmix_shmem.h"
-#include "src/util/pmix_vmem.h"
-
-#include "src/mca/preg/preg.h"
-#include "src/mca/gds/gds.h"
-
-#include "include/pmix_common.h"
-
 // TODO(skg) Remove
 #include "pmix_hash_table2.h"
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 /**
  * The name of this module.
@@ -123,15 +111,6 @@ typedef struct {
     pmix_tma_t tma;
     /** Holds the current address of the shared-memory allocator. */
     void *current_addr;
-    /** Stores static remote job data. */
-    pmix_hash_table2_t *hashtab;
-} pmix_gds_shmem_shared_modex_data_t;
-
-typedef struct {
-    /** Shared-memory allocator for data this structure. */
-    pmix_tma_t tma;
-    /** Holds the current address of the shared-memory allocator. */
-    void *current_addr;
     /** Points to this job's session information. */
     pmix_gds_shmem_session_t *session;
     /** List containing job information. */
@@ -139,10 +118,19 @@ typedef struct {
     /** List containing this job's node information. */
     pmix_list_t *nodeinfo;
     /** List of applications in this job. */
-    pmix_list_t *apps;
+    pmix_list_t *appinfo;
     /** Stores static local (node) job data. */
     pmix_hash_table2_t *local_hashtab;
 } pmix_gds_shmem_shared_job_data_t;
+
+typedef struct {
+    /** Shared-memory allocator for data this structure. */
+    pmix_tma_t tma;
+    /** Holds the current address of the shared-memory allocator. */
+    void *current_addr;
+    /** Stores static modex data. */
+    pmix_hash_table2_t *hashtab;
+} pmix_gds_shmem_shared_modex_data_t;
 
 typedef struct {
     pmix_list_item_t super;
@@ -152,16 +140,13 @@ typedef struct {
     pmix_namespace_t *nspace;
     /** Flag indicating whether or not to release shmem. */
     bool release_shmem;
-    /** Shared-memory object that maintains information for smjob data. */
+    /** Shared-memory object that maintains information for smdata data. */
     pmix_shmem_t *shmem;
     /** Shared-memory object that maintains information for smmodex data. */
     pmix_shmem_t *modex_shmem;
-    /** Points to shared data located in shared-memory segment. */
+    /** Points to shared data located in a shared-memory segment. */
     pmix_gds_shmem_shared_job_data_t *smdata;
-    /**
-     * Points to a structure that maintains static modex
-     * data residing in another shared-memory segment.
-     */
+    /** Points to shared modex data located in a shared-memory segment. */
     pmix_gds_shmem_shared_modex_data_t *smmodex;
 } pmix_gds_shmem_job_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_gds_shmem_job_t);
@@ -170,6 +155,7 @@ typedef struct {
     pmix_list_item_t super;
     uint32_t appnum;
     pmix_list_t *appinfo;
+    /** Node information. */
     pmix_list_t *nodeinfo;
     pmix_gds_shmem_job_t *job;
 } pmix_gds_shmem_app_t;

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -22,9 +22,6 @@
 #include "pmix_hash2.h"
 #endif
 
-#include "src/mca/bfrops/bfrops.h"
-#include "src/mca/pcompress/base/base.h"
-
 // TODO(skg) Avoid copies where appropriate.
 
 static pmix_gds_shmem_nodeinfo_t *
@@ -613,7 +610,7 @@ pmix_gds_shmem_fetch(
         }
         // Collect the relevant app-level info.
         rc = fetch_appinfo(
-            NULL, job, job->smdata->apps, qualifiers, nqual, kvs
+            NULL, job, job->smdata->appinfo, qualifiers, nqual, kvs
         );
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             return rc;
@@ -706,7 +703,7 @@ pmix_gds_shmem_fetch(
         }
         else if (appinfo) {
             rc = fetch_appinfo(
-                key, job, job->smdata->apps, qualifiers, nqual, kvs
+                key, job, job->smdata->appinfo, qualifiers, nqual, kvs
             );
             if (PMIX_SUCCESS != rc && PMIX_RANK_WILDCARD == proc->rank) {
                 // Let hash deal with this one.

--- a/src/mca/gds/shmem/gds_shmem_utils.c
+++ b/src/mca/gds/shmem/gds_shmem_utils.c
@@ -17,7 +17,7 @@
 #include "gds_shmem_utils.h"
 
 #include "src/util/pmix_show_help.h"
-#include "src/mca/pcompress/base/base.h"
+#include "src/util/pmix_vmem.h"
 
 pmix_status_t
 pmix_gds_shmem_get_job_tracker(
@@ -45,12 +45,12 @@ pmix_gds_shmem_get_job_tracker(
     // Create one if not found and asked to create one.
     if (!target_tracker && create) {
         target_tracker = PMIX_NEW(pmix_gds_shmem_job_t);
-        if (!target_tracker) {
+        if (PMIX_UNLIKELY(!target_tracker)) {
             rc = PMIX_ERR_NOMEM;
             goto out;
         }
         target_tracker->nspace_id = strdup(nspace);
-        if (!target_tracker->nspace_id) {
+        if (PMIX_UNLIKELY(!target_tracker->nspace_id)) {
             rc = PMIX_ERR_NOMEM;
             goto out;
         }
@@ -65,12 +65,12 @@ pmix_gds_shmem_get_job_tracker(
         // If not, create one and update global namespace list.
         if (!inspace) {
             inspace = PMIX_NEW(pmix_namespace_t);
-            if (!inspace) {
+            if (PMIX_UNLIKELY(!inspace)) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
             }
             inspace->nspace = strdup(nspace);
-            if (!inspace->nspace) {
+            if (PMIX_UNLIKELY(!inspace->nspace)) {
                 rc = PMIX_ERR_NOMEM;
                 goto out;
             }
@@ -82,7 +82,7 @@ pmix_gds_shmem_get_job_tracker(
         pmix_list_append(&component->jobs, &target_tracker->super);
     }
 out:
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         if (target_tracker) {
             PMIX_RELEASE(target_tracker);
             target_tracker = NULL;
@@ -102,9 +102,9 @@ pmix_gds_shmem_check_session(
     if (!job) {
         return NULL;
     }
-    // Stash a pointer to the job's TMA.
-    pmix_gds_shmem_component_t *const comp = &pmix_mca_gds_shmem_component;
+
     pmix_tma_t *const tma = pmix_gds_shmem_get_job_tma(job);
+    pmix_gds_shmem_component_t *const comp = &pmix_mca_gds_shmem_component;
 
     if (NULL == job->smdata->session) {
         bool found = false;
@@ -174,7 +174,6 @@ pmix_gds_shmem_check_session(
         // It's a wildcard request, so return the job-tracker session.
         return job->smdata->session;
     }
-
     // The job tracker already was assigned a session ID.
     // Check if the new one matches.
     if (job->smdata->session->session != sid) {
@@ -185,7 +184,6 @@ pmix_gds_shmem_check_session(
     // The two must match, so return it.
     return job->smdata->session;
 }
-
 
 bool
 pmix_gds_shmem_check_hostname(
@@ -374,12 +372,10 @@ shmem_attach(
     PMIX_GDS_SHMEM_VOUT(
         "%s: mmapd at address=0x%zx", __func__, (size_t)mmap_addr
     );
-
 out:
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(shmem);
     }
-
     return rc;
 }
 
@@ -428,7 +424,6 @@ out:
     if (PMIX_SUCCESS == rc) {
         job->release_shmem = true;
     }
-
     return rc;
 }
 

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -115,14 +115,14 @@ pmix_gds_shmem_vout_smdata(
         "smdata tma@%p, "
         "smdata tma data_ptr=%p, "
         "jobinfo@%p, "
-        "apps@%p, "
+        "appinfo@%p, "
         "nodeinfo@%p, "
         "local_hashtab@%p",
         (void *)job->shmem->base_address,
         (void *)&job->smdata->tma,
         (void *)job->smdata->tma.data_ptr,
         (void *)job->smdata->jobinfo,
-        (void *)job->smdata->apps,
+        (void *)job->smdata->appinfo,
         (void *)job->smdata->nodeinfo,
         (void *)job->smdata->local_hashtab
     );


### PR DESCRIPTION
* Make sure that a modex exchange has occurred before server_mark_modex_complete() was called.
* Incorporate minor cleanup unrelated to fix.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>