### PR TITLE
Plug memory leaks in reinit paths.

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1070,6 +1071,9 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     /* flush anything that is still trying to be written out */
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
+
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stdout);
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     for (i = 0; i < pmix_client_globals.peers.size; i++) {

--- a/src/mca/base/pmix_mca_base_close.c
+++ b/src/mca/base/pmix_mca_base_close.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,9 +50,15 @@ int pmix_mca_base_close(void)
         /* release the default paths */
         if (NULL != pmix_mca_base_system_default_path) {
             free(pmix_mca_base_system_default_path);
+            pmix_mca_base_system_default_path = NULL;
         }
         if (NULL != pmix_mca_base_user_default_path) {
             free(pmix_mca_base_user_default_path);
+            pmix_mca_base_user_default_path = NULL;
+        }
+        if (NULL != pmix_mca_base_component_path) {
+            free(pmix_mca_base_component_path);
+            pmix_mca_base_component_path = NULL;
         }
 
         /* Close down the component repository */

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -48,6 +48,7 @@
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/pmix_net.h"
 #include "src/runtime/pmix_init_util.h"
 #include <event.h>
 
@@ -95,6 +96,9 @@ void pmix_rte_finalize(void)
 
     /* close GDS */
     (void) pmix_mca_base_framework_close(&pmix_gds_base_framework);
+
+    /* Finalize the network helper subsystem. */
+    (void)pmix_net_finalize();
 
     /* finalize the mca */
     /* Clear out all the registered MCA params */
@@ -158,6 +162,7 @@ void pmix_rte_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_globals.keyindex);
+    free(pmix_globals.myidval.data.proc);
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_stop(NULL);


### PR DESCRIPTION
A straightforward looping program over PMIx_Init(), PMIx_Fence(), and PMIx_Finalize() running on my computer is now Valgrind memcheck clean.