### PR TITLE
Multiple commits

### DIFF
--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Redistribution and use in source and binary forms, with or without
@@ -695,7 +696,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_TOPOLOGY_FREE(m, n) \
     PMIx_Topology_free(m, n)
 
-
 #define PMIX_COORD_CREATE(m, n, d)  \
     (m) = PMIx_Coord_create(d, n)
 
@@ -705,10 +705,10 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_COORD_DESTRUCT(m)  \
     PMIx_Coord_destruct(m)
 
+// free(m) is done inside PMIx_Coord_free().
 #define PMIX_COORD_FREE(m, n)   \
     do {                        \
         PMIx_Coord_free(m, n);  \
-        free((m));              \
         (m) = NULL;             \
     } while(0)
 
@@ -782,10 +782,10 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ENVAR_CREATE(m, n) \
     (m) = PMIx_Envar_create(n)
 
+// free(m) is done inside PMIx_Envar_free().
 #define PMIX_ENVAR_FREE(m, n)   \
     do {                        \
         PMIx_Envar_free(m, n);  \
-        pmix_free(m);           \
         (m) = NULL;             \
     } while(0)
 
@@ -831,19 +831,17 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_PROC_DESTRUCT(m) \
     PMIx_Proc_destruct(m)
 
+// free(m) is done inside PMIx_Proc_free().
 #define PMIX_PROC_FREE(m, n)    \
     do {                        \
         PMIx_Proc_free(m, n);   \
-        if (NULL != (m)) {      \
-            pmix_free((m));     \
-            (m) = NULL;         \
-        }                       \
+        (m) = NULL;             \
     } while (0)
 
+// free(m) is done inside PMIx_Proc_free().
 #define PMIX_PROC_RELEASE(m)    \
 do {                            \
     PMIX_PROC_FREE(m, 1);       \
-    pmix_free(m);               \
     (m) = NULL;                 \
 } while(0)
 
