### PR TITLE
Avoid multiple reference decrements in pmix_shmem.

### DIFF
--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -213,6 +213,9 @@ pmix_shmem_segment_detach(
     pmix_shmem_t *shmem
 ) {
     if (shmem->attached) {
+        // Set to false here to avoid multiple
+        // reference updates in shmem_destruct().
+        shmem->attached = false;
         const int32_t refc = update_ref_count(shmem->hdr_address, -1);
         if (0 == refc) {
             return segment_detach(shmem);
@@ -266,9 +269,8 @@ static void
 shmem_destruct(
     pmix_shmem_t *s
 ) {
-    // We don't have access to a reference count, so cleanup as much as we can.
+    // We don't have access to a reference count, so bail.
     if (!s->attached) {
-        (void)segment_unlink(s);
         return;
     }
 


### PR DESCRIPTION
Avoid potential for multiple reference decrements from a single attachment site in shmem_destruct() if pmix_shmem_segment_detach() was called beforehand.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>