### PR TITLE
Add an attribute for passing an auxiliary event base

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -157,6 +157,9 @@ typedef uint32_t pmix_rank_t;
 /* initialization attributes */
 #define PMIX_EXTERNAL_PROGRESS              "pmix.evext"            // (bool) The host shall progress the PMIx library via
                                                                     //        calls to PMIx_Progress
+#define PMIX_EXTERNAL_AUX_EVENT_BASE        "pmix.evaux"            // (void*) event base to be used for auxiliary
+                                                                    //        functions (e.g., capturing signals) that would
+                                                                    //        otherwise interfere with the host
 #define PMIX_SERVER_TOOL_SUPPORT            "pmix.srvr.tool"        // (bool) The host RM wants to declare itself as willing
                                                                     //        to accept tool connection requests
 #define PMIX_SERVER_REMOTE_CONNECTIONS      "pmix.srvr.remote"      // (bool) Allow connections from remote tools (do not use

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -608,7 +608,7 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets, pmix_b
                              * filedescriptor is not a tty, don't worry about it
                              * and always stay connected.
                              */
-                            pmix_event_signal_set(pmix_globals.evbase, &stdinsig_ev, SIGCONT,
+                            pmix_event_signal_set(pmix_globals.evauxbase, &stdinsig_ev, SIGCONT,
                                                   pmix_iof_stdin_cb, NULL);
 
                             /* setup a read event to read stdin, but don't activate it yet. The

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -675,6 +675,7 @@ typedef struct {
     uint32_t sessionid;  // my sessionid, if given
     int pindex;
     pmix_event_base_t *evbase;
+    pmix_event_base_t *evauxbase;
     int debug_output;
     pmix_events_t events; // my event handler registrations.
     bool connected;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -91,6 +91,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .sessionid = UINT32_MAX,
     .pindex = 0,
     .evbase = NULL,
+    .evauxbase = NULL,
     .debug_output = -1,
     .events = PMIX_EVENTS_STATIC_INIT,
     .connected = false,
@@ -262,6 +263,8 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_EXTERNAL_PROGRESS)) {
                 pmix_globals.external_progress = PMIX_INFO_TRUE(&info[n]);
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_EXTERNAL_AUX_EVENT_BASE)) {
+                pmix_globals.evauxbase = (pmix_event_base_t*)info[n].value.data.ptr;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME_KEEP_FQDN)) {
                 keepfqdn = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_BIND_PROGRESS_THREAD)) {
@@ -284,6 +287,10 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
         error = "progress thread";
         ret = PMIX_ERROR;
         goto return_error;
+    }
+    /* if we were not given an aux event base, set it to our internal one */
+    if (NULL == pmix_globals.evauxbase) {
+        pmix_globals.evauxbase = pmix_globals.evbase;
     }
 
     /* setup the globals structure */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -859,8 +859,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
              * filedescriptor is not a tty, don't worry about it
              * and always stay connected.
              */
-            pmix_event_signal_set(pmix_globals.evbase, &stdinsig, SIGCONT, pmix_iof_stdin_cb,
-                                  &stdinev);
+            pmix_event_signal_set(pmix_globals.evauxbase, &stdinsig, SIGCONT,
+                                  pmix_iof_stdin_cb, &stdinev);
 
             /* setup a read event to read stdin, but don't activate it yet. The
              * dst_name indicates who should receive the stdin. If that recipient


### PR DESCRIPTION
The PMIx library catches some signals to support things like IOF (e.g., start/stop of stdin forwarding). If the host has its own libevent or libev event base and is also using that base to trap signals, then this can cause confusion - neither libevent or libev handle the case of two event bases simultaneously trapping signals. So allow the host to pass in their event base for such purposes and have PMIx use it instead of its own base.

Signed-off-by: Ralph Castain <rhc@pmix.org>