### PR TITLE
Include the OAC subdir in the autoconf make directories

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 # Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -50,7 +50,7 @@ AC_PREREQ([2.69])
 AC_CONFIG_AUX_DIR(./config)
 # Note that this directory must *exactly* match what was specified via
 # -I in ACLOCAL_AMFLAGS in the top-level Makefile.am.
-AC_CONFIG_MACRO_DIR(./config)
+AC_CONFIG_MACRO_DIRS([./config config/oac])
 
 AC_PROG_SED
 


### PR DESCRIPTION
Avoid having to explicitly include it in an autoreconf line.