### PR TITLE
Add a query attribute for number of available slots

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -46,7 +46,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -640,6 +640,14 @@ typedef uint32_t pmix_rank_t;
                                                                     //         within the current topology that meet the specified query qualifications. This
                                                                     //         includes specifying return of all devices of a given type via the PMIX_DEVICE_TYPE
                                                                     //         attribute.
+#define PMIX_QUERY_AVAILABLE_SLOTS          "pmix.qry.aslots"       // (uint32_t) Number of slots currently available
+                                                                    //         in the session. This is a snapshot in
+                                                                    //         time as the number may have changed
+                                                                    //         (e.g., if another job was submitted after
+                                                                    //         the host generated its response). Request
+                                                                    //         may optionally specify the session using
+                                                                    //         the PMIX_SESSION_ID attribute - default
+                                                                    //         is the session of the requestor
 
 
 /* query qualifiers - these are used to provide information to narrow/modify the query. Value type shown is the type of data expected


### PR DESCRIPTION
Allow someone to query the number of slots available in a given session. Note that this is purely a point-in-time measurement as jobs may be working there way thru the state machine for mapping, and more jobs may be
submitted at any moment.