### PR TITLE
Add support for blocks of resources

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -484,6 +484,20 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
                                                      pmix_info_t *info, size_t ninfo,
                                                      pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Define a resource "block" that can be used in allocation operations.
+ * Include the ability to define/delete, remove/extend block definitions.
+ * The provided block name must be unique within the requestor's current
+ * session
+ */
+PMIX_EXPORT pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t directive,
+                                              char *block, pmix_info_t *info, size_t ninfo);
+
+
+PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t directive,
+                                                 char *block, pmix_info_t *info, size_t ninfo,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
 /* Request a session control action. The sessionID identifies the session
  * to which the specified control action is to be applied. A UINT32_MAX
  * value can be used to indicate all sessions under the caller's control.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -614,7 +614,13 @@ typedef uint32_t pmix_rank_t;
                                                                     //         Each of the remaining elements of the array is a pmix_info_t containing the query key
                                                                     //         and the corresponding value returned by the query. This attribute is solely for
                                                                     //         reporting purposes and cannot be used in PMIx_Get or other query operations
-
+#define PMIX_QUERY_MIN_ALLOC_UNIT           "pmix.qry.minau"        // (pmix_data_array_t*) array of pmix_info_t identifying the resources
+                                                                    //         composing the minimum allocatable unit for this system
+#define PMIX_QUERY_RES_BLOCKS               "pmix.qry.resblks"      // (pmix_data_array_t*) array of string names for currently defined
+                                                                    //         resource blocks
+#define PMIX_QUERY_RES_BLOCK_DEF            "pmix.qry.resdef"       // (pmix_data_array_t*) given the name of a resource block as its qualifier,
+                                                                    //         return an array of pmix_info_t describing the resources contained
+                                                                    //         in the block
 
 /* query qualifiers - these are used to provide information to narrow/modify the query. Value type shown is the type of data expected
  * to be provided with the key */
@@ -638,6 +644,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_SUPPORTED_QUALIFIERS     "pmix.qry.quals"        // (bool) return comma-delimited list of qualifiers supported by
                                                                     //        a query on the provided key, instead of actually performing
                                                                     //        the query on the key.
+#define PMIX_RESOURCE_BLOCK_NAME            "pmix.resblkname"       // (char*) Name of the resource block being queried about
 
 
 /* PMIx_Get information retrieval qualifiers */
@@ -881,6 +888,9 @@ typedef uint32_t pmix_rank_t;
                                                                     //        allocated session and leave it idle. The requestor will discover the
                                                                     //        allocation by either monitoring for the "allocated" event or by querying
                                                                     //        the system
+
+#define PMIX_ALLOC_RES_BLOCK                "pmix.alloc.blk"        // (char*) name of the previously-defined resource block to be allocated
+#define PMIX_ALLOC_NUM_BLOCKS               "pmix.alloc.nblks"      // (uint64_t) number of specified resource blocks to allocate
 
 
 /* job control attributes */
@@ -1619,6 +1629,18 @@ typedef uint8_t pmix_alloc_directive_t;
 /* define a value boundary beyond which implementers are free
  * to define their own directive values */
 #define PMIX_ALLOC_EXTERNAL     128
+
+/* define a set of directives for resource block requests */
+typedef uint8_t pmix_resource_block_directive_t;
+#define PMIX_RESOURCE_BLOCK_DEFINE  1   // define a new resource block
+#define PMIX_RESOURCE_BLOCK_EXTEND  2   // extend an existing block definition by adding the specified resources
+                                        // to the block
+#define PMIX_RESOURCE_BLOCK_REMOVE  3   // remove the specified resources from the block definition
+#define PMIX_RESOURCE_BLOCK_DELETE  4   // delete the resource block definition
+
+/* define a value boundary beyond which implementers are free
+ * to define their own directive values */
+#define PMIX_RESOURCE_BLOCK_EXTERNAL     128
 
 
 /* define a set of bit-mask flags for specifying IO

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -542,6 +542,14 @@ typedef pmix_status_t (*pmix_server_session_control_fn_t)(const pmix_proc_t *req
                                                           const pmix_info_t directives[], size_t ndirs,
                                                           pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Define/delete or extend/remove resources from a resource block */
+typedef pmix_status_t (*pmix_server_resource_block_fn_t)(const pmix_proc_t *requestor,
+                                                         pmix_resource_block_directive_t directive,
+                                                         const char *block,
+                                                         const pmix_info_t data[], size_t ndata,
+                                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
 typedef struct pmix_server_module_4_0_0_t {
     /* v1x interfaces */
     pmix_server_client_connected_fn_t   client_connected;
@@ -577,6 +585,7 @@ typedef struct pmix_server_module_4_0_0_t {
     pmix_server_client_connected2_fn_t  client_connected2;
     /* v5x interfaces */
     pmix_server_session_control_fn_t    session_control;
+    pmix_server_resource_block_fn_t     resource_block;
 } pmix_server_module_t;
 
 /****    HOST RM FUNCTIONS FOR INTERFACE TO PMIX SERVER    ****/

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -112,6 +112,7 @@ static void relcbfunc(void *cbdata)
     }
     PMIX_RELEASE(cd);
 }
