### PR TITLE
Provide support for estimating the size of value objects

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1118,6 +1118,15 @@ PMIX_EXPORT void PMIx_Progress(void);
  * - pmix_iof_channel_t  (PMIX_IOF_CHANNEL)
  * - pmix_job_state_t  (PMIX_JOB_STATE)
  * - pmix_proc_state_t  (PMIX_PROC_STATE)
+ * - attribute string value of provided name
+ * - attribute name corresponding to provided string
+ * - pmix_list_state_t (PMIX_LINK_STATE)
+ * - pmix_device_type_t (PMIX_DEVTYPE)
+ * - pmix_value_cmp_t (enum)
+ * - pmix_info_t (PMIX_INFO)
+ * - pmix_value_t (PMIX_VALUE)
+ * - pmix_info_directives_t (PMIX_INFO_DIRECTIVES)
+ * - pmix_app_t (PMIX_APP)
  */
 PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t status);
 PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
@@ -1150,6 +1159,29 @@ PMIX_EXPORT const char* PMIx_Get_version(void);
  * never be "pushed" externally */
 PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
                                               const char key[], pmix_value_t *val);
+
+
+/* Compute and return the size (in bytes) of the data
+ * payload in a pmix_value_t structure. Returns:
+ *
+ * - PMIX_SUCCESS if the value could be computed
+ *
+ * - an appropriate error value (e.g., PMIX_ERR_UNKNOWN_DATA_TYPE
+ *   if the data type is unknown) if the value could not be computed.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Value_get_size(const pmix_value_t *val,
+                                              size_t *size);
+
+/* Compute and return the size (in bytes) of the data
+ * payload in a pmix_info_t structure. Returns:
+ *
+ * - PMIX_SUCCESS if the value could be computed
+ *
+ * - an appropriate error value (e.g., PMIX_ERR_UNKNOWN_DATA_TYPE
+ *   if the data type is unknown) if the value could not be computed.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Info_get_size(const pmix_info_t *val,
+                                             size_t *size);
 
 
 /******    DATA BUFFER PACK/UNPACK SUPPORT    ******/
@@ -2005,6 +2037,11 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const void *value,
                                              pmix_data_type_t type);
 
+PMIX_EXPORT pmix_status_t PMIx_Info_list_prepend(void *ptr,
+                                                 const char *key,
+                                                 const void *value,
+                                                 pmix_data_type_t type);
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 /* Transfer the data in an existing pmix_info_t struct to a list. This
@@ -2021,6 +2058,12 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
 
 /* Release all data on the list and destruct all internal tracking */
 PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
+
+/* retrieve the next info on the list - passing a NULL
+ * to the "prev" parameter will return the first pmix_info_t
+ * on the list. A return of NULL indicates the end of the list
+ */
+PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next);
 
 #endif
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -414,6 +414,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOCAL_COLLECTIVE_STATUS        "pmix.loc.col.st"       // (pmix_status_t) status code for local collective operation being
                                                                     //         reported to host by server library
 #define PMIX_SORTED_PROC_ARRAY              "pmix.sorted.parr"      // (bool) Proc array being passed has been sorted
+#define PMIX_SIZE_ESTIMATE                  "pmix.size.est"         // (size_t) Number of bytes in the enclosed payload
 
 
 /* event handler registration and notification info keys */

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -449,6 +449,11 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const void *value,
                                              pmix_data_type_t type);
 
+PMIX_EXPORT pmix_status_t PMIx_Info_list_prepend(void *ptr,
+                                                 const char *key,
+                                                 const void *value,
+                                                 pmix_data_type_t type);
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr,
@@ -457,6 +462,8 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr,
 PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *par);
 
 PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
+
+PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next);
 
 /* Macros that have been converted to functions */
 
@@ -663,6 +670,9 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr);
 
 #define PMIX_INFO_LIST_ADD(r, p, a, v, t)     \
     (r) = PMIx_Info_list_add((p), (a), (v), (t))
