### PR TITLE
Fix a few corner cases in the cmd line parser

### DIFF
--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -330,15 +330,10 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             // this was not an option
                             goto done;
                         }
-                        if ((optind == argc || 0 == strcmp(argv[optind], ":")) && 0 == argind) {
-                            // command without any options
-                            optind = 1;
-                            goto done;
-                        }
-                        if (0 == strcmp(argv[argind], "--")) {
+                        if (0 == strcmp(argv[optind-1], "--")) {
                             // double-dash indicates separator between launcher
                             // directives and the application
-                            break;
+                            goto done;
                         }
                         str = pmix_show_help_string("help-cli.txt", "short-no-long", true,
                                                     pmix_tool_basename, argv[optind-1]);
@@ -372,6 +367,15 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         PMIx_Argv_free(argv);
                         return PMIX_ERR_SILENT;
                     }
+                }
+                if (0 == strcmp(argv[optind-1], "--")) {
+                    // double-dash indicates separator between launcher
+                    // directives and the application
+                    goto done;
+                }
+                if (1 == optind) {
+                    // command without any options
+                    goto done;
                 }
                 str = pmix_show_help_string("help-cli.txt", "unregistered-option", true,
                                             pmix_tool_basename, argv[optind-1], pmix_tool_basename);


### PR DESCRIPTION
Reordering some parsing reintroduced problems with cmds that have no options and cmd lines that
use a '--' to indicate end of options. Plug those
corner cases.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit f42e531e163ff188820142089daf923ecef3da4b)