### PR TITLE
hash: Update pmix_hash functions to accept a pmix_keyindex_t*.

### DIFF
--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +80,7 @@ PMIX_EXPORT void pmix_init_registered_attrs(void)
             p->string = strdup(pmix_dictionary[n].string);
             p->type = pmix_dictionary[n].type;
             p->description = PMIx_Argv_copy(pmix_dictionary[n].description);
-            pmix_hash_register_key(p->index, p);
+            pmix_hash_register_key(p->index, p, NULL);
         }
         initialized = true;
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -698,6 +698,22 @@ typedef struct {
 } pmix_notify_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_notify_caddy_t);
 
+typedef struct {
+    pmix_object_t super;
+    /** Points to key <--> index translation table. */
+    pmix_pointer_array_t *table;
+    /** Stores the next ID. */
+    uint32_t next_id;
+} pmix_keyindex_t;
+PMIX_CLASS_DECLARATION(pmix_keyindex_t);
+
+#define PMIX_KEYINDEX_STATIC_INIT                 \
+{                                                 \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t), \
+    .table = NULL,                                \
+    .next_id = PMIX_INDEX_BOUNDARY                \
+}
+
 /****    GLOBAL STORAGE    ****/
 /* define a global construct that includes values that must be shared
  * between various parts of the code library. The client, tool,
@@ -741,8 +757,7 @@ typedef struct {
     bool external_topology;
     bool external_progress;
     pmix_iof_flags_t iof_flags;
-    pmix_pointer_array_t keyindex;  // translation table of key <-> index
-    uint32_t next_keyid;
+    pmix_keyindex_t keyindex;
 } pmix_globals_t;
 
 /* provide access to a function to cleanup epilogs */

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -532,7 +532,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
      * info for this nspace - retrieve it */
     if (NULL == key && PMIX_RANK_WILDCARD == proc->rank) {
         /* fetch all values from the hash table tied to rank=wildcard */
-        rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs);
+        rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs, NULL);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             return rc;
         }
@@ -566,7 +566,7 @@ pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, b
         /* finally, we need the job-level info for each rank in the job */
         for (rnk = 0; rnk < trk->nptr->nprocs; rnk++) {
             PMIX_CONSTRUCT(&rkvs, pmix_list_t);
-            rc = pmix_hash_fetch(&trk->internal, rnk, NULL, NULL, 0, &rkvs);
+            rc = pmix_hash_fetch(&trk->internal, rnk, NULL, NULL, 0, &rkvs, NULL);
             if (PMIX_ERR_NOMEM == rc) {
                 PMIX_LIST_DESTRUCT(&rkvs);
                 return rc;
@@ -673,7 +673,7 @@ doover:
      * be the source */
     if (PMIX_RANK_UNDEF == proc->rank) {
         for (rnk = 0; rnk < trk->nptr->nprocs; rnk++) {
-            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs);
+            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs, NULL);
             if (PMIX_ERR_NOMEM == rc) {
                 return rc;
             }
@@ -701,12 +701,12 @@ doover:
         if (NULL == key) {
             /* and need to add all job info just in case that was
              * passed via a different GDS component */
-            rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs);
+            rc = pmix_hash_fetch(&trk->internal, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs, NULL);
         } else {
             rc = PMIX_ERR_NOT_FOUND;
         }
     } else {
-        rc = pmix_hash_fetch(ht, proc->rank, key, qualifiers, nqual, kvs);
+        rc = pmix_hash_fetch(ht, proc->rank, key, qualifiers, nqual, kvs, NULL);
     }
     if (PMIX_SUCCESS == rc) {
         if (PMIX_GLOBAL == scope) {
@@ -742,7 +742,7 @@ doover:
         if (PMIX_RANK_IS_VALID(proc->rank)) {
             if (PMIX_LOCAL == scope) {
                 /* check the remote scope */
-                rc = pmix_hash_fetch(&trk->remote, proc->rank, key, qualifiers, nqual, kvs);
+                rc = pmix_hash_fetch(&trk->remote, proc->rank, key, qualifiers, nqual, kvs, NULL);
                 if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
                     while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
                         PMIX_RELEASE(kv);
@@ -753,7 +753,7 @@ doover:
                 }
             } else if (PMIX_REMOTE == scope) {
                 /* check the local scope */
-                rc = pmix_hash_fetch(&trk->local, proc->rank, key, qualifiers, nqual, kvs);
+                rc = pmix_hash_fetch(&trk->local, proc->rank, key, qualifiers, nqual, kvs, NULL);
                 if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
                     while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
                         PMIX_RELEASE(kv);

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -314,7 +314,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                     kv.key = iptr[j].key;
                     kv.value = &iptr[j].value;
                     /* store it in the hash_table */
-                    rc = pmix_hash_store(ht, rank, &kv, NULL, 0);
+                    rc = pmix_hash_store(ht, rank, &kv, NULL, 0, NULL);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         goto release;
@@ -336,7 +336,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 kv.key = PMIX_APPNUM;
                 kv.value = &val;
                 PMIX_VALUE_LOAD(&val, &zero, PMIX_UINT32);
-                rc = pmix_hash_store(ht, rank, &kv, NULL, 0);
+                rc = pmix_hash_store(ht, rank, &kv, NULL, 0, NULL);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto release;
@@ -445,7 +445,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 /* just a value relating to the entire job */
                 kv.key = info[n].key;
                 kv.value = &info[n].value;
-                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv, NULL, 0);
+                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv, NULL, 0, NULL);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto release;
@@ -480,7 +480,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             if (PMIX_CHECK_KEY(kvptr, PMIX_QUALIFIED_VALUE)) {
                 rc = pmix_gds_hash_store_qualified(ht, PMIX_RANK_WILDCARD, kvptr->value);
             } else {
-                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kvptr, NULL, 0);
+                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kvptr, NULL, 0, NULL);
             }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -539,7 +539,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* fetch all values from the hash table tied to rank=wildcard */
     PMIX_CONSTRUCT(&values, pmix_list_t);
