### PR TITLE
Fix "get" of key with undefined rank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ test/simple/simpjctrl
 test/simple/simpio
 test/simple/data-*
 test/simple/simpcoord
+test/simple/legacy
 test/python/run_sched.sh
 test/python/run_server.sh
 test/simple/pmitest

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -297,7 +297,8 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
         while (PMIX_SUCCESS == rc) {
             if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY) ||
                 PMIX_CHECK_KEY(kv, PMIX_APP_INFO_ARRAY) ||
-                PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY)) {
+                PMIX_CHECK_KEY(kv, PMIX_SESSION_INFO_ARRAY) ||
+                PMIX_CHECK_KEY(kv, PMIX_JOB_SIZE)) {
                 PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &undef, PMIX_INTERNAL, kv);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid
+                  hybrid legacy
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -174,4 +174,11 @@ hybrid_SOURCES = $(headers) \
 hybrid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hybrid_LDADD = \
     $(top_builddir)/src/libpmix.la
+
+legacy_SOURCES = $(headers) \
+        legacy.c
+legacy_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+legacy_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <stdio.h>
+#include <pmix.h>
+#include <string.h>
+
+int
+main(int argc, char *argv[])
+{
+pmix_value_t *val = NULL;
+pmix_status_t rc = PMIX_SUCCESS;
+pmix_proc_t global_proc, proc;
+
+rc = PMIx_Init(&global_proc, NULL, 0);
+assert(PMIX_SUCCESS == rc);
+
+rc = PMIx_Get(&global_proc, PMIX_LOCAL_RANK, NULL, 0, &val);
+assert(PMIX_SUCCESS == rc);
+
+int local_rank = val->data.uint16;
+PMIX_VALUE_RELEASE(val);
+
+char key_p[32];
+pmix_value_t value_p;
+
+sprintf(key_p, "%s-%d", "foo", local_rank);
+value_p.type = PMIX_UINT32;
+value_p.data.uint32 = local_rank + 10;
+
+rc = PMIx_Put(PMIX_GLOBAL, key_p, &value_p);
+assert(PMIX_SUCCESS == rc);
+
+rc = PMIx_Commit();
+assert(PMIX_SUCCESS == rc);
+
+PMIX_PROC_CONSTRUCT(&proc);
+proc.rank = PMIX_RANK_UNDEF;
+strcpy(proc.nspace, global_proc.nspace);
+
+for (int i = 0; i < 2; i++) {
+    char key_g[32];
+    pmix_value_t *value_g;
+
+    sprintf(key_g, "%s-%d", "foo", i);
+    rc = PMIx_Get(&proc, key_g, NULL, 0, &value_g);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Get got %d\n", rc);
+    } else {
+    fprintf(stderr, "Got %d\n", value_g->data.uint32);
+    }
+}
+
+PMIx_Finalize(NULL, 0);
+
+return 0;
+
+}


### PR DESCRIPTION
Users are allowed to request a key using
PMIX_RANK_UNDEF _if_ the key is globally
unique. In order to do this, the gds/hash
component in the client needs to know how
many procs are in the job, and we need to
return the requested data from the server
to the client so it can be found since
the dstore cannot handle undefined ranks.

Thanks to @RaymondMichael for the report.

Fixes https://github.com/openpmix/openpmix/issues/3259

bot:notacherrypick