### PR TITLE
Intro the pmix_resource_unit_t struct

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -487,14 +487,18 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 /* Define a resource "block" that can be used in allocation operations.
  * Include the ability to define/delete, remove/extend block definitions.
  * The provided block name must be unique within the requestor's current
- * session
+ * session.
  */
 PMIX_EXPORT pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t directive,
-                                              char *block, pmix_info_t *info, size_t ninfo);
+                                              char *block,
+                                              const pmix_resource_unit_t *res, size_t nres,
+                                              const pmix_info_t *info, size_t ninfo);
 
 
 PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t directive,
-                                                 char *block, pmix_info_t *info, size_t ninfo,
+                                                 char *block,
+                                                 const pmix_resource_unit_t *res, size_t nres,
+                                                 const pmix_info_t *info, size_t ninfo,
                                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
@@ -1186,6 +1190,7 @@ PMIX_EXPORT char* PMIx_Value_string(const pmix_value_t *value);
 PMIX_EXPORT char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 PMIX_EXPORT char* PMIx_App_string(const pmix_app_t *app);
 PMIX_EXPORT char* PMIx_Proc_string(const pmix_proc_t *proc);
+PMIX_EXPORT char* PMIx_Resource_unit_string(const pmix_resource_unit_t *unit);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */
@@ -1880,8 +1885,21 @@ PMIX_EXPORT void PMIx_Device_destruct(pmix_device_t *d);
 PMIX_EXPORT pmix_device_t* PMIx_Device_create(size_t n);
 
 /* free memory stored inside an array of device structs (does
- * not free the struct memory itself */
+ * not free the struct memory itself) */
 PMIX_EXPORT void PMIx_Device_free(pmix_device_t *d, size_t n);
+
+/* initialize a resource unit struct */
+PMIX_EXPORT void PMIx_Resource_unit_construct(pmix_resource_unit_t *d);
+
+/* free memory stored inside a resource unit struct */
+PMIX_EXPORT void PMIx_Resource_unit_destruct(pmix_resource_unit_t *d);
+
+/* create and initialize an array of resource unit structs */
+PMIX_EXPORT pmix_resource_unit_t* PMIx_Resource_unit_create(size_t n);
+
+/* free memory stored inside an array of resource unit structs (does
+ * not free the struct memory itself) */
+PMIX_EXPORT void PMIx_Resource_unit_free(pmix_resource_unit_t *d, size_t n);
 
 /* initialize a device distance struct */
 PMIX_EXPORT void PMIx_Device_distance_construct(pmix_device_distance_t *d);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -634,7 +634,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_RES_BLOCKS               "pmix.qry.resblks"      // (pmix_data_array_t*) array of string names for currently defined
                                                                     //         resource blocks
 #define PMIX_QUERY_RES_BLOCK_DEF            "pmix.qry.resdef"       // (pmix_data_array_t*) given the name of a resource block as its qualifier,
-                                                                    //         return an array of pmix_info_t describing the resources contained
+                                                                    //         return an array of pmix_resource_unit_t describing the resources contained
                                                                     //         in the block
 #define PMIX_QUERY_DEVICES                  "pmix.qry.dev"          // (pmix_data_array_t*) Return an array of pmix_device_t containing the devices
                                                                     //         within the current topology that meet the specified query qualifications. This
@@ -914,7 +914,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_MAU                      "pmix.alloc.mau"        // (pmix_data_array_t*) Minimum allocatable unit for the system. This attribute
                                                                     //         is used by the system scheduler to inform the system controller
                                                                     //         of the MAU so the information can be passed along. Alternatively,
-                                                                    //         a host can pass the information into its PMIx server.
+                                                                    //         a host can pass the information into its PMIx server. Array consists
+                                                                    //         of pmix_resource_unit_t structs.
 
 
 /* job control attributes */
@@ -1582,6 +1583,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_STOR_ACCESS_TYPE           69
 #define PMIX_DEVICE                     70
 #define PMIX_RESBLOCK_DIRECTIVE         71
