### PR TITLE
Enable building of tarball

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1076,12 +1076,14 @@ if test "$enable_devel_check" = "yes"; then
 elif test "$enable_devel_check" = "no"; then
     AC_MSG_RESULT([no])
     WANT_PICKY_COMPILER=0
-elif test "$pmix_git_repo_build" = "yes"; then
+    CFLAGS="$CFLAGS -Wno-unused-parameter"
+elif test "$pmix_git_repo_build" = "yes" && test "$pmix_debug" = "1"; then
     AC_MSG_RESULT([yes])
     WANT_PICKY_COMPILER=1
 else
     AC_MSG_RESULT([no])
     WANT_PICKY_COMPILER=0
+    CFLAGS="$CFLAGS -Wno-unused-parameter"
 fi
 
 AC_DEFINE_UNQUOTED(PMIX_PICKY_COMPILERS, $WANT_PICKY_COMPILER,


### PR DESCRIPTION
Disable the unused param check when not enabling the developer picky compiler setting. If not specifically requested, then disable the developer picky compiler setting unless (a) we are in a git repo, and (b) we enable debug.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 03ea1de1c91c35f8fc7e20709fb1ad6f3e73d516)