### PR TITLE
Add option to abort on component find failure

### DIFF
--- a/src/mca/base/pmix_base.h
+++ b/src/mca/base/pmix_base.h
@@ -70,6 +70,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_component_priority_list_item_t)
  */
 PMIX_EXPORT extern char *pmix_mca_base_component_path;
 PMIX_EXPORT extern char *pmix_mca_base_component_show_load_errors;
+PMIX_EXPORT extern bool pmix_mca_base_component_abort_on_load_error;
 PMIX_EXPORT extern bool pmix_mca_base_component_track_load_errors;
 PMIX_EXPORT extern bool pmix_mca_base_component_disable_dlopen;
 PMIX_EXPORT extern char *pmix_mca_base_system_default_path;

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -327,6 +327,9 @@ static int component_find_check(pmix_mca_base_framework_t *framework,
             gethostname(h, sizeof(h) - 1);
             pmix_show_help("help-pmix-mca-base.txt", "find-available:not-valid", true, h,
                            framework->framework_name, requested_component_names[i]);
+            if (pmix_mca_base_component_abort_on_load_error) {
+                return PMIX_ERR_NOT_FOUND;
+            }
         }
     }
 

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -51,6 +51,7 @@ int pmix_mca_base_opened = 0;
 char *pmix_mca_base_system_default_path = NULL;
 char *pmix_mca_base_user_default_path = NULL;
 char *pmix_mca_base_component_show_load_errors = NULL;
+bool pmix_mca_base_component_abort_on_load_error = false;
 bool pmix_mca_base_component_track_load_errors = false;
 bool pmix_mca_base_component_disable_dlopen = false;
 
@@ -145,6 +146,14 @@ int pmix_mca_base_open(const char *add_path)
     if (PMIX_SUCCESS != ret) {
         return ret;
     }
+
+    pmix_mca_base_component_abort_on_load_error = false;
+    var_id = pmix_mca_base_var_register(
+        "pmix", "mca", "base", "abort_on_load_error",
+        "Whether to abort when a specified component isn't found or cannot be loaded",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_mca_base_component_abort_on_load_error);
+
 
     pmix_mca_base_component_track_load_errors = false;
     var_id = pmix_mca_base_var_register(


### PR DESCRIPTION
If a specified component (i.e., PMIX_MCA_foo=a,b,c) cannot be found or refuses to load, provide an MCA param to indicate that we should error out. Otherwise, ignore the situation (reporting it if show_load_errors is set) - the framework itself will abort if none of the components are available.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 4012cc8dbfec92662a7be96a1b9fe249d5d76f57)