### PR TITLE
Do not follow links when doing "chown"

### DIFF
--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -244,7 +244,7 @@ static int ptys_open(int fdm, char *pts_name)
         gid = -1; /* group tty is not in the group file */
     }
     /* following two functions don't work unless we're root */
-    chown(pts_name, getuid(), gid);
+    lchown(pts_name, getuid(), gid);  // DO NOT FOLLOW LINKS
     chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
     fds = open(pts_name, O_RDWR);
     if (fds < 0) {

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -198,7 +198,7 @@ pmix_shmem_segment_chown(
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
 
-    if (chown(shmem->backing_path, owner, group) != 0) {
+    if (lchown(shmem->backing_path, owner, group) != 0) {  // DO NOT FOLLOW LINKS
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(rc);
     }


### PR DESCRIPTION
There is a potential issue with allowing a "chown" operation to follow user-created links, so let's limit any use of that function to "lchown" - which directs the "chown" operation to NOT follow a link.