### PR TITLE
Add new API and cleanup pevent tool

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1140,7 +1140,7 @@ PMIX_EXPORT void PMIx_Progress(void);
  * - pmix_proc_state_t  (PMIX_PROC_STATE)
  * - attribute string value of provided name
  * - attribute name corresponding to provided string
- * - pmix_list_state_t (PMIX_LINK_STATE)
+ * - pmix_link_state_t (PMIX_LINK_STATE)
  * - pmix_device_type_t (PMIX_DEVTYPE)
  * - pmix_value_cmp_t (enum)
  * - pmix_info_t (PMIX_INFO)
@@ -1149,6 +1149,7 @@ PMIX_EXPORT void PMIx_Progress(void);
  * - pmix_app_t (PMIX_APP)
  */
 PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t status);
+PMIX_EXPORT pmix_status_t PMIx_Error_code(const char *errname);
 PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
 PMIX_EXPORT const char* PMIx_Scope_string(pmix_scope_t scope);
 PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist);

--- a/src/tools/pevent/help-pevent.txt
+++ b/src/tools/pevent/help-pevent.txt
@@ -24,7 +24,7 @@
 [usage]
 %s (%s) %s
 
-Usage: %s [OPTION]...
+Usage: %s [OPTION] <EVENT>
 Inject PMIx events
 
 
@@ -39,18 +39,16 @@ Inject PMIx events
                                      for file containing the PID
    --tmpdir <arg0>                   Set the root for the session directory tree
 
-/*****      Required Options      *****/
-   --event <arg0>                    Status code (integer value or name) of event to be sent
    --range <arg0>                    Range of event to be sent
+
+The provided event can be either an integer status code (e.g., -31) or
+the string name of a status code (e.g., "PMIX_EVENT_NODE_DOWN")
 
 Report bugs to %s
 #
 [pid]
 PID of the daemon to which we should connect (int => PID or file:<file>
 for file containing the PID
-#
-[event]
-Status code (integer value or name) of event to be sent
 #
 [range]
 Range (pmix_range_t) of event to be sent

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -174,7 +174,6 @@ int main(int argc, char **argv)
     };
     char **qkeys = NULL;
     const char *attr;
-    bool server = false;
     pmix_list_t querylist, qlist;
     pmix_querylist_t *qry;
     char **qprs;
@@ -290,7 +289,6 @@ int main(int argc, char **argv)
     } else {
         /* we set ourselves up as a tool, but no connections required */
         PMIX_INFO_LOAD(&info[0], PMIX_TOOL_CONNECT_OPTIONAL, NULL, PMIX_BOOL);
-        server = true;
     }
 
     /* assign our own name */
@@ -447,11 +445,7 @@ int main(int argc, char **argv)
     }
 
 done:
-    if (server) {
-        PMIx_server_finalize();
-    } else {
-        PMIx_tool_finalize();
-    }
+    PMIx_tool_finalize();
 
     return (rc);
 }

--- a/src/util/pmix_error.c
+++ b/src/util/pmix_error.c
@@ -38,3 +38,16 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
 
     return "ERROR STRING NOT FOUND";
 }
+
+PMIX_EXPORT pmix_status_t PMIx_Error_code(const char *errname)
+{
+    size_t n;
+
+    for (n=0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
+        if (0 == strcasecmp(pmix_event_strings[n].name, errname)) {
+            return pmix_event_strings[n].code;
+        }
+    }
+
+    return INT32_MIN;
+}


### PR DESCRIPTION
Add a new PMIx_Error_code that takes the string name of an error/event and returns the corresponding integer code. Utilize it in the pevent tool, and change the cmd line of that tool to support better server specification and for ease of use.