### PR TITLE
v4.0: .github/workflows: update actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build
       uses: ./.github/actions/mlnx
       with:


### PR DESCRIPTION
Update Github-provided actions to newer versions. This will squelch warnings that we get about using outdated Node.js versions.