### PR TITLE
Skip a double-dash on cmd line

### DIFF
--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -270,6 +270,11 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     optind = 1;
                     goto done;
                 }
+                if (0 == strcmp(argv[argind], "--")) {
+                    // double-dash indicates separator between launcher
+                    // directives and the application
+                    break;
+                }
                 found = false;
                 for (n=0; '\0' != shorts[n]; n++) {
                     int ascii = shorts[n];


### PR DESCRIPTION
Used as separator between cmd directives
and application.

Fixes #2980 
Signed-off-by: Ralph Castain <rhc@pmix.org>