### PR TITLE
Return final group membership to client

### DIFF
--- a/examples/group.c
+++ b/examples/group.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     mylock_t lock;
     pmix_info_t *results, info;
-    size_t nresults, cid;
+    size_t nresults, cid, n;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -147,9 +147,14 @@ int main(int argc, char **argv)
         /* we should have a single results object */
         if (NULL != results) {
             cid = 0;
-            PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
-            fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
-                    myproc.rank, PMIx_Error_string(rc), results[0].key, (unsigned long) cid);
+            for (n=0; n < nresults; n++) {
+                if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
+                    PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
+                    fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
+                            myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);
+                    break;
+                }
+            }
         } else {
             fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
         }

--- a/examples/group.c
+++ b/examples/group.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include <pmix.h>
 #include "examples.h"
@@ -53,8 +54,6 @@ static void op_callbk(pmix_status_t status, void *cbdata)
 {
     mylock_t *lock = (mylock_t *) cbdata;
 
-    fprintf(stderr, "Client %s:%d OP CALLBACK CALLED WITH STATUS %d\n", myproc.nspace, myproc.rank,
-            status);
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
 }
@@ -62,10 +61,8 @@ static void op_callbk(pmix_status_t status, void *cbdata)
 static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
 {
     mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
 
-    fprintf(stderr,
-            "Client %s:%d ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu\n",
-            myproc.nspace, myproc.rank, status, (unsigned long) errhandler_ref);
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
 }
@@ -74,13 +71,29 @@ int main(int argc, char **argv)
 {
     int rc;
     pmix_value_t *val = NULL;
-    pmix_proc_t proc, *procs;
+    pmix_proc_t proc, *procs, *parray;
     uint32_t nprocs;
     mylock_t lock;
-    pmix_info_t *results, info;
-    size_t nresults, cid, n;
-
+    pmix_info_t *results, info[2];
+    size_t nresults, cid, n, m, psize;
+    pmix_data_array_t dry;
+    char *tmp;
+    pmix_query_t query;
+    int i;
+    bool addmembers = false;
+    bool testquery = false;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    for (i=1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--add-members")) {
+            addmembers = true;
+        } else if (0 == strcmp(argv[i], "--test-query")) {
+            testquery = true;
+        } else {
+            fprintf(stderr, "Usage: %s [--add-members] [--test-query]\n", basename(argv[0]));
+            exit(1);
+        }
+    }
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -137,8 +150,19 @@ int main(int argc, char **argv)
         PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
         PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
         PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
-        PMIX_INFO_LOAD(&info, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
-        rc = PMIx_Group_construct("ourgroup", procs, nprocs, &info, 1, &results, &nresults);
+        PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+
+        if (addmembers && 3 == myproc.rank) {
+            PMIX_DATA_ARRAY_CONSTRUCT(&dry, 2, PMIX_PROC);
+            parray = (pmix_proc_t*)dry.array;
+            PMIX_LOAD_PROCID(&parray[0], myproc.nspace, 7);
+            PMIX_LOAD_PROCID(&parray[1], myproc.nspace, 10);
+            PMIX_INFO_LOAD(&info[1], PMIX_GROUP_ADD_MEMBERS, &dry, PMIX_DATA_ARRAY);
+            PMIX_DATA_ARRAY_DESTRUCT(&dry);
+            rc = PMIx_Group_construct("ourgroup", procs, nprocs, info, 2, &results, &nresults);
+        } else {
+            rc = PMIx_Group_construct("ourgroup", procs, nprocs, info, 1, &results, &nresults);
+        }
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
@@ -152,20 +176,72 @@ int main(int argc, char **argv)
                     PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
                     fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
                             myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);
-                    break;
+                } else if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_MEMBERSHIP)) {
+                    parray = (pmix_proc_t*)results[n].value.data.darray->array;
+                    psize = results[n].value.data.darray->size;
+                    if (0 == myproc.rank) {
+                        fprintf(stderr, "NUM MEMBERS: %u MEMBERSHIP:\n", (unsigned)psize);
+                        for (m=0; m < psize; m++) {
+                            fprintf(stderr, "\t%s:%u\n", parray[m].nspace, parray[m].rank);
+                        }
+                    }
                 }
             }
