### PR TITLE
Multiple commits

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -101,7 +101,7 @@ progressThread = threading.Thread(target = pyevhdlr, daemon = True, args =(lambd
 
 cdef void dmodx_cbfunc(pmix_status_t status,
                        char *data, size_t sz,
-                       void *cbdata):
+                       void *cbdata) noexcept:
     global active
     if PMIX_SUCCESS == status:
         active.cache_data(data, sz)
@@ -111,7 +111,7 @@ cdef void dmodx_cbfunc(pmix_status_t status,
 cdef void setupapp_cbfunc(pmix_status_t status,
                           pmix_info_t info[], size_t ninfo,
                           void *provided_cbdata,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -126,7 +126,7 @@ cdef void setupapp_cbfunc(pmix_status_t status,
 cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
                                   size_t ninfo, void *cbdata,
                                   pmix_release_cbfunc_t release_fn,
-                                  void *release_cbdata) with gil:
+                                  void *release_cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -140,7 +140,7 @@ cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
 
 cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
                        pmix_proc_t *source, pmix_byte_object_t *payload,
-                       pmix_info_t info[], size_t ninfo) with gil:
+                       pmix_info_t info[], size_t ninfo) noexcept with gil:
     cdef char* kystr
     pychannel = int(channel)
     pyiof_id  = int(iofhdlr_id)
@@ -205,7 +205,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
                          pmix_info_t info[], size_t ninfo,
                          pmix_info_t *results, size_t nresults,
                          pmix_event_notification_cbfunc_fn_t cbfunc,
-                         void *cbdata) with gil:
+                         void *cbdata) noexcept with gil:
     cdef pmix_info_t *myresults
     cdef pmix_info_t **myresults_ptr
     cdef size_t nmyresults

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1071,12 +1071,14 @@ if test "$enable_devel_check" = "yes"; then
 elif test "$enable_devel_check" = "no"; then
     AC_MSG_RESULT([no])
     WANT_PICKY_COMPILER=0
-elif test "$pmix_git_repo_build" = "yes"; then
+    CFLAGS="$CFLAGS -Wno-unused-parameter"
+elif test "$pmix_git_repo_build" = "yes" && test "$pmix_debug" = "1"; then
     AC_MSG_RESULT([yes])
     WANT_PICKY_COMPILER=1
 else
     AC_MSG_RESULT([no])
     WANT_PICKY_COMPILER=0
+    CFLAGS="$CFLAGS -Wno-unused-parameter"
 fi
 
 AC_DEFINE_UNQUOTED(PMIX_PICKY_COMPILERS, $WANT_PICKY_COMPILER,

--- a/docs/building-apps/index.rst
+++ b/docs/building-apps/index.rst
@@ -1,8 +1,8 @@
-Building MPI applications
-=========================
+Building PMIx applications
+==========================
 
-The simplest way to compile and link MPI applications is to use the
-Open MPI "wrapper" compilers.
+The simplest way to compile and link PMIx applications is to use the
+PMIx "wrapper" compilers.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,3 +195,16 @@ rst_prolog = f"""
 .. |flex_min_version| replace:: {flex_min_version}
 
 """
+
+# The sphinx_rtd_theme does not properly handle wrapping long lines in
+# table cells when rendering to HTML due to a CSS issue (see
+# https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).  Until
+# the issue is fixed upstream in sphinx_rtd_theme, we can simply
+# override the CSS here.
+rst_prolog += """
+.. raw:: html
+
+   <style>
+   .wy-table-responsive table td,.wy-table-responsive table th{white-space:normal}
+   </style>
+"""

--- a/docs/installing-pmix/required-support-libraries.rst
+++ b/docs/installing-pmix/required-support-libraries.rst
@@ -14,13 +14,13 @@ PMIx requires the following support libraries with the minimum listed versions:
      - Notes
    * - `Hardware Locality <https://www.open-mpi.org/projects/hwloc/>`_
      - |hwloc_min_version|
-     - | This library is required; PMIx will not build without it.
+     - This library is required; PMIx will not build without it.
    * - `Libevent <https://libevent.org/>`_
      - |event_min_version|
-     - | Either libevent or libev must be provided
+     - Either libevent or libev must be provided
    * - `libev <https://metacpan.org/dist/EV/view/libev/ev.pod>`_
-     - | no specified minimum
-     - | Either libevent or libev must be provided
+     - no specified minimum
+     - Either libevent or libev must be provided
 
 These support libraries are fundamental to PMIx's operation
 and pretty universally available in all environments. Worst case,

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
@@ -26,7 +26,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
-                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset
+                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -124,6 +124,9 @@ pset_SOURCES = pset.c examples.h
 pset_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pset_LDADD = $(top_builddir)/src/libpmix.la
 
+log_SOURCES = log.c examples.h
+log_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+log_LDADD = $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -321,33 +321,40 @@ tryxml:
     PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb);
     if (PMIX_SUCCESS == rc) {
         file = popstr(&cb);
-        rc = load_xml(file);
-        free(file);
+        if (NULL == file) {
+            rc = PMIX_ERR_NOT_FOUND;
+        } else {
+            rc = load_xml(file);
+            free(file);
+        }
         cb.key = NULL;
         PMIX_DESTRUCT(&cb);
-        if (PMIX_SUCCESS == rc) {
-            pmix_output_verbose(2, pmix_hwloc_output,
-                                "%s:%s v2 xml adopted", __FILE__, __func__);
-            /* record locally in case someone does a PMIx_Get to retrieve it */
-            kv.key = PMIX_TOPOLOGY2;
-            kv.value = &val;
-            val.type = PMIX_TOPO;
-            val.data.topo = &pmix_globals.topology;
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
-            pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
-                                __FILE__, __func__);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-            if (share) {
-                goto sharetopo;
-            }
+        if (PMIX_SUCCESS != rc) {
+            goto tryv1;
+        }
+
+        pmix_output_verbose(2, pmix_hwloc_output,
+                            "%s:%s v2 xml adopted", __FILE__, __func__);
+        /* record locally in case someone does a PMIx_Get to retrieve it */
+        kv.key = PMIX_TOPOLOGY2;
+        kv.value = &val;
+        val.type = PMIX_TOPO;
+        val.data.topo = &pmix_globals.topology;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
+        pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
+                            __FILE__, __func__);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        if (share) {
+            goto sharetopo;
         }
         return rc;
     }
 
 #endif
 
