### PR TITLE
Do not follow links when doing "chown"

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -531,7 +531,7 @@ static int _esh_session_init(pmix_common_dstore_ctx_t *ds_ctx, size_t idx, ns_ma
             }
         }
         if (s->setjobuid > 0){
-            if (0 > chown(s->nspace_path, (uid_t) s->jobuid, (gid_t) -1)){
+            if (0 > lchown(s->nspace_path, (uid_t) s->jobuid, (gid_t) -1)){
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 return rc;
@@ -1711,7 +1711,7 @@ pmix_common_dstore_ctx_t *pmix_common_dstor_init(const char *ds_name, pmix_info_
             }
         }
         if (ds_ctx->setjobuid > 0) {
-            if (chown(ds_ctx->base_path, (uid_t) ds_ctx->jobuid, (gid_t) -1) < 0){
+            if (lchown(ds_ctx->base_path, (uid_t) ds_ctx->jobuid, (gid_t) -1) < 0){
                 rc = PMIX_ERR_NO_PERMISSIONS;
                 PMIX_ERROR_LOG(rc);
                 goto err_exit;

--- a/src/mca/common/dstore/dstore_segment.c
+++ b/src/mca/common/dstore/dstore_segment.c
@@ -121,7 +121,7 @@ PMIX_EXPORT pmix_dstore_seg_desc_t *pmix_common_dstor_create_new_lock_seg(const 
 
             if (setuid > 0){
                 rc = PMIX_ERR_PERM;
-                if (0 > chown(file_name, (uid_t) uid, (gid_t) -1)){
+                if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){
                     PMIX_ERROR_LOG(rc);
                     goto err_exit;
                 }
@@ -212,7 +212,7 @@ PMIX_EXPORT pmix_dstore_seg_desc_t *pmix_common_dstor_create_new_segment(pmix_ds
 
         if (setuid > 0){
             rc = PMIX_ERR_PERM;
-            if (0 > chown(file_name, (uid_t) uid, (gid_t) -1)){
+            if (0 > lchown(file_name, (uid_t) uid, (gid_t) -1)){
                 PMIX_ERROR_LOG(rc);
                 goto err_exit;
             }

--- a/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_fcntl.c
@@ -128,7 +128,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             }
         }
         if (0 != setuid) {
-            if (0 > chown(lock_ctx->lockfile, uid, (gid_t) -1)) {
+            if (0 > lchown(lock_ctx->lockfile, uid, (gid_t) -1)) {
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 goto error;

--- a/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -114,7 +114,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
         }
         memset(lock_ctx->segment->seg_base_addr, 0, size);
         if (0 != setuid) {
-            if (0 > chown(lock_ctx->lockfile, (uid_t) uid, (gid_t) -1)){
+            if (0 > lchown(lock_ctx->lockfile, (uid_t) uid, (gid_t) -1)){
                 rc = PMIX_ERROR;
                 PMIX_ERROR_LOG(rc);
                 goto error;

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -244,7 +244,7 @@ static int ptys_open(int fdm, char *pts_name)
         gid = -1; /* group tty is not in the group file */
     }
     /* following two functions don't work unless we're root */
-    chown(pts_name, getuid(), gid);
+    lchown(pts_name, getuid(), gid);  // DO NOT FOLLOW LINKS
     chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
     fds = open(pts_name, O_RDWR);
     if (fds < 0) {


### PR DESCRIPTION
There is a potential issue with allowing a "chown" operation to follow user-created links, so let's limit any use of that function to "lchown" - which directs the "chown" operation to NOT follow a link.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ae62cdf67b19e80fd821420816f09bf0a56a8166) (cherry picked from commit da036933c2795c1f40d0835e15f17e204e4daf0f)