+            PMIX_INFO_FREE(results, nresults);
         } else {
-            fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
+            fprintf(stderr, "%d Group construct complete, but results returned\n", myproc.rank);
         }
         PMIX_PROC_FREE(procs, nprocs);
-        fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
-        rc = PMIx_Group_destruct("ourgroup", NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
+        if (!addmembers) {
+            fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+            rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+                goto done;
+            }
+        }
+    }
+    if (testquery && 0 == myproc.rank) {
+        /* first ask for a list of active namespaces */
+        PMIX_QUERY_CONSTRUCT(&query);
+        PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NAMESPACES);
+
+        rc = PMIx_Query_info(&query, 1, &results, &nresults);
+        if (PMIX_SUCCESS != rc ) {
+            fprintf(stderr, "Error: PMIx_Query_info for namespaces failed: %d (%s)\n", rc, PMIx_Error_string(rc));
             goto done;
         }
+        fprintf(stderr, "\n\n--> Query returned (ninfo %d)\n", (int)nresults);
+        for (n = 0; n < nresults; ++n) {
+            tmp = PMIx_Info_string(&results[n]);
+            fprintf(stderr, "%s\n", tmp);
+            free(tmp);
+        }
+        fprintf(stderr, "<--- END\n\n\n");
+        PMIX_QUERY_DESTRUCT(&query);
+        PMIX_INFO_FREE(results, nresults);
+        /* we can then parse the results to find a namespace of interest, and
+         * query about that namespace in particular. Or we can simply query
+         * for info on ALL namespaces */
+
+        PMIX_QUERY_CONSTRUCT(&query);
+        PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NAMESPACE_INFO);
+
+        rc = PMIx_Query_info(&query, 1, &results, &nresults);
+        if (PMIX_SUCCESS != rc ) {
+            fprintf(stderr, "Error: PMIx_Query_info for namespace info failed: %d (%s)\n", rc, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "--> Query returned (ninfo %d)\n", (int)nresults);
+        for (n = 0; n < nresults; ++n) {
+            tmp = PMIx_Info_string(&results[n]);
+            fprintf(stderr, "%s\n", tmp);
+            free(tmp);
+        }
+        fprintf(stderr, "<--- END\n\n\n");
+        PMIX_QUERY_DESTRUCT(&query);
+        PMIX_INFO_FREE(results, nresults);
     }
 
 done:

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -4,6 +4,7 @@
 # Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
 #                         All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,4 +24,5 @@ sources += \
         client/pmix_client_connect.c \
         client/pmix_client_group.c \
         client/pmix_client_fabric.c \
