### PR TITLE
Disable GDS shmem component

### DIFF
--- a/src/mca/gds/shmem/.pmix_unignore
+++ b/src/mca/gds/shmem/.pmix_unignore
@@ -1,0 +1,1 @@
+samuelkguiterrez


### PR DESCRIPTION
Appears to be causing a process to exit with zero status under certain (currently unclear) conditions during PMIx_Init.