### PR TITLE
Silence TSan data race warnings.

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -15,7 +15,7 @@
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
-# Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -61,6 +61,7 @@ headers += \
         pmix_atomic.h \
         pmix_hash_string.h \
         pmix_socket_errno.h \
+        pmix_stdatomic.h \
         pmix_stdint.h \
         pmix_prefetch.h \
         pmix_types.h \

--- a/src/include/pmix_stdatomic.h
+++ b/src/include/pmix_stdatomic.h
@@ -1,0 +1,60 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_STDATOMIC_H
+#define PMIX_STDATOMIC_H
+
+#include "pmix_stdint.h"
+#include <stdbool.h>
+
+#if PMIX_ATOMIC_C11
+
+#include <stdatomic.h>
+
+typedef atomic_int pmix_atomic_int_t;
+typedef atomic_long pmix_atomic_long_t;
+
+typedef _Atomic bool pmix_atomic_bool_t;
+typedef _Atomic int32_t pmix_atomic_int32_t;
+typedef _Atomic uint32_t pmix_atomic_uint32_t;
+typedef _Atomic int64_t pmix_atomic_int64_t;
+typedef _Atomic uint64_t pmix_atomic_uint64_t;
+
+typedef _Atomic size_t pmix_atomic_size_t;
+typedef _Atomic ssize_t pmix_atomic_ssize_t;
+typedef _Atomic intptr_t pmix_atomic_intptr_t;
+typedef _Atomic uintptr_t pmix_atomic_uintptr_t;
+
+#else
+
+typedef volatile int pmix_atomic_int_t;
+typedef volatile long pmix_atomic_long_t;
+
+typedef volatile bool pmix_atomic_bool_t;
+typedef volatile int32_t pmix_atomic_int32_t;
+typedef volatile uint32_t pmix_atomic_uint32_t;
+typedef volatile int64_t pmix_atomic_int64_t;
+typedef volatile uint64_t pmix_atomic_uint64_t;
+
+typedef volatile size_t pmix_atomic_size_t;
+typedef volatile ssize_t pmix_atomic_ssize_t;
+typedef volatile intptr_t pmix_atomic_intptr_t;
+typedef volatile uintptr_t pmix_atomic_uintptr_t;
+
+#endif
+
+#endif

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,6 +40,7 @@
 #include "src/mca/mca.h"
 
 #include "src/include/pmix_globals.h"
+#include "src/include/pmix_stdatomic.h"
 #include "src/mca/ptl/base/ptl_base_handshake.h"
 #include "src/mca/ptl/ptl.h"
 
@@ -63,7 +65,7 @@ struct pmix_ptl_base_t {
     pmix_list_t posted_recvs; // list of pmix_ptl_posted_recv_t
     pmix_list_t unexpected_msgs;
     int stop_thread[2];
-    bool listen_thread_active;
+    pmix_atomic_bool_t listen_thread_active;
     pmix_listener_t listener;
     struct sockaddr_storage *connection;
     uint32_t current_tag;

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +25,7 @@
 
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_globals.h"
+#include "src/include/pmix_stdatomic.h"
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/threads/pmix_threads.h"
@@ -41,7 +43,7 @@ typedef struct {
 
     /* This will be set to false when it is time for the progress
        thread to exit */
-    volatile bool ev_active;
+    pmix_atomic_bool_t ev_active;
 
     /* This event will always be set on the ev_base (so that the
        ev_base is not empty!) */


### PR DESCRIPTION
Use atomic types approach seen in PRRTE: use _Atomic when available.