### PR TITLE
Restore default to enable-devel-check in Git repos

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -192,23 +192,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     fi
     AC_SUBST(PMIX_RELEASE_DATE)
 
-    # Debug mode?
-    AC_MSG_CHECKING([if want pmix maintainer support])
-    pmix_debug=
-    AS_IF([test "$pmix_debug" = "" && test "$enable_debug" = "yes"],
-          [pmix_debug=1
-           pmix_debug_msg="enabled"])
-    AS_IF([test "$pmix_debug" = ""],
-          [pmix_debug=0
-           pmix_debug_msg="disabled"])
-    # Grr; we use #ifndef for PMIX_DEBUG!  :-(
-    AH_TEMPLATE(PMIX_ENABLE_DEBUG, [Whether we are in debugging mode or not])
-    AS_IF([test "$pmix_debug" = "1"], [AC_DEFINE([PMIX_ENABLE_DEBUG])])
-    AC_MSG_RESULT([$pmix_debug_msg])
-
-    AC_MSG_CHECKING([for pmix directory prefix])
-    AC_MSG_RESULT(m4_ifval([$1], pmix_config_prefix, [(none)]))
-
     # Note that private/config.h *MUST* be listed first so that it
     # becomes the "main" config header file.  Any AC-CONFIG-HEADERS
     # after that (pmix/config.h) will only have selective #defines
@@ -1065,6 +1048,20 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
 # Check the OS flavor here
 #
 OAC_CHECK_OS_FLAVORS
+
+# Debug mode?
+AC_MSG_CHECKING([if want pmix maintainer support])
+pmix_debug=0
+pmix_debug_msg="disabled"
+AS_IF([test "$enable_debug" = "yes"],
+      [pmix_debug=1
+       pmix_debug_msg="enabled"])
+# Grr; we use #ifndef for PMIX_DEBUG!  :-(
+AH_TEMPLATE(PMIX_ENABLE_DEBUG, [Whether we are in debugging mode or not])
+AS_IF([test "$pmix_debug" = "1"], [AC_DEFINE([PMIX_ENABLE_DEBUG])])
+AC_MSG_RESULT([$pmix_debug_msg])
+AC_MSG_CHECKING([for pmix directory prefix])
+AC_MSG_RESULT(m4_ifval([$1], pmix_config_prefix, [(none)]))
 
 #
 # Developer picky compiler options

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -1,7 +1,11 @@
+#include "src/include/pmix_config.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <pmix.h>
 #include <string.h>
+
+#include "src/include/pmix_globals.h"
 
 int
 main(int argc, char *argv[])
@@ -9,6 +13,7 @@ main(int argc, char *argv[])
 pmix_value_t *val = NULL;
 pmix_status_t rc = PMIX_SUCCESS;
 pmix_proc_t global_proc, proc;
+PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
 rc = PMIx_Init(&global_proc, NULL, 0);
 assert(PMIX_SUCCESS == rc);


### PR DESCRIPTION
Don't know how it happened, but let's restore the default to enable-devel-check when building in Git clones. Protect some unused params in a test program.