+#define PMIX_RESOURCE_UNIT              72
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1932,7 +1934,8 @@ typedef uint64_t pmix_device_type_t;
 #define PMIX_DEVTYPE_DMA            0x0000000000000010
 #define PMIX_DEVTYPE_COPROC         0x0000000000000020
 #define PMIX_DEVTYPE_MEMORY         0x0000000000000040
-
+#define PMIX_DEVTYPE_CORE           0x0000000000000080
+#define PMIX_DEVTYPE_HWT            0x0000000000000100
 
 /****    PMIX_DEVICE    ****/
 typedef struct pmix_device {
@@ -1946,6 +1949,19 @@ typedef struct pmix_device {
     .uuid = NULL,                       \
     .osname = NULL,                     \
     .type = PMIX_DEVTYPE_UNKNOWN        \
+}
+
+
+/****    PMIX_RESOURCE_UNIT    ****/
+typedef struct pmix_resource_unit {
+    pmix_device_type_t type;
+    size_t count;
+} pmix_resource_unit_t;
+
+#define PMIX_RESOURCE_UNIT_STATIC_INIT  \
+{                                       \
+    .type = PMIX_DEVTYPE_UNKNOWN,       \
+    .count = 0                          \
 }
 
 
@@ -2304,6 +2320,7 @@ typedef struct pmix_value {
         pmix_disk_stats_t *dkstats;
         pmix_net_stats_t *netstats;
         pmix_node_stats_t *ndstats;
+        pmix_resource_unit_t *resunit;
     } data;
 } pmix_value_t;
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -318,6 +318,12 @@ PMIX_EXPORT pmix_device_t* PMIx_Device_create(size_t n);
 PMIX_EXPORT void PMIx_Device_free(pmix_device_t *d, size_t n);
 
 
+PMIX_EXPORT void PMIx_Resource_unit_construct(pmix_resource_unit_t *d);
+PMIX_EXPORT void PMIx_Resource_unit_destruct(pmix_resource_unit_t *d);
+PMIX_EXPORT pmix_resource_unit_t* PMIx_Resource_unit_create(size_t n);
+PMIX_EXPORT void PMIx_Resource_unit_free(pmix_resource_unit_t *d, size_t n);
+
+
 PMIX_EXPORT void PMIx_Device_distance_construct(pmix_device_distance_t *d);
 PMIX_EXPORT void PMIx_Device_distance_destruct(pmix_device_distance_t *d);
 PMIX_EXPORT pmix_device_distance_t* PMIx_Device_distance_create(size_t n);
@@ -769,10 +775,26 @@ PMIX_EXPORT pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **n
 #define PMIX_DEVICE_CREATE(m, n) \
     (m) = PMIx_Device_create(n)
 
