### PR TITLE
Fix return of job-info for get operation with wildcard rank.

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -294,7 +294,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
         /* they are asking for the job-level info for (or at least a
          * reserved key from) this nspace */
-        rc = get_job_data(nptr->nspace, cd, key, &pbkt);
+        rc = get_job_data(nptr->nspace, cd, NULL, &pbkt);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&pbkt);
             return rc;


### PR DESCRIPTION
When the rank is a wildcard, a NULL key is required in order to fetch all job-info from the GDS for the given namespace.

Signed-off-by: Heena Sirwani <heena.sirwani@itwm.fraunhofer.de>