### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -401,7 +401,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       netdb.h ucred.h zlib.h sys/auxv.h \
                       sys/sysctl.h termio.h termios.h pty.h \
                       libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h \
-                      sys/utsname.h])
+                      sys/utsname.h stdatomic.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],
                      [AC_INCLUDES_DEFAULT

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -21,7 +21,7 @@ dnl Copyright (c) 2020-2023 Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -180,16 +180,16 @@ AC_DEFUN([PMIX_SETUP_CC],[
     if test $pmix_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the
         # following lines and update the warning when we require a C11 compiler.
-        # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
+        # AC_MSG_WARNING([PMIx requires a C11 (or newer) compiler])
         # AC_MSG_ERROR([Aborting.])
-        # From Open MPI 1.7 on we require a C99 compliant compiler
+        # We require a C99 compliant compiler
         # with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
         m4_version_prereq([2.70],
             [],
             [AC_PROG_CC_C99])
         # The C99 result of AC_PROG_CC is stored in ac_cv_prog_cc_c99
         if test "x$ac_cv_prog_cc_c99" = xno ; then
-            AC_MSG_WARN([Open MPI requires a C99 (or newer) compiler. C11 is recommended.])
+            AC_MSG_WARN([PMIx requires a C99 (or newer) compiler. C11 is recommended.])
             AC_MSG_ERROR([Aborting.])
         fi
 
@@ -405,7 +405,7 @@ AC_DEFUN([_PMIX_PROG_CC],[
     AC_PROG_CC
     BASECC="`basename $CC`"
     CFLAGS="$pmix_cflags_save"
-    AC_DEFINE_UNQUOTED(PMIX_CC, "$CC", [OMPI underlying C compiler])
+    AC_DEFINE_UNQUOTED(PMIX_CC, "$CC", [PMIx underlying C compiler])
     set dummy $CC
     pmix_cc_argv0=[$]2
     PMIX_WHICH([$pmix_cc_argv0], [PMIX_CC_ABSOLUTE])

--- a/src/include/pmix_stdatomic.h
+++ b/src/include/pmix_stdatomic.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
@@ -23,7 +23,9 @@
 
 #if PMIX_USE_C11_ATOMICS
 
+#ifdef HAVE_STDATOMIC_H
 #include <stdatomic.h>
+#endif
 
 typedef atomic_int pmix_atomic_int_t;
 typedef atomic_long pmix_atomic_long_t;

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -312,7 +312,9 @@ int pmix_mca_base_var_enum_create_flag(const char *name,
          * hasn't already been specified. */
         assert(!(flags[i].flag & (flags[i].flag - 1)));
         assert(!(flags[i].flag & flags[i].conflicting_flag));
+#if PMIX_ENABLE_DEBUG
         assert(!(all_flags & flags[i].flag));
+#endif
         assert(flags[i].flag);
 #if PMIX_ENABLE_DEBUG
         all_flags |= flags[i].flag;


### PR DESCRIPTION
[Protect a variable](https://github.com/openpmix/openpmix/commit/b26dfb1dd91d98cfb65cd8d6b99fefbb945bbc58)

Only defined if PMIx built with --enable-debug

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/f02c3c4ec9d4dfbc9bdb5eae48cee87ec5002951)

[Check for stdatomic.h](https://github.com/openpmix/openpmix/commit/eddf88ecb1b7ba186175bf403f4925b57b625101)

Protect against it not being found. Cleanup
a few OMPI vs PMIx typos

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/fe47cd5b8c04974a9e499078d10ece428b10e284)
