### PR TITLE
No need to fetch info arrays for job info

### DIFF
--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,14 +110,19 @@ static int process_repository_item(const char *filename, void *data)
 
     /* check if the plugin has the appropriate prefix */
     pmix_asprintf(&prefix, "%s_mca_", project);
-    if (0 != strncmp(base, prefix, strlen(prefix))) {
+    pmix_asprintf(&type, "lib%s_mca_", project);
+    if (0 != strncmp(base, prefix, strlen(prefix)) &&
+        0 != strncmp(base, type, strlen(type))) {
         if (pmix_mca_base_show_load_errors(NULL, NULL)) {
-            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected %s", filename, prefix);
+            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected:\n\t%s\nor\n\t%s",
+                        filename, prefix, type);
         }
         free(base);
         free(prefix);
+        free(type);
         return PMIX_SUCCESS;
     }
+    free(type);
 
     /* read framework and component names. framework names may not include an _
      * but component names may */

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -216,6 +216,12 @@ static int pdlopen_foreachfile(const char *search_path,
 
                 /* Skip libtool files */
                 if (strcmp(ptr, ".la") == 0 || strcmp(ptr, ".lo") == 0) {
+                    free(abs_name);
+                    continue;
+                }
+
+                /* Skip .o files */
+                if (strcmp(ptr, ".o") == 0) {
                     free(abs_name);
                     continue;
                 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4617,17 +4617,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
             PMIX_RELEASE(reply);
             return rc;
         }
-        /* if the peer is using the "dstore" component, then
-         * we also have to send back any session/node/app-level
-         * info so it can be stored locally in their hash */
-        if (0 != strcmp("hash", peer->nptr->compat.gds->name)) {
-            PMIX_GDS_FETCH_INFO_ARRAYS(rc, peer, reply);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(reply);
-                return rc;
-            }
-        }
         PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, reply);
         if (PMIX_SUCCESS != rc) {
             PMIX_RELEASE(reply);


### PR DESCRIPTION
[No need to fetch info arrays for job info](https://github.com/openpmix/openpmix/pull/2914/commits/0b1b74a75f0eacd6767cfb092453873ec51f3835)

We no longer have GDS components that do not
understand info arrays, so we don't need to
worry about providing that info to the client's
"hash" component.

Signed-off-by: Ralph Castain <rhc@pmix.org>
