### PR TITLE
Cleanup a few typos and remove debug output

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -168,9 +168,6 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char 
                                                         pmix_info_t *iptr, size_t niptr);
 PMIX_EXPORT void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace,
                                                    pmix_rank_t rank, char *uri);
-PMIX_EXPORT pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer, char **msgout,
-                                                          size_t *sz, pmix_info_t *iptr,
-                                                          size_t niptr);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct timeval *save,
                                                     pmix_socklen_t *sz, bool *sockopt);
 PMIX_EXPORT void pmix_ptl_base_setup_socket(pmix_peer_t *peer);

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -783,8 +783,6 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t 
         if (!optional) {
             goto cleanup;
         }
-    } else {
-        pmix_output(0, "RATS");
     }
     rc = PMIX_ERR_UNREACH;
     goto cleanup;

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -52,6 +52,8 @@
 
 /****    SUPPORTING FUNCTIONS    ****/
 static void timeout(int sd, short args, void *cbdata);
+static pmix_status_t construct_message(pmix_peer_t *peer, char **msgout, size_t *sz,
+                                       pmix_info_t *iptr, size_t niptr);
 
 pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar)
 {
@@ -551,7 +553,7 @@ static pmix_status_t send_connect_ack(pmix_peer_t *peer,
     peer->proc_type.flag = pmix_ptl_base_set_flag(&sdsize);
 
     /* construct the contact message */
-    rc = pmix_ptl_base_construct_message(peer, &msg, &sdsize, iptr, niptr);
+    rc = construct_message(peer, &msg, &sdsize, iptr, niptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -787,8 +789,8 @@ pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz)
     return flag;
 }
 
-pmix_status_t pmix_ptl_base_construct_message(pmix_peer_t *peer, char **msgout, size_t *sz,
-                                              pmix_info_t *iptr, size_t niptr)
+static pmix_status_t construct_message(pmix_peer_t *peer, char **msgout, size_t *sz,
+                                       pmix_info_t *iptr, size_t niptr)
 {
     char *msg;
     char *sec, *bfrops, *gds;

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -225,7 +225,8 @@ cleanup:
      * If the directory is empty, then remove it - but
      * leave the system tmpdir alone!
      */
-    if (0 != strcmp(path, pmix_server_globals.system_tmpdir)) {
+    if (NULL == pmix_server_globals.system_tmpdir ||
+        0 != strcmp(path, pmix_server_globals.system_tmpdir)) {
         if (pmix_os_dirpath_is_empty(path)) {
             rmdir(path);
         }


### PR DESCRIPTION
Remove debug output. Correctly use our own peer
(instead of the one passed to us) when constructing a connection handshake message.