### PR TITLE
Multiple commits

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -107,7 +107,7 @@ progressThread = threading.Thread(target = pyevhdlr, daemon = True, args =(lambd
 
 cdef void dmodx_cbfunc(pmix_status_t status,
                        char *data, size_t sz,
-                       void *cbdata):
+                       void *cbdata) noexcept:
     global active
     if PMIX_SUCCESS == status:
         active.cache_data(data, sz)
@@ -117,7 +117,7 @@ cdef void dmodx_cbfunc(pmix_status_t status,
 cdef void setupapp_cbfunc(pmix_status_t status,
                           pmix_info_t info[], size_t ninfo,
                           void *provided_cbdata,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -132,7 +132,7 @@ cdef void setupapp_cbfunc(pmix_status_t status,
 cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
                                   size_t ninfo, void *cbdata,
                                   pmix_release_cbfunc_t release_fn,
-                                  void *release_cbdata) with gil:
+                                  void *release_cbdata) noexcept with gil:
     global active
     if PMIX_SUCCESS == status:
         ilist = []
@@ -146,7 +146,7 @@ cdef void collectinventory_cbfunc(pmix_status_t status, pmix_info_t info[],
 
 cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
                        pmix_proc_t *source, pmix_byte_object_t *payload,
-                       pmix_info_t info[], size_t ninfo) with gil:
+                       pmix_info_t info[], size_t ninfo) noexcept with gil:
     cdef char* kystr
     pychannel = int(channel)
     pyiof_id  = int(iofhdlr_id)
@@ -211,7 +211,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
                          pmix_info_t info[], size_t ninfo,
                          pmix_info_t *results, size_t nresults,
                          pmix_event_notification_cbfunc_fn_t cbfunc,
-                         void *cbdata) with gil:
+                         void *cbdata) noexcept with gil:
     cdef pmix_info_t *myresults
     cdef pmix_info_t **myresults_ptr
     cdef size_t nmyresults

--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020-2022 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -256,12 +256,12 @@ BEGIN_C_DECLS
 
 PMIX_EXPORT extern const pmix_regattr_input_t pmix_dictionary[{ne}];
 
-#define PMIX_INDEX_BOUNDARY {nem1}
+#define PMIX_INDEX_BOUNDARY {ne}
 
 END_C_DECLS
 
 #endif\n
-'''.format(ne=num_elements, nem1=num_elements - 1)
+'''.format(ne=num_elements)
 
     if options.dryrun:
         constants = sys.stdout

--- a/docs/building-apps/index.rst
+++ b/docs/building-apps/index.rst
@@ -1,8 +1,8 @@
-Building MPI applications
-=========================
+Building PMIx applications
+==========================
 
-The simplest way to compile and link MPI applications is to use the
-Open MPI "wrapper" compilers.
+The simplest way to compile and link PMIx applications is to use the
+PMIx "wrapper" compilers.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,3 +195,16 @@ rst_prolog = f"""
 .. |flex_min_version| replace:: {flex_min_version}
 
 """
+
+# The sphinx_rtd_theme does not properly handle wrapping long lines in
+# table cells when rendering to HTML due to a CSS issue (see
+# https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).  Until
+# the issue is fixed upstream in sphinx_rtd_theme, we can simply
+# override the CSS here.
+rst_prolog += """
+.. raw:: html
+
+   <style>
+   .wy-table-responsive table td,.wy-table-responsive table th{white-space:normal}
+   </style>
+"""

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,10 +1,6 @@
 Exceptions to the PMIx Standard
 ===============================
 
-.. |br| raw:: html
-
-    <br/>
-
 Exceptions to the base PMIx Standard are listed here. These exceptions
 are not indicative of any intent to stray
 from the Standard, but instead represent the difference between the
@@ -1065,206 +1061,206 @@ Attributes
      - Type
      - Description
 
-   * - ``PMIX_EXTERNAL_AUX_EVENT_BASE`` |br| ``"pmix.evaux"``
+   * - ``PMIX_EXTERNAL_AUX_EVENT_BASE`` ``"pmix.evaux"``
      - ``(void*)``
-     - event base to be used for auxiliary |br|
-       functions (e.g., capturing signals) that |br| would
-       otherwise interfere with the |br|
+     - event base to be used for auxiliary
+       functions (e.g., capturing signals) that would
+       otherwise interfere with the
        host
        
-   * - ``PMIX_CONNECT_TO_SCHEDULER`` |br| ``"pmix.cnct.sched"``
+   * - ``PMIX_CONNECT_TO_SCHEDULER`` ``"pmix.cnct.sched"``
      - ``(bool)``
      - Connect to the system scheduler
        
-   * - ``PMIX_BIND_PROGRESS_THREAD`` |br| ``"pmix.bind.pt"``
+   * - ``PMIX_BIND_PROGRESS_THREAD`` ``"pmix.bind.pt"``
      - ``(char*)``
-     - Comma-delimited ranges of CPUs |br|
-       that the internal PMIx progress |br|
+     - Comma-delimited ranges of CPUs
+       that the internal PMIx progress
        thread shall be bound to
          
-   * - ``PMIX_BIND_REQUIRED`` |br| ``"pmix.bind.reqd"``
+   * - ``PMIX_BIND_REQUIRED`` ``"pmix.bind.reqd"``
      - ``(bool)``
-     - Return error if the internal PMIx |br|
+     - Return error if the internal PMIx
        progress thread cannot be bound
            
-   * - ``PMIX_COLOCATE_PROCS`` |br| ``"pmix.colproc"``
+   * - ``PMIX_COLOCATE_PROCS`` ``"pmix.colproc"``
      - ``(pmix_data_array_t*)``
-     - Array of ``pmix_proc_t`` identifying the |br|
-       procs with which the new job's procs |br|
+     - Array of ``pmix_proc_t`` identifying the
+       procs with which the new job's procs
        are to be colocated
        
-   * - ``PMIX_COLOCATE_NPERPROC`` |br| ``"pmix.colnum.proc"``
+   * - ``PMIX_COLOCATE_NPERPROC`` ``"pmix.colnum.proc"``
      - ``(uint16_t)``
-     - Number of procs to colocate with |br|
+     - Number of procs to colocate with
        each identified proc
        
-   * - ``PMIX_COLOCATE_NPERNODE`` |br| ``"pmix.colnum.node"``
+   * - ``PMIX_COLOCATE_NPERNODE`` ``"pmix.colnum.node"``
      - ``(uint16_t)``
-     - Number of procs to colocate on the |br|
+     - Number of procs to colocate on the
        node of each identified proc
        
-   * - ``PMIX_EVENT_ONESHOT`` |br| ``pmix.evone``
+   * - ``PMIX_EVENT_ONESHOT`` ``pmix.evone``
      - ``(bool)``
-     - when registering, indicate that this |br|
-       event handler is to be deleted after |br|
+     - when registering, indicate that this
+       event handler is to be deleted after
        being invoked
 
-   * - ``PMIX_GROUP_ADD_MEMBERS`` |br| ``pmix.grp.add``
+   * - ``PMIX_GROUP_ADD_MEMBERS`` ``pmix.grp.add``
      - ``(pmix_data_array_t*)``
-     - Array of ``pmix_proc_t`` identifying |br|
-       procs that are not included in the |br|
-       membership specified in the procs |br|
-       array passed to the |br|
-       ``PMIx_Group_construct[_nb]()`` call, |br|
-       but are to be included in the final |br|
-       group. The identified procs will be |br|
-       sent an invitation to join the group |br|
-       during the construction procedure. |br|
-       This is used when some members of |br|
-       the proposed group do not know the |br|
-       full membership and therefore cannot |br|
-       include all members in the call to |br|
+     - Array of ``pmix_proc_t`` identifying
+       procs that are not included in the
+       membership specified in the procs
+       array passed to the
+       ``PMIx_Group_construct[_nb]()`` call,
+       but are to be included in the final
+       group. The identified procs will be
+       sent an invitation to join the group
+       during the construction procedure.
+       This is used when some members of
+       the proposed group do not know the
+       full membership and therefore cannot
+       include all members in the call to
        construct.
        
-   * - ``PMIX_GROUP_LOCAL_CID`` |br| ``pmix.grp.lclid``
+   * - ``PMIX_GROUP_LOCAL_CID`` ``pmix.grp.lclid``
      - ``(size_t)``
-     - Local context ID for the specified |br|
+     - Local context ID for the specified
        process member of a group
        
-   * - ``PMIX_GROUP_INFO`` |br| ``pmix.grp.info``
+   * - ``PMIX_GROUP_INFO`` ``pmix.grp.info``
      - ``pmix_data_array_t``
-     - Array of pmix_info_t containing data |br|
-       that is to be shared across all |br|
-       members of a group during group |br|
+     - Array of pmix_info_t containing data
+       that is to be shared across all
+       members of a group during group
        construction
 
-   * - ``PMIX_IOF_TAG_DETAILED_OUTPUT`` |br| ``pmix.iof.tagdet``
+   * - ``PMIX_IOF_TAG_DETAILED_OUTPUT`` ``pmix.iof.tagdet``
      - ``(bool)``
-     - Tag output with the |br|
-       [local jobid,rank][hostname:pid] |br|
+     - Tag output with the
+       [local jobid,rank][hostname:pid]
        and channel it comes from
        
-   * - ``PMIX_IOF_TAG_FULLNAME_OUTPUT`` |br| ``pmix.iof.tagfull``
+   * - ``PMIX_IOF_TAG_FULLNAME_OUTPUT`` ``pmix.iof.tagfull``
      - ``(bool)``
-     - Tag output with the [nspace,rank] |br|
+     - Tag output with the [nspace,rank]
        and channel it comes from
        
-   * - ``PMIX_LOG_AGG`` |br| ``pmix.log.agg``
+   * - ``PMIX_LOG_AGG`` ``pmix.log.agg``
      - ``(bool)``
-     - Whether to aggregate and prevent |br|
-       duplicate logging messages based |br|
+     - Whether to aggregate and prevent
+       duplicate logging messages based
        on key value pairs.
          
-   * - ``PMIX_LOG_KEY`` |br| ``pmix.log.key``
+   * - ``PMIX_LOG_KEY`` ``pmix.log.key``
      - ``(char*)``
      - key to a logging message
          
-   * - ``PMIX_LOG_VAL`` |br| ``pmix.log.val``
+   * - ``PMIX_LOG_VAL`` ``pmix.log.val``
      - ``(char*)``
      - value to a logging message
          
-   * - ``PMIX_MYSERVER_URI`` |br| ``pmix.mysrvr.uri``
+   * - ``PMIX_MYSERVER_URI`` ``pmix.mysrvr.uri``
      - ``(char*)``
      - URI of this proc's listener socket
          
-   * - ``PMIX_QUALIFIED_VALUE`` |br| ``pmix.qual.val``
+   * - ``PMIX_QUALIFIED_VALUE`` ``pmix.qual.val``
      - ``(pmix_data_array_t*)``
-     - Value being provided consists of the |br|
-       primary key-value pair in first position, |br|
-       followed by one or more key-value |br|
-       qualifiers to be used when |br|
-       subsequently retrieving the primary |br|
+     - Value being provided consists of the
+       primary key-value pair in first position,
+       followed by one or more key-value
+       qualifiers to be used when
+       subsequently retrieving the primary
        value
          
-   * - ``PMIX_WDIR_USER_SPECIFIED`` |br| ``pmix.wdir.user``
+   * - ``PMIX_WDIR_USER_SPECIFIED`` ``pmix.wdir.user``
      - ``(bool)``
      - User specified the working directory
          
-   * - ``PMIX_RUNTIME_OPTIONS`` |br| ``pmix.runopt``
+   * - ``PMIX_RUNTIME_OPTIONS`` ``pmix.runopt``
      - ``(char*)``
-     - Environment-specific runtime |br|
+     - Environment-specific runtime
        directives that control job behavior
          
-   * - ``PMIX_ABORT_NON_ZERO_TERM`` |br| ``pmix.abnz``
+   * - ``PMIX_ABORT_NON_ZERO_TERM`` ``pmix.abnz``
      - ``(bool)``
-     - Abort the spawned job if any process |br|
+     - Abort the spawned job if any process
        terminates with non-zero status
          
-   * - ``PMIX_DO_NOT_LAUNCH`` |br| ``pmix.dnl``
+   * - ``PMIX_DO_NOT_LAUNCH`` ``pmix.dnl``
      - ``(bool)``
-     - Execute all procedures to prepare the |br|
-       requested job for launch, but do not |br|
-       launch it. Typically combined with the |br|
-       PMIX_DISPLAY_MAP or |br|
-       PMIX_DISPLAY_MAP_DETAILED for |br|
+     - Execute all procedures to prepare the
+       requested job for launch, but do not
+       launch it. Typically combined with the
+       PMIX_DISPLAY_MAP or
+       PMIX_DISPLAY_MAP_DETAILED for
        debugging purposes.
          
-   * - ``PMIX_SHOW_LAUNCH_PROGRESS`` |br| ``pmix.showprog``
+   * - ``PMIX_SHOW_LAUNCH_PROGRESS`` ``pmix.showprog``
      - ``(bool)``
