### PR TITLE
gds:shmem Decouple session and job data.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem_component.c
+++ b/src/mca/gds/shmem/gds_shmem_component.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,8 +91,9 @@ gds_shmem_component_register(void)
         &pmix_mca_gds_shmem_component.super,
         "segment_size_multiplier",
         "Multiplier that influences the ultimate sizes of the shared-memory "
-        "segments used for gds data storage. Values less or greater than 1.0 "
-        "decrease or increase final segment sizes, respectively.",
+        "segments used for gds data storage. As a percentage, values less or "
+        "greater than 1.0 decrease or increase the final segment sizes, "
+        "respectively.",
         PMIX_MCA_BASE_VAR_TYPE_DOUBLE,
         &pmix_gds_shmem_segment_size_multiplier
     );

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -432,8 +432,8 @@ xfer_sessioninfo(
     pmix_list_t *kvs
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_list_t *const sessionlist = sesh->sessioninfo;
-    const uint32_t sid = sesh->session;
+    pmix_list_t *const sessionlist = sesh->smdata->sessioninfo;
+    const uint32_t sid = sesh->smdata->id;
 
     if (NULL == key) {
         if (job->nspace->version.major < 4 ||
@@ -493,7 +493,6 @@ xfer_sessioninfo(
             return PMIX_SUCCESS;
         }
     }
-
     return PMIX_ERR_NOT_FOUND;
 }
 
@@ -522,8 +521,8 @@ fetch_sessioninfo(
     }
 
     pmix_gds_shmem_session_t *sesh;
-    sesh = pmix_gds_shmem_check_session(job, sid, false);
-    if (NULL == sesh) {
+    sesh = pmix_gds_shmem_get_session_tracker(job, sid, false);
+    if (PMIX_UNLIKELY(NULL == sesh)) {
         return PMIX_ERR_NOT_FOUND;
     }
 
@@ -541,6 +540,8 @@ pmix_gds_shmem_fetch(
     size_t nqual,
     pmix_list_t *kvs
 ) {
+    PMIX_GDS_SHMEM_VVOUT_HERE();
+
     pmix_status_t rc = PMIX_SUCCESS;
     bool sessioninfo = false;
     bool nodeinfo = false;

--- a/src/mca/gds/shmem/gds_shmem_utils.h
+++ b/src/mca/gds/shmem/gds_shmem_utils.h
@@ -41,8 +41,8 @@ do {                                                                           \
 do { } while (0)
 #endif
 
-#define PMIX_GDS_SHMEM_VOUT_HERE()                                             \
-PMIX_GDS_SHMEM_VVOUT(":%s called at line %d", __func__, __LINE__)
+#define PMIX_GDS_SHMEM_VVOUT_HERE()                                            \
+PMIX_GDS_SHMEM_VVOUT("HERE AT %s,%d", __func__, __LINE__)
 
 BEGIN_C_DECLS
 
@@ -54,7 +54,7 @@ pmix_gds_shmem_get_job_tracker(
 );
 
 PMIX_EXPORT pmix_gds_shmem_session_t *
-pmix_gds_shmem_check_session(
+pmix_gds_shmem_get_session_tracker(
     pmix_gds_shmem_job_t *job,
     uint32_t sid,
     bool create
@@ -110,6 +110,17 @@ pmix_gds_shmem_get_job_tma(
     return &job->smdata->tma;
 }
 
+static inline pmix_tma_t *
+pmix_gds_shmem_get_session_tma(
+    pmix_gds_shmem_job_t *job
+) {
+    assert(job->session);
+    if (!job->session) {
+        return NULL;
+    }
+    return &job->session->smdata->tma;
+}
+
 static inline void
 pmix_gds_shmem_vout_smdata(
     pmix_gds_shmem_job_t *job
@@ -147,6 +158,26 @@ pmix_gds_shmem_vout_smmodex(
         (void *)&job->smmodex->tma,
         (void *)job->smmodex->tma.data_ptr,
         (void *)job->smmodex->hashtab
+    );
+}
+
+static inline void
+pmix_gds_shmem_vout_smsession(
+    pmix_gds_shmem_session_t *sesh
+) {
+    PMIX_GDS_SHMEM_VOUT(
+        "shmem_hdr@%p, "
+        "shmem_data@%p, "
+        "smdata tma@%p, "
+        "smdata tma data_ptr=%p, "
+        "sessioninfo@%p, "
+        "nodeinfo@%p",
+        (void *)sesh->shmem->hdr_address,
+        (void *)sesh->shmem->data_address,
+        (void *)&sesh->smdata->tma,
+        (void *)sesh->smdata->tma.data_ptr,
+        (void *)sesh->smdata->sessioninfo,
+        (void *)sesh->smdata->nodeinfo
     );
 }
 


### PR DESCRIPTION
IBM's CI found an issue with how we were storing job and session data in shared-memory. This commit checkpoints our work toward fixing that issue. I still need to cleanup some code, but my initial tests look promising. The solution here that appears to work requires that session data be stored in distinct shared-memory segments.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>