### PR TITLE
Implement attribute to specify connection order and process MCA params 

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -73,6 +73,7 @@ struct pmix_ptl_base_t {
     char *report_uri;
     char *uri;
     char *urifile;
+    char *sysctrlr_filename;
     char *scheduler_filename;
     char *system_filename;
     char *session_filename;
@@ -82,6 +83,7 @@ struct pmix_ptl_base_t {
     bool created_rendezvous_file;
     bool created_session_tmpdir;
     bool created_system_tmpdir;
+    bool created_sysctrlr_filename;
     bool created_scheduler_filename;
     bool created_system_filename;
     bool created_session_filename;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -76,6 +76,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .report_uri = NULL,
     .uri = NULL,
     .urifile = NULL,
+    .sysctrlr_filename = NULL,
     .scheduler_filename = NULL,
     .system_filename = NULL,
     .session_filename = NULL,
@@ -85,6 +86,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .created_rendezvous_file = false,
     .created_session_tmpdir = false,
     .created_system_tmpdir = false,
+    .created_sysctrlr_filename = false,
     .created_scheduler_filename = false,
     .created_system_filename = false,
     .created_session_filename = false,
@@ -264,6 +266,17 @@ static pmix_status_t pmix_ptl_close(void)
             }
         }
         free(pmix_ptl_base.scheduler_filename);
+    }
+    if (NULL != pmix_ptl_base.sysctrlr_filename) {
+        if (pmix_ptl_base.created_sysctrlr_filename) {
+            rc = remove(pmix_ptl_base.sysctrlr_filename);
+            if (0 != rc) {
+                pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                                    "Remove of %s failed: %s",
+                                    pmix_ptl_base.sysctrlr_filename, strerror(errno));
+            }
+        }
+        free(pmix_ptl_base.sysctrlr_filename);
     }
     if (NULL != pmix_ptl_base.system_filename) {
         if (pmix_ptl_base.created_system_filename) {

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -646,6 +646,21 @@ nextstep:
         pmix_ptl_base.created_scheduler_filename = true;
     }
 
+    /* if we are the system controller, then drop an appropriately named
+     * contact file so others can find us */
+    if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
+        if (0 > asprintf(&pmix_ptl_base.sysctrlr_filename, "%s/pmix.sysctrlr.%s",
+                         pmix_ptl_base.system_tmpdir, pmix_globals.hostname)) {
+            goto sockerror;
+        }
+        rc = pmix_base_write_rndz_file(pmix_ptl_base.sysctrlr_filename, lt->uri,
+                                       &pmix_ptl_base.created_system_tmpdir);
+        if (PMIX_SUCCESS != rc) {
+            goto sockerror;
+        }
+        pmix_ptl_base.created_sysctrlr_filename = true;
+    }
+
     /* if we are going to support tools, then drop contact file(s) */
     if (pmix_ptl_base.system_tool) {
         if (0 > asprintf(&pmix_ptl_base.system_filename, "%s/pmix.sys.%s",

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -835,7 +835,7 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
                                     "%s:%d EXECUTE CALLBACK for tag %u with %d bytes",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                                    msg->hdr.tag, (int)msg->hdr.nbytes);
+                                    msg->hdr.tag, (int)buf.bytes_used);
                 rcv->cbfunc(msg->peer, &msg->hdr, &buf, rcv->cbdata);
                 pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
                                     "%s:%d CALLBACK COMPLETE", pmix_globals.myid.nspace,

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -53,6 +53,7 @@
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -127,6 +128,20 @@ static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel, int room_n
 }
 
 static bool util_initialized = false;
+
+void pmix_expose_param(char *param)
+{
+    char *value, *pm;
+
+    value = strchr(param, '=');
+    *value = '\0';
+    ++value;
+    pmix_asprintf(&pm, "PMIX_MCA_%s", param);
+    setenv(pm, value, true);
+    free(pm);
+    --value;
+    *value = '=';
+}
 
 int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
 {

--- a/src/runtime/pmix_init_util.h
+++ b/src/runtime/pmix_init_util.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +37,8 @@ PMIX_EXPORT extern const char* pmix_tool_msg;
 
 PMIX_EXPORT int pmix_init_util(pmix_info_t info[], size_t ninfo, char *helpdir);
 PMIX_EXPORT int pmix_finalize_util(void);
+
+PMIX_EXPORT void pmix_expose_param(char *param);
 
 END_C_DECLS
 

--- a/src/tools/palloc/help-palloc.txt
+++ b/src/tools/palloc/help-palloc.txt
@@ -34,6 +34,7 @@ PMIx Allocation Request tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --uri <arg0>                      Specify the URI of the server to which we are to connect, or
                                      the name of the file (specified as file:filename) that contains that info
@@ -44,6 +45,8 @@ PMIx Allocation Request tool
    --system-server-first             First look for a system server and connect to it if found
    --system-server-only              Connect only to a system-level server
    --tmpdir <arg0>                   Set the root for the session directory tree
+   --connect-order <arg0>            Specify search order for server connections - e.g., scheduler,
+                                     system controller, system-level server, or local server
    --wait-to-connect <arg0>          Delay specified number of seconds before trying to connect
    --num-connect-retries <arg0>      Max number of times to try to connect
 
@@ -153,6 +156,24 @@ location.
 #
 [wait-to-connect]
 Delay specified number of seconds before trying to connect
+#
+[connect-order]
+Comma-delimited list of attributes defining the order in which
+connections should be attempted, from first to last. If the
+final entry is not an "only" flag (e.g., PMIX_CONNECT_TO_SYSTEM),
+then connection will default to the local server if no preceding
+option succeeds. Thus, the following list:
+    PMIX_CONNECT_TO_SCHEDULER
+    PMIX_CONNECT_TO_SYS_CONTROLLER
+    PMIX_CONNECT_TO_SYSTEM
+would first attempt to connect to the scheduler, then the system
+controller, and then the local system-level server. If none of those
+succeed, then the connection attempt will error out.
+
+However, if the last entry were PMIX_CONNECT_SYSTEM_FIRST, then the
+connection procedure would (after failing to connect to a local
+system-level server) continue to include an attempt to connect
+to any local server that accepted the connection request.
 #
 #  QALLOC-SPECIFIC OPTIONS
 #

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -51,6 +51,7 @@ static struct option pallocptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERSION, PMIX_ARG_NONE, 'V'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_SYS_SERVER_FIRST, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PMIX_CLI_SYSTEM_SERVER, PMIX_ARG_NONE),
@@ -60,6 +61,7 @@ static struct option pallocptions[] = {
     PMIX_OPTION_DEFINE(PMIX_CLI_NAMESPACE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_URI, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_TMPDIR, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_CONNECTION_ORDER, PMIX_ARG_REQD),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_REQ_ID, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_QUEUE, PMIX_ARG_REQD, 'q'),
@@ -194,10 +196,6 @@ int main(int argc, char **argv)
     pmix_tool_basename = "palloc";
     gethostname(hostname, sizeof(hostname));
 
-    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
-        return PMIX_ERROR;
-    }
-
     /* Parse the command line options */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = pmix_cmd_line_parse(argv, pallocshorts, pallocptions,
@@ -213,7 +211,21 @@ int main(int argc, char **argv)
         exit(rc);
     }
 
-     /* if we were given the pid of a starter, then direct that
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                pmix_expose_param(opt->values[n]);
+            }
+        }
+    }
+
+    // setup the base infrastructure
+    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
+        return PMIX_ERROR;
+    }
+
+    /* if we were given the pid of a starter, then direct that
      * we connect to it */
     n = 3;
     PMIX_INFO_CREATE(info, n);
