### PR TITLE
Attempt to resolve gcc13 complaint

### DIFF
--- a/src/util/pmix_if.h
+++ b/src/util/pmix_if.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,15 +78,6 @@ PMIX_EXPORT extern pmix_list_t pmix_if_list;
 /* global flags */
 PMIX_EXPORT extern bool pmix_if_do_not_resolve;
 PMIX_EXPORT extern bool pmix_if_retain_loopback;
-
-/**
- *  Lookup an interface by name and return its primary address.
- *
- *  @param if_name (IN)   Interface name
- *  @param if_addr (OUT)  Interface address buffer
- *  @param size    (IN)   Interface address buffer size
- */
-PMIX_EXPORT int pmix_ifnametoaddr(const char *if_name, struct sockaddr *if_addr, int size);
 
 /**
  *  Lookup an interface by address and return its name.


### PR DESCRIPTION
Remove unused functions. Attempt to resolve complaint about "reading 1 or more bytes from a region of size 0" by restricting the string comparison to the length of the fixed field.

Thanks to @tonycurtis for the report and help with the fix!

Fixes #3026
