### PR TITLE
Fix incorrect print string

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1933,9 +1933,12 @@ typedef uint64_t pmix_device_type_t;
 #define PMIX_DEVTYPE_OPENFABRICS    0x0000000000000008
 #define PMIX_DEVTYPE_DMA            0x0000000000000010
 #define PMIX_DEVTYPE_COPROC         0x0000000000000020
+/* devices used by resource units */
 #define PMIX_DEVTYPE_MEMORY         0x0000000000000040
 #define PMIX_DEVTYPE_CORE           0x0000000000000080
 #define PMIX_DEVTYPE_HWT            0x0000000000000100
+#define PMIX_DEVTYPE_CPU            0x0000000000000200
+#define PMIX_DEVTYPE_NODE           0x0000000000000400
 
 /****    PMIX_DEVICE    ****/
 typedef struct pmix_device {

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -500,6 +500,6 @@ char* PMIx_Resource_unit_string(const pmix_resource_unit_t *p)
 {
     char *tmp;
 
-    pmix_asprintf(&tmp, "TYPE: %s  COUNT: %" PRIsize_t "", PMIx_Data_type_string(p->type), p->count);
+    pmix_asprintf(&tmp, "TYPE: %s  COUNT: %" PRIsize_t "", PMIx_Device_type_string(p->type), p->count);
     return tmp;
 }


### PR DESCRIPTION
Resource units have device types, not data type field. Add a couple of missing device types.