-    rc = pmix_hash_fetch(ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, &values);
+    rc = pmix_hash_fetch(ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, &values, NULL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_LIST_DESTRUCT(&values);
@@ -639,7 +639,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "FETCHING PROC INFO FOR RANK %s", PMIX_RANK_PRINT(rank));
         PMIX_CONSTRUCT(&values, pmix_list_t);
-        rc = pmix_hash_fetch(ht, rank, NULL, NULL, 0, &values);
+        rc = pmix_hash_fetch(ht, rank, NULL, NULL, 0, &values, NULL);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_LIST_DESTRUCT(&values);
@@ -843,7 +843,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 if (PMIX_CHECK_KEY(&kp2, PMIX_QUALIFIED_VALUE)) {
                     rc = pmix_gds_hash_store_qualified(ht, rank, kp2.value);
                 } else {
-                    rc = pmix_hash_store(ht, rank, &kp2, NULL, 0);
+                    rc = pmix_hash_store(ht, rank, &kp2, NULL, 0, NULL);
                 }
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
@@ -944,7 +944,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                         2, pmix_gds_base_framework.framework_output,
                         "[%s:%u] pmix:gds:hash store map info for rank %u working key %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, rank, kv2.key);
-                    rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv2, NULL, 0);
+                    rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv2, NULL, 0, NULL);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&kptr);
@@ -965,7 +965,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 val.type = PMIX_STRING;
                 val.data.string = PMIx_Argv_join(nodelist, ',');
                 PMIx_Argv_free(nodelist);
