### PR TITLE
Remove environ from public header

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -68,8 +68,6 @@
 #include <unistd.h> /* for uid_t and gid_t */
 #include <sys/types.h> /* for uid_t and gid_t */
 
-extern char **environ;
-
 /* Whether C compiler supports -fvisibility */
 #undef PMIX_HAVE_VISIBILITY
 

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -40,6 +40,8 @@
 
 #include "src/util/pmix_printf.h"
 
+extern char **environ;
+
 static inline
 void pmix_bfrops_base_tma_value_destruct(pmix_value_t *v,
                                          pmix_tma_t *tma);


### PR DESCRIPTION
Now that we have moved all those "static inline" functions in pmix_common.h into APIs, there is no longer a reason for the "extern char **environ" being in that file and it generates warnings in some environments.