### PR TITLE
Adjust preg component priorities

### DIFF
--- a/src/mca/preg/native/preg_native_component.c
+++ b/src/mca/preg/native/preg_native_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,7 +62,7 @@ static int component_open(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
-    *priority = 50;
+    *priority = 30;
     *module = (pmix_mca_base_module_t *) &pmix_preg_native_module;
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/raw/preg_raw_component.c
+++ b/src/mca/preg/raw/preg_raw_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,7 +62,7 @@ static int component_open(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
-    *priority = 40;
+    *priority = 50;
     *module = (pmix_mca_base_module_t *) &pmix_preg_raw_module;
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Pick the "raw" component over the "native" one if zlib isn't available. While it is unusual, there are cases where "native" seems to have problems with randomized lists of hostnames. Since those cases almost always involve small numbers of nodes, just default to the "raw" listing.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit f5609a315f43838bd51d85a0da04de444f3fbe80)