@@ -278,6 +290,9 @@ int main(int argc, char **argv)
 
     } else if (pmix_cmd_line_is_taken(&results, PMIX_CLI_SYSTEM_SERVER)) {
         PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
+
+    } else if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_CONNECTION_ORDER))) {
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECTION_ORDER, opt->values[0], PMIX_STRING);
 
     } else {
         /* if none of the above, we just try to connect directly to the scheduler */

--- a/src/tools/pattrs/help-pattrs.txt
+++ b/src/tools/pattrs/help-pattrs.txt
@@ -34,6 +34,7 @@ PMIx Supported Attributes and Functions tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --do-not-connect                  Do not connect to a server
    --uri <arg0>                      Specify the URI of the server to which we are to connect, or

--- a/src/tools/pctrl/help-pctrl.txt
+++ b/src/tools/pctrl/help-pctrl.txt
@@ -34,6 +34,7 @@ PMIx Job control tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --uri <arg0>                      Specify the URI of the server to which we are to connect, or
                                      the name of the file (specified as file:filename) that contains that info

--- a/src/tools/pevent/help-pevent.txt
+++ b/src/tools/pevent/help-pevent.txt
@@ -34,6 +34,7 @@ Inject PMIx events
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --pid <arg0>                      PID of the daemon to which we should connect (int => PID or file:<file>
                                      for file containing the PID

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -92,6 +92,7 @@ static struct option peventoptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERSION, PMIX_ARG_NONE, 'V'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_SYS_SERVER_FIRST, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PMIX_CLI_SYSTEM_SERVER, PMIX_ARG_NONE),
@@ -179,12 +180,6 @@ int main(int argc, char **argv)
         return PMIX_ERROR;
     }
 
-    /* register params for pmix */
-    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
-        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
-        return PMIX_ERROR;
-    }
-
     /* Parse the command line options */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = pmix_cmd_line_parse(argv, peventshorts, peventoptions,
@@ -213,6 +208,21 @@ int main(int argc, char **argv)
             free(str);
         }
         exit(1);
+    }
+
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                pmix_expose_param(opt->values[n]);
+            }
+        }
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
     }
 
     /* if the event is a name, look it up */

--- a/src/tools/plookup/help-plookup.txt
+++ b/src/tools/plookup/help-plookup.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc. All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,6 +34,7 @@ PMIx Lookup tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --pid <arg0>                      PID of the daemon to which we should connect (int => PID or file:<file>
                                      for file containing the PID

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -89,6 +89,7 @@ static struct option plkoptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERSION, PMIX_ARG_NONE, 'V'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_PID, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_TMPDIR, PMIX_ARG_REQD),
@@ -159,12 +160,6 @@ int main(int argc, char **argv)
         return PMIX_ERROR;
     }
 
-    /* register params for pmix */
-    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
-        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
-        return PMIX_ERROR;
-    }
-
     /* Parse the command line options */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = pmix_cmd_line_parse(argv, plkshorts, plkoptions,
@@ -178,6 +173,21 @@ int main(int argc, char **argv)
             rc = PMIX_SUCCESS;
         }
         exit(rc);
+    }
+
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                pmix_expose_param(opt->values[n]);
+            }
+        }
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
     }
 
     if (pmix_cmd_line_is_taken(&results, "wait")) {

--- a/src/tools/pquery/help-pquery.txt
+++ b/src/tools/pquery/help-pquery.txt
@@ -34,6 +34,7 @@ PMIx Query tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --uri <arg0>                      Specify the URI of the server to which we are to connect, or
                                      the name of the file (specified as file:filename) that contains that info

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -194,10 +194,6 @@ int main(int argc, char **argv)
     pmix_tool_basename = "pquery";
     gethostname(hostname, sizeof(hostname));
 
-    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
-        return PMIX_ERROR;
-    }
-
     /* Parse the command line options */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = pmix_cmd_line_parse(argv, pqshorts, pqoptions,
@@ -211,6 +207,20 @@ int main(int argc, char **argv)
             rc = PMIX_SUCCESS;
         }
         exit(rc);
+    }
+
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                pmix_expose_param(opt->values[n]);
+            }
+        }
+    }
+
+    // setup the base infrastructure
+    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
+        return PMIX_ERROR;
     }
 
     /* get the argv array of keys they want us to query */

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -122,6 +122,7 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_URI                    "uri"                       // required
 #define PMIX_CLI_TIMEOUT                "timeout"                   // required
 #define PMIX_CLI_TMPDIR                 "tmpdir"                    // required
+#define PMIX_CLI_CONNECTION_ORDER       "connect-order"             // required
 
 // Allocation request options
 #define PMIX_CLI_REQ_ID                 "request-id"                // required


### PR DESCRIPTION
Rather than trying to define specific attributes for "first" vs
any other connection order, use an attribute that takes a comma-delimited
list of connection directives to process the order in which
server connections are to be attempted by tools.


Ensure that all PMIx tools include a "--pmixmca foo bar" cmd line option to set MCA params.