### PR TITLE
Improve shared-memory reference counting.

### DIFF
--- a/src/mca/gds/shmem/gds_shmem.h
+++ b/src/mca/gds/shmem/gds_shmem.h
@@ -69,8 +69,8 @@ typedef enum {
 typedef uint8_t pmix_gds_shmem_status_t;
 
 typedef enum {
-    /** Indicates that caller is responsible for shmem release. */
-    PMIX_GDS_SHMEM_RELEASE = 0x01,
+    /** Indicates that caller is shmem creator. */
+    PMIX_GDS_SHMEM_MINE = 0x01,
     /** Indicates that the shared-memory segment is attached to. */
     PMIX_GDS_SHMEM_ATTACHED = 0x02,
     /** Indicates that the shared-memory segment is ready for use. */

--- a/src/util/pmix_shmem.h
+++ b/src/util/pmix_shmem.h
@@ -34,7 +34,7 @@ typedef struct pmix_shmem_t {
     /** Parent class. */
     pmix_object_t super;
     /** Flag indicating if attached to segment. */
-    bool attached;
+    volatile bool attached;
     /** Size of shared-memory segment. */
     size_t size;
     /** Address of shared memory segment header. */


### PR DESCRIPTION
...or at least try! This commit attempts to address failing client-side attachments caused by an eager unlinking of shared-memory backing files.

We also unignore gds/shmem to resume broader CI testing.