### PR TITLE
Protect against empty envar definition for mca_base_param_files

### DIFF
--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -359,7 +359,8 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     }
 
     /* Disable reading MCA parameter files. */
-    if (0 == strcmp(pmix_mca_base_var_files, "none")) {
+    if (NULL == pmix_mca_base_var_files ||
+        0 == strcmp(pmix_mca_base_var_files, "none")) {
         return PMIX_SUCCESS;
     }
 
@@ -1058,9 +1059,14 @@ static int fixup_files(char **file_list, char *path, bool rel_path_search, char 
 
 static int read_files(char *file_list, pmix_list_t *file_values, char sep)
 {
-    char **tmp = PMIx_Argv_split(file_list, sep);
+    char **tmp;
     int i, count, rc;
 
+    if (NULL == file_list) {
+        return PMIX_SUCCESS;
+    }
+
+    tmp = PMIx_Argv_split(file_list, sep);
     if (!tmp) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }


### PR DESCRIPTION
If someone defines the PMIX_MCA_mca_base_param_files or the PMIX_MCA_mca_base_override_param_file envar as NULL (i.e., they specify the envar "name=" with no value), then the envar will be found but have a NULL value. Current code doesn't protect against that contingency, so fix it.