### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -81,6 +81,38 @@ jobs:
         make install
         make uninstall
 
+  ubuntu-oldHWLOC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libevent-dev
+    - name: Git clone HWLOC v1.x
+      uses: actions/checkout@v4
+      with:
+            repository: open-mpi/hwloc
+            ref: hwloc-1.11.13
+    - name: Build HWLOC
+      run: |
+        ./autogen.sh
+        ./configure --prefix=$RUNNER_TEMP/hwlocinstall
+        make -j install
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+    - name: Build OpenPMIx
+      run: |
+        ./autogen.pl
+        ./configure --prefix=${PWD}/install --with-hwloc=$RUNNER_TEMP/hwlocinstall
+        make -j
+        cd test
+        make check
+        cd ..
+        make install
+        make uninstall
+
   distcheck:
     runs-on: ubuntu-latest
     steps:

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -1,4 +1,4 @@
-# -*- autoconf -*-
+# -*- shell-script -*-
 #
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
@@ -16,7 +16,7 @@
 # MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_SETUP_HWLOC],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_check_hwloc_save_CPPFLAGS])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -32,17 +32,15 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                                   [If --disable-hwloc-lib-checks is specified, configure will assume that -lhwloc is available])])
 
     pmix_hwloc_support=1
-    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
-    pmix_have_topology_dup=0
 
     if test "$with_hwloc" = "no"; then
-        AC_MSG_WARN([PMIx requires HWLOC topology library support.])
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
     fi
 
     AS_IF([test "$with_hwloc_extra_libs" = "yes" -o "$with_hwloc_extra_libs" = "no"],
-	  [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
+    [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test "$enable_hwloc_lib_checks" != "no"],
           [OAC_CHECK_PACKAGE([hwloc],
@@ -52,72 +50,58 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                              [hwloc_topology_init],
                              [],
                              [pmix_hwloc_support=0])],
-          [PMIX_FLAGS_APPEND_UNIQ([PMIX_DELAYED_LIBS], [$with_hwloc_extra_libs])])
+          [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
-        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
+        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
         AC_MSG_WARN([an adequate version of that library was not found.])
         AC_MSG_WARN([Please reconfigure and point to a location where])
         AC_MSG_WARN([the HWLOC library can be found.])
         AC_MSG_ERROR([Cannot continue.])
     fi
 
-    # update global flags to test for HWLOC version
-    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
-
-    AC_MSG_CHECKING([if hwloc version is 1.5 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_API_VERSION < 0x00010500
-    #error "hwloc version is less than 0x00010500"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])],
-          [AC_MSG_RESULT([no])
-           AC_MSG_ERROR([Cannot continue])])
-
-    AC_MSG_CHECKING([if hwloc version is 1.8 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_API_VERSION < 0x00010800
-    #error "hwloc version is less than 0x00010800"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           pmix_have_topology_dup=1],
-          [AC_MSG_RESULT([no])])
+    # NOTE: We have already read PMIx's VERSION file, so we can use
+    # those values
+    pmix_hwloc_min_num_version=PMIX_HWLOC_NUMERIC_MIN_VERSION
+    pmix_hwloc_min_version=PMIX_HWLOC_MIN_VERSION
+    AC_MSG_CHECKING([version at or above v$pmix_hwloc_min_version])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if (HWLOC_API_VERSION < $pmix_hwloc_min_num_version)
+                                        #error "not version $pmix_hwloc_min_num_version or above"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([yes])],
+                      [AC_MSG_RESULT(no)
+                       AC_MSG_WARN([PMIx requires HWLOC v$pmix_hwloc_min_version or above.])
+                       AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_MSG_CHECKING([if hwloc version is at least 2.0])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_VERSION_MAJOR < 2
-    #error "hwloc version is less than 2.0"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           pmix_version_high=1],
-          [AC_MSG_RESULT([no])
-           pmix_version_high=0])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if HWLOC_VERSION_MAJOR < 2
+                                        #error "hwloc version is less than 2.0"
+                                        #endif
+                                       ], [])],
+                        [AC_MSG_RESULT([yes])
+                         pmix_version_high=1],
+                        [AC_MSG_RESULT([no])
+                         pmix_version_high=0])
+    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
 
     AC_MSG_CHECKING([if hwloc version is greater than 2.x])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([#include <hwloc.h>],
-          [[
-    #if HWLOC_VERSION_MAJOR > 2
-    #error "hwloc version is greater than 2.x"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([no])],
-          [AC_MSG_RESULT([yes])
-           AC_MSG_WARN([This PMIx version does not support HWLOC])
-           AC_MSG_WARN([versions 3.x or higher. Please direct us])
-           AC_MSG_WARN([to an HWLOC version in the 1.11-2.x range.])
-           AC_MSG_ERROR([Cannot continue])])
-
-    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <hwloc.h>
+                                        #if (HWLOC_VERSION_MAJOR > 2)
+                                        #error "hwloc version is greater than 2.x"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([no])],
+                      [AC_MSG_RESULT([yes])
+                       AC_MSG_WARN([This PMIx version does not support HWLOC])
+                       AC_MSG_WARN([versions 3.x or higher. Please direct us])
+                       AC_MSG_WARN([to an HWLOC version in the $pmix_hwloc_min_version-2.x range.])
+                       AC_MSG_ERROR([Cannot continue])])
 
     PMIX_FLAGS_APPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
     PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
@@ -132,10 +116,7 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
 
     PMIX_WRAPPER_FLAGS_ADD([PC_MODULES], [$pmix_hwloc_PC_MODULES])
 
-    AC_DEFINE_UNQUOTED([PMIX_HAVE_HWLOC_TOPOLOGY_DUP], [$pmix_have_topology_dup],
-                       [Whether or not hwloc_topology_dup is available])
 
-    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
 
     PMIX_SUMMARY_ADD([Required Packages], [HWLOC], [], [$pmix_hwloc_SUMMARY])
 

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -51,7 +51,7 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                              [hwloc_topology_init],
                              [],
                              [pmix_hwloc_support=0])],
