### PR TITLE
PMIx_Query_info: removed duplicated PMIX_RELEASE

### DIFF
--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -542,7 +542,6 @@ complete:
             }
             cd->queries = NULL;
             cd->nqueries = 0;
-            PMIX_RELEASE(cd);
         }
         return;
     }


### PR DESCRIPTION
there was a path through pmix_parse_localquery that ended up doing a PMIX_RELEASE on the caddy, but soon thereafter it was re-relesed in PMIx_Query_info, causing a

PMIx_Query_info: Assertion `PMIX_OBJ_MAGIC_ID == _obj->obj_magic_id' failed.

for this case.

Related to https://github.com/open-mpi/ompi/pull/12217 Related to https://github.com/open-mpi/ompi/pull/10886

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 4baeb9f0a11f9aa272a998bf8c97c0ba795c9dd4)