### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=5
 minor=0
-release=0
+release=1
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -24,7 +24,7 @@ release=0
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=rc2
+greek=a1
 
 # PMIx required dependency versions.
 # List in x.y.z format.

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -64,8 +64,6 @@ struct pmix_ptl_base_t {
     bool selected;
     pmix_list_t posted_recvs; // list of pmix_ptl_posted_recv_t
     pmix_list_t unexpected_msgs;
-    int stop_thread[2];
-    pmix_atomic_bool_t listen_thread_active;
     pmix_listener_t listener;
     struct sockaddr_storage *connection;
     uint32_t current_tag;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +67,6 @@ pmix_ptl_base_t pmix_ptl_base = {
     .selected = false,
     .posted_recvs = PMIX_LIST_STATIC_INIT,
     .unexpected_msgs = PMIX_LIST_STATIC_INIT,
-    .stop_thread = {0, 0},
-    .listen_thread_active = false,
     .listener = PMIX_LISTENER_STATIC_INIT,
     .connection = NULL,
     .current_tag = 0,
@@ -364,7 +362,6 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     pmix_ptl_base.initialized = true;
     PMIX_CONSTRUCT(&pmix_ptl_base.posted_recvs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_ptl_base.unexpected_msgs, pmix_list_t);
-    pmix_ptl_base.listen_thread_active = false;
     PMIX_CONSTRUCT(&pmix_ptl_base.listener, pmix_listener_t);
     pmix_ptl_base.current_tag = PMIX_PTL_TAG_DYNAMIC;
     pmix_ptl_base.connection = (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
@@ -433,7 +430,9 @@ static void sdes(pmix_ptl_send_t *p)
         PMIX_RELEASE(p->data);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_send_t, pmix_list_item_t, scon, sdes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_send_t,
+                                pmix_list_item_t,
+                                scon, sdes);
 
 static void rcon(pmix_ptl_recv_t *p)
 {
@@ -452,7 +451,9 @@ static void rdes(pmix_ptl_recv_t *p)
         PMIX_RELEASE(p->peer);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_recv_t, pmix_list_item_t, rcon, rdes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_recv_t,
+                                pmix_list_item_t,
+                                rcon, rdes);
 
 static void prcon(pmix_ptl_posted_recv_t *p)
 {
@@ -460,7 +461,9 @@ static void prcon(pmix_ptl_posted_recv_t *p)
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_posted_recv_t, pmix_list_item_t, prcon, NULL);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_posted_recv_t,
+                                pmix_list_item_t,
+                                prcon, NULL);
 
 static void srcon(pmix_ptl_sr_t *p)
 {
@@ -475,7 +478,9 @@ static void srdes(pmix_ptl_sr_t *p)
         PMIX_RELEASE(p->peer);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_sr_t, pmix_object_t, srcon, srdes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_sr_t,
+                                pmix_object_t,
+                                srcon, srdes);
 
 static void pccon(pmix_pending_connection_t *p)
 {
@@ -516,10 +521,14 @@ static void pcdes(pmix_pending_connection_t *p)
         free(p->cred);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_pending_connection_t, pmix_object_t, pccon, pcdes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_pending_connection_t,
+                                pmix_object_t,
+                                pccon, pcdes);
 
 static void lcon(pmix_listener_t *p)
 {
+    memset(&p->ev, 0, sizeof(pmix_event_t));
+    p->active = false;
     p->socket = -1;
     p->varname = NULL;
     p->uri = NULL;
@@ -539,7 +548,9 @@ static void ldes(pmix_listener_t *p)
         free(p->uri);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_listener_t, pmix_list_item_t, lcon, ldes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_listener_t,
+                                pmix_list_item_t,
+                                lcon, ldes);
 
 static void qcon(pmix_ptl_queue_t *p)
 {
@@ -553,7 +564,9 @@ static void qdes(pmix_ptl_queue_t *p)
         PMIX_RELEASE(p->peer);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_queue_t, pmix_object_t, qcon, qdes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_queue_t,
+                                pmix_object_t,
+                                qcon, qdes);
 
 static void ccon(pmix_connection_t *p)
 {
@@ -575,4 +588,6 @@ static void dcon(pmix_connection_t *p)
         free(p->version);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_connection_t, pmix_list_item_t, ccon, dcon);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_connection_t,
+                                pmix_list_item_t,
+                                ccon, dcon);

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,6 +49,7 @@
 #include <pthread.h>
 
 #include "src/class/pmix_list.h"