+
+#define PMIX_INFO_LIST_PREPEND(r, p, a, v, t)     \
+    (r) = PMIx_Info_list_prepend((p), (a), (v), (t))
 
 #define PMIX_INFO_LIST_INSERT(r, p, i)     \
     (r) = PMIx_Info_list_insert((p), (i))

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -120,6 +120,8 @@ PMIX_EXPORT void pmix_hwloc_destruct_cpuset(pmix_cpuset_t *cpuset);
 
 PMIX_EXPORT void pmix_hwloc_release_cpuset(pmix_cpuset_t *ptr, size_t sz);
 
+PMIX_EXPORT pmix_status_t pmix_hwloc_get_cpuset_size(pmix_cpuset_t *ptr, size_t *sz);
+
 /* topology pack/unpack/copy/print functions */
 PMIX_EXPORT pmix_status_t pmix_hwloc_pack_topology(pmix_buffer_t *buf, pmix_topology_t *src,
                                                    pmix_pointer_array_t *regtypes);
@@ -134,6 +136,8 @@ PMIX_EXPORT char *pmix_hwloc_print_topology(pmix_topology_t *src);
 PMIX_EXPORT void pmix_hwloc_destruct_topology(pmix_topology_t *ptr);
 
 PMIX_EXPORT void pmix_hwloc_release_topology(pmix_topology_t *ptr, size_t sz);
+
+PMIX_EXPORT pmix_status_t pmix_hwloc_get_topology_size(pmix_topology_t *ptr, size_t *sz);
 
 /****  PRESERVE ABI  ****/
 PMIX_EXPORT void pmix_ploc_base_destruct_cpuset(pmix_cpuset_t *cpuset);

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -32,6 +32,7 @@
 #include "pmix.h"
 
 #include "src/include/pmix_globals.h"
+#include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
@@ -740,6 +741,23 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
     return PMIX_SUCCESS;
 }
 
