### PR TITLE
python: updates for Python bindings

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -23,36 +23,123 @@
 # $HEADER$
 #
 
-# we do NOT want picky compilers down here
+# We do NOT want picky compilers down here
 CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
-PYTHONPATH=$PYTHONPATH:$(DESTDIR)$(prefix)/lib/python$(PYTHON_VERSION)/site-packages
 
-helpers = setup.py pmix.pyx pmix.pxi construct.py
+helpers = \
+        setup.py \
+        construct.py
 
-EXTRA_DIST = $(helpers)
+src_files = \
+        pmix.pxi \
+        pmix.pyx
+
+EXTRA_DIST = $(helpers) $(src_files)
 
 if WANT_PYTHON_BINDINGS
 
-install-exec-local: $(helpers)
+harvested_headers = \
+        $(top_srcdir)/include/pmix.h \
+        $(top_builddir)/include/pmix_common.h \
+        $(top_srcdir)/include/pmix_deprecated.h \
+        $(top_srcdir)/include/pmix_server.h \
+        $(top_srcdir)/include/pmix_tool.h
+
+constants_files = \
+        pmix_constants.pxd \
+        pmix_constants.pxi
+
+# Create pmix_constants.pxd and pmix_constants.pxi by harvesting a
+# bunch of PMIx header files These will be generated in the PMIx build
+# dir.
+$(constants_files): construct.py $(harvested_headers)
 	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include" --include-dir="$(top_srcdir)/include"
-	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
-		$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --library-dirs="$(DESTDIR)$(libdir)" --user
-		if [ $(PMIX_TOP_SRCDIR) != $(PMIX_TOP_BUILDDIR) ]; then \
-			pushd $(PMIX_TOP_BUILDDIR)/bindings/python; \
-			rm -f setup.py; \
-			cp $(PMIX_TOP_SRCDIR)/bindings/python/setup.py .; \
-			popd; \
-		fi
-	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
-		$(PYTHON) -m pip install --prefix="$(DESTDIR)$(prefix)" --editable $(top_builddir)/bindings/python
 
