### PR TITLE
Resolve a problem with updated "put" key-value pairs

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2226,7 +2226,8 @@ static void _dmodex_req(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "DMODX LOOKING FOR %s",
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "DMODX LOOKING FOR %s",
                         PMIX_NAME_PRINT(&cd->proc));
 
     /* this should be one of my clients, but a race condition

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -398,7 +398,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
      * we do know how many clients to expect, so first check to see if
      * all clients have been registered with us */
     if (!nptr->all_registered) {
-        pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d NSPACE %s not all registered",
+        pmix_output_verbose(2, pmix_server_globals.get_output,
+                            "%s:%d NSPACE %s not all registered",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, nspace);
         rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
         if (PMIX_ERR_NOT_FOUND == rc) {
@@ -452,10 +453,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     if (local && refresh_cache) {
         return PMIX_OPERATION_SUCCEEDED;
     } else if (refresh_cache) {
-        if (NULL != key) {
-            free(key);
-            key = NULL;
-        }
         goto request;
     }
 
@@ -1180,9 +1177,9 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                 PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
                 while (PMIX_SUCCESS == rc) {
                     if (caddy->lcd->proc.rank == PMIX_RANK_WILDCARD) {
-                        PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_INTERNAL, kv);
+                        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &caddy->lcd->proc, PMIX_INTERNAL, kv);
                     } else {
-                        PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_REMOTE, kv);
+                        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &caddy->lcd->proc, PMIX_REMOTE, kv);
                     }
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3926,7 +3926,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                             PMIX_INFO_FREE(grpinfo, ngrpinfo);
                             goto release;
                         }
-                        /* reconstruct each value as a qualified one basd
+                        /* reconstruct each value as a qualified one based
                          * on the ctxid */
                         PMIX_CONSTRUCT(&kp, pmix_kval_t);
                         kp.value = &val;

--- a/test/simple/doubleget.c
+++ b/test/simple/doubleget.c
@@ -1,13 +1,15 @@
-#define _GNU_SOURCE
-#include "include/pmix.h"
+#include <pmix.h>
 #include <sched.h>
 #include <stdio.h>
 
-static pmix_proc_t allproc = {0};
-static pmix_proc_t myproc = {0};
+static pmix_proc_t allproc = PMIX_PROC_STATIC_INIT;
+static pmix_proc_t myproc = PMIX_PROC_STATIC_INIT;
+static pmix_proc_t * all_procs = NULL;
 static bool mywait = false;
 static bool refresh = false;
 static bool timeout = false;
+static bool group = false;
+static uint32_t nprocs;
 
 static int pmi_set_string(const char *key, void *data, size_t size)
 {
@@ -19,26 +21,26 @@ static int pmi_set_string(const char *key, void *data, size_t size)
     value.data.bo.bytes = data;
     value.data.bo.size = size;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
+            PMIx_Error_string(rc));
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace, myproc.rank,
+            PMIx_Error_string(rc));
     }
 
     /* protect the data */
     value.data.bo.bytes = NULL;
     value.data.bo.size = 0;
     PMIX_VALUE_DESTRUCT(&value);
-    printf("%s:%d PMIx_Put on %s\n", myproc.nspace, myproc.rank, key);
+    fprintf(stdout, "%s:%d PMIx_Put on %s with value %s\n", myproc.nspace, myproc.rank, key, (char*) data);
 
     return 0;
 }
 
-static int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out,
-                          size_t *data_size_out)
+static int pmi_get_string(uint32_t peer_rank, const char *key,
+                          void **data_out, size_t *data_size_out, bool retry)
 {
     int rc;
     pmix_proc_t proc;
@@ -46,7 +48,7 @@ static int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out,
     pmix_info_t info;
 
     PMIX_LOAD_PROCID(&proc, myproc.nspace, peer_rank);
-    if (refresh) {
+    if (refresh && retry) {
         PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, &refresh, PMIX_BOOL);
         rc = PMIx_Get(&proc, key, &info, 1, &pvalue);
         PMIX_INFO_DESTRUCT(&info);
@@ -59,12 +61,13 @@ static int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out,
         rc = PMIx_Get(&proc, key, NULL, 0, &pvalue);
     }
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get on rank %u %s: %s\n", myproc.nspace,
-                myproc.rank, peer_rank, key, PMIx_Error_string(rc));
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Get on rank %u %s: %s\n", myproc.nspace, myproc.rank,
+            peer_rank, key, PMIx_Error_string(rc));
+        return rc;
     }
     if (pvalue->type != PMIX_BYTE_OBJECT) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s: got wrong data type\n", myproc.nspace,
-                myproc.rank, key);
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Get %s: got wrong data type\n", myproc.nspace, myproc.rank,
+            key);
     }
     *data_out = pvalue->data.bo.bytes;
     *data_size_out = pvalue->data.bo.size;
@@ -75,8 +78,8 @@ static int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out,
     PMIX_VALUE_RELEASE(pvalue);
     PMIX_PROC_DESTRUCT(&proc);
 
