### PR TITLE
Remove support for PMIX_SIZE_ESTIMATE

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1232,11 +1232,6 @@ Attributes
        form of a comma separated list of |br|
        "MAJOR.MINOR" pairs
 
-   * - ``PMIX_SIZE_ESTIMATE`` |br| ``pmix.size.est``
-     - ``(size_t)``
-     - Number of bytes in the enclosed |br|
-       payload
-
 .. note:: The attribute ``PMIX_DEBUG_STOP_IN_APP`` has been modified
           to only support a ``PMIX_BOOL`` value instead of an optional
           array of ranks due to questions over the use-case calling

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -413,7 +413,6 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOCAL_COLLECTIVE_STATUS        "pmix.loc.col.st"       // (pmix_status_t) status code for local collective operation being
                                                                     //         reported to host by server library
 #define PMIX_SORTED_PROC_ARRAY              "pmix.sorted.parr"      // (bool) Proc array being passed has been sorted
-#define PMIX_SIZE_ESTIMATE                  "pmix.size.est"         // (size_t) Number of bytes in the enclosed payload
 
 
 /* event handler registration and notification info keys */

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -173,13 +173,6 @@ static pmix_status_t ds12_recv_modex_complete(pmix_buffer_t *buff)
     return PMIX_SUCCESS;
 }
 
-static void ds12_set_size(struct pmix_namespace_t *ns,
-                          size_t memsize)
-{
-    PMIX_HIDE_UNUSED_PARAMS(ns, memsize);
-    return;
-}
-
 pmix_gds_base_module_t pmix_ds12_module = {
     .name = "ds12",
     .is_tsafe = false,
@@ -197,7 +190,6 @@ pmix_gds_base_module_t pmix_ds12_module = {
     .del_nspace = ds12_del_nspace,
     .fetch_arrays = ds12_fetch_arrays,
     .mark_modex_complete = ds12_mark_modex_complete,
-    .recv_modex_complete = ds12_recv_modex_complete,
-    .set_size = ds12_set_size
+    .recv_modex_complete = ds12_recv_modex_complete
 };
 

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -179,14 +179,6 @@ static pmix_status_t ds21_recv_modex_complete(pmix_buffer_t *buff)
     return PMIX_SUCCESS;
 }
 
