### PR TITLE
Ensure tools send requests to their server

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1112,7 +1112,8 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[], pmix_proc_t procs[], size_t nprocs)
+PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
+                                     pmix_proc_t procs[], size_t nprocs)
 {
     pmix_buffer_t *bfr;
     pmix_cmd_t cmd = PMIX_ABORT_CMD;
@@ -1126,6 +1127,22 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[], pmix_proc_t pro
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
+    }
+
+    /* if we are a server (and not a tool), then try to
+     * handle this directly */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        if (NULL != pmix_host_server.abort) {
+            rc = pmix_host_server.abort(&pmix_globals.myid,
+                                        pmix_globals.mypeer->info->server_object,
+                                        flag, msg, procs, nprocs,
+                                        NULL, NULL);
+        } else {
+            rc = PMIX_ERR_NOT_SUPPORTED;
+        }
+        return rc;
     }
 
     /* if we aren't connected, don't attempt to send */
@@ -1434,8 +1451,9 @@ PMIX_EXPORT pmix_status_t PMIx_Commit(void)
         return PMIX_SUCCESS;
     }
 
-    /* if we are a server, or we aren't connected, don't attempt to send */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+    /* if we are a server (but not a tool), or we aren't connected, don't attempt to send */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_SUCCESS; // not an error
     }

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -162,7 +162,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix:fabric register");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:fabric register");
 
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */
@@ -198,15 +199,16 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FABRIC_REGISTER_CMD;
 
-    /* if I am a scheduler server, then I should be able
-     * to support this myself */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+    /* if I am a scheduler or a server (but not a tool),
+     * then I should be able to support this myself */
+    if ((PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) ||
         PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
         rc = pmix_pnet.register_fabric(fabric, directives, ndirs, cbfunc, cbdata);
         return rc;
     }
 
-    /* finally, if I am a tool or client, then I need to send it to
+    /* otherwise, I need to send it to
      * a daemon for processing */
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (!pmix_globals.connected) {
@@ -277,7 +279,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update(pmix_fabric_t *fabric)
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix:fabric update");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:fabric update");
 
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */
@@ -319,7 +322,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
 
     /* otherwise, if we are a server, then see if we can pass
      * it up to our host so they can send it to the scheduler */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.fabric) {
             return PMIX_ERR_NOT_SUPPORTED;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1043,10 +1043,11 @@ doget:
     }
 
     /* if we got here, then we don't have the data for this proc. If we
-     * are a server, or we are a client and not connected, then there is
+     * are a server, or we are not connected, then there is
      * nothing more we can do */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
-        (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected)) {
+    if ((PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) ||
+         !pmix_globals.connected) {
         cb->status = PMIX_ERR_NOT_FOUND;
         goto done;
     }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,20 +76,13 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.spawn_output, "%s pmix: spawn called",
+    pmix_output_verbose(2, pmix_client_globals.spawn_output,
+                        "%s pmix: spawn called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
-    }
-
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
-        !pmix_globals.connected &&
-        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
@@ -158,7 +151,8 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         /* if I am a launcher, we default to local fork/exec */
         if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
             forkexec = true;
-        } else if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+        } else if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+                   PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return PMIX_ERR_UNREACH;
         }
@@ -260,7 +254,8 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     /* if we are a server, then process this ourselves */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
 
         if (NULL == pmix_host_server.spawn) {
             return PMIX_ERR_NOT_SUPPORTED;

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -312,8 +312,10 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
     }
 
 request:
-    /* if I am a server or I am not connected, there is nothing more I can do */
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) || !pmix_globals.connected) {
+    /* if I am a server (but not a tool) or I am not connected, there is nothing more I can do */
+    if ((PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) ||
+        !pmix_globals.connected) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         PMIX_RELEASE(cb);
         return PMIX_ERR_UNREACH;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -141,7 +141,8 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_proc_t *procs = NULL;
     pmix_proc_t proc;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "recvd ABORT");
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "recvd ABORT");
 
     /* unpack the status */
     cnt = 1;


### PR DESCRIPTION
Tools may register server module function pointers to allow them to handle certain requests. The Python bindings are an example were the pointers can be registered, even though the host tool doesn't support them. Ensure that tools only use those pointers for requests that come up to them from clients, and don't call themselves back for those operations.