### PR TITLE
Remove stat call when destroying a dirpath

### DIFF
--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,6 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2023      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -68,3 +69,8 @@ PMIx detected a call to mkdir was unable to create the desired directory:
 
 Please check to ensure you have adequate permissions to perform
 the desired operation.
+[unlink-error]
+We attempted to remove a file, but were unable to do so:
+
+  Path:  %s
+  Error: %s


### PR DESCRIPTION
Just respond to the unlink error.