### PR TITLE
Fix a couple of typos

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1094,7 +1094,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
     }
-    PMIX_DESTRUCT(&pmix_client_globals.groups);
+    PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);
 
     if (0 <= pmix_client_globals.myserver->sd) {
         CLOSE_THE_SOCKET(pmix_client_globals.myserver->sd);

--- a/test/simple/simptool.c
+++ b/test/simple/simptool.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 done:
     /* finalize us */
     pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+    if (PMIX_SUCCESS != (rc = PMIx_tool_finalize())) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
     } else {


### PR DESCRIPTION
Destruct the list and not just the list object during client finalize. Simptool test should use PMIx_tool_finalize instead of client finalize.