### PR TITLE
Return the correct status from PMIx_Init

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -515,7 +515,8 @@ cleanup:
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_t ninfo)
+pmix_status_t PMIx_Init(pmix_proc_t *proc,
+                        pmix_info_t info[], size_t ninfo)
 {
     char *evar;
     pmix_status_t rc = PMIX_SUCCESS;
@@ -925,7 +926,11 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc, pmix_info_t info[], size_
 
     /* register the client supported attrs */
     rc = pmix_register_client_attrs();
-    return rc;
+    if (PMIX_SUCCESS == pmix_init_result &&
+        PMIX_SUCCESS != rc) {
+        pmix_init_result = rc;
+    }
+    return pmix_init_result;
 }
 
 PMIX_EXPORT int PMIx_Initialized(void)


### PR DESCRIPTION
The pmix_init_result variable contains the correct return status, so use it.