### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -192,23 +192,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     fi
     AC_SUBST(PMIX_RELEASE_DATE)
 
-    # Debug mode?
-    AC_MSG_CHECKING([if want pmix maintainer support])
-    pmix_debug=
-    AS_IF([test "$pmix_debug" = "" && test "$enable_debug" = "yes"],
-          [pmix_debug=1
-           pmix_debug_msg="enabled"])
-    AS_IF([test "$pmix_debug" = ""],
-          [pmix_debug=0
-           pmix_debug_msg="disabled"])
-    # Grr; we use #ifndef for PMIX_DEBUG!  :-(
-    AH_TEMPLATE(PMIX_ENABLE_DEBUG, [Whether we are in debugging mode or not])
-    AS_IF([test "$pmix_debug" = "1"], [AC_DEFINE([PMIX_ENABLE_DEBUG])])
-    AC_MSG_RESULT([$pmix_debug_msg])
-
-    AC_MSG_CHECKING([for pmix directory prefix])
-    AC_MSG_RESULT(m4_ifval([$1], pmix_config_prefix, [(none)]))
-
     # Note that private/config.h *MUST* be listed first so that it
     # becomes the "main" config header file.  Any AC-CONFIG-HEADERS
     # after that (pmix/config.h) will only have selective #defines
@@ -1060,6 +1043,20 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
 # Check the OS flavor here
 #
 PMIX_CHECK_OS_FLAVORS
+
+# Debug mode?
+AC_MSG_CHECKING([if want pmix maintainer support])
+pmix_debug=0
+pmix_debug_msg="disabled"
+AS_IF([test "$enable_debug" = "yes"],
+      [pmix_debug=1
+       pmix_debug_msg="enabled"])
+# Grr; we use #ifndef for PMIX_DEBUG!  :-(
+AH_TEMPLATE(PMIX_ENABLE_DEBUG, [Whether we are in debugging mode or not])
+AS_IF([test "$pmix_debug" = "1"], [AC_DEFINE([PMIX_ENABLE_DEBUG])])
+AC_MSG_RESULT([$pmix_debug_msg])
+AC_MSG_CHECKING([for pmix directory prefix])
+AC_MSG_RESULT(m4_ifval([$1], pmix_config_prefix, [(none)]))
 
 #
 # Developer picky compiler options

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -34,6 +34,9 @@ value_p.data.uint32 = local_rank + 10;
 rc = PMIx_Put(PMIX_GLOBAL, key_p, &value_p);
 assert(PMIX_SUCCESS == rc);
 
+if (1 == global_proc.rank) {
+    sleep(1);
+}
 rc = PMIx_Commit();
 assert(PMIX_SUCCESS == rc);
 
@@ -48,9 +51,9 @@ for (int i = 0; i < 2; i++) {
     sprintf(key_g, "%s-%d", "foo", i);
     rc = PMIx_Get(&proc, key_g, NULL, 0, &value_g);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "PMIx_Get got %d\n", rc);
+        fprintf(stderr, "Rank %u: PMIx_Get got %d\n", global_proc.rank, rc);
     } else {
-    fprintf(stderr, "Got %d\n", value_g->data.uint32);
+    fprintf(stderr, "Rank %u: Got %d\n", global_proc.rank, value_g->data.uint32);
     }
 }
 

--- a/test/simple/legacy.c
+++ b/test/simple/legacy.c
@@ -1,7 +1,11 @@
+#include "src/include/pmix_config.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <pmix.h>
 #include <string.h>
+
+#include "src/include/pmix_globals.h"
 
 int
 main(int argc, char *argv[])
@@ -9,6 +13,7 @@ main(int argc, char *argv[])
 pmix_value_t *val = NULL;
 pmix_status_t rc = PMIX_SUCCESS;
 pmix_proc_t global_proc, proc;
+PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
 rc = PMIx_Init(&global_proc, NULL, 0);
 assert(PMIX_SUCCESS == rc);


### PR DESCRIPTION
[Restore default to enable-devel-check in Git repos](https://github.com/openpmix/openpmix/pull/3274/commits/8a20fee61a5cd256f9aeb3c84db215680901478f)
[8a20fee](https://github.com/openpmix/openpmix/pull/3274/commits/8a20fee61a5cd256f9aeb3c84db215680901478f)

Don't know how it happened, but let's restore the default
to enable-devel-check when building in Git clones. Protect
some unused params in a test program.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/openpmix/commit/a62ddbfbc51ddd54d67e8b97c366c01129506321)

[Protect against empty envar definition for mca_base_param_files](https://github.com/openpmix/openpmix/pull/3274/commits/0e26aeacf24bbeb4fe210c9fb73efe9e05983627)
[0e26aea](https://github.com/openpmix/openpmix/pull/3274/commits/0e26aeacf24bbeb4fe210c9fb73efe9e05983627)

If someone defines the PMIX_MCA_mca_base_param_files or the
PMIX_MCA_mca_base_override_param_file envar as NULL (i.e., they
specify the envar "name=" with no value), then the envar will
be found but have a NULL value. Current code doesn't protect
against that contingency, so fix it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/openpmix/commit/1e614aba6e312834e357b5e858bbd4217fa7ecb4)
