### PR TITLE
Re-implement the timeout support for purely local grp ops

### DIFF
--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -200,6 +200,11 @@ pmix_status_t pmix_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_server_globals.base_verbose);
 
+    (void) pmix_mca_base_var_register("pmix", "pmix", "server", "group_verbose",
+                                      "Verbosity for server group operations",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_server_globals.group_verbose);
+
     pmix_server_globals.fence_localonly_opt = true;
     (void) pmix_mca_base_var_register(
         "pmix", "pmix", "server", "fence_localonly_opt",

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -92,6 +92,7 @@ pmix_server_globals_t pmix_server_globals = {
     .genvars = NULL,
     .events = PMIX_LIST_STATIC_INIT,
     .groups = PMIX_LIST_STATIC_INIT,
+    .failedgrps = NULL,
     .iof = PMIX_LIST_STATIC_INIT,
     .iof_residuals = PMIX_LIST_STATIC_INIT,
     .psets = PMIX_LIST_STATIC_INIT,
@@ -115,7 +116,9 @@ pmix_server_globals_t pmix_server_globals = {
     .iof_output = -1,
     .iof_verbose = 0,
     .base_output = -1,
-    .base_verbose = 0
+    .base_verbose = 0,
+    .group_output = -1,
+    .group_verbose = 0
 };
 
 // local variables
@@ -437,7 +440,8 @@ pmix_status_t pmix_server_initialize(void)
     if (0 < pmix_server_globals.pub_verbose) {
         /* set default output */
         pmix_server_globals.pub_output = pmix_output_open(NULL);
-        pmix_output_set_verbosity(pmix_server_globals.pub_output, pmix_server_globals.pub_verbose);
+        pmix_output_set_verbosity(pmix_server_globals.pub_output, \
+                                  pmix_server_globals.pub_verbose);
     }
     if (0 < pmix_server_globals.spawn_verbose) {
         /* set default output */
@@ -454,7 +458,8 @@ pmix_status_t pmix_server_initialize(void)
     if (0 < pmix_server_globals.iof_verbose) {
         /* set default output */
         pmix_server_globals.iof_output = pmix_output_open(NULL);
-        pmix_output_set_verbosity(pmix_server_globals.iof_output, pmix_server_globals.iof_verbose);
+        pmix_output_set_verbosity(pmix_server_globals.iof_output,
+                                  pmix_server_globals.iof_verbose);
     }
     /* setup the base verbosity */
     if (0 < pmix_server_globals.base_verbose) {
@@ -462,6 +467,12 @@ pmix_status_t pmix_server_initialize(void)
         pmix_server_globals.base_output = pmix_output_open(NULL);
         pmix_output_set_verbosity(pmix_server_globals.base_output,
                                   pmix_server_globals.base_verbose);
+    }
+    if (0 < pmix_server_globals.group_verbose) {
+        /* set default output */
+        pmix_server_globals.group_output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(pmix_server_globals.group_output,
+                                  pmix_server_globals.group_verbose);
     }
 
     /* get our available security modules */
@@ -1014,6 +1025,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         pmix_execute_epilog(&ns->epilog);
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.groups);
+    if (NULL != pmix_server_globals.failedgrps) {
+        PMIx_Argv_free(pmix_server_globals.failedgrps);
+    }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.psets);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -189,6 +189,7 @@ typedef struct {
     char **genvars;     // argv array of envars given to me for passing to all clients
     pmix_list_t events; // list of pmix_regevents_info_t registered events
     pmix_list_t groups; // list of pmix_group_t group memberships
+    char **failedgrps;    // group IDs that failed to construct
     pmix_list_t iof;    // IO to be forwarded to clients
     pmix_list_t iof_residuals;  // leftover bytes waiting for newline
     pmix_list_t psets;  // list of known psets and memberships
@@ -221,6 +222,9 @@ typedef struct {
     // verbosity for basic server functions
     int base_output;
     int base_verbose;
+    // verbosity for server group operations
+    int group_output;
+    int group_verbose;
 } pmix_server_globals_t;
 
 #define PMIX_GDS_CADDY(c, p, t)              \


### PR DESCRIPTION
Internally support timeout for purely local group operations such as construct and destruct. Track group IDs of groups that fail to complete construct so that latecomers are rejected and don't hang. Ensure we notify all prior participants so they don't hang. Add a new verbose output channel solely for server-side group operations.

Signed-off-by: Ralph Castain <rhc@pmix.org>