-    printf("%s:%d PMIx_get %s returned %zi bytes\n", myproc.nspace, myproc.rank, key,
-           data_size_out[0]);
+    fprintf(stdout, "%s:%d PMIx_get %s returned %zi bytes (value %s)\n", myproc.nspace, myproc.rank, key,
+            data_size_out[0], (char*) *data_out);
 
     return 0;
 }
@@ -89,7 +92,13 @@ static int pmix_exchange(bool flag)
     fprintf(stderr, "Execute fence\n");
     PMIX_INFO_CONSTRUCT(&info);
     PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-    rc = PMIx_Fence(&allproc, 1, &info, 1);
+    if (all_procs) {
+        /* Array with procs (group case)*/
+        rc = PMIx_Fence(all_procs, nprocs, &info, 1);
+    } else {
+        /* Rank wildcard */
+        rc = PMIx_Fence(&allproc, 1, &info, 1);
+    }
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Fence_nb failed: %d\n", myproc.nspace,
                 myproc.rank, rc);
@@ -100,9 +109,66 @@ static int pmix_exchange(bool flag)
     return 0;
 }
 
+static int pmix_create_group(void) {
+
+    pmix_status_t rc = PMIX_SUCCESS;
+    bool assign_context_id = true;
+    pmix_info_t * directives = NULL;
+    pmix_info_t *results = NULL;
+    size_t ndirs = 2;
+    size_t nresults = 0;
+    int group_timeout = 10;
+
+    PMIX_PROC_CREATE(all_procs, nprocs);
+    for (size_t i = 0; i < nprocs; i++) {
+        PMIX_PROC_LOAD(&(all_procs[i]), myproc.nspace, i);
+    }
+
+    fprintf(stdout, "Client ns %s rank %d: Group construction...\n", myproc.nspace,
+            myproc.rank);
+
+    PMIX_INFO_CREATE(directives, ndirs);
+    PMIX_INFO_LOAD(&(directives[0]), PMIX_GROUP_ASSIGN_CONTEXT_ID, &assign_context_id, PMIX_BOOL);
+    PMIX_INFO_LOAD(&(directives[1]), PMIX_TIMEOUT, &group_timeout, PMIX_INT);
+    if (PMIX_SUCCESS != (rc = PMIx_Group_construct("mygroup", all_procs, nprocs, directives, ndirs,
+                                     &results, &nresults))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return rc;
+    }
+
+    for (size_t k = 0; k < nresults; k++) {
+        fprintf(stdout, "%s-%d: %s\n", myproc.nspace, myproc.rank, PMIx_Info_string(&results[k]));
+    }
+
+    if (directives != NULL) {
+        PMIX_INFO_FREE(directives, ndirs);
+    }
+    if (results != NULL) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    return rc;
+}
+
+static int pmix_destruct_group(void) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t ndirs = 1;
+    pmix_info_t * directives = NULL;
+    PMIX_INFO_CREATE(directives, ndirs);
+    PMIX_INFO_LOAD(&(directives[0]), PMIX_TIMEOUT, &timeout, PMIX_INT);
+    if (PMIX_SUCCESS != (rc = PMIx_Group_destruct("mygroup", directives, ndirs))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (directives != NULL) {
+        PMIX_INFO_FREE(directives, ndirs);
+    }
+    return rc;
+}
+
 int main(int argc, char *argv[])
 {
-    char data[256] = {0};
+    char data[256];
     char *data_out;
     size_t size_out;
     int rc;
@@ -115,6 +181,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "\t--wait       Test PMIX_GET_WAIT_FOR_KEY\n");
             fprintf(stderr, "\t--refresh    Test PMIX_GET_REFRESH_CACHE\n");
             fprintf(stderr, "\t--timeout    Test PMIX_GET_WAIT_FOR_KEY, but timeout\n");
+            fprintf(stderr, "\t--group      Test PMIX_GET_REFRESH_CACHE and PMIx Process Group\n");
             exit(0);
         }
         if (0 == strncmp(argv[1], "--w", 3)) {
@@ -123,23 +190,28 @@ int main(int argc, char *argv[])
             refresh = true;
         } else if (0 == strncmp(argv[1], "--t", 3)) {
             timeout = true;
+        } else if (0 == strncmp(argv[1], "--g", 3)) {
+            group = true;
+            refresh = true;
         } else {
             fprintf(stderr, "Invalid cmd line option: %s\n", argv[1]);
             fprintf(stderr, "Usage:\n");
             fprintf(stderr, "\t--wait       Test PMIX_GET_WAIT_FOR_KEY\n");
             fprintf(stderr, "\t--refresh    Test PMIX_GET_REFRESH_CACHE\n");
             fprintf(stderr, "\t--timeout    Test PMIX_GET_WAIT_FOR_KEY, but timeout\n");
+            fprintf(stderr, "\t--group      Test PMIX_GET_REFRESH_CACHE and PMIx Process Group\n");
             exit(1);
         }
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "PMIx_Init failed");
+        fprintf(stderr, "ERROR: PMIx_Init failed");
         exit(1);
     }
     if (myproc.rank == 0) {
         printf("PMIx initialized\n");
     }
