### PR TITLE
Better support global keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ test/simple/hybrid
 test/simple/asyncio
 test/simple/simpqual
 test/simple/simpdist
+test/simple/legacy
 
 test/sshot/daemon
 test/sshot/generate

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,11 +83,12 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_reply_caddy_t, pmix_object_t, dcd_con, NULL);
 
 static void dmdx_cbfunc(pmix_status_t status, const char *data, size_t ndata, void *cbdata,
                         pmix_release_cbfunc_t relfn, void *relcbdata);
-static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, char *key,
                                       pmix_server_caddy_t *cd, bool diffnspace, pmix_scope_t scope,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, pmix_info_t info[],
-                                          size_t ninfo, pmix_modex_cbfunc_t cbfunc, void *cbdata,
+static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, char *key,
+                                          pmix_info_t info[], size_t ninfo,
+                                          pmix_modex_cbfunc_t cbfunc, void *cbdata,
                                           pmix_dmdx_local_t **lcd, pmix_dmdx_request_t **rq);
 static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd,
                                   char *key, pmix_buffer_t *pbkt);
@@ -104,8 +105,9 @@ static void relfn(void *cbdata)
     }
 }
 
-static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, pmix_server_caddy_t *cd,
-                                    bool localonly, pmix_modex_cbfunc_t cbfunc, void *cbdata,
+static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, char *key,
+                                    pmix_server_caddy_t *cd, bool localonly,
+                                    pmix_modex_cbfunc_t cbfunc, void *cbdata,
                                     struct timeval *tv, pmix_dmdx_local_t **locald)
 {
     pmix_status_t rc;
@@ -123,13 +125,15 @@ static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, pmix_server_
     }
     /* we cannot do anything further, so just track this request
      * for now */
-    rc = create_local_tracker(nspace, rank, cd->info, cd->ninfo, cbfunc, cbdata, &lcd, &req);
+    rc = create_local_tracker(nspace, rank, key, cd->info, cd->ninfo, cbfunc, cbdata, &lcd, &req);
     if (PMIX_ERR_NOMEM == rc || NULL == lcd) {
         return rc;
     }
