### PR TITLE
Implement data type support for resource blocks

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1170,6 +1170,7 @@ PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist);
 PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
 PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
+PMIX_EXPORT const char* PMIx_Resource_block_directive_string(pmix_resource_block_directive_t directive);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
 PMIX_EXPORT const char* PMIx_Job_state_string(pmix_job_state_t state);
 PMIX_EXPORT const char* PMIx_Get_attribute_string(const char *attribute);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1577,6 +1577,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_STOR_PERSIST               68
 #define PMIX_STOR_ACCESS_TYPE           69
 #define PMIX_DEVICE                     70
+#define PMIX_RESBLOCK_DIRECTIVE         71
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -2280,6 +2281,7 @@ typedef struct pmix_value {
         pmix_data_array_t *darray;
         void *ptr;
         pmix_alloc_directive_t adir;
+        pmix_resource_block_directive_t rbdir;
         pmix_envar_t envar;
         pmix_coord_t *coord;
         pmix_link_state_t linkstate;

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -203,6 +203,22 @@ PMIX_EXPORT const char *PMIx_Alloc_directive_string(pmix_alloc_directive_t direc
     }
 }
 
+PMIX_EXPORT const char *PMIx_Resource_block_directive_string(pmix_resource_block_directive_t directive)
+{
+    switch (directive) {
+    case PMIX_RESOURCE_BLOCK_DEFINE:
+        return "DEFINE";
+    case PMIX_RESOURCE_BLOCK_EXTEND:
+        return "EXTEND";
+    case PMIX_RESOURCE_BLOCK_REMOVE:
+        return "REMOVE";
+    case PMIX_RESOURCE_BLOCK_DELETE:
+        return "DELETE";
+    default:
+        return "UNSPECIFIED";
+    }
+}
+
 PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
 {
     switch (cmd) {

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -444,6 +444,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_pointer_arr
                                                                 pmix_buffer_t *buffer,
                                                                 const void *src, int32_t num_vals,
                                                                 pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_resblock_directive(pmix_pointer_array_t *regtypes,
+                                                                   pmix_buffer_t *buffer,
+                                                                   const void *src, int32_t num_vals,
+                                                                   pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
                                                             pmix_buffer_t *buffer, const void *src,
                                                             int32_t num_vals,
@@ -647,6 +651,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_pointer_a
                                                                   pmix_buffer_t *buffer, void *dest,
                                                                   int32_t *num_vals,
                                                                   pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_resblock_directive(pmix_pointer_array_t *regtypes,
+                                                                     pmix_buffer_t *buffer, void *dest,
+                                                                     int32_t *num_vals,
+                                                                     pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
                                                               pmix_buffer_t *buffer, void *dest,
                                                               int32_t *num_vals,
@@ -918,6 +926,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_rank(char **output, char *prefi
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix,
                                                                  pmix_alloc_directive_t *src,
                                                                  pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_resblock_directive(char **output, char *prefix,
+                                                                    pmix_resource_block_directive_t *src,
+                                                                    pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
                                                              pmix_iof_channel_t *src,
                                                              pmix_data_type_t type);

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -1214,6 +1214,10 @@ static pmix_value_cmp_t cmp_darray(pmix_data_array_t *d1,
             ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_alloc_directive_t));
             PMIX_CHECK_SIMPLE(ret);
             break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_resource_block_directive_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
         case PMIX_ENVAR:
             e1 = (pmix_envar_t*)d1->array;
             e2 = (pmix_envar_t*)d2->array;
@@ -1525,6 +1529,10 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p1,
         break;
     case PMIX_ALLOC_DIRECTIVE:
         ret = memcmp(&p1->data.adir, &p2->data.adir, sizeof(pmix_alloc_directive_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_RESBLOCK_DIRECTIVE:
+        ret = memcmp(&p1->data.rbdir, &p2->data.rbdir, sizeof(pmix_resource_block_directive_t));
         PMIX_CHECK_SIMPLE(ret);
         break;
     case PMIX_ENVAR:

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -165,6 +165,10 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src, pmix_data_type_t
         datasize = sizeof(pmix_alloc_directive_t);
         break;
 
+    case PMIX_RESBLOCK_DIRECTIVE:
+        datasize = sizeof(pmix_resource_block_directive_t);
+        break;
+
     case PMIX_JOB_STATE:
         datasize = sizeof(pmix_job_state_t);
         break;

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -210,6 +210,9 @@ void pmix_bfrops_base_value_load(pmix_value_t *v,
         case PMIX_ALLOC_DIRECTIVE:
             memcpy(&(v->data.adir), data, sizeof(pmix_alloc_directive_t));
             break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            memcpy(&(v->data.rbdir), data, sizeof(pmix_resource_block_directive_t));
+            break;
         case PMIX_ENVAR:
             envar = (pmix_envar_t *) data;
             if (NULL != envar->envar) {
@@ -493,6 +496,10 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         case PMIX_ALLOC_DIRECTIVE:
             memcpy(*data, &(kv->data.adir), sizeof(pmix_alloc_directive_t));
             *sz = sizeof(pmix_alloc_directive_t);
+            break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            memcpy(*data, &(kv->data.rbdir), sizeof(pmix_resource_block_directive_t));
+            *sz = sizeof(pmix_resource_block_directive_t);
             break;
         case PMIX_ENVAR:
             PMIX_ENVAR_CREATE(envar, 1);
@@ -1029,6 +1036,9 @@ static pmix_status_t get_darray_size(pmix_data_array_t *array,
         case PMIX_ALLOC_DIRECTIVE:
             *sz = array->size * sizeof(pmix_alloc_directive_t);
             break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            *sz = array->size * sizeof(pmix_resource_block_directive_t);
+            break;
         case PMIX_ENVAR:
             *sz = array->size * sizeof(pmix_envar_t);
             en = (pmix_envar_t*)array->array;
@@ -1366,6 +1376,9 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
             break;
         case PMIX_ALLOC_DIRECTIVE:
             *sz = sizeof(pmix_alloc_directive_t);
+            break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            *sz = sizeof(pmix_resource_block_directive_t);
             break;
         case PMIX_ENVAR:
             *sz = sizeof(pmix_envar_t);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1017,6 +1017,18 @@ pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_pointer_array_t *regtyp
     return ret;
 }
 
+pmix_status_t pmix_bfrops_base_pack_resblock_directive(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
+                                                       int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
+}
+
 pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
                                                 pmix_buffer_t *buffer, const void *src,
                                                 int32_t num_vals, pmix_data_type_t type)

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -756,6 +756,9 @@ static int print_val(char **output, pmix_value_t *src)
         case PMIX_ALLOC_DIRECTIVE:
             rc = pmix_bfrops_base_print_alloc_directive(&tp, NULL, &src->data.adir, PMIX_ALLOC_DIRECTIVE);
             break;
+        case PMIX_RESBLOCK_DIRECTIVE:
+            rc = pmix_bfrops_base_print_resblock_directive(&tp, NULL, &src->data.adir, PMIX_RESBLOCK_DIRECTIVE);
+            break;
         case PMIX_ENVAR:
             rc = pmix_bfrops_base_print_envar(&tp, NULL, &src->data.envar, PMIX_ENVAR);
             break;
@@ -1212,6 +1215,7 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
     pmix_data_array_t *daptr;
     pmix_regattr_t *rgptr;
     pmix_alloc_directive_t *adptr;
+    pmix_resource_block_directive_t *rbptr;
     pmix_envar_t *evptr;
     pmix_coord_t *coptr;
     pmix_link_state_t *lkptr;
@@ -1365,6 +1369,10 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
             case PMIX_ALLOC_DIRECTIVE:
                 adptr = (pmix_alloc_directive_t*)src->array;
                 rc = pmix_bfrops_base_print_alloc_directive(&tp, prefix, &adptr[n], PMIX_ALLOC_DIRECTIVE);
+                break;
+            case PMIX_RESBLOCK_DIRECTIVE:
+                rbptr = (pmix_resource_block_directive_t*)src->array;
+                rc = pmix_bfrops_base_print_resblock_directive(&tp, prefix, &rbptr[n], PMIX_RESBLOCK_DIRECTIVE);
                 break;
             case PMIX_ENVAR:
                 evptr = (pmix_envar_t*)src->array;
@@ -1563,6 +1571,25 @@ pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix
     ret = asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Alloc_directive_string(*src));
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_resblock_directive(char **output, char *prefix,
+                                                        pmix_resource_block_directive_t *src,
+                                                        pmix_data_type_t type)
+{
+    int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ret = asprintf(output, "%sData type: PMIX_RESBLOCK_DIRECTIVE\tValue: %s",
+                   (NULL == prefix) ? " " : prefix,
+                   PMIx_Resource_block_directive_string(*src));
 
     if (0 > ret) {
         return PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1374,6 +1374,18 @@ pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_pointer_array_t *regt
     return ret;
 }
 
+pmix_status_t pmix_bfrops_base_unpack_resblock_directive(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
+                                                         int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
+}
+
 pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
                                                   pmix_buffer_t *buffer, void *dest,
                                                   int32_t *num_vals, pmix_data_type_t type)

--- a/src/mca/bfrops/v51/bfrop_pmix51.c
+++ b/src/mca/bfrops/v51/bfrop_pmix51.c
@@ -255,6 +255,11 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_alloc_directive, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_alloc_directive, &pmix_mca_bfrops_v51_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_RESBLOCK_DIRECTIVE", PMIX_RESBLOCK_DIRECTIVE,
+                       pmix_bfrops_base_pack_resblock_directive,
+                       pmix_bfrops_base_unpack_resblock_directive, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_resblock_directive, &pmix_mca_bfrops_v51_component.types);
+
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL", PMIX_IOF_CHANNEL, pmix_bfrops_base_pack_iof_channel,
                        pmix_bfrops_base_unpack_iof_channel, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_iof_channel, &pmix_mca_bfrops_v51_component.types);


### PR DESCRIPTION
Fill in all the pack/unpack/print/copy support for pmix_resource_block_directive_t.