### PR TITLE
Extend size computation

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -415,6 +415,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //         reported to host by server library
 #define PMIX_SORTED_PROC_ARRAY              "pmix.sorted.parr"      // (bool) Proc array being passed has been sorted
 #define PMIX_SIZE_ESTIMATE                  "pmix.size.est"         // (size_t) Number of bytes in the enclosed payload
+#define PMIX_NUM_KEYS                       "pmix.nkeys"            // (size_t) Number of keys in the enclosed payload
 
 
 /* event handler registration and notification info keys */

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -1490,7 +1490,10 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
         default:
             /* silence warnings */
             break;
-        }
+    }
+
+    /* account for the size of the pmix_value_t itself */
+    *sz += sizeof(pmix_value_t);
 
     return rc;
 }


### PR DESCRIPTION
Include the size of the pmix_value_t itself and
the hash table struct that holds it. Also add in
the number of keys that were included in the
payload.

Signed-off-by: Ralph Castain <rhc@pmix.org>