### PR TITLE
Enable auto-connect of sys ctrlr and scheduler

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -123,7 +123,9 @@ PMIX_CLASS_DECLARATION(pmix_connection_t);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *peer,
                                                         pmix_info_t info[], size_t ninfo);
-PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri_file(char *filename, pmix_list_t *connections);
+PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
+                                                       bool optional,
+                                                       pmix_list_t *connections);
 
 PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_connection(char *uri,
                                                          struct sockaddr_storage *connection,
@@ -160,7 +162,7 @@ PMIX_EXPORT void pmix_ptl_base_query_servers(int sd, short args, void *cbdata);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri(const char *evar, char **nspace,
                                                   pmix_rank_t *rank, char **suri);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix, pmix_info_t info[],
-                                                  size_t ninfo, pmix_list_t *connections);
+                                                  size_t ninfo, bool optional, pmix_list_t *connections);
 PMIX_EXPORT pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,
                                                         pmix_info_t *iptr, size_t niptr);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -134,23 +134,21 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                &max_msg_size);
     pmix_ptl_base.max_msg_size = max_msg_size * 1024 * 1024;
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "if_include",
-        "Comma-delimited list of devices and/or CIDR notation of TCP networks "
-        "(e.g., \"eth0,192.168.0.0/16\").  Mutually exclusive with ptl_tcp_if_exclude.",
-        PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &pmix_ptl_base.if_include);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "if_include",
+                                     "Comma-delimited list of devices and/or CIDR notation of TCP networks "
+                                     "(e.g., \"eth0,192.168.0.0/16\").  Mutually exclusive with ptl_tcp_if_exclude.",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &pmix_ptl_base.if_include);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_include",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "if_exclude",
-        "Comma-delimited list of devices and/or CIDR notation of TCP networks to NOT use "
-        "-- all devices not matching these specifications will be used (e.g., "
-        "\"eth0,192.168.0.0/16\"). "
-        "If set to a non-default value, it is mutually exclusive with ptl_tcp_if_include.",
-        PMIX_MCA_BASE_VAR_TYPE_STRING,
-        &pmix_ptl_base.if_exclude);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "if_exclude",
+                                     "Comma-delimited list of devices and/or CIDR notation of TCP networks to NOT use "
+                                     "-- all devices not matching these specifications will be used (e.g., "
+                                     "\"eth0,192.168.0.0/16\"). "
+                                     "If set to a non-default value, it is mutually exclusive with ptl_tcp_if_include.",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &pmix_ptl_base.if_exclude);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "if_exclude",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
@@ -187,35 +185,31 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "disable_ipv6_family",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "connection_wait_time",
-        "Number of seconds to wait for the server connection file to appear",
-        PMIX_MCA_BASE_VAR_TYPE_INT,
-        &pmix_ptl_base.wait_to_connect);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "connection_wait_time",
+                                     "Number of seconds to wait for the server connection file to appear",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &pmix_ptl_base.wait_to_connect);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "connection_wait_time",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "max_retries",
-        "Number of times to look for the connection file before quitting",
-        PMIX_MCA_BASE_VAR_TYPE_INT,
-        &pmix_ptl_base.max_retries);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "max_retries",
+                                     "Number of times to look for the connection file before quitting",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &pmix_ptl_base.max_retries);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "max_retries",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "handshake_wait_time",
-        "Number of seconds to wait for the server reply to the handshake request",
-        PMIX_MCA_BASE_VAR_TYPE_INT,
-        &pmix_ptl_base.handshake_wait_time);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "handshake_wait_time",
+                                     "Number of seconds to wait for the server reply to the handshake request",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &pmix_ptl_base.handshake_wait_time);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_wait_time",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    idx = pmix_mca_base_var_register(
-        "pmix", "ptl", "base", "handshake_max_retries",
-        "Number of times to retry the handshake request before giving up",
-        PMIX_MCA_BASE_VAR_TYPE_INT,
-        &pmix_ptl_base.handshake_max_retries);
+    idx = pmix_mca_base_var_register("pmix", "ptl", "base", "handshake_max_retries",
+                                     "Number of times to retry the handshake request before giving up",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &pmix_ptl_base.handshake_max_retries);
     (void) pmix_mca_base_var_register_synonym(idx, "pmix", "ptl", "tcp", "handshake_max_retries",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 

--- a/src/mca/ptl/client/ptl_client.c
+++ b/src/mca/ptl/client/ptl_client.c
@@ -139,7 +139,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info, 
                                 "ptl:client looking for system server at %s", rendfile);
             /* try to read the file */
             PMIX_CONSTRUCT(&connections, pmix_list_t);
-            rc = pmix_ptl_base_parse_uri_file(rendfile, &connections);
+            rc = pmix_ptl_base_parse_uri_file(rendfile, true, &connections);
             free(rendfile);
             rendfile = NULL;
             if (PMIX_SUCCESS == rc && 0 < pmix_list_get_size(&connections)) {

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -759,6 +759,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
             pmix_client_globals.myserver->info->gid = pmix_globals.gid;
+            // set the type of the server to be our own
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, ptype.type);
         }
     } else {
         /* connect to the server */
@@ -785,10 +787,13 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
             pmix_client_globals.myserver->info->gid = pmix_globals.gid;
+            // set the type of the server to be our own
+            PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, ptype.type);
             /* mark us as not connecting to avoid asking for our job info */
             do_not_connect = true;
         }
     }
+
     /* setup the wildcard ID */
     PMIX_LOAD_PROCID(&wildcard, pmix_globals.myid.nspace, PMIX_RANK_WILDCARD);
     /* pass back the ID */
@@ -969,6 +974,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         }
         PMIX_DESTRUCT(&cb);
     }
+
     // enable show_help subsystem
     pmix_show_help_enabled = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);


### PR DESCRIPTION
Regardless of which one (system controller or scheduler) is started first, enable the auto-connection of the pair when requested. Ensure we don't hang waiting for a connection file to appear if the host specifies that the connection is optional.