-                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv2, NULL, 0);
+                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kv2, NULL, 0, NULL);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&kptr);
@@ -1110,7 +1110,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 if (PMIX_CHECK_KEY(&kv, PMIX_QUALIFIED_VALUE)) {
                     rc = pmix_gds_hash_store_qualified(ht, rank, kv.value);
                 } else {
-                    rc = pmix_hash_store(ht, rank, &kv, NULL, 0);
+                    rc = pmix_hash_store(ht, rank, &kv, NULL, 0, NULL);
                 }
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
@@ -1125,7 +1125,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
             if (PMIX_CHECK_KEY(&kptr, PMIX_QUALIFIED_VALUE)) {
                 rc = pmix_gds_hash_store_qualified(ht, PMIX_RANK_WILDCARD, kptr.value);
             } else {
-                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kptr, NULL, 0);
+                rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, &kptr, NULL, 0, NULL);
             }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -1204,7 +1204,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
             if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
                 rc = pmix_gds_hash_store_qualified(&trk->internal, proc->rank, kv->value);
             } else {
-                rc = pmix_hash_store(&trk->internal, proc->rank, kv, NULL, 0);
+                rc = pmix_hash_store(&trk->internal, proc->rank, kv, NULL, 0, NULL);
             }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -1254,7 +1254,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
                                     "%s gds:hash:STORE data for nspace %s rank %u: key %s",
                                     PMIX_NAME_PRINT(&pmix_globals.myid), trk->ns, rank, kp.key);
                 /* store it in the hash_table */
-                rc = pmix_hash_store(&trk->internal, rank, &kp, NULL, 0);
+                rc = pmix_hash_store(&trk->internal, rank, &kp, NULL, 0, NULL);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     return rc;
@@ -1266,7 +1266,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
         if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
             rc = pmix_gds_hash_store_qualified(&trk->internal, proc->rank, kv->value);
         } else {
-            rc = pmix_hash_store(&trk->internal, proc->rank, kv, NULL, 0);
+            rc = pmix_hash_store(&trk->internal, proc->rank, kv, NULL, 0, NULL);
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1276,7 +1276,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
         if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
             rc = pmix_gds_hash_store_qualified(&trk->remote, proc->rank, kv->value);
         } else {
-            rc = pmix_hash_store(&trk->remote, proc->rank, kv, NULL, 0);
+            rc = pmix_hash_store(&trk->remote, proc->rank, kv, NULL, 0, NULL);
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1286,7 +1286,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
         if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
             rc = pmix_gds_hash_store_qualified(&trk->local, proc->rank, kv->value);
         } else {
-            rc = pmix_hash_store(&trk->local, proc->rank, kv, NULL, 0);
+            rc = pmix_hash_store(&trk->local, proc->rank, kv, NULL, 0, NULL);
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1301,12 +1301,12 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
             }
             rc = pmix_gds_hash_store_qualified(&trk->local, proc->rank, kv->value);
         } else {
-            rc = pmix_hash_store(&trk->remote, proc->rank, kv, NULL, 0);
+            rc = pmix_hash_store(&trk->remote, proc->rank, kv, NULL, 0, NULL);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
-            rc = pmix_hash_store(&trk->local, proc->rank, kv, NULL, 0);
+            rc = pmix_hash_store(&trk->local, proc->rank, kv, NULL, 0, NULL);
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1367,7 +1367,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx, pmix_proc_t *pro
             if (PMIX_CHECK_KEY(&kv, PMIX_QUALIFIED_VALUE)) {
                 rc = pmix_gds_hash_store_qualified(&trk->remote, 0, kv.value);
             } else {
-                rc = pmix_hash_store(&trk->remote, 0, &kv, NULL, 0);
+                rc = pmix_hash_store(&trk->remote, 0, &kv, NULL, 0, NULL);
             }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -1378,7 +1378,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx, pmix_proc_t *pro
             if (PMIX_CHECK_KEY(&kv, PMIX_QUALIFIED_VALUE)) {
                 rc = pmix_gds_hash_store_qualified(&trk->remote, proc->rank, kv.value);
             } else {
-                rc = pmix_hash_store(&trk->remote, proc->rank, &kv, NULL, 0);
+                rc = pmix_hash_store(&trk->remote, proc->rank, &kv, NULL, 0, NULL);
             }
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/hash/gds_hash_component.c
+++ b/src/mca/gds/hash/gds_hash_component.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -111,11 +112,11 @@ static void htdes(pmix_job_t *p)
         PMIX_RELEASE(p->nptr);
     }
     PMIX_LIST_DESTRUCT(&p->jobinfo);
-    pmix_hash_remove_data(&p->internal, PMIX_RANK_WILDCARD, NULL);
+    pmix_hash_remove_data(&p->internal, PMIX_RANK_WILDCARD, NULL, NULL);
     PMIX_DESTRUCT(&p->internal);