-static void ds21_set_size(struct pmix_namespace_t *ns,
-                          size_t memsize)
-{
-    PMIX_HIDE_UNUSED_PARAMS(ns, memsize);
-    return;
-}
-
-
 pmix_gds_base_module_t pmix_ds21_module = {
     .name = "ds21",
     .is_tsafe = true,
@@ -204,7 +196,6 @@ pmix_gds_base_module_t pmix_ds21_module = {
     .del_nspace = ds21_del_nspace,
     .fetch_arrays = ds21_fetch_arrays,
     .mark_modex_complete = ds21_mark_modex_complete,
-    .recv_modex_complete = ds21_recv_modex_complete,
-    .set_size = ds21_set_size
+    .recv_modex_complete = ds21_recv_modex_complete
 };
 

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -78,20 +78,6 @@ typedef pmix_status_t (*pmix_gds_base_assign_module_fn_t)(pmix_info_t *info, siz
 #define PMIX_GDS_CHECK_PEER_COMPONENT(p1, p2) \
     (0 == strcmp((p1)->nptr->compat.gds->name, (p2)->nptr->compat.gds->name))
 
-/* set the memory size in anticipation of storing a payload (e.g., registration
- * data for modex info). */
-typedef void (*pmix_gds_base_module_set_size_fn_t)(struct pmix_namespace_t *ns,
-                                                   size_t memsize);
-
-#define PMIX_GDS_SET_SIZE(n, m) \
-    do {                                                                \
-        pmix_output_verbose(1, pmix_gds_base_output,                    \
-                            "[%s:%d] GDS SET SIZE WITH %s", __FILE__,   \
-                            __LINE__, (n)->compat.gds->name);           \
-        (n)->compat.gds->set_size((struct pmix_namespace_t *) n, m);    \
-    } while (0)
-
-
 /* SERVER FN: assemble the keys buffer for server answer */
 typedef pmix_status_t (*pmix_gds_base_module_assemb_kvs_req_fn_t)(const pmix_proc_t *proc,
                                                                   pmix_list_t *kvs,
@@ -489,7 +475,6 @@ typedef struct {
     pmix_gds_base_module_fetch_array_fn_t           fetch_arrays;
     pmix_gds_base_module_mark_modex_complete_fn_t   mark_modex_complete;
     pmix_gds_base_module_recv_modex_complete_fn_t   recv_modex_complete;
-    pmix_gds_base_module_set_size_fn_t              set_size;
 } pmix_gds_base_module_t;
 
 /* NOTE: there is no public GDS interface structure - all access is

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -88,8 +88,6 @@ static pmix_status_t mark_modex_complete(struct pmix_peer_t *peer,
 
 static pmix_status_t recv_modex_complete(pmix_buffer_t *buff);
 
-static void set_size(struct pmix_namespace_t *ns, size_t memsize);
-
 pmix_gds_base_module_t pmix_hash_module = {
     .name = "hash",
     .is_tsafe = false,
@@ -109,8 +107,7 @@ pmix_gds_base_module_t pmix_hash_module = {
     .accept_kvs_resp = accept_kvs_resp,
     .fetch_arrays = pmix_gds_hash_fetch_arrays,
     .mark_modex_complete = mark_modex_complete,
-    .recv_modex_complete = recv_modex_complete,
-    .set_size = set_size
+    .recv_modex_complete = recv_modex_complete
 };
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
@@ -1594,10 +1591,4 @@ static pmix_status_t recv_modex_complete(pmix_buffer_t *buff)
 {
     PMIX_HIDE_UNUSED_PARAMS(buff);
     return PMIX_SUCCESS;
-}
-
-static void set_size(struct pmix_namespace_t *ns, size_t memsize)
-{
-    PMIX_HIDE_UNUSED_PARAMS(ns, memsize);
-    return;
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3298,11 +3298,6 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
     pmix_nspace_caddy_t *nptr;
     pmix_list_t nslist;
     bool found;
-    int32_t cnt;
-    pmix_info_t info;
-    size_t memsize = 0;
-    char *payload = NULL;
-    size_t sz;
 
     PMIX_ACQUIRE_OBJECT(scd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -3366,52 +3361,9 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
         goto finish_collective;
     }
 
-    /* see if the host provided any controls directives (e.g., an estimate
-     * of the stored data size requirements for this payload) - they would
-     * be given as pmix_info_t at the beginning of the payload */
-    PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(ret, pmix_globals.mypeer, &xfer, &info, &cnt, PMIX_INFO);
-    while (PMIX_SUCCESS == ret) {
-        if (PMIX_CHECK_KEY(&info, PMIX_SIZE_ESTIMATE)) {
-            PMIX_VALUE_GET_NUMBER(ret, &info.value, memsize, size_t);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_ERROR_LOG(ret);
-                break;
-            }
-        }
-        /* save where we are */
-        payload = xfer.unpack_ptr;
-        /* cleanup */
-        PMIX_INFO_DESTRUCT(&info);
-        /* get the next object */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(ret, pmix_globals.mypeer, &xfer, &info, &cnt, PMIX_INFO);
-    }
-    if (0 < memsize) {
-        /* set the memory size for each of the participating namespaces.
-         * Note: this will be an overestimate as the value represents the
-         * total across ALL participating namespaces, not an estimate for
-         * each namespace
-         */
-        PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
-            PMIX_GDS_SET_SIZE(nptr->ns, memsize);
-        }
-    }
-
-    /* do NOT destruct the xfer buffer as that would release the payload! We do,
-     * however, need to exclude any controls directives from the next step, so
-     * let's define a pointer to the place in the payload where we stopped unpacking */
-    if (NULL == payload) {
-        payload = (char*)scd->data;
-        sz = scd->ndata;
-    } else {
-        sz = xfer.base_ptr + xfer.bytes_used - payload;
-    }
-
     PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
         /* pass the blobs being returned */
-        PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, payload, sz);
+        PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
         PMIX_GDS_STORE_MODEX(rc, nptr->ns, &xfer, tracker);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -644,7 +644,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_rank_t rel_rank;
     pmix_nspace_caddy_t *nm;