+#include "src/include/pmix_socket_errno.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_error.h"
@@ -63,13 +64,14 @@
 
 #include "src/mca/ptl/base/base.h"
 
-// local functions for connection support
-static void *listen_thread(void *obj);
-static pthread_t engine;
+// local connection handler
+static void connection_event_handler(int incoming_sd, short flags, void *cbdata);
+
+// local value for connection support
 static bool setup_complete = false;
 
 /*
- * start listening thread
+ * start listening event
  */
 pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo)
 {
@@ -84,155 +86,111 @@ pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo)
     }
     setup_complete = true;
 
-    /*** spawn internal listener thread */
-    if (0 > pipe(pmix_ptl_base.stop_thread)) {
-        PMIX_ERROR_LOG(PMIX_ERR_IN_ERRNO);
-        return PMIX_ERR_OUT_OF_RESOURCE;
-    }
-    /* Make sure the pipe FDs are set to close-on-exec so that
-       they don't leak into children */
-    if (pmix_fd_set_cloexec(pmix_ptl_base.stop_thread[0]) != PMIX_SUCCESS
-        || pmix_fd_set_cloexec(pmix_ptl_base.stop_thread[1]) != PMIX_SUCCESS) {
-        PMIX_ERROR_LOG(PMIX_ERR_IN_ERRNO);
-        close(pmix_ptl_base.stop_thread[0]);
-        close(pmix_ptl_base.stop_thread[1]);
-        return PMIX_ERR_OUT_OF_RESOURCE;
-    }
-    /* fork off the listener thread */
-    pmix_ptl_base.listen_thread_active = true;
-    if (0 > pthread_create(&engine, NULL, listen_thread, NULL)) {
-        pmix_ptl_base.listen_thread_active = false;
-        return PMIX_ERROR;
-    }
+    pmix_event_set(pmix_globals.evbase, &pmix_ptl_base.listener.ev,
+               pmix_ptl_base.listener.socket,
+               PMIX_EV_READ|PMIX_EV_PERSIST,
+               connection_event_handler, 0);
+    pmix_ptl_base.listener.active = true;
+    pmix_event_add(&pmix_ptl_base.listener.ev, 0);
 
     return PMIX_SUCCESS;
 }
 
 void pmix_ptl_base_stop_listening(void)
 {
-    int i;
     pmix_listener_t *lt = &pmix_ptl_base.listener;
 
-    pmix_output_verbose(8, pmix_ptl_base_framework.framework_output, "listen_thread: shutdown");
+    pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
+                        "listen_thread: shutdown");
 
-    if (!pmix_ptl_base.listen_thread_active) {
-        /* nothing we can do */
+    if (!lt->active) {
+        /* nothing we need do */
         return;
     }
 
     /* mark it as inactive */
-    pmix_ptl_base.listen_thread_active = false;
-    /* use the block to break it loose just in
-     * case the thread is blocked in a call to select for
-     * a long time */
-    i = 1;
-    if (0 > write(pmix_ptl_base.stop_thread[1], &i, sizeof(int))) {
-        return;
-    }
-    /* wait for thread to exit */
-    pthread_join(engine, NULL);
+    lt->active = false;
+    pmix_event_del(&lt->ev);
     /* close the socket to remove the connection points */
     CLOSE_THE_SOCKET(lt->socket);
     lt->socket = -1;
 }
 
