### PR TITLE
Convert the majority of PMIX_*_FREE() macros.

### DIFF
--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -544,12 +544,11 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_VALUE_CREATE(m, n) \
     (m) = PMIx_Value_create(n)
 
-// free(m) is NOT called inside PMIx_Value_destruct(), so do it here.
-#define PMIX_VALUE_RELEASE(m)       \
-    do {                            \
-        PMIx_Value_destruct((m));   \
-        pmix_free((m));             \
-        (m) = NULL;                 \
+// free(m) is called inside PMIx_Value_free().
+#define PMIX_VALUE_RELEASE(m)  \
+    do {                       \
+        PMIx_Value_free(m, 1); \
+        (m) = NULL;            \
     } while (0)
 
 // free(m) is called inside PMIx_Value_free().
@@ -831,12 +830,11 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DATA_BUFFER_CREATE(m)  \
     (m) = PMIx_Data_buffer_create()
 
-// free(m) is NOT called inside PMIx_Data_buffer_release(), so do it here.
-#define PMIX_DATA_BUFFER_RELEASE(m)     \
-    do {                                \
-        PMIx_Data_buffer_release(m);    \
-        pmix_free((m));                 \
-        (m) = NULL;                     \
+// free(m) is called inside PMIx_Data_buffer_release().
+#define PMIX_DATA_BUFFER_RELEASE(m)  \
+    do {                             \
+        PMIx_Data_buffer_release(m); \
+        (m) = NULL;                  \
     } while (0)
 
 #define PMIX_DATA_BUFFER_CONSTRUCT(m)       \
@@ -871,10 +869,9 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 // free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_RELEASE(m)    \
 do {                            \
-    PMIX_PROC_FREE(m, 1);       \
+    PMIx_Proc_free(m, 1);       \
     (m) = NULL;                 \
 } while(0)
-
 
 #define PMIX_PROC_LOAD(m, n, r) \
     PMIx_Proc_load(m, n, r)
@@ -895,18 +892,17 @@ do {                            \
 #define PMIX_PROC_INFO_DESTRUCT(m) \
     PMIx_Proc_info_destruct(m)
 
-// TODO(skg) FIXME
-#define PMIX_PROC_INFO_FREE(m, n)   \
-    do {                            \
-        PMIx_Proc_info_free(m, n);  \
-        pmix_free((m));             \
+// free(m) is called inside PMIx_Proc_info_free().
+#define PMIX_PROC_INFO_FREE(m, n)  \
+    do {                           \
+        PMIx_Proc_info_free(m, n); \
+        (m) = NULL;                \
     } while (0)
 
-// TODO(skg) FIXME
+// free(m) is called inside PMIx_Proc_info_free().
 #define PMIX_PROC_INFO_RELEASE(m)   \
 do {                                \
-    PMIX_PROC_INFO_FREE((m), 1)     \
-    pmix_free(m);                   \
+    PMIx_Proc_info_free(m, 1)       \
     (m) = NULL;                     \
 } while(0)
 
@@ -929,7 +925,7 @@ do {                                \
 // free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_RELEASE(m)  \
 do {                                \
-    PMIX_PROC_STATS_FREE((m), 1);   \
+    PMIx_Proc_stats_free(m, 1);     \
     (m) = NULL;                     \
 } while(0)
 
@@ -950,12 +946,11 @@ do {                                \
 } while(0)
 
 // free(m) is called inside PMIx_Disk_stats_free().
-#define PMIX_DISK_STATS_RELEASE(m)  \
-do {                                \
-    PMIX_DISK_STATS_FREE((m), 1);   \
-    (m) = NULL;                     \
+#define PMIX_DISK_STATS_RELEASE(m) \
+do {                               \
+    PMIx_Disk_stats_free(m, 1);    \
+    (m) = NULL;                    \
 } while(0)
-
 
 #define PMIX_NET_STATS_CONSTRUCT(m) \
     PMIx_Net_stats_construct(m)
@@ -975,7 +970,7 @@ do {                               \
 
 #define PMIX_NET_STATS_RELEASE(m)  \
 do {                               \
-    PMIx_Net_stats_free((m), 1);   \
+    PMIx_Net_stats_free(m, 1);     \
     (m) = NULL;                    \
 } while(0)
 
@@ -998,7 +993,7 @@ do {                                \
 // free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_RELEASE(m)  \
 do {                                \
-    PMIx_Node_stats_free((m), 1);   \
+    PMIx_Node_stats_free(m, 1);     \
     (m) = NULL;                     \
 } while(0)
 
@@ -1021,7 +1016,7 @@ do {                            \
 // free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_RELEASE(m)   \
 do {                            \
-    PMIx_Pdata_free((m), 1);    \
+    PMIx_Pdata_free(m, 1);      \
     (m) = NULL;                 \
 } while(0)
 
@@ -1037,11 +1032,10 @@ do {                            \
 #define PMIX_APP_INFO_CREATE(m, n) \
     PMIx_App_info_create(m, n)
 
-// free(m) is NOT called inside PMIx_App_destruct(), so do it here.
+// free(m) is called inside PMIx_App_free().
 #define PMIX_APP_RELEASE(m)     \
     do {                        \
-        PMIx_App_destruct((m)); \
-        pmix_free((m));         \
+        PMIx_App_free(m, 1);    \
         (m) = NULL;             \
     } while (0)
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -216,7 +216,7 @@ PMIX_EXPORT bool PMIx_Check_reserved_key(const char *key);
 PMIX_EXPORT void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str);
 PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
-PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p, 
+PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p,
                                   const char *ns,
                                   pmix_rank_t rk);
 PMIX_EXPORT void PMIx_Xfer_procid(pmix_proc_t *dst,
@@ -468,9 +468,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 
 /* Macros that have been converted to functions */
 
-// XXX it's odd that some _FREE macros call X_free and then call pmix_free
-// after. Whey not just call pmix_free inside of X_free?
-
 #define PMIX_LOAD_KEY(a, b) \
     PMIx_Load_key(a, b)
 
@@ -519,8 +516,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ARGV_APPEND_UNIQUE(r, a, b) \
     (r) = PMIx_Argv_append_unique_nosize(a, b)
 
-#define PMIX_ARGV_FREE(a)  \
-    PMIx_Argv_free(a)
+// free(a) is called inside PMIx_Argv_free().
+#define PMIX_ARGV_FREE(a)    \
+    do {                     \
+        PMIx_Argv_free((a)); \
+        (a) = NULL;          \
+    } while (0)
 
 #define PMIX_ARGV_SPLIT(a, b, c) \
     (a) = PMIx_Argv_split(b, c)
@@ -534,7 +535,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_SETENV(r, a, b, c) \
     (r) = PMIx_Setenv((a), (b), true, (c))
 
-
 #define PMIX_VALUE_CONSTRUCT(m) \
     PMIx_Value_construct(m)
 
@@ -544,6 +544,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_VALUE_CREATE(m, n) \
     (m) = PMIx_Value_create(n)
 
+// free(m) is NOT called inside PMIx_Value_destruct(), so do it here.
 #define PMIX_VALUE_RELEASE(m)       \
     do {                            \
         PMIx_Value_destruct((m));   \
@@ -551,10 +552,10 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
         (m) = NULL;                 \
     } while (0)
 
+// free(m) is called inside PMIx_Value_free().
 #define PMIX_VALUE_FREE(m, n)   \
     do {                        \
         PMIx_Value_free(m, n);  \
-        pmix_free((m));         \
         (m) = NULL;             \
     } while (0)
 
@@ -597,6 +598,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_INFO_CREATE(m, n) \
     (m) = PMIx_Info_create(n)
 
+// TODO(skg) FIXME
 #define PMIX_INFO_FREE(m, n)    \
     do {                        \
         PMIx_Info_free(m, n);   \
@@ -696,8 +698,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_TOPOLOGY_DESTRUCT(x) \
     PMIx_Topology_destruct(x)
 
-#define PMIX_TOPOLOGY_FREE(m, n) \
-    PMIx_Topology_free(m, n)
+// free(m) is called inside PMIx_Topology_free().
+#define PMIX_TOPOLOGY_FREE(m, n)  \
+    do {                          \
+        PMIx_Topology_free(m, n); \
+        (m) = NULL;               \
+    while (0)
 
 #define PMIX_COORD_CREATE(m, n, d)  \
     (m) = PMIx_Coord_create(d, n)
@@ -708,7 +714,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_COORD_DESTRUCT(m)  \
     PMIx_Coord_destruct(m)
 
-// free(m) is done inside PMIx_Coord_free().
+// free(m) is called inside PMIx_Coord_free().
 #define PMIX_COORD_FREE(m, n)   \
     do {                        \
         PMIx_Coord_free(m, n);  \
@@ -724,8 +730,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_CPUSET_CREATE(m, n) \
     (m) = PMIx_Cpuset_create(n)
 
-#define PMIX_CPUSET_FREE(m, n) \
-    PMIx_Cpuset_free(m, n)
+// free(m) is called inside PMIx_Cpuset_free().
+#define PMIX_CPUSET_FREE(m, n)    \
+    do {                          \
+        PMIx_Cpuset_free(m, n);   \
+        (m) = NULL;               \
+    } while(0)
 
 #define PMIX_GEOMETRY_CONSTRUCT(m) \
     PMIx_Geometry_construct(m)
@@ -736,8 +746,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_GEOMETRY_CREATE(m, n) \
     (m) = PMIx_Geometry_create(n)
 
-#define PMIX_GEOMETRY_FREE(m, n) \
-    PMIx_Geometry_free(m, n)
+// free(m) is called inside PMIx_Geometry_free().
+#define PMIX_GEOMETRY_FREE(m, n)    \
+    do {                            \
+        PMIx_Geometry_free(m, n);   \
+        (m) = NULL;                 \
+    } while(0)
 
 #define PMIX_DEVICE_DIST_CONSTRUCT(m) \
     PMIx_Device_distance_construct(m)
@@ -748,8 +762,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DEVICE_DIST_CREATE(m, n) \
     (m) = PMIx_Device_distance_create(n)
 
-#define PMIX_DEVICE_DIST_FREE(m, n) \
-    PMIx_Device_distance_free(m, n)
+// free(m) is called inside PMIx_Device_distance_free().
+#define PMIX_DEVICE_DIST_FREE(m, n)      \
+    do {                                 \
+        PMIx_Device_distance_free(m, n); \
+        (m) = NULL;                      \
+    } while(0)
 
 #define PMIX_BYTE_OBJECT_CONSTRUCT(m) \
     PMIx_Byte_object_construct(m)
@@ -760,8 +778,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_BYTE_OBJECT_CREATE(m, n) \
     (m) = PMIx_Byte_object_create(n)
 
-#define PMIX_BYTE_OBJECT_FREE(m, n) \
-    PMIx_Byte_object_free(m, n)
+// free(m) is called inside PMIx_Byte_object_free().
+#define PMIX_BYTE_OBJECT_FREE(m, n)  \
+    do {                             \
+        PMIx_Byte_object_free(m, n); \
+        (m) = NULL;                  \
+    } while(0)
 
 #define PMIX_BYTE_OBJECT_LOAD(b, d, s)  \
     do {                                \
@@ -779,13 +801,17 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ENDPOINT_CREATE(m, n) \
     (m) = PMIx_Endpoint_create(n)
 
-#define PMIX_ENDPOINT_FREE(m, n) \
-    PMIx_Endpoint_free(m, n)
+// free(m) is called inside PMIx_Endpoint_free().
+#define PMIX_ENDPOINT_FREE(m, n)  \
+    do {                          \
+        PMIx_Endpoint_free(m, n); \
+        (m) = NULL;               \
+    } while(0)
 
 #define PMIX_ENVAR_CREATE(m, n) \
     (m) = PMIx_Envar_create(n)
 
-// free(m) is done inside PMIx_Envar_free().
+// free(m) is called inside PMIx_Envar_free().
 #define PMIX_ENVAR_FREE(m, n)   \
     do {                        \
         PMIx_Envar_free(m, n);  \
@@ -805,6 +831,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DATA_BUFFER_CREATE(m)  \
     (m) = PMIx_Data_buffer_create()
 
+// free(m) is NOT called inside PMIx_Data_buffer_release(), so do it here.
 #define PMIX_DATA_BUFFER_RELEASE(m)     \
     do {                                \
         PMIx_Data_buffer_release(m);    \
@@ -834,14 +861,14 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_PROC_DESTRUCT(m) \
     PMIx_Proc_destruct(m)
 
-// free(m) is done inside PMIx_Proc_free().
+// free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_FREE(m, n)    \
     do {                        \
         PMIx_Proc_free(m, n);   \
         (m) = NULL;             \
     } while (0)
 
-// free(m) is done inside PMIx_Proc_free().
+// free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_RELEASE(m)    \
 do {                            \
     PMIX_PROC_FREE(m, 1);       \
@@ -868,19 +895,20 @@ do {                            \
 #define PMIX_PROC_INFO_DESTRUCT(m) \
     PMIx_Proc_info_destruct(m)
 
+// TODO(skg) FIXME
 #define PMIX_PROC_INFO_FREE(m, n)   \
     do {                            \
         PMIx_Proc_info_free(m, n);  \
         pmix_free((m));             \
     } while (0)
 
+// TODO(skg) FIXME
 #define PMIX_PROC_INFO_RELEASE(m)   \
 do {                                \
     PMIX_PROC_INFO_FREE((m), 1)     \
     pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_PROC_STATS_CONSTRUCT(m) \
     PMIx_Proc_stats_construct(m)
@@ -891,20 +919,19 @@ do {                                \
 #define PMIX_PROC_STATS_CREATE(m, n) \
     (m) = PMIx_Proc_stats_create(n)
 
+// free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Proc_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_RELEASE(m)  \
 do {                                \
     PMIX_PROC_STATS_FREE((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_DISK_STATS_CONSTRUCT(m) \
     PMIx_Disk_stats_construct(m)
@@ -915,17 +942,17 @@ do {                                \
 #define PMIX_DISK_STATS_CREATE(m, n) \
     (m) = PMIx_Disk_stats_create(n)
 
+// free(m) is called inside PMIx_Disk_stats_free().
 #define PMIX_DISK_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Disk_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Disk_stats_free().
 #define PMIX_DISK_STATS_RELEASE(m)  \
 do {                                \
     PMIX_DISK_STATS_FREE((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
@@ -939,20 +966,18 @@ do {                                \
 #define PMIX_NET_STATS_CREATE(m, n) \
     (m) = PMIx_Net_stats_create(n)
 
+// free(m) is called inside PMIx_Net_stats_free().
 #define PMIX_NET_STATS_FREE(m, n)  \
 do {                               \
     PMIx_Net_stats_free(m, n);     \
-    pmix_free(m);                  \
     (m) = NULL;                    \
 } while(0)
 
 #define PMIX_NET_STATS_RELEASE(m)  \
 do {                               \
     PMIx_Net_stats_free((m), 1);   \
-    pmix_free(m);                  \
     (m) = NULL;                    \
 } while(0)
-
 
 #define PMIX_NODE_STATS_CONSTRUCT(m) \
     PMIx_Node_stats_construct(m)
@@ -963,20 +988,19 @@ do {                               \
 #define PMIX_NODE_STATS_CREATE(m, n) \
     (m) = PMIx_Node_stats_create(n)
 
+// free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Node_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_RELEASE(m)  \
 do {                                \
     PMIx_Node_stats_free((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_PDATA_CONSTRUCT(m) \
     PMIx_Pdata_construct(m)
@@ -987,20 +1011,19 @@ do {                                \
 #define PMIX_PDATA_CREATE(m, n) \
     (m) = PMIx_Pdata_create(n)
 
+// free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_FREE(m, n)   \
 do {                            \
     PMIx_Pdata_free(m, n);      \
-    pmix_free(m);               \
     (m) = NULL;                 \
 } while(0)
 
+// free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_RELEASE(m)   \
 do {                            \
     PMIx_Pdata_free((m), 1);    \
-    pmix_free(m);               \
     (m) = NULL;                 \
 } while(0)
-
 
 #define PMIX_APP_CONSTRUCT(m) \
     PMIx_App_construct(m)
@@ -1014,6 +1037,7 @@ do {                            \
 #define PMIX_APP_INFO_CREATE(m, n) \
     PMIx_App_info_create(m, n)
 
+// free(m) is NOT called inside PMIx_App_destruct(), so do it here.
 #define PMIX_APP_RELEASE(m)     \
     do {                        \
         PMIx_App_destruct((m)); \
@@ -1021,13 +1045,12 @@ do {                            \
         (m) = NULL;             \
     } while (0)
 
+// free(m) is called inside PMIx_App_free().
 #define PMIX_APP_FREE(m, n)     \
     do {                        \
         PMIx_App_free(m, n);    \
-        pmix_free(m);           \
         (m) = NULL;             \
     } while (0)
-
 
 #define PMIX_QUERY_CONSTRUCT(m) \
     PMIx_Query_construct(m)
@@ -1041,20 +1064,19 @@ do {                            \
 #define PMIX_QUERY_QUALIFIERS_CREATE(m, n) \
     PMIx_Query_qualifiers_create(m, n)
 
+// free(m) is called inside PMIx_Query_release().
 #define PMIX_QUERY_RELEASE(m)       \
     do {                            \
         PMIx_Query_release((m));    \
-        pmix_free((m));             \
         (m) = NULL;                 \
     } while (0)
 
+// free(m) is called inside PMIx_Query_free().
 #define PMIX_QUERY_FREE(m, n)   \
     do {                        \
         PMIx_Query_free(m, n);  \
-        pmix_free((m));         \
         (m) = NULL;             \
     } while (0)
-
 
 #define PMIX_REGATTR_CONSTRUCT(a) \
     PMIx_Regattr_construct(a)
@@ -1068,16 +1090,15 @@ do {                            \
 #define PMIX_REGATTR_CREATE(m, n) \
     (m)= PMIx_Regattr_create(n)
 
+// free(m) is called inside PMIx_Regattr_free().
 #define PMIX_REGATTR_FREE(m, n)     \
     do {                            \
         PMIx_Regattr_free(m, n);    \
-        pmix_free((m));             \
         (m) = NULL;                 \
     } while (0)
 
 #define PMIX_REGATTR_XFER(a, b) \
     PMIx_Regattr_xfer(a, b)
-
 
 #define PMIX_DATA_ARRAY_INIT(m, t) \
     PMIx_Data_array_init(m, t)
@@ -1091,7 +1112,7 @@ do {                            \
 #define PMIX_DATA_ARRAY_CREATE(m, n, t) \
     (m) = PMIx_Data_array_create(n, t)
 
-// free(m) is done inside PMIx_Coord_free().
+// free(m) is called inside PMIx_Data_array_free().
 #define PMIX_DATA_ARRAY_FREE(m)     \
     do {                            \
         PMIx_Data_array_free(m);    \

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -459,11 +459,11 @@ pmix_bfrops_base_tma_proc_info_free(
     size_t n,
     pmix_tma_t *tma
 ) {
-    if (NULL == p) {
-        return;
-    }
-    for (size_t m = 0; m < n; m++) {
-        pmix_bfrops_base_tma_proc_info_destruct(&p[m], tma);
+    if (NULL != p) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_proc_info_destruct(&p[m], tma);
+        }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -2200,6 +2200,7 @@ pmix_bfrops_base_tma_data_buffer_release(
 ) {
     if (NULL != b) {
         pmix_bfrops_base_tma_data_buffer_destruct(b, tma);
+        pmix_tma_free(tma, b);
     }
 }
 
@@ -3711,7 +3712,6 @@ pmix_bfrops_base_tma_data_array_destruct(
         }
         case PMIX_PROC_INFO:
             pmix_bfrops_base_tma_proc_info_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_DATA_ARRAY:
             pmix_bfrops_base_tma_data_array_destruct(d->array, tma);

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -27,9 +27,6 @@
  * If tma is NULL, then the default heap manager is used.
  */
 
-// TODO(skg) pmix_bfrops_base_tma_info_free paths
-// need work on this side and prrte's.
-
 #ifndef PMIX_BFROP_BASE_TMA_H
 #define PMIX_BFROP_BASE_TMA_H
 
@@ -624,6 +621,7 @@ pmix_bfrops_base_tma_info_destruct(
     }
 }
 
+// TODO(skg) FIXME.
 static inline void
 pmix_bfrops_base_tma_info_free(
     pmix_info_t *p,
@@ -1129,11 +1127,11 @@ pmix_bfrops_base_tma_geometry_free(
     size_t n,
     pmix_tma_t *tma
 ) {
-    if (NULL == g) {
-        return;
-    }
-    for (size_t m = 0; m < n; m++) {
-        pmix_bfrops_base_tma_geometry_destruct(&g[m], tma);
+    if (NULL != g) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_geometry_destruct(&g[m], tma);
+        }
+        pmix_tma_free(tma, g);
     }
 }
 
@@ -1322,11 +1320,11 @@ pmix_bfrops_base_tma_byte_object_free(
     size_t n,
     pmix_tma_t *tma
 ) {
-    if (NULL == b) {
-        return;
-    }
-    for (size_t m = 0; m < n; m++) {
-        pmix_bfrops_base_tma_byte_object_destruct(&b[m], tma);
+    if (NULL != b) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_byte_object_destruct(&b[m], tma);
+        }
+        pmix_tma_free(tma, b);
     }
 }
 
@@ -1362,11 +1360,11 @@ pmix_bfrops_base_tma_endpoint_free(
     size_t n,
     pmix_tma_t *tma
 ) {
-    if (NULL == e) {
-        return;
-    }
-    for (size_t m = 0; m < n; m++) {
-        pmix_bfrops_base_tma_endpoint_destruct(&e[m], tma);
+    if (NULL != e) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_endpoint_destruct(&e[m], tma);
+        }
+        pmix_tma_free(tma, e);
     }
 }
 
@@ -1551,13 +1549,12 @@ pmix_bfrops_base_tma_argv_free(
     char **argv,
     pmix_tma_t *tma
 ) {
-    if (NULL == argv) {
-        return;
+    if (NULL != argv) {
+        for (char **p = argv; NULL != *p; ++p) {
+            pmix_tma_free(tma, *p);
+        }
+        pmix_tma_free(tma, argv);
     }
-    for (char **p = argv; NULL != *p; ++p) {
-        pmix_tma_free(tma, *p);
-    }
-    pmix_tma_free(tma, argv);
 }
 
 static inline char **
@@ -1746,6 +1743,7 @@ pmix_bfrops_base_tma_query_destruct(
 ) {
     if (NULL != p->keys) {
         pmix_bfrops_base_tma_argv_free(p->keys, tma);
+        p->keys = NULL;
     }
     if (NULL != p->qualifiers) {
         pmix_bfrops_base_tma_info_free(p->qualifiers, p->nqual, tma);
@@ -1765,6 +1763,7 @@ pmix_bfrops_base_tma_query_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_query_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -1839,6 +1838,7 @@ pmix_bfrops_base_tma_pdata_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_pdata_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -1917,6 +1917,7 @@ pmix_bfrops_base_tma_app_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_app_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -1973,9 +1974,11 @@ pmix_bfrops_base_tma_regattr_destruct(
     if (NULL != p) {
         if (NULL != p->name) {
             pmix_tma_free(tma, p->name);
+            p->name = NULL;
         }
         if (NULL != p->description) {
             pmix_bfrops_base_tma_argv_free(p->description, tma);
+            p->description = NULL;
         }
     }
 }
@@ -1990,6 +1993,7 @@ pmix_bfrops_base_tma_regattr_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_regattr_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -2194,10 +2198,9 @@ pmix_bfrops_base_tma_data_buffer_release(
     pmix_data_buffer_t *b,
     pmix_tma_t *tma
 ) {
-    if (NULL == b) {
-        return;
+    if (NULL != b) {
+        pmix_bfrops_base_tma_data_buffer_destruct(b, tma);
     }
-    pmix_bfrops_base_tma_data_buffer_destruct(b, tma);
 }
 
 static inline pmix_status_t
@@ -2224,11 +2227,11 @@ pmix_bfrops_base_tma_value_free(
     size_t n,
     pmix_tma_t *tma
 ) {
-    if (NULL == v) {
-        return;
-    }
-    for (size_t m = 0; m < n; m++) {
-        pmix_bfrops_base_tma_value_destruct(&v[m], tma);
+    if (NULL != v) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_value_destruct(&v[m], tma);
+        }
+        pmix_tma_free(tma, v);
     }
 }
 
@@ -2393,6 +2396,7 @@ pmix_bfrops_base_tma_proc_stats_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_proc_stats_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -2490,6 +2494,7 @@ pmix_bfrops_base_tma_disk_stats_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_disk_stats_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -2564,6 +2569,7 @@ pmix_bfrops_base_tma_net_stats_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_net_stats_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -2640,9 +2646,13 @@ pmix_bfrops_base_tma_node_stats_destruct(
     }
     if (NULL != p->diskstats) {
         pmix_bfrops_base_tma_disk_stats_free(p->diskstats, p->ndiskstats, tma);
+        p->diskstats = NULL;
+        p->ndiskstats = 0;
     }
     if (NULL != p->netstats) {
         pmix_bfrops_base_tma_net_stats_free(p->netstats, p->nnetstats, tma);
+        p->netstats = NULL;
+        p->nnetstats = 0;
     }
 }
 
@@ -2673,6 +2683,7 @@ pmix_bfrops_base_tma_node_stats_free(
         for (size_t m = 0; m < n; m++) {
             pmix_bfrops_base_tma_node_stats_destruct(&p[m], tma);
         }
+        pmix_tma_free(tma, p);
     }
 }
 
@@ -3657,7 +3668,6 @@ pmix_bfrops_base_tma_data_array_destruct(
             break;
         case PMIX_APP:
             pmix_bfrops_base_tma_app_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_INFO:
             pmix_bfrops_base_tma_info_free(d->array, d->size, tma);
@@ -3665,7 +3675,6 @@ pmix_bfrops_base_tma_data_array_destruct(
             break;
         case PMIX_PDATA:
             pmix_bfrops_base_tma_pdata_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_BUFFER: {
             pmix_buffer_t *const pb = (pmix_buffer_t *)d->array;
@@ -3709,7 +3718,6 @@ pmix_bfrops_base_tma_data_array_destruct(
             break;
         case PMIX_QUERY:
             pmix_bfrops_base_tma_query_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_ENVAR:
             pmix_bfrops_base_tma_envar_free(d->array, d->size, tma);
@@ -3719,7 +3727,6 @@ pmix_bfrops_base_tma_data_array_destruct(
             break;
         case PMIX_REGATTR:
             pmix_bfrops_base_tma_regattr_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_PROC_CPUSET:
             // TODO(skg) Add TMA support when necessary.
@@ -3750,6 +3757,7 @@ pmix_bfrops_base_tma_data_array_destruct(
             break;
         }
         case PMIX_DATA_BUFFER: {
+            // TODO(skg) This needs work. Can maybe just call free?
             pmix_data_buffer_t *const db = (pmix_data_buffer_t *)d->array;
             for (size_t n = 0; n < d->size; n++) {
                 pmix_bfrops_base_tma_data_buffer_destruct(&db[n], tma);
@@ -3759,19 +3767,15 @@ pmix_bfrops_base_tma_data_array_destruct(
         }
         case PMIX_PROC_STATS:
             pmix_bfrops_base_tma_proc_stats_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_DISK_STATS:
             pmix_bfrops_base_tma_disk_stats_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_NET_STATS:
             pmix_bfrops_base_tma_net_stats_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         case PMIX_NODE_STATS:
             pmix_bfrops_base_tma_node_stats_free(d->array, d->size, tma);
-            pmix_tma_free(tma, d->array);
             break;
         default:
             if (NULL != d->array) {
@@ -4070,28 +4074,24 @@ pmix_bfrops_base_tma_value_destruct(
         case PMIX_PROC_STATS:
             if (NULL != v->data.pstats) {
                 pmix_bfrops_base_tma_proc_stats_free(v->data.pstats, 1, tma);
-                pmix_tma_free(tma, v->data.pstats);
                 v->data.pstats = NULL;
             }
             break;
         case PMIX_DISK_STATS:
             if (NULL != v->data.dkstats) {
                 pmix_bfrops_base_tma_disk_stats_free(v->data.dkstats, 1, tma);
-                pmix_tma_free(tma, v->data.dkstats);
                 v->data.dkstats = NULL;
             }
             break;
         case PMIX_NET_STATS:
             if (NULL != v->data.netstats) {
                 pmix_bfrops_base_tma_net_stats_free(v->data.netstats, 1, tma);
-                pmix_tma_free(tma, v->data.netstats);
                 v->data.netstats = NULL;
             }
             break;
         case PMIX_NODE_STATS:
             if (NULL != v->data.ndstats) {
                 pmix_bfrops_base_tma_node_stats_free(v->data.ndstats, 1, tma);
-                pmix_tma_free(tma, v->data.ndstats);
                 v->data.ndstats = NULL;
             }
             break;


### PR DESCRIPTION
Convert the majority of PMIX_*_FREE() macros by moving (or adding) the frees into the underlying function calls. Also NULLify the incoming pointers after freeing the base pointers where appropriate.

More to come, but the marked FIXME locations need more thought.