-    bool found;
+    bool found, data_added = false;
     pmix_list_t rank_blobs;
     rank_blob_t *blob;
     uint32_t kmap_size;
@@ -674,7 +674,6 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
             uint32_t *key_count = NULL;
 
             pmix_value_array_init(key_count_array, sizeof(uint32_t));
-            *size = 0;
 
             PMIX_LIST_FOREACH (scd, &trk->local_cbs, pmix_server_caddy_t) {
                 pmix_strncpy(pcs.nspace, scd->peer->info->pname.nspace, PMIX_MAX_NSLEN);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -52,6 +52,10 @@
 #endif
 #include <event.h>
 
+#ifndef MAX
+#    define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"
@@ -629,8 +633,7 @@ static void fence_timeout(int sd, short args, void *cbdata)
 }
 
 static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
-                                   pmix_buffer_t *buf,
-                                   size_t *size)
+                                   pmix_buffer_t *buf)
 {
     pmix_buffer_t bucket, *pbkt = NULL;
     pmix_cb_t cb;
@@ -646,7 +649,6 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
     rank_blob_t *blob;
     uint32_t kmap_size;
     int key_idx;
-    size_t sz;
 
     /* key names map, the position of the key name
      * in the array determines the unique key index */
@@ -813,22 +815,6 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                 }
                 /* pack the returned kval's */
                 PMIX_LIST_FOREACH (kv, &cb.kvs, pmix_kval_t) {
-                    rc = PMIx_Value_get_size(kv->value, &sz);
-                    if (rc != PMIX_SUCCESS) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DESTRUCT(&cb);
-                        PMIX_LIST_DESTRUCT(&rank_blobs);
-                        PMIX_RELEASE(pbkt);
-                        goto cleanup;
-                    }
-                    *size += sz;
-                    // account for the key
-                    sz = strnlen(kv->key, PMIX_MAX_KEYLEN);
-                    if (PMIX_MAX_KEYLEN == sz) {
-                        *size += PMIX_MAX_KEYLEN;
-                    } else {
-                        *size += sz + 1;
-                    }
                     rc = pmix_gds_base_modex_pack_kval(kmap_type, pbkt, &kmap, kv);
                     if (rc != PMIX_SUCCESS) {
                         PMIX_ERROR_LOG(rc);
@@ -838,7 +824,9 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                         goto cleanup;
                     }
                 }
-
+                data_added = true;
+            }
+            if (data_added) {
                 /* add part of the process modex to the list */
                 blob = PMIX_NEW(rank_blob_t);
                 blob->buf = pbkt;
@@ -927,9 +915,9 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     bool collect_data = false;
     pmix_server_trkr_t *trk;
     char *data = NULL;
-    size_t sz = 0, size;
+    size_t sz = 0;
     pmix_buffer_t bucket;
-    pmix_info_t *info = NULL, *iptr;
+    pmix_info_t *info = NULL;
     size_t ninfo = 0, ninf, n, nmbrs, idx;
     struct timeval tv = {0, 0};
     pmix_list_t expand;
@@ -1185,7 +1173,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
          * or global distribution */
 
         PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
-        if (PMIX_SUCCESS != (rc = _collect_data(trk, &bucket, &size))) {
+        if (PMIX_SUCCESS != (rc = _collect_data(trk, &bucket))) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&bucket);
             /* clear the caddy from this tracker so it can be
@@ -1206,18 +1194,6 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_UNLOAD_BUFFER(&bucket, data, sz);
         PMIX_DESTRUCT(&bucket);
         trk->host_called = true;
-        /* add the size to the info array */
-        ninf = trk->ninfo + 1;
-        PMIX_INFO_CREATE(iptr, ninf);
-        for (n=0; n < trk->ninfo; n++) {
-            PMIX_INFO_XFER(&iptr[n], &trk->info[n]);
-        }
-        PMIX_INFO_LOAD(&iptr[ninf-1], PMIX_SIZE_ESTIMATE, &size, PMIX_SIZE);
-        if (NULL != trk->info) {
-            PMIX_INFO_FREE(trk->info, trk->ninfo);
-        }
-        trk->info = iptr;
-        trk->ninfo = ninf;
         rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo, data, sz,
                                        trk->modexcbfunc, trk);
         if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
