### PR TITLE
Add const qualifier to nspace strings

### DIFF
--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -356,7 +356,7 @@ PMIX_EXPORT void PMIx_Proc_destruct(pmix_proc_t *p);
 PMIX_EXPORT pmix_proc_t* PMIx_Proc_create(size_t n);
 PMIX_EXPORT void PMIx_Proc_free(pmix_proc_t *p, size_t n);
 PMIX_EXPORT void PMIx_Proc_load(pmix_proc_t *p,
-                                char *nspace, pmix_rank_t rank);
+                                const char *nspace, pmix_rank_t rank);
 PMIX_EXPORT void PMIx_Multicluster_nspace_construct(pmix_nspace_t target,
                                                     pmix_nspace_t cluster,
                                                     pmix_nspace_t nspace);

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -509,7 +509,7 @@ void PMIx_Proc_free(pmix_proc_t *p, size_t n)
 }
 
 void PMIx_Proc_load(pmix_proc_t *p,
-                    char *nspace, pmix_rank_t rank)
+                    const char *nspace, pmix_rank_t rank)
 {
     pmix_bfrops_base_tma_proc_load(p, nspace, rank, NULL);
 }

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -351,7 +351,7 @@ pmix_bfrops_base_tma_proc_destruct(
 static inline void
 pmix_bfrops_base_tma_proc_load(
     pmix_proc_t *p,
-    char *nspace,
+    const char *nspace,
     pmix_rank_t rank,
     pmix_tma_t *tma
 ) {


### PR DESCRIPTION
Just adds some missing const qualifiers to avoid meaningless compiler warnings when using `PMIx_Proc_load` with const namespace string.