### PR TITLE
Fix singleton support

### DIFF
--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -194,7 +194,8 @@ pmix_status_t pmix_ptl_base_recv_blocking(int sd, char *data, size_t size)
 
 #define PMIX_MAX_RETRIES 10
 
-pmix_status_t pmix_ptl_base_connect(struct sockaddr_storage *addr, pmix_socklen_t addrlen, int *fd)
+pmix_status_t pmix_ptl_base_connect(struct sockaddr_storage *addr,
+                                    pmix_socklen_t addrlen, int *fd)
 {
     int sd = -1, sd2;
     int retries = -1;

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -526,9 +526,6 @@ static pmix_status_t send_connect_ack(pmix_peer_t *peer,
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:ptl SEND CONNECT ACK");
 
-    /* allow space for a marker indicating client vs tool */
-    sdsize = 1;
-
     /* set our ID flag and compute the required handshake size */
     peer->proc_type.flag = pmix_ptl_base_set_flag(&sdsize);
 
@@ -602,8 +599,8 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri, pmix_info_t *iptr,
-                                            size_t niptr)
+pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,
+                                            pmix_info_t *iptr, size_t niptr)
 {
     struct sockaddr_storage myconnection;
     pmix_status_t rc;
@@ -942,8 +939,8 @@ pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer, char **msgout, 
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct timeval *save, pmix_socklen_t *sz,
-                                        bool *sockopt)
+pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct timeval *save,
+                                        pmix_socklen_t *sz, bool *sockopt)
 {
     struct timeval tv;
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -768,9 +768,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     }
 
     /* open the psensor framework */
-    if (PMIX_SUCCESS
-        != (rc = pmix_mca_base_framework_open(&pmix_psensor_base_framework,
-                                              PMIX_MCA_BASE_OPEN_DEFAULT))) {
+    rc = pmix_mca_base_framework_open(&pmix_psensor_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }


### PR DESCRIPTION
Correct some issues in the connection handshake where the singleton client case wasn't being handled. Cleanup some formatting. Silence a Coverity warning.

Signed-off-by: Ralph Castain <rhc@pmix.org>