### PR TITLE
Blacklist the HWLOC GL component to avoid deadlock

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1400,6 +1400,15 @@ static int set_flags(hwloc_topology_t topo, unsigned int flags)
     if (0 != hwloc_topology_set_flags(topo, flags)) {
         return PMIX_ERR_INIT;
     }
+    // Blacklist the "gl" component due to potential conflicts.
+    // See "https://github.com/open-mpi/ompi/issues/10025" for
+    // an explanation
+#if HWLOC_VERSION_MAJOR > 2
+    hwloc_topology_set_components(topo, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#elif HWLOC_VERSION_MAJOR == 2 && HWLOC_VERSION_MINOR >= 1
+    hwloc_topology_set_components(topo, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#endif
+
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
See https://github.com/open-mpi/ompi/issues/10025
for an explanation of the problem.

Thanks to @bgoglin for the assistance.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ba19bac53e25145341ec4ba07e714eb19878e103)