### PR TITLE
ptl/base: retry recv() when it encounter EAGAIN or EWOULDBLOCK

### DIFF
--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -160,7 +160,7 @@ pmix_status_t pmix_ptl_base_recv_blocking(int sd, char *data, size_t size)
                 pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
                                     "blocking_recv received error %d:%s from remote - cycling",
                                     pmix_socket_errno, strerror(pmix_socket_errno));
-                return PMIX_ERR_TEMP_UNAVAILABLE;
+		continue;
             }
             if (pmix_socket_errno != EINTR) {
                 /* If we overflow the listen backlog, it's


### PR DESCRIPTION
currently, pmix_ptl_base_recv_blocking() return
PMIX_ERR_TEMP_UNAVAILABLE when recv() encounter EAGAIN or EWOULDBLOCK.

This caused client to close socket, and re-establish connection in try_connect().

The close of socket caused server to receive the SIGPIPE signal, and got aborted.

To address the issue, this patch makes pmix_ptl_base_recv_blocking() to retry recv() when it encountered EAGAIN or EWOULDBLOCK

Signed-off-by: Wei Zhang <wzam@amazon.com>