### PR TITLE
Silence a warning during Python binding install

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -37,8 +37,14 @@ install-exec-local: $(helpers)
 	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include" --include-dir="$(top_srcdir)/include"
 	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
 		$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --library-dirs="$(DESTDIR)$(libdir)" --user
+		if [ $(PMIX_TOP_SRCDIR) != $(PMIX_TOP_BUILDDIR) ]; then \
+			pushd $(PMIX_TOP_BUILDDIR)/bindings/python; \
+			rm -f setup.py; \
+			cp $(PMIX_TOP_SRCDIR)/bindings/python/setup.py .; \
+			popd; \
+		fi
 	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
-		$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --prefix="$(DESTDIR)$(prefix)"
+		$(PYTHON) -m pip install --prefix="$(DESTDIR)$(prefix)" --editable $(top_builddir)/bindings/python
 
 uninstall-hook:
 	rm -f $(pythondir)/pmix*.so

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) 2022      Nanook Consulting. All rights reserved
 
 import os, os.path, sys, shutil, signal
 from optparse import OptionParser, OptionGroup

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1,3 +1,8 @@
+#file: pmix.pxi
+#
+# Copyright (c) 2022      Nanook Consulting. All rights reserved
+#
+
 from libc.string cimport memset, strncpy, strcpy, strlen, strdup
 from libc.stdlib cimport malloc, realloc, free
 from libc.string cimport memcpy

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1,4 +1,6 @@
 #file: pmix.pyx
+#
+# Copyright (c) 2022      Nanook Consulting. All rights reserved
 
 from libc.string cimport memset, strncpy, strcpy, strlen, strdup
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022      Nanook Consulting. All rights reserved
+
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
@@ -48,33 +52,52 @@ def getVersion():
         version = ".".join(vers)
         return version
 
-setup(
-    name = 'pypmix',
-    version = getVersion(),
-    url = 'https://pmix.org',
-    license = '3-clause BSD',
-    author = 'Ralph H. Castain',
-    author_email = 'rhc@pmix.org',
-    description = 'Python bindings for PMIx',
-    classifiers = [
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'Topic :: HPC :: Parallel Programming :: System Management',
-            'License :: OSI Approved :: BSD License',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12'],
-    keywords = 'PMI PMIx HPC MPI SHMEM',
-    platforms = 'any',
-    ext_modules = cythonize([Extension("pmix",
-                                       [os.environ['PMIX_BINDINGS_TOP_SRCDIR']+"/bindings/python/pmix.pyx"],
-                                       libraries=["pmix"]) ],
-                            compiler_directives={'language_level': 3}),
-    include_dirs = get_include()
-)
+def package_setup(package_name, package_vers):
+    '''
+    Package setup routine.
+    '''
+    setup(
+        name = 'pypmix',
+        version = getVersion(),
+        url = 'https://pmix.org',
+        license = '3-clause BSD',
+        author = 'Ralph H. Castain',
+        author_email = 'rhc@pmix.org',
+        description = 'Python bindings for PMIx',
+        classifiers = [
+                'Development Status :: 5 - Production/Stable',
+                'Intended Audience :: Developers',
+                'Topic :: HPC :: Parallel Programming :: System Management',
+                'License :: OSI Approved :: BSD License',
+                'Programming Language :: Python :: 3.4',
+                'Programming Language :: Python :: 3.5',
+                'Programming Language :: Python :: 3.6',
+                'Programming Language :: Python :: 3.7',
+                'Programming Language :: Python :: 3.8',
+                'Programming Language :: Python :: 3.9',
+                'Programming Language :: Python :: 3.10',
+                'Programming Language :: Python :: 3.11',
+                'Programming Language :: Python :: 3.12'],
+        keywords = 'PMI PMIx HPC MPI SHMEM',
+        platforms = 'any',
+        ext_modules = cythonize([Extension("pmix",
+                                           [os.environ['PMIX_BINDINGS_TOP_SRCDIR']+"/bindings/python/pmix.pyx"],
+                                           libraries=["pmix"]) ],
+                                compiler_directives={'language_level': 3}),
+        include_dirs = get_include()
+    )
+
+def main():
+    '''
+    The main entry point for this program.
+    '''
+    package_name = 'pypmix'
+    package_vers = getVersion()
+
+    package_setup(package_name, package_vers)
+
+    return os.EX_OK
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Use pip to do the install, modifying the setup.py
to support that model.

Thanks to Sam Gutierrez for showing how to do it.

Signed-off-by: Ralph Castain <rhc@pmix.org>