+pmix_status_t PMIx_Info_list_prepend(void *ptr,
+                                     const char *key,
+                                     const void *value,
+                                     pmix_data_type_t type)
+{
+    pmix_list_t *p = (pmix_list_t *) ptr;
+    pmix_infolist_t *iptr;
+
+    iptr = PMIX_NEW(pmix_infolist_t);
+    if (NULL == iptr) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_INFO_LOAD(&iptr->info, key, value, type);
+    pmix_list_prepend(p, &iptr->super);
+    return PMIX_SUCCESS;
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr,
                                                 pmix_info_t *info)
 {
@@ -812,4 +830,645 @@ PMIX_EXPORT void PMIx_Info_list_release(void *ptr)
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
     PMIX_LIST_RELEASE(p);
+}
+
+
+pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next)
+{
+    pmix_list_t *p = (pmix_list_t *) ptr;
+    pmix_list_item_t *prv = (pmix_list_item_t*)prev;
+    pmix_infolist_t *active;
+
+    if (NULL == prev) {
+        prv = pmix_list_get_first(p);
+        active = (pmix_infolist_t*)prv;
+    } else {
+        active = (pmix_infolist_t*)prv;
+    }
+    if (prv == pmix_list_get_last(p)) {
+        *next = NULL;
+    } else {
+        *next = (void*)pmix_list_get_next(prv);
+    }
+    return &active->info;
+}
+
+static pmix_status_t get_darray_size(pmix_data_array_t *array, 
+                                     size_t *sz)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t m, n, sz2;
+    char **str;
+    pmix_byte_object_t *bo;
+    pmix_proc_info_t *pi;
+    pmix_envar_t *en;
+    pmix_coord_t *coord;
+    pmix_topology_t *topo;
+    pmix_cpuset_t *cset;
+    pmix_geometry_t *geo;
+    pmix_device_distance_t *dd;
+    pmix_endpoint_t *endpt;
+    pmix_regattr_t *rg;
+    pmix_data_buffer_t *db;
+    pmix_proc_stats_t *ps;
+    pmix_disk_stats_t *ds;
+    pmix_net_stats_t *nts;
+    pmix_node_stats_t *nds;
+    pmix_info_t *iptr;
+
+    switch (array->type) {
+        case PMIX_UNDEF:
+            rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+            break;
+        case PMIX_BOOL:
+        case PMIX_BYTE:
+        case PMIX_INT8:
+        case PMIX_UINT8:
+            *sz = array->size;
+            break;
+        case PMIX_STRING:
+            *sz = array->size * sizeof(void*);
+            str = (char**)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != str[n]) {
+                    *sz += strlen(str[n]) + 1;
+                }
+            }
+            break;
+        case PMIX_SIZE:
+            *sz = array->size * sizeof(size_t);
+            break;
+        case PMIX_PID:
+            *sz = array->size * sizeof(pid_t);
+            break;
+        case PMIX_INT:
+        case PMIX_UINT:
+            *sz = array->size * sizeof(int);
+            break;
+        case PMIX_INT16:
+        case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
+            *sz = array->size * 2;
+            break;
+        case PMIX_INT32:
+        case PMIX_UINT32:
+            *sz = array->size * 4;
+            break;
+        case PMIX_INT64:
+        case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
+            *sz = array->size * 8;
+            break;
+        case PMIX_FLOAT:
+            *sz = array->size * sizeof(float);
+            break;
+        case PMIX_DOUBLE:
+            *sz = array->size * sizeof(double);
+            break;
+        case PMIX_TIMEVAL:
+            *sz = array->size * sizeof(struct timeval);
+            break;
+        case PMIX_TIME:
+            *sz = array->size * sizeof(time_t);
+            break;
+        case PMIX_STATUS:
+            *sz = array->size * sizeof(pmix_status_t);
+            break;
+        case PMIX_PROC_RANK:
+            *sz = array->size * sizeof(pmix_rank_t);
+            break;
+        case PMIX_PROC_NSPACE:
+            *sz = array->size * PMIX_MAX_NSLEN;
+            break;
+        case PMIX_PROC:
+            *sz = array->size * sizeof(pmix_proc_t);
+            break;
+        case PMIX_INFO:
+            iptr = (pmix_info_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                rc = PMIx_Info_get_size(&iptr[n], &sz2);
+                if (PMIX_SUCCESS == rc) {
+                    *sz += sz2;
+                } else {
+                    return rc;
+                }
+            }
+            break;
+        case PMIX_BYTE_OBJECT:
+            *sz = array->size * sizeof(pmix_byte_object_t);
+            bo = (pmix_byte_object_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                *sz += bo[n].size;
+            }
+            break;
+        case PMIX_COMPRESSED_STRING:
+            *sz = array->size * sizeof(void*);
+            bo = (pmix_byte_object_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                *sz += pmix_compress.get_decompressed_strlen(&bo[n]);
+            }
+            break;
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            *sz = array->size * sizeof(void*);
+            bo = (pmix_byte_object_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                *sz += pmix_compress.get_decompressed_size(&bo[n]);
+            }
+            break;
+        case PMIX_PERSIST:
+            *sz = array->size * sizeof(pmix_persistence_t);
+            break;
+        case PMIX_SCOPE:
+            *sz = array->size * sizeof(pmix_scope_t);
+            break;
+        case PMIX_DATA_RANGE:
+            *sz = array->size * sizeof(pmix_data_range_t);
+            break;
+        case PMIX_PROC_STATE:
+            *sz = array->size * sizeof(pmix_proc_state_t);
+            break;
+        case PMIX_PROC_INFO:
+            *sz = array->size * sizeof(pmix_proc_info_t);
+            pi = (pmix_proc_info_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != pi[n].hostname) {
+                    *sz += strlen(pi[n].hostname) + 1;
+                }
+                if (NULL != pi[n].executable_name) {
+                    *sz += strlen(pi[n].executable_name) + 1;
+                }
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            break;
+        case PMIX_POINTER:
+            *sz = array->size * sizeof(void *);
+            break;
+        case PMIX_ALLOC_DIRECTIVE:
+            *sz = array->size * sizeof(pmix_alloc_directive_t);
+            break;
+        case PMIX_ENVAR:
+            *sz = array->size * sizeof(pmix_envar_t);
+            en = (pmix_envar_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != en[n].envar) {
+                    *sz += strlen(en[n].envar) + 1;
+                }
+                if (NULL != en[n].value) {
+                    *sz += strlen(en[n].value) + 1;
+                }
+            }
+            break;
+        case PMIX_COORD:
+            *sz = array->size * sizeof(pmix_coord_t);
+            coord = (pmix_coord_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (0 < coord[n].dims) {
+                    *sz += coord[n].dims * sizeof(uint32_t);
+                }
+            }
+            break;
+        case PMIX_LINK_STATE:
+            *sz = array->size * sizeof(pmix_link_state_t);
+            break;
+        case PMIX_JOB_STATE:
+            *sz = array->size * sizeof(pmix_job_state_t);
+            break;
+        case PMIX_TOPO:
+            *sz = array->size * sizeof(pmix_topology_t);
+            topo = (pmix_topology_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                rc = pmix_hwloc_get_topology_size(&topo[n], &sz2);
+                if (PMIX_SUCCESS == rc) {
+                    *sz += sz2;
+                } else {
+                    return rc;
+                }
+            }
+            break;
+        case PMIX_PROC_CPUSET:
+            *sz = array->size * sizeof(pmix_cpuset_t);
+            cset = (pmix_cpuset_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                rc = pmix_hwloc_get_cpuset_size(&cset[n], &sz2);
+                if (PMIX_SUCCESS == rc) {
+                    *sz += sz2;
+                } else {
+                    return rc;
+                }
+            }
+            break;
+        case PMIX_LOCTYPE:
+            *sz = array->size * sizeof(pmix_locality_t);
+            break;
+        case PMIX_GEOMETRY:
+            *sz = array->size * sizeof(pmix_geometry_t);
+            geo = (pmix_geometry_t*)array->array;
+            for (m=0; m < array->size; m++) {
+                if (NULL != geo[m].uuid) {
+                    *sz += strlen(geo[m].uuid) + 1;
+                }
+                if (NULL != geo[m].osname) {
+                    *sz += strlen(geo[m].osname) + 1;
+                }
+                for (n=0; n < geo[m].ncoords; n++) {
+                    *sz += sizeof(pmix_coord_t);
+                    if (0 < geo[m].coordinates[n].dims) {
+                        *sz += geo[m].coordinates[n].dims * sizeof(uint32_t);
+                    }
+                }
+            }
+            break;
+        case PMIX_DEVTYPE:
+            *sz = array->size * sizeof(pmix_device_type_t);
+            break;
+        case PMIX_DEVICE_DIST:
+            *sz = array->size * sizeof(pmix_device_distance_t);
+            dd = (pmix_device_distance_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != dd[n].uuid) {
+                    *sz += strlen(dd[n].uuid) + 1;
+                }
+                if (NULL != dd[n].osname) {
+                    *sz += strlen(dd[n].osname) + 1;
+                }
+            }
+            break;
+        case PMIX_ENDPOINT:
+            *sz = array->size * sizeof(pmix_endpoint_t);
+            endpt = (pmix_endpoint_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != endpt[n].uuid) {
+                    *sz += strlen(endpt[n].uuid) + 1;
+                }
+                if (NULL != endpt[n].osname) {
+                    *sz += strlen(endpt[n].osname) + 1;
+                }
+                *sz += endpt[n].endpt.size;
+            }
+            break;
+        case PMIX_REGATTR:
+            *sz = array->size * sizeof(pmix_regattr_t);
+            rg = (pmix_regattr_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != rg[n].name) {
+                    *sz += strlen(rg[n].name) + 1;
+                }
+                if (NULL != rg[n].description) {
+                    for (m=0; NULL != rg[n].description[m]; m++) {
+                        *sz += strlen(rg[n].description[m]) + 1;
+                    }
+                }
+            }
+            break;
+        case PMIX_REGEX:
+            *sz = array->size * sizeof(pmix_byte_object_t);
+            bo = (pmix_byte_object_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                *sz += bo[n].size;
+            }
+            break;
+        case PMIX_DATA_BUFFER:
+            *sz = array->size * sizeof(pmix_data_buffer_t);
+            db = (pmix_data_buffer_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                *sz += db[n].bytes_used;
+            }
+            break;
+        case PMIX_PROC_STATS:
+            *sz = array->size * sizeof(pmix_proc_stats_t);
+            ps = (pmix_proc_stats_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != ps[n].node) {
+                    *sz += strlen(ps[n].node) + 1;
+                }
+                if (NULL != ps[n].cmd) {
+                    *sz += strlen(ps[n].cmd) + 1;
+                }
+            }
+            break;
+        case PMIX_DISK_STATS:
+            *sz = array->size * sizeof(pmix_disk_stats_t);
+            ds = (pmix_disk_stats_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != ds[n].disk) {
+                    *sz += strlen(ds[n].disk) + 1;
+                }
+            }
+            break;
+        case PMIX_NET_STATS:
+            *sz = array->size * sizeof(pmix_net_stats_t);
+            nts = (pmix_net_stats_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != nts[n].net_interface) {
+                    *sz += strlen(nts[n].net_interface) + 1;
+                }
+            }
+            break;
+        case PMIX_NODE_STATS:
+            *sz = array->size * sizeof(pmix_node_stats_t);
+            nds = (pmix_node_stats_t*)array->array;
+            for (n=0; n < array->size; n++) {
+                if (NULL != nds[n].node) {
+                    *sz += strlen(nds[n].node) + 1;
+                }
+                for (m=0; m < nds[n].ndiskstats; m++) {
+                    *sz += sizeof(pmix_disk_stats_t);
+                    if (NULL != nds[n].diskstats[m].disk) {
+                        *sz += strlen(nds[n].diskstats[m].disk) + 1;
+                    }
+                }
+                for (m=0; m < nds[n].nnetstats; m++) {
+                    *sz += sizeof(pmix_net_stats_t);
+                    if (NULL != nds[n].netstats[m].net_interface) {
+                        *sz += strlen(nds[n].netstats[m].net_interface) + 1;
+                    }
+                }
+            }
+            break;
+
+        default:
+            /* silence warnings */
+            break;
+        }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
+                                  size_t *sz)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t n;
+    pmix_regattr_t *regattr;
+
+    switch (v->type) {
+        case PMIX_UNDEF:
+            rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+            break;
+        case PMIX_BOOL:
+        case PMIX_BYTE:
+        case PMIX_INT8:
+        case PMIX_UINT8:
+            *sz = 1;
+            break;
+        case PMIX_STRING:
+            *sz = strlen(v->data.string) + 1;
+            break;
+        case PMIX_SIZE:
+            *sz = sizeof(size_t);
+            break;
+        case PMIX_PID:
+            *sz = sizeof(pid_t);
+            break;
+        case PMIX_INT:
+        case PMIX_UINT:
+            *sz = sizeof(int);
+            break;
+        case PMIX_INT16:
+        case PMIX_UINT16:
+        case PMIX_STOR_ACCESS_TYPE:
+            *sz = 2;
+            break;
+        case PMIX_INT32:
+        case PMIX_UINT32:
+            *sz = 4;
+            break;
+        case PMIX_INT64:
+        case PMIX_UINT64:
+        case PMIX_STOR_MEDIUM:
+        case PMIX_STOR_ACCESS:
+        case PMIX_STOR_PERSIST:
+            *sz = 8;
+            break;
+        case PMIX_FLOAT:
+            *sz = sizeof(float);
+            break;
+        case PMIX_DOUBLE:
+            *sz = sizeof(double);
+            break;
+        case PMIX_TIMEVAL:
+            *sz = sizeof(struct timeval);
+            break;
+        case PMIX_TIME:
+            *sz = sizeof(time_t);
+            break;
+        case PMIX_STATUS:
+            *sz = sizeof(pmix_status_t);
+            break;
+        case PMIX_PROC_RANK:
+            *sz = sizeof(pmix_rank_t);
+            break;
+        case PMIX_PROC_NSPACE:
+            *sz = PMIX_MAX_NSLEN;
+            break;
+        case PMIX_PROC:
+            *sz = sizeof(pmix_proc_t);
+            break;
+        case PMIX_BYTE_OBJECT:
+            *sz = sizeof(pmix_byte_object_t);
+            if (NULL != v->data.bo.bytes) {
+                *sz += v->data.bo.size;
+            }
+            break;
+        case PMIX_COMPRESSED_STRING:
+            *sz = pmix_compress.get_decompressed_strlen(&v->data.bo);
+            break;
+        case PMIX_COMPRESSED_BYTE_OBJECT:
+            *sz = pmix_compress.get_decompressed_size(&v->data.bo);
+            break;
+        case PMIX_PERSIST:
+            *sz = sizeof(pmix_persistence_t);
+            break;
+        case PMIX_SCOPE:
+            *sz = sizeof(pmix_scope_t);
+            break;
+        case PMIX_DATA_RANGE:
+            *sz = sizeof(pmix_data_range_t);
+            break;
+        case PMIX_PROC_STATE:
+            *sz = sizeof(pmix_proc_state_t);
+            break;
+        case PMIX_PROC_INFO:
+            *sz = sizeof(pmix_proc_info_t);
+            if (NULL != v->data.pinfo->hostname) {
+                *sz += strlen(v->data.pinfo->hostname) + 1;
+            }
+            if (NULL != v->data.pinfo->executable_name) {
+                *sz += strlen(v->data.pinfo->executable_name) + 1;
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            rc = get_darray_size(v->data.darray, sz);
+            if (PMIX_SUCCESS == rc) {
+                *sz += sizeof(pmix_data_array_t);
+            }
+            break;
+        case PMIX_POINTER:
+            *sz = sizeof(void *);
+            break;
+        case PMIX_ALLOC_DIRECTIVE:
+            *sz = sizeof(pmix_alloc_directive_t);
+            break;
+        case PMIX_ENVAR:
+            *sz = sizeof(pmix_envar_t);
+            if (NULL != v->data.envar.envar) {
+                *sz += strlen(v->data.envar.envar) + 1;
+            }
+            if (NULL != v->data.envar.value) {
+                *sz += strlen(v->data.envar.value) + 1;
+            }
+            break;
+        case PMIX_COORD:
+            *sz = sizeof(pmix_coord_t);
+            if (0 < v->data.coord->dims) {
+                *sz += v->data.coord->dims * sizeof(uint32_t);
+            }
+            break;
+        case PMIX_LINK_STATE:
+            *sz = sizeof(pmix_link_state_t);
+            break;
+        case PMIX_JOB_STATE:
+            *sz = sizeof(pmix_job_state_t);
+            break;
+        case PMIX_TOPO:
+            rc = pmix_hwloc_get_topology_size(v->data.topo, sz);
+            if (PMIX_SUCCESS == rc) {
+                *sz += sizeof(pmix_topology_t);
+            }
+            break;
+        case PMIX_PROC_CPUSET:
+            rc = pmix_hwloc_get_cpuset_size(v->data.cpuset, sz);
+            if (PMIX_SUCCESS == rc) {
+                *sz += sizeof(pmix_cpuset_t);
+            }
+            break;
+        case PMIX_LOCTYPE:
+            *sz = sizeof(pmix_locality_t);
+            break;
+        case PMIX_GEOMETRY:
+            *sz = sizeof(pmix_geometry_t);
+            if (NULL != v->data.geometry->uuid) {
+                *sz += strlen(v->data.geometry->uuid) + 1;
+            }
+            if (NULL != v->data.geometry->osname) {
+                *sz += strlen(v->data.geometry->osname) + 1;
+            }
+            for (n=0; n < v->data.geometry->ncoords; n++) {
+                *sz += sizeof(pmix_coord_t);
+                if (0 < v->data.geometry->coordinates[n].dims) {
+                    *sz += v->data.geometry->coordinates[n].dims * sizeof(uint32_t);
+                }
+            }
+            break;
+        case PMIX_DEVTYPE:
+            *sz = sizeof(pmix_device_type_t);
+            break;
+        case PMIX_DEVICE_DIST:
+            *sz = sizeof(pmix_device_distance_t);
+            if (NULL != v->data.devdist->uuid) {
+                *sz += strlen(v->data.devdist->uuid) + 1;
+            }
+            if (NULL != v->data.devdist->osname) {
+                *sz += strlen(v->data.devdist->osname) + 1;
+            }
+            break;
+        case PMIX_ENDPOINT:
+            *sz = sizeof(pmix_endpoint_t);
+            if (NULL != v->data.endpoint->uuid) {
+                *sz += strlen(v->data.endpoint->uuid) + 1;
+            }
+            if (NULL != v->data.endpoint->osname) {
+                *sz += strlen(v->data.endpoint->osname) + 1;
+            }
+            *sz += v->data.endpoint->endpt.size;
+            break;
+        case PMIX_REGATTR:
+            *sz = sizeof(pmix_regattr_t);
+            regattr = (pmix_regattr_t *)v->data.ptr;
+            if (NULL != regattr->name) {
+                *sz += strlen(regattr->name) + 1;
+            }
+            if (NULL != regattr->description) {
+                for (n=0; NULL != regattr->description[n]; n++) {
+                    *sz += strlen(regattr->description[n]) + 1;
+                }
+            }
+            break;
+        case PMIX_REGEX:
+            *sz = sizeof(pmix_byte_object_t);
+            *sz += v->data.bo.size;
+            break;
+        case PMIX_DATA_BUFFER:
+            *sz = sizeof(pmix_data_buffer_t);
+            *sz += v->data.dbuf->bytes_used;
+            break;
+        case PMIX_PROC_STATS:
+            *sz = sizeof(pmix_proc_stats_t);
+            if (NULL != v->data.pstats->node) {
+                *sz += strlen(v->data.pstats->node) + 1;
+            }
+            if (NULL != v->data.pstats->cmd) {
+                *sz += strlen(v->data.pstats->cmd) + 1;
+            }
+            break;
+        case PMIX_DISK_STATS:
+            *sz = sizeof(pmix_disk_stats_t);
+            if (NULL != v->data.dkstats->disk) {
+                *sz += strlen(v->data.dkstats->disk) + 1;
+            }
+            break;
+        case PMIX_NET_STATS:
+            *sz = sizeof(pmix_net_stats_t);
+            if (NULL != v->data.netstats->net_interface) {
+                *sz += strlen(v->data.netstats->net_interface) + 1;
+            }
+            break;
+        case PMIX_NODE_STATS:
+            *sz = sizeof(pmix_node_stats_t);
+            if (NULL != v->data.ndstats->node) {
+                *sz += strlen(v->data.ndstats->node) + 1;
+            }
+            for (n=0; n < v->data.ndstats->ndiskstats; n++) {
+                *sz += sizeof(pmix_disk_stats_t);
+                if (NULL != v->data.ndstats->diskstats[n].disk) {
+                    *sz += strlen(v->data.ndstats->diskstats[n].disk) + 1;
+                }
+            }
+            for (n=0; n < v->data.ndstats->nnetstats; n++) {
+                *sz += sizeof(pmix_net_stats_t);
+                if (NULL != v->data.ndstats->netstats[n].net_interface) {
+                    *sz += strlen(v->data.ndstats->netstats[n].net_interface) + 1;
+                }
+            }
+            break;
+
+        default:
+            /* silence warnings */
+            break;
+        }
+
+    return rc;
+}
+
+pmix_status_t PMIx_Info_get_size(const pmix_info_t *val,
+                                 size_t *size)
+{
+    pmix_status_t rc;
+    size_t len;
+
+    rc = PMIx_Value_get_size(&val->value, size);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    len = strnlen(val->key, PMIX_MAX_KEYLEN);
+    if (PMIX_MAX_KEYLEN == len) {
+        *size += PMIX_MAX_KEYLEN;
+    } else {
+        *size += len + 1;
+    }
+    *size += sizeof(pmix_info_t);
+    return PMIX_SUCCESS;
 }

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -69,10 +69,13 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     return false;
 }
 
