### PR TITLE
Implement the allocate, resource block, and session control support

### DIFF
--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,13 +38,15 @@ static void relcbfunc(void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix:job_ctrl release callback");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:job_ctrl release callback");
 
     if (NULL != cd->info) {
         PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
     PMIX_RELEASE(cd);
 }
+
 static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata)
 {
@@ -55,7 +57,8 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_HIDE_UNUSED_PARAMS(hdr);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:job_ctrl cback from server with %d bytes", (int) buf->bytes_used);
+                        "pmix:job_ctrl cback from server with %d bytes",
+                        (int) buf->bytes_used);
 
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */
@@ -99,7 +102,8 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     }
 
 complete:
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix:job_ctrl cback from server releasing");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:job_ctrl cback from server releasing");
     /* release the caller */
     if (NULL != cd->cbfunc) {
         cd->cbfunc(results->status, results->info, results->ninfo, cd->cbdata, relcbfunc, results);

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -286,6 +286,10 @@ PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
         return "COMPUTE DEVICE DIST";
     case PMIX_REFRESH_CACHE:
         return "REFRESH CACHE";
+    case PMIX_RESBLK_CMD:
+        return "RESOURCE BLOCK";
+    case PMIX_SESSION_CTRL_CMD:
+        return "SESSION CONTROL";
     default:
         return "UNKNOWN";
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -209,6 +209,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_COMPUTE_DEVICE_DISTANCES_CMD 32
 #define PMIX_REFRESH_CACHE                33
 #define PMIX_RESBLK_CMD                   34
+#define PMIX_SESSION_CTRL_CMD             35
 
 /* provide a "pretty-print" function for cmds */
 const char *pmix_command_string(pmix_cmd_t cmd);

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -393,7 +393,6 @@ static pmix_status_t tryfile(pmix_peer_t *peer, char **nspace,
         cn->uri = NULL;
         peer->protocol = PMIX_PROTOCOL_V2;
         PMIX_SET_PEER_VERSION(peer, cn->version, 2, 0);
-        PMIX_LIST_DESTRUCT(&connections);
     }
     PMIX_LIST_DESTRUCT(&connections);
     return rc;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -362,6 +362,10 @@ PMIX_EXPORT pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
                                              pmix_buffer_t *buf,
                                              pmix_op_cbfunc_t cbfunc);
 
+PMIX_EXPORT pmix_status_t pmix_server_session_ctrl(pmix_server_caddy_t *cd,
+                                                   pmix_buffer_t *buf,
+                                                   pmix_info_cbfunc_t cbfunc);
+
 PMIX_EXPORT void pmix_server_query_cbfunc(pmix_status_t status,
                                           pmix_info_t *info, size_t ninfo, void *cbdata,
                                           pmix_release_cbfunc_t release_fn, void *release_cbdata);


### PR DESCRIPTION
Relay to the server where available. Server passes requests to its host where appropriate, returning
response to requestor.

Fix a bug in ptl_base_connect