### PR TITLE
Disable the "sentinel" attribute in Solaris

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -23,7 +23,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl
-dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
@@ -1047,6 +1047,11 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
            AC_MSG_RESULT([yes])])
     AC_DEFINE_UNQUOTED(PMIX_ENABLE_DLOPEN_SUPPORT, $PMIX_ENABLE_DLOPEN_SUPPORT,
                       [Whether we want to enable dlopen support])
+
+#
+# Check the OS flavor here
+#
+PMIX_CHECK_OS_FLAVORS
 
 #
 # Developer picky compiler options

--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -15,7 +15,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -296,7 +296,11 @@
 #endif
 
 #if PMIX_HAVE_ATTRIBUTE_SENTINEL
-#    define __pmix_attribute_sentinel__ __attribute__((__sentinel__))
+    #if PMIX_HAVE_SOLARIS
+    #    define __pmix_attribute_sentinel__
+    #else
+    #    define __pmix_attribute_sentinel__ __attribute__((__sentinel__))
+    #endif
 #else
 #    define __pmix_attribute_sentinel__
 #endif


### PR DESCRIPTION
Turn the "sentinel" attribute checking off when
under a Solaris environment to avoid some
oddities.

Signed-off-by: Ralph Castain <rhc@pmix.org>