### PR TITLE
Fix a typo in the macro backers and add a "stop" pt in deprecated.h

### DIFF
--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -44,6 +44,8 @@ def harvest_constants(options, src, constants, definitions):
         myline = line.strip()
         # remove comment lines
         if "/*" in myline or "*/" in myline or myline.startswith("*"):
+            if "DUPLICATES" in myline:
+                break
             n += 1
             continue
         # if the line starts with #define, then we want it

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2486,9 +2486,6 @@ cdef int spawn(const pmix_proc_t *proc,
     else:
         rc = PMIX_ERR_NOT_SUPPORTED
 
-    cdef pmix_nspace_t ns
-    pmix_copy_nspace(ns, nspace)
-
     # we cannot execute a callback function here as
     # that would cause PMIx to lockup. Likewise, the
     # Python function we called can't do it as it
@@ -2500,7 +2497,7 @@ cdef int spawn(const pmix_proc_t *proc,
         mycaddy = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
         mycaddy.op = strdup("spawn")
         mycaddy.status = rc
-        mycaddy.nspace = ns
+        pmix_copy_nspace(mycaddy.nspace, nspace)
         mycaddy.spawn  = cbfunc
         mycaddy.cbdata = cbdata
         cb = PyCapsule_New(mycaddy, NULL, NULL)

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -203,6 +203,8 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
                                                                     //        its namespace in the event
 
 
+/* DUPLICATES */
+
 /* Bring some function definitions across from pmix.h for now-deprecated
  * macros that utilize them. We have to do this as there are people who
  * only included pmix_common.h if they were using macros but not APIs */

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -39,15 +39,15 @@ void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str)
     }
 }
 
-bool PMIx_Check_nspace(const char *key1, const char *key2)
+bool PMIx_Check_nspace(const char *nspace1, const char *nspace2)
 {
-    if (PMIx_Nspace_invalid(key1)) {
+    if (PMIx_Nspace_invalid(nspace1)) {
         return true;
     }
-    if (PMIx_Nspace_invalid(key2)) {
+    if (PMIx_Nspace_invalid(nspace2)) {
         return true;
     }
-    if (PMIx_Check_key(key1, key2)) {
+    if (0 == strncmp(nspace1, nspace2, PMIX_MAX_NSLEN)) {
         return true;
     }
     return false;


### PR DESCRIPTION
Check nspace incorrectly called check key. Add a stop point in deprecated .h to avoid having the macro backers show up twice in the Python binding defs.

Fix bad variable assignment in the Python binding
for "spawn"

Signed-off-by: Ralph Castain <rhc@pmix.org>