### PR TITLE
Fix bitrot in pquery tool

### DIFF
--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -472,15 +472,13 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
                 PMIX_KVAL_NEW(kv, cb.key);
                 PMIx_Value_load(kv->value, PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
                 pmix_list_append(&cb.kvs, &kv->super);
-                rc = PMIX_SUCCESS;
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
                 PMIX_KVAL_NEW(kv, cb.key);
                 PMIx_Value_load(kv->value, PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
                 pmix_list_append(&cb.kvs, &kv->super);
-                rc = PMIX_SUCCESS;
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
                 PMIX_THREADSHIFT(cd, pmix_attrs_query_support);
-                return ;
+                return;
             /* check for request to scan the local node for available
              * servers the caller could connect to */
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_AVAIL_SERVERS)) {
@@ -500,6 +498,7 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
                 pmix_list_append(&results, &kv->super);
             }
             PMIX_DESTRUCT(&cb);
+            goto complete;
         }
     }
 
@@ -508,6 +507,7 @@ nextstep:
      * interfaces to see if someone can resolve it */
     rc = pmix_pstrg.query(queries, nqueries, &results, nxtcbfunc, cd);
     if (PMIX_OPERATION_SUCCEEDED == rc) {
+complete:
         /* if we get here, then all queries were locally
          * resolved, so construct the results for return */
         cd->status = PMIX_SUCCESS;

--- a/src/tools/pquery/help-pquery.txt
+++ b/src/tools/pquery/help-pquery.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,7 +24,7 @@
 [usage]
 %s (%s) %s
 
-Usage: %s [OPTION]...
+Usage: %s [OPTION] KEY[qualifier(s)]
 PMIx Query tool
 
 
@@ -46,18 +46,6 @@ PMIx Query tool
    --wait-to-connect <arg0>          Delay specified number of seconds before trying to connect
    --num-connect-retries <arg0>      Max number of times to try to connect
 
-   --client <arg0>                   Comma-delimited list of client functions whose attributes are to be
-                                     printed (function or "all")
-   --server <arg0>                   Comma-delimited list of server functions whose attributes are to be
-                                     printed (function or "all")
-   --tool <arg0>                     Comma-delimited list of tool functions whose attributes are to be
-                                     printed (function or "all")
-   --host <arg0>                     Comma-delimited list of host functions whose attributes are to be
-                                     printed (function or "all")
-   --client                          List the functions supported in this client library
-   --server                          List the functions supported in this server library
-   --tool                            List the functions supported in this tool library
-   --host                            List the functions supported by this host environment
 Keys passed to pquery may optionally include one or more qualifiers, with the
 individual qualifiers delimited by semi-colons. For example:
 


### PR DESCRIPTION
Cleanup the help output. Ensure proper return of results when query is locally resolved. Allow pquery to run as tool, but sometimes unconnected if a server isn't available.