-    pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d TRACKER CREATED - WAITING",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank);
-    /* if they specified a timeout, set it up now */
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "%s:%d TRACKER CREATED - WAITING TIMEOUT %d",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank, 
+                       (NULL == tv) ? -1 : (int)tv->tv_sec);
+     /* if they specified a timeout, set it up now */
     if (NULL != tv && 0 < tv->tv_sec) {
         pmix_event_evtimer_set(pmix_globals.evbase, &req->ev, get_timeout, req);
         pmix_event_evtimer_add(&req->ev, tv);
@@ -401,9 +405,11 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
      * we do know how many clients to expect, so first check to see if
      * all clients have been registered with us */
     if (!nptr->all_registered) {
-        pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d NSPACE %s not all registered",
-                            pmix_globals.myid.nspace, pmix_globals.myid.rank, nspace);
-        rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
+        pmix_output_verbose(2, pmix_server_globals.get_output,
+                           "%s:%d NSPACE %s not all registered - delay %d",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                            nspace, (int)tv.tv_sec);
+        rc = defer_response(nspace, rank, key, cd, localonly, cbfunc, cbdata, &tv, &lcd);
         if (PMIX_ERR_NOT_FOUND == rc) {
             /* just means we created a tracker */
             rc = PMIX_SUCCESS;
@@ -427,7 +433,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
                 if (rank == iptr->pname.rank) {
                     if (0 > iptr->peerid) {
                         /* this rank has not connected yet, so this request needs to be held */
-                        rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
+                        rc = defer_response(nspace, rank, key, cd, localonly, cbfunc, cbdata, &tv, &lcd);
                         if (PMIX_ERR_NOT_FOUND == rc) {
                             /* just means we created a tracker */
                             rc = PMIX_SUCCESS;
@@ -521,7 +527,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
                 if (0 == tv.tv_sec) {
                     tv.tv_sec = 2;
                 }
-                rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, &tv, &lcd);
+                rc = defer_response(nspace, rank, key, cd, localonly, cbfunc, cbdata, &tv, &lcd);
                 if (PMIX_ERR_NOT_FOUND == rc) {
                     /* just means we created a tracker */
                     rc = PMIX_SUCCESS;
@@ -564,7 +570,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     }
 
     /* since everyone has registered, see if we already have this data */
-    rc = _satisfy_request(nptr, rank, cd, diffnspace, scope, cbfunc, cbdata);
+    rc = _satisfy_request(nptr, rank, key, cd, diffnspace, scope, cbfunc, cbdata);
     if (PMIX_SUCCESS == rc) {
         /* return success as the satisfy_request function
          * calls the cbfunc for us, and it will have
@@ -579,7 +585,7 @@ request:
     /* setup to handle this remote request, but don't set any timeout as
      * this might create a race condition with our host if they also
      * support the timeout */
-    rc = defer_response(nspace, rank, cd, localonly, cbfunc, cbdata, NULL, &lcd);
+    rc = defer_response(nspace, rank, key, cd, localonly, cbfunc, cbdata, NULL, &lcd);
     if (PMIX_SUCCESS == rc) {
         /* we are already waiting for the data - nothing more
          * for us to do as the function added the new request
@@ -634,8 +640,9 @@ request:
     return rc;
 }
 
-static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, pmix_info_t info[],
-                                          size_t ninfo, pmix_modex_cbfunc_t cbfunc, void *cbdata,
+static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, char *key,
+                                          pmix_info_t info[], size_t ninfo,
+                                          pmix_modex_cbfunc_t cbfunc, void *cbdata,
                                           pmix_dmdx_local_t **ld, pmix_dmdx_request_t **rq)
 {
     pmix_dmdx_local_t *lcd, *cd;
@@ -688,6 +695,9 @@ complete:
     if (NULL == req) {
         *ld = lcd;
         return PMIX_ERR_NOMEM;
+    }
+    if (NULL != key) {
+        req->key = strdup(key);
     }
     PMIX_RETAIN(lcd);
     req->lcd = lcd;
@@ -823,7 +833,7 @@ static pmix_status_t get_job_data(char *nspace,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, char *key,
                                       pmix_server_caddy_t *cd, bool diffnspace, pmix_scope_t scope,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
@@ -863,6 +873,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
      * of returning a copy of the data, or a pointer to
      * local storage */
     cb.proc = &proc;
+    cb.key = key;
     cb.scope = scope;
     cb.copy = false;
     cb.info = cd->info;
@@ -957,50 +968,34 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
     return PMIX_ERR_NOT_FOUND;
 }
 
-/* Resolve pending requests to this namespace/rank */
-pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr,
-                                   pmix_rank_t rank,
-                                   pmix_status_t status,
-                                   pmix_scope_t scope,
-                                   pmix_dmdx_local_t *lcd)
+static void check_req(pmix_namespace_t *nptr,
+                      pmix_rank_t rank,
+                      pmix_status_t status,
+                      pmix_scope_t scope,
+                      pmix_dmdx_local_t *ptr)
 {
-    pmix_dmdx_local_t *cd, *ptr;
     pmix_dmdx_request_t *req, *rnext;
     pmix_server_caddy_t scd;
-
-    /* find corresponding request (if exists) */
-    if (NULL == lcd) {
-        ptr = NULL;
-        if (NULL != nptr) {
-            PMIX_LIST_FOREACH (cd, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
-                if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->proc.nspace) || rank != cd->proc.rank) {
-                    continue;
-                }
-                ptr = cd;
-                break;
-            }
-        }
-        if (NULL == ptr) {
-            return PMIX_SUCCESS;
-        }
-    } else {
-        ptr = lcd;
-    }
+    bool diffnspace;
+    pmix_status_t rc;
+    char *key;
 
     /* if there are no local reqs on this request (e.g., only
      * one proc requested it and that proc has died), then
      * just remove the request */
     if (0 == pmix_list_get_size(&ptr->loc_reqs)) {
-        goto cleanup;
+        return;
     }
 
     /* somebody was interested in this rank */
     if (PMIX_SUCCESS != status) {
         /* if we've got an error for this request - just forward it*/
-        PMIX_LIST_FOREACH (req, &ptr->loc_reqs, pmix_dmdx_request_t) {
+        PMIX_LIST_FOREACH_SAFE(req, rnext, &ptr->loc_reqs, pmix_dmdx_request_t) {
             req->cbfunc(status, NULL, 0, req->cbdata, NULL, NULL);
+            pmix_list_remove_item(&ptr->loc_reqs, &req->super);
+            PMIX_RELEASE(req);
         }
-    } else if (NULL != nptr) {
+    } else {
         /* if we've got the blob - try to satisfy requests */
         /* run through all the requests for this rank */
         /* this info is going back to one of our peers, so provide a server
@@ -1008,33 +1003,65 @@ pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr,
         PMIX_CONSTRUCT(&scd, pmix_server_caddy_t);
         PMIX_RETAIN(pmix_globals.mypeer);
         scd.peer = pmix_globals.mypeer;
-        PMIX_LIST_FOREACH (req, &ptr->loc_reqs, pmix_dmdx_request_t) {
-            pmix_status_t rc;
-            bool diffnspace = !PMIX_CHECK_NSPACE(nptr->nspace, req->lcd->proc.nspace);
-            rc = _satisfy_request(nptr, rank, &scd, diffnspace, scope,
+        PMIX_LIST_FOREACH_SAFE(req, rnext, &ptr->loc_reqs, pmix_dmdx_request_t) {
+            diffnspace = !PMIX_CHECK_NSPACE(nptr->nspace, req->lcd->proc.nspace);
+            // if the rank is undef, then only ask for the one key - otherwise,
+            // return all keys for that rank. This is an optimization as we
+            // assume if someone asked for one key for a specific rank, they
+            // are likely to ask for more of them
+            if (PMIX_RANK_UNDEF == rank) {
+                key = req->key;
+            } else {
+                key = NULL;
+            }
+           rc = _satisfy_request(nptr, rank, key, &scd, diffnspace, scope,
                                   req->cbfunc, req->cbdata);
             if (PMIX_SUCCESS != rc) {
                 /* if we can't satisfy this particular request (missing key?) */
                 req->cbfunc(rc, NULL, 0, req->cbdata, NULL, NULL);
             }
+            pmix_list_remove_item(&ptr->loc_reqs, &req->super);
+            PMIX_RELEASE(req);
         }
         PMIX_DESTRUCT(&scd);
     }
+}
 
-cleanup:
-    /* remove all requests to this rank and cleanup the corresponding structure */
-    pmix_list_remove_item(&pmix_server_globals.local_reqs, &ptr->super);
-    /* the dmdx request is linked back to its local request for ease
-     * of lookup upon return from the server. However, this means that
-     * the refcount of the local request has been increased by the number
-     * dmdx requests attached to it. In order to release the local request's
-     * storage, we first have to drive the refcount down by releasing all
-     * of the associated dmdx requests */
-    PMIX_LIST_FOREACH_SAFE (req, rnext, &ptr->loc_reqs, pmix_dmdx_request_t) {
-        pmix_list_remove_item(&ptr->loc_reqs, &req->super);
-        PMIX_RELEASE(req); // decrements refcount of ptr
+/* Resolve pending requests to this namespace/rank */
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr,
+                                   pmix_rank_t rank,
+                                   pmix_status_t status,
+                                   pmix_scope_t scope,
+                                   pmix_dmdx_local_t *lcd)
+{
+    pmix_dmdx_local_t *cd, *cdnext;
+    pmix_dmdx_request_t *req, *rnext;
+    pmix_server_caddy_t scd;
+    pmix_status_t rc;
+    bool diffnspace;
+
+    /* find corresponding request (if exists) */
+    if (NULL == lcd) {
+        PMIX_LIST_FOREACH_SAFE(cd, cdnext, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
+            if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->proc.nspace) ) {
+                continue;
+            }
+            if (PMIX_RANK_UNDEF == cd->proc.rank ||
+                rank == cd->proc.rank) {
+                check_req(nptr, cd->proc.rank, status, scope, cd);
+            }
+            if (0 == pmix_list_get_size(&cd->loc_reqs)) {
+                pmix_list_remove_item(&pmix_server_globals.local_reqs, &cd->super);
+                PMIX_RELEASE(cd);
+            }
+        }
+    } else {
+        check_req(nptr, rank, status, scope, lcd);
+        if (0 == pmix_list_get_size(&lcd->loc_reqs)) {
+            pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
+            PMIX_RELEASE(lcd);
+        }
     }
