### PR TITLE
Multiple commits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,10 +23,15 @@ other, a single NEWS-worthy item might apply to different series. For
 example, a bug might be fixed in the master, and then moved to
 multiple release branches.
 
-4.2.3 -- TBD
+4.2.3 -- 8 Feb 2023
 ----------------------
+ - PR #2937 Multiple commits
+    - Update exceptions doc
+    - Disable the "sentinel" attribute in Solaris
+    - Handle some Solaris errors/warnings
+    - Hide unused params
+    - Turn off the "format" attribute on Solaris
  - PR #2927 Add option to abort on component find failure
- = PR #2923 configure: abort in 32-bit environments
  - PR #2922 Fix memory leak in pmix_hash_fetch
  - PR #2920 ptl/base: retry recv() when it encounter EAGAIN or EWOULDBLOCK
  - PR #2913 Multiple commits

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -273,9 +273,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CHECK_SIZEOF(int)
     AC_CHECK_SIZEOF(long)
     AC_CHECK_SIZEOF(void *)
-    AS_IF([test $ac_cv_sizeof_void_p -eq 4],
-	  [AC_MSG_WARN([OpenPMIX does not support 32-bit environments])
-	   AC_MSG_ERROR([Cannot continue])])
     AC_CHECK_SIZEOF(size_t)
     AC_CHECK_SIZEOF(pid_t)
 

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -17,7 +17,7 @@ dnl                         reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2020      Triad National Security, LLC. All rights
+dnl Copyright (c) 2020-2023 Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl
@@ -313,12 +313,12 @@ AC_DEFUN([PMIX_SETUP_CC],[
     # see if the C compiler supports __builtin_expect
     AC_CACHE_CHECK([if $CC supports __builtin_expect],
         [pmix_cv_cc_supports___builtin_expect],
-        [AC_LINK_IFELSE([AC_LANG_PROGRAM([,
-          [void *ptr = (void*) 0;
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[ ]],
+          [[void *ptr = (void*) 0;
            if (__builtin_expect (ptr != (void*) 0, 1)) return 0;
-          ]],
+          ]])],
           [pmix_cv_cc_supports___builtin_expect="yes"],
-          [pmix_cv_cc_supports___builtin_expect="no"])])])
+          [pmix_cv_cc_supports___builtin_expect="no"])])
     if test "$pmix_cv_cc_supports___builtin_expect" = "yes" ; then
         have_cc_builtin_expect=1
     else

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -382,7 +383,7 @@ static void cycle_events(int sd, short args, void *cbdata)
     }
 
     /* save this handler's returned status */
-    if (NULL != chain->evhdlr->name) {
+    if (NULL != chain->evhdlr && NULL != chain->evhdlr->name) {
         pmix_strncpy(newinfo[cnt].key, chain->evhdlr->name, PMIX_MAX_KEYLEN);
     } else {
         pmix_strncpy(newinfo[cnt].key, "UNKNOWN", PMIX_MAX_KEYLEN);


### PR DESCRIPTION
[Use the GDS verbosity in the util/hash functions](https://github.com/openpmix/openpmix/commit/1f91ff61f7f5b07512a73c05179df6bd8ad327e3)

The two are tightly coupled, so let's use the same
verbosity in the two code areas.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/4aa9e933461cb5a4a08f5211c0b75f614216fde2)

[Don't get evhdlr name unless we know it is valid.](https://github.com/openpmix/openpmix/commit/1932260506436ed0210d62802ade5aade5b8ebb1)

Silences ASAN warning.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/0b8d04355ee4fecb99b0514701a8c1aa4527af50)

[Fix configure for __builtin_expect support.](https://github.com/openpmix/openpmix/commit/25f651c8556cc86e58fe2a160a013be2caf0785d)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/84071430ed198ce34cfea81027206a19d3f8c855)

[Revert "configure: abort in 32-bit environments"](https://github.com/openpmix/openpmix/commit/ee85e0082aabf57a28477858143195ad9b0bbe48)

This reverts commit https://github.com/openpmix/openpmix/commit/8e0225280bd032948287ef0fa3e732370d0e2817.

We are not going to take the blame for OMPI no longer being
default Debian MPI. Note this does nothing to "fix" 32-bit
compile or operations - it just no longer errors out if one
attempts to build it under a 32-bit environment.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Update NEWS for release](https://github.com/openpmix/openpmix/commit/320889bc2058291cdcc49b047b50327e4a579426)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick