### PR TITLE
Move pmix_pointer_array_init to pmix_keyindex_t constructor.

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -201,6 +201,8 @@ static void keyindex_construct(pmix_keyindex_t *ki)
     pmix_tma_t *const tma = pmix_obj_get_tma(&ki->super);
 
     ki->table = PMIX_NEW(pmix_pointer_array_t, tma);
+    pmix_pointer_array_init(ki->table, 1024, INT_MAX, 128);
+
     ki->next_id = PMIX_INDEX_BOUNDARY;
 }
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -328,7 +328,6 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                           pmix_globals.event_eviction_time, _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_globals.keyindex, pmix_keyindex_t);
-    pmix_pointer_array_init(pmix_globals.keyindex.table, 1024, INT_MAX, 128);
     PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
     /* need to hold off checking the hotel init return code
      * until after we construct all the globals so they can


### PR DESCRIPTION
Code cleanup: move pmix_pointer_array_init to pmix_keyindex_t constructor, as suggested in a recent review of code that allowed pmix_hash functions to accept a pmix_keyindex_t*.

See discussion in #3190 for more details.