### PR TITLE
Checkpoint work on macro conversion to functions

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1564,6 +1564,30 @@ PMIX_EXPORT bool PMIx_Data_decompress(const uint8_t *inbytes,
  * see them and know they exist. So include them here as well. */
 
 #ifndef PMIx_DEPRECATED_H
+
+/* load a key */
+PMIX_EXPORT void PMIx_Load_key(pmix_key_t key, const char *src);
+
+/* initialize a coord struct */
+PMIX_EXPORT void PMIx_Value_construct(pmix_value_t *val);
+
+/* free memory stored inside a value struct */
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
+
+/* create and initialize an array of value structs */
+PMIX_EXPORT pmix_value_t* PMIx_Value_create(size_t n);
+
+/* free memory stored inside an array of coord structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Value_free(pmix_value_t *v, size_t n);
+
+/* Check the given value struct to determine if it includes
+ * a boolean value (includes strings for "true" and "false",
+ * including abbreviations such as "t" or "f"), and if so,
+ * then its value. A value type of PMIX_UNDEF is taken to imply
+ * a boolean "true". */
+PMIX_EXPORT pmix_boolean_t PMIx_Value_true(const pmix_value_t *v);
+
 /* Load data into a pmix_value_t structure. The data can be of any
  * PMIx data type - which means the load can be somewhat complex
  * to implement (e.g., in the case of a pmix_data_array_t). The
@@ -1578,8 +1602,6 @@ PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
 
-PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
-
 /* Transfer data from one pmix_value_t to another - this is actually
  * executed as a COPY operation, so the original data is not altered.
  */
@@ -1590,7 +1612,18 @@ PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
 
+
+
 PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
+
+
+/* Check the given info struct to determine if it includes
+ * a boolean value (includes strings for "true" and "false",
+ * including abbreviations such as "t" or "f"), and if so,
+ * then its value. A value type of PMIX_UNDEF is taken to imply
+ * a boolean "true" as the presence of the key defaults to
+ * indicating "true". */
+PMIX_EXPORT pmix_boolean_t PMIx_Info_true(const pmix_info_t *p);
 
 /* Load key/value data into a pmix_info_t struct. Note that this
  * effectively is a PMIX_LOAD_KEY operation to copy the key,
@@ -1605,6 +1638,22 @@ PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
  * executed as a COPY operation, so the original data is not altered */
 PMIX_EXPORT pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
                                          const pmix_info_t *src);
+
+
+/* initialize a coord struct */
+PMIX_EXPORT void PMIx_Coord_construct(pmix_coord_t *m);
+
+/* free memory stored inside a coord struct */
+PMIX_EXPORT void PMIx_Coord_destruct(pmix_coord_t *m);
+
+/* create and initialize an array of coord structs */
+PMIX_EXPORT pmix_coord_t* PMIx_Coord_create(size_t dims,
+                                            size_t number);
+
+/* free memory stored inside an array of coord structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Coord_free(pmix_coord_t *m, size_t number);
+
 
 /* initialize a topology struct */
 PMIX_EXPORT void PMIx_Topology_construct(pmix_topology_t *t);
@@ -1688,6 +1737,131 @@ PMIX_EXPORT pmix_endpoint_t* PMIx_Endpoint_create(size_t n);
 /* free memory stored inside an array of endpoint structs (does
  * not free the struct memory itself */
 PMIX_EXPORT void PMIx_Endpoint_free(pmix_endpoint_t *e, size_t n);