-    pmix_hash_remove_data(&p->remote, PMIX_RANK_WILDCARD, NULL);
+    pmix_hash_remove_data(&p->remote, PMIX_RANK_WILDCARD, NULL, NULL);
     PMIX_DESTRUCT(&p->remote);
-    pmix_hash_remove_data(&p->local, PMIX_RANK_WILDCARD, NULL);
+    pmix_hash_remove_data(&p->local, PMIX_RANK_WILDCARD, NULL, NULL);
     PMIX_DESTRUCT(&p->local);
     PMIX_LIST_DESTRUCT(&p->apps);
     PMIX_LIST_DESTRUCT(&p->nodeinfo);

--- a/src/mca/gds/hash/gds_utils.c
+++ b/src/mca/gds/hash/gds_utils.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -320,7 +320,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map adding key %s to job info",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0, NULL))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -436,7 +436,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                 "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                 pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                 kp2->key);
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(kp2);
                 PMIx_Argv_free(procs);
@@ -454,7 +454,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
                 kp2->value->data.uint32 = n;
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     PMIx_Argv_free(procs);
@@ -471,7 +471,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     PMIx_Argv_free(procs);
@@ -489,7 +489,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                     "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
                                     kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0))) {
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(kp2);
                     PMIx_Argv_free(procs);
@@ -512,7 +512,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-    if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
+    if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0, NULL))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(kp2);
         return rc;
@@ -531,7 +531,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0, NULL))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -553,7 +553,7 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%d] gds:hash:store_map for nspace %s: key %s",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, kp2->key);
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2, NULL, 0, NULL))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kp2);
             return rc;
@@ -593,7 +593,7 @@ pmix_status_t pmix_gds_hash_store_qualified(pmix_hash_table_t *ht,
     }
 
     /* store the result */
