### PR TITLE
Handle the case of unbound proc. Also ensure topology is available

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -598,6 +598,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
+
     /* setup the base verbosity */
     if (0 < pmix_client_globals.base_verbose) {
         /* set default output */
@@ -788,6 +789,10 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return rc;
         }
+        /* set our server ID to be ourselves */
+        pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+        pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
+        /* mark that the server is unreachable */
         rc = PMIX_ERR_UNREACH;
     } else if (PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
         /* we are a connected singleton */
@@ -823,14 +828,8 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
         rc = cb.status;
         PMIX_DESTRUCT(&cb);
     }
+    pmix_init_result = rc;
 
-    if (PMIX_SUCCESS == rc) {
-        pmix_init_result = PMIX_SUCCESS;
-    } else {
-        pmix_init_result = rc;
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
     // enable show_help subsystem
     pmix_show_help_enabled = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1003,7 +1003,7 @@ pmix_status_t pmix_hwloc_get_cpuset(pmix_cpuset_t *cpuset, pmix_bind_envelope_t 
     }
     if (0 != rc) {
         hwloc_bitmap_free(cpuset->bitmap);
-        return PMIX_ERR_TAKE_NEXT_OPTION;
+        return PMIX_ERR_NOT_FOUND;
     }
     if (NULL == cpuset->source) {
         cpuset->source = strdup("hwloc");


### PR DESCRIPTION
Ensure the topology is available to singletons. Properly handle the cpuset case for unbound procs.