### PR TITLE
Expose pmix_getline utility

### DIFF
--- a/src/util/pmix_string_copy.c
+++ b/src/util/pmix_string_copy.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,4 +38,19 @@ void pmix_string_copy(char *dest, const char *src, size_t dest_len)
     }
 
     dest[i - 1] = '\0';
+}
+
+char *pmix_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[1024];
+
+    ret = fgets(input, 1024, fp);
+    if (NULL != ret) {
+        input[strlen(input) - 1] = '\0'; /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
 }

--- a/src/util/pmix_string_copy.h
+++ b/src/util/pmix_string_copy.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +27,12 @@
 
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
 #endif
 
 BEGIN_C_DECLS
@@ -73,6 +79,9 @@ PMIX_EXPORT void pmix_string_copy(char *dest, const char *src, size_t dest_len)
  * See the description of pmix_string_copy() for an explanation.
  */
 #define PMIX_MAX_SIZE_ALLOWED_BY_PMIX_STRING_COPY (128 * 1024)
+
+PMIX_EXPORT char *pmix_getline(FILE *fp);
+
 
 END_C_DECLS
 


### PR DESCRIPTION
We have been copying a "getline" utility across
both PMIx and PRRTE. Centralize it.