### PR TITLE
Cleanup error paths in gds/shmem, silence Coverity warning.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem_utils.c
+++ b/src/mca/gds/shmem/gds_shmem_utils.c
@@ -96,7 +96,7 @@ pmix_gds_shmem_check_session(
     bool create
 ) {
     // This is an error: we should always be given a job.
-    if (!job) {
+    if (PMIX_UNLIKELY(!job)) {
         return NULL;
     }
 
@@ -262,28 +262,6 @@ pmix_gds_shmem_has_status(
     pmix_gds_shmem_status_flag_t flag
 ) {
     return (*get_job_shmem_status_flagp(job, shmem_id) & flag);
-}
-
-/**
- * Returns page size.
- */
-static inline size_t
-get_page_size(void)
-{
-    const long i = sysconf(_SC_PAGE_SIZE);
-    if (-1 == i) {
-        PMIX_ERROR_LOG(PMIX_ERROR);
-        return 0;
-    }
-    return i;
-}
-
-size_t
-pmix_gds_shmem_pad_amount_to_page(
-    size_t size
-) {
-    const size_t page_size = get_page_size();
-    return ((~size) + page_size + 1) & (page_size - 1);
 }
 
 /*

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -76,14 +76,6 @@ pmix_gds_shmem_get_job_shmem_by_shmem_id(
     pmix_shmem_t **shmem
 );
 
-/**
- * Returns amount needed to pad provided size to page boundary.
- */
-PMIX_EXPORT size_t
-pmix_gds_shmem_pad_amount_to_page(
-    size_t size
-);
-
 PMIX_EXPORT void
 pmix_gds_shmem_set_status(
     pmix_gds_shmem_job_t *job,

--- a/src/mca/gds/shmem/pmix_hash2.c
+++ b/src/mca/gds/shmem/pmix_hash2.c
@@ -94,7 +94,7 @@ typedef struct {
 
 static void pdcon(pmix_proc_data2_t *p)
 {
-    pmix_tma_t *tma = pmix_obj_get_tma(&p->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&p->super);
     // TODO(skg) Note that we moved to PMIX_NEW. Cannot use PMIX_CONSTRUCT with
     // the TMA we care about.
 #if 0
@@ -117,7 +117,7 @@ static void pddes(pmix_proc_data2_t *p)
     pmix_dstor_t *d;
     pmix_qual_t *q;
     pmix_data_array_t *darray;
-    pmix_tma_t *tma = pmix_obj_get_tma(&p->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&p->super);
 
     for (n=0; n < p->data->size; n++) {
         d = (pmix_dstor_t*)pmix_pointer_array2_get_item(p->data, n);
@@ -164,7 +164,7 @@ pmix_status_t pmix_hash2_store(pmix_hash_table2_t *table,
     pmix_data_array_t *darray;
     pmix_qual_t *qarray;
     size_t n, m = 0;
-    pmix_tma_t *tma = pmix_obj_get_tma(&table->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&table->super);
 
     pmix_output_verbose(10, pmix_globals.debug_output,
                         "HASH:STORE:QUAL rank %s key %s",
@@ -511,7 +511,7 @@ pmix_status_t pmix_hash2_remove_data(pmix_hash_table2_t *table,
     int n;
     char *node;
     pmix_regattr_input_t *p;
-    pmix_tma_t *tma = pmix_obj_get_tma(&table->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&table->super);
 
     if (NULL != key) {
         p = pmix_hash2_lookup_key(UINT32_MAX, key);
@@ -687,7 +687,7 @@ static pmix_dstor_t *lookup_keyval(pmix_proc_data2_t *proc_data, uint32_t kid,
 static pmix_proc_data2_t *lookup_proc(pmix_hash_table2_t *jtable, uint32_t id, bool create)
 {
     pmix_proc_data2_t *proc_data = NULL;
-    pmix_tma_t *tma = pmix_obj_get_tma(&jtable->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&jtable->super);
 
     pmix_hash_table2_get_value_uint32(jtable, id, (void **) &proc_data);
     if (NULL == proc_data && create) {
@@ -811,7 +811,7 @@ static void erase_qualifiers(pmix_proc_data2_t *proc,
     pmix_data_array_t *darray;
     pmix_qual_t *qarray;
     size_t n;
-    pmix_tma_t *tma = pmix_obj_get_tma(&proc->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&proc->super);
 
     darray = (pmix_data_array_t*)pmix_pointer_array2_get_item(proc->quals, index);
     if (NULL == darray || NULL == darray->array) {

--- a/src/mca/gds/shmem/pmix_pointer_array2.c
+++ b/src/mca/gds/shmem/pmix_pointer_array2.c
@@ -69,7 +69,7 @@ static void pmix_pointer_array2_construct(pmix_pointer_array2_t *array)
  */
 static void pmix_pointer_array2_destruct(pmix_pointer_array2_t *array)
 {
-    pmix_tma_t *tma = pmix_obj_get_tma(&array->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&array->super);
     /* free table */
     if (NULL != array->free_bits) {
         pmix_tma_free(tma, array->free_bits);
@@ -197,13 +197,14 @@ static void pmix_pointer_array2_validate(pmix_pointer_array2_t *array)
 int pmix_pointer_array2_init(pmix_pointer_array2_t *array, int initial_allocation, int max_size,
                             int block_size)
 {
-    pmix_tma_t *tma = pmix_obj_get_tma(&array->super);
     size_t num_bytes;
 
     /* check for errors */
     if (NULL == array || max_size < block_size) {
         return PMIX_ERR_BAD_PARAM;
     }
+
+    pmix_tma_t *const tma = pmix_obj_get_tma(&array->super);
 
     array->max_size = max_size;
     array->block_size = (0 == block_size ? 8 : block_size);
@@ -415,7 +416,7 @@ int pmix_pointer_array2_set_size(pmix_pointer_array2_t *array, int new_size)
 
 static bool grow_table(pmix_pointer_array2_t *table, int at_least)
 {
-    pmix_tma_t *tma = pmix_obj_get_tma(&table->super);
+    pmix_tma_t *const tma = pmix_obj_get_tma(&table->super);
     int i, new_size, new_size_int;
     void *p;
 


### PR DESCRIPTION
Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>