### PR TITLE
Disable gds/shmem component on Mac

### DIFF
--- a/src/mca/gds/shmem/configure.m4
+++ b/src/mca/gds/shmem/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
@@ -18,7 +18,7 @@ AC_DEFUN([MCA_pmix_gds_shmem_CONFIG], [
     dnl address space is probably too small for the 'virtual memory hole'
     dnl finding that we do here. Below assumes support for only 32- and 64-bit
     dnl architectures.
-    AS_IF([test $ac_cv_sizeof_void_p -ne 4],
+    AS_IF([test $ac_cv_sizeof_void_p -ne 4 && test $oac_have_apple == 0],
           [$1
            pmix_gds_shmem=yes],
           [$2


### PR DESCRIPTION
The shmem mechanism is not supported on Mac, so no point in building the component.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 7d25bd021b57d4e3cea40d23bd3662180c269827)