### PR TITLE
Touchup the dirpath_destroy code

### DIFF
--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -472,6 +472,7 @@ bool pmix_path_nfs(char *fname, char **fstype)
 #else
     // cannot do anything
     PMIX_HIDE_UNUSED_PARAMS(fname, fstype);
+    *fstype = strdup("unknown");
     return false;
 #endif
 }


### PR DESCRIPTION
If the directory entry is itself a directory, make an immediate attempt to remove it. If it isn't empty and we are recursively removing things, then recurse downward.

When checking for network file systems, ensure that we provide a string for the fstype if we don't have the necessary support to detect fs types.