### PR TITLE
Plug memory leak.

### DIFF
--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -504,14 +504,14 @@ void pmix_hwloc_destruct_topology(pmix_topology_t *src)
         0 != strncasecmp(src->source, "hwloc", 5)) {
         return;
     }
+
     if (NULL != src->topology) {
         hwloc_topology_destroy(src->topology);
         src->topology = NULL;
     }
-    if (NULL != src->source) {
-        free(src->source);
-        src->source = NULL;
-    }
+
+    free(src->source);
+    src->source = NULL;
 }
 
 // avoid ABI break

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -972,6 +972,7 @@ pmix_bfrops_base_tma_topology_free(
     for (size_t m = 0; m < n; m++) {
         pmix_bfrops_base_tma_topology_destruct(&t[m], tma);
     }
+    pmix_tma_free(tma, t);
 }
 
 static inline void
@@ -4026,8 +4027,7 @@ pmix_bfrops_base_tma_value_destruct(
             break;
         case PMIX_TOPO:
             if (NULL != v->data.topo) {
-                // TODO(skg)
-                pmix_hwloc_release_topology(v->data.topo, 1);
+                pmix_bfrops_base_tma_topology_free(v->data.topo, 1, tma);
             }
             break;
         case PMIX_PROC_CPUSET:


### PR DESCRIPTION
A straightforward PMIx_Init() then PMIx_Finalize() program running on my computer is now Valgrind memcheck clean.