-    PMIX_RELEASE(ptr);
 
     return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -5414,7 +5414,9 @@ static void tdes(pmix_server_trkr_t *t)
     PMIX_LIST_DESTRUCT(&t->grpinfo);
     PMIX_LIST_DESTRUCT(&t->nslist);
 }
-PMIX_CLASS_INSTANCE(pmix_server_trkr_t, pmix_list_item_t, tcon, tdes);
+PMIX_CLASS_INSTANCE(pmix_server_trkr_t,
+                    pmix_list_item_t,
+                    tcon, tdes);
 
 static void cdcon(pmix_server_caddy_t *cd)
 {
@@ -5440,7 +5442,9 @@ static void cddes(pmix_server_caddy_t *cd)
         PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_server_caddy_t, pmix_list_item_t, cdcon, cddes);
+PMIX_CLASS_INSTANCE(pmix_server_caddy_t,
+                    pmix_list_item_t,
+                    cdcon, cddes);
 
 static void scadcon(pmix_setup_caddy_t *p)
 {
@@ -5499,7 +5503,9 @@ static void scaddes(pmix_setup_caddy_t *p)
         free(p->flags.directory);
     }
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t, pmix_object_t, scadcon, scaddes);
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,
+                                pmix_object_t,
+                                scadcon, scaddes);
 
 PMIX_CLASS_INSTANCE(pmix_trkr_caddy_t, pmix_object_t, NULL, NULL);
 