+# Cython does not natively understand VPATH builds.  Specifically,
+# Cython will build things in the same tree where it finds
+# pmix.[pxi|pyx] (which is the PMIx source tree).
+#
+# Cython's "setup.py build_ext
+# --build-lib=SOMEWHERE_IN_THE_BUILD_TREE" *almost* does what we want.
+# But even though it makes the build/install trees in the directory we
+# tell it (vs. the source tree), it still writes pmix.c in the source
+# tree, which is definitely not what we want.
+#
+# We want to properly support VPATH builds, so we fake out Cython and
+# force it to build in the PMIx build tree by making sym links for
+# pmix.[pxi|pyx] from the source tree to the build tree.  Cython can
+# then find these files in the build tree, and build everything there
+# (including pmix.c).
+#
+# This is a little gross, but it works. :-/
+$(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pxi:
+	$(LN_S) $(PMIX_TOP_SRCDIR)/bindings/python/pmix.pxi $(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pxi
+$(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pyx:
+	$(LN_S) $(PMIX_TOP_SRCDIR)/bindings/python/pmix.pyx $(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pyx
+
+# When we run "setup.pu build_ext ...", several files/directories are
+# created.  The exact files / directory names may be system-dependent,
+# so we don't try to check for most of them.  Instead, we just check
+# for one sentinel file that is always created during this step:
+# pmix.c, and use that as a proxy for all the other things that were
+# created during this step.
+SENTINEL_FILE = pmix.c
+
+# Create $(SENTINEL_FILE) from its sources and the constants we
+# harvested from various PMIx header files.  Ensure to depend on the
+# pmix.[pxi|pyx] in the build tree so that those rules get triggered
+# and we get sym links over to the source tree, if necessary.
+$(SENTINEL_FILE): $(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pxi
+$(SENTINEL_FILE): $(PMIX_TOP_BUILDDIR)/bindings/python/pmix.pyx
+$(SENTINEL_FILE): $(constants_files)
+	PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+		$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --library-dirs="$(PMIX_TOP_BUILDDIR)/src/.libs" --user
+
+BUILT_SOURCES = $(constants_files)
+
+# We don't put $(SENTINEL_FILE) BUILT_SOURCES because then "make dist"
+# will fail if it can't be created (e.g., if no suitable Python +
+# Cython + etc. is available) -- because the files in BUILT_SOURCES
+# are dependencies of "distdir".
+#
+# More specifically: $(SENTINEL_FILE) isn't shipped in the tarball, so
+# it doesn't seem right to require it to be able to be built for "make
+# dist" to succeed.  Hence, we (slightly) abuse Automake's "noinst"
+# and "DATA" to force $(SENTINEL_FILE) to be built during "make all"
+# when WANT_PYTHON_BINDINGS is true.
+noinst_DATA = $(SENTINEL_FILE)
+
+install-exec-local:
+	PYTHONPATH=$$PYTHONPATH:$(DESTDIR)$(pythondir):$(DESTDIR)$(pyexecdir) \
+		PMIX_BINDINGS_TOP_SRCDIR=$(PMIX_TOP_SRCDIR) PMIX_BINDINGS_TOP_BUILDDIR=$(PMIX_TOP_BUILDDIR) \
+		$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --quiet --prefix="$(DESTDIR)$(prefix)"
+
+# Be careful with easy-install.pth -- we may not be the only entity
+# that put things in there.  Therefore, carefully remove the pmix
+# entry from it, and then remove the file altogether if is then
+# otherwise empty.  Finally, remove the installed pypmix Python egg.
 uninstall-hook:
-	rm -f $(pythondir)/pmix*.so
-	rm -f $(pythondir)/pypmix-*.egg-info
+	-@file=$(pythondir)/easy-install.pth; \
+	tmpfile=$(pythondir)/easy-install.pth.$$; \
+	if test -r $$file; then \
+	    grep -v /pypmix- $$file > $$tmpfile; \
+	    diff -q $$file $$tmpfile 2>&1 >/dev/null; \
+	    if test $$? -ne 0; then \
+	        cp $$tmpfile $$file; \
+	    fi; \
+	    rm -f $$tmpfile; \
+	    if test ! -s $$file; then \
+	        rm -f $$file; \
+	    fi; \
+	fi
+	rm -rf $(pythondir)/pypmix*
 
-CLEANFILES += pmix.c
+CLEANFILES += $(constants_files)
 
+# Also delete the other files and dirs that Cython creates during its
+# "setup.py build_ext ..." step.  We need to use clean-local because
+# the names in CLEANFILE are not "rm -rf"'ed.
 clean-local:
-	rm -rf build pypmix.egg-info dist
+	rm -rf $(SENTINEL_FILE) build dist pypmix.egg-info
 
-endif
+endif # WANT_PYTHON_BINDINGS

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -1,0 +1,2 @@
+cython
+setuptools


### PR DESCRIPTION
- Separate build vs. install: the Python bindings will now be built during "make all", and installed during "make install" (vs. being built and installed during "make install").
  - Fix regression introduced in 9cd0aa4f where the Python bindings were not actually installed in $prefix.
- Update from Python distutils to setuptools.  We still use setup.py instead of the newer setup.cfg or pyproject.toml, but that can be upgraded later.
  - Suppress "setup.py" deprecated warnings during the installation.
- Fix keywords listing in the Python package
- Setup dependencies properly so that the Python bindings will properly re-build if any of its dependent header files change.
- Use a workaround to make Cython work properly in VPATH builds.
- Update "make uninstall" for the Python bindings to be a bit more robust.
- Make "make clean" remove the generated constants files.
- Removed some stale kruft from setup.py; updated to use setuptools instead of disttools.
- Add bindings/python/requirements.txt

Signed-off-by: Jeff Squyres <jeff@squyres.com>