### PR TITLE
Add the ability to retrieve the PMIx library version

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1277,6 +1277,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_PROVISIONAL_ABI_VERSION  "pmix.qry.prabiver"    // (char*) The PMIx Standard Provisional ABI version supported returned in the form of a comma separated "MAJOR.MINOR"
                                                                    //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
 
+#define PMIX_VERSION_NUMERIC                "pmix.vers.num"        // (uint32_t) Numeric representation of the version of the PMIx library
+                                                                   //            being used
+
+
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;
 #define PMIX_PROC_STATE_UNDEF                    0  /* undefined process state */

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -216,6 +216,24 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         return PMIX_OPERATION_SUCCEEDED;
     }
 
+    /* see if they just want our version */
+    if (NULL == proc && 0 == strncmp(key, PMIX_VERSION_NUMERIC, PMIX_MAX_KEYLEN)) {
+        if (lg->stval) {
+            ival = *val;
+            ival->type = PMIX_UINT32;
+            ival->data.uint32 = PMIX_NUMERIC_VERSION;
+        } else {
+            PMIX_VALUE_CREATE(ival, 1);
+            if (NULL == ival) {
+                return PMIX_ERR_NOMEM;
+            }
+            ival->type = PMIX_UINT32;
+            ival->data.uint32 = PMIX_NUMERIC_VERSION;
+            *val = ival;
+        }
+        return PMIX_OPERATION_SUCCEEDED;
+    }
+
     /* if the given proc param is NULL, or the nspace is
      * empty, then the caller is referencing our own nspace */
     if (NULL == proc || 0 == strlen(proc->nspace)) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2393,8 +2393,13 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const cha
     if (NULL == cd) {
         return PMIX_ERR_NOMEM;
     }
-    cd->pname.nspace = strdup(proc->nspace);
-    cd->pname.rank = proc->rank;
+    if (NULL == proc) {
+        cd->pname.nspace = strdup(pmix_globals.myid.nspace);
+        cd->pname.rank = pmix_globals.myid.rank;
+    } else {
+        cd->pname.nspace = strdup(proc->nspace);
+        cd->pname.rank = proc->rank;
+    }
 
     cd->kv = PMIX_NEW(pmix_kval_t);
     if (NULL == cd->kv) {


### PR DESCRIPTION
We would like to be able to retrieve the numeric library version so we can verify compatibility at runtime. Add a new key for that purpose and a quick retrieval path.