-          [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
+          [PMIX_FLAGS_APPEND_UNIQ([PMIX_DELAYED_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
         AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
@@ -122,8 +122,6 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
     PMIX_WRAPPER_FLAGS_ADD([STATIC_LIBS], [$pmix_hwloc_STATIC_LIBS])
 
     PMIX_WRAPPER_FLAGS_ADD([PC_MODULES], [$pmix_hwloc_PC_MODULES])
-
-
 
     PMIX_SUMMARY_ADD([Required Packages], [HWLOC], [], [$pmix_hwloc_SUMMARY])
 

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -16,7 +16,7 @@
 # MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PMIX_SETUP_HWLOC],[
-    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir])
+    PMIX_VAR_SCOPE_PUSH([pmix_hwloc_dir pmix_hwloc_libdir pmix_check_hwloc_save_CPPFLAGS])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -32,9 +32,10 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                                   [If --disable-hwloc-lib-checks is specified, configure will assume that -lhwloc is available])])
 
     pmix_hwloc_support=1
+    pmix_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
 
     if test "$with_hwloc" = "no"; then
-        AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
+        AC_MSG_WARN([PMIx requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])
     fi
@@ -53,12 +54,15 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
           [PMIX_FLAGS_APPEND_UNIQ([PMIX_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $pmix_hwloc_support -eq 0; then
-        AC_MSG_WARN([PRRTE requires HWLOC topology library support, but])
+        AC_MSG_WARN([PMIx requires HWLOC topology library support, but])
         AC_MSG_WARN([an adequate version of that library was not found.])
         AC_MSG_WARN([Please reconfigure and point to a location where])
         AC_MSG_WARN([the HWLOC library can be found.])
         AC_MSG_ERROR([Cannot continue.])
     fi
+
+    # update global flags to test for HWLOC version
+    PMIX_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
 
     # NOTE: We have already read PMIx's VERSION file, so we can use
     # those values
@@ -102,6 +106,9 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                        AC_MSG_WARN([versions 3.x or higher. Please direct us])
                        AC_MSG_WARN([to an HWLOC version in the $pmix_hwloc_min_version-2.x range.])
                        AC_MSG_ERROR([Cannot continue])])
+
+    # reset global flags
+    CPPFLAGS=$pmix_check_hwloc_save_CPPFLAGS
 
     PMIX_FLAGS_APPEND_UNIQ([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])
     PMIX_WRAPPER_FLAGS_ADD([CPPFLAGS], [$pmix_hwloc_CPPFLAGS])

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -53,7 +53,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
            pmix_libevent_support=0])
 
     AS_IF([test "$with_libevent_extra_libs" = "yes" -o "$with_libevent_extra_libs" = "no"],
-	  [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
+      [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test $pmix_libevent_support -eq 1],
           [pmix_check_libevent_save_CPPFLAGS="$CPPFLAGS"
@@ -113,7 +113,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
           ]])],
           [AC_MSG_RESULT([yes])],
           [AC_MSG_RESULT([no])
-           AC_MSG_WARN([PMIX requires libevent to be compiled with thread support enabled])
+           AC_MSG_WARN([PMIX rquires libevent to be compiled with thread support enabled])
            pmix_libevent_support=0])
     fi
 