+
 static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata)
 {
@@ -844,8 +845,190 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 }
 
 
+static void blkcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
+                      pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
+    pmix_status_t rc, status;
+    int cnt;
+    PMIX_HIDE_UNUSED_PARAMS(hdr);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:query cback from server");
+
+    /* a zero-byte buffer indicates that this recv is being
+     * completed due to a lost connection */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        return;
+    }
+
+    /* unpack the returned status */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        status = rc;
+    }
+
+    /* if we have a cbfunc, execute it */
+    if (NULL != cd->cbfunc.opcbfn) {
+        cd->cbfunc.opcbfn(status, cd->cbdata);
+    }
+
+    /* cleanup */
+    PMIX_RELEASE(cd);
+}
+
+static void opcb(pmix_status_t status, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+
+    cb->status = status;
+    PMIX_RELEASE_THREAD(&cb->lock);
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t directive,
+                                              char *block, pmix_info_t *info, size_t ninfo)
+{
+    pmix_cb_t cb;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_globals.debug_output, 
+                        "%s pmix:resource block op",
+                        PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    rc = PMIx_Resource_block_nb(directive, block, info, ninfo, opcb, &cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&cb);
+        return rc;
+    }
+
+    /* wait for the operation to complete */
+    PMIX_WAIT_THREAD(&cb.lock);
+    rc = cb.status;
+    PMIX_DESTRUCT(&cb);
+
+    pmix_output_verbose(2, pmix_globals.debug_output, 
+                        "pmix:resource block operation completed");
+
+    return rc;
+}
+
+
+PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t directive,
+                                                 char *block, pmix_info_t *info, size_t ninfo,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_RESBLK_CMD;
+    pmix_status_t rc;
+    pmix_shift_caddy_t *cb;
+
+    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: allocate called");
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we are the server, then we just issue the request and
+     * return the response */
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        if (NULL == pmix_host_server.resource_block) {
+            /* nothing we can do */
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+        pmix_output_verbose(2, pmix_globals.debug_output, "pmix:allocate handed to RM");
+        rc = pmix_host_server.resource_block(&pmix_globals.myid, directive, block,
+                                             info, ninfo, cbfunc, cbdata);
+        return rc;
+    }
+
+    /* if we are a client, then relay this request to the server */
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    msg = PMIX_NEW(pmix_buffer_t);
+    /* pack the cmd */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+
+    /* pack the directive */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &directive, 1, PMIX_ALLOC_DIRECTIVE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+
+    /* pack the block name */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &block, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+
+    /* pack the info */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+    }
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_shift_caddy_t);
+    cb->cbfunc.opcbfn = cbfunc;
+    cb->cbdata = cbdata;
+
+    /* push the message into our event base to send to the server */
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, blkcbfunc, (void *) cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cb);
+    }
+
+    return rc;
+}
+
+
 /*
- * Determine if the keys is meant to be locally resolved
+ * Determine if the keysis meant to be locally resolved
  */
 static bool pmix_query_check_is_local_resolve(const char *key)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -208,6 +208,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_FABRIC_UPDATE_CMD            31
 #define PMIX_COMPUTE_DEVICE_DISTANCES_CMD 32
 #define PMIX_REFRESH_CACHE                33
+#define PMIX_RESBLK_CMD                   34
 
 /* provide a "pretty-print" function for cmds */
 const char *pmix_command_string(pmix_cmd_t cmd);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4839,6 +4839,14 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         return rc;
     }
 
+    if (PMIX_RESBLK_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_resblk(cd, buf, op_cbfunc))) {
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+
     return PMIX_ERR_NOT_SUPPORTED;
 }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -5135,6 +5135,15 @@ pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
+pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
+                                 pmix_buffer_t *buf,
+                                 pmix_op_cbfunc_t cbfunc)
+{
+    PMIX_HIDE_UNUSED_PARAMS(cd, buf, cbfunc);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+
 /*****    INSTANCE SERVER LIBRARY CLASSES    *****/
 static void gcon(pmix_grpinfo_t *p)
 {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -358,6 +358,10 @@ PMIX_EXPORT pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
                                                     pmix_buffer_t *buf,
                                                     pmix_op_cbfunc_t cbfunc);
 
+PMIX_EXPORT pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
+                                             pmix_buffer_t *buf,
+                                             pmix_op_cbfunc_t cbfunc);
+
 PMIX_EXPORT void pmix_server_query_cbfunc(pmix_status_t status,
                                           pmix_info_t *info, size_t ninfo, void *cbdata,
                                           pmix_release_cbfunc_t release_fn, void *release_cbdata);


### PR DESCRIPTION
Provide a means for apps to define blocks of resources for use in allocation and spawn requests. Support modification and deletion of the blocks, as well as queries to discover named blocks and their contents.

Include query for minimum allocatable unit as some systems define a default resource block.