-     - Provide periodic progress reports on |br|
-       job launch procedure (e.g., after |br|
-       every 100 processes have been |br|
+     - Provide periodic progress reports on
+       job launch procedure (e.g., after
+       every 100 processes have been
        spawned)
          
-   * - ``PMIX_AGGREGATE_HELP`` |br| ``pmix.agg.help``
+   * - ``PMIX_AGGREGATE_HELP`` ``pmix.agg.help``
      - ``(bool)``
-     - Aggregate help messages, reporting |br|
-       each unique help message once |br|
-       accompanied by the number of |br|
+     - Aggregate help messages, reporting
+       each unique help message once
+       accompanied by the number of
        processes that reported it
          
-   * - ``PMIX_REPORT_CHILD_SEP`` |br| ``pmix.rptchildsep``
+   * - ``PMIX_REPORT_CHILD_SEP`` ``pmix.rptchildsep``
      - ``(bool)``
-     - Report the exit status of any child |br|
-       jobs spawned by the primary job |br|
-       separately. If false, then the final |br|
-       exit status reported will be zero if the |br|
-       primary job and all spawned jobs exit |br|
-       normally, or the first non-zero status |br|
-       returned by either primary or child |br|
+     - Report the exit status of any child
+       jobs spawned by the primary job
+       separately. If false, then the final
+       exit status reported will be zero if the
+       primary job and all spawned jobs exit
+       normally, or the first non-zero status
+       returned by either primary or child
        jobs.
          
-   * - ``PMIX_DISPLAY_MAP_DETAILED`` |br| ``pmix.dispmapdet``
+   * - ``PMIX_DISPLAY_MAP_DETAILED`` ``pmix.dispmapdet``
      - ``(bool)``
-     - display a highly detailed placement |br|
+     - display a highly detailed placement
        map upon spawn
        
-   * - ``PMIX_DISPLAY_ALLOCATION`` |br| ``pmix.dispalloc``
+   * - ``PMIX_DISPLAY_ALLOCATION`` ``pmix.dispalloc``
      - ``(bool)``
      - display the resource allocation
          
-   * - ``PMIX_DISPLAY_TOPOLOGY`` |br| ``pmix.disptopo``
+   * - ``PMIX_DISPLAY_TOPOLOGY`` ``pmix.disptopo``
      - ``(char*)``
-     - comma-delimited list of hosts whose |br|
+     - comma-delimited list of hosts whose
        topology is to be displayed
          
-   * - ``PMIX_DISPLAY_PROCESSORS`` |br| ``pmix.dispcpus``
+   * - ``PMIX_DISPLAY_PROCESSORS`` ``pmix.dispcpus``
      - ``(char*)``
-     - comma-delimited list of hosts whose |br|
+     - comma-delimited list of hosts whose
        available CPUs are to be displayed
 
-   * - ``PMIX_DISPLAY_PARSEABLE_OUTPUT`` |br| ``pmix.dispparse``
+   * - ``PMIX_DISPLAY_PARSEABLE_OUTPUT`` ``pmix.dispparse``
      - ``(bool)``
-     - display requested info in a format |br|
+     - display requested info in a format
        more amenable to machine parsing
 
-   * - ``PMIX_SORTED_PROC_ARRAY`` |br| ``pmix.sorted.parr``
+   * - ``PMIX_SORTED_PROC_ARRAY`` ``pmix.sorted.parr``
      - ``(bool)``
-     - Proc array being passed has been |br|
+     - Proc array being passed has been
        sorted
          
-   * - ``PMIX_QUERY_PROVISIONAL_ABI_VERSION`` |br| ``pmix.qry.prabiver``
+   * - ``PMIX_QUERY_PROVISIONAL_ABI_VERSION`` ``pmix.qry.prabiver``
      - ``(char*)``
-     - The PMIx Standard Provisional ABI |br|
-       version(s) supported, returned in the |br|
-       form of a comma separated list of |br|
+     - The PMIx Standard Provisional ABI
+       version(s) supported, returned in the
+       form of a comma separated list of
        "MAJOR.MINOR" pairs
 
-   * - ``PMIX_QUERY_STABLE_ABI_VERSION`` |br| ``pmix.qry.stabiver``
+   * - ``PMIX_QUERY_STABLE_ABI_VERSION`` ``pmix.qry.stabiver``
      - ``(char*)``
-     - The PMIx Standard Stable ABI |br|
-       version(s) supported, returned in the |br|
-       form of a comma separated list of |br|
+     - The PMIx Standard Stable ABI
+       version(s) supported, returned in the
+       form of a comma separated list of
        "MAJOR.MINOR" pairs
 
 .. note:: The attribute ``PMIX_DEBUG_STOP_IN_APP`` has been modified
@@ -1436,62 +1432,62 @@ Attributes supported by this API when called by the scheduler include:
      - Type
      - Description
 
-   * - ``PMIX_SESSION_APP`` |br| ``pmix.ssn.app``
+   * - ``PMIX_SESSION_APP`` ``pmix.ssn.app``
      - ``(pmix_data_array_t*)``
-     - Array of ``pmix_app_t`` to be executed |br|
-       in the assigned session upon session |br|
+     - Array of ``pmix_app_t`` to be executed
+       in the assigned session upon session
        instantiation
 
-   * - ``PMIX_SESSION_PROVISION`` |br| ``pmix.ssn.pvn``
+   * - ``PMIX_SESSION_PROVISION`` ``pmix.ssn.pvn``
      - ``(pmix_data_array_t*)``
-     - description of nodes to be |br|
+     - description of nodes to be
        provisioned with specified image
 
-   * - ``PMIX_SESSION_PROVISION_NODES`` |br| ``pmix.ssn.pvnnds``
+   * - ``PMIX_SESSION_PROVISION_NODES`` ``pmix.ssn.pvnnds``
      - ``(char*)``
-     - regex identifying nodes that are to be |br|
+     - regex identifying nodes that are to be
        provisioned
 
-   * - ``PMIX_SESSION_PROVISION_IMAGE`` |br| ``pmix.ssn.pvnimg``
+   * - ``PMIX_SESSION_PROVISION_IMAGE`` ``pmix.ssn.pvnimg``
      - ``(char*)``
-     - name of the image that is to be |br|
+     - name of the image that is to be
        provisioned
 
-   * - ``PMIX_SESSION_PAUSE`` |br| ``pmix.ssn.pause``
+   * - ``PMIX_SESSION_PAUSE`` ``pmix.ssn.pause``
      - ``(bool)``
      - pause all jobs in the specified session
 
-   * - ``PMIX_SESSION_RESUME`` |br| ``pmix.ssn.resume``
+   * - ``PMIX_SESSION_RESUME`` ``pmix.ssn.resume``
      - ``(bool)``
      - "un-pause" all jobs in the specified session
 
-   * - ``PMIX_SESSION_TERMINATE`` |br| ``pmix.ssn.terminate``
+   * - ``PMIX_SESSION_TERMINATE`` ``pmix.ssn.terminate``
      - ``(bool)``
-     - terminate all jobs in the specified |br|
-       session and recover all resources |br|
+     - terminate all jobs in the specified
+       session and recover all resources
        included in the session.
 
-   * - ``PMIX_SESSION_PREEMPT`` |br| ``pmix.ssn.preempt``
+   * - ``PMIX_SESSION_PREEMPT`` ``pmix.ssn.preempt``
      - ``(bool)``
-     - preempt indicated jobs (given in |br|
-       accompanying ``pmix_info_t`` via the |br|
-       ``PMIX_NSPACE`` attribute) in the specified |br|
-       session and recover all their resources. If |br|
-       no ``PMIX_NSPACE`` is specified, then preempt |br|
+     - preempt indicated jobs (given in
+       accompanying ``pmix_info_t`` via the
+       ``PMIX_NSPACE`` attribute) in the specified
+       session and recover all their resources. If
+       no ``PMIX_NSPACE`` is specified, then preempt
        all jobs in the session.
 
-   * - ``PMIX_SESSION_RESTORE`` |br| ``pmix.ssn.restore``
+   * - ``PMIX_SESSION_RESTORE`` ``pmix.ssn.restore``
      - ``(bool)``
-     - restore indicated jobs (given in |br|
-       accompanying ``pmix_info_t`` via the |br|
-       ``PMIX_NSPACE`` attribute) in the specified |br|
-       session, including all their resources. If |br|
-       no ``PMIX_NSPACE`` is specified, then restore |br|
+     - restore indicated jobs (given in
+       accompanying ``pmix_info_t`` via the
+       ``PMIX_NSPACE`` attribute) in the specified
+       session, including all their resources. If
+       no ``PMIX_NSPACE`` is specified, then restore
        all jobs in the session.
 
-   * - ``PMIX_SESSION_SIGNAL`` |br| ``pmix.ssn.sig``
+   * - ``PMIX_SESSION_SIGNAL`` ``pmix.ssn.sig``
      - ``(int)``
-     - send given signal to all processes of every |br|
+     - send given signal to all processes of every
        job in the session
 
 
@@ -1504,11 +1500,11 @@ Attributes supported by this API when called by the RTE include:
      - Type
      - Description
 
-   * - ``PMIX_SESSION_COMPLETE`` |br| ``pmix.ssn.complete``
+   * - ``PMIX_SESSION_COMPLETE`` ``pmix.ssn.complete``
      - ``(bool)``
-     - specified session has completed, all resources have been |br|
-       recovered and are available for scheduling. Must include |br|
-       ``pmix_info_t`` indicating ID and returned status of any jobs |br|
+     - specified session has completed, all resources have been
+       recovered and are available for scheduling. Must include
+       ``pmix_info_t`` indicating ID and returned status of any jobs
        executing in the session.
 
 
@@ -1548,11 +1544,11 @@ attribute has been added to that list:
      - Type
      - Description
 
-   * - ``PMIX_SESSION_CTRL_ID`` |br| ``pmix.ssnctrl.id``
+   * - ``PMIX_SESSION_CTRL_ID`` ``pmix.ssnctrl.id``
      - ``(char*)``
-     - provide a string identifier for this request. |br|
-       This identifier shall be included |br|
-       in all subsequent interactions relating to |br|
+     - provide a string identifier for this request.
+       This identifier shall be included
+       in all subsequent interactions relating to
        the request.
 
 
@@ -1570,27 +1566,27 @@ the query:
      - Type
      - Description
 
-   * - ``PMIX_QUERY_ALLOCATION`` |br| ``pmix.query.allc``
+   * - ``PMIX_QUERY_ALLOCATION`` ``pmix.query.allc``
      - ``(pmix_data_array_t*)``
-     - returns an array of ``pmix_info_t`` |br|
-       describing the nodes known to the |br|
-       server. Each array element will consist |br|
-       of the ``PMIX_NODE_INFO`` key containing |br|
-       a ``pmix_data_array_t`` of ``pmix_info_t``. |br|
-       The first element of the array must be |br|
-       the hostname of that node, with |br|
-       additional info on the node in |br|
-       subsequent entries. |br|
-       SUPPORTED_QUALIFIER: a |br|
-       ``PMIX_ALLOC_ID`` qualifier indicating |br|
+     - returns an array of ``pmix_info_t``
+       describing the nodes known to the
+       server. Each array element will consist
+       of the ``PMIX_NODE_INFO`` key containing
+       a ``pmix_data_array_t`` of ``pmix_info_t``.
+       The first element of the array must be
+       the hostname of that node, with
+       additional info on the node in
+       subsequent entries.
+       SUPPORTED_QUALIFIER: a
+       ``PMIX_ALLOC_ID`` qualifier indicating
        the specific allocation of interest
 
-   * - ``PMIX_TOPOLOGY_INDEX`` |br| ``pmix.topo.index``
+   * - ``PMIX_TOPOLOGY_INDEX`` ``pmix.topo.index``
      - ``(int)``
-     - index of a topology in a storage array. Used |br|
-       when returning an allocation to avoid duplicate |br|
-       topology information - the RTE can return an array |br|
-       of topologies and then indicate the index |br|
+     - index of a topology in a storage array. Used
+       when returning an allocation to avoid duplicate
+       topology information - the RTE can return an array
+       of topologies and then indicate the index
        to the topology as part of each node entry.
 
 
@@ -1608,11 +1604,11 @@ attribute has been added to that list:
      - Type
      - Description
 
-   * - ``PMIX_ALLOC_PREEMPTIBLE`` |br| ``pmix.alloc.preempt``
+   * - ``PMIX_ALLOC_PREEMPTIBLE`` ``pmix.alloc.preempt``
      - ``(bool)``
-     - by default, all jobs in the resulting |br|
-       allocation are to be considered |br|
-       preemptible (can be overridden at |br|
+     - by default, all jobs in the resulting
+       allocation are to be considered
+       preemptible (can be overridden at
        per-job level)
 
 

--- a/docs/installing-pmix/required-support-libraries.rst
+++ b/docs/installing-pmix/required-support-libraries.rst
@@ -14,13 +14,13 @@ PMIx requires the following support libraries with the minimum listed versions:
      - Notes
    * - `Hardware Locality <https://www.open-mpi.org/projects/hwloc/>`_
      - |hwloc_min_version|
-     - | This library is required; PMIx will not build without it.
+     - This library is required; PMIx will not build without it.
    * - `Libevent <https://libevent.org/>`_
      - |event_min_version|
-     - | Either libevent or libev must be provided
+     - Either libevent or libev must be provided
    * - `libev <https://metacpan.org/dist/EV/view/libev/ev.pod>`_
-     - | no specified minimum
-     - | Either libevent or libev must be provided
+     - no specified minimum
+     - Either libevent or libev must be provided
 
 These support libraries are fundamental to PMIx's operation
 and pretty universally available in all environments. Worst case,

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
@@ -26,7 +26,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
-                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset
+                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -124,6 +124,9 @@ pset_SOURCES = pset.c examples.h
 pset_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pset_LDADD = $(top_builddir)/src/libpmix.la
 
+log_SOURCES = log.c examples.h
+log_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+log_LDADD = $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -181,7 +181,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SERVER_GATEWAY                 "pmix.srv.gway"         // (bool) Server is acting as a gateway for PMIx requests
                                                                     //        that cannot be serviced on backend nodes
                                                                     //        (e.g., logging to email)
-#define PMIX_SERVER_SCHEDULER               "pmix.srv.sched"        // (bool) Server supports system scheduler
+#define PMIX_SERVER_SYS_CONTROLLER          "pmix.srv.ctrlr"        // (bool) Server is hosted by the system controller for
+                                                                    //        the cluster
+#define PMIX_SERVER_SCHEDULER               "pmix.srv.sched"        // (bool) Server is hosted by the system scheduler
 #define PMIX_SERVER_START_TIME              "pmix.srv.strtime"      // (char*) Time when the server started - i.e., when the server created
                                                                     //         it's rendezvous file (given in ctime string format)
 #define PMIX_HOMOGENEOUS_SYSTEM             "pmix.homo"             // (bool) The nodes comprising the session are homogeneous - i.e., they
@@ -202,6 +204,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        a local system-level PMIx server
 #define PMIX_CONNECT_SYSTEM_FIRST           "pmix.cnct.sys.first"   // (bool) Preferentially look for a system-level PMIx server first
 #define PMIX_CONNECT_TO_SCHEDULER           "pmix.cnct.sched"       // (bool) Connect to the system scheduler
+#define PMIX_CONNECT_TO_SYS_CONTROLLER      "pmix.cnct.ctrlr"       // (bool) Connect to the system controller
 #define PMIX_SERVER_URI                     "pmix.srvr.uri"         // (char*) URI of server to be contacted
 #define PMIX_MYSERVER_URI                   "pmix.mysrvr.uri"       // (char*) URI of this proc's listener socket
 #define PMIX_SERVER_HOSTNAME                "pmix.srvr.host"        // (char*) node where target server is located

--- a/src/mca/pdl/pdlopen/configure.m4
+++ b/src/mca/pdl/pdlopen/configure.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,18 +47,21 @@ AC_DEFUN([MCA_pmix_pdl_pdlopen_CONFIG],[
 
     dnl This is effectively a back-door for PMIX developers to
     dnl force the use of the libltdl pdl component.
-    AC_ARG_ENABLE([dl-dlopen],
-        [AS_HELP_STRING([--disable-dl-dlopen],
-                        [Disable the "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
+    AC_ARG_ENABLE([pmix-dlopen],
+        [AS_HELP_STRING([--disable-pmix-dlopen],
+                        [Disable the PMIx "dlopen" PDL component (and probably force the use of the "libltdl" PDL component).])
         ])
 
-    OAC_CHECK_PACKAGE([dlopen],
-              [pmix_pdl_pdlopen],
-              [dlfcn.h],
-              [dl],
-              [dlopen],
-              [pmix_pdl_pdlopen_happy=yes],
-              [pmix_pdl_pdlopen_happy=no])
+    pmix_pdl_pdlopen_happy=no
+    AS_IF([test "$enable_pmix_dlopen" != "no"],
+        [OAC_CHECK_PACKAGE([dlopen],
+                  [pmix_pdl_pdlopen],
+                  [dlfcn.h],
+                  [dl],
+                  [dlopen],
+                  [pmix_pdl_pdlopen_happy=yes],
+                  [pmix_pdl_pdlopen_happy=no])
+        ])
 
     AS_IF([test "$pmix_pdl_pdlopen_happy" = "yes"],
           [pmix_pdl_pdlopen_ADD_LIBS=$pmix_pdl_pdlopen_LIBS

--- a/src/mca/pdl/plibltdl/configure.m4
+++ b/src/mca/pdl/plibltdl/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -45,20 +45,23 @@ AC_DEFUN([MCA_pmix_pdl_plibltdl_CONFIG],[
     AC_CONFIG_FILES([src/mca/pdl/plibltdl/Makefile])
 
     # Add --with options
-    AC_ARG_WITH([plibltdl],
+    AC_ARG_WITH([libltdl],
         [AS_HELP_STRING([--with-libltdl(=DIR)],
              [Build libltdl support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     AC_ARG_WITH([libltdl-libdir],
        [AS_HELP_STRING([--with-libltdl-libdir=DIR],
              [Search for libltdl libraries in DIR])])
 
-    OAC_CHECK_PACKAGE([libltdl],
-                  [pmix_pdl_plibltdl],
-                  [ltdl.h],
-                  [ltdl],
-                  [lt_dlopen],
-                  [pmix_pdl_plibltdl_happy=yes],
-                  [pmix_pdl_plibltdl_happy=no])
+    pmix_pdl_plibltdl_happy=no
+    AS_IF([test "$with_libltdl" != "no"],
+        [OAC_CHECK_PACKAGE([libltdl],
+                      [pmix_pdl_plibltdl],
+                      [ltdl.h],
+                      [ltdl],
+                      [lt_dlopen],
+                      [pmix_pdl_plibltdl_happy=yes],
+                      [pmix_pdl_plibltdl_happy=no])
+        ])
 
     # If we have plibltdl, do we have lt_dladvise?
     pmix_pdl_plibltdl_have_lt_dladvise=0

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -104,6 +104,9 @@ typedef struct {
 #define PMIX_PROC_GATEWAY         (PMIX_PROC_SERVER | PMIX_PROC_GATEWAY_ACT)
 #define PMIX_PROC_SCHEDULER_ACT   0x80000000
 #define PMIX_PROC_SCHEDULER       (PMIX_PROC_SERVER | PMIX_PROC_SCHEDULER_ACT)
+#define PMIX_PROC_SYS_CTRLR_ACT   0x01000000
+#define PMIX_PROC_SYS_CTRLR       (PMIX_PROC_SERVER | PMIX_PROC_SYS_CTRLR_ACT)
+
 
 #define PMIX_SET_PEER_TYPE(a, b) (a)->proc_type.type |= (b)
 #define PMIX_SET_PROC_TYPE(a, b) (a)->type |= (b)
@@ -120,6 +123,8 @@ typedef struct {
     ((PMIX_PROC_CLIENT_TOOL_ACT & (p)->proc_type.type) && (PMIX_PROC_CLIENT & (p)->proc_type.type))
 #define PMIX_PEER_IS_GATEWAY(p)   (PMIX_PROC_GATEWAY_ACT & (p)->proc_type.type)
 #define PMIX_PEER_IS_SCHEDULER(p) (PMIX_PROC_SCHEDULER_ACT & (p)->proc_type.type)
+#define PMIX_PEER_IS_SYS_CTRLR(p) (PMIX_PROC_SYS_CTRLR_ACT & (p)->proc_type.type)
+
 
 #define PMIX_PROC_IS_CLIENT(p)   (PMIX_PROC_CLIENT & (p)->type)
 #define PMIX_PROC_IS_SERVER(p)   (PMIX_PROC_SERVER & (p)->type)
@@ -131,6 +136,8 @@ typedef struct {
     ((PMIX_PROC_CLIENT_TOOL_ACT & (p)->type) && (PMIX_PROC_CLIENT & (p)->type))
 #define PMIX_PROC_IS_GATEWAY(p)   (PMIX_PROC_GATEWAY_ACT & (p)->type)
 #define PMIX_PROC_IS_SCHEDULER(p) (PMIX_PROC_SCHEDULER_ACT & (p)->type)
+#define PMIX_PROC_IS_SYS_CTRLR(p) (PMIX_PROC_SYS_CTRLR_ACT & (p)->type)
+
 
 /* provide macros for setting the major, minor, and release values
  * just so people don't have to deal with the details of the struct */

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -547,6 +547,7 @@ static pmix_status_t read_topic(FILE *fp, char ***array)
 {
     int rc;
     char *line, *file, *tp;
+    char **tmparray = NULL;
 
     while (NULL != (line = localgetline(fp))) {
         /* the topic ends when we see either the end of
@@ -566,7 +567,7 @@ static pmix_status_t read_topic(FILE *fp, char ***array)
                 *tp = '\0';  // NULL-terminate the filename
                 ++tp;
             }
-            rc = load_array(array, file, tp);
+            rc = load_array(&tmparray, file, tp);
             if (PMIX_SUCCESS != rc) {
                 free(line);
                 return rc;
@@ -580,15 +581,48 @@ static pmix_status_t read_topic(FILE *fp, char ***array)
         if ('[' == line[0]) {
             /* start of the next topic */
             free(line);
-            return PMIX_SUCCESS;
+
+            /* Fall through to strip out leading / trailing blank
+               lines */
+            break;
         }
         /* save the line */
-        rc = PMIx_Argv_append_nosize(array, line);
+        rc = PMIx_Argv_append_nosize(&tmparray, line);
         free(line);
         if (rc != PMIX_SUCCESS) {
             return rc;
         }
     }
+
+    /* Strip off empty lines at the beginning and end of the resulting
+       array, because RST/Sphinx requires us to have blank lines to
+       separate paragraphs.
+
+       This algorithm is neither clever nor efficient, but it's
+       simple.  First, find the first and last non-blank lines. */
+    int first_nonblank = -1;
+    int last_nonblank = -1;
+    for (int i = 0; NULL != tmparray[i]; ++i) {
+        if (tmparray[i][0] != '\0') {
+            if (-1 == first_nonblank) {
+                first_nonblank = i;
+            }
+            last_nonblank = i;
+        }
+    }
+
+    /* If there were no non-blank lines, that's an error */
+    if (-1 == first_nonblank) {
+        PMIx_Argv_free(tmparray);
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    /* Copy the range of [first_nonblank, last_nonblank] to the output
+       array */
+    for (int i = first_nonblank; i <= last_nonblank; ++i) {
+        PMIx_Argv_append_nosize(array, tmparray[i]);
+    }
+    PMIx_Argv_free(tmparray);
 
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
[Properly support the "log" example](https://github.com/openpmix/openpmix/commit/9bd481fc6ac539913a6da0e1a19fc012f61c5e61)

Needs a little more plumbing in the Makefile

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/23499ab4303b1c89fa533791acaba000e30f9d5c)

[show_help: strip leading/trailing blank lines](https://github.com/openpmix/openpmix/commit/0da994463267ec3ed0abd35b036a2961fdb29201)

When we read a [topic] from a help file, strip any leading or trailing
blank lines from that topic.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9b09a2d3ee67d2dd1009dd732a629247a7a23087)

[docs: fix some leftover "Open MPI" references](https://github.com/openpmix/openpmix/commit/016008ce2ce121bbe43d3ce06a1daf8e257cd721)

Basically, do a s/Open MPI/PMIx/g on a file that was previously
missed.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7720337bb8a9f89970bc3702efe9faaf1dab3ec0)

[docs: fix HTML word wapping in table cells](https://github.com/openpmix/openpmix/commit/03ec9f60804c9d30b758da5feb0e04509204b30e)

The sphinx_rtd_theme does not properly handle wrapping long lines in
table cells when rendering to HTML due to a CSS issue (see
https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).

Until the issue is fixed upstream in sphinx_rtd_theme, we can simply
override the CSS here.  This commit overrides the CSS in conf.py and
also touches up some places where we previously tried to work around
the lack of word wrapping.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9b3bdf8d1648ee2adb116e9b133cf1797da9617a)

[Improve error handling in setup_topology](https://github.com/openpmix/openpmix/commit/377f7fc55b27a6e991f1be90f4bfdc3d79648ec7)

Ensure we go thru the progression and then do our own
discovery if there are problems.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/03cdd09d049197f314b82e2953fcbeec97cfae0c)

[Define a new server type and connection flags](https://github.com/openpmix/openpmix/commit/d22ec4135f5ad4c11785d27bd1f0b2e31b3ab4bf)

Identify the server acting as the system-wide controller
and provide an attribute by which the scheduler can
request to be connected to it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3ce556659eec4b3ab04ec4b98e7e42779e5f5a8c)

[Minor cleanups for disable-dlopen](https://github.com/openpmix/openpmix/commit/f96155357bca8f60333b6ab5cc1632b95257663e)

We provide a backdoor way to disable dlopen, but
then ignored the option. Simplify the name of the
option a little bit.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6ae2e0c6ddaec024d3aef6bb369d7427de90f72b)

[Fix Python bindings](https://github.com/openpmix/openpmix/commit/f0f27cfd4edb594ddf2805f0f1f530cee58c2de0)

Newer versions of Cython are taking issue with some of the
exceptions compatibility on callback functions. Follow
their suggestions to silence the errors.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/552f5afe85c7d81b153331c5718ec6b01b857fcc)