@@ -134,20 +134,24 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
     fi
 
     if test $pmix_libevent_support -eq 1; then
-        # Pin the "oldest supported" version to 2.0.21
-        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                           [[
-                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #endif
-                                           ]])],
-                          [AC_MSG_RESULT([yes])],
-                          [AC_MSG_RESULT([no])
-                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                           pmix_libevent_support=0])
+        pmix_event_min_num_version=PMIX_EVENT_NUMERIC_MIN_VERSION
+        pmix_event_min_version=PMIX_EVENT_MIN_VERSION
+        AC_MSG_CHECKING([version at or above v$pmix_event_min_version])
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                            #include <event2/event.h>
+#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < $pmix_event_min_num_version
+#error "libevent API version is less than $pmix_event_min_version"
+#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < $pmix_event_min_num_version
+#error "libevent API version is less than $pmix_event_min_version"
+#endif
+                                       ], [])],
+                      [pmix_libevent_cv_version_check=yes
+                       AC_MSG_RESULT([yes])],
+                      [pmix_libevent_cv_version_check=no
+                       AC_MSG_RESULT([no])])
+        AS_IF([test "${pmix_libevent_cv_version_check}" = "no"],
+              [AC_MSG_WARN([libevent version is too old ($pmix_event_min_version or later required)])
+               pmix_libevent_support=0])
     fi
 
     # restore global flags

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -205,6 +205,21 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CONNECT_SYSTEM_FIRST           "pmix.cnct.sys.first"   // (bool) Preferentially look for a system-level PMIx server first
 #define PMIX_CONNECT_TO_SCHEDULER           "pmix.cnct.sched"       // (bool) Connect to the system scheduler
 #define PMIX_CONNECT_TO_SYS_CONTROLLER      "pmix.cnct.ctrlr"       // (bool) Connect to the system controller