-        client/pmix_client_topology.c
+        client/pmix_client_topology.c \
+        client/pmix_client_convert.c

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -1,0 +1,154 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2021 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+
+#include "src/class/pmix_object.h"
+#include "src/class/pmix_list.h"
+#include "src/client/pmix_client_ops.h"
+#include "src/include/pmix_globals.h"
+
+pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t insize,
+                                              pmix_proc_t **outprocs, size_t *outsize)
+{
+    pmix_list_t cache;
+    pmix_proclist_t *nm;
+    pmix_group_t *grp;
+    size_t n, i, cnt, sz;
+    bool match;
+    uint32_t jsize;
+    pmix_status_t rc;
+    pmix_kval_t *kv;
+    pmix_proc_t *procs;
+    pmix_cb_t cb2;
+
+    PMIX_CONSTRUCT(&cache, pmix_list_t);
+
+    /* cycle thru the procs and check to see if any reference
+     * a PMIx group */
+    for (n = 0; n < insize; n++) {
+        match = false;
+        PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
+
+            if (PMIX_CHECK_NSPACE(grp->grpid, inprocs[n].nspace)) {
+                match = true;
+                /* the nspace matches this group ID */
+
+                if (PMIX_RANK_WILDCARD == inprocs[n].rank) {
+                    /* we need to replace this proc with the grp members */
+                    for (i=0; i < grp->nmbrs; i++) {
+                        nm = PMIX_NEW(pmix_proclist_t);
+                        memcpy(&nm->proc, &grp->members[i], sizeof(pmix_proc_t));
+                        pmix_list_append(&cache, &nm->super);
+                    }
+                    continue;
+                }
+
+                /* if the rank isn't wildcard, then we want a specific
+                 * proc from within the group. The group might include
+                 * members that have rank=wildcard for their nspace,
+                 * and so we have to count from the beginning to find
+                 * the proc of the specified group rank */
+                cnt = 0;
+                for (i = 0; i < grp->nmbrs; i++) {
+                    /* we are looking for the cnt=inprocs[n].rank proc
+                     * within the group. so count our way across */
+
+                    if (PMIX_RANK_WILDCARD == grp->members[i].rank) {
+                        /* We must get the number of procs in this nspace so
+                         * we can check to see if the specified rank actually
+                         * falls within it */
+                        PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+                        cb2.proc = (pmix_proc_t*)&grp->members[i];
+                        cb2.key = PMIX_JOB_SIZE;
+                        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+                            /* couldn't get the job size, so have to abort */
+                            PMIX_LIST_DESTRUCT(&cache);
+                            PMIX_DESTRUCT(&cb2);
+                            return rc;
+                        }
+                        kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                        PMIX_DESTRUCT(&cb2);
+                        if (NULL == kv) {  // should never be NULL
+                            /* couldn't retrieve the size, so we have
+                             * to abort */
+                            PMIX_LIST_DESTRUCT(&cache);
+                            return PMIX_ERR_NOT_FOUND;
+                        }
+                        PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
+                        PMIX_RELEASE(kv);
+                        if (PMIX_SUCCESS != rc) {
+                            PMIX_LIST_DESTRUCT(&cache);
+                            return PMIX_ERR_BAD_PARAM;
+                        }
+                        if (cnt + jsize > inprocs[n].rank) {
+                            /* the specified rank is within this job */
+                            nm = PMIX_NEW(pmix_proclist_t);
+                            PMIX_LOAD_NSPACE(nm->proc.nspace, grp->members[i].nspace);
+                            nm->proc.rank = inprocs[n].rank - cnt;
+                            break;
+                        } else {
+                            /* increment the count */
+                            cnt += jsize;
+                            /* continue to the next group member */
+                        }
+                    } else {
+                        /* this is a single proc entry, so just see if
+                         * it matches the one they asked for */
+                        if (cnt == inprocs[n].rank) {
+                            nm = PMIX_NEW(pmix_proclist_t);
+                            memcpy(&nm->proc, &grp->members[i], sizeof(pmix_proc_t));
+                            pmix_list_append(&cache, &nm->super);
+                            break;
+                        } else {
+                            /* increment the count */
+                            ++cnt;
+                            /* continue to the next group member */
+                        }
+                    }
+                }
+            }
+            if (match) {
+                break;
+            }
+        }
+        if (!match) {
+            /* xfer the incoming proc across to the cache */
+            nm = PMIX_NEW(pmix_proclist_t);
+            memcpy(&nm->proc, &inprocs[n], sizeof(pmix_proc_t));
+            pmix_list_append(&cache, &nm->super);
+        }
+    }
+
+    /* we have to return the cached array because
+     * we might have replaced some of the entries */
+    sz = pmix_list_get_size(&cache);
+    PMIX_PROC_CREATE(procs, sz);
+    n = 0;
+    PMIX_LIST_FOREACH(nm, &cache, pmix_proclist_t) {
+        memcpy(&procs[n], &nm->proc, sizeof(pmix_proc_t));
+        ++n;
+    }
+    PMIX_LIST_DESTRUCT(&cache);
+    *outprocs = procs;
+    *outsize = sz;
+    return PMIX_SUCCESS;
+}

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,11 +80,8 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
 {
     pmix_status_t rc;
     pmix_value_t *ival;
-    size_t n;
-    pmix_group_t *grp;
-    pmix_cb_t cb2;
-    uint32_t running_size = 0, jsize = 0;
-    pmix_kval_t *kv;
+    size_t n, nprocs;
+    pmix_proc_t *procs;
 
     /* if the proc is NULL, then the caller is assuming
      * that the key is universally unique within the caller's
@@ -258,74 +255,21 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     }
 
     /* if they passed a group in the nspace of proc, 
-     * replace with the translated proc. */
+     * replace it with the translated proc. */
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
-        proc != NULL && 0 != strlen(proc->nspace))
-    {
-        PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
-            if (0 == strcmp(grp->grpid, proc->nspace))
-            {
-                if (PMIX_RANK_WILDCARD == proc->rank)
-                {
-                    /* we don't support wildcard queries
-                     * for groups yet.*/
-                    return PMIX_ERR_BAD_PARAM;
-                }
-                else
-                {
-                    /* find the translation to actual proc */
-                    for(size_t i = 0; i < grp->nmbrs; i++)
-                    {
-                        jsize = 0;
-                        if (PMIX_RANK_WILDCARD == grp->members[i].rank) {
-                            /* must get the number of procs in this nspace */
-                            PMIX_CONSTRUCT(&cb2, pmix_cb_t);
-                            cb2.proc = (pmix_proc_t*)&grp->members[i];
-                            cb2.key = PMIX_JOB_SIZE;
-                            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-                            if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
-                                kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                                PMIX_DESTRUCT(&cb2);
-                                if (NULL != kv) {  // should never be NULL
-                                    PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
-                                    PMIX_RELEASE(kv);
-                                    if (PMIX_SUCCESS != rc) {
-                                        PMIX_DESTRUCT(&cb2);
-                                        return PMIX_ERR_BAD_PARAM;
-                                    }
-                                    if (running_size + jsize > proc->rank)
-                                    {
-                                        PMIX_LOAD_NSPACE(lg->p.nspace, grp->members[i].nspace);
-                                        lg->p.rank = proc->rank - running_size;
-                                        running_size += jsize;
-                                        break;
-                                    }
-                                }
-                            } else {
-                                PMIX_DESTRUCT(&cb2);
-                                return PMIX_ERR_BAD_PARAM;
-                            }
-                        } else {
-                            jsize = 1;
-                            if (running_size + jsize > proc->rank)
-                            {
-                                PMIX_LOAD_NSPACE(lg->p.nspace, grp->members[i].nspace);
-                                lg->p.rank = grp->members[i].rank;
-                                running_size += jsize;
-                                break;
-                            }
-                        }
-                        running_size += jsize;
-                    }
-                }
-                if (proc->rank >= running_size)
-                {
-                    /* the rank is invalid */
-                    return PMIX_ERR_BAD_PARAM;
-                }
-                break;
-            }
+        proc != NULL && 0 != strlen(proc->nspace)) {
+        rc = pmix_client_convert_group_procs(proc, 1, &procs, &nprocs);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
         }
