### PR TITLE
Make checking min versions consistent

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -81,6 +81,38 @@ jobs:
         make install
         make uninstall
 
+  ubuntu-oldHWLOC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libevent-dev
+    - name: Git clone HWLOC v1.x
+      uses: actions/checkout@v4
+      with:
+            repository: open-mpi/hwloc
+            ref: hwloc-1.11.13
+    - name: Build HWLOC
+      run: |
+        ./autogen.sh
+        ./configure --prefix=$RUNNER_TEMP/hwlocinstall
+        make -j install
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+    - name: Build OpenPMIx
+      run: |
+        ./autogen.pl
+        ./configure --prefix=${PWD}/install --with-hwloc=$RUNNER_TEMP/hwlocinstall
+        make -j
+        cd test
+        make check
+        cd ..
+        make install
+        make uninstall
+
   distcheck:
     runs-on: ubuntu-latest
     steps:

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -1,4 +1,4 @@
-# -*- autoconf -*-
+# -*- shell-script -*-
 #
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
@@ -16,7 +16,7 @@
 # MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_SETUP_HWLOC],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_check_hwloc_save_CPPFLAGS])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -32,17 +32,15 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                                   [If --disable-hwloc-lib-checks is specified, configure will assume that -lhwloc is available])])
 
     pmix_hwloc_support=1
-    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
-    pmix_have_topology_dup=0
 
     if test "$with_hwloc" = "no"; then
-        AC_MSG_WARN([PMIx requires HWLOC topology library support.])
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
     fi
 
     AS_IF([test "$with_hwloc_extra_libs" = "yes" -o "$with_hwloc_extra_libs" = "no"],
-	  [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
+    [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test "$enable_hwloc_lib_checks" != "no"],
           [OAC_CHECK_PACKAGE([hwloc],
@@ -52,72 +50,58 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                              [hwloc_topology_init],
                              [],
                              [pmix_hwloc_support=0])],
-          [PMIX_FLAGS_APPEND_UNIQ([PMIX_DELAYED_LIBS], [$with_hwloc_extra_libs])])
+          [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
-        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
         AC_MSG_WARN([an adequate version of that library was not found.])
         AC_MSG_WARN([Please reconfigure and point to a location where])
         AC_MSG_WARN([the HWLOC library can be found.])
         AC_MSG_ERROR([Cannot continue.])
     fi
 
-    # update global flags to test for HWLOC version
-    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
-
-    AC_MSG_CHECKING([if hwloc version is 1.5 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_API_VERSION < 0x00010500
-    #error "hwloc version is less than 0x00010500"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])],
-          [AC_MSG_RESULT([no])
-           AC_MSG_ERROR([Cannot continue])])
-
-    AC_MSG_CHECKING([if hwloc version is 1.8 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_API_VERSION < 0x00010800
-    #error "hwloc version is less than 0x00010800"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           pmix_have_topology_dup=1],
-          [AC_MSG_RESULT([no])])
+    # NOTE: We have already read PMIx's VERSION file, so we can use
+    # those values
+    pmix_hwloc_min_num_version=PMIX_HWLOC_NUMERIC_MIN_VERSION
+    pmix_hwloc_min_version=PMIX_HWLOC_MIN_VERSION
+    AC_MSG_CHECKING([version at or above v$pmix_hwloc_min_version])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if (HWLOC_API_VERSION < $pmix_hwloc_min_num_version)
+                                        #error "not version $pmix_hwloc_min_num_version or above"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([yes])],
+                      [AC_MSG_RESULT(no)
+                       AC_MSG_WARN([PMIx requires HWLOC v$pmix_hwloc_min_version or above.])
+                       AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_MSG_CHECKING([if hwloc version is at least 2.0])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_VERSION_MAJOR < 2
-    #error "hwloc version is less than 2.0"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           pmix_version_high=1],
-          [AC_MSG_RESULT([no])
-           pmix_version_high=0])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if HWLOC_VERSION_MAJOR < 2
+                                        #error "hwloc version is less than 2.0"
+                                        #endif
+                                       ], [])],
+                        [AC_MSG_RESULT([yes])
+                         pmix_version_high=1],
+                        [AC_MSG_RESULT([no])
+                         pmix_version_high=0])
+    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
 
     AC_MSG_CHECKING([if hwloc version is greater than 2.x])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_VERSION_MAJOR > 2
-    #error "hwloc version is greater than 2.x"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([no])],
-          [AC_MSG_RESULT([yes])
-           AC_MSG_WARN([This PMIx version does not support HWLOC])
-           AC_MSG_WARN([versions 3.x or higher. Please direct us])
-           AC_MSG_WARN([to an HWLOC version in the 1.11-2.x range.])
-           AC_MSG_ERROR([Cannot continue])])
-
-    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if (HWLOC_VERSION_MAJOR > 2)
+                                        #error "hwloc version is greater than 2.x"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([no])],
+                      [AC_MSG_RESULT([yes])
+                       AC_MSG_WARN([This PMIx version does not support HWLOC])
+                       AC_MSG_WARN([versions 3.x or higher. Please direct us])
+                       AC_MSG_WARN([to an HWLOC version in the $pmix_hwloc_min_version-2.x range.])
+                       AC_MSG_ERROR([Cannot continue])])
 
     PMIX_FLAGS_APPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
     PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
