### PR TITLE
Use git describe on a known PMIx commit sha instead of checking for .…

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1036,9 +1036,9 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
 
     # A hint to tell us if we are working with a build from Git or a tarball.
     # Helpful when preparing diagnostic output.
-    if test -e $PMIX_TOP_SRCDIR/.git; then
+    if git describe 731178f7ea0367fada846782dbb0561c86db20a2 &> /dev/null ; then
         AC_DEFINE_UNQUOTED([PMIX_GIT_REPO_BUILD], ["1"],
-            [If built from a git repo])
+                           [If built from a git repo])
         pmix_git_repo_build=yes
     fi
 


### PR DESCRIPTION
…git directory

Supports VPATH builds. Copied from https://github.com/open-mpi/ompi/pull/12173.

Thanks to @devreal for the original PR.