+
+
+/* initialize an envar struct */
+PMIX_EXPORT void PMIx_Envar_construct(pmix_envar_t *e);
+
+/* free memory stored inside an envar struct */
+PMIX_EXPORT void PMIx_Envar_destruct(pmix_envar_t *e);
+
+/* create and initialize an array of envar structs */
+PMIX_EXPORT pmix_envar_t* PMIx_Envar_create(size_t n);
+
+/* free memory stored inside an array of envar structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Envar_free(pmix_envar_t *e, size_t n);
+
+/* load an envar struct */
+PMIX_EXPORT void PMIx_Envar_load(pmix_envar_t *e,
+                                 char *var,
+                                 char *value,
+                                 char separator);
+
+/* initialize a data buffer struct */
+PMIX_EXPORT void PMIx_Data_buffer_construct(pmix_data_buffer_t *b);
+
+/* free memory stored inside a data buffer struct */
+PMIX_EXPORT void PMIx_Data_buffer_destruct(pmix_data_buffer_t *b);
+
+/* create a data buffer struct */
+PMIX_EXPORT pmix_data_buffer_t* PMIx_Data_buffer_create(void);
+
+/* free memory stored inside a data buffer struct */
+PMIX_EXPORT void PMIx_Data_buffer_release(pmix_data_buffer_t *b);
+
+/* load a data buffer struct */
+PMIX_EXPORT void PMIx_Data_buffer_load(pmix_data_buffer_t *b,
+                                       char *bytes, size_t sz);
+
+/* unload a data buffer struct */
+PMIX_EXPORT void PMIx_Data_buffer_unload(pmix_data_buffer_t *b,
+                                         char **bytes, size_t *sz);
+
+
+/* initialize a proc struct */
+PMIX_EXPORT void PMIx_Proc_construct(pmix_proc_t *p);
+
+/* clear memory inside a proc struct */
+PMIX_EXPORT void PMIx_Proc_destruct(pmix_proc_t *p);
+
+/* create and initialize an array of proc structs */
+PMIX_EXPORT pmix_proc_t* PMIx_Proc_create(size_t n);
+
+/* free memory stored inside an array of proc structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Proc_free(pmix_proc_t *p, size_t n);
+
+/* load a proc struct */
+PMIX_EXPORT void PMIx_Proc_load(pmix_proc_t *p,
+                                char *nspace, pmix_rank_t rank);
+
+/* construct a multicluster nspace struct from cluster and nspace values */
+PMIX_EXPORT void PMIx_Multicluster_nspace_construct(pmix_nspace_t target,
+                                                    pmix_nspace_t cluster,
+                                                    pmix_nspace_t nspace);
+
+/* parse a multicluster nspace struct to separate out the cluster
+ * and nspace portions */
+PMIX_EXPORT void PMIx_Multicluster_nspace_parse(pmix_nspace_t target,
+                                                pmix_nspace_t cluster,
+                                                pmix_nspace_t nspace);
+
+
+/* initialize a proc info struct */
+PMIX_EXPORT void PMIx_Proc_info_construct(pmix_proc_info_t *p);
+
+/* clear memory inside a proc info struct */
+PMIX_EXPORT void PMIx_Proc_info_destruct(pmix_proc_info_t *p);
+
+/* create and initialize an array of proc info structs */
+PMIX_EXPORT pmix_proc_info_t* PMIx_Proc_info_create(size_t n);
+
+/* free memory stored inside an array of proc info structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Proc_info_free(pmix_proc_info_t *p, size_t n);
+
+
+/* initialize a proc stats struct */
+PMIX_EXPORT void PMIx_Proc_stats_construct(pmix_proc_stats_t *p);
+
+/* clear memory inside a proc stats struct */
+PMIX_EXPORT void PMIx_Proc_stats_destruct(pmix_proc_stats_t *p);
+
+/* create and initialize an array of proc stats structs */
+PMIX_EXPORT pmix_proc_stats_t* PMIx_Proc_stats_create(size_t n);
+
+/* free memory stored inside an array of proc stats structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Proc_stats_free(pmix_proc_stats_t *p, size_t n);
+
+
+/* initialize a disk stats struct */
+PMIX_EXPORT void PMIx_Disk_stats_construct(pmix_disk_stats_t *p);
+
+/* clear memory inside a disk stats struct */
+PMIX_EXPORT void PMIx_Disk_stats_destruct(pmix_disk_stats_t *p);
+
+/* create and initialize an array of disk stats structs */
+PMIX_EXPORT pmix_disk_stats_t* PMIx_Disk_stats_create(size_t n);
+
+/* free memory stored inside an array of disk stats structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Disk_stats_free(pmix_disk_stats_t *p, size_t n);
+
+
+/* initialize a net stats struct */
+PMIX_EXPORT void PMIx_Net_stats_construct(pmix_net_stats_t *p);
+
+/* clear memory inside a net stats struct */
+PMIX_EXPORT void PMIx_Net_stats_destruct(pmix_net_stats_t *p);
+
+/* create and initialize an array of net stats structs */
+PMIX_EXPORT pmix_net_stats_t* PMIx_Net_stats_create(size_t n);
+
+/* free memory stored inside an array of net stats structs (does
+ * not free the struct memory itself */
+PMIX_EXPORT void PMIx_Net_stats_free(pmix_net_stats_t *p, size_t n);
 
 
 /* Constructing arrays of pmix_info_t for passing to an API can

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1683,14 +1683,6 @@ static inline void* pmix_calloc(size_t n, size_t m)
 #define PMIX_CHECK_RESERVED_KEY(a) \
     (0 == strncmp((a), "pmix", 4))
 
-#define PMIX_LOAD_KEY(a, b)                                                 \
-    do {                                                                    \
-        memset((a), 0, PMIX_MAX_KEYLEN+1);                                  \
-        if (NULL != (b)) {                                                  \
-            pmix_strncpy((char*)(a), (const char*)(b), PMIX_MAX_KEYLEN);    \
-        }                                                                   \
-    }while(0)
-
 /* define a convenience macro for loading nspaces */
 #define PMIX_LOAD_NSPACE(a, b)                              \
     do {                                                    \
@@ -2268,65 +2260,6 @@ typedef struct pmix_coord {
     .dims = 0                       \
 }
 
-static inline pmix_coord_t* PMIx_Coord_create(size_t dims,
-                                              size_t number)
-{
-    pmix_coord_t *m;
-
-    if (0 == number) {
-        return NULL;
-    }
-    m = (pmix_coord_t*)pmix_malloc(number * sizeof(pmix_coord_t));
-    if (NULL == m) {
-        return NULL;
-    }
-    m->view = PMIX_COORD_VIEW_UNDEF;
-    m->dims = dims;
-    if (0 == dims) {
-        m->coord = NULL;
-    } else {
-        m->coord = (uint32_t*)pmix_malloc(dims * sizeof(uint32_t));
-        if (NULL != m->coord) {
-            memset(m->coord, 0, dims * sizeof(uint32_t));
-        }
-    }
-    return m;
-}
-
-static inline void PMIx_Coord_construct(pmix_coord_t *m)
-{
-    if (NULL == m) {
-        return;
-    }
-    m->view = PMIX_COORD_VIEW_UNDEF;
-    m->coord = NULL;
-    m->dims = 0;
-}
-
-static inline void PMIx_Coord_destruct(pmix_coord_t *m)
-{
-    if (NULL == m) {
-        return;
-    }
-    m->view = PMIX_COORD_VIEW_UNDEF;
-    if (NULL != m->coord) {
-        pmix_free(m->coord);
-        m->coord = NULL;
-        m->dims = 0;
-    }
-}
-
-static inline void PMIx_Coord_free(pmix_coord_t *m, size_t number)
-{
-    size_t n;
-    if (NULL == m) {
-        return;
-    }
-    for (n=0; n < number; n++) {
-        PMIx_Coord_destruct(&m[n]);
-    }
-}
-
 
 /****    PMIX LINK STATES    ****/
 typedef uint8_t pmix_link_state_t;
@@ -2479,284 +2412,6 @@ typedef struct {
     .separator = '\0'           \
 }
 
-#define PMIX_ENVAR_CREATE(m, n)                                             \
-    do {                                                                    \
-        if (0 == (n)) {                                                     \
-            (m) = NULL;                                                     \
-        } else {                                                            \
-            (m) = (pmix_envar_t*)pmix_malloc((n) * sizeof(pmix_envar_t));   \
-            if (NULL != (m)) {                                              \
-                memset((m), 0, (n) * sizeof(pmix_envar_t));                 \
-            }                                                               \
-        }                                                                   \
-    } while (0)
-#define PMIX_ENVAR_FREE(m, n)                       \
-    do {                                            \
-        size_t _ek;                                 \
-        if (NULL != (m)) {                          \
-            for (_ek=0; _ek < (n); _ek++) {         \
-               PMIX_ENVAR_DESTRUCT(&(m)[_ek]);      \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
-#define PMIX_ENVAR_CONSTRUCT(m)        \
-    do {                               \
-        (m)->envar = NULL;             \
-        (m)->value = NULL;             \
-        (m)->separator = '\0';         \
-    } while(0)
-#define PMIX_ENVAR_DESTRUCT(m)         \
-    do {                               \
-        if (NULL != (m)->envar) {      \
-            pmix_free((m)->envar);     \
-            (m)->envar = NULL;         \
-        }                              \
-        if (NULL != (m)->value) {      \
-            pmix_free((m)->value);      \
-            (m)->value = NULL;         \
-        }                              \
-    } while(0)
-#define PMIX_ENVAR_LOAD(m, e, v, s)    \
-    do {                               \
-        if (NULL != (e)) {             \
-            (m)->envar = strdup(e);    \
-        }                              \
-        if (NULL != (v)) {             \
-            (m)->value = strdup(v);    \
-        }                              \
-        (m)->separator = (s);          \
-    } while(0)
-
-
-/****    PMIX DATA BUFFER MACROS   ****/
-#define PMIX_DATA_BUFFER_STATIC_INIT    \
-{                                       \
-    .base_ptr = NULL,                   \
-    .pack_ptr = NULL,                   \
-    .unpack_ptr = NULL,                 \
-    .bytes_allocated = 0,               \
-    .bytes_used = 0                     \
-}
-#define PMIX_DATA_BUFFER_CREATE(m)                                          \
-    do {                                                                    \
-        (m) = (pmix_data_buffer_t*)pmix_malloc(sizeof(pmix_data_buffer_t)); \
-        if (NULL != (m)) {                                                  \
-            memset((m), 0, sizeof(pmix_data_buffer_t));                     \
-        }                                                                   \
-    } while (0)
-#define PMIX_DATA_BUFFER_RELEASE(m)             \
-    do {                                        \
-        if (NULL != (m)->base_ptr) {            \
-            pmix_free((m)->base_ptr);           \
-        }                                       \
-        pmix_free((m));                         \
-        (m) = NULL;                             \
-    } while (0)
-#define PMIX_DATA_BUFFER_CONSTRUCT(m)       \
-    memset((m), 0, sizeof(pmix_data_buffer_t))
-#define PMIX_DATA_BUFFER_DESTRUCT(m)        \
-    do {                                    \
-        if (NULL != (m)->base_ptr) {        \
-            pmix_free((m)->base_ptr);       \
-            (m)->base_ptr = NULL;           \
-        }                                   \
-        (m)->pack_ptr = NULL;               \
-        (m)->unpack_ptr = NULL;             \
-        (m)->bytes_allocated = 0;           \
-        (m)->bytes_used = 0;                \
-    } while (0)
-#define PMIX_DATA_BUFFER_LOAD(b, d, s)  \
-    do {                                \
-        pmix_byte_object_t _bo;         \
-        _bo.bytes = (char*)(d);         \
-        _bo.size = (s);                 \
-        PMIx_Data_load((b), &_bo);      \
-    } while(0)
-
-#define PMIX_DATA_BUFFER_UNLOAD(b, d, s)    \
-    do {                                    \
-        pmix_byte_object_t _bo;             \
-        pmix_status_t _r;                   \
-        _r = PMIx_Data_unload((b), &_bo);   \
-        if (PMIX_SUCCESS == _r) {           \
-            (d) = _bo.bytes;                \
-            (s) = _bo.size;                 \
-        } else {                            \
-            (d) = NULL;                     \
-            (s) = 0;                        \
-        }                                   \
-    } while(0)
-
-/****    PMIX PROC OBJECT    ****/
-typedef struct pmix_proc {
-    pmix_nspace_t nspace;
-    pmix_rank_t rank;
-} pmix_proc_t;
-
-#define PMIX_PROC_STATIC_INIT   \
-{                               \
-    .nspace = {0},              \
-    .rank = PMIX_RANK_UNDEF     \
-}
-
-#define PMIX_PROC_CREATE(m, n)                                          \
-    do {                                                                \
-        if (0 == (n)) {                                                 \
-            (m) = NULL;                                                 \
-        } else {                                                        \
-            (m) = (pmix_proc_t*)pmix_malloc((n) * sizeof(pmix_proc_t)); \
-            if (NULL != (m)) {                                          \
-                memset((m), 0, (n) * sizeof(pmix_proc_t));              \
-            }                                                           \
-        }                                                               \
-    } while (0)
-
-#define PMIX_PROC_RELEASE(m)    \
-    do {                        \
-        pmix_free((m));         \
-        (m) = NULL;             \
-    } while (0)
-
-#define PMIX_PROC_CONSTRUCT(m)                  \
-    do {                                        \
-        memset((m), 0, sizeof(pmix_proc_t));    \
-    } while (0)
-
-#define PMIX_PROC_DESTRUCT(m)
-
-#define PMIX_PROC_FREE(m, n)                    \
-    do {                                        \
-        if (NULL != (m)) {                      \
-            pmix_free((m));                     \
-            (m) = NULL;                         \
-        }                                       \
-    } while (0)
-
-#define PMIX_PROC_LOAD(m, n, r)                                 \
-    do {                                                        \
-        PMIX_PROC_CONSTRUCT((m));                               \
-        pmix_strncpy((char*)(m)->nspace, (n), PMIX_MAX_NSLEN);  \
-        (m)->rank = (r);                                        \
-    } while(0)
-
-#define PMIX_MULTICLUSTER_NSPACE_CONSTRUCT(t, c, n)                         \
-    do {                                                                    \
-        size_t _len;                                                        \
-        memset((t), 0, PMIX_MAX_NSLEN+1);                                   \
-        _len = pmix_nslen((c));                                             \
-        if ((_len + pmix_nslen((n))) < PMIX_MAX_NSLEN) {                    \
-            pmix_strncpy((char*)(t), (c), PMIX_MAX_NSLEN);                  \
-            (t)[_len] = ':';                                                \
-            pmix_strncpy((char*)&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);  \
-        }                                                                   \
-    } while(0)
-
-#define PMIX_MULTICLUSTER_NSPACE_PARSE(t, c, n)             \
-    do {                                                    \
-        size_t _n, _j;                                      \
-        for (_n=0; '\0' != (t)[_n] && ':' != (t)[_n] &&     \
-             _n <= PMIX_MAX_NSLEN; _n++) {                  \
-            (c)[_n] = (t)[_n];                              \
-        }                                                   \
-        _n++;                                               \
-        for (_j=0; _n <= PMIX_MAX_NSLEN &&                  \
-             '\0' != (t)[_n]; _n++, _j++) {                 \
-            (n)[_j] = (t)[_n];                              \
-        }                                                   \
-    } while(0)
-
-
-/****    PMIX PROC INFO STRUCT    ****/
-typedef struct pmix_proc_info {
-    pmix_proc_t proc;
-    char *hostname;
-    char *executable_name;
-    pid_t pid;
-    int exit_code;
-    pmix_proc_state_t state;
-} pmix_proc_info_t;
-
-#define PMIX_PROC_INFO_STATIC_INIT  \
-{                                   \
-    .proc = PMIX_PROC_STATIC_INIT,  \
-    .hostname = NULL,               \
-    .executable_name = NULL,        \
-    .pid = 0,                       \
-    .exit_code = 0,                 \
-    .state = PMIX_PROC_STATE_UNDEF  \
-}
-
-#define PMIX_PROC_INFO_CREATE(m, n)                                                 \
-    do {                                                                            \
-        if (0 == (n)) {                                                             \
-            (m) = NULL;                                                             \
-        } else {                                                                    \
-            (m) = (pmix_proc_info_t*)pmix_malloc((n) * sizeof(pmix_proc_info_t));   \
-            if (NULL != (m)) {                                                      \
-                memset((m), 0, (n) * sizeof(pmix_proc_info_t));                     \
-            }                                                                       \
-        }                                                                           \
-    } while (0)
-
-#define PMIX_PROC_INFO_RELEASE(m)      \
-    do {                               \
-        PMIX_PROC_INFO_FREE((m), 1);   \
-    } while (0)
-
-#define PMIX_PROC_INFO_CONSTRUCT(m)                 \
-    do {                                            \
-        memset((m), 0, sizeof(pmix_proc_info_t));   \
-    } while (0)
-
-#define PMIX_PROC_INFO_DESTRUCT(m)              \
-    do {                                        \
-        if (NULL != (m)->hostname) {            \
-            pmix_free((m)->hostname);           \
-            (m)->hostname = NULL;               \
-        }                                       \
-        if (NULL != (m)->executable_name) {     \
-            pmix_free((m)->executable_name);    \
-            (m)->executable_name = NULL;        \
-        }                                       \
-    } while(0)
-
-#define PMIX_PROC_INFO_FREE(m, n)                   \
-    do {                                            \
-        size_t _k;                                  \
-        if (NULL != (m)) {                          \
-            for (_k=0; _k < (n); _k++) {            \
-                PMIX_PROC_INFO_DESTRUCT(&(m)[_k]);  \
-            }                                       \
-            pmix_free((m));                         \
-        }                                           \
-    } while (0)
-
-
-/****    PMIX DATA ARRAY STRUCT    ****/
-
-typedef struct pmix_data_array {
-    pmix_data_type_t type;
-    size_t size;
-    void *array;
-} pmix_data_array_t;
-
-#define PMIX_DATA_ARRAY_STATIC_INIT     \
-{                                       \
-    .type = PMIX_UNDEF,                 \
-    .size = 0,                          \
-    .array = NULL                       \
-}
-
-/**** THE PMIX_DATA_ARRAY SUPPORT MACROS ARE DEFINED ****/
-/**** DOWN BELOW (NEAR THE BOTTOM OF THE FILE) TO    ****/
-/**** AVOID CIRCULAR DEPENDENCIES                    ****/
-
-
-/* we cannot forward-declare the pmix_regattr_t struct
- * as Cython doesn't know what to do with it. Thus, we
- * will utilize the void* entry of the pmix_value_t to
- * hold the pointer to pmix_regattr_t */
 
 /****    PMIX DATA BUFFER    ****/
 typedef struct pmix_data_buffer {
@@ -2783,6 +2438,62 @@ typedef struct pmix_data_buffer {
     .bytes_allocated = 0,               \
     .bytes_used = 0                     \
 }
+
+
+/****    PMIX PROC OBJECT    ****/
+typedef struct pmix_proc {
+    pmix_nspace_t nspace;
+    pmix_rank_t rank;
+} pmix_proc_t;
+
+#define PMIX_PROC_STATIC_INIT   \
+{                               \
+    .nspace = {0},              \
+    .rank = PMIX_RANK_UNDEF     \
+}
+
+
+/****    PMIX PROC INFO STRUCT    ****/
+typedef struct pmix_proc_info {
+    pmix_proc_t proc;
+    char *hostname;
+    char *executable_name;
+    pid_t pid;
+    int exit_code;
+    pmix_proc_state_t state;
+} pmix_proc_info_t;
+
+#define PMIX_PROC_INFO_STATIC_INIT  \
+{                                   \
+    .proc = PMIX_PROC_STATIC_INIT,  \
+    .hostname = NULL,               \
+    .executable_name = NULL,        \
+    .pid = 0,                       \
+    .exit_code = 0,                 \
+    .state = PMIX_PROC_STATE_UNDEF  \
+}
+
+
+
+/****    PMIX DATA ARRAY STRUCT    ****/
+
+typedef struct pmix_data_array {
+    pmix_data_type_t type;
+    size_t size;
+    void *array;
+} pmix_data_array_t;
+
+#define PMIX_DATA_ARRAY_STATIC_INIT     \
+{                                       \
+    .type = PMIX_UNDEF,                 \
+    .size = 0,                          \
+    .array = NULL                       \
+}
+
+/* we cannot forward-declare the pmix_regattr_t struct
+ * as Cython doesn't know what to do with it. Thus, we
+ * will utilize the void* entry of the pmix_value_t to
+ * hold the pointer to pmix_regattr_t */
 
 /****   STATISTICS STRUCTURES  ****/
 typedef struct pmix_proc_stats {
@@ -2825,57 +2536,6 @@ typedef struct pmix_proc_stats {
     .sample_time = {0, 0}               \
 }
 
-#define PMIX_PROC_STATS_CREATE(m, n)                                                \
-    do {                                                                            \
-        if (0 == (n)) {                                                             \
-            (m) = NULL;                                                             \
-        } else {                                                                    \
-            (m) = (pmix_proc_stats_t*)pmix_malloc((n) * sizeof(pmix_proc_stats_t)); \
-            if (NULL != (m)) {                                                      \
-                memset((m), 0, (n) * sizeof(pmix_proc_stats_t));                    \
-            }                                                                       \
-        }                                                                           \
-    } while (0)
-
-#define PMIX_PROC_STATS_RELEASE(m)      \
-    do {                                \
-        PMIX_PROC_STATS_FREE((m), 1);   \
-    } while (0)
-
-#define PMIX_PROC_STATS_CONSTRUCT(m)                \
-    do {                                            \
-        memset((m), 0, sizeof(pmix_proc_stats_t));  \
-    } while (0)
-
-#define PMIX_PROC_STATS_DESTRUCT(m)     \
-    do {                                \
-        if (NULL != (m)->node) {        \
-            pmix_free((m)->node);       \
-            (m)->node = NULL;           \
-        }                               \
-        if (NULL != (m)->cmd) {         \
-            pmix_free((m)->cmd);        \
-            (m)->cmd = NULL;            \
-        }                               \
-    } while(0)
-
-static inline void pmix_proc_stats_free(pmix_proc_stats_t *ps, size_t n)
-{
-    size_t k;
-
-    if (NULL != ps) {
-        for (k=0; k < n; k++) {
-            PMIX_PROC_STATS_DESTRUCT(&ps[k]);
-        }
-    }
-}
-
-#define PMIX_PROC_STATS_FREE(m, n)  \
-do {                                \
-    pmix_proc_stats_free(m, n);     \
-    pmix_free(m);                   \
-    (m) = NULL;                     \
-} while(0)
 
 typedef struct {
     char *disk;
@@ -2908,53 +2568,6 @@ typedef struct {
     .weighted_milliseconds_io = 0       \
 }
 
-#define PMIX_DISK_STATS_CREATE(m, n)                                                \
-    do {                                                                            \
-        if (0 == (n)) {                                                             \
-            (m) = NULL;                                                             \
-        } else {                                                                    \
-            (m) = (pmix_disk_stats_t*)pmix_malloc((n) * sizeof(pmix_disk_stats_t)); \
-            if (NULL != (m)) {                                                      \
-                memset((m), 0, (n) * sizeof(pmix_disk_stats_t));                    \
-            }                                                                       \
-        }                                                                           \
-    } while (0)
-
-#define PMIX_DISK_STATS_RELEASE(m)      \
-    do {                                \
-        PMIX_DISK_STATS_FREE((m), 1);   \
-    } while (0)
-
-#define PMIX_DISK_STATS_CONSTRUCT(m)                \
-    do {                                            \
-        memset((m), 0, sizeof(pmix_disk_stats_t));  \
-    } while (0)
-
-#define PMIX_DISK_STATS_DESTRUCT(m)     \
-    do {                                \
-        if (NULL != (m)->disk) {        \
-            pmix_free((m)->disk);       \
-            (m)->disk = NULL;           \
-        }                               \
-    } while(0)
-
-static inline void pmix_disk_stats_free(pmix_disk_stats_t *d, size_t n)
-{
-    size_t k;
-
-    if (NULL != d) {
-        for (k=0; k < n; k++) {
-            PMIX_DISK_STATS_DESTRUCT(&d[k]);
-        }
-    }
-}
-
-#define PMIX_DISK_STATS_FREE(m, n)  \
-do {                                \
-    pmix_disk_stats_free(m, n);     \
-    pmix_free(m);                   \
-    (m) = NULL;                     \
-} while(0)
 
 typedef struct {
     char *net_interface;
@@ -2977,53 +2590,6 @@ typedef struct {
     .num_send_errs = 0              \
 }
 
-#define PMIX_NET_STATS_CREATE(m, n)                                                 \
-    do {                                                                            \
-        if (0 == (n)) {                                                             \
-            (m) = NULL;                                                             \
-        } else {                                                                    \
-            (m) = (pmix_net_stats_t*)pmix_malloc((n) * sizeof(pmix_net_stats_t));   \
-            if (NULL != (m)) {                                                      \
-                memset((m), 0, (n) * sizeof(pmix_net_stats_t));                     \
-            }                                                                       \
-        }                                                                           \
-    } while (0)
-
-#define PMIX_NET_STATS_RELEASE(m)       \
-    do {                                \
-        PMIX_NET_STATS_FREE((m), 1);    \
-    } while (0)
-
-#define PMIX_NET_STATS_CONSTRUCT(m)                 \
-    do {                                            \
-        memset((m), 0, sizeof(pmix_net_stats_t));   \
-    } while (0)
-
-#define PMIX_NET_STATS_DESTRUCT(m)          \
-    do {                                    \
-        if (NULL != (m)->net_interface) {   \
-            pmix_free((m)->net_interface);  \
-            (m)->net_interface = NULL;      \
-        }                                   \
-    } while(0)
-
-static inline void pmix_net_stats_free(pmix_net_stats_t *nst, size_t n)
-{
-    size_t k;
-
-    if (NULL != nst) {
-        for (k=0; k < n; k++) {
-            PMIX_NET_STATS_DESTRUCT(&nst[k]);
-        }
-    }
-}
-
-#define PMIX_NET_STATS_FREE(m, n)   \
-do {                                \
-    pmix_net_stats_free(m, n);      \
-    pmix_free(m);                   \
-    (m) = NULL;                     \
-} while(0)
 
 typedef struct {
     char *node;
@@ -3070,58 +2636,6 @@ typedef struct {
     .netstats = NULL,                   \
     .nnetstats = 0                      \
 }
-
-#define PMIX_NODE_STATS_CREATE(m, n)                                                \
-    do {                                                                            \
-        if (0 == (n)) {                                                             \
-            (m) = NULL;                                                             \
-        } else {                                                                    \
-            (m) = (pmix_node_stats_t*)pmix_malloc((n) * sizeof(pmix_node_stats_t)); \
-            if (NULL != (m)) {                                                      \
-                memset((m), 0, (n) * sizeof(pmix_node_stats_t));                    \
-            }                                                                       \
-        }                                                                           \
-    } while (0)
-
-#define PMIX_NODE_STATS_CONSTRUCT(m)                \
-    do {                                            \
-        memset((m), 0, sizeof(pmix_node_stats_t));  \
-    } while (0)
-
-#define PMIX_NODE_STATS_DESTRUCT(m)                                 \
-    do {                                                            \
-        if (NULL != (m)->node) {                                    \
-            pmix_free((m)->node);                                   \
-            (m)->node = NULL;                                       \
-        }                                                           \
-        if (NULL != (m)->diskstats) {                               \
-            PMIX_DISK_STATS_FREE((m)->diskstats, (m)->ndiskstats);  \
-        }                                                           \
-        if (NULL != (m)->netstats) {                                \
-            PMIX_NET_STATS_FREE((m)->netstats, (m)->nnetstats);     \
-        }                                                           \
-    } while(0)
-
-static inline void pmix_node_stats_free(pmix_node_stats_t *nd, size_t n)
-{
-    size_t k;
-
-    if (NULL != nd) {
-        for (k=0; k < n; k++) {
-            PMIX_NODE_STATS_DESTRUCT(&nd[k]);
-        }
-    }
-}
-
-#define PMIX_NODE_STATS_FREE(m, n)  \
-do {                                \
-    pmix_node_stats_free(m, n);     \
-    pmix_free(m);                   \
-    (m) = NULL;                     \
-} while(0)
-
-#define PMIX_NODE_STATS_RELEASE(m)  \
-    pmix_node_stats_free(m, 1)
 
 
 /****    PMIX VALUE STRUCT    ****/
@@ -3190,26 +2704,6 @@ typedef struct pmix_value {
     .type = PMIX_UNDEF,         \
     .data.ptr = NULL            \
 }
-
-/* allocate and initialize a specified number of value structs */
-#define PMIX_VALUE_CREATE(m, n)                                             \
-    do {                                                                    \
-        if (0 == (n)) {                                                     \
-            (m) = NULL;                                                     \
-        } else {                                                            \
-            (m) = (pmix_value_t*)pmix_malloc((n) * sizeof(pmix_value_t));   \
-            if (NULL != (m)) {                                              \
-                memset((m), 0, (n)*sizeof(pmix_value_t));                   \
-            }                                                               \
-        }                                                                   \
-    } while (0)
-
-/* initialize a single value struct */
-#define PMIX_VALUE_CONSTRUCT(m)                 \
-    do {                                        \
-        memset((m), 0, sizeof(pmix_value_t));   \
-        (m)->type = PMIX_UNDEF;                 \
-    } while (0)
 
 #define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
     do {                                                \
@@ -3327,74 +2821,6 @@ typedef enum {
     PMIX_BOOL_FALSE,
     PMIX_NON_BOOL
 } pmix_boolean_t;
-
-/**
- * Provide a check to see if a value is "true" or
- * "false", whether given as a string or boolean
- * input.
- */
-static inline pmix_boolean_t pmix_check_true(const pmix_value_t *value)
-{
-    char *ptr;
-
-    if (PMIX_UNDEF == value->type) {
-        return PMIX_BOOL_TRUE; // default to true
-    }
-    if (PMIX_BOOL == value->type) {
-        if (value->data.flag) {
-            return PMIX_BOOL_TRUE;
-        } else {
-            return PMIX_BOOL_FALSE;
-        }
-    }
-    if (PMIX_STRING == value->type) {
-        if (NULL == value->data.string) {
-            return PMIX_BOOL_TRUE;
-        }
-        ptr = value->data.string;
-        /* Trim leading whitespace */
-        while (isspace(*ptr)) {
-            ++ptr;
-        }
-        if ('\0' == *ptr) {
-            return PMIX_BOOL_TRUE;
-        }
-        if (isdigit(*ptr)) {
-            if (0 == atoi(ptr)) {
-                return PMIX_BOOL_FALSE;
-            } else {
-                return PMIX_BOOL_TRUE;
-            }
-        } else if (0 == strncasecmp(ptr, "yes", 3) ||
-                   0 == strncasecmp(ptr, "true", 4)) {
-            return PMIX_BOOL_TRUE;
-        } else if (0 == strncasecmp(ptr, "no", 2) ||
-                   0 == strncasecmp(ptr, "false", 5)) {
-            return PMIX_BOOL_FALSE;
-        }
-    }
-
-    return PMIX_NON_BOOL;
-}
-
-/* provide a macro version of it for those preferring
- * that syntax in their codes where they know the
- * value being checked IS a boolean of some form
- */
-#define PMIX_CHECK_TRUE(a) \
-    (PMIX_BOOL_TRUE == pmix_check_true(a) ? true : false)
-
-#define PMIX_CHECK_BOOL(a) \
-    (PMIX_NON_BOOL == pmix_check_true(a) ? false : true)
-
-/* define a special macro for checking if a boolean
- * info is true - when info structs are provided, a
- * type of PMIX_UNDEF is taken to imply a boolean "true"
- * as the presence of the key defaults to indicating
- * "true". Also supports passing of string representations
- * such as "t" or "f" */
-#define PMIX_INFO_TRUE(m)   \
-    (PMIX_BOOL_TRUE == pmix_check_true(&(m)->value) ? true : false)
 
 
 /****    PMIX LOOKUP RETURN STRUCT    ****/
@@ -4075,29 +3501,6 @@ typedef void (*pmix_device_dist_cbfunc_t)(pmix_status_t status,
 #include <pmix_deprecated.h>
 
 /********    STANDARD MACROS FOR DARRAY AND VALUE SUPPORT     ********/
-
-/* release the memory in the value struct data field */
-#define PMIX_VALUE_DESTRUCT(m) PMIx_Value_destruct(m)
-
-/* release a single pmix_value_t struct, including its data */
-#define PMIX_VALUE_RELEASE(m)       \
-    do {                            \
-        PMIX_VALUE_DESTRUCT((m));   \
-        pmix_free((m));             \
-        (m) = NULL;                 \
-    } while (0)
-
-#define PMIX_VALUE_FREE(m, n)                           \
-    do {                                                \
-        size_t _vv;                                     \
-        if (NULL != (m)) {                              \
-            for (_vv=0; _vv < (n); _vv++) {             \
-                PMIX_VALUE_DESTRUCT(&((m)[_vv]));       \
-            }                                           \
-            pmix_free((m));                             \
-            (m) = NULL;                                 \
-        }                                               \
-    } while (0)
 
 #define PMIX_INFO_DESTRUCT(m)                   \
     do {                                        \

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -207,27 +207,52 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
  * macros that utilize them. We have to do this as there are people who
  * only included pmix_common.h if they were using macros but not APIs */
 
+PMIX_EXPORT void PMIx_Load_key(pmix_key_t key, const char *src);
+
+PMIX_EXPORT void PMIx_Value_construct(pmix_value_t *val);
+PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
+PMIX_EXPORT pmix_value_t* PMIx_Value_create(size_t n);
+PMIX_EXPORT void PMIx_Value_free(pmix_value_t *v, size_t n);
+PMIX_EXPORT pmix_boolean_t PMIx_Value_true(const pmix_value_t *v);
 PMIX_EXPORT pmix_status_t PMIx_Value_load(pmix_value_t *val,
                                           const void *data,
                                           pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t PMIx_Value_unload(pmix_value_t *val,
                                             void **data,
                                             size_t *sz);
-PMIX_EXPORT void PMIx_Value_destruct(pmix_value_t *val);
 PMIX_EXPORT pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                                           const pmix_value_t *src);
 PMIX_EXPORT pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
                                                 pmix_value_t *v2);
+
+
 PMIX_EXPORT void PMIx_Data_array_destruct(pmix_data_array_t *d);
 
+PMIX_EXPORT void PMIx_Info_construct(pmix_info_t *p);
+PMIX_EXPORT void PMIx_Info_destruct(pmix_info_t *p);
+PMIX_EXPORT pmix_info_t* PMIx_Info_create(size_t n);
+PMIX_EXPORT void PMIx_Info_free(pmix_info_t *p, size_t n);
+PMIX_EXPORT pmix_boolean_t PMIx_Info_true(const pmix_info_t *p);
 PMIX_EXPORT pmix_status_t PMIx_Info_load(pmix_info_t *info,
                                          const char *key,
                                          const void *data,
                                          pmix_data_type_t type);
-
+PMIX_EXPORT void PMIx_Info_required(pmix_info_t *p);
+PMIX_EXPORT bool PMIx_Info_is_required(pmix_info_t *p);
+PMIX_EXPORT void PMIx_Info_processed(pmix_info_t *p);
+PMIX_EXPORT bool PMIx_Info_was_processed(pmix_info_t *p);
+PMIX_EXPORT void PMIx_Info_set_end(pmix_info_t *p);
+PMIX_EXPORT bool PMIx_Info_is_end(pmix_info_t *p);
+PMIX_EXPORT void PMIx_Info_persistent(pmix_info_t *p);
+PMIX_EXPORT bool PMIx_Info_is_persistent(pmix_info_t *p);
 PMIX_EXPORT pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
                                          const pmix_info_t *src);
 
+PMIX_EXPORT void PMIx_Coord_construct(pmix_coord_t *m);
+PMIX_EXPORT void PMIx_Coord_destruct(pmix_coord_t *m);
+PMIX_EXPORT pmix_coord_t* PMIx_Coord_create(size_t dims,
+                                            size_t number);
+PMIX_EXPORT void PMIx_Coord_free(pmix_coord_t *m, size_t number);
 
 PMIX_EXPORT void PMIx_Topology_construct(pmix_topology_t *t);
 PMIX_EXPORT void PMIx_Topology_destruct(pmix_topology_t *topo);
@@ -261,6 +286,64 @@ PMIX_EXPORT void PMIx_Endpoint_destruct(pmix_endpoint_t *e);
 PMIX_EXPORT pmix_endpoint_t* PMIx_Endpoint_create(size_t n);
 PMIX_EXPORT void PMIx_Endpoint_free(pmix_endpoint_t *e, size_t n);
 
+PMIX_EXPORT void PMIx_Envar_construct(pmix_envar_t *e);
+PMIX_EXPORT void PMIx_Envar_destruct(pmix_envar_t *e);
+PMIX_EXPORT pmix_envar_t* PMIx_Envar_create(size_t n);
+PMIX_EXPORT void PMIx_Envar_free(pmix_envar_t *e, size_t n);
+PMIX_EXPORT void PMIx_Envar_load(pmix_envar_t *e,
+                                 char *var,
+                                 char *value,
+                                 char separator);
+
+PMIX_EXPORT void PMIx_Data_buffer_construct(pmix_data_buffer_t *b);
+PMIX_EXPORT void PMIx_Data_buffer_destruct(pmix_data_buffer_t *b);
+PMIX_EXPORT pmix_data_buffer_t* PMIx_Data_buffer_create(void);
+PMIX_EXPORT void PMIx_Data_buffer_release(pmix_data_buffer_t *b);
+PMIX_EXPORT void PMIx_Data_buffer_load(pmix_data_buffer_t *b,
+                                       char *bytes, size_t sz);
+PMIX_EXPORT void PMIx_Data_buffer_unload(pmix_data_buffer_t *b,
+                                         char **bytes, size_t *sz);
+
+PMIX_EXPORT void PMIx_Proc_construct(pmix_proc_t *p);
+PMIX_EXPORT void PMIx_Proc_destruct(pmix_proc_t *p);
+PMIX_EXPORT pmix_proc_t* PMIx_Proc_create(size_t n);
+PMIX_EXPORT void PMIx_Proc_free(pmix_proc_t *p, size_t n);
+PMIX_EXPORT void PMIx_Proc_load(pmix_proc_t *p,
+                                char *nspace, pmix_rank_t rank);
+PMIX_EXPORT void PMIx_Multicluster_nspace_construct(pmix_nspace_t target,
+                                                    pmix_nspace_t cluster,
+                                                    pmix_nspace_t nspace);
+PMIX_EXPORT void PMIx_Multicluster_nspace_parse(pmix_nspace_t target,
+                                                pmix_nspace_t cluster,
+                                                pmix_nspace_t nspace);
+
+PMIX_EXPORT void PMIx_Proc_info_construct(pmix_proc_info_t *p);
+PMIX_EXPORT void PMIx_Proc_info_destruct(pmix_proc_info_t *p);
+PMIX_EXPORT pmix_proc_info_t* PMIx_Proc_info_create(size_t n);
+PMIX_EXPORT void PMIx_Proc_info_free(pmix_proc_info_t *p, size_t n);
+
+PMIX_EXPORT void PMIx_Proc_stats_construct(pmix_proc_stats_t *p);
+PMIX_EXPORT void PMIx_Proc_stats_destruct(pmix_proc_stats_t *p);
+PMIX_EXPORT pmix_proc_stats_t* PMIx_Proc_stats_create(size_t n);
+PMIX_EXPORT void PMIx_Proc_stats_free(pmix_proc_stats_t *p, size_t n);
+
+PMIX_EXPORT void PMIx_Disk_stats_construct(pmix_disk_stats_t *p);
+PMIX_EXPORT void PMIx_Disk_stats_destruct(pmix_disk_stats_t *p);
+PMIX_EXPORT pmix_disk_stats_t* PMIx_Disk_stats_create(size_t n);
+PMIX_EXPORT void PMIx_Disk_stats_free(pmix_disk_stats_t *p, size_t n);
+
+PMIX_EXPORT void PMIx_Net_stats_construct(pmix_net_stats_t *p);
+PMIX_EXPORT void PMIx_Net_stats_destruct(pmix_net_stats_t *p);
+PMIX_EXPORT pmix_net_stats_t* PMIx_Net_stats_create(size_t n);
+PMIX_EXPORT void PMIx_Net_stats_free(pmix_net_stats_t *p, size_t n);
+
+PMIX_EXPORT void PMIx_Node_stats_construct(pmix_node_stats_t *p);
+PMIX_EXPORT void PMIx_Node_stats_destruct(pmix_node_stats_t *p);
+PMIX_EXPORT pmix_node_stats_t* PMIx_Node_stats_create(size_t n);
+PMIX_EXPORT void PMIx_Node_stats_free(pmix_node_stats_t *p, size_t n);
+
+
+
 PMIX_EXPORT void* PMIx_Info_list_start(void);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
@@ -278,6 +361,39 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
 PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 
 /* Macros that have been converted to functions */
+
+#define PMIX_LOAD_KEY(a, b) \
+    PMIx_Load_key(a, b)
+
+
+#define PMIX_VALUE_CONSTRUCT(m) \
+    PMIx_Value_construct(m)
+
+#define PMIX_VALUE_DESTRUCT(m) \
+    PMIx_Value_destruct(m)
+
+#define PMIX_VALUE_CREATE(m, n) \
+    (m) = PMIx_Value_create(n)
+
+#define PMIX_VALUE_RELEASE(m)       \
+    do {                            \
+        PMIx_Value_destruct((m));   \
+        pmix_free((m));             \
+        (m) = NULL;                 \
+    } while (0)
+
+#define PMIX_VALUE_FREE(m, n)   \
+    do {                        \
+        PMIx_Value_free(m, n);  \
+        pmix_free((m));         \
+        (m) = NULL;             \
+    } while (0)
+
+#define PMIX_CHECK_TRUE(a) \
+    (PMIX_BOOL_TRUE == PMIx_Value_true(a) ? true : false)
+
+#define PMIX_CHECK_BOOL(a) \
+    (PMIX_NON_BOOL == PMIx_Value_true(a) ? false : true)
 
 #define PMIX_VALUE_LOAD(v, d, t) \
     PMIx_Value_load((v), (d), (t))
@@ -308,6 +424,7 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 #define PMIX_INFO_XFER(d, s)    \
     (void) PMIx_Info_xfer(d, s)
 
+
 #define PMIX_PDATA_LOAD(m, p, k, v, t)                                      \
     do {                                                                    \
         if (NULL != (m)) {                                                  \
@@ -329,6 +446,9 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
             PMIx_Value_xfer(&((d)->value), &((s)->value));                      \
         }                                                                       \
     } while (0)
+
+#define PMIX_INFO_TRUE(m)   \
+    (PMIX_BOOL_TRUE == PMIx_Info_true(m) ? true : false)
 
 #define PMIX_INFO_LIST_START(p)    \
     (p) = PMIx_Info_list_start()
@@ -443,6 +563,179 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 
 #define PMIX_ENDPOINT_FREE(m, n) \
     PMIx_Endpoint_free(m, n)
+
+#define PMIX_ENVAR_CREATE(m, n) \
+    (m) = PMIx_Envar_create(n)
+
+#define PMIX_ENVAR_FREE(m, n)   \
+    do {                        \
+        PMIx_Envar_free(m, n);  \
+        pmix_free(m);           \
+        (m) = NULL;             \
+    } while(0)
+
+#define PMIX_ENVAR_CONSTRUCT(m) \
+    PMIx_Envar_construct(m)
+
+#define PMIX_ENVAR_DESTRUCT(m) \
+    PMIx_Envar_destruct(m)
+
+#define PMIX_ENVAR_LOAD(m, e, v, s) \
+    PMIx_Envar_load(m, e, v, s)
+
+
+#define PMIX_DATA_BUFFER_CREATE(m)  \
+    (m) = PMIx_Data_buffer_create()
+
+#define PMIX_DATA_BUFFER_RELEASE(m)     \
+    do {                                \
+        PMIx_Data_buffer_release(m);    \
+        pmix_free((m));                 \
+        (m) = NULL;                     \
+    } while (0)
+
+#define PMIX_DATA_BUFFER_CONSTRUCT(m)       \
+    PMIx_Data_buffer_construct(m)
+
+#define PMIX_DATA_BUFFER_DESTRUCT(m)        \
+    PMIx_Data_buffer_destruct(m)
+
+#define PMIX_DATA_BUFFER_LOAD(b, d, s)  \
+    PMIx_Data_buffer_load(b, d, s)
+
+#define PMIX_DATA_BUFFER_UNLOAD(b, d, s)    \
+    PMIx_Data_buffer_unload(b, &(d), &(s))
+
+
+#define PMIX_PROC_CREATE(m, n) \
+    (m) = PMIx_Proc_create(n)
+
+#define PMIX_PROC_CONSTRUCT(m) \
+    PMIx_Proc_construct(m)
+
+#define PMIX_PROC_DESTRUCT(m) \
+    PMIx_Proc_destruct(m)
+
+#define PMIX_PROC_FREE(m, n)    \
+    do {                        \
+        PMIx_Proc_free(m, n);   \
+        if (NULL != (m)) {      \
+            pmix_free((m));     \
+            (m) = NULL;         \
+        }                       \
+    } while (0)
+
+#define PMIX_PROC_RELEASE(m)    \
+    PMIX_PROC_FREE(m, 1)
+
+
+#define PMIX_PROC_LOAD(m, n, r) \
+    PMIx_Proc_load(m, n, r)
+
+#define PMIX_MULTICLUSTER_NSPACE_CONSTRUCT(t, c, n) \
+    PMIx_Multicluster_nspace_construct(t, c, n)
+
+#define PMIX_MULTICLUSTER_NSPACE_PARSE(t, c, n) \
+    PMIx_Multicluster_nspace_parse(t, c, n)
+
+
+#define PMIX_PROC_INFO_CREATE(m, n) \
+    (m) = PMIx_Proc_info_create(n)
+
+#define PMIX_PROC_INFO_CONSTRUCT(m) \
+    PMIx_Proc_info_construct(m)
+
+#define PMIX_PROC_INFO_DESTRUCT(m) \
+    PMIx_Proc_info_destruct(m)
+
+#define PMIX_PROC_INFO_FREE(m, n)   \
+    do {                            \
+        PMIx_Proc_info_free(m, n);  \
+        pmix_free((m));             \
+    } while (0)
+
+#define PMIX_PROC_INFO_RELEASE(m) \
+    PMIX_PROC_INFO_FREE((m), 1)
+
+
+#define PMIX_PROC_STATS_CONSTRUCT(m) \
+    PMIx_Proc_stats_construct(m)
+
+#define PMIX_PROC_STATS_DESTRUCT(m) \
+    PMIx_Proc_stats_destruct(m)
+
+#define PMIX_PROC_STATS_CREATE(m, n) \
+    (m) = PMIx_Proc_stats_create(n)
+
+#define PMIX_PROC_STATS_FREE(m, n)  \
+do {                                \
+    PMIx_Proc_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
+
+#define PMIX_PROC_STATS_RELEASE(m) \
+        PMIX_PROC_STATS_FREE((m), 1);
+
+
+#define PMIX_DISK_STATS_CONSTRUCT(m) \
+    PMIx_Disk_stats_construct(m)
+
+#define PMIX_DISK_STATS_DESTRUCT(m) \
+    PMIx_Disk_stats_destruct(m)
+
+#define PMIX_DISK_STATS_CREATE(m, n) \
+    (m) = PMIx_Disk_stats_create(n)
+
+#define PMIX_DISK_STATS_FREE(m, n)  \
+do {                                \
+    PMIx_Disk_stats_free(m, n);     \
+    pmix_free(m);                   \
+    (m) = NULL;                     \
+} while(0)
+
+#define PMIX_DISK_STATS_RELEASE(m)      \
+        PMIX_DISK_STATS_FREE((m), 1);   \
+
+
+#define PMIX_NET_STATS_CONSTRUCT(m) \
+    PMIx_Net_stats_construct(m)
+
+#define PMIX_NET_STATS_DESTRUCT(m) \
+    PMIx_Net_stats_destruct(m)
+
+#define PMIX_NET_STATS_CREATE(m, n) \
+    (m) = PMIx_Net_stats_create(n)
+
+#define PMIX_NET_STATS_FREE(m, n)  \
+do {                               \
+    PMIx_Net_stats_free(m, n);     \
+    pmix_free(m);                  \
+    (m) = NULL;                    \
+} while(0)
+
+#define PMIX_NET_STATS_RELEASE(m)      \
+        PMIX_NET_STATS_FREE((m), 1);   \
+
+
+#define PMIX_NODE_STATS_CONSTRUCT(m) \
+    PMIx_Node_stats_construct(m)
+
+#define PMIX_NODE_STATS_DESTRUCT(m) \
+    PMIx_Node_stats_destruct(m)
+
+#define PMIX_NODE_STATS_CREATE(m, n) \
+    (m) = PMIx_Node_stats_create(n)
+
+#define PMIX_NODE_STATS_FREE(m, n)  \
+do {                               \
+    PMIx_Node_stats_free(m, n);     \
+    pmix_free(m);                  \
+    (m) = NULL;                    \
+} while(0)
+
+#define PMIX_NODE_STATS_RELEASE(m)      \
+        PMIX_NODE_STATS_FREE((m), 1);   \
 
 
 #if defined(c_plusplus) || defined(__cplusplus)

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -106,7 +106,7 @@ int pmix_mca_base_show_load_errors_init(void)
     // boolean value
     pmix_value_t value;
     PMIX_VALUE_LOAD(&value, pmix_mca_base_component_show_load_errors, PMIX_STRING);
-    pmix_boolean_t ret = pmix_check_true(&value);
+    pmix_boolean_t ret = PMIx_Value_true(&value);
 
     // Treat true values as a synonym for "all", and false values
     // as a synonym for "none".

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -15,6 +15,99 @@
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/base/base.h"
 
+void PMIx_Load_key(pmix_key_t key, const char *src)
+{
+    memset(key, 0, PMIX_MAX_KEYLEN+1);
+    if (NULL != src) {
+        pmix_strncpy((char*)key, src, PMIX_MAX_KEYLEN);
+    }
+}
+
+void PMIx_Value_construct(pmix_value_t *val)
+{
+    memset(val, 0, sizeof(pmix_value_t));
+    val->type = PMIX_UNDEF;
+}
+
+void PMIx_Value_destruct(pmix_value_t *val)
+{
+    pmix_bfrops_base_value_destruct(val);
+}
+
+pmix_value_t* PMIx_Value_create(size_t n)
+{
+    pmix_value_t *v;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    v = (pmix_value_t*)pmix_malloc(n * sizeof(pmix_value_t));
+    if (NULL == v) {
+        return NULL;
+    }
+    for (m=0; m < n; m++) {
+        PMIx_Value_construct(&v[m]);
+    }
+    return v;
+}
+
+void PMIx_Value_free(pmix_value_t *v, size_t n)
+{
+    size_t m;
+
+    if (NULL == v) {
+        return;
+    }
+    for (m=0; m < n; m++) {
+        PMIx_Value_destruct(&v[m]);
+    }
+}
+
+pmix_boolean_t PMIx_Value_true(const pmix_value_t *value)
+{
+    char *ptr;
+
+    if (PMIX_UNDEF == value->type) {
+        return PMIX_BOOL_TRUE; // default to true
+    }
+    if (PMIX_BOOL == value->type) {
+        if (value->data.flag) {
+            return PMIX_BOOL_TRUE;
+        } else {
+            return PMIX_BOOL_FALSE;
+        }
+    }
+    if (PMIX_STRING == value->type) {
+        if (NULL == value->data.string) {
+            return PMIX_BOOL_TRUE;
+        }
+        ptr = value->data.string;
+        /* Trim leading whitespace */
+        while (isspace(*ptr)) {
+            ++ptr;
+        }
+        if ('\0' == *ptr) {
+            return PMIX_BOOL_TRUE;
+        }
+        if (isdigit(*ptr)) {
+            if (0 == atoi(ptr)) {
+                return PMIX_BOOL_FALSE;
+            } else {
+                return PMIX_BOOL_TRUE;
+            }
+        } else if (0 == strncasecmp(ptr, "yes", 3) ||
+                   0 == strncasecmp(ptr, "true", 4)) {
+            return PMIX_BOOL_TRUE;
+        } else if (0 == strncasecmp(ptr, "no", 2) ||
+                   0 == strncasecmp(ptr, "false", 5)) {
+            return PMIX_BOOL_FALSE;
+        }
+    }
+
+    return PMIX_NON_BOOL;
+}
+
 pmix_status_t PMIx_Value_load(pmix_value_t *v,
                               const void *data,
                               pmix_data_type_t type)
@@ -30,11 +123,6 @@ pmix_status_t PMIx_Value_unload(pmix_value_t *kv,
     return pmix_bfrops_base_value_unload(kv, data, sz);
 }
 
-void PMIx_Value_destruct(pmix_value_t *val)
-{
-    pmix_bfrops_base_value_destruct(val);
-}
-
 pmix_status_t PMIx_Value_xfer(pmix_value_t *dest,
                               const pmix_value_t *src)
 {
@@ -47,9 +135,29 @@ pmix_value_cmp_t PMIx_Value_compare(pmix_value_t *v1,
     return pmix_bfrops_base_value_cmp(v1, v2);
 }
 
+
 void PMIx_Data_array_destruct(pmix_data_array_t *d)
 {
     pmix_bfrops_base_darray_destruct(d);
+}
+
+
+PMIX_EXPORT void PMIx_Info_construct(pmix_info_t *p)
+{
+    PMIx_Load_key(p->key, NULL);
+    PMIx_Value_construct(&p->value);
+}
+
+PMIX_EXPORT void PMIx_Info_destruct(pmix_info_t *p);
+PMIX_EXPORT pmix_info_t* PMIx_Info_create(size_t n);
+PMIX_EXPORT void PMIx_Info_free(pmix_info_t *p, size_t n);
+
+pmix_boolean_t PMIx_Info_true(const pmix_info_t *p)
+{
+    pmix_boolean_t ret;
+
+    ret = PMIx_Value_true(&p->value);
+    return ret;
 }
 
 pmix_status_t PMIx_Info_load(pmix_info_t *info,
@@ -82,6 +190,65 @@ pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,
         rc = PMIx_Value_xfer(&dest->value, &src->value);
     }
     return rc;
+}
+
+void PMIx_Coord_construct(pmix_coord_t *m)
+{
+    if (NULL == m) {
+        return;
+    }
+    m->view = PMIX_COORD_VIEW_UNDEF;
+    m->coord = NULL;
+    m->dims = 0;
+}
+
+void PMIx_Coord_destruct(pmix_coord_t *m)
+{
+    if (NULL == m) {
+        return;
+    }
+    m->view = PMIX_COORD_VIEW_UNDEF;
+    if (NULL != m->coord) {
+        pmix_free(m->coord);
+        m->coord = NULL;
+        m->dims = 0;
+    }
+}
+
+pmix_coord_t* PMIx_Coord_create(size_t dims,
+                                size_t number)
+{
+    pmix_coord_t *m;
+
+    if (0 == number) {
+        return NULL;
+    }
+    m = (pmix_coord_t*)pmix_malloc(number * sizeof(pmix_coord_t));
+    if (NULL == m) {
+        return NULL;
+    }
+    m->view = PMIX_COORD_VIEW_UNDEF;
+    m->dims = dims;
+    if (0 == dims) {
+        m->coord = NULL;
+    } else {
+        m->coord = (uint32_t*)pmix_malloc(dims * sizeof(uint32_t));
+        if (NULL != m->coord) {
+            memset(m->coord, 0, dims * sizeof(uint32_t));
+        }
+    }
+    return m;
+}
+
+void PMIx_Coord_free(pmix_coord_t *m, size_t number)
+{
+    size_t n;
+    if (NULL == m) {
+        return;
+    }
+    for (n=0; n < number; n++) {
+        PMIx_Coord_destruct(&m[n]);
+    }
 }
 
 void PMIx_Topology_construct(pmix_topology_t *t)
@@ -346,5 +513,427 @@ void PMIx_Endpoint_free(pmix_endpoint_t *e, size_t n)
     }
     for (m=0; m < n; m++) {
         PMIx_Endpoint_destruct(&e[m]);
+    }
+}
+
+PMIX_EXPORT void PMIx_Envar_construct(pmix_envar_t *e)
+{
+    e->envar = NULL;
+    e->value = NULL;
+    e->separator = '\0';
+}
+
+PMIX_EXPORT void PMIx_Envar_destruct(pmix_envar_t *e)
+{
+    if (NULL != e->envar) {
+        pmix_free(e->envar);
+        e->envar = NULL;
+    }
+    if (NULL != e->value) {
+        pmix_free(e->value);
+        e->value = NULL;
+    }
+}
+
+PMIX_EXPORT pmix_envar_t* PMIx_Envar_create(size_t n)
+{
+    pmix_envar_t *e;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    e = (pmix_envar_t*)pmix_malloc(n * sizeof(pmix_envar_t));
+    if (NULL != e) {
+        for (m=0; m < n; m++) {
+            PMIx_Envar_construct(&e[m]);
+        }
+    }
+    return e;
+}
+
+void PMIx_Envar_free(pmix_envar_t *e, size_t n)
+{
+    size_t m;
+
+    if (NULL == e) {
+        return;
+    }
+    for (m=0; m < n; m++) {
+        PMIx_Envar_destruct(&e[m]);
+    }
+}
+
+void PMIx_Envar_load(pmix_envar_t *e,
+                     char *var,
+                     char *value,
+                     char separator)
+{
+    if (NULL != var) {
+        e->envar = strdup(var);
+    }
+    if (NULL != value) {
+        e->value = strdup(value);
+    }
+    e->separator = separator;
+}
+
+void PMIx_Data_buffer_construct(pmix_data_buffer_t *b)
+{
+    memset(b, 0, sizeof(pmix_data_buffer_t));
+}
+
+void PMIx_Data_buffer_destruct(pmix_data_buffer_t *b)
+{
+    if (NULL != b->base_ptr) {
+        pmix_free(b->base_ptr);
+        b->base_ptr = NULL;
+    }
+    b->pack_ptr = NULL;
+    b->unpack_ptr = NULL;
+    b->bytes_allocated = 0;
+    b->bytes_used = 0;
+}
+
+pmix_data_buffer_t* PMIx_Data_buffer_create(void)
+{
+    pmix_data_buffer_t *b;
+
+    b = (pmix_data_buffer_t*)pmix_malloc(sizeof(pmix_data_buffer_t));
+    if (NULL != b) {
+        PMIx_Data_buffer_construct(b);
+    }
+    return b;
+
+}
+void PMIx_Data_buffer_release(pmix_data_buffer_t *b)
+{
+    if (NULL == b) {
+        return;
+    }
+    PMIx_Data_buffer_destruct(b);
+}
+
+void PMIx_Data_buffer_load(pmix_data_buffer_t *b,
+                           char *bytes, size_t sz)
+{
+    pmix_byte_object_t bo;
+
+    bo.bytes = bytes;
+    bo.size = sz;
+    PMIx_Data_load(b, &bo);
+}
+
+void PMIx_Data_buffer_unload(pmix_data_buffer_t *b,
+                             char **bytes, size_t *sz)
+{
+    pmix_byte_object_t bo;
+    pmix_status_t r;
+
+    r = PMIx_Data_unload(b, &bo);
+    if (PMIX_SUCCESS == r) {
+        *bytes = bo.bytes;
+        *sz = bo.size;
+    } else {
+        *bytes = NULL;
+        *sz = 0;
+    }
+}
+
+void PMIx_Proc_construct(pmix_proc_t *p)
+{
+    memset(p, 0, sizeof(pmix_proc_t));
+    p->rank = PMIX_RANK_UNDEF;
+}
+
+void PMIx_Proc_destruct(pmix_proc_t *p)
+{
+    PMIx_Proc_construct(p);
+    return;
+}
+
+pmix_proc_t* PMIx_Proc_create(size_t n)
+{
+    pmix_proc_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_proc_t*)pmix_malloc(n * sizeof(pmix_proc_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Proc_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Proc_free(pmix_proc_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL == p) {
+        return;
+    }
+    for (m=0; m < n; m++) {
+        PMIx_Proc_destruct(&p[m]);
+    }
+}
+
+void PMIx_Proc_load(pmix_proc_t *p,
+                    char *nspace, pmix_rank_t rank)
+{
+    PMIx_Proc_construct(p);
+    PMIX_LOAD_PROCID(p, nspace, rank);
+}
+
+void PMIx_Multicluster_nspace_construct(pmix_nspace_t target,
+                                        pmix_nspace_t cluster,
+                                        pmix_nspace_t nspace)
+{
+    size_t len;
+
+    PMIX_LOAD_NSPACE(target, NULL);
+    len = pmix_nslen(cluster);
+    if ((len + pmix_nslen(nspace)) < PMIX_MAX_NSLEN) {
+        pmix_strncpy((char*)target, cluster, PMIX_MAX_NSLEN);
+        target[len] = ':';
+        pmix_strncpy((char*)&target[len+1], nspace, PMIX_MAX_NSLEN - len);
+    }
+}
+
+void PMIx_Multicluster_nspace_parse(pmix_nspace_t target,
+                                    pmix_nspace_t cluster,
+                                    pmix_nspace_t nspace)
+{
+    size_t n, j;
+
+    for (n=0; '\0' != target[n] && ':' != target[n] && n <= PMIX_MAX_NSLEN; n++) {
+        cluster[n] = target[n];
+    }
+    n++;
+    for (j=0; n <= PMIX_MAX_NSLEN && '\0' != target[n]; n++, j++) {
+        nspace[j] = target[n];
+    }
+}
+
+void PMIx_Proc_info_construct(pmix_proc_info_t *p)
+{
+    memset(p, 0, sizeof(pmix_proc_info_t));
+    p->state = PMIX_PROC_STATE_UNDEF;
+}
+
+void PMIx_Proc_info_destruct(pmix_proc_info_t *p)
+{
+    if (NULL != p->hostname) {
+        pmix_free(p->hostname);
+    }
+    if (NULL != p->executable_name) {
+        pmix_free(p->executable_name);
+    }
+    PMIx_Proc_info_construct(p);
+}
+
+pmix_proc_info_t* PMIx_Proc_info_create(size_t n)
+{
+    pmix_proc_info_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_proc_info_t*)pmix_malloc(n * sizeof(pmix_proc_info_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Proc_info_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Proc_info_free(pmix_proc_info_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL == p) {
+        return;
+    }
+    for (m=0; m < n; m++) {
+        PMIx_Proc_info_destruct(&p[m]);
+    }
+}
+
+void PMIx_Proc_stats_construct(pmix_proc_stats_t *p)
+{
+    memset(p, 0, sizeof(pmix_proc_stats_t));
+}
+
+void PMIx_Proc_stats_destruct(pmix_proc_stats_t *p)
+{
+    if (NULL != p->node) {
+        pmix_free(p->node);
+        p->node = NULL;
+    }
+    if (NULL != p->cmd) {
+        pmix_free(p->cmd);
+        p->cmd = NULL;
+    }
+}
+
+pmix_proc_stats_t* PMIx_Proc_stats_create(size_t n)
+{
+    pmix_proc_stats_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_proc_stats_t*)pmix_malloc(n * sizeof(pmix_proc_stats_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Proc_stats_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Proc_stats_free(pmix_proc_stats_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Proc_stats_destruct(&p[m]);
+        }
+    }
+}
+
+void PMIx_Disk_stats_construct(pmix_disk_stats_t *p)
+{
+    memset(p, 0, sizeof(pmix_disk_stats_t));
+}
+
+void PMIx_Disk_stats_destruct(pmix_disk_stats_t *p)
+{
+    if (NULL != p->disk) {
+        pmix_free(p->disk);
+        p->disk = NULL;
+    }
+}
+
+pmix_disk_stats_t* PMIx_Disk_stats_create(size_t n)
+{
+    pmix_disk_stats_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_disk_stats_t*)pmix_malloc(n * sizeof(pmix_disk_stats_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Disk_stats_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Disk_stats_free(pmix_disk_stats_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Disk_stats_destruct(&p[m]);
+        }
+    }
+}
+
+void PMIx_Net_stats_construct(pmix_net_stats_t *p)
+{
+    memset(p, 0, sizeof(pmix_net_stats_t));
+}
+
+void PMIx_Net_stats_destruct(pmix_net_stats_t *p)
+{
+    if (NULL != p->net_interface) {
+        pmix_free(p->net_interface);
+        p->net_interface = NULL;
+    }
+}
+
+pmix_net_stats_t* PMIx_Net_stats_create(size_t n)
+{
+    pmix_net_stats_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_net_stats_t*)pmix_malloc(n * sizeof(pmix_net_stats_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Net_stats_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Net_stats_free(pmix_net_stats_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Net_stats_destruct(&p[m]);
+        }
+    }
+}
+
+void PMIx_Node_stats_construct(pmix_node_stats_t *p)
+{
+    memset(p, 0, sizeof(pmix_node_stats_t));
+}
+
+void PMIx_Node_stats_destruct(pmix_node_stats_t *p)
+{
+    if (NULL != p->node) {
+        pmix_free(p->node);
+        p->node = NULL;
+    }
+    if (NULL != p->diskstats) {
+        PMIX_DISK_STATS_FREE(p->diskstats, p->ndiskstats);
+    }
+    if (NULL != p->netstats) {
+        PMIX_NET_STATS_FREE(p->netstats, p->nnetstats);
+    }
+}
+
+pmix_node_stats_t* PMIx_Node_stats_create(size_t n)
+{
+    pmix_node_stats_t *p;
+    size_t m;
+
+    if (0 == n) {
+        return NULL;
+    }
+    p = (pmix_node_stats_t*)pmix_malloc(n * sizeof(pmix_node_stats_t));
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Node_stats_construct(&p[m]);
+        }
+    }
+    return p;
+}
+
+void PMIx_Node_stats_free(pmix_node_stats_t *p, size_t n)
+{
+    size_t m;
+
+    if (NULL != p) {
+        for (m=0; m < n; m++) {
+            PMIx_Node_stats_destruct(&p[m]);
+        }
     }
 }

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -587,7 +587,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
             /* now transfer rest of data across */
             n = 1;
             PMIX_LIST_FOREACH(kvptr, &rkvs, pmix_kval_t) {
-                PMIX_LOAD_KEY(&iptr[n].key, kvptr->key);
+                PMIX_LOAD_KEY(iptr[n].key, kvptr->key);
                 PMIx_Value_xfer(&iptr[n].value, kvptr->value);
                 ++n;
             }

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -650,7 +650,7 @@ pmix_gds_shmem_fetch(
             // Now transfer rest of data across.
             size_t i = 1;
             PMIX_LIST_FOREACH(kvi, &rkvs, pmix_kval_t) {
-                PMIX_LOAD_KEY(&iptr[i].key, kvi->key);
+                PMIX_LOAD_KEY(iptr[i].key, kvi->key);
                 PMIx_Value_xfer(&iptr[i].value, kvi->value);
                 i++;
             }

--- a/src/mca/gds/shmem/pmix_hash2.c
+++ b/src/mca/gds/shmem/pmix_hash2.c
@@ -427,7 +427,7 @@ pmix_status_t pmix_hash2_fetch(pmix_hash_table2_t *table,
                         /* the first location is the actual value */
                         // TODO(skg) We need to modify this.
                         assert(false);
-                        PMIX_LOAD_KEY(&iptr[0].key, p->string);
+                        PMIX_LOAD_KEY(iptr[0].key, p->string);
                         PMIx_Value_xfer(&iptr[0].value, hv->value);
                         /* now add the qualifiers */
                         for (m=0; m < nq; m++) {
@@ -438,7 +438,7 @@ pmix_status_t pmix_hash2_fetch(pmix_hash_table2_t *table,
                                 PMIX_DATA_ARRAY_FREE(darray);
                                 return PMIX_ERR_BAD_PARAM;
                             }
-                            PMIX_LOAD_KEY(&iptr[m+1].key, p->string);
+                            PMIX_LOAD_KEY(iptr[m+1].key, p->string);
                             PMIx_Value_xfer(&iptr[m+1].value, quals[m].value);
                             PMIX_INFO_SET_QUALIFIER(&iptr[m+1]);
                         }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -1267,7 +1267,7 @@ complete:
     /* convert the list to an array */
     if (0 < (ndata = pmix_list_get_size(&mylist))) {
         ians = PMIX_NEW(pmix_infolist_t);
-        PMIX_LOAD_KEY(&ians->info.key, PMIX_SERVER_INFO_ARRAY);
+        PMIX_LOAD_KEY(ians->info.key, PMIX_SERVER_INFO_ARRAY);
         ians->info.value.type = PMIX_DATA_ARRAY;
         PMIX_DATA_ARRAY_CREATE(ians->info.value.data.darray, ndata, PMIX_INFO);
         sdata = (pmix_info_t *) ians->info.value.data.darray->array;

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -349,7 +349,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
                         PMIX_DATA_ARRAY_CREATE(darray, nq+1, PMIX_INFO);
                         iptr = (pmix_info_t*)darray->array;
                         /* the first location is the actual value */
-                        PMIX_LOAD_KEY(&iptr[0].key, p->string);
+                        PMIX_LOAD_KEY(iptr[0].key, p->string);
                         PMIx_Value_xfer(&iptr[0].value, hv->value);
                         /* now add the qualifiers */
                         for (m=0; m < nq; m++) {
@@ -360,7 +360,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
                                 PMIX_DATA_ARRAY_FREE(darray);
                                 return PMIX_ERR_BAD_PARAM;
                             }
-                            PMIX_LOAD_KEY(&iptr[m+1].key, p->string);
+                            PMIX_LOAD_KEY(iptr[m+1].key, p->string);
                             PMIx_Value_xfer(&iptr[m+1].value, quals[m].value);
                             PMIX_INFO_SET_QUALIFIER(&iptr[m+1]);
                         }


### PR DESCRIPTION
Cover another group. Discovered some memory corruption where PMIX_LOAD_KEY was being passed the address of the target key instead of the target key itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>