+    memset(data, 0, 256);
 
     /* job-related info is found in our nspace, assigned to the
      * wildcard rank as it doesn't relate to a specific rank. Setup
@@ -152,11 +224,18 @@ int main(int argc, char *argv[])
                 myproc.rank, rc);
         exit(1);
     }
+    nprocs = pvalue->data.uint32;
     PMIX_VALUE_RELEASE(pvalue);
 
-    /* the below two lines break the subsequent PMIx_Get query on a key set later */
-    sprintf(data, "FIRST TIME rank %d", myproc.rank);
-    pmi_set_string("test-key-1", data, 256);
+
+    /* Each rank puts a unique key-value pair in the KVS */
+    sprintf(data, "ORIG rank %d", myproc.rank);
+    if (0 == myproc.rank) {
+        pmi_set_string("test-key-0", data, 256);
+    } else {
+        pmi_set_string("test-key-1", data, 256);
+    }
+
     pmix_exchange(true);
 
     if (1 == myproc.rank) {
@@ -167,23 +246,78 @@ int main(int argc, char *argv[])
         }
     }
 
-    sprintf(data, "SECOND TIME rank %d", myproc.rank);
+    /* Each rank gets the key-value pair that was put by the other rank */
     if (0 == myproc.rank) {
-        pmi_set_string("test-key-2", data, 256);
+        rc = pmi_get_string(1, "test-key-1", (void **) &data_out, &size_out, false);
+        if (0 != rc) {
+            goto done;
+        }
+        fprintf(stdout, "%d: obtained data for test-key-1 \"%s\"\n", myproc.rank, data_out);
     } else {
-        pmi_set_string("test-key-3", data, 256);
+        rc = pmi_get_string(0, "test-key-0", (void **) &data_out, &size_out, false);
+        if (0 != rc) {
+            goto done;
+        }
+        fprintf(stdout, "%d: obtained data for test-key-0 \"%s\"\n", myproc.rank, data_out);
     }
 
-    if (0 == myproc.rank) {
-        pmi_get_string(1, "test-key-3", (void **) &data_out, &size_out);
-    } else {
-        pmi_get_string(0, "test-key-2", (void **) &data_out, &size_out);
+    /* Create a group */
+    if (group) {
+        rc = pmix_create_group();
+        if (rc != PMIX_SUCCESS) {
+            exit(1);
+        }
     }
-    printf("%d: obtained data \"%s\"\n", myproc.rank, data_out);
+
+    /* Each rank attempts to overwrite the value that was previously put */
+    sprintf(data, "OVERWRITE rank %d", myproc.rank);
+    if (0 == myproc.rank) {
+        pmi_set_string("test-key-0", data, 256);
+    } else {
+        pmi_set_string("test-key-1", data, 256);
+    }
+
+    pmix_exchange(true);
+
+    if (1 == myproc.rank) {
+        if (timeout) {
+            sleep(10);
+        } else if (mywait) {
+            sleep(2);
+        }
+    }
+
+    /* Each rank gets the value put by the other rank
+     * If overwrite was successful, each rank should get the new value here */
+    if (0 == myproc.rank) {
+        rc = pmi_get_string(1, "test-key-1", (void **) &data_out, &size_out, true);
+        if (0 != rc) {
+            goto done;
+        }
+        fprintf(stdout, "%d: obtained data for test-key-1 \"%s\"\n", myproc.rank, data_out);
+    } else {
+        rc = pmi_get_string(0, "test-key-0", (void **) &data_out, &size_out, true);
+        if (0 != rc) {
+            goto done;
+        }
+        fprintf(stdout, "%d: obtained data for test-key-0 \"%s\"\n", myproc.rank, data_out);
+    }
+
+    /* Destroy group*/
+    if (group) {
+        rc = pmix_destruct_group();
+        if (rc != PMIX_SUCCESS) {
+            exit(1);
+        }
+    }
+
+done:
+    if (all_procs != NULL) {
+        PMIX_PROC_FREE(all_procs, nprocs);
+    }
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
-                myproc.rank, rc);
+        fprintf(stderr, "ERROR: Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     }
     if (myproc.rank == 0)
         printf("PMIx finalized\n");


### PR DESCRIPTION
Correctly retrieve updated "put" keys. In this release series, the mechanism for executing "refresh" is done by direct modex, which while inefficient does at least retrieve the data. In order for it to work with refresh, we have to pass the key to the remove daemon so it can specifically retrieve it.

Not sure why the updated data isn't included in the "fence" that is being executed after the values have been changed. Nor why the insertion of a "group construct" call before updating the values should have any impact on the operation as the two are completely orthogonal.

However, I do note that simply disabling the dstore resolves all observed problems. So I suspect we are again running up against the limitations of that subsystem.

Note: this change requires a corresponding change on the host server's handling of the direct modex request. See https://github.com/openpmix/prrte/pull/1873

This change is specific to the v4.2 branch - not applicable to any other branch.
bot:notacherrypick

Fixes #3201 