@@ -132,10 +116,7 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
 
     PMIX_WRAPPER_FLAGS_ADD([PC_MODULES], [$pmix_hwloc_PC_MODULES])
 
-    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
-                       [Whether or not hwloc_topology_dup is available])
 
-    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
 
     PMIX_SUMMARY_ADD([Required Packages], [HWLOC], [], [$pmix_hwloc_SUMMARY])
 

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -16,7 +16,7 @@
 # MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_SETUP_HWLOC],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_check_hwloc_save_CPPFLAGS])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -32,9 +32,10 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                                   [If --disable-hwloc-lib-checks is specified, configure will assume that -lhwloc is available])])
 
     pmix_hwloc_support=1
+    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
 
     if test "$with_hwloc" = "no"; then
-        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
+        AC_MSG_WARN([PMIx requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
     fi
@@ -53,12 +54,15 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
           [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
-        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
+        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
         AC_MSG_WARN([an adequate version of that library was not found.])
         AC_MSG_WARN([Please reconfigure and point to a location where])
         AC_MSG_WARN([the HWLOC library can be found.])
         AC_MSG_ERROR([Cannot continue.])
     fi
+
+    # update global flags to test for HWLOC version
+    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
 
     # NOTE: We have already read PMIx's VERSION file, so we can use
     # those values
@@ -102,6 +106,9 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                        AC_MSG_WARN([versions 3.x or higher. Please direct us])
                        AC_MSG_WARN([to an HWLOC version in the $pmix_hwloc_min_version-2.x range.])
                        AC_MSG_ERROR([Cannot continue])])
+
+    # reset global flags
+    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
 
     PMIX_FLAGS_APPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
     PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -53,7 +53,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
            pmix_libevent_support=0])
 
     AS_IF([test "$with_libevent_extra_libs" = "yes" -o "$with_libevent_extra_libs" = "no"],
-	  [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
+      [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test $pmix_libevent_support -eq 1],
           [pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
@@ -113,7 +113,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
           ]])],
           [AC_MSG_RESULT([yes])],
           [AC_MSG_RESULT([no])
-           AC_MSG_WARN([PMIX requires libevent to be compiled with thread support enabled])
+           AC_MSG_WARN([PMIX rquires libevent to be compiled with thread support enabled])
            pmix_libevent_support=0])
     fi
 
@@ -134,20 +134,24 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     fi
 
     if test $pmix_libevent_support -eq 1; then
-        # Pin the "oldest supported" version to 2.0.21
-        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                           [[
-                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #endif
-                                           ]])],
-                          [AC_MSG_RESULT([yes])],
-                          [AC_MSG_RESULT([no])
-                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                           pmix_libevent_support=0])
+        pmix_event_min_num_version=PMIX_EVENT_NUMERIC_MIN_VERSION
+        pmix_event_min_version=PMIX_EVENT_MIN_VERSION
+        AC_MSG_CHECKING([version at or above v$pmix_event_min_version])
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                            #include <event2/event.h>
+#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < $pmix_event_min_num_version
+#error "libevent API version is less than $pmix_event_min_version"
+#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < $pmix_event_min_num_version
+#error "libevent API version is less than $pmix_event_min_version"
+#endif
+                                       ], [])],
+                      [pmix_libevent_cv_version_check=yes
+                       AC_MSG_RESULT([yes])],
+                      [pmix_libevent_cv_version_check=no
+                       AC_MSG_RESULT([no])])
+        AS_IF([test "${pmix_libevent_cv_version_check}" = "no"],
+              [AC_MSG_WARN([libevent version is too old ($pmix_event_min_version or later required)])
+               pmix_libevent_support=0])
     fi
 
     # restore global flags

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -389,16 +389,12 @@ pmix_status_t pmix_hwloc_copy_topology(pmix_topology_t *dest, pmix_topology_t *s
     flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
     flags |= HWLOC_TOPOLOGY_FLAG_IO_DEVICES;
 #else
-    if (0 != hwloc_topology_set_io_types_filter(t, HWLOC_TYPE_FILTER_KEEP_IMPORTANT)) {
+    if (0 != hwloc_topology_set_io_types_filter(dest->topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT)) {
         hwloc_topology_destroy(dest->topology);
         free(xmlbuffer);
         return PMIX_ERROR;
     }
-#    if HWLOC_API_VERSION < 0x00020100
-    flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
-#    else
     flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
-#    endif
 #endif
     if (0 != hwloc_topology_set_flags(dest->topology, flags)) {
         hwloc_topology_destroy(dest->topology);


### PR DESCRIPTION
We have two dependent libraries we care about, and minimum version requirements on both of them. Let's connect them to the min values in the VERSION file and "standardize" the check configure code to make it easier to understand and maintain.

Also, since we require a min HWLOC version of 1.11, there is no longer a need to check for at least 1.8 so we know we have hwloc_topology_dup.