-pmix_compress_base_module_t pmix_compress = {.compress = compress_block,
-                                             .decompress = decompress_block,
-                                             .compress_string = compress_string,
-                                             .decompress_string = decompress_string};
+pmix_compress_base_module_t pmix_compress = {
+    .compress = compress_block,
+    .decompress = decompress_block,
+    .compress_string = compress_string,
+    .decompress_string = decompress_string
+};
+
 pmix_compress_base_t pmix_compress_base = {
     .compress_limit = 0,
     .selected = false,

--- a/src/mca/pcompress/pcompress.h
+++ b/src/mca/pcompress/pcompress.h
@@ -62,6 +62,7 @@ typedef bool (*pmix_compress_base_module_compress_string_fn_t)(char *instring, u
                                                                size_t *nbytes);
 typedef bool (*pmix_compress_base_module_decompress_string_fn_t)(char **outstring, uint8_t *inbytes,
                                                                  size_t len);
+typedef size_t (*pmix_compress_base_module_get_decompressed_strlen_fn_t)(const pmix_byte_object_t *bo);
 
 /**
  * Compress a block
@@ -74,6 +75,7 @@ typedef bool (*pmix_compress_base_module_compress_fn_t)(const uint8_t *inbytes, 
 
 typedef bool (*pmix_compress_base_module_decompress_fn_t)(uint8_t **outbytes, size_t *outlen,
                                                           const uint8_t *inbytes, size_t len);
+typedef size_t (*pmix_compress_base_module_get_decompressed_size_fn_t)(const pmix_byte_object_t *bo);
 
 /**
  * Structure for COMPRESS components.
@@ -85,19 +87,20 @@ typedef  pmix_mca_base_component_t pmix_compress_base_component_t;
  */
 struct pmix_compress_base_module_1_0_0_t {
     /** Initialization Function */
-    pmix_compress_base_module_init_fn_t init;
+    pmix_compress_base_module_init_fn_t                     init;
     /** Finalization Function */
-    pmix_compress_base_module_finalize_fn_t finalize;
+    pmix_compress_base_module_finalize_fn_t                 finalize;
 
     /** Compress interface */
-    pmix_compress_base_module_compress_fn_t compress;
+    pmix_compress_base_module_compress_fn_t                 compress;
 
     /** Decompress Interface */
-    pmix_compress_base_module_decompress_fn_t decompress;
-
+    pmix_compress_base_module_decompress_fn_t               decompress;
+    pmix_compress_base_module_get_decompressed_size_fn_t    get_decompressed_size;
     /* COMPRESS STRING */
-    pmix_compress_base_module_compress_string_fn_t compress_string;
-    pmix_compress_base_module_decompress_string_fn_t decompress_string;
+    pmix_compress_base_module_compress_string_fn_t          compress_string;
+    pmix_compress_base_module_decompress_string_fn_t        decompress_string;
+    pmix_compress_base_module_get_decompressed_strlen_fn_t  get_decompressed_strlen;
 };
 typedef struct pmix_compress_base_module_1_0_0_t pmix_compress_base_module_1_0_0_t;
 typedef struct pmix_compress_base_module_1_0_0_t pmix_compress_base_module_t;


### PR DESCRIPTION
Add a couple of new APIs for estimating the size of data held in pmix_value_t and pmix_info_t objects:

* PMIx_Value_get_size
* PMIx_Info_get_size

Since the objective is to estimate the size of data included in nspace registration and modex operations, and such arrays are often constructed using the PMIx_Info_list_xxx APIs, provide an API to help loop over the list:

* PMIx_Info_list_get_info - returns a pointer to the info in the current object and a pointer to the next object on the list

Add another API to allow prepending a value to the list, and the PMIX_SIZE_ESTIMATE attribute for communicating the overall size of the payload.

Signed-off-by: Ralph Castain <rhc@pmix.org>