+        if (1 < nprocs) {
+            /* we can't support multi-proc gets */
+            PMIX_PROC_FREE(procs, nprocs);
+            return PMIX_ERR_BAD_PARAM;
+        }
+        /* transfer it across in case it was changed */
+        memcpy(&lg->p, &procs[0], sizeof(pmix_proc_t));
+        PMIX_PROC_FREE(procs, nprocs);
     }
     /* indicate that everything was okay */
     return PMIX_SUCCESS;

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -60,6 +60,9 @@ PMIX_EXPORT extern pmix_client_globals_t pmix_client_globals;
 
 PMIX_EXPORT void pmix_parse_localquery(int sd, short args, void *cbdata);
 
+PMIX_EXPORT pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t insize,
+                                                          pmix_proc_t **outprocs, size_t *outsize);
+
 END_C_DECLS
 
 #endif /* PMIX_CLIENT_OPS_H */

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1054,49 +1054,6 @@ static void _notify_client_event(int sd, short args, void *cbdata)
         PMIX_RELEASE(cd);
         PMIX_RELEASE(chain);
         return;
-    }
-
-    /* check to see if this is a group_complete notification
-     * indicating that a group has asynchronously been formed.
-     * If it is, then we need to track the group */
-    if (PMIX_GROUP_CONSTRUCT_COMPLETE == cd->status) {
-        char *grpid = NULL;
-        pmix_group_t *grp;
-        /* must include the group id */
-        for (n = 0; n < cd->ninfo; n++) {
-            if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_ID)) {
-                grpid = cd->info[n].value.data.string;
-                break;
-            }
-        }
-        if (NULL == grpid) {
-            /* failed to provide the ID */
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            /* notify the caller */
-            if (NULL != cd->cbfunc) {
-                cd->cbfunc(PMIX_ERR_BAD_PARAM, cd->cbdata);
-            }
-            PMIX_RELEASE(cd);
-            PMIX_RELEASE(chain);
-            return;
-        }
-        /* must include members */
-        if (NULL == cd->targets || 0 == cd->ntargets) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            /* notify the caller */
-            if (NULL != cd->cbfunc) {
-                cd->cbfunc(PMIX_ERR_BAD_PARAM, cd->cbdata);
-            }
-            PMIX_RELEASE(cd);
-            PMIX_RELEASE(chain);
-            return;
-        }
-        grp = PMIX_NEW(pmix_group_t);
-        grp->grpid = strdup(grpid);
-        grp->nmbrs = cd->ntargets;
-        PMIX_PROC_CREATE(grp->members, grp->nmbrs);
-        memcpy(grp->members, cd->targets, cd->ntargets * sizeof(pmix_proc_t));
-        pmix_list_append(&pmix_server_globals.groups, &grp->super);
     }
 
     holdcd = false;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -74,6 +74,10 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes, pmix_buffe
 
     /* check for error */
     if (NULL == buffer || NULL == dst || NULL == num_vals) {
+        pmix_output(0, "SOMEONE IS NULL: buffer %s dst %s num_vals %s",
+            (NULL == buffer) ? "NULL" : "GOOD",
+            (NULL == dst) ? "NULL" : "GOOD",
+            (NULL == num_vals) ? "NULL" : "GOOD");
         return PMIX_ERR_BAD_PARAM;
     }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -91,7 +91,6 @@ pmix_server_globals_t pmix_server_globals = {
     .gdata = PMIX_LIST_STATIC_INIT,
     .genvars = NULL,
     .events = PMIX_LIST_STATIC_INIT,
-    .groups = PMIX_LIST_STATIC_INIT,
     .failedgrps = NULL,
     .iof = PMIX_LIST_STATIC_INIT,
     .iof_residuals = PMIX_LIST_STATIC_INIT,
@@ -412,7 +411,6 @@ pmix_status_t pmix_server_initialize(void)
     PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.gdata, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.events, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.iof_residuals, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.psets, pmix_list_t);
@@ -992,9 +990,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
          * at zero refcount */
         pmix_execute_epilog(&ns->epilog);
     }
-    PMIX_LIST_DESTRUCT(&pmix_server_globals.groups);
     if (NULL != pmix_server_globals.failedgrps) {
-        PMIx_Argv_free(pmix_server_globals.failedgrps);
+        PMIX_ARGV_FREE(pmix_server_globals.failedgrps);
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -180,7 +180,6 @@ typedef struct {
     pmix_list_t gdata;  // cache of data given to me for passing to all clients
     char **genvars;     // argv array of envars given to me for passing to all clients
     pmix_list_t events; // list of pmix_regevents_info_t registered events
-    pmix_list_t groups; // list of pmix_group_t group memberships
     char **failedgrps;    // group IDs that failed to construct
     pmix_list_t iof;    // IO to be forwarded to clients
     pmix_list_t iof_residuals;  // leftover bytes waiting for newline


### PR DESCRIPTION
It is possible that the group membership may have been altered during group_construct - e.g., if one or more participants adds members that are not visible to all. Ensure we pass back the actual final membership, and use that to define the group in the client's storage