### PR TITLE
Cleanup palloc and prun connections

### DIFF
--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -761,7 +761,8 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t 
             goto cleanup;
         }
         goto complete;
-    } else if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+    } else if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+               PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* we aren't a client, so we will search to see what session-level
          * tools are available to this user. We will take the first connection
          * that succeeds - this is based on the likelihood that there is only
@@ -782,6 +783,8 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t 
         if (!optional) {
             goto cleanup;
         }
+    } else {
+        pmix_output(0, "RATS");
     }
     rc = PMIX_ERR_UNREACH;
     goto cleanup;

--- a/src/tools/palloc/help-palloc.txt
+++ b/src/tools/palloc/help-palloc.txt
@@ -44,6 +44,7 @@ PMIx Allocation Request tool
                                      for file containing the PID
    --system-server-first             First look for a system server and connect to it if found
    --system-server-only              Connect only to a system-level server
+   --system-controller               Connect to the system controller
    --tmpdir <arg0>                   Set the root for the session directory tree
    --connect-order <arg0>            Specify search order for server connections - e.g., scheduler,
                                      system controller, system-level server, or local server
@@ -139,6 +140,9 @@ First look for a system server and connect to it if found
 #
 [system-server-only]
 Connect only to a system-level server - abort if one is not found
+#
+[system-controller]
+Look for a system controller and connect to it if found
 #
 [tmpdir]
 Define the root location for the session directory tree where the

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -62,6 +62,7 @@ static struct option pallocptions[] = {
     PMIX_OPTION_DEFINE(PMIX_CLI_URI, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_TMPDIR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_CONNECTION_ORDER, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_SYS_CONTROLLER, PMIX_ARG_NONE),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_REQ_ID, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_QUEUE, PMIX_ARG_REQD, 'q'),
@@ -294,9 +295,18 @@ int main(int argc, char **argv)
     } else if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_CONNECTION_ORDER))) {
         PMIX_INFO_LOAD(&info[0], PMIX_CONNECTION_ORDER, opt->values[0], PMIX_STRING);
 
+    } else if (pmix_cmd_line_is_taken(&results, PMIX_CLI_SYS_CONTROLLER)) {
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SYS_CONTROLLER, NULL, PMIX_BOOL);
+
     } else {
-        /* if none of the above, we just try to connect directly to the scheduler */
-        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
+        /* if none of the above, setup a common "order" to check */
+        char **tmp = NULL, *t2;
+        PMIx_Argv_append_nosize(&tmp, PMIX_CONNECT_TO_SCHEDULER);
+        PMIx_Argv_append_nosize(&tmp, PMIX_CONNECT_TO_SYS_CONTROLLER);
+        t2 = PMIx_Argv_join(tmp, ',');
+        PMIx_Argv_free(tmp);
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECTION_ORDER, t2, PMIX_STRING);
+        free(t2);
     }
 
     /* assign our own name */


### PR DESCRIPTION
Add the system controller to the list of connection candidates for palloc. Allow launchers to default
to picking up the local session daemon.