### PR TITLE
Remove the PMIX_SIZE_ESTIMATE attribute

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1232,11 +1232,6 @@ Attributes
        form of a comma separated list of |br|
        "MAJOR.MINOR" pairs
 
-   * - ``PMIX_SIZE_ESTIMATE`` |br| ``pmix.size.est``
-     - ``(size_t)``
-     - Number of bytes in the enclosed |br|
-       payload
-
 .. note:: The attribute ``PMIX_DEBUG_STOP_IN_APP`` has been modified
           to only support a ``PMIX_BOOL`` value instead of an optional
           array of ranks due to questions over the use-case calling

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -414,8 +414,6 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOCAL_COLLECTIVE_STATUS        "pmix.loc.col.st"       // (pmix_status_t) status code for local collective operation being
                                                                     //         reported to host by server library
 #define PMIX_SORTED_PROC_ARRAY              "pmix.sorted.parr"      // (bool) Proc array being passed has been sorted
-#define PMIX_SIZE_ESTIMATE                  "pmix.size.est"         // (size_t) Number of bytes in the enclosed payload
-#define PMIX_NUM_KEYS                       "pmix.nkeys"            // (size_t) Number of keys in the enclosed payload
 
 
 /* event handler registration and notification info keys */


### PR DESCRIPTION
No longer required - ditto for PMIX_NUM_KEYS

Signed-off-by: Ralph Castain <rhc@pmix.org>