### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -273,6 +273,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CHECK_SIZEOF(int)
     AC_CHECK_SIZEOF(long)
     AC_CHECK_SIZEOF(void *)
+    AS_IF([test "$ac_cv_sizeof_void_p" -eq 4],
+          [AC_MSG_WARN([PMIx does not support 32 bit builds.])
+           AC_MSG_ERROR([Cannot continue])])
     AC_CHECK_SIZEOF(size_t)
     AC_CHECK_SIZEOF(pid_t)
 

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -45,13 +45,13 @@
 #include "src/util/pmix_if.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/pmix_string_copy.h"
 
 #include "src/mca/ptl/base/base.h"
 #include "src/mca/ptl/base/ptl_base_handshake.h"
 
 /****    SUPPORTING FUNCTIONS    ****/
 static void timeout(int sd, short args, void *cbdata);
-static char *pmix_getline(FILE *fp);
 
 pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar)
 {
@@ -1386,21 +1386,6 @@ static void timeout(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_WAKEUP_THREAD(lock);
-}
-
-static char *pmix_getline(FILE *fp)
-{
-    char *ret, *buff;
-    char input[1024];
-
-    ret = fgets(input, 1024, fp);
-    if (NULL != ret) {
-        input[strlen(input) - 1] = '\0'; /* remove newline */
-        buff = strdup(input);
-        return buff;
-    }
-
-    return NULL;
 }
 
 /*

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -333,7 +333,9 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         if (0 == strcmp(argv[optind-1], "--")) {
                             // double-dash indicates separator between launcher
                             // directives and the application
-                            goto done;
+                            results->tail = PMIx_Argv_copy(&argv[optind]);
+                            PMIx_Argv_free(argv);
+                            return PMIX_SUCCESS;
                         }
                         str = pmix_show_help_string("help-cli.txt", "short-no-long", true,
                                                     pmix_tool_basename, shorts[n]);


### PR DESCRIPTION
[Error out of attempts for 32-bit builds](https://github.com/openpmix/openpmix/commit/1a4ef71260666d40f06fcdc70e8d48b7b9f56a27)

PMIx has never supported 32-bit environments,
so let's not allow them to configure.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d1027efcf6cd7f74e04a45ea24418af944823a31)

[Remove static version of global function](https://github.com/openpmix/openpmix/commit/f9bfc5fc0eb4262a5a53e628704eb010939eae05)

Use the global pmix_getline

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/4159f65d3132620e53de73eddfd2e186ea248efc)

[Fix handling of "--" in cmd lines](https://github.com/openpmix/openpmix/commit/e84f0350233de01bd3fffac6880587729c0df873)

Need to add everything after the double-dash to the
results tail.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9095457b2c5b2370178a9a0ffaff7a6918af632e)