@@ -1093,7 +1091,6 @@ do {                            \
 #define PMIX_DATA_ARRAY_FREE(m)     \
     do {                            \
         PMIx_Data_array_free(m);    \
-        pmix_free((m));             \
         (m) = NULL;                 \
     } while(0)
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -587,7 +587,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_VALUE_XFER_DIRECT(r, v, s)     \
     (r) = PMIx_Value_xfer((v), (s))
 
-
 #define PMIX_INFO_CONSTRUCT(m) \
     PMIx_Info_construct(m)
 
@@ -597,26 +596,28 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_INFO_CREATE(m, n) \
     (m) = PMIx_Info_create(n)
 
-// TODO(skg) FIXME
-#define PMIX_INFO_FREE(m, n)    \
-    do {                        \
-        PMIx_Info_free(m, n);   \
-        pmix_free((m));         \
-        (m) = NULL;             \
+// free(m) is called inside PMIx_Info_free().
+#define PMIX_INFO_FREE(m, n)  \
+    do {                      \
+        PMIx_Info_free(m, n); \
+        (m) = NULL;           \
     } while (0)
 
 #define PMIX_INFO_REQUIRED(m) \
     PMIx_Info_required(m)
+
 #define PMIX_INFO_OPTIONAL(m) \
     PMIx_Info_optional(m)
 
 #define PMIX_INFO_IS_REQUIRED(m) \
     PMIx_Info_is_required(m)
+
 #define PMIX_INFO_IS_OPTIONAL(m) \
     PMIx_Info_is_optional(m)
 
 #define PMIX_INFO_PROCESSED(m)  \
     PMIx_Info_processed(m)
+
 #define PMIX_INFO_WAS_PROCESSED(m)  \
     PMIx_Info_was_processed(m)
 
@@ -627,11 +628,13 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 
 #define PMIX_INFO_SET_QUALIFIER(i)   \
     PMIx_Info_qualifier(i)
+
 #define PMIX_INFO_IS_QUALIFIER(i)    \
     PMIx_Info_is_qualifier(i)
 
 #define PMIX_INFO_SET_PERSISTENT(ii) \
     PMIx_Info_persistent(ii)
+
 #define PMIX_INFO_IS_PERSISTENT(ii)  \
     PMIx_Info_is_persistent(ii)
 
@@ -640,7 +643,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 
 #define PMIX_INFO_XFER(d, s)    \
     (void) PMIx_Info_xfer(d, s)
-
 
 #define PMIX_PDATA_LOAD(m, p, k, v, t)                                      \
     do {                                                                    \
@@ -826,7 +828,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ENVAR_LOAD(m, e, v, s) \
     PMIx_Envar_load(m, e, v, s)
 
-
 #define PMIX_DATA_BUFFER_CREATE(m)  \
     (m) = PMIx_Data_buffer_create()
 
@@ -848,7 +849,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 
 #define PMIX_DATA_BUFFER_UNLOAD(b, d, s)    \
     PMIx_Data_buffer_unload(b, &(d), &(s))
-
 
 #define PMIX_PROC_CREATE(m, n) \
     (m) = PMIx_Proc_create(n)
@@ -881,7 +881,6 @@ do {                            \
 
 #define PMIX_MULTICLUSTER_NSPACE_PARSE(t, c, n) \
     PMIx_Multicluster_nspace_parse(t, c, n)
-
 
 #define PMIX_PROC_INFO_CREATE(m, n) \
     (m) = PMIx_Proc_info_create(n)

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -544,12 +544,11 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_VALUE_CREATE(m, n) \
     (m) = PMIx_Value_create(n)
 
-// free(m) is NOT called inside PMIx_Value_destruct(), so do it here.
-#define PMIX_VALUE_RELEASE(m)       \
-    do {                            \
-        PMIx_Value_destruct((m));   \
-        pmix_free((m));             \
-        (m) = NULL;                 \
+// free(m) is called inside PMIx_Value_free().
+#define PMIX_VALUE_RELEASE(m)  \
+    do {                       \
+        PMIx_Value_free(m, 1); \
+        (m) = NULL;            \
     } while (0)
 
 // free(m) is called inside PMIx_Value_free().
@@ -831,12 +830,11 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DATA_BUFFER_CREATE(m)  \
     (m) = PMIx_Data_buffer_create()
 
-// free(m) is NOT called inside PMIx_Data_buffer_release(), so do it here.
-#define PMIX_DATA_BUFFER_RELEASE(m)     \
-    do {                                \
-        PMIx_Data_buffer_release(m);    \
-        pmix_free((m));                 \
-        (m) = NULL;                     \
+// free(m) is called inside PMIx_Data_buffer_release().
+#define PMIX_DATA_BUFFER_RELEASE(m)  \
+    do {                             \
+        PMIx_Data_buffer_release(m); \
+        (m) = NULL;                  \
     } while (0)
 
 #define PMIX_DATA_BUFFER_CONSTRUCT(m)       \
@@ -871,10 +869,9 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 // free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_RELEASE(m)    \
 do {                            \
-    PMIX_PROC_FREE(m, 1);       \
+    PMIx_Proc_free(m, 1);       \
     (m) = NULL;                 \
 } while(0)
-
 
 #define PMIX_PROC_LOAD(m, n, r) \
     PMIx_Proc_load(m, n, r)
@@ -895,18 +892,17 @@ do {                            \
 #define PMIX_PROC_INFO_DESTRUCT(m) \
     PMIx_Proc_info_destruct(m)
 
-// TODO(skg) FIXME
-#define PMIX_PROC_INFO_FREE(m, n)   \
-    do {                            \
-        PMIx_Proc_info_free(m, n);  \
-        pmix_free((m));             \
+// free(m) is called inside PMIx_Proc_info_free().
+#define PMIX_PROC_INFO_FREE(m, n)  \
+    do {                           \
+        PMIx_Proc_info_free(m, n); \
+        (m) = NULL;                \
     } while (0)
 
-// TODO(skg) FIXME
+// free(m) is called inside PMIx_Proc_info_free().
 #define PMIX_PROC_INFO_RELEASE(m)   \
 do {                                \
-    PMIX_PROC_INFO_FREE((m), 1)     \
-    pmix_free(m);                   \
+    PMIx_Proc_info_free(m, 1)       \
     (m) = NULL;                     \
 } while(0)
 
@@ -929,7 +925,7 @@ do {                                \
 // free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_RELEASE(m)  \
 do {                                \
-    PMIX_PROC_STATS_FREE((m), 1);   \
+    PMIx_Proc_stats_free(m, 1);     \
     (m) = NULL;                     \
 } while(0)
 
@@ -950,12 +946,11 @@ do {                                \
 } while(0)
 
 // free(m) is called inside PMIx_Disk_stats_free().
-#define PMIX_DISK_STATS_RELEASE(m)  \
-do {                                \
-    PMIX_DISK_STATS_FREE((m), 1);   \
-    (m) = NULL;                     \
+#define PMIX_DISK_STATS_RELEASE(m) \
+do {                               \
+    PMIx_Disk_stats_free(m, 1);    \
+    (m) = NULL;                    \
 } while(0)
-
 
 #define PMIX_NET_STATS_CONSTRUCT(m) \
     PMIx_Net_stats_construct(m)
@@ -975,7 +970,7 @@ do {                               \
 
 #define PMIX_NET_STATS_RELEASE(m)  \
 do {                               \
-    PMIx_Net_stats_free((m), 1);   \
+    PMIx_Net_stats_free(m, 1);     \
     (m) = NULL;                    \
 } while(0)
 
@@ -998,7 +993,7 @@ do {                                \
 // free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_RELEASE(m)  \
 do {                                \
-    PMIx_Node_stats_free((m), 1);   \
+    PMIx_Node_stats_free(m, 1);     \
     (m) = NULL;                     \
 } while(0)
 
@@ -1021,7 +1016,7 @@ do {                            \
 // free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_RELEASE(m)   \
 do {                            \
-    PMIx_Pdata_free((m), 1);    \
+    PMIx_Pdata_free(m, 1);      \
     (m) = NULL;                 \
 } while(0)
 
@@ -1037,11 +1032,10 @@ do {                            \
 #define PMIX_APP_INFO_CREATE(m, n) \
     PMIx_App_info_create(m, n)
 
-// free(m) is NOT called inside PMIx_App_destruct(), so do it here.
+// free(m) is called inside PMIx_App_free().
 #define PMIX_APP_RELEASE(m)     \
     do {                        \
-        PMIx_App_destruct((m)); \
-        pmix_free((m));         \
+        PMIx_App_free(m, 1);    \
         (m) = NULL;             \
     } while (0)
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1111,6 +1111,40 @@ do {                            \
         PMIx_Data_array_free(m);    \
         (m) = NULL;                 \
     } while(0)
+
+
+// functions that are no longer visible from inside
+// the PMIx library
+
+#define pmix_argv_append_nosize(a, b) \
+    PMIx_Argv_append_nosize(a, b)
+
+#define pmix_argv_append_unique_nosize(a, b) \
+    PMIx_Argv_append_unique_nosize(a, b)
+
+#define pmix_argv_split(a, b) \
+    PMIx_Argv_split(a, b)
+
+#define pmix_argv_split_with_empty(a, b) \
+    PMIx_Argv_split_with_empty(a, b)
+
+#define pmix_argv_free(a) \
+    PMIx_Argv_free(a)
+
+#define pmix_argv_count(a) \
+    PMIx_Argv_count(a)
+
+#define pmix_argv_join(a, b) \
+    PMIx_Argv_join(a, b)
+
+#define pmix_argv_prepend_nosize(a, b) \
+    PMIx_Argv_prepend_nosize(a, b)
+
+#define pmix_argv_copy(a) \
+    PMIx_Argv_copy(a)
+
+#define pmix_setenv(a, b, c, d) \
+    PMIx_Setenv(a, b, c, d)
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -216,7 +216,7 @@ PMIX_EXPORT bool PMIx_Check_reserved_key(const char *key);
 PMIX_EXPORT void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str);
 PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
-PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p, 
+PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p,
                                   const char *ns,
                                   pmix_rank_t rk);
 PMIX_EXPORT void PMIx_Xfer_procid(pmix_proc_t *dst,
@@ -516,8 +516,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ARGV_APPEND_UNIQUE(r, a, b) \
     (r) = PMIx_Argv_append_unique_nosize(a, b)
 
-#define PMIX_ARGV_FREE(a)  \
-    PMIx_Argv_free(a)
+// free(a) is called inside PMIx_Argv_free().
+#define PMIX_ARGV_FREE(a)    \
+    do {                     \
+        PMIx_Argv_free((a)); \
+        (a) = NULL;          \
+    } while (0)
 
 #define PMIX_ARGV_SPLIT(a, b, c) \
     (a) = PMIx_Argv_split(b, c)
@@ -531,7 +535,6 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_SETENV(r, a, b, c) \
     (r) = PMIx_Setenv((a), (b), true, (c))
 
-
 #define PMIX_VALUE_CONSTRUCT(m) \
     PMIx_Value_construct(m)
 
@@ -541,6 +544,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_VALUE_CREATE(m, n) \
     (m) = PMIx_Value_create(n)
 
+// free(m) is NOT called inside PMIx_Value_destruct(), so do it here.
 #define PMIX_VALUE_RELEASE(m)       \
     do {                            \
         PMIx_Value_destruct((m));   \
@@ -548,10 +552,10 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
         (m) = NULL;                 \
     } while (0)
 
+// free(m) is called inside PMIx_Value_free().
 #define PMIX_VALUE_FREE(m, n)   \
     do {                        \
         PMIx_Value_free(m, n);  \
-        pmix_free((m));         \
         (m) = NULL;             \
     } while (0)
 
@@ -594,6 +598,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_INFO_CREATE(m, n) \
     (m) = PMIx_Info_create(n)
 
+// TODO(skg) FIXME
 #define PMIX_INFO_FREE(m, n)    \
     do {                        \
         PMIx_Info_free(m, n);   \
@@ -693,8 +698,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_TOPOLOGY_DESTRUCT(x) \
     PMIx_Topology_destruct(x)
 
-#define PMIX_TOPOLOGY_FREE(m, n) \
-    PMIx_Topology_free(m, n)
+// free(m) is called inside PMIx_Topology_free().
+#define PMIX_TOPOLOGY_FREE(m, n)  \
+    do {                          \
+        PMIx_Topology_free(m, n); \
+        (m) = NULL;               \
+    while (0)
 
 #define PMIX_COORD_CREATE(m, n, d)  \
     (m) = PMIx_Coord_create(d, n)
@@ -705,7 +714,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_COORD_DESTRUCT(m)  \
     PMIx_Coord_destruct(m)
 
-// free(m) is done inside PMIx_Coord_free().
+// free(m) is called inside PMIx_Coord_free().
 #define PMIX_COORD_FREE(m, n)   \
     do {                        \
         PMIx_Coord_free(m, n);  \
@@ -721,8 +730,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_CPUSET_CREATE(m, n) \
     (m) = PMIx_Cpuset_create(n)
 
-#define PMIX_CPUSET_FREE(m, n) \
-    PMIx_Cpuset_free(m, n)
+// free(m) is called inside PMIx_Cpuset_free().
+#define PMIX_CPUSET_FREE(m, n)    \
+    do {                          \
+        PMIx_Cpuset_free(m, n);   \
+        (m) = NULL;               \
+    } while(0)
 
 #define PMIX_GEOMETRY_CONSTRUCT(m) \
     PMIx_Geometry_construct(m)
@@ -733,8 +746,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_GEOMETRY_CREATE(m, n) \
     (m) = PMIx_Geometry_create(n)
 
-#define PMIX_GEOMETRY_FREE(m, n) \
-    PMIx_Geometry_free(m, n)
+// free(m) is called inside PMIx_Geometry_free().
+#define PMIX_GEOMETRY_FREE(m, n)    \
+    do {                            \
+        PMIx_Geometry_free(m, n);   \
+        (m) = NULL;                 \
+    } while(0)
 
 #define PMIX_DEVICE_DIST_CONSTRUCT(m) \
     PMIx_Device_distance_construct(m)
@@ -745,8 +762,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DEVICE_DIST_CREATE(m, n) \
     (m) = PMIx_Device_distance_create(n)
 
-#define PMIX_DEVICE_DIST_FREE(m, n) \
-    PMIx_Device_distance_free(m, n)
+// free(m) is called inside PMIx_Device_distance_free().
+#define PMIX_DEVICE_DIST_FREE(m, n)      \
+    do {                                 \
+        PMIx_Device_distance_free(m, n); \
+        (m) = NULL;                      \
+    } while(0)
 
 #define PMIX_BYTE_OBJECT_CONSTRUCT(m) \
     PMIx_Byte_object_construct(m)
@@ -757,8 +778,12 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_BYTE_OBJECT_CREATE(m, n) \
     (m) = PMIx_Byte_object_create(n)
 
-#define PMIX_BYTE_OBJECT_FREE(m, n) \
-    PMIx_Byte_object_free(m, n)
+// free(m) is called inside PMIx_Byte_object_free().
+#define PMIX_BYTE_OBJECT_FREE(m, n)  \
+    do {                             \
+        PMIx_Byte_object_free(m, n); \
+        (m) = NULL;                  \
+    } while(0)
 
 #define PMIX_BYTE_OBJECT_LOAD(b, d, s)  \
     do {                                \
@@ -776,13 +801,17 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_ENDPOINT_CREATE(m, n) \
     (m) = PMIx_Endpoint_create(n)
 
-#define PMIX_ENDPOINT_FREE(m, n) \
-    PMIx_Endpoint_free(m, n)
+// free(m) is called inside PMIx_Endpoint_free().
+#define PMIX_ENDPOINT_FREE(m, n)  \
+    do {                          \
+        PMIx_Endpoint_free(m, n); \
+        (m) = NULL;               \
+    } while(0)
 
 #define PMIX_ENVAR_CREATE(m, n) \
     (m) = PMIx_Envar_create(n)
 
-// free(m) is done inside PMIx_Envar_free().
+// free(m) is called inside PMIx_Envar_free().
 #define PMIX_ENVAR_FREE(m, n)   \
     do {                        \
         PMIx_Envar_free(m, n);  \
@@ -802,6 +831,7 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DATA_BUFFER_CREATE(m)  \
     (m) = PMIx_Data_buffer_create()
 
+// free(m) is NOT called inside PMIx_Data_buffer_release(), so do it here.
 #define PMIX_DATA_BUFFER_RELEASE(m)     \
     do {                                \
         PMIx_Data_buffer_release(m);    \
@@ -831,14 +861,14 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_PROC_DESTRUCT(m) \
     PMIx_Proc_destruct(m)
 
-// free(m) is done inside PMIx_Proc_free().
+// free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_FREE(m, n)    \
     do {                        \
         PMIx_Proc_free(m, n);   \
         (m) = NULL;             \
     } while (0)
 
-// free(m) is done inside PMIx_Proc_free().
+// free(m) is called inside PMIx_Proc_free().
 #define PMIX_PROC_RELEASE(m)    \
 do {                            \
     PMIX_PROC_FREE(m, 1);       \
@@ -865,19 +895,20 @@ do {                            \
 #define PMIX_PROC_INFO_DESTRUCT(m) \
     PMIx_Proc_info_destruct(m)
 
+// TODO(skg) FIXME
 #define PMIX_PROC_INFO_FREE(m, n)   \
     do {                            \
         PMIx_Proc_info_free(m, n);  \
         pmix_free((m));             \
     } while (0)
 
+// TODO(skg) FIXME
 #define PMIX_PROC_INFO_RELEASE(m)   \
 do {                                \
     PMIX_PROC_INFO_FREE((m), 1)     \
     pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_PROC_STATS_CONSTRUCT(m) \
     PMIx_Proc_stats_construct(m)
@@ -888,20 +919,19 @@ do {                                \
 #define PMIX_PROC_STATS_CREATE(m, n) \
     (m) = PMIx_Proc_stats_create(n)
 
+// free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Proc_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Proc_stats_free().
 #define PMIX_PROC_STATS_RELEASE(m)  \
 do {                                \
     PMIX_PROC_STATS_FREE((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_DISK_STATS_CONSTRUCT(m) \
     PMIx_Disk_stats_construct(m)
@@ -912,17 +942,17 @@ do {                                \
 #define PMIX_DISK_STATS_CREATE(m, n) \
     (m) = PMIx_Disk_stats_create(n)
 
+// free(m) is called inside PMIx_Disk_stats_free().
 #define PMIX_DISK_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Disk_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Disk_stats_free().
 #define PMIX_DISK_STATS_RELEASE(m)  \
 do {                                \
     PMIX_DISK_STATS_FREE((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
@@ -936,20 +966,18 @@ do {                                \
 #define PMIX_NET_STATS_CREATE(m, n) \
     (m) = PMIx_Net_stats_create(n)
 
+// free(m) is called inside PMIx_Net_stats_free().
 #define PMIX_NET_STATS_FREE(m, n)  \
 do {                               \
     PMIx_Net_stats_free(m, n);     \
-    pmix_free(m);                  \
     (m) = NULL;                    \
 } while(0)
 
 #define PMIX_NET_STATS_RELEASE(m)  \
 do {                               \
     PMIx_Net_stats_free((m), 1);   \
-    pmix_free(m);                  \
     (m) = NULL;                    \
 } while(0)
-
 
 #define PMIX_NODE_STATS_CONSTRUCT(m) \
     PMIx_Node_stats_construct(m)
@@ -960,20 +988,19 @@ do {                               \
 #define PMIX_NODE_STATS_CREATE(m, n) \
     (m) = PMIx_Node_stats_create(n)
 
+// free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_FREE(m, n)  \
 do {                                \
     PMIx_Node_stats_free(m, n);     \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
 
+// free(m) is called inside PMIx_Node_stats_free().
 #define PMIX_NODE_STATS_RELEASE(m)  \
 do {                                \
     PMIx_Node_stats_free((m), 1);   \
-    pmix_free(m);                   \
     (m) = NULL;                     \
 } while(0)
-
 
 #define PMIX_PDATA_CONSTRUCT(m) \
     PMIx_Pdata_construct(m)
@@ -984,20 +1011,19 @@ do {                                \
 #define PMIX_PDATA_CREATE(m, n) \
     (m) = PMIx_Pdata_create(n)
 
+// free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_FREE(m, n)   \
 do {                            \
     PMIx_Pdata_free(m, n);      \
-    pmix_free(m);               \
     (m) = NULL;                 \
 } while(0)
 
+// free(m) is called inside PMIx_Pdata_free().
 #define PMIX_PDATA_RELEASE(m)   \
 do {                            \
     PMIx_Pdata_free((m), 1);    \
-    pmix_free(m);               \
     (m) = NULL;                 \
 } while(0)
-
 
 #define PMIX_APP_CONSTRUCT(m) \
     PMIx_App_construct(m)
@@ -1011,6 +1037,7 @@ do {                            \
 #define PMIX_APP_INFO_CREATE(m, n) \
     PMIx_App_info_create(m, n)
 
+// free(m) is NOT called inside PMIx_App_destruct(), so do it here.
 #define PMIX_APP_RELEASE(m)     \
     do {                        \
         PMIx_App_destruct((m)); \
@@ -1018,13 +1045,12 @@ do {                            \
         (m) = NULL;             \
     } while (0)
 
+// free(m) is called inside PMIx_App_free().
 #define PMIX_APP_FREE(m, n)     \
     do {                        \
         PMIx_App_free(m, n);    \
-        pmix_free(m);           \
         (m) = NULL;             \
     } while (0)
-
 
 #define PMIX_QUERY_CONSTRUCT(m) \
     PMIx_Query_construct(m)
@@ -1038,20 +1064,19 @@ do {                            \
 #define PMIX_QUERY_QUALIFIERS_CREATE(m, n) \
     PMIx_Query_qualifiers_create(m, n)
 
+// free(m) is called inside PMIx_Query_release().
 #define PMIX_QUERY_RELEASE(m)       \
     do {                            \
         PMIx_Query_release((m));    \
-        pmix_free((m));             \
         (m) = NULL;                 \
     } while (0)
 
+// free(m) is called inside PMIx_Query_free().
 #define PMIX_QUERY_FREE(m, n)   \
     do {                        \
         PMIx_Query_free(m, n);  \
-        pmix_free((m));         \
         (m) = NULL;             \
     } while (0)
-
 
 #define PMIX_REGATTR_CONSTRUCT(a) \
     PMIx_Regattr_construct(a)
@@ -1065,16 +1090,15 @@ do {                            \
 #define PMIX_REGATTR_CREATE(m, n) \
     (m)= PMIx_Regattr_create(n)
 
+// free(m) is called inside PMIx_Regattr_free().
 #define PMIX_REGATTR_FREE(m, n)     \
     do {                            \
         PMIx_Regattr_free(m, n);    \
-        pmix_free((m));             \
         (m) = NULL;                 \
     } while (0)
 
 #define PMIX_REGATTR_XFER(a, b) \
     PMIx_Regattr_xfer(a, b)
-
 
 #define PMIX_DATA_ARRAY_INIT(m, t) \
     PMIx_Data_array_init(m, t)
@@ -1088,6 +1112,7 @@ do {                            \
 #define PMIX_DATA_ARRAY_CREATE(m, n, t) \
     (m) = PMIx_Data_array_create(n, t)
 
+// free(m) is called inside PMIx_Data_array_free().
 #define PMIX_DATA_ARRAY_FREE(m)     \
     do {                            \
         PMIx_Data_array_free(m);    \

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1119,6 +1120,9 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     /* flush anything that is still trying to be written out */
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
+
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stdout);
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     for (i = 0; i < pmix_client_globals.peers.size; i++) {

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -5,8 +5,8 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -506,8 +506,12 @@ void pmix_hwloc_destruct_topology(pmix_topology_t *src)
     }
     if (NULL != src->topology) {
         hwloc_topology_destroy(src->topology);
+        src->topology = NULL;
     }
-    free(src->source);
+    if (NULL != src->source) {
+        free(src->source);
+        src->source = NULL;
+    }
 }
 
 // avoid ABI break

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -504,14 +504,14 @@ void pmix_hwloc_destruct_topology(pmix_topology_t *src)
         0 != strncasecmp(src->source, "hwloc", 5)) {
         return;
     }
+
     if (NULL != src->topology) {
         hwloc_topology_destroy(src->topology);
         src->topology = NULL;
     }
-    if (NULL != src->source) {
-        free(src->source);
-        src->source = NULL;
-    }
+
+    free(src->source);
+    src->source = NULL;
 }
 
 // avoid ABI break

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -66,9 +66,25 @@ BEGIN_C_DECLS
     "pmix.pnet.setapp" // (pmix_byte_object_t) blob containing info to be given to
                        //      pnet framework on remote nodes
 
+// define some bit handling macros
+#define PMIX_SET_BIT(a, f) \
+    (a) |= (f)
+
+#define PMIX_UNSET_BIT(a, f) \
+    (a) &= ~(f)
+
+#define PMIX_CHECK_BIT_IS_SET(a, f) \
+    ((a) & (f))
+
+#define PMIX_CHECK_BIT_NOT_SET(a, f) \
+    !PMIX_CHECK_BIT_IS_SET(a, f)
+
 #define PMIX_INFO_OP_COMPLETE       0x80000000
-#define PMIX_INFO_OP_COMPLETED(m)   ((pmix_info_t *) (m))->flags |= PMIX_INFO_OP_COMPLETE
-#define PMIX_INFO_OP_IS_COMPLETE(m) ((m)->flags & PMIX_INFO_OP_COMPLETE)
+#define PMIX_INFO_OP_COMPLETED(m) \
+      PMIX_SET_BIT((m)->flags, PMIX_INFO_OP_COMPLETE)
+#define PMIX_INFO_OP_IS_COMPLETE(m) \
+      PMIX_CHECK_BIT_IS_SET((m)->flags, PMIX_INFO_OP_COMPLETE)
+
 
 /* define an internal-only object for creating
  * lists of names */

--- a/src/mca/base/pmix_mca_base_close.c
+++ b/src/mca/base/pmix_mca_base_close.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,9 +50,15 @@ int pmix_mca_base_close(void)
         /* release the default paths */
         if (NULL != pmix_mca_base_system_default_path) {
             free(pmix_mca_base_system_default_path);
+            pmix_mca_base_system_default_path = NULL;
         }
         if (NULL != pmix_mca_base_user_default_path) {
             free(pmix_mca_base_user_default_path);
+            pmix_mca_base_user_default_path = NULL;
+        }
+        if (NULL != pmix_mca_base_component_path) {
+            free(pmix_mca_base_component_path);
+            pmix_mca_base_component_path = NULL;
         }
 
         /* Close down the component repository */

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -668,80 +668,62 @@ pmix_status_t PMIx_Info_load(pmix_info_t *info,
 
 void PMIx_Info_required(pmix_info_t *p)
 {
-    p->flags |= PMIX_INFO_REQD;
+    PMIX_SET_BIT(p->flags, PMIX_INFO_REQD);
 }
 
 void PMIx_Info_optional(pmix_info_t *p)
 {
-    p->flags &= ~PMIX_INFO_REQD;
+    PMIX_UNSET_BIT(p->flags, PMIX_INFO_REQD);
 }
 
 bool PMIx_Info_is_required(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = p->flags & PMIX_INFO_REQD;
-    return ans;
+    return PMIX_CHECK_BIT_IS_SET(p->flags, PMIX_INFO_REQD);
 }
 
 bool PMIx_Info_is_optional(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = !(p->flags & PMIX_INFO_REQD);
-    return ans;
+    return PMIX_CHECK_BIT_NOT_SET(p->flags, PMIX_INFO_REQD);
 }
 
 void PMIx_Info_processed(pmix_info_t *p)
 {
-    p->flags |= PMIX_INFO_REQD_PROCESSED;
+    PMIX_SET_BIT(p->flags, PMIX_INFO_REQD_PROCESSED);
 }
 
 bool PMIx_Info_was_processed(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = p->flags & PMIX_INFO_REQD_PROCESSED;
-    return ans;
+    return PMIX_CHECK_BIT_IS_SET(p->flags, PMIX_INFO_REQD_PROCESSED);
 }
 
 void PMIx_Info_set_end(pmix_info_t *p)
 {
-    p->flags |= PMIX_INFO_ARRAY_END;
+    PMIX_SET_BIT(p->flags, PMIX_INFO_ARRAY_END);
 }
 
 bool PMIx_Info_is_end(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = p->flags & PMIX_INFO_ARRAY_END;
-    return ans;
+    return PMIX_CHECK_BIT_IS_SET(p->flags, PMIX_INFO_ARRAY_END);
 }
 
 void PMIx_Info_qualifier(pmix_info_t *p)
 {
-    p->flags |= PMIX_INFO_QUALIFIER;
+    PMIX_SET_BIT(p->flags, PMIX_INFO_QUALIFIER);
 }
 
 bool PMIx_Info_is_qualifier(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = p->flags & PMIX_INFO_QUALIFIER;
-    return ans;
+    return PMIX_CHECK_BIT_IS_SET(p->flags, PMIX_INFO_QUALIFIER);
 }
 
 void PMIx_Info_persistent(pmix_info_t *p)
 {
-    p->flags |= PMIX_INFO_PERSISTENT;
+    PMIX_SET_BIT(p->flags, PMIX_INFO_PERSISTENT);
 }
 
 bool PMIx_Info_is_persistent(const pmix_info_t *p)
 {
-    bool ans;
-
-    ans = p->flags & PMIX_INFO_PERSISTENT;
-    return ans;
+    return PMIX_CHECK_BIT_IS_SET(p->flags, PMIX_INFO_PERSISTENT);
 }
 
 pmix_status_t PMIx_Info_xfer(pmix_info_t *dest,

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,6 +81,7 @@ pmix_status_t pmix_plog_base_log(const pmix_proc_t *source,
     bool all_complete = true;
     char *key = NULL, *val = NULL;
     bool agg = true;  // default to aggregating show_help messages
+    pmix_info_t *dt = (pmix_info_t*)data;
 
     if (!pmix_plog_globals.initialized) {
         return PMIX_ERR_INIT;
@@ -134,7 +135,7 @@ pmix_status_t pmix_plog_base_log(const pmix_proc_t *source,
                 for (k = 0; k < ndata; k++) {
                     // This is a dup and has been tracked as such,
                     // mark this as complete so we don't log it again.
-                    PMIX_INFO_OP_COMPLETED(&data[k]);
+                    PMIX_INFO_OP_COMPLETED(&dt[k]);
                 }
             }
         }

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -48,6 +48,7 @@
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/pmix_net.h"
 #include "src/runtime/pmix_init_util.h"
 #include <event.h>
 
@@ -95,6 +96,9 @@ void pmix_rte_finalize(void)
 
     /* close GDS */
     (void) pmix_mca_base_framework_close(&pmix_gds_base_framework);
+
+    /* Finalize the network helper subsystem. */
+    (void)pmix_net_finalize();
 
     /* finalize the mca */
     /* Clear out all the registered MCA params */
@@ -160,6 +164,7 @@ void pmix_rte_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_globals.keyindex);
+    free(pmix_globals.myidval.data.proc);
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_stop(NULL);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -740,6 +740,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
         rinfo = PMIX_NEW(pmix_rank_info_t);
         pmix_globals.mypeer->info = rinfo;
     } else {
+        PMIX_RETAIN(pmix_globals.mypeer->info);
         rinfo = pmix_globals.mypeer->info;
     }
     if (NULL == pmix_globals.mypeer->nptr) {
@@ -753,7 +754,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     rinfo->pname.rank = pmix_globals.myid.rank;
     rinfo->uid = pmix_globals.uid;
     rinfo->gid = pmix_globals.gid;
-    PMIX_RETAIN(pmix_globals.mypeer->info);
     pmix_client_globals.myserver->info = pmix_globals.mypeer->info;
 
     /* open the pmdl framework and select the active modules for this environment */
@@ -869,6 +869,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
                                 (void *) &reglock);
     /* wait for registration to complete */
     PMIX_WAIT_THREAD(&reglock);
+    PMIX_INFO_DESTRUCT(&evinfo[0]);
     PMIX_DESTRUCT_LOCK(&reglock);
 
     /* see if they gave us a rendezvous URI to which we are to call back */

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,11 +54,15 @@ static struct timeval show_help_interval = {5, 0};
 
 static void show_help_cbfunc(pmix_status_t status, void *cbdata)
 {
-    pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
+    pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(status);
 
-    PMIX_INFO_FREE(cd->dirs, cd->ndirs);
-    PMIX_INFO_FREE(cd->info, cd->ninfo);
+    if (NULL != cd->directives) {
+        PMIX_INFO_FREE(cd->directives, cd->ndirs);
+    }
+    if (NULL != cd->info) {
+        PMIX_INFO_FREE(cd->info, cd->ninfo);
+    }
     PMIX_RELEASE(cd);
 }
 

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -530,6 +530,7 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
     pmix_info_t *info;
     pmix_rank_t rank;
     uint16_t lr;
+    pmix_nspace_t ns;
 
     gethostname(hostname, sizeof(hostname));
     x->ninfo = 7 + nprocs;
@@ -576,7 +577,8 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
         x->info[7 + n].value.data.darray = darray;
     }
 
-    PMIx_server_register_nspace(nspace, nprocs, x->info, x->ninfo, cbfunc, x);
+    PMIX_LOAD_NSPACE(ns, nspace);
+    PMIx_server_register_nspace(ns, nprocs, x->info, x->ninfo, cbfunc, x);
 }
 
 static void errhandler(size_t evhdlr_registration_id, pmix_status_t status,

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -213,6 +214,7 @@ int main(int argc, char **argv)
                     myproc.rank, PMIx_Error_string(rc));
         exit(rc);
     }
+    free(tmp);
 
     /* get a list of our local peers */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
@@ -245,6 +247,7 @@ int main(int argc, char **argv)
                         myproc.rank, PMIx_Error_string(rc));
             exit(rc);
         }
+        free(tmp);
 
         (void) asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt);
         value.type = PMIX_STRING;
@@ -254,6 +257,7 @@ int main(int argc, char **argv)
                         myproc.rank, PMIx_Error_string(rc));
             exit(rc);
         }
+        free(tmp);
 
         if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
             pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Commit failed: %s", myproc.nspace,

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -636,8 +637,10 @@ static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myx
     }
     iptr = (pmix_info_t *) x->info[n].value.data.darray->array;
     PMIX_INFO_LOAD(&iptr[0], PMIX_NODE_MAP, regex, PMIX_REGEX);
+    free(regex);
     isv1 = &iptr[0];
     PMIX_INFO_LOAD(&iptr[1], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    free(ppn);
     isv2 = &iptr[1];
     PMIX_INFO_LOAD(&iptr[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
     PMIX_INFO_LOAD(&iptr[3], PMIX_JOBID, "1234", PMIX_STRING);

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -17,8 +17,8 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -610,6 +610,7 @@ static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myx
     myxfer_t cd, lock;
     pmix_status_t rc;
     char tmp[50], **agg = NULL;
+    pmix_nspace_t ns;
 
     /* everything on one node */
     PMIx_generate_regex(pmix_globals.hostname, &regex);
@@ -741,7 +742,8 @@ static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myx
         ++n;
     }
 
-    PMIx_server_register_nspace(nspace, nprocs, x->info, x->ninfo, cbfunc, x);
+    PMIX_LOAD_NSPACE(ns, nspace);
+    PMIx_server_register_nspace(ns, nprocs, x->info, x->ninfo, cbfunc, x);
 }
 
 static void errhandler(size_t evhdlr_registration_id, pmix_status_t status,


### PR DESCRIPTION
[Plug memory leaks.](https://github.com/openpmix/openpmix/commit/d38af88c777f318d9d07935f78d5adf3e26d7bc6)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c9eac66e9a312aaf420fbf1ca18c6de4cb8b16ab)

[Plug memory leak.](https://github.com/openpmix/openpmix/commit/32ca17ac1144b819b68ba428609b36c3077a00f4)

A straightforward PMIx_Init() then PMIx_Finalize() program running on my
computer is now Valgrind memcheck clean.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/54e83048496980b1fc5608fab3a07ef3b0295dfc)

[Plug memory leaks in reinit paths.](https://github.com/openpmix/openpmix/commit/6da0caae1eb3a8346a8d59ec92ed9b95c18e989c)

A straightforward looping program over PMIx_Init(), PMIx_Fence(), and
PMIx_Finalize() running on my computer is now Valgrind memcheck clean.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/41c7ce73e59d801afbb1082b843f959742c674bc)

[Plug memory leaks.](https://github.com/openpmix/openpmix/commit/29c17e5f952fb2a20a6fbd698ad6aade741d027a)

Plug memory leaks identified by memcheck on the prterun side.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/51b2010d8a7bf7558ba86ee338d494612e437798)

[Convert the majority of PMIX_*_FREE() macros.](https://github.com/openpmix/openpmix/commit/d7029d192726d2e8bba60eb989519d8fb5b9633f)

Convert the majority of PMIX_*_FREE() macros by moving (or adding) the
frees into the underlying function calls. Also NULLify the incoming
pointers after freeing the base pointers where appropriate.

More to come, but the marked FIXME locations need more thought.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/97ba3b6eb6b4f425e7859e4c6d48ad47f4adc09a)

[Improve PMIX_*_RELEASE() consistency.](https://github.com/openpmix/openpmix/commit/b46fe51c59a8a268950d951dec7aa9f97165d54a)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6edbcf58bfe8110965aa806cb8c40fa59ef32127)

[Silence couple of nit warnings](https://github.com/openpmix/openpmix/commit/3c9ec5097a1b74c6ae8eb1e03aee26f2951072f0)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2c99535222f2731cb649e0a3e65c6976c5f8d6c5)

[Complete PMIX_*_FREE() conversion.](https://github.com/openpmix/openpmix/commit/afcd85c8450c5353d73d2d77ae054ff22860ac23)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/cc319738234f158528b311dab8a37744e059f0e4)

[Fix some Python bindings errors](https://github.com/openpmix/openpmix/commit/6061170347919aa2723dd56e8b4a152cf550df8c)

Ensure we return a proper status when calling the callback
functions. Fix a segfault in the 'toolconnected' function.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2cdc291d68cb4aabd58b7a046bd0746dc69568f8)

[Correct cbdata type in pmix_show_help callback function](https://github.com/openpmix/openpmix/commit/8d97f4d0f4375594cc3f9511085e2e071a2048f0)

It is being passed a pmix_shift_caddy_t, not a pmix_query_caddy_t

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/78c19417b5743ffcffff4ebdfe2022a6726f7c4f)

[Cleanup code style, fix bit checks, and fix backward compatibility](https://github.com/openpmix/openpmix/commit/bfb58d291bdaf1624096b0bacadbfc7217e22dab)

Begin cleanup of code style violations. Fix the way we perform
bit checks for pmix_info_t directives - now that we have
multiple bits being set at a time, we need to correctly ensure
we are testing only the bit of immediate interest.

Restore the pmix_argv_xxx function definitions so codes using
prior PMIx versions can still find them when compiling.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/0b7d94ae2f51070ad636d2d8170d80ca6b7a469e)