@@ -5513,13 +5519,16 @@ static void dmdes(pmix_dmdx_remote_t *p)
         PMIX_RELEASE(p->cd);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_dmdx_remote_t, pmix_list_item_t, dmcon, dmdes);
+PMIX_CLASS_INSTANCE(pmix_dmdx_remote_t,
+                    pmix_list_item_t,
+                    dmcon, dmdes);
 
 static void dmrqcon(pmix_dmdx_request_t *p)
 {
     memset(&p->ev, 0, sizeof(pmix_event_t));
     p->event_active = false;
     p->lcd = NULL;
+    p->key = NULL;
 }
 static void dmrqdes(pmix_dmdx_request_t *p)
 {
@@ -5529,8 +5538,13 @@ static void dmrqdes(pmix_dmdx_request_t *p)
     if (NULL != p->lcd) {
         PMIX_RELEASE(p->lcd);
     }
+    if (NULL != p->key) {
+        free(p->key);
+    }
 }
-PMIX_CLASS_INSTANCE(pmix_dmdx_request_t, pmix_list_item_t, dmrqcon, dmrqdes);
+PMIX_CLASS_INSTANCE(pmix_dmdx_request_t,
+                    pmix_list_item_t,
+                    dmrqcon, dmrqdes);
 
 static void lmcon(pmix_dmdx_local_t *p)
 {
@@ -5546,7 +5560,9 @@ static void lmdes(pmix_dmdx_local_t *p)
     }
     PMIX_LIST_DESTRUCT(&p->loc_reqs);
 }
-PMIX_CLASS_INSTANCE(pmix_dmdx_local_t, pmix_list_item_t, lmcon, lmdes);
+PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,
+                    pmix_list_item_t,
+                    lmcon, lmdes);
 
 static void prevcon(pmix_peer_events_info_t *p)
 {
@@ -5563,7 +5579,9 @@ static void prevdes(pmix_peer_events_info_t *p)
         PMIX_PROC_FREE(p->affected, p->naffected);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_peer_events_info_t, pmix_list_item_t, prevcon, prevdes);
+PMIX_CLASS_INSTANCE(pmix_peer_events_info_t,
+                    pmix_list_item_t,
+                    prevcon, prevdes);
 
 static void regcon(pmix_regevents_info_t *p)
 {
@@ -5573,7 +5591,9 @@ static void regdes(pmix_regevents_info_t *p)
 {
     PMIX_LIST_DESTRUCT(&p->peers);
 }
-PMIX_CLASS_INSTANCE(pmix_regevents_info_t, pmix_list_item_t, regcon, regdes);
+PMIX_CLASS_INSTANCE(pmix_regevents_info_t,
+                    pmix_list_item_t,
+                    regcon, regdes);
 
 static void ilcon(pmix_inventory_rollup_t *p)
 {
@@ -5595,9 +5615,13 @@ static void ildes(pmix_inventory_rollup_t *p)
     PMIX_DESTRUCT_LOCK(&p->lock);
     PMIX_LIST_DESTRUCT(&p->payload);
 }
-PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t, pmix_object_t, ilcon, ildes);
+PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t,
+                    pmix_object_t,
+                    ilcon, ildes);
 
