### PR TITLE
Minor cleanups for disable-dlopen

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -107,7 +107,7 @@ progressThread = threading.Thread(target = pyevhdlr, daemon = True, args =(lambd
 
 cdef void dmodx_cbfunc(pmix_status_t status,
                        char *data, size_t sz,
-                       void *cbdata):
+                       void *cbdata) noexcept:
     global active
     if PMIX_SUCCESS == status:
         active.cache_data(data, sz)
@@ -117,7 +117,7 @@ cdef void dmodx_cbfunc(pmix_status_t status,
 cdef void setupapp_cbfunc(pmix_status_t status,
                           pmix_info_t info[], size_t ninfo,
                           void *provided_cbdata,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -132,7 +132,7 @@ cdef void setupapp_cbfunc(pmix_status_t status,
 cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
                                   size_t ninfo, void *cbdata,
                                   pmix_release_cbfunc_t release_fn,
-                                  void *release_cbdata) with gil:
+                                  void *release_cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -146,7 +146,7 @@ cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
 
 cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
                        pmix_proc_t *source, pmix_byte_object_t *payload,
-                       pmix_info_t info[], size_t ninfo) with gil:
+                       pmix_info_t info[], size_t ninfo) noexcept with gil:
     cdef char* kystr
     pychannel = int(channel)
     pyiof_id  = int(iofhdlr_id)
@@ -211,7 +211,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
                          pmix_info_t info[], size_t ninfo,
                          pmix_info_t *results, size_t nresults,
                          pmix_event_notification_cbfunc_fn_t cbfunc,
-                         void *cbdata) with gil:
+                         void *cbdata) noexcept with gil:
     cdef pmix_info_t *myresults
     cdef pmix_info_t **myresults_ptr
     cdef size_t nmyresults

--- a/src/mca/pdl/pdlopen/configure.m4
+++ b/src/mca/pdl/pdlopen/configure.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,18 +47,21 @@ AC_DEFUN([MCA_pmix_pdl_pdlopen_CONFIG],[
 
     dnl This is effectively a back-door for PMIX developers to
     dnl force the use of the libltdl pdl component.
-    AC_ARG_ENABLE([dl-dlopen],
-        [AS_HELP_STRING([--disable-dl-dlopen],
-                        [Disable the "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
+    AC_ARG_ENABLE([pmix-dlopen],
+        [AS_HELP_STRING([--disable-pmix-dlopen],
+                        [Disable the PMIx "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
         ])
 
-    OAC_CHECK_PACKAGE([dlopen],
-              [pmix_pdl_pdlopen],
-              [dlfcn.h],
-              [dl],
-              [dlopen],
-              [pmix_pdl_pdlopen_happy=yes],
-              [pmix_pdl_pdlopen_happy=no])
+    pmix_pdl_pdlopen_happy=no
+    AS_IF([test "$enable_pmix_dlopen" != "no"],
+        [OAC_CHECK_PACKAGE([dlopen],
+                  [pmix_pdl_pdlopen],
+                  [dlfcn.h],
+                  [dl],
+                  [dlopen],
+                  [pmix_pdl_pdlopen_happy=yes],
+                  [pmix_pdl_pdlopen_happy=no])
+        ])
 
     AS_IF([test "$pmix_pdl_pdlopen_happy" = "yes"],
           [pmix_pdl_pdlopen_ADD_LIBS=$pmix_pdl_pdlopen_LIBS

--- a/src/mca/pdl/plibltdl/configure.m4
+++ b/src/mca/pdl/plibltdl/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -45,20 +45,23 @@ AC_DEFUN([MCA_pmix_pdl_plibltdl_CONFIG],[
     AC_CONFIG_FILES([src/mca/pdl/plibltdl/Makefile])
 
     # Add --with options
-    AC_ARG_WITH([plibltdl],
+    AC_ARG_WITH([libltdl],
         [AS_HELP_STRING([--with-libltdl(=DIR)],
              [Build libltdl support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     AC_ARG_WITH([libltdl-libdir],
        [AS_HELP_STRING([--with-libltdl-libdir=DIR],
              [Search for libltdl libraries in DIR])])
 
-    OAC_CHECK_PACKAGE([libltdl],
-                  [pmix_pdl_plibltdl],
-                  [ltdl.h],
-                  [ltdl],
-                  [lt_dlopen],
-                  [pmix_pdl_plibltdl_happy=yes],
-                  [pmix_pdl_plibltdl_happy=no])
+    pmix_pdl_plibltdl_happy=no
+    AS_IF([test "$with_libltdl" != "no"],
+        [OAC_CHECK_PACKAGE([libltdl],
+                      [pmix_pdl_plibltdl],
+                      [ltdl.h],
+                      [ltdl],
+                      [lt_dlopen],
+                      [pmix_pdl_plibltdl_happy=yes],
+                      [pmix_pdl_plibltdl_happy=no])
+        ])
 
     # If we have plibltdl, do we have lt_dladvise?
     pmix_pdl_plibltdl_have_lt_dladvise=0


### PR DESCRIPTION
We provide a backdoor way to disable dlopen, but
then ignored the option. Simplify the name of the
option a little bit.