### PR TITLE
Avoid double-caching of events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ examples/abi_no_init
 examples/abi_with_init
 examples/group_lcl_cid
 examples/nodeinfo
+examples/pset
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -26,7 +26,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
-                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid
+                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -119,6 +119,11 @@ group_lcl_cid_LDADD =  $(top_builddir)/src/libpmix.la
 nodeinfo_SOURCES = nodeinfo.c examples.h
 nodeinfo_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 nodeinfo_LDADD =  $(top_builddir)/src/libpmix.la
+
+pset_SOURCES = pset.c examples.h
+pset_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+pset_LDADD = $(top_builddir)/src/libpmix.la
+
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -39,6 +39,7 @@ typedef struct {
     volatile bool active;
     pmix_status_t status;
     int count;
+    char *answer;
     size_t evhandler_ref;
 } mylock_t;
 
@@ -49,6 +50,7 @@ typedef struct {
         (l)->active = true;                    \
         (l)->status = PMIX_SUCCESS;            \
         (l)->count = 0;                        \
+        (l)->answer = NULL;                    \
         (l)->evhandler_ref = 0;                \
     } while (0)
 
@@ -56,6 +58,9 @@ typedef struct {
     do {                                    \
         pthread_mutex_destroy(&(l)->mutex); \
         pthread_cond_destroy(&(l)->cond);   \
+        if (NULL != (l)->answer) {          \
+            free((l)->answer);              \
+        }                                   \
     } while (0)
 
 #define DEBUG_WAIT_THREAD(lck)                              \

--- a/examples/pset.c
+++ b/examples/pset.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, info, ninfo, results, nresults);
+
+    fprintf(stderr, "Default error handler called with status %s\n", PMIx_Error_string(status));
+}
+
+/* this is an event notification function that we explicitly request
+ * be called when the PMIX_PROCESS_SET_DEFINE notification is issued.
+ */
+static void release_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    myrel_t *lock;
+    size_t n;
+    char *pset = NULL;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
+
+    /* find the return object */
+    lock = NULL;
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_RETURN_OBJECT)) {
+            lock = (myrel_t *) info[n].value.data.ptr;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_PSET_NAME)) {
+            pset = info[n].value.data.string;
+        }
+    }
+    /* if the object wasn't returned, then that is an error */
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+        /* let the event handler progress */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+    /* the status will be PMIX_PROCESS_SET_DEFINE since that is the code
+     * we registered to receive, so just return success */
+    lock->lock.status = PMIX_SUCCESS;
+    if (NULL != pset) {
+        lock->lock.answer = strdup(pset);
+    }
+
+    /* tell the event handler state machine that we are the last step */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    /* release the lock */
+    DEBUG_WAKEUP_THREAD(&lock->lock);
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                myproc.nspace, myproc.rank, status, (unsigned long) evhandler_ref);
+    }
+    lock->status = status;
+    lock->evhandler_ref = evhandler_ref;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_status_t pnm = PMIX_PROCESS_SET_DEFINE;
+    mylock_t mylock;
+    myrel_t myrel;
+    pmix_info_t info;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* register our default event handler */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace,
+                myproc.rank);
+        goto done;
+    }
+
+    /* register for process set name being defined */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIX_INFO_CONSTRUCT(&info);
+    DEBUG_CONSTRUCT_MYREL(&myrel);
+    PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    PMIx_Register_event_handler(&pnm, 1, &info, 1, release_fn, evhandler_reg_callbk,
+                                (void *) &mylock);
+    /* wait for registration to complete */
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_DESTRUCT(&info);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Debug handler registration failed\n", myproc.nspace,
+                myproc.rank);
+        goto done;
+    }
+    /* wait for process set name to be defined */
+    DEBUG_WAIT_THREAD(&myrel.lock);
+    if (NULL != myrel.lock.answer) {
+        fprintf(stderr, "Received process set name %s\n", myrel.lock.answer);
+    } else {
+        fprintf(stderr, "Received bad answer\n");
+    }
+    DEBUG_DESTRUCT_MYREL(&myrel);
+
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -91,56 +91,9 @@ static pmix_status_t pmix_init_result = PMIX_ERR_INIT;
 static void _notify_complete(pmix_status_t status, void *cbdata)
 {
     pmix_event_chain_t *chain = (pmix_event_chain_t *) cbdata;
-    pmix_notify_caddy_t *cd;
-    size_t n;
-    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     PMIX_ACQUIRE_OBJECT(chain);
-
-    /* if the event wasn't found, then cache it as it might
-     * be registered later */
-    if (PMIX_ERR_NOT_FOUND == status && !chain->cached) {
-        cd = PMIX_NEW(pmix_notify_caddy_t);
-        cd->status = chain->status;
-        PMIX_LOAD_PROCID(&cd->source, chain->source.nspace, chain->source.rank);
-        cd->range = chain->range;
-        if (0 < chain->ninfo) {
-            cd->ninfo = chain->ninfo;
-            PMIX_INFO_CREATE(cd->info, cd->ninfo);
-            cd->nondefault = chain->nondefault;
-            /* need to copy the info */
-            for (n = 0; n < cd->ninfo; n++) {
-                PMIX_INFO_XFER(&cd->info[n], &chain->info[n]);
-            }
-        }
-        if (NULL != chain->targets) {
-            cd->ntargets = chain->ntargets;
-            PMIX_PROC_CREATE(cd->targets, cd->ntargets);
-            memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
-        }
-        if (NULL != chain->affected) {
-            cd->naffected = chain->naffected;
-            PMIX_PROC_CREATE(cd->affected, cd->naffected);
-            if (NULL == cd->affected) {
-                cd->naffected = 0;
-                goto cleanup;
-            }
-            memcpy(cd->affected, chain->affected, cd->naffected * sizeof(pmix_proc_t));
-        }
-        /* cache it */
-        pmix_output_verbose(2, pmix_client_globals.event_output,
-                            "%s pmix:client_notify - processing complete, caching",
-                            PMIX_NAME_PRINT(&pmix_globals.myid));
-        rc = pmix_notify_event_cache(cd);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(cd);
-            goto cleanup;
-        }
-        chain->cached = true;
-    }
-
-cleanup:
     PMIX_RELEASE(chain);
 }
 