-PMIX_CLASS_INSTANCE(pmix_group_caddy_t, pmix_list_item_t, NULL, NULL);
+PMIX_CLASS_INSTANCE(pmix_group_caddy_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
 
 static void iocon(pmix_iof_cache_t *p)
 {
@@ -5612,7 +5636,9 @@ static void iodes(pmix_iof_cache_t *p)
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_iof_cache_t, pmix_list_item_t, iocon, iodes);
+PMIX_CLASS_INSTANCE(pmix_iof_cache_t,
+                    pmix_list_item_t,
+                    iocon, iodes);
 
 static void pscon(pmix_pset_t *p)
 {
@@ -5629,4 +5655,6 @@ static void psdes(pmix_pset_t *p)
         free(p->members);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_pset_t, pmix_list_item_t, pscon, psdes);
+PMIX_CLASS_INSTANCE(pmix_pset_t,
+                    pmix_list_item_t,
+                    pscon, psdes);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -124,6 +124,7 @@ typedef struct {
     pmix_event_t ev;
     bool event_active;
     pmix_dmdx_local_t *lcd;
+    char *key;
     pmix_modex_cbfunc_t cbfunc; // cbfunc to be executed when data is available
     void *cbdata;
 } pmix_dmdx_request_t;

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid simpqual simpdist
+                  hybrid simpqual simpdist legacy
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -185,4 +185,10 @@ simpdist_SOURCES = $(headers) \
         simpdist.c
 simpdist_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpdist_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+legacy_SOURCES = $(headers) \
+        legacy.c
+legacy_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+legacy_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <stdio.h>
+#include <pmix.h>
+#include <string.h>
+
+int
+main(int argc, char *argv[])
+{
+pmix_value_t *val = NULL;
+pmix_status_t rc = PMIX_SUCCESS;
+pmix_proc_t global_proc, proc;
+
+rc = PMIx_Init(&global_proc, NULL, 0);
+assert(PMIX_SUCCESS == rc);
+
+rc = PMIx_Get(&global_proc, PMIX_LOCAL_RANK, NULL, 0, &val);
+assert(PMIX_SUCCESS == rc);
+
+int local_rank = val->data.uint16;
+PMIX_VALUE_RELEASE(val);
+
+char key_p[32];
+pmix_value_t value_p;
+
+sprintf(key_p, "%s-%d", "foo", local_rank);
+value_p.type = PMIX_UINT32;
+value_p.data.uint32 = local_rank + 10;
+
+rc = PMIx_Put(PMIX_GLOBAL, key_p, &value_p);
+assert(PMIX_SUCCESS == rc);
+
+if (1 == global_proc.rank) {
+    sleep(1);
+}
+rc = PMIx_Commit();
+assert(PMIX_SUCCESS == rc);
+
+PMIX_PROC_CONSTRUCT(&proc);
+proc.rank = PMIX_RANK_UNDEF;
+strcpy(proc.nspace, global_proc.nspace);
+
+for (int i = 0; i < 2; i++) {
+    char key_g[32];
+    pmix_value_t *value_g;
+
+    sprintf(key_g, "%s-%d", "foo", i);
+    rc = PMIx_Get(&proc, key_g, NULL, 0, &value_g);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Rank %u: PMIx_Get got %d\n", global_proc.rank, rc);
+    } else {
+    fprintf(stderr, "Rank %u: Got %d\n", global_proc.rank, value_g->data.uint32);
+    }
+}
+
+PMIx_Finalize(NULL, 0);
+
+return 0;
+
+}


### PR DESCRIPTION
When caching get requests at the server level, we need to track what key they were asking about. When a proc later commits data, check outstanding requests to see if it arrived - this includes a check of any request for rank=PMIX_RANK_UNDEF since it could be a global key that was committed.