### PR TITLE
Address a few issues in gds/shmem.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -25,6 +25,7 @@
 #ifdef HAVE_STDINT_h
 #include <stdint.h>
 #endif
+#include <inttypes.h>
 
 /**
  * The name of this module.

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -37,7 +37,7 @@ get_nodeinfo_by_nodename(
     // First, just check all the node names as this is the most likely match.
     pmix_gds_shmem_nodeinfo_t *ni;
     PMIX_LIST_FOREACH (ni, nodes, pmix_gds_shmem_nodeinfo_t) {
-        if (0 == strcmp(ni->hostname, hostname)) {
+        if (pmix_gds_shmem_hostnames_eq(ni->hostname, hostname)) {
             return ni;
         }
         if (!pmix_list_is_empty(ni->aliases)) {
@@ -52,7 +52,7 @@ get_nodeinfo_by_nodename(
     PMIX_LIST_FOREACH (ni, nodes, pmix_gds_shmem_nodeinfo_t) {
         pmix_gds_shmem_host_alias_t *nai = NULL;
         PMIX_LIST_FOREACH (nai, ni->aliases, pmix_gds_shmem_host_alias_t) {
-            if (0 == strcmp(nai->name, hostname)) {
+            if (pmix_gds_shmem_hostnames_eq(nai->name, hostname)) {
                 return ni;
             }
         }
@@ -574,12 +574,6 @@ pmix_gds_shmem_fetch(
     const bool mdrfu = pmix_gds_shmem_has_status(
         job, PMIX_GDS_SHMEM_MODEX_ID, PMIX_GDS_SHMEM_READY_FOR_USE
     );
-    if (mdrfu) {
-        PMIX_GDS_SHMEM_VVOUT("%p READY FOR USE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", (void *)job->smmodex->hashtab);
-    }
-    else {
-        PMIX_GDS_SHMEM_VVOUT("NRFU!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    }
     // Modex data are stored in PMIX_REMOTE.
     pmix_hash_table2_t *const remote_ht = mdrfu ? job->smmodex->hashtab : NULL;
 

--- a/src/mca/gds/shmem/gds_shmem_store.c
+++ b/src/mca/gds/shmem/gds_shmem_store.c
@@ -652,6 +652,8 @@ pmix_gds_shmem_store_modex_in_shmem(
     }
     else {
         // Segment is ready for use.
+        // TODO(skg) This is not true. Only valid for use once all modex
+        // participants have stored their data.
         pmix_gds_shmem_set_status(
             job, PMIX_GDS_SHMEM_MODEX_ID, PMIX_GDS_SHMEM_READY_FOR_USE
         );

--- a/src/mca/gds/shmem/gds_shmem_utils.c
+++ b/src/mca/gds/shmem/gds_shmem_utils.c
@@ -183,7 +183,7 @@ pmix_gds_shmem_check_session(
 }
 
 bool
-pmix_gds_shmem_check_hostname(
+pmix_gds_shmem_hostnames_eq(
     const char *h1,
     const char *h2
 ) {

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -19,36 +19,30 @@
 
 #include "gds_shmem.h"
 
-// FIXME
-
-#if PMIX_ENABLE_DEBUG
-#define PMIX_GDS_SHMEM_VOUT_HERE()                                             \
+#define PMIX_GDS_SHMEM_OUT(...)                                                \
 do {                                                                           \
-    pmix_output_verbose(1, pmix_gds_base_framework.framework_output,          \
-                        "gds:" PMIX_GDS_SHMEM_NAME                             \
-                        ":%s called at line %d", __func__, __LINE__);          \
+    pmix_output(0, "gds:" PMIX_GDS_SHMEM_NAME ":" __VA_ARGS__);                \
 } while (0)
-#else
-#define PMIX_GDS_SHMEM_VOUT_HERE()                                             \
-do { } while (0)
-#endif
 
 #define PMIX_GDS_SHMEM_VOUT(...)                                               \
 do {                                                                           \
-    pmix_output_verbose(1, pmix_gds_base_framework.framework_output,           \
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,           \
                         "gds:" PMIX_GDS_SHMEM_NAME ":" __VA_ARGS__);           \
 } while (0)
 
 #if PMIX_ENABLE_DEBUG
 #define PMIX_GDS_SHMEM_VVOUT(...)                                              \
 do {                                                                           \
-    pmix_output_verbose(1, pmix_gds_base_framework.framework_output,          \
+    pmix_output_verbose(12, pmix_gds_base_framework.framework_output,          \
                         "gds:" PMIX_GDS_SHMEM_NAME ":" __VA_ARGS__);           \
 } while (0)
 #else
 #define PMIX_GDS_SHMEM_VVOUT(...)                                              \
 do { } while (0)
 #endif
+
+#define PMIX_GDS_SHMEM_VOUT_HERE()                                             \
+PMIX_GDS_SHMEM_VVOUT(":%s called at line %d", __func__, __LINE__)
 
 BEGIN_C_DECLS
 
@@ -67,7 +61,7 @@ pmix_gds_shmem_check_session(
 );
 
 PMIX_EXPORT bool
-pmix_gds_shmem_check_hostname(
+pmix_gds_shmem_hostnames_eq(
     const char *h1,
     const char *h2
 );


### PR DESCRIPTION
Fixes crashes during shared modex information access.

* Don't directly unpack connection info into a pmix_shmem_t.
* Don't overwrite shared contents in server_store_modex().
* Do improve debug output.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>