### PR TITLE
pmix.h: Add capability flags

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -52,6 +52,16 @@
 /* Structure and constant definitions */
 #include <pmix_common.h>
 
+/* Individual capability flags */
+#define PMIX_CAP_202311CLI       1
+#define PMIX_CAP_SOMETHING_ELSE  2
+#define PMIX_CAP_THIRD_THING     4
+
+/* These are the capabilities that this version of OpenPMIx has */
+#define PMIX_CAPABILITIES \
+    (PMIX_CAP_202311CLI | \
+     PMIX_CAP_THIRD_THING)
+
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {
 #endif

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -52,16 +52,6 @@
 /* Structure and constant definitions */
 #include <pmix_common.h>
 
-/* Individual capability flags */
-#define PMIX_CAP_202311CLI       1
-#define PMIX_CAP_SOMETHING_ELSE  2
-#define PMIX_CAP_THIRD_THING     4
-
-/* These are the capabilities that this version of OpenPMIx has */
-#define PMIX_CAPABILITIES \
-    (PMIX_CAP_202311CLI | \
-     PMIX_CAP_THIRD_THING)
-
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {
 #endif

--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -5,6 +5,7 @@
  * Copyright (c) 2018      Intel, Inc. All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2023      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,4 +23,27 @@
 #define PMIX_VERSION_RELEASE @pmixrelease@
 
 #define PMIX_NUMERIC_VERSION @pmixnumeric@
+
+
+/* Define a mechanism by which we can flag PMIx versions
+ * with "capabilities" - this allows consumers of the library
+ * to differentiate based on capabilities instead of release
+ * numbers. Note that this differs from the Standard version
+ * and ABI version numbers for the release as the capabilities
+ * refer to internal behaviors - e.g., how the cmd line parser
+ * is operating. So someone who uses the cmd line parser might
+ * compensate for some difference that occurs during/between
+ * a PMIx release series
+ */
+
+/* Individual capability flags */
+#define PMIX_CAP_BASE            1
+
+/* These are the capabilities that this version of OpenPMIx has.
+ * For now, we just define/use a "base" marker as a starting
+ * point
+ */
+#define PMIX_CAPABILITIES \
+    (PMIX_CAP_BASE)
+
 #endif


### PR DESCRIPTION
Add some capability flags to PMIx.  This will allow PMIx clients to do build-time checking to see if the PMIx they are building with have specific capabiltiies or not (without having to rely on version range checking).

This commit adds 3 silly/demo capabilities, and should be edited before merging.

Additionally, it would be good to expose these capability flags at run time as well (perhaps as an uint64_t -- or even a variable-length array of unsigned bytes -- so that there are plenty of bits available for future expansion).  This is an exercise left for the reader.