### PR TITLE
configure: abort in 32-bit environments

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -273,6 +273,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CHECK_SIZEOF(int)
     AC_CHECK_SIZEOF(long)
     AC_CHECK_SIZEOF(void *)
+    AS_IF([test $ac_cv_sizeof_void_p -eq 4],
+	  [AC_MSG_WARN([OpenPMIX does not support 32-bit environments])
+	   AC_MSG_ERROR([Cannot continue])])
     AC_CHECK_SIZEOF(size_t)
     AC_CHECK_SIZEOF(pid_t)
 


### PR DESCRIPTION
OpenPMIX does not support 32-bit environments, so make configure fail early.

Signed-off-by: Joe Downs <joe@dwns.dev>
(cherry picked from commit 8e0225280bd032948287ef0fa3e732370d0e2817)