### PR TITLE
avoid loopback in resolve_nspace_requests when using PMIX_ADD_HOST

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -722,10 +722,15 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
             continue;
         }
 
-        PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
-            if (info->pname.rank == cd->proc.rank) {
-                found = true; // we will satisy this request upon commit from new proc
-                break;
+        /*  If they asked for job level data, then the data was just registered */
+        if(cd->proc.rank == PMIX_RANK_WILDCARD){
+            found = true;
+        }else{
+            PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
+                if (info->pname.rank == cd->proc.rank) {
+                    found = true; // we will satisy this request upon commit from new proc
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
There occurs a problem in the following situation:

1. Job A uses PMIx_Spawn with the PMIX_ADD_HOST option to spawn Job B on some added nodes
2. A process from Job B (running on an added node) requests job level data of Job A (i.e. using PMIX_RANK_WILDCARD in PMIx_Get)

This leads to a crash of the PRRTE daemon hosting the requesting process from Job B.

The root of this problem is a loopback in resolve_nspace_requests:

- As the PMIx servers on the added nodes do not host any processes from Job A, the namespace of Job A is not yet registered when processes from job B request the job level data.
- The request is then forwarded to PRRTE which registers the namespace of Job A in the direct_modex host function
- The PMIx_register_nspace implementation calls resolve_nspace_requests to resolve any outstanding requests for data from this nspace.
- resolve_nspace_requests compares the rank of the process who's data was requested with the ranks of local procs from this namespace
- As PMIX_RANK_WILDCARD was specified the rank is not found and it is assumed that it must be a remote proc -> the host's direct_modex funtion is called again
- ...


This patch adds a check for PMIX_RANK_WILDCARD in resolve_nspace_requests to avoid calling the host's direct_modex function. 

 