### PR TITLE
Delay registering top-level MCA params

### DIFF
--- a/docs/news/news-v4.x.rst
+++ b/docs/news/news-v4.x.rst
@@ -6,6 +6,7 @@ series, in reverse chronological order.
 
 4.2.8 -- TBD
 ------------
+ - PR #3220: Delay registering top-level MCA params
  - PR #3218: Update VERSION and NEWS for release
  - PR #3216: Multiple commits
     - Remove unused function

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -175,12 +175,6 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
         return ret;
     }
 
-    /* register params for pmix */
-    if (PMIX_SUCCESS != (ret = pmix_register_params())) {
-        fprintf(stderr, "pmix_register_params failed\n");
-        return ret;
-    }
-
     /* initialize the mca */
     if (PMIX_SUCCESS != (ret = pmix_mca_base_open(libdir))) {
         fprintf(stderr, "pmix_mca_base_open failed\n");
@@ -229,6 +223,12 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 
     if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (ret = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed\n");
+        return ret;
     }
 
     /* scan incoming info for directives */


### PR DESCRIPTION
Need to give tools that use PMIx a chance to parse their cmd lines and push params into the environment before we register them.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ebb60d9b974f47f6252df2148b1631141c7af0e6)