### PR TITLE
Revert "Check for presence of git before using it in configure"

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1034,19 +1034,12 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
 AC_DEFUN([PMIX_DEFINE_ARGS],[
 
-    # check for presence of "git" command
-    AC_CHECK_PROG(pmix_git_cmd, git, [git])
-    if test "$pmix_git_cmd" != ""; then
-        # A hint to tell us if we are working with a build from Git or a tarball.
-        # Helpful when preparing diagnostic output.
-        if git describe 731178f7ea0367fada846782dbb0561c86db20a2 &> /dev/null ; then
-            AC_DEFINE_UNQUOTED([PMIX_GIT_REPO_BUILD], ["1"],
-                               [If built from a git repo])
-            pmix_git_repo_build=yes
-        fi
-    else
-        # we cannot check, so assume it isn't a repo build
-        pmix_git_repo_build=no
+    # A hint to tell us if we are working with a build from Git or a tarball.
+    # Helpful when preparing diagnostic output.
+    if test -e $PMIX_TOP_SRCDIR/.git; then
+        AC_DEFINE_UNQUOTED([PMIX_GIT_REPO_BUILD], ["1"],
+            [If built from a git repo])
+        pmix_git_repo_build=yes
     fi
 
     # do we want dlopen support ?


### PR DESCRIPTION
This reverts commit 374aa0e1ece60f7b7585c682e509ec1519ff16d5.

Revert "Use git describe on a known PMIx commit sha instead of checking for .git directory"

This reverts commit 58126b8ea7c5e4c530b6b7e1d768a3dc71f24580.