+#define PMIX_CONNECTION_ORDER               "pmix.cnct.ord"         // (char*) Comma-delimited list of attributes defining the order in which
+                                                                    //        connections should be attempted, from first to last. If the
+                                                                    //        final entry is not an "only" flag (e.g., PMIX_CONNECT_TO_SYSTEM),
+                                                                    //        then connection will default to the local server if no preceding
+                                                                    //        option succeeds. Thus, the following list:
+                                                                    //              PMIX_CONNECT_TO_SCHEDULER
+                                                                    //              PMIX_CONNECT_TO_SYS_CONTROLLER
+                                                                    //              PMIX_CONNECT_TO_SYSTEM
+                                                                    //        would first attempt to connect to the scheduler, then the system
+                                                                    //        controller, and then the local system-level server. If none of those
+                                                                    //        succeed, then the connection attempt will error out.
+                                                                    //        However, if the last entry were PMIX_CONNECT_SYSTEM_FIRST, then the
+                                                                    //        connection procedure would (after failing to connect to a local
+                                                                    //        system-level server) continue to include an attempt to connect
+                                                                    //        to any local server that accepted the connection request.
 #define PMIX_SERVER_URI                     "pmix.srvr.uri"         // (char*) URI of server to be contacted
 #define PMIX_MYSERVER_URI                   "pmix.mysrvr.uri"       // (char*) URI of this proc's listener socket
 #define PMIX_SERVER_HOSTNAME                "pmix.srvr.host"        // (char*) node where target server is located

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -389,16 +389,12 @@ pmix_status_t pmix_hwloc_copy_topology(pmix_topology_t *dest, pmix_topology_t *s
     flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
     flags |= HWLOC_TOPOLOGY_FLAG_IO_DEVICES;
 #else
-    if (0 != hwloc_topology_set_io_types_filter(t, HWLOC_TYPE_FILTER_KEEP_IMPORTANT)) {
+    if (0 != hwloc_topology_set_io_types_filter(dest->topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT)) {
         hwloc_topology_destroy(dest->topology);
         free(xmlbuffer);
         return PMIX_ERROR;
     }
-#    if HWLOC_API_VERSION < 0x00020100
-    flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
-#    else
     flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
-#    endif
 #endif
     if (0 != hwloc_topology_set_flags(dest->topology, flags)) {
         hwloc_topology_destroy(dest->topology);

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -97,7 +97,6 @@ static void cbfunc(pmix_status_t status,
 
     PMIX_ACQUIRE_OBJECT(req);
 
-pmix_output(0, "CALLBACK RECVD: %s", PMIx_Error_string(status));
     req->status = status;
     if (PMIX_SUCCESS == status && 0 < ninfo) {
         req->ninfo = ninfo;

--- a/src/util/help-cli.txt
+++ b/src/util/help-cli.txt
@@ -61,7 +61,7 @@ When used in conjunction with other parameters, the output information
 A short option was provided to %s and recognized by the parser,
 but has no matching long option:
 
-  Short option: %s
+  Short option: %c
 
 This might require help from the developers.
 [unregistered-option]
@@ -76,7 +76,7 @@ supported options.
 A short option was provided to %s and recognized by the parser,
 but included an argument while the option does not support one:
 
-  Short option: %s
+  Short option: %c
   Given argument: %s
 
 Please correct the command line and try again.

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -93,7 +93,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         char *helpfile)
 {
     int option_index = 0;   /* getopt_long stores the option index here. */
-    int n, opt, argc, argind;
+    int n, m, opt, argc, argind;
     bool found;
     char *ptr, *str, **argv;
     pmix_cmd_line_store_fn_t mystore;
@@ -293,9 +293,9 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         } else {
                             ptr = NULL;
                         }
-                        for (n=0; NULL != myoptions[n].name; n++) {
-                            if (ascii == myoptions[n].val) {
-                                if (PMIX_ARG_NONE == myoptions[n].has_arg) {
+                        for (m=0; NULL != myoptions[m].name; m++) {
+                            if (ascii == myoptions[m].val) {
+                                if (PMIX_ARG_NONE == myoptions[m].has_arg) {
                                     /* if ptr isn't NULL, then that means we were given
                                      * an argument to an option that doesn't take one.
                                      * Report the error */
@@ -310,7 +310,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                         return PMIX_ERR_SILENT;
                                     }
                                     ptr = NULL;
-                                } else if (0 == strcmp(myoptions[n].name, "np") &&
+                                } else if (0 == strcmp(myoptions[m].name, "np") &&
                                            0 == strcmp(optarg, "p")) {
                                     /* we special-case the very common "-np" option */
                                     ptr = argv[optind];
@@ -336,7 +336,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             goto done;
                         }
                         str = pmix_show_help_string("help-cli.txt", "short-no-long", true,
-                                                    pmix_tool_basename, argv[optind-1]);
+                                                    pmix_tool_basename, shorts[n]);
                         if (NULL != str) {
                             printf("%s", str);
                             free(str);

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -316,7 +316,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                     ptr = argv[optind];
                                     ++optind;
                                 }
-                                mystore(myoptions[n].name, ptr, results);
+                                mystore(myoptions[m].name, ptr, results);
                                 found = true;
                                 break;
                             }


### PR DESCRIPTION
[Remove debug print](https://github.com/openpmix/openpmix/commit/10e8d0afacc5cd220e14cb3a63fbf294657df23d)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/70cc61a4b75566902f91fb460ccbe79f3eac4136)

[Make checking min versions consistent](https://github.com/openpmix/openpmix/commit/19e801095da7323b3d9d1fbc0b308d3e26b92a23)

We have two dependent libraries we care about, and minimum version requirements on both of them. Let's connect them to the min values in the VERSION file and "standardize" the check configure code to make it easier to understand and maintain.

Also, since we require a min HWLOC version of 1.11, there is no longer a need to check for at least 1.8 so we know we have hwloc_topology_dup.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9ddcf0ad522998d8a04beb9ae428ecc5864f64f7)

[Add an action to test older HWLOC version](https://github.com/openpmix/openpmix/commit/8f558555ba537d5514ab46fccb63750305a40ba9)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9a7e95f4cf010b62d34b94eaab5d978ad3b3b6f1)

[Touchup the OMPI integration](https://github.com/openpmix/openpmix/commit/d3c5e4eef7c7a9a169121213b3918e33bd883bf3)

Append the extra libs to the proper global variable

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/023e50bafe0ae6ee7447b6c4a1425dfa23212e0f)

[Fix couple of bugs in cmd line parser](https://github.com/openpmix/openpmix/commit/36314f3f92c29f7d89812062ee2d2419f95e54d8)

Fix shadow variable use of loop counter. Fix incorrect
format in help file (should be '%c' instead of '%s')

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/918b2e1ea852e7fe5a0266f128c7fed3941a0b36)

[Fix typo in cmd line processor](https://github.com/openpmix/openpmix/commit/3dd3f35a9a479abb7b8c2c8172cfab4100def8ff)

Use correct loop index to store found result

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/df3b30f89e161260e623da4708987dd02ede5b43)

[Add a new attribute to specify connection order](https://github.com/openpmix/openpmix/commit/6f78441092f18d57396b76e3fc96bfad1baacae0)

Instead of having individual attributes to specify a
connection target and others to specify an order for
each target, just have an attribute that allows one
to specify an ordered list of targets.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/5ccefd7764e952404df64fab448f8d7ca8f97ef1)