-// free(m) is called inside PMIx_Device_distance_free().
+// free(m) is called inside PMIx_Device_free().
 #define PMIX_DEVICE_FREE(m, n)  \
     do {                        \
         PMIx_Device_free(m, n); \
+        (m) = NULL;             \
+    } while(0)
+
+#define PMIX_RESOURCE_UNIT_CONSTRUCT(m) \
+    PMIx_Resource_unit_construct(m)
+
+#define PMIX_RESOURCE_UNIT_DESTRUCT(m) \
+    PMIx_Resource_unit_destruct(m)
+
+#define PMIX_RESOURCE_UNIT_CREATE(m, n) \
+    (m) = PMIx_Resource_unit_create(n)
+
+// free(m) is called inside PMIx_Resource_unit_free().
+#define PMIX_RESOURCE_UNIT_FREE(m, n)  \
+    do {                        \
+        PMIx_Resource_unit_free(m, n); \
         (m) = NULL;             \
     } while(0)
 

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -546,7 +546,8 @@ typedef pmix_status_t (*pmix_server_session_control_fn_t)(const pmix_proc_t *req
 typedef pmix_status_t (*pmix_server_resource_block_fn_t)(const pmix_proc_t *requestor,
                                                          pmix_resource_block_directive_t directive,
                                                          const char *block,
-                                                         const pmix_info_t data[], size_t ndata,
+                                                         const pmix_resource_unit_t *units, size_t nunit,
+                                                         const pmix_info_t *info, size_t ninfo,
                                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -290,6 +290,8 @@ PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
         return "RESOURCE BLOCK";
     case PMIX_SESSION_CTRL_CMD:
         return "SESSION CONTROL";
+    case PMIX_REQ_SYSINFO_CMD:
+        return "REQUEST SYSTEM INFO";
     default:
         return "UNKNOWN";
     }
@@ -492,4 +494,12 @@ char* PMIx_Proc_string(const pmix_proc_t *proc)
     tmp = pmix_util_print_name_args(proc);
     result = strdup(tmp);
     return result;
+}
+
+char* PMIx_Resource_unit_string(const pmix_resource_unit_t *p)
+{
+    char *tmp;
+
+    pmix_asprintf(&tmp, "TYPE: %s  COUNT: %" PRIsize_t "", PMIx_Data_type_string(p->type), p->count);
+    return tmp;
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -210,6 +210,7 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_REFRESH_CACHE                33
 #define PMIX_RESBLK_CMD                   34
 #define PMIX_SESSION_CTRL_CMD             35
+#define PMIX_REQ_SYSINFO_CMD              36
 
 /* provide a "pretty-print" function for cmds */
 const char *pmix_command_string(pmix_cmd_t cmd);

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -479,6 +479,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_geometry(pmix_pointer_array_t *r
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_device(pmix_pointer_array_t *regtypes,
                                                        pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_resunit(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, const void *src,
+                                                        int32_t num_vals, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_devdist(pmix_pointer_array_t *regtypes,
                                                         pmix_buffer_t *buffer, const void *src,
                                                         int32_t num_vals, pmix_data_type_t type);
@@ -689,6 +692,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_geometry(pmix_pointer_array_t 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_device(pmix_pointer_array_t *regtypes,
                                                          pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_resunit(pmix_pointer_array_t *regtypes,
+                                                          pmix_buffer_t *buffer, void *dest,
+                                                          int32_t *num_vals, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_devdist(pmix_pointer_array_t *regtypes,
                                                           pmix_buffer_t *buffer, void *dest,
                                                           int32_t *num_vals, pmix_data_type_t type);
@@ -798,6 +804,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_geometry(pmix_geometry_t **dest,
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_device(pmix_device_t **dest,
                                                        pmix_device_t *src,
                                                        pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_resunit(pmix_resource_unit_t **dest,
+                                                        pmix_resource_unit_t *src,
+                                                        pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_devdist(pmix_device_distance_t **dest,
                                                         pmix_device_distance_t *src,
                                                         pmix_data_type_t type);
@@ -955,6 +964,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_geometry(char **output, char *p
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_device(char **output, char *prefix,
                                                         pmix_device_t *src,
                                                         pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_resunit(char **output, char *prefix,
+                                                         pmix_resource_unit_t *src,
+                                                         pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_devdist(char **output, char *prefix,
                                                          pmix_device_distance_t *src,
                                                          pmix_data_type_t type);

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -442,6 +442,23 @@ pmix_status_t pmix_bfrops_base_copy_device(pmix_device_t **dest,
     return PMIX_SUCCESS;
 }
 
+pmix_status_t pmix_bfrops_base_copy_resunit(pmix_resource_unit_t **dest,
+                                            pmix_resource_unit_t *src, pmix_data_type_t type)
+{
+    pmix_resource_unit_t *dst;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    PMIX_RESOURCE_UNIT_CREATE(dst, 1);
+    if (NULL == dst) {
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(dst, src, sizeof(pmix_resource_unit_t));
+
+    *dest = dst;
+    return PMIX_SUCCESS;
+}
+
 pmix_status_t pmix_bfrops_base_copy_devdist(pmix_device_distance_t **dest,
                                             pmix_device_distance_t *src, pmix_data_type_t type)
 {

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -57,6 +57,7 @@ void pmix_bfrops_base_value_load(pmix_value_t *v,
     pmix_geometry_t *geometry;
     pmix_endpoint_t *endpoint;
     pmix_device_t *device;
+    pmix_resource_unit_t *resunit;
     pmix_device_distance_t *devdist;
     pmix_data_buffer_t *dbuf;
     pmix_nspace_t *nspace;
@@ -270,6 +271,13 @@ void pmix_bfrops_base_value_load(pmix_value_t *v,
         case PMIX_DEVICE:
             device = (pmix_device_t *) data;
             rc = pmix_bfrops_base_copy_device(&v->data.device, device, PMIX_DEVICE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+            break;
+        case PMIX_RESOURCE_UNIT:
+            resunit = (pmix_resource_unit_t *) data;
+            rc = pmix_bfrops_base_copy_resunit(&v->data.resunit, resunit, PMIX_RESOURCE_UNIT);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
@@ -574,6 +582,13 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
                                                PMIX_DEVICE);
             if (PMIX_SUCCESS == rc) {
                 *sz = sizeof(pmix_device_t);
+            }
+            break;
+        case PMIX_RESOURCE_UNIT:
+            rc = pmix_bfrops_base_copy_resunit((pmix_resource_unit_t **) data,
+                                                kv->data.resunit, PMIX_RESOURCE_UNIT);
+            if (PMIX_SUCCESS == rc) {
+                *sz = sizeof(pmix_resource_unit_t);
             }
             break;
         case PMIX_DEVICE_DIST:
@@ -1132,6 +1147,9 @@ static pmix_status_t get_darray_size(pmix_data_array_t *array,
                 }
             }
             break;
+        case PMIX_RESOURCE_UNIT:
+            *sz = array->size * sizeof(pmix_resource_unit_t);
+            break;
         case PMIX_DEVICE_DIST:
             *sz = array->size * sizeof(pmix_device_distance_t);
             dd = (pmix_device_distance_t*)array->array;
@@ -1448,6 +1466,9 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
             if (NULL != v->data.device->osname) {
                 *sz += strlen(v->data.device->osname);
             }
+            break;
+        case PMIX_RESOURCE_UNIT:
+            *sz = sizeof(pmix_resource_unit_t);
             break;
         case PMIX_DEVICE_DIST:
             *sz = sizeof(pmix_device_distance_t);

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -387,6 +387,26 @@ void PMIx_Device_free(pmix_device_t *d, size_t n)
     pmix_bfrops_base_tma_device_free(d, n, NULL);
 }
 
+void PMIx_Resource_unit_construct(pmix_resource_unit_t *d)
+{
+    pmix_bfrops_base_tma_resource_unit_construct(d, NULL);
+}
+
+void PMIx_Resource_unit_destruct(pmix_resource_unit_t *d)
+{
+    pmix_bfrops_base_tma_resource_unit_destruct(d, NULL);
+}
+
+pmix_resource_unit_t* PMIx_Resource_unit_create(size_t n)
+{
+    return pmix_bfrops_base_tma_resource_unit_create(n, NULL);
+}
+
+void PMIx_Resource_unit_free(pmix_resource_unit_t *d, size_t n)
+{
+    pmix_bfrops_base_tma_resource_unit_free(d, n, NULL);
+}
+
 void PMIx_Device_distance_construct(pmix_device_distance_t *d)
 {
     pmix_bfrops_base_tma_device_distance_construct(d, NULL);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -986,6 +986,7 @@ pmix_status_t pmix_bfrops_base_pack_val(pmix_pointer_array_t *regtypes, pmix_buf
     case PMIX_DISK_STATS:
     case PMIX_NET_STATS:
     case PMIX_NODE_STATS:
+    case PMIX_RESOURCE_UNIT:
         PMIX_BFROPS_PACK_TYPE(ret, buffer, p->data.ptr, 1, p->type, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
@@ -1260,6 +1261,29 @@ pmix_status_t pmix_bfrops_base_pack_device(pmix_pointer_array_t *regtypes, pmix_
             return ret;
         }
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].type, 1, PMIX_DEVTYPE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_bfrops_base_pack_resunit(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                            const void *src, int32_t num_vals,
+                                            pmix_data_type_t type)
+{
+    pmix_resource_unit_t *ptr = (pmix_resource_unit_t *) src;
+    int32_t i;
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    for (i = 0; i < num_vals; ++i) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].type, 1, PMIX_DEVTYPE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].count, 1, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1226,6 +1226,7 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
     pmix_geometry_t *geoptr;
     pmix_device_type_t *dvptr;
     pmix_device_t *dev;
+    pmix_resource_unit_t *resunit;
     pmix_device_distance_t *ddptr;
     pmix_endpoint_t *endptr;
     pmix_storage_medium_t *smptr;
@@ -1413,6 +1414,10 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
             case PMIX_DEVICE:
                 dev = (pmix_device_t*)src->array;
                 rc = pmix_bfrops_base_print_device(&tp, prefix, &dev[n], PMIX_DEVICE);
+                break;
+            case PMIX_RESOURCE_UNIT:
+                resunit = (pmix_resource_unit_t*)src->array;
+                rc = pmix_bfrops_base_print_resunit(&tp, prefix, &resunit[n], PMIX_RESOURCE_UNIT);
                 break;
             case PMIX_DEVICE_DIST:
                 ddptr = (pmix_device_distance_t*)src->array;
@@ -1811,6 +1816,25 @@ pmix_status_t pmix_bfrops_base_print_device(char **output, char *prefix,
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->uuid) ? "NULL" : src->uuid, (NULL == src->osname) ? "NULL" : src->osname,
                    PMIx_Device_type_string(src->type));
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_resunit(char **output, char *prefix,
+                                             pmix_resource_unit_t *src, pmix_data_type_t type)
+{
+    int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ret = asprintf(output,
+                   "%sData type: PMIX_RESOURCE_UNIT\tValue: Type: %s  Count: %" PRIsize_t "",
+                   (NULL == prefix) ? " " : prefix,
+                   PMIx_Device_type_string(src->type), src->count);
 
     if (0 > ret) {
         return PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -36,8 +36,6 @@ static const char *basic_type_string(pmix_data_type_t type)
     switch (type) {
     case PMIX_BOOL:
         return "PMIX_BOOL";
-    case PMIX_REGEX:
-        return "PMIX_REGEX";
     case PMIX_BYTE:
         return "PMIX_BYTE";
     case PMIX_STRING:
@@ -114,8 +112,6 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_DATA_ARRAY";
     case PMIX_PROC_RANK:
         return "PMIX_PROC_RANK";
-    case PMIX_PROC_NSPACE:
-        return "PMIX_PROC_NSPACE";
     case PMIX_QUERY:
         return "PMIX_QUERY";
     case PMIX_COMPRESSED_STRING:
@@ -130,6 +126,8 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_COORD";
     case PMIX_REGATTR:
         return "PMIX_REGATTR";
+    case PMIX_REGEX:
+        return "PMIX_REGEX";
     case PMIX_JOB_STATE:
         return "PMIX_JOB_STATE";
     case PMIX_LINK_STATE:
@@ -138,8 +136,6 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_PROC_CPUSET";
     case PMIX_GEOMETRY:
         return "PMIX_GEOMETRY";
-    case PMIX_DEVICE:
-        return "PMIX_DEVICE";
     case PMIX_DEVICE_DIST:
         return "PMIX_DEVICE_DIST";
     case PMIX_ENDPOINT:
@@ -148,6 +144,12 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_TOPO";
     case PMIX_DEVTYPE:
         return "PMIX_DEVTYPE";
+    case PMIX_LOCTYPE:
+        return "PMIX_LOCTYPE";
+    case PMIX_COMPRESSED_BYTE_OBJECT:
+        return "PMIX_COMPRESSED_BYTE_OBJECT";
+    case PMIX_PROC_NSPACE:
+        return "PMIX_PROC_NSPACE";
     case PMIX_PROC_STATS:
         return "PMIX_PROC_STATS";
     case PMIX_DISK_STATS:
@@ -158,6 +160,20 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_NODE_STATS";
     case PMIX_DATA_BUFFER:
         return "PMIX_DATA_BUFFER";
+    case PMIX_STOR_MEDIUM:
+        return "PMIX_STOR_MEDIUM";
+    case PMIX_STOR_ACCESS:
+        return "PMIX_STOR_ACCESS";
+    case PMIX_STOR_PERSIST:
+        return "PMIX_STOR_PERSIST";
+    case PMIX_STOR_ACCESS_TYPE:
+        return "PMIX_STOR_ACCESS_TYPE";
+    case PMIX_DEVICE:
+        return "PMIX_DEVICE";
+    case PMIX_RESBLOCK_DIRECTIVE:
+        return "PMIX_RESBLOCK_DIRECTIVE";
+    case PMIX_RESOURCE_UNIT:
+        return "PMIX_RESOURCE_UNIT";
     default:
         return "NOT INITIALIZED";
     }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -640,6 +640,13 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
             }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.device, &m, PMIX_DEVICE, regtypes);
             return ret;
+        case PMIX_RESOURCE_UNIT:
+            PMIX_RESOURCE_UNIT_CREATE(val->data.resunit, 1);
+            if (NULL == val->data.resunit) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.resunit, &m, PMIX_RESOURCE_UNIT, regtypes);
+            return ret;
         case PMIX_DEVICE_DIST:
             PMIX_DEVICE_DIST_CREATE(val->data.devdist, 1);
             if (NULL == val->data.devdist) {
@@ -1712,6 +1719,41 @@ pmix_status_t pmix_bfrops_base_unpack_device(pmix_pointer_array_t *regtypes, pmi
         }
         m = 1;
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].type, &m, PMIX_DEVTYPE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_bfrops_base_unpack_resunit(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                              void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_resource_unit_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d resource units", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ptr = (pmix_resource_unit_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_RESOURCE_UNIT_CONSTRUCT(&ptr[i]);
+        /* unpack the type */
+        m = 1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].type, &m, PMIX_DEVTYPE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        /* get the number of them */
+        m = 1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].count, &m, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             return ret;

--- a/src/mca/bfrops/v51/bfrop_pmix51.c
+++ b/src/mca/bfrops/v51/bfrop_pmix51.c
@@ -300,6 +300,10 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_device, pmix_bfrops_base_copy_device,
                        pmix_bfrops_base_print_device, &pmix_mca_bfrops_v51_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_RESOURCE_UNIT", PMIX_RESOURCE_UNIT, pmix_bfrops_base_pack_resunit,
+                       pmix_bfrops_base_unpack_resunit, pmix_bfrops_base_copy_resunit,
+                       pmix_bfrops_base_print_resunit, &pmix_mca_bfrops_v51_component.types);
+
     PMIX_REGISTER_TYPE("PMIX_DEVICE_DIST", PMIX_DEVICE_DIST, pmix_bfrops_base_pack_devdist,
                        pmix_bfrops_base_unpack_devdist, pmix_bfrops_base_copy_devdist,
                        pmix_bfrops_base_print_devdist, &pmix_mca_bfrops_v51_component.types);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -232,7 +232,8 @@ cleanup:
 }
 
 /* callback to receive job info */
-static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf, void *cbdata)
+static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
+                     pmix_buffer_t *buf, void *cbdata)
 {
     pmix_status_t rc;
     char *nspace;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -58,6 +58,8 @@ typedef struct {
     int nlocalprocs;
     pmix_info_t *info;
     size_t ninfo;
+    pmix_resource_unit_t *units;
+    size_t nunits;
     bool copied;
     char **keys;
     pmix_app_t *apps;


### PR DESCRIPTION
When describing the resource units to be included
in a resource block, we really need a struct to
contain the description. We can't use pmix_device_t as that describes a specific device - instead, we need a device type and number, the scheduler will assign the specific device(s) later.

Change the signature of the "resource block" APIs to include an array of resource units. Update the data type handlers to accommodate it.