-    rc = pmix_hash_store(ht, rank, &kv, quals, nquals);
+    rc = pmix_hash_store(ht, rank, &kv, quals, nquals, NULL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/mca/gds/shmem/gds_shmem.c
+++ b/src/mca/gds/shmem/gds_shmem.c
@@ -1950,8 +1950,9 @@ server_store_modex_cb(
             );
         }
         else {
+            // TODO(skg)
             rc = pmix_hash_store(
-                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, kv, NULL, 0
+                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, kv, NULL, 0, NULL
             );
         }
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {

--- a/src/mca/gds/shmem/gds_shmem_fetch.c
+++ b/src/mca/gds/shmem/gds_shmem_fetch.c
@@ -580,8 +580,9 @@ pmix_gds_shmem_fetch(
     // complete copy of the job-level info for this nspace, so retrieve it.
     if (NULL == key && PMIX_RANK_WILDCARD == proc->rank) {
         // Fetch all values from the hash table tied to rank=wildcard.
+        // TODO(skg)
         rc = pmix_hash_fetch(
-            local_ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs
+            local_ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs, NULL
         );
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             return rc;
@@ -622,9 +623,9 @@ pmix_gds_shmem_fetch(
         for (pmix_rank_t rank = 0; rank < job->nspace->nprocs; rank++) {
             pmix_list_t rkvs;
             PMIX_CONSTRUCT(&rkvs, pmix_list_t);
-
+            // TODO(skg)
             rc = pmix_hash_fetch(
-                local_ht, rank, NULL, NULL, 0, &rkvs
+                local_ht, rank, NULL, NULL, 0, &rkvs, NULL
             );
             if (PMIX_UNLIKELY(PMIX_ERR_NOMEM == rc)) {
                 PMIX_LIST_DESTRUCT(&rkvs);
@@ -742,7 +743,8 @@ doover:
     // be the source.
     if (PMIX_RANK_UNDEF == proc->rank && ht) {
         for (pmix_rank_t rnk = 0; rnk < job->nspace->nprocs; rnk++) {
-            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs);
+            // TODO(skg)
+            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs, NULL);
             if (PMIX_ERR_NOMEM == rc) {
                 return rc;
             }
@@ -771,8 +773,9 @@ doover:
         if (NULL == key) {
             // And need to add all job info just in case
             // that was passed via a different GDS component.
+            // TODO(skg)
             rc = pmix_hash_fetch(
-                local_ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs
+                local_ht, PMIX_RANK_WILDCARD, NULL, NULL, 0, kvs, NULL
             );
         }
         else {
@@ -781,8 +784,9 @@ doover:
     }
     else {
         if (ht) {
+            // TODO(skg)
             rc = pmix_hash_fetch(
-                ht, proc->rank, key, qualifiers, nqual, kvs
+                ht, proc->rank, key, qualifiers, nqual, kvs, NULL
             );
         }
         else {

--- a/src/mca/gds/shmem/gds_shmem_store.c
+++ b/src/mca/gds/shmem/gds_shmem_store.c
@@ -418,7 +418,8 @@ store_proc_data(
             job->nspace_id, rank, kv->key
         );
         // Store it in the hash_table.
-        rc = pmix_hash_store(ht, rank, kv, NULL, 0);
+        // TODO(skg)
+        rc = pmix_hash_store(ht, rank, kv, NULL, 0, NULL);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
@@ -545,7 +546,8 @@ pmix_gds_shmem_store_qualified(
     kv->key = info[0].key;
     kv->value = &info[0].value;
     // Store the result.
-    rc = pmix_hash_store(ht, rank, kv, quals, nquals);
+    // TODO(skg)
+    rc = pmix_hash_store(ht, rank, kv, quals, nquals, NULL);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
     }
@@ -621,9 +623,9 @@ pmix_gds_shmem_store_local_job_data_in_shmem(
                 PMIX_ERROR_LOG(rc);
                 break;
             }
-
+            // TODO(skg)
             rc = pmix_hash_store(
-                local_ht, PMIX_RANK_WILDCARD, kv, NULL, 0
+                local_ht, PMIX_RANK_WILDCARD, kv, NULL, 0, NULL
             );
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_RELEASE(kv);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -63,7 +63,6 @@ void pmix_rte_finalize(void)
     int i;
     pmix_notify_caddy_t *cd;
     pmix_iof_req_t *req;
-    pmix_regattr_input_t *p;
 
     if (!pmix_init_called) {
         return;
@@ -147,22 +146,6 @@ void pmix_rte_finalize(void)
     }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);
-
-    for (i=0; i < pmix_globals.keyindex.size; i++) {
-        p = (pmix_regattr_input_t*)pmix_pointer_array_get_item(&pmix_globals.keyindex, i);
-        if (NULL != p) {
-            if (NULL != p->name) {
-                free(p->name);
-            }
-            if (NULL != p->string) {
-                free(p->string);
-            }
-            if (NULL != p->description) {
-                PMIx_Argv_free(p->description);
-            }
-            free(p);
-        }
-    }
     PMIX_DESTRUCT(&pmix_globals.keyindex);
     free(pmix_globals.myidval.data.proc);
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,8 +115,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .external_topology = false,
     .external_progress = false,
     .iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
-    .keyindex = PMIX_POINTER_ARRAY_STATIC_INIT,
-    .next_keyid = PMIX_INDEX_BOUNDARY
+    .keyindex = PMIX_KEYINDEX_STATIC_INIT
 };
 
 static void _notification_eviction_cbfunc(struct pmix_hotel_t *hotel, int room_num, void *occupant)
@@ -328,8 +327,8 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     ret = pmix_hotel_init(&pmix_globals.notifications, pmix_globals.max_events, pmix_globals.evbase,
                           pmix_globals.event_eviction_time, _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_globals.keyindex, pmix_pointer_array_t);
-    pmix_pointer_array_init(&pmix_globals.keyindex, 1024, INT_MAX, 128);
+    PMIX_CONSTRUCT(&pmix_globals.keyindex, pmix_keyindex_t);
+    pmix_pointer_array_init(pmix_globals.keyindex.table, 1024, INT_MAX, 128);
     PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
     /* need to hold off checking the hotel init return code
      * until after we construct all the globals so they can

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -9,7 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -3782,9 +3782,9 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
      * store it for us before releasing the group members */
     if (NULL != bo) {
         /* get the indices of the types of data */
-        p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_ENDPT_DATA);
+        p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_ENDPT_DATA, NULL);
         endptidx = p->index;
-        p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_INFO);
+        p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_INFO, NULL);
         infoidx = p->index;
 
         PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
@@ -4461,7 +4461,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
             /* add the endpt data */
             PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
             if (0 < bo.size) {
-                p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_ENDPT_DATA);
+                p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_ENDPT_DATA, NULL);
                 PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket, &p->index, 1, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
@@ -4477,7 +4477,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
                 PMIX_BYTE_OBJECT_DESTRUCT(&bo);
             }
             if (0 < pmix_list_get_size(&trk->grpinfo)) {
-                p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_INFO);
+                p = pmix_hash_lookup_key(UINT32_MAX, PMIX_GROUP_INFO, NULL);
                 PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket, &p->index, 1, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -28,14 +28,16 @@ BEGIN_C_DECLS
  * rank index.*/
 PMIX_EXPORT pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
                                           pmix_rank_t rank, pmix_kval_t *kin,
-                                          pmix_info_t *qualifiers, size_t nquals);
+                                          pmix_info_t *qualifiers, size_t nquals,
+                                          pmix_keyindex_t *kidx);
 
 /* Fetch the value for a specified key and rank from within
  * the given hash_table */
 PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
                                           const char *key,
                                           pmix_info_t *qualifiers, size_t nquals,
