### PR TITLE
Better support global keys

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -5213,7 +5213,9 @@ static void tdes(pmix_server_trkr_t *t)
     PMIX_LIST_DESTRUCT(&t->grpinfo);
     PMIX_DESTRUCT(&t->nslist);
 }
-PMIX_CLASS_INSTANCE(pmix_server_trkr_t, pmix_list_item_t, tcon, tdes);
+PMIX_CLASS_INSTANCE(pmix_server_trkr_t,
+                    pmix_list_item_t,
+                    tcon, tdes);
 
 static void cdcon(pmix_server_caddy_t *cd)
 {
@@ -5239,7 +5241,9 @@ static void cddes(pmix_server_caddy_t *cd)
         PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_server_caddy_t, pmix_list_item_t, cdcon, cddes);
+PMIX_CLASS_INSTANCE(pmix_server_caddy_t,
+                    pmix_list_item_t,
+                    cdcon, cddes);
 
 static void scadcon(pmix_setup_caddy_t *p)
 {
@@ -5295,9 +5299,13 @@ static void scaddes(pmix_setup_caddy_t *p)
         free(p->flags.directory);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t, pmix_object_t, scadcon, scaddes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,
+                                pmix_object_t,
+                                scadcon, scaddes);
 
-PMIX_CLASS_INSTANCE(pmix_trkr_caddy_t, pmix_object_t, NULL, NULL);
+PMIX_CLASS_INSTANCE(pmix_trkr_caddy_t,
+                    pmix_object_t,
+                    NULL, NULL);
 
 static void dmcon(pmix_dmdx_remote_t *p)
 {
@@ -5315,6 +5323,7 @@ static void dmrqcon(pmix_dmdx_request_t *p)
 {
     memset(&p->ev, 0, sizeof(pmix_event_t));
     p->event_active = false;
+    p->key = NULL;
     p->lcd = NULL;
 }
 static void dmrqdes(pmix_dmdx_request_t *p)
@@ -5322,11 +5331,16 @@ static void dmrqdes(pmix_dmdx_request_t *p)
     if (p->event_active) {
         pmix_event_del(&p->ev);
     }
+    if (NULL != p->key) {
+        free(p->key);
+    }
     if (NULL != p->lcd) {
         PMIX_RELEASE(p->lcd);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_dmdx_request_t, pmix_list_item_t, dmrqcon, dmrqdes);
+PMIX_CLASS_INSTANCE(pmix_dmdx_request_t,
+                    pmix_list_item_t,
+                    dmrqcon, dmrqdes);
 
 static void lmcon(pmix_dmdx_local_t *p)
 {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -122,6 +122,7 @@ typedef struct {
     pmix_event_t ev;
     bool event_active;
     pmix_dmdx_local_t *lcd;
+    char *key;
     pmix_modex_cbfunc_t cbfunc; // cbfunc to be executed when data is available
     void *cbdata;
 } pmix_dmdx_request_t;

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -29,6 +29,9 @@ value_p.data.uint32 = local_rank + 10;
 rc = PMIx_Put(PMIX_GLOBAL, key_p, &value_p);
 assert(PMIX_SUCCESS == rc);
 
+if (1 == global_proc.rank) {
+    sleep(3);
+}
 rc = PMIx_Commit();
 assert(PMIX_SUCCESS == rc);
 
@@ -43,9 +46,9 @@ for (int i = 0; i < 2; i++) {
     sprintf(key_g, "%s-%d", "foo", i);
     rc = PMIx_Get(&proc, key_g, NULL, 0, &value_g);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "PMIx_Get got %d\n", rc);
+        fprintf(stderr, "Rank %u: PMIx_Get got %d\n", global_proc.rank, rc);
     } else {
-    fprintf(stderr, "Got %d\n", value_g->data.uint32);
+    fprintf(stderr, "Rank %u: Got %d\n", global_proc.rank, value_g->data.uint32);
     }
 }
 


### PR DESCRIPTION
When caching get requests at the server level, we need to track what key they were asking about. When a proc later commits data, check outstanding requests to see if it arrived - this includes a check of any request for rank=PMIX_RANK_UNDEF since it could be a global key that was committed.

Refs #3259 

bot:notacherrypick