### PR TITLE
Restore support for detecting shared file systems

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -412,7 +412,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       netdb.h ucred.h zlib.h sys/auxv.h \
                       sys/sysctl.h termio.h termios.h pty.h \
                       libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h \
-                      sys/utsname.h stdatomic.h])
+                      sys/utsname.h stdatomic.h mntent.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],
                      [AC_INCLUDES_DEFAULT

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -63,6 +63,9 @@
 #ifdef HAVE_PATHS_H
 #    include <paths.h>
 #endif
+#ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#endif
 
 #ifdef _PATH_MOUNTED
 #    define MOUNTED_FILE _PATH_MOUNTED
@@ -73,6 +76,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_stdint.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_basename.h"
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_path.h"
@@ -368,6 +372,108 @@ char *pmix_find_absolute_path(char *app_name)
         return resolved_path;
     }
     return NULL;
+}
+
+/**
+ * @brief Figure out whether fname is on network file system
+ *
+ * Try to figure out whether the file name specified through fname is
+ * on any network file system (currently NFS, Lustre, Panasas and GPFS).
+ *
+ * @fname[in]          File name to check
+ * @fstype[out]        File system type if retval is true
+ *
+ * @retval true       If fname is on NFS, Lustre, Panasas or GPFS
+ * @retval false      otherwise
+ *
+ */
+bool pmix_path_nfs(char *fname, char **fstype)
+{
+#ifdef HAVE_MNTENT_H
+    struct stat s;
+    struct mntent mnt;
+    FILE *fp;
+    dev_t dev;
+    char buf[1024];
+    int fd, n;
+    char* fs_types[] = {
+        "lustre",
+        "nfs",
+        "autofs",
+        "panfs",
+        "gpfs",
+        "pvfs2",
+        NULL
+    };
+    char *parent;
+
+    fd = open(fname, O_RDONLY);
+    if (0 > fd) {
+        // try the parent
+        parent = pmix_dirname(fname);
+        fd = open(parent, O_RDONLY);
+        free(parent);
+        if (0 > fd) {
+            // give up
+            return false;
+        }
+    }
+    if (fstat(fd, &s) != 0) {
+        return false;
+    }
+    close(fd);
+
+    // retain the inode of the file
+    dev = s.st_dev;
+
+    // try a couple of possible locations for the
+    // mount table
+    if ((fp = setmntent("/proc/mounts", "r")) == NULL) {
+        if ((fp = setmntent("/etc/mtab", "r")) == NULL) {
+            return false;
+        }
+    }
+
+    // search the mount table for an entry with
+    // matching inode
+    while (getmntent_r(fp, &mnt, buf, sizeof(buf))) {
+        fd = open(mnt.mnt_dir, O_RDONLY);
+        if (0 > fd) {
+            // probably lack permissions
+            continue;
+        }
+        if (fstat(fd, &s) != 0) {
+            close(fd);
+            continue;
+        }
+
+        if (s.st_dev == dev) {
+            *fstype = strdup(mnt.mnt_type);
+            close(fd);
+            endmntent(fp);
+            // check if this is a file system of concern
+            for (n=0; NULL != fs_types[n]; n++) {
+                if (0 == strcmp(fs_types[n], mnt.mnt_type)) {
+                    // yep, this is a shared file system
+                    return true;
+                }
+            }
+            // if we get here, then this is not a file
+            // system of concern
+            return false;
+        }
+        close(fd);
+    }
+
+    endmntent(fp);
+
+    // Should never reach here.
+    return false;
+#else
+    // cannot do anything
+    PMIX_HIDE_UNUSED_PARAMS(fname, fstype);
+    return false;
+#endif
 }
 
 int pmix_path_df(const char *path, uint64_t *out_avail)

--- a/src/util/pmix_path.h
+++ b/src/util/pmix_path.h
@@ -128,6 +128,25 @@ PMIX_EXPORT char *pmix_path_access(char *fname, char *path, int mode)
     __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
 /**
+ * @brief Figure out whether fname is on network file system
+ * and return fstype if known
+ *
+ * Try to figure out whether the file name specified through fname is
+ * on any network file system (currently NFS, Lustre, GPFS,  Panasas
+ * and PVFS2 ).
+ *
+ * If the file is not created, the parent directory is checked.
+ * This allows checking for NFS prior to opening the file.
+ *
+ * @fname[in]     File name to check
+ * @fstype[out]   File system type if retval is true
+ *
+ * @retval true                If fname is on NFS, Lustre or Panasas
+ * @retval false               otherwise
+ */
+PMIX_EXPORT bool pmix_path_nfs(char *fname, char **fstype) __pmix_attribute_warn_unused_result__;
+
+/**
  * @brief Returns the disk usage of path.
  *
  * @param[in] path       Path to check


### PR DESCRIPTION
Use new algorithm based on code provided by @bosilca to minimize impact on the file system. Detect identified shared file system types, reporting that the provided directory is on such a system.