-                                          pmix_list_t *kvals);
+                                          pmix_list_t *kvals,
+                                          pmix_keyindex_t *kidx);
 
 /* remove the specified key-value from the given hash_table.
  * A NULL key will result in removal of all data for the
@@ -46,23 +48,16 @@ PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t 
  * table */
 PMIX_EXPORT pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
                                                 pmix_rank_t rank,
-                                                const char *key);
-
-PMIX_EXPORT void pmix_hash_register_key_in_keyindex(pmix_pointer_array_t *keyindex,
-                                                    uint32_t *next_keyid_ptr,
-                                                    uint32_t inid,
-                                                    pmix_regattr_input_t *ptr);
+                                                const char *key,
+                                                pmix_keyindex_t *kidx);
 
 PMIX_EXPORT void pmix_hash_register_key(uint32_t inid,
-                                        pmix_regattr_input_t *ptr);
-
-PMIX_EXPORT pmix_regattr_input_t* pmix_hash_lookup_key_in_keyindex(pmix_pointer_array_t *keyindex,
-                                                                   uint32_t *next_keyid_ptr,
-                                                                   uint32_t inid,
-                                                                   const char *key);
+                                        pmix_regattr_input_t *ptr,
+                                        pmix_keyindex_t *kidx);
 
 PMIX_EXPORT pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
-                                                       const char *key);
+                                                       const char *key,
+                                                       pmix_keyindex_t *kidx);
 
 #define PMIX_HASH_TRACE_KEY_ACTUAL(s, r, k, id, tbl, v)                     \
 do {                                                                        \
@@ -70,7 +65,7 @@ do {                                                                        \
     char *_v;                                                               \
     pmix_regattr_input_t *_p;                                               \
     if (NULL == (k) && UINT32_MAX != id) {                                  \
-        _p = pmix_hash_lookup_key((id), NULL);                              \
+        _p = pmix_hash_lookup_key((id), NULL, NULL);                        \
         if (NULL == _p) {                                                   \
             _k = "KEY NOT FOUND";                                           \
         } else {                                                            \


### PR DESCRIPTION
Update all pmix_hash functions to include an extra parameter: a pmix_keyindex_t *. This provides the ability to have hash lookups across different key/index translation tables, not just pmix_globals.keyindex.

Provide a new pmix_keyindex_t data type that eases the embedding of key/index structures into shared-memory.

Remove all internal pmix_hash APIs of the form pmix_hash_*in_keyindex in favor of the new form provided here.

Note: this work is slated for use in gds/shmem. Specifically, we are aiming to fix a potential issue that may arise when using gds/shmem when key/index values differ between server and client versions.