@@ -3871,7 +3847,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
         return;
     }
 
-    pmix_output_verbose(2, pmix_server_globals.connect_output,
+    pmix_output_verbose(2, pmix_server_globals.group_output,
                         "server:grpcbfunc processing WITH %d MEMBERS",
                         (int) pmix_list_get_size(&trk->local_cbs));
 
@@ -4090,7 +4066,7 @@ release:
                 break;
             }
         }
-        pmix_output_verbose(2, pmix_server_globals.connect_output,
+        pmix_output_verbose(2, pmix_server_globals.group_output,
                             "server:grp_cbfunc reply being sent to %s:%u",
                             cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
         PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
@@ -4117,7 +4093,7 @@ static void grpcbfunc(pmix_status_t status,
     pmix_server_trkr_t *tracker = (pmix_server_trkr_t *) cbdata;
     pmix_shift_caddy_t *scd;
 
-    pmix_output_verbose(2, pmix_server_globals.connect_output,
+    pmix_output_verbose(2, pmix_server_globals.group_output,
                         "server:grpcbfunc called with %d info", (int) ninfo);
 
     if (NULL == tracker) {
@@ -4214,7 +4190,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
     pmix_proc_t *procs;
     pmix_group_t *grp, *pgrp;
     pmix_info_t *info = NULL, *iptr = NULL, *grpinfoptr = NULL;
-    size_t n, ninfo, ninf, nprocs, n2, ngrpinfo = 0, size = 0;
+    size_t n, ninfo, ninf, nprocs, n2, ngrpinfo = 0;
     pmix_server_trkr_t *trk;
     bool need_cxtid = false;
     bool match, force_local = false;
@@ -4229,7 +4205,8 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
     struct timeval tv = {0, 0};
 
     pmix_output_verbose(2, pmix_server_globals.group_output,
-                        "recvd grpconstruct cmd");
+                        "recvd grpconstruct cmd from %s",
+                        PMIX_PEER_PRINT(cd->peer));
 
     /* unpack the group ID */
     cnt = 1;
@@ -4279,6 +4256,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
         goto error;
     }
     if (0 == nprocs) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_PROC_CREATE(procs, nprocs);
@@ -4562,7 +4540,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
         0 < pmix_list_get_size(&trk->grpinfo)) {
         /* collect any remote contributions provided by group members */
         PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
-        rc = _collect_data(trk, &bucket, &size);
+        rc = _collect_data(trk, &bucket);
         if (PMIX_SUCCESS != rc) {
             /* remove the tracker from the list */
             pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
@@ -4577,7 +4555,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
          * fence operation */
         if (0 < bo.size ||
             0 < pmix_list_get_size(&trk->grpinfo)) {
-            n2 = trk->ninfo + 1;
+            n2 = trk->ninfo + 1; // include space for endpt data
             PMIX_INFO_CREATE(iptr, n2);
             for (n = 0; n < trk->ninfo; n++) {
                 PMIX_INFO_XFER(&iptr[n], &trk->info[n]);


### PR DESCRIPTION
[Remove the PMIX_SIZE_ESTIMATE attribute](https://github.com/openpmix/openpmix/commit/236e80a2d046f2e2d252994a0f09e9c04f52c98a)

No longer required - ditto for PMIX_NUM_KEYS

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3b9d91d7f0e424982b0939556b5ef82f153a2ac9)

[Remove GDS "set_size" entry points](https://github.com/openpmix/openpmix/commit/4950351fcf5ba22ac79685ec56d62ad18b1e59ea)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/ea531ef552395474bc32144db7fd17f0f52fa37b)