@@ -239,10 +192,9 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
 
 error:
     /* we always need to return */
-    pmix_output_verbose(
-        2, pmix_client_globals.event_output,
-        "%s pmix:client_notify_recv - unpack error status =%s, calling def errhandler",
-        PMIX_NAME_PRINT(&pmix_globals.myid), PMIx_Error_string(rc));
+    pmix_output_verbose(2, pmix_client_globals.event_output,
+                        "%s pmix:client_notify_recv - unpack error status =%s, calling def errhandler",
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIx_Error_string(rc));
     chain = PMIX_NEW(pmix_event_chain_t);
     if (NULL == chain) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -417,11 +417,9 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
             /* need to copy the info */
             for (n = 0; n < ncd->ninfo; n++) {
                 PMIX_INFO_XFER(&chain->info[n], &ncd->info[n]);
-                if (0 == strncmp(ncd->info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
+                if (PMIX_CHECK_KEY(&ncd->info[n], PMIX_EVENT_NON_DEFAULT)) {
                     chain->nondefault = true;
-                } else if (0
-                           == strncmp(ncd->info[n].key, PMIX_EVENT_AFFECTED_PROC,
-                                      PMIX_MAX_KEYLEN)) {
+                } else if (PMIX_CHECK_KEY(&ncd->info[n], PMIX_EVENT_AFFECTED_PROC)) {
                     PMIX_PROC_CREATE(chain->affected, 1);
                     if (NULL == chain->affected) {
                         PMIX_RELEASE(chain);
@@ -429,9 +427,7 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
                     }
                     chain->naffected = 1;
                     memcpy(chain->affected, ncd->info[n].value.data.proc, sizeof(pmix_proc_t));
-                } else if (0
-                           == strncmp(ncd->info[n].key, PMIX_EVENT_AFFECTED_PROCS,
-                                      PMIX_MAX_KEYLEN)) {
+                } else if (PMIX_CHECK_KEY(&ncd->info[n], PMIX_EVENT_AFFECTED_PROCS)) {
                     chain->naffected = ncd->info[n].value.data.darray->size;
                     PMIX_PROC_CREATE(chain->affected, chain->naffected);
                     if (NULL == chain->affected) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3046,8 +3046,8 @@ static void psetdef(int sd, short args, void *cbdata)
     ptr = (pmix_proc_t *) darray->array;
     memcpy(ptr, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
 
-    PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid, PMIX_RANGE_LOCAL, mydat->info,
-                      mydat->ninfo, release_info, (void *) mydat);
+    PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
+                      mydat->info,  mydat->ninfo, release_info, (void *) mydat);
 
     /* now record the process set */
     ps = PMIX_NEW(pmix_pset_t);


### PR DESCRIPTION
Cache proc-local events at the client as those don't go up to the server and therefore cannot be cached there. All other events are cached solely at the server to avoid duplicate deliveries.

Thanks to @krempel-pt and @sonjahapp for the detailed triage report!

Refs https://github.com/openpmix/openpmix/issues/2886
Signed-off-by: Ralph Castain <rhc@pmix.org>