+tryv1:
     /* try to get the v1 XML string */
     pmix_output_verbose(2, pmix_hwloc_output,
                         "%s:%s checking v1 xml",
@@ -359,35 +366,38 @@ tryxml:
     PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb);
     if (PMIX_SUCCESS == rc) {
         file = popstr(&cb);
-        rc = load_xml(file);
-        free(file);
+        if (NULL == file) {
+            rc = PMIX_ERR_NOT_FOUND;
+        } else {
+            rc = load_xml(file);
+            free(file);
+        }
         cb.key = NULL;
         PMIX_DESTRUCT(&cb);
-        if (PMIX_SUCCESS == rc) {
-            pmix_output_verbose(2, pmix_hwloc_output,
-                                "%s:%s v1 xml adopted", __FILE__, __func__);
+        if (PMIX_SUCCESS != rc) {
+            goto tryself;
+        }
+        pmix_output_verbose(2, pmix_hwloc_output,
+                            "%s:%s v1 xml adopted", __FILE__, __func__);
 
-            /* record locally in case someone does a PMIx_Get to retrieve it */
-            kv.key = PMIX_TOPOLOGY2;
-            kv.value = &val;
-            val.type = PMIX_TOPO;
-            val.data.topo = &pmix_globals.topology;
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
-            pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
-                                __FILE__, __func__);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-            if (share) {
-                goto sharetopo;
-            }
+        /* record locally in case someone does a PMIx_Get to retrieve it */
+        kv.key = PMIX_TOPOLOGY2;
+        kv.value = &val;
+        val.type = PMIX_TOPO;
+        val.data.topo = &pmix_globals.topology;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, &kv);
+        pmix_output_verbose(2, pmix_hwloc_output, "%s:%s stored",
+                            __FILE__, __func__);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        if (share) {
+            goto sharetopo;
         }
         return rc;
     }
 
-#if HWLOC_API_VERSION >= 0x20000
 tryself:
-#endif
     /* did they give us one to use? */
     if (NULL != topo_file) {
         pmix_output_verbose(2, pmix_hwloc_output,
@@ -440,6 +450,7 @@ tryself:
                             "%s:%s discovery complete - source %s", __FILE__, __func__,
                             pmix_globals.topology.source);
     }
+
     /* record locally in case someone does a PMIx_Get to retrieve it */
     kv.key = PMIX_TOPOLOGY2;
     kv.value = &val;

--- a/src/mca/pdl/pdlopen/configure.m4
+++ b/src/mca/pdl/pdlopen/configure.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,18 +47,21 @@ AC_DEFUN([MCA_pmix_pdl_pdlopen_CONFIG],[
 
     dnl This is effectively a back-door for PMIX developers to
     dnl force the use of the libltdl pdl component.
-    AC_ARG_ENABLE([dl-dlopen],
-        [AS_HELP_STRING([--disable-dl-dlopen],
-                        [Disable the "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
+    AC_ARG_ENABLE([pmix-dlopen],
+        [AS_HELP_STRING([--disable-pmix-dlopen],
+                        [Disable the PMIx "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
         ])
 
-    OAC_CHECK_PACKAGE([dlopen],
-              [pmix_pdl_pdlopen],
-              [dlfcn.h],
-              [dl],
-              [dlopen],
-              [pmix_pdl_pdlopen_happy=yes],
-              [pmix_pdl_pdlopen_happy=no])
+    pmix_pdl_pdlopen_happy=no
+    AS_IF([test "$enable_pmix_dlopen" != "no"],
+        [OAC_CHECK_PACKAGE([dlopen],
+                  [pmix_pdl_pdlopen],
+                  [dlfcn.h],
+                  [dl],
+                  [dlopen],
+                  [pmix_pdl_pdlopen_happy=yes],
+                  [pmix_pdl_pdlopen_happy=no])
+        ])
 
     AS_IF([test "$pmix_pdl_pdlopen_happy" = "yes"],
           [pmix_pdl_pdlopen_ADD_LIBS=$pmix_pdl_pdlopen_LIBS

--- a/src/mca/pdl/plibltdl/configure.m4
+++ b/src/mca/pdl/plibltdl/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -45,20 +45,23 @@ AC_DEFUN([MCA_pmix_pdl_plibltdl_CONFIG],[
     AC_CONFIG_FILES([src/mca/pdl/plibltdl/Makefile])
 
     # Add --with options
-    AC_ARG_WITH([plibltdl],
+    AC_ARG_WITH([libltdl],
         [AS_HELP_STRING([--with-libltdl(=DIR)],
              [Build libltdl support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     AC_ARG_WITH([libltdl-libdir],
        [AS_HELP_STRING([--with-libltdl-libdir=DIR],
              [Search for libltdl libraries in DIR])])
 
-    OAC_CHECK_PACKAGE([libltdl],
-                  [pmix_pdl_plibltdl],
-                  [ltdl.h],
-                  [ltdl],
-                  [lt_dlopen],
-                  [pmix_pdl_plibltdl_happy=yes],
-                  [pmix_pdl_plibltdl_happy=no])
+    pmix_pdl_plibltdl_happy=no
+    AS_IF([test "$with_libltdl" != "no"],
+        [OAC_CHECK_PACKAGE([libltdl],
+                      [pmix_pdl_plibltdl],
+                      [ltdl.h],
+                      [ltdl],
+                      [lt_dlopen],
+                      [pmix_pdl_plibltdl_happy=yes],
+                      [pmix_pdl_plibltdl_happy=no])
+        ])
 
     # If we have plibltdl, do we have lt_dladvise?
     pmix_pdl_plibltdl_have_lt_dladvise=0


### PR DESCRIPTION
[Properly support the "log" example](https://github.com/openpmix/openpmix/commit/9bd481fc6ac539913a6da0e1a19fc012f61c5e61)

Needs a little more plumbing in the Makefile

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/23499ab4303b1c89fa533791acaba000e30f9d5c)

[Enable building of tarball](https://github.com/openpmix/openpmix/commit/238a22f7ffc18c0be08f94aaf4eb55a90336b521)

Disable the unused param check when not enabling the
developer picky compiler setting. If not specifically
requested, then disable the developer picky compiler
setting unless (a) we are in a git repo, and (b) we
enable debug.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/03ea1de1c91c35f8fc7e20709fb1ad6f3e73d516)

[show_help: strip leading/trailing blank lines](https://github.com/openpmix/openpmix/commit/417e307c3cce668e3ed3940973912d2dbe9199df)

When we read a [topic] from a help file, strip any leading or trailing
blank lines from that topic.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9b09a2d3ee67d2dd1009dd732a629247a7a23087)

[docs: fix some leftover "Open MPI" references](https://github.com/openpmix/openpmix/commit/016008ce2ce121bbe43d3ce06a1daf8e257cd721)

Basically, do a s/Open MPI/PMIx/g on a file that was previously
missed.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7720337bb8a9f89970bc3702efe9faaf1dab3ec0)

[docs: fix HTML word wapping in table cells](https://github.com/openpmix/openpmix/commit/03ec9f60804c9d30b758da5feb0e04509204b30e)

The sphinx_rtd_theme does not properly handle wrapping long lines in
table cells when rendering to HTML due to a CSS issue (see
https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).

Until the issue is fixed upstream in sphinx_rtd_theme, we can simply
override the CSS here.  This commit overrides the CSS in conf.py and
also touches up some places where we previously tried to work around
the lack of word wrapping.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9b3bdf8d1648ee2adb116e9b133cf1797da9617a)

[Improve error handling in setup_topology](https://github.com/openpmix/openpmix/commit/377f7fc55b27a6e991f1be90f4bfdc3d79648ec7)

Ensure we go thru the progression and then do our own
discovery if there are problems.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/03cdd09d049197f314b82e2953fcbeec97cfae0c)

[Minor cleanups for disable-dlopen](https://github.com/openpmix/openpmix/commit/f96155357bca8f60333b6ab5cc1632b95257663e)

We provide a backdoor way to disable dlopen, but
then ignored the option. Simplify the name of the
option a little bit.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6ae2e0c6ddaec024d3aef6bb369d7427de90f72b)

[Fix Python bindings](https://github.com/openpmix/openpmix/commit/f0f27cfd4edb594ddf2805f0f1f530cee58c2de0)

Newer versions of Cython are taking issue with some of the
exceptions compatibility on callback functions. Follow
their suggestions to silence the errors.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/552f5afe85c7d81b153331c5718ec6b01b857fcc)
