### PR TITLE
Address to-do items in gds/shmem.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -52,6 +52,11 @@ BEGIN_C_DECLS
 extern pmix_gds_base_module_t pmix_shmem_module;
 
 /**
+ * Stores MCA parameter value for segment_size_multiplier.
+ */
+PMIX_EXPORT extern double pmix_gds_shmem_segment_size_multiplier;
+
+/**
  * IDs for pmix_shmem_ts in pmix_gds_shmem_job_t.
  */
 typedef enum {

--- a/src/mca/gds/shmem/gds_shmem_component.c
+++ b/src/mca/gds/shmem/gds_shmem_component.c
@@ -31,6 +31,9 @@
 #include "gds_shmem.h"
 
 static int
+gds_shmem_component_register(void);
+
+static int
 component_query(
     pmix_mca_base_module_t **module,
     int *priority
@@ -68,6 +71,8 @@ pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
             PMIX_MINOR_VERSION,
             PMIX_RELEASE_VERSION
         ),
+        /** Component register. */
+        .pmix_mca_register_component_params = gds_shmem_component_register,
         /** Component query function. */
         .pmix_mca_query_component = component_query,
         .reserved = {0}
@@ -75,6 +80,28 @@ pmix_gds_shmem_component_t pmix_mca_gds_shmem_component = {
     .jobs = PMIX_LIST_STATIC_INIT,
     .sessions = PMIX_LIST_STATIC_INIT
 };
+
+double pmix_gds_shmem_segment_size_multiplier = 1.0;
+
+static int
+gds_shmem_component_register(void)
+{
+#if (!PMIX_GDS_SHMEM_DISABLE)
+    const int varidx = pmix_mca_base_component_var_register(
+        &pmix_mca_gds_shmem_component.super,
+        "segment_size_multiplier",
+        "Multiplier that influences the ultimate sizes of the shared-memory "
+        "segments used for gds data storage. Values less or greater than 1.0 "
+        "decrease or increase final segment sizes, respectively.",
+        PMIX_MCA_BASE_VAR_TYPE_DOUBLE,
+        &pmix_gds_shmem_segment_size_multiplier
+    );
+    if (varidx < 0) {
+        return PMIX_ERROR;
+    }
+#endif
+    return PMIX_SUCCESS;
+}
 
 /*
  * vim: ft=cpp ts=4 sts=4 sw=4 expandtab

--- a/src/mca/gds/shmem/gds_shmem_utils.c
+++ b/src/mca/gds/shmem/gds_shmem_utils.c
@@ -191,7 +191,7 @@ pmix_gds_shmem_hostnames_eq(
 }
 
 pmix_status_t
-pmix_gds_shmem_get_job_shmem_by_shmem_id(
+pmix_gds_shmem_get_job_shmem_by_id(
     pmix_gds_shmem_job_t *job,
     pmix_gds_shmem_job_shmem_id_t shmem_id,
     pmix_shmem_t **shmem

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -70,7 +70,7 @@ pmix_gds_shmem_hostnames_eq(
  * Sets shmem to the appropriate pmix_shmem_t *.
  */
 PMIX_EXPORT pmix_status_t
-pmix_gds_shmem_get_job_shmem_by_shmem_id(
+pmix_gds_shmem_get_job_shmem_by_id(
     pmix_gds_shmem_job_t *job,
     pmix_gds_shmem_job_shmem_id_t shmem_id,
     pmix_shmem_t **shmem


### PR DESCRIPTION
* Expose an MCA parameter that influences the ultimate sizes of the shared-memory segments used to back gds/shmem data.
* Emit shared-memory usage statistics during job termination when appropriate.
* Incorporate other minor modifications that happened to be captured during this work.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>