### PR TITLE
Disable gds/shmem by default.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -32,7 +32,7 @@
 /**
  * Set to 1 to completely disable this component.
  */
-#define PMIX_GDS_SHMEM_DISABLE 0
+#define PMIX_GDS_SHMEM_DISABLE 1
 
 /**
  * Default component/module priority.


### PR DESCRIPTION
It looks like gds/shmem still needs some work, so disable it for now.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>