### PR TITLE
Add initial support for PMIx_Get operations on groups.

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -211,6 +211,7 @@ pmix_client_globals_t pmix_client_globals = {
     .singleton = false,
     .pending_requests = PMIX_LIST_STATIC_INIT,
     .peers = PMIX_POINTER_ARRAY_STATIC_INIT,
+    .groups = PMIX_LIST_STATIC_INIT,
     .get_output = -1,
     .get_verbose = 0,
     .connect_output = -1,
@@ -621,6 +622,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
                          PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* setup the globals */
+    PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
@@ -1088,6 +1090,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
     }
+    PMIX_DESTRUCT(&pmix_client_globals.groups);
 
     if (0 <= pmix_client_globals.myserver->sd) {
         CLOSE_THE_SOCKET(pmix_client_globals.myserver->sd);

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -26,6 +26,7 @@ typedef struct {
     bool singleton;               // no server
     pmix_list_t pending_requests; // list of pmix_cb_t pending data requests
     pmix_pointer_array_t peers;   // array of pmix_peer_t cached for data ops
+    pmix_list_t groups;           // list of groups this client is part of
     // verbosity for client get operations
     int get_output;
     int get_verbose;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -517,6 +517,23 @@ pmix_dstor_release_tma(
     pmix_tma_free(tma, d);
 }
 
+static void grcon(pmix_group_t *p)
+{
+    p->grpid = NULL;
+    p->members = NULL;
+    p->nmbrs = 0;
+}
+static void grdes(pmix_group_t *p)
+{
+    if (NULL != p->grpid) {
+        free(p->grpid);
+    }
+    if (NULL != p->members) {
+        PMIX_PROC_FREE(p->members, p->nmbrs);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_group_t, pmix_list_item_t, grcon, grdes);
+
 void pmix_execute_epilog(pmix_epilog_t *epi)
 {
     pmix_cleanup_file_t *cf, *cfnext;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -462,6 +462,14 @@ PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;
+    char *grpid;
+    pmix_proc_t *members;
+    size_t nmbrs;
+} pmix_group_t;
+PMIX_CLASS_DECLARATION(pmix_group_t);
+
+typedef struct {
+    pmix_list_item_t super;
     pmix_proc_t proc;
     pmix_byte_object_t blob;  // packed blob of info provided by this proc
 } pmix_grpinfo_t;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -5409,23 +5409,6 @@ static void ildes(pmix_inventory_rollup_t *p)
 }
 PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t, pmix_object_t, ilcon, ildes);
 
-static void grcon(pmix_group_t *p)
-{
-    p->grpid = NULL;
-    p->members = NULL;
-    p->nmbrs = 0;
-}
-static void grdes(pmix_group_t *p)
-{
-    if (NULL != p->grpid) {
-        free(p->grpid);
-    }
-    if (NULL != p->members) {
-        PMIX_PROC_FREE(p->members, p->nmbrs);
-    }
-}
-PMIX_CLASS_INSTANCE(pmix_group_t, pmix_list_item_t, grcon, grdes);
-
 PMIX_CLASS_INSTANCE(pmix_group_caddy_t, pmix_list_item_t, NULL, NULL);
 
 static void iocon(pmix_iof_cache_t *p)

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -146,14 +146,6 @@ PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
 typedef struct {
     pmix_list_item_t super;
-    char *grpid;
-    pmix_proc_t *members;
-    size_t nmbrs;
-} pmix_group_t;
-PMIX_CLASS_DECLARATION(pmix_group_t);
-
-typedef struct {
-    pmix_list_item_t super;
     pmix_group_t *grp;
     pmix_rank_t rank;
     size_t idx;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -645,6 +645,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     pmix_globals.iof_flags.local_output = outputio;
 
     /* setup the globals */
+    PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);


### PR DESCRIPTION
The following commit adds support for PMIx_Get operations on groups for realm (node, process) attributes that depend on the process rank. The support is only for PMIx reserved keys and for groups constructed with embedded barriers.