-static void *listen_thread(void *obj)
+/*
+ * Handler for accepting connections from the event library
+ */
+static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
 {
-    (void) obj;
-    int rc, max;
-    socklen_t addrlen = sizeof(struct sockaddr_storage);
+    struct sockaddr addr;
+    pmix_socklen_t addrlen = sizeof(struct sockaddr);
+    int sd;
     pmix_pending_connection_t *pending_connection;
-    struct timeval timeout;
-    fd_set readfds;
     pmix_listener_t *lt = &pmix_ptl_base.listener;
+    PMIX_HIDE_UNUSED_PARAMS(flags, cbdata);
 
-    pmix_output_verbose(8, pmix_ptl_base_framework.framework_output, "listen_thread: active");
-
-    while (pmix_ptl_base.listen_thread_active) {
-        FD_ZERO(&readfds);
-        FD_SET(lt->socket, &readfds);
-        max = lt->socket;
-
-        /* add the stop_thread fd */
-        FD_SET(pmix_ptl_base.stop_thread[0], &readfds);
-        max = (pmix_ptl_base.stop_thread[0] > max) ? pmix_ptl_base.stop_thread[0] : max;
-
-        /* set timeout interval */
-        timeout.tv_sec = 2;
-        timeout.tv_usec = 0;
-
-        /* Block in a select to avoid hammering the cpu.  If a connection
-         * comes in, we'll get woken up right away.
-         */
-        rc = select(max + 1, &readfds, NULL, NULL, &timeout);
-        if (!pmix_ptl_base.listen_thread_active) {
-            /* we've been asked to terminate */
-            close(pmix_ptl_base.stop_thread[0]);
-            close(pmix_ptl_base.stop_thread[1]);
-            return NULL;
-        }
-        if (rc < 0) {
-            continue;
+    sd = accept(incoming_sd, (struct sockaddr *) &addr, &addrlen);
+    pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
+                        "connection_event_handler: working connection "
+                        "(%d, %d) %s:%d\n",
+                        sd, pmix_socket_errno,
+                        pmix_net_get_hostname((struct sockaddr *) &addr),
+                        pmix_net_get_port((struct sockaddr *) &addr));
+    if (sd < 0) {
+        /* Non-fatal errors */
+        if (EINTR == pmix_socket_errno ||
+            EAGAIN == pmix_socket_errno ||
+            EWOULDBLOCK == pmix_socket_errno) {
+            return;
         }
 
-        /* according to the man pages, select replaces the given descriptor
-         * set with a subset consisting of those descriptors that are ready
-         * for the specified operation - in this case, a read. So we need to
-         * first check to see if this file descriptor is included in the
-         * returned subset
-         */
-        if (0 == FD_ISSET(lt->socket, &readfds)) {
-            /* this descriptor is not included */
-            continue;
+        /* If we run out of file descriptors, log an extra warning (so
+           that the user can know to fix this problem) and abandon all
+           hope. */
+        else if (EMFILE == pmix_socket_errno) {
+            CLOSE_THE_SOCKET(incoming_sd);
+            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            pmix_show_help("help-ptl-base.txt", "accept failed", true,
+                           pmix_globals.hostname,
+                           pmix_socket_errno, strerror(pmix_socket_errno),
+                           "Out of file descriptors");
+            return;
         }
 
-        /* this descriptor is ready to be read, which means a connection
-         * request has been received - so harvest it. All we want to do
-         * here is accept the connection and push the info onto the event
-         * library for subsequent processing - we don't want to actually
-         * process the connection here as it takes too long, and so the
-         * OS might start rejecting connections due to timeout.
-         */
-        pending_connection = PMIX_NEW(pmix_pending_connection_t);
-        pending_connection->protocol = lt->protocol;
-        pmix_event_assign(&pending_connection->ev, pmix_globals.evbase, -1, EV_WRITE, lt->cbfunc,
-                          pending_connection);
-        pending_connection->sd = accept(lt->socket, (struct sockaddr *) &(pending_connection->addr),
-                                        &addrlen);
-        if (pending_connection->sd < 0) {
-            PMIX_RELEASE(pending_connection);
-            if (pmix_socket_errno != EAGAIN || pmix_socket_errno != EWOULDBLOCK) {
-                if (EMFILE == pmix_socket_errno || ENOBUFS == pmix_socket_errno
-                    || ENOMEM == pmix_socket_errno) {
-                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                } else if (EINVAL == pmix_socket_errno || EINTR == pmix_socket_errno) {
-                    /* race condition at finalize */
-                    goto done;
-                } else if (ECONNABORTED == pmix_socket_errno) {
-                    /* they aborted the attempt */
-                    continue;
-                } else {
-                    pmix_output(0, "listen_thread: accept() failed: %s (%d).",
-                                strerror(pmix_socket_errno), pmix_socket_errno);
-                }
-                goto done;
-            }
-            continue;
+        /* For all other cases, close the socket, print a warning but
+           try to continue */
+        else {
+            CLOSE_THE_SOCKET(incoming_sd);
+            pmix_show_help("help-ptl-base.txt", "accept failed", true,
+                           pmix_globals.hostname,
+                           pmix_socket_errno, strerror(pmix_socket_errno),
+                           "Unknown cause; job will try to continue");
+            return;
         }
-
-        pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
-                            "listen_thread: new connection: (%d, %d)", pending_connection->sd,
-                            pmix_socket_errno);
-        /* post the object */
-        PMIX_POST_OBJECT(pending_connection);
-        /* activate the event */
-        pmix_event_active(&pending_connection->ev, EV_WRITE, 1);
     }
 
-done:
-    pmix_ptl_base.listen_thread_active = false;
-    return NULL;
+    /* this descriptor is ready to be read, which means a connection
+     * request has been received - so harvest it. All we want to do
+     * here is accept the connection and push the info onto the event
+     * library for subsequent processing - we don't want to actually
+     * process the connection here as it takes too long, and so the
+     * OS might start rejecting connections due to timeout.
+     */
+    pending_connection = PMIX_NEW(pmix_pending_connection_t);
+    pending_connection->protocol = lt->protocol;
+    pmix_event_assign(&pending_connection->ev, pmix_globals.evbase,
+                      -1, EV_WRITE,
+                      lt->cbfunc, pending_connection);
+    pending_connection->sd = sd;
+
+    pmix_output_verbose(8, pmix_ptl_base_framework.framework_output,
+                        "connection_event_handler: new connection: (%d, %d)", pending_connection->sd,
+                        pmix_socket_errno);
+    /* post the object */
+    PMIX_POST_OBJECT(pending_connection);
+    /* activate the event */
+    pmix_event_active(&pending_connection->ev, EV_WRITE, 1);
 }
+
 
 pmix_status_t pmix_base_write_rndz_file(char *filename, char *uri, bool *created)
 {
@@ -498,15 +456,13 @@ pmix_status_t pmix_ptl_base_setup_listener(pmix_info_t info[], size_t ninfo)
 
     /* set the port */
     if (AF_INET == pmix_ptl_base.connection->ss_family) {
-        ((struct sockaddr_in *) pmix_ptl_base.connection)->sin_port = htons(
-            pmix_ptl_base.ipv4_port);
+        ((struct sockaddr_in *) pmix_ptl_base.connection)->sin_port = htons(pmix_ptl_base.ipv4_port);
         addrlen = sizeof(struct sockaddr_in);
         if (0 != pmix_ptl_base.ipv4_port) {
             flags = 1;
         }
     } else if (AF_INET6 == pmix_ptl_base.connection->ss_family) {
-        ((struct sockaddr_in6 *) pmix_ptl_base.connection)->sin6_port = htons(
-            pmix_ptl_base.ipv6_port);
+        ((struct sockaddr_in6 *) pmix_ptl_base.connection)->sin6_port = htons(pmix_ptl_base.ipv6_port);
         addrlen = sizeof(struct sockaddr_in6);
         if (0 != pmix_ptl_base.ipv6_port) {
             flags = 1;

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,6 +53,7 @@
 #include <event.h>
 
 #include "src/class/pmix_list.h"
+#include "src/include/pmix_stdatomic.h"
 #include "src/mca/bfrops/bfrops_types.h"
 #include "src/mca/ptl/base/ptl_base_handshake.h"
 #include "src/util/pmix_output.h"
@@ -321,6 +322,8 @@ PMIX_CLASS_DECLARATION(pmix_pending_connection_t);
 /* listener objects */
 typedef struct pmix_listener_t {
     pmix_list_item_t super;
+    pmix_event_t ev;
+    pmix_atomic_bool_t active;
     pmix_listener_protocol_t protocol;
     int socket;
     char *varname;
@@ -337,6 +340,7 @@ PMIX_CLASS_DECLARATION(pmix_listener_t);
 #define PMIX_LISTENER_STATIC_INIT           \
 {                                           \
     .super = PMIX_LIST_ITEM_STATIC_INIT,    \
+    .active = false,                        \
     .protocol = PMIX_PROTOCOL_UNDEF,        \
     .socket = 0,                            \
     .varname = NULL,                        \


### PR DESCRIPTION
[Switch to using event lib for connections](https://github.com/openpmix/openpmix/commit/fbfced2a8417010b074a496a13f46979863ead3e)

The "select" function has an inherent limitation on the
number of file descriptors that can be open at any given
time. In some environments, this can cause problems - so
switch to using the event library for harvesting client-server
connection requests.

Note: we were directly using "select" to avoid dropped
connections due to an incoming connection flood at large
scale. This was copied from an "mpirun" implementation.
PMIx, however, doesn't have that flood problem - at most,
one might see a few hundred local clients attempting to
connect at the same time. Probably not an issue, but worth
remembering.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6e8d12dd4d8fa3d276411aa1eba6107a4f90d2d5)

[Roll to version 5.0.1](https://github.com/openpmix/openpmix/commit/42830c0e08283a80ce2d16e987c2ddc45ceb5f6d)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick