### PR TITLE
Eliminate double-free

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -1614,7 +1614,6 @@ void PMIx_Query_destruct(pmix_query_t *p)
     }
     if (NULL != p->qualifiers) {
         PMIx_Info_free(p->qualifiers, p->nqual);
-        pmix_free(p->qualifiers);
         p->qualifiers = NULL;
         p->nqual = 0;
     }


### PR DESCRIPTION
PMIx_Info_free releases the base storage, so don't attempt to free it in PMIx_Query_destruct
bot:notacherrypick