### PR TITLE
Protect against NULL topology when destructing pmix_topology_t

### DIFF
--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -489,7 +489,9 @@ void pmix_hwloc_destruct_topology(pmix_topology_t *src)
         0 != strncasecmp(src->source, "hwloc", 5)) {
         return;
     }
-    hwloc_topology_destroy(src->topology);
+    if (NULL != src->topology) {
+        hwloc_topology_destroy(src->topology);
+    }
     free(src->source);
 }
 


### PR DESCRIPTION
Prior versions of PMIx have this protection, but it was lost when converting macros to functions.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 5bd97056ccd994c711fde4ac19aded8e4eac8285)