### PR TITLE
Do not remove the system tmpdir during cleanup

### DIFF
--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -289,7 +289,7 @@ static pmix_status_t pmix_ptl_close(void)
             if (0 != rc) {
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "Remove of %s failed: %s",
-                                    pmix_ptl_base.system_filename, strerror(errno));
+                                    pmix_ptl_base.session_filename, strerror(errno));
             }
         }
         free(pmix_ptl_base.session_filename);
@@ -300,7 +300,7 @@ static pmix_status_t pmix_ptl_close(void)
             if (0 != rc) {
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "Remove of %s failed: %s",
-                                    pmix_ptl_base.system_filename, strerror(errno));
+                                    pmix_ptl_base.nspace_filename, strerror(errno));
             }
         }
         free(pmix_ptl_base.nspace_filename);
@@ -311,7 +311,7 @@ static pmix_status_t pmix_ptl_close(void)
             if (0 != rc) {
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "Remove of %s failed: %s",
-                                    pmix_ptl_base.system_filename, strerror(errno));
+                                    pmix_ptl_base.pid_filename, strerror(errno));
             }
         }
         free(pmix_ptl_base.pid_filename);
@@ -322,7 +322,7 @@ static pmix_status_t pmix_ptl_close(void)
             if (0 != rc) {
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "Remove of %s failed: %s",
-                                    pmix_ptl_base.system_filename, strerror(errno));
+                                    pmix_ptl_base.rendezvous_filename, strerror(errno));
             }
         }
         free(pmix_ptl_base.rendezvous_filename);
@@ -337,7 +337,7 @@ static pmix_status_t pmix_ptl_close(void)
             if (0 != rc) {
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "Remove of %s failed: %s",
-                                    pmix_ptl_base.system_filename, strerror(errno));
+                                    pmix_ptl_base.urifile, strerror(errno));
             }
         }
         free(pmix_ptl_base.urifile);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1069,9 +1069,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     if (NULL != gds_mode) {
         free(gds_mode);
     }
-    if (NULL != pmix_server_globals.tmpdir) {
-        free(pmix_server_globals.tmpdir);
-    }
+
     /* close the psensor framework */
     (void) pmix_mca_base_framework_close(&pmix_psensor_base_framework);
     /* close the pnet framework */
@@ -1087,7 +1085,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         PMIX_RELEASE(pmix_globals.mypeer);
     }
 
-    pmix_output_verbose(2, pmix_server_globals.base_output, "pmix:server finalize complete");
+    if (NULL != pmix_server_globals.tmpdir) {
+        free(pmix_server_globals.tmpdir);
+    }
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server finalize complete");
 
     /* finalize the class/object system */
     pmix_class_finalize();

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -123,6 +123,7 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_TIMEOUT                "timeout"                   // required
 #define PMIX_CLI_TMPDIR                 "tmpdir"                    // required
 #define PMIX_CLI_CONNECTION_ORDER       "connect-order"             // required
+#define PMIX_CLI_SYS_CONTROLLER         "system-controller"         // none
 
 // Allocation request options
 #define PMIX_CLI_REQ_ID                 "request-id"                // required

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -40,6 +40,7 @@
 
 #include "pmix_common.h"
 #include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_os_dirpath.h"
@@ -221,10 +222,13 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
 cleanup:
 
     /*
-     * If the directory is empty, them remove it
+     * If the directory is empty, then remove it - but
+     * leave the system tmpdir alone!
      */
-    if (pmix_os_dirpath_is_empty(path)) {
-        rmdir(path);
+    if (0 != strcmp(path, pmix_server_globals.system_tmpdir)) {
+        if (pmix_os_dirpath_is_empty(path)) {
+            rmdir(path);
+        }
     }
 
     return exit_status;


### PR DESCRIPTION
Ensure os_dirpath_destroy protects the system tmpdir from removal.