### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,12 @@
 # -- Project information -----------------------------------------------------
 
 import datetime
-mydate = datetime.datetime.now()
+import os
+import time
+
+mydate = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
 year = mydate.year
 month = mydate.strftime("%B")
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.

See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Without this patch, I got variations in our `openmpi5` package:
```diff
+++ new//usr/lib64/mpi/gcc/openmpi5/share/doc/pmix/html/developers/frameworks.html      2023-07-25 00:00:00.000000000 +0000
@@ -109,7 +109,7 @@
 – most services and functionality are implemented through MCA
 components.</p>
 <p>Here is a list of all the component frameworks in PMIx as of
-this writing August-2023:</p>
+this writing September-2039:</p>
```

This patch was done while working on reproducible builds for openSUSE.

Signed-off-by: Bernhard M. Wiedemann bwiedemann suse de