### PR TITLE
Assign NULL to free'd pointer

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1016,6 +1016,7 @@ pmix_status_t pmix_hwloc_get_cpuset(pmix_cpuset_t *cpuset, pmix_bind_envelope_t 
     }
     if (0 != rc) {
         hwloc_bitmap_free(cpuset->bitmap);
+        cpuset->bitmap = NULL;
         return PMIX_ERR_NOT_FOUND;
     }
     if (NULL == cpuset->source) {


### PR DESCRIPTION
Ensure that the cpuset bitmap field isn't left
pointing to free'd memory.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ffd830cacb169e3c69f460598ebdc8a63a68bc8d)