### PR TITLE
Add missing unlink in pmix_shmem_segment_detach().

### DIFF
--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -210,11 +210,15 @@ pmix_shmem_segment_detach(
     pmix_shmem_t *shmem
 ) {
     if (shmem->attached) {
-        (void)update_ref_count(shmem->hdr_address, -1);
+        const int32_t refc = update_ref_count(shmem->hdr_address, -1);
         pmix_status_t rc = segment_detach(shmem);
         // Set to false here to avoid multiple
         // reference updates in shmem_destruct().
         shmem->attached = false;
+        // If we were the last one to hold a reference, also unlink.
+        if (0 == refc) {
+            (void)segment_unlink(shmem);
+        }
         return rc;
     }
     return PMIX_SUCCESS;


### PR DESCRIPTION
If the shared-memory reference count reaches zero in the pmix_shmem_segment_detach() path, then also unlink the backing file.