### PR TITLE
Move release of pmix_client_globals.myserver to later

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,8 +23,9 @@ other, a single NEWS-worthy item might apply to different series. For
 example, a bug might be fixed in the master, and then moved to
 multiple release branches.
 
-4.2.3 -- 8 Feb 2023
+4.2.3 -- 7 Feb 2023
 ----------------------
+ - PR #2959 Move release of pmix_client_globals.myserver to later
  - PR #2937 Multiple commits
     - Update exceptions doc
     - Disable the "sentinel" attribute in Solaris

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1513,7 +1513,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
 
-    PMIX_RELEASE(pmix_client_globals.myserver);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     for (n = 0; n < pmix_client_globals.peers.size; n++) {
         if (NULL
@@ -1550,6 +1549,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     pmix_rte_finalize();
     if (NULL != pmix_globals.mypeer) {
         PMIX_RELEASE(pmix_globals.mypeer);
+    }
+    if (NULL != pmix_client_globals.myserver) {
+        PMIX_RELEASE(pmix_client_globals.myserver);
     }
 
     /* finalize the class/object system */


### PR DESCRIPTION
Move the release to after rte_finalize as it might be used.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 028f5a29197fc9fae89c0bb41c41dcd0d63783e8)