### PR TITLE
Fix some backport issues

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -123,4 +123,4 @@ libpmix_so_version=9:0:7
 # # well.  Yuck; this somewhat breaks the
 # # components-don't-affect-the-build-system abstraction.
 #
-libmca_common_dstore_so_version=1:4:0
+libpmix_mca_common_dstore_so_version=1:4:0

--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -678,7 +678,7 @@ AC_DEFUN([MCA_PROCESS_COMPONENT],[
             # Static libraries in "common" frameworks are installed, and
             # therefore must obey the $FRAMEWORK_LIB_PREFIX that was
             # set.
-            $6="mca/$1/$2/lib${m4_translit([pmix], [a-z], [A-Z])_LIB_PREFIX}mca_$1_$2.la $$6"
+            $6="mca/$1/$2/lib${m4_translit([pmix], [a-z], [A-Z])_LIB_PREFIX}pmix_mca_$1_$2.la $$6"
         else
             # Other frameworks do not have to obey the
             # $FRAMEWORK_LIB_PREFIX prefix.

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 # Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -335,7 +335,7 @@ AC_SUBST([CONFIGURE_DEPENDENCIES], ['$(top_srcdir)/VERSION'])
 AC_SUBST([libpmix_so_version])
 AC_SUBST([libpmi_so_version])
 AC_SUBST([libpmi2_so_version])
-AC_SUBST([libmca_common_dstore_so_version])
+AC_SUBST([libpmix_mca_common_dstore_so_version])
 
 AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[examples/Makefile]

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -315,9 +315,8 @@ static int component_find_check(pmix_mca_base_framework_t *framework,
         bool found = false;
 
         PMIX_LIST_FOREACH (cli, components, pmix_mca_base_component_list_item_t) {
-            if (0
-                == strcmp(requested_component_names[i],
-                          cli->cli_component->pmix_mca_component_name)) {
+            if (0 == strcmp(requested_component_names[i],
+                            cli->cli_component->pmix_mca_component_name)) {
                 found = true;
                 break;
             }

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,14 +110,19 @@ static int process_repository_item(const char *filename, void *data)
 
     /* check if the plugin has the appropriate prefix */
     pmix_asprintf(&prefix, "%s_mca_", project);
-    if (0 != strncmp(base, prefix, strlen(prefix))) {
+    pmix_asprintf(&type, "lib%s_mca_", project);
+    if (0 != strncmp(base, prefix, strlen(prefix)) &&
+        0 != strncmp(base, type, strlen(type))) {
         if (pmix_mca_base_show_load_errors(NULL, NULL)) {
-            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected %s", filename, prefix);
+            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected:\n\t%s\nor\n\t%s",
+                        filename, prefix, type);
         }
         free(base);
         free(prefix);
+        free(type);
         return PMIX_SUCCESS;
     }
+    free(type);
 
     /* read framework and component names. framework names may not include an _
      * but component names may */

--- a/src/mca/common/dstore/Makefile.am
+++ b/src/mca/common/dstore/Makefile.am
@@ -40,7 +40,7 @@ endif
 libpmix_mca_common_dstore_la_SOURCES = $(headers) $(sources)
 libpmix_mca_common_dstore_la_LDFLAGS =
 if MCA_BUILD_pmix_common_dstore_DSO
-libpmix_mca_common_dstore_la_LDFLAGS += -version-info $(libmca_common_dstore_so_version)
+libpmix_mca_common_dstore_la_LDFLAGS += -version-info $(libpmix_mca_common_dstore_so_version)
 endif
 libpmix_mca_common_dstore_la_LIBADD =
 

--- a/src/mca/common/dstore/Makefile.am
+++ b/src/mca/common/dstore/Makefile.am
@@ -4,7 +4,7 @@
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
 #
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,17 +32,17 @@ lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
 
 if MCA_BUILD_pmix_common_dstore_DSO
-lib_LTLIBRARIES += libmca_common_dstore.la
+lib_LTLIBRARIES += libpmix_mca_common_dstore.la
 else
-noinst_LTLIBRARIES += libmca_common_dstore.la
+noinst_LTLIBRARIES += libpmix_mca_common_dstore.la
 endif
 
-libmca_common_dstore_la_SOURCES = $(headers) $(sources)
-libmca_common_dstore_la_LDFLAGS =
+libpmix_mca_common_dstore_la_SOURCES = $(headers) $(sources)
+libpmix_mca_common_dstore_la_LDFLAGS =
 if MCA_BUILD_pmix_common_dstore_DSO
-libmca_common_dstore_la_LDFLAGS += -version-info $(libmca_common_dstore_so_version)
+libpmix_mca_common_dstore_la_LDFLAGS += -version-info $(libmca_common_dstore_so_version)
 endif
-libmca_common_dstore_la_LIBADD =
+libpmix_mca_common_dstore_la_LIBADD =
 
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)

--- a/src/mca/gds/ds12/Makefile.am
+++ b/src/mca/gds/ds12/Makefile.am
@@ -16,7 +16,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -66,7 +66,7 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 pmix_mca_gds_ds12_la_SOURCES = $(component_sources)
 pmix_mca_gds_ds12_la_LDFLAGS = -module -avoid-version \
-    $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
+    $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libpmix_mca_common_dstore.la
 if NEED_LIBPMIX
 pmix_mca_gds_ds12_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -152,6 +152,34 @@ static pmix_status_t ds12_del_nspace(const char* nspace)
     return pmix_common_dstor_del_nspace(ds12_ctx, nspace);
 }
 
+static pmix_status_t ds12_fetch_arrays(struct pmix_peer_t *pr,
+                                       pmix_buffer_t *reply)
+{
+    PMIX_HIDE_UNUSED_PARAMS(pr, reply);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static pmix_status_t ds12_mark_modex_complete(struct pmix_peer_t *peer,
+                                              pmix_list_t *nslist,
+                                              pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(peer, nslist, buff);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t ds12_recv_modex_complete(pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(buff);
+    return PMIX_SUCCESS;
+}
+
+static void ds12_set_size(struct pmix_namespace_t *ns,
+                          size_t memsize)
+{
+    PMIX_HIDE_UNUSED_PARAMS(ns, memsize);
+    return;
+}
+
 pmix_gds_base_module_t pmix_ds12_module = {
     .name = "ds12",
     .is_tsafe = false,
@@ -167,5 +195,9 @@ pmix_gds_base_module_t pmix_ds12_module = {
     .setup_fork = ds12_setup_fork,
     .add_nspace = ds12_add_nspace,
     .del_nspace = ds12_del_nspace,
+    .fetch_arrays = ds12_fetch_arrays,
+    .mark_modex_complete = ds12_mark_modex_complete,
+    .recv_modex_complete = ds12_recv_modex_complete,
+    .set_size = ds12_set_size
 };
 

--- a/src/mca/gds/ds21/Makefile.am
+++ b/src/mca/gds/ds21/Makefile.am
@@ -16,7 +16,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017-2018 Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -58,7 +58,7 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 pmix_mca_gds_ds21_la_SOURCES = $(component_sources)
 pmix_mca_gds_ds21_la_LDFLAGS = -module -avoid-version \
-    $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
+    $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libpmix_mca_common_dstore.la
 if NEED_LIBPMIX
 pmix_mca_gds_ds21_la_LIBADD = $(top_builddir)/src/libpmix.la
 endif

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -158,6 +158,35 @@ static pmix_status_t ds21_del_nspace(const char* nspace)
     return pmix_common_dstor_del_nspace(ds21_ctx, nspace);
 }
 
+static pmix_status_t ds21_fetch_arrays(struct pmix_peer_t *pr,
+                                       pmix_buffer_t *reply)
+{
+    PMIX_HIDE_UNUSED_PARAMS(pr, reply);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static pmix_status_t ds21_mark_modex_complete(struct pmix_peer_t *peer,
+                                              pmix_list_t *nslist,
+                                              pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(peer, nslist, buff);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t ds21_recv_modex_complete(pmix_buffer_t *buff)
+{
+    PMIX_HIDE_UNUSED_PARAMS(buff);
+    return PMIX_SUCCESS;
+}
+
+static void ds21_set_size(struct pmix_namespace_t *ns,
+                          size_t memsize)
+{
+    PMIX_HIDE_UNUSED_PARAMS(ns, memsize);
+    return;
+}
+
+
 pmix_gds_base_module_t pmix_ds21_module = {
     .name = "ds21",
     .is_tsafe = true,
@@ -173,5 +202,9 @@ pmix_gds_base_module_t pmix_ds21_module = {
     .setup_fork = ds21_setup_fork,
     .add_nspace = ds21_add_nspace,
     .del_nspace = ds21_del_nspace,
+    .fetch_arrays = ds21_fetch_arrays,
+    .mark_modex_complete = ds21_mark_modex_complete,
+    .recv_modex_complete = ds21_recv_modex_complete,
+    .set_size = ds21_set_size
 };
 

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -216,6 +216,12 @@ static int pdlopen_foreachfile(const char *search_path,
 
                 /* Skip libtool files */
                 if (strcmp(ptr, ".la") == 0 || strcmp(ptr, ".lo") == 0) {
+                    free(abs_name);
+                    continue;
+                }
+
+                /* Skip .o files */
+                if (strcmp(ptr, ".o") == 0) {
                     free(abs_name);
                     continue;
                 }

--- a/src/mca/plog/default/plog_default.h
+++ b/src/mca/plog/default/plog_default.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +33,7 @@ BEGIN_C_DECLS
  * Plog interfaces
  */
 
-PMIX_EXPORT extern pmix_plog_base_component_t mca_plog_default_component;
+PMIX_EXPORT extern pmix_plog_base_component_t pmix_mca_plog_default_component;
 extern pmix_plog_module_t pmix_plog_default_module;
 
 END_C_DECLS

--- a/src/mca/psec/none/psec_none.h
+++ b/src/mca/psec/none/psec_none.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
 BEGIN_C_DECLS
 
 /* the component must be visible data for the linker to find it */
-PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_none_component;
+PMIX_EXPORT extern pmix_psec_base_component_t pmix_mca_psec_none_component;
 extern pmix_psec_module_t pmix_none_module;
 
 END_C_DECLS

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4621,7 +4621,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
          * we also have to send back any session/node/app-level
          * info so it can be stored locally in their hash */
         if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
-            PMIX_GDS_FETCH_INFO_ARRAYS(rc, peer, reply);
+            PMIX_GDS_FETCH_INFO_ARRAYS(rc, pmix_globals.mypeer, reply);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(reply);


### PR DESCRIPTION
The dstore components lacked some required entry points that caused the daemons to segfault. Also, correct the peer used to fetch info arrays when the client isn't using the "hash" GDS component.

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick