### PR TITLE
Turn off the "format" attribute on Solaris

### DIFF
--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -187,7 +187,11 @@
 #endif
 
 #if PMIX_HAVE_ATTRIBUTE_FORMAT
-#    define __pmix_attribute_format__(a, b, c) __attribute__((__format__(a, b, c)))
+    #if PMIX_HAVE_SOLARIS
+    #    define __pmix_attribute_format__(a, b, c)
+    #else
+    #    define __pmix_attribute_format__(a, b, c) __attribute__((__format__(a, b, c)))
+    #endif
 #else
 #    define __pmix_attribute_format__(a, b, c)
 #endif


### PR DESCRIPTION
According to the docs, this is the one that would
trigger complaints about NULL pointers in va_args, even though the error talks about the "sentinel"
attribute. Might as well swat them both.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit f0cd7dbc5287dc7fd074a6f4e1298fef18d50685)