### PR TITLE
Fix a couple of bugs in the modex/get path

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3397,7 +3397,7 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
         // see if we already have this nspace
         found = false;
         PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
-            if (0 == strcmp(nptr->ns->compat.gds->name, cd->peer->nptr->compat.gds->name)) {
+            if (0 == strcmp(nptr->ns->nspace, cd->peer->nptr->nspace)) {
                 found = true;
                 break;
             }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -861,7 +861,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
         /* pass it back */
         cbfunc(rc, data, sz, cbdata, relfn, data);
         // Safe to free pkt.
-        PMIX_DATA_BUFFER_DESTRUCT(&pkt);
+        PMIX_DESTRUCT(&pkt);
         return rc;
     }
 


### PR DESCRIPTION
Error path in server/get released the wrong
object type.

Construction of the list of unique nspaces did
an improper comparison - need to just look at
the nspace itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>