### PR TITLE
Define pmix atomic ops for c11 atomics

### DIFF
--- a/src/include/pmix_atomic.h
+++ b/src/include/pmix_atomic.h
@@ -18,7 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
- * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -80,6 +80,22 @@ static inline void pmix_atomic_rmb(void)
 #    endif
 }
 
+#define PMIX_ATOMIC_DEFINE_OP(type, bits, operator, name)                   \
+    static inline type                                                      \
+    pmix_atomic_fetch_##name##_##bits(pmix_atomic_##type *addr, type value) \
+    {                                                                       \
+        return atomic_fetch_##name##_explicit(                              \
+            addr, value, memory_order_relaxed);                             \
+    }                                                                       \
+                                                                            \
+    static inline type                                                      \
+    pmix_atomic_##name##_fetch_##bits(pmix_atomic_##type *addr, type value) \
+    {                                                                       \
+        return atomic_fetch_##name##_explicit(                              \
+            addr, value, memory_order_relaxed) operator value;              \
+    }
+
+/* end of PMIX_USE_C11_ATOMICS */
 #elif PMIX_USE_GCC_BUILTIN_ATOMICS
 
 static inline void pmix_atomic_wmb(void)
@@ -112,12 +128,15 @@ static inline void pmix_atomic_rmb(void)
         return __atomic_##name##_fetch(addr, value, __ATOMIC_RELAXED);         \
     }
 
+/* end of PMIX_USE_GCC_BUILTIN_ATOMICS */
+#else
+#error OpenPMIx requires either C11 atomics support or GCC built-in atomics.
+#endif
+
 PMIX_ATOMIC_DEFINE_OP(int32_t, 32, +, add)
 PMIX_ATOMIC_DEFINE_OP(int32_t, 32, &, and)
 PMIX_ATOMIC_DEFINE_OP(int32_t, 32, |, or)
 PMIX_ATOMIC_DEFINE_OP(int32_t, 32, ^, xor)
 PMIX_ATOMIC_DEFINE_OP(int32_t, 32, -, sub)
-
-#endif
 
 #endif /* PMIX_SYS_ATOMIC_H */

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -13,9 +13,9 @@
 #include "pmix_common.h"
 #include "pmix_output.h"
 #include "src/include/pmix_globals.h"
-#include "src/include/pmix_stdatomic.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_string_copy.h"
+#include "src/include/pmix_atomic.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -15,7 +15,6 @@
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_string_copy.h"
-#include "src/include/pmix_atomic.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>


### PR DESCRIPTION
Define pmix atomic ops for c11 atomics

Previously these ops were only available when using GCC atomics, but now
they can be used when C11 atomics are selected.

