### PR TITLE
Add pretty-print proc name API

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1169,6 +1169,7 @@ PMIX_EXPORT char* PMIx_Info_string(const pmix_info_t *info);
 PMIX_EXPORT char* PMIx_Value_string(const pmix_value_t *value);
 PMIX_EXPORT char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 PMIX_EXPORT char* PMIx_App_string(const pmix_app_t *app);
+PMIX_EXPORT char* PMIx_Proc_string(const pmix_proc_t *proc);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +37,7 @@
 
 #include "src/common/pmix_attributes.h"
 #include "src/include/pmix_globals.h"
+#include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_printf.h"
 
 PMIX_EXPORT const char *PMIx_Proc_state_string(pmix_proc_state_t state)
@@ -462,4 +463,13 @@ char* PMIx_App_string(const pmix_app_t *app)
     tmp = PMIx_Argv_join(ans, '\n');
     PMIx_Argv_free(ans);
     return tmp;
+}
+
+char* PMIx_Proc_string(const pmix_proc_t *proc)
+{
+    char *tmp, *result;
+
+    tmp = pmix_util_print_name_args(proc);
+    result = strdup(tmp);
+    return result;
 }

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -166,6 +166,12 @@ char *pmix_util_print_rank(const pmix_rank_t vpid)
         pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "UNDEF");
     } else if (PMIX_RANK_WILDCARD == vpid) {
         pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "WILDCARD");
+    } else if (PMIX_RANK_LOCAL_NODE == vpid) {
+        pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "LOCAL_NODE");
+    } else if (PMIX_RANK_LOCAL_PEERS == vpid) {
+        pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "LOCAL_PEERS");
+    } else if (PMIX_RANK_INVALID == vpid) {
+        pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "INVALID");
     } else {
         pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "%ld", (long) vpid);
     }


### PR DESCRIPTION
We have several special rank values defined in PMIx (e.g., PMIX_RANK_INVALID). Help users in their
print statements by providing a new "pretty-print" function for printing out pmix_proc_t structures
that includes recognizing the special rank values.