### PR TITLE
Multiple commits

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ man_pages = list()
 for root, dirs, files in os.walk("man"):
     for filename in files:
         # Parse filenames of the format a "foo.X.rst"
-        parts = re.search("^([^/]+?)\.([0-9]+)\.rst$", filename)
+        parts = re.search(r"^([^/]+?).([0-9]+).rst$", filename)
 
         # Skip files that do not match that format (e.g.,
         # "index.rst")

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -367,7 +368,10 @@ int main(int argc, char **argv)
     /* we have a single namespace for all clients */
     atmp = NULL;
     for (n = 0; n < nprocs; n++) {
-        asprintf(&tmp, "%d", n);
+        if (0 > asprintf(&tmp, "%d", n)) {
+            errno = ENOMEM;
+            abort();
+        }
         PMIx_Argv_append_nosize(&atmp, tmp);
         free(tmp);
     }

--- a/test/simple/quietclient.c
+++ b/test/simple/quietclient.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -179,7 +180,10 @@ int main(int argc, char **argv)
     PMIX_VALUE_RELEASE(val);
 
     /* put a few values */
-    (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -210,7 +214,10 @@ int main(int argc, char **argv)
     PMIx_Argv_free(peers);
 
     for (cnt = 0; cnt < MAXCNT; cnt++) {
-        (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, myproc.rank, cnt);
+        if (0 > asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, myproc.rank, cnt)) {
+            errno = ENOMEM;
+            abort();
+        }
         value.type = PMIX_UINT64;
         value.data.uint64 = 1234;
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
@@ -219,7 +226,10 @@ int main(int argc, char **argv)
             goto done;
         }
 
-        (void) asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt);
+        if (0 > asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt)) {
+            errno = ENOMEM;
+            abort();
+        }
         value.type = PMIX_STRING;
         value.data.string = "1234";
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
@@ -262,7 +272,10 @@ int main(int argc, char **argv)
                     }
                 }
                 if (local) {
-                    (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j);
+                    if (0 > asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j)) {
+                        errno = ENOMEM;
+                        abort();
+                    }
                     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
                                     myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
@@ -295,7 +308,10 @@ int main(int argc, char **argv)
                     /* now check that we don't get data for a remote proc - note that we
                      * always can get our own remote data as we published it */
                     if (proc.rank != myproc.rank) {
-                        (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
+                        if (0 > asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j)) {
+                            errno = ENOMEM;
+                            abort();
+                        }
                         if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                             /* this data should _not_ be found as we are on the same node
                              * and the data was "put" with a PMIX_REMOTE scope */
@@ -308,7 +324,10 @@ int main(int argc, char **argv)
                         free(tmp);
                     }
                 } else {
-                    (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
+                    if (0 > asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j)) {
+                        errno = ENOMEM;
+                        abort();
+                    }
                     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                         pmix_output(
                             0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed for remote proc",

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
- * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2023-2024 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -206,7 +206,10 @@ int main(int argc, char **argv)
     PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, NULL, NULL);
 
     /* put a few values */
-    (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -239,7 +242,10 @@ int main(int argc, char **argv)
 
     for (cnt = 0; cnt < MAXCNT; cnt++) {
         pmix_output(0, "Client %s:%d executing loop %d", myproc.nspace, myproc.rank, cnt);
-        (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, myproc.rank, cnt);
+        if (0 > asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, myproc.rank, cnt)) {
+            errno = ENOMEM;
+            abort();
+        }
         value.type = PMIX_UINT64;
         value.data.uint64 = 1234;
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
@@ -249,7 +255,10 @@ int main(int argc, char **argv)
         }
         free(tmp);
 
-        (void) asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt);
+        if (0 > asprintf(&tmp, "%s-%d-remote-%d", myproc.nspace, myproc.rank, cnt)) {
+            errno = ENOMEM;
+            abort();
+        }
         value.type = PMIX_STRING;
         value.data.string = "1234";
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
@@ -293,7 +302,10 @@ int main(int argc, char **argv)
                     }
                 }
                 if (local) {
-                    (void) asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j);
+                    if (0 > asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j)) {
+                        errno = ENOMEM;
+                        abort();
+                    }
                     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
                                     myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
@@ -328,7 +340,10 @@ int main(int argc, char **argv)
                     /* now check that we don't get data for a remote proc - note that we
                      * always can get our own remote data as we published it */
                     if (proc.rank != myproc.rank) {
-                        (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
+                        if (0 > asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j)) {
+                            errno = ENOMEM;
+                            abort();
+                        }
                         if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                             /* this data should _not_ be found as we are on the same node
                              * and the data was "put" with a PMIX_REMOTE scope */
@@ -349,7 +364,10 @@ int main(int argc, char **argv)
                     }
                 } else {
                     val = NULL;
-                    (void) asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
+                    if (0 > asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j)) {
+                        errno = ENOMEM;
+                        abort();
+                    }
                     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
                         pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct",
                                     myproc.nspace, myproc.rank, j, tmp);

--- a/test/simple/simpcoord.c
+++ b/test/simple/simpcoord.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -127,7 +128,10 @@ nextstep:
             char **foo = NULL;
             char *view;
             for (n = 0; n < coords[m].dims; n++) {
-                asprintf(&tmp, "%d", coords[m].coord[n]);
+                if (0 > asprintf(&tmp, "%d", coords[m].coord[n])) {
+                    errno = ENOMEM;
+                    abort();
+                }
                 PMIx_Argv_append_nosize(&foo, tmp);
                 free(tmp);
             }
@@ -146,7 +150,10 @@ nextstep:
         char **foo = NULL;
         char *view;
         for (n = 0; n < val->data.coord->dims; n++) {
-            asprintf(&tmp, "%d", val->data.coord->coord[n]);
+            if (0 > asprintf(&tmp, "%d", val->data.coord->coord[n])) {
+                errno = ENOMEM;
+                abort();
+            }
             PMIx_Argv_append_nosize(&foo, tmp);
             free(tmp);
         }

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -17,7 +17,8 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,7 +143,10 @@ int main(int argc, char **argv)
     PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, NULL, NULL);
 
     /* put a few values */
-    (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -181,7 +182,10 @@ int main(int argc, char **argv)
     ++msgnum;
 
     /* put a few values */
-    (void) asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -191,7 +195,10 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    (void) asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
@@ -201,7 +208,10 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    (void) asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank)) {
+        errno = ENOMEM;
+        abort();
+    }
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, tmp, &value))) {
@@ -279,7 +289,10 @@ int main(int argc, char **argv)
             }
         }
         if (local) {
-            (void) asprintf(&tmp, "%s-%d-local", myproc.nspace, n);
+            if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, n)) {
+                errno = ENOMEM;
+                abort();
+            }
             pmix_output(0, "Rank %u[msg=%d]: retrieving %s from local proc %u", myproc.rank, msgnum, tmp, n);
             ++msgnum;
             proc.rank = n;
@@ -291,7 +304,10 @@ int main(int argc, char **argv)
             }
             ++num_gets;
         } else {
-            (void) asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
+            if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, n)) {
+                errno = ENOMEM;
+                abort();
+            }
             pmix_output(0, "Rank %u[msg=%d]: retrieving %s from remote proc %u", myproc.rank, msgnum, tmp, n);
             if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, iptr, ninfo, valcbfunc, tmp))) {
                 pmix_output(0, "Rank %d[msg=%d]: PMIx_Get %s failed: %d", myproc.rank, msgnum, tmp, rc);

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2023-2024 Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -665,7 +665,10 @@ static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myx
     iptr[3].value.type = PMIX_DATA_ARRAY;
     PMIX_DATA_ARRAY_CREATE(iptr[3].value.data.darray, 2, PMIX_INFO);
     ip = (pmix_info_t *) iptr[3].value.data.darray->array;
-    asprintf(&rks, "%s.net", nspace);
+    if (0 > asprintf(&rks, "%s.net", nspace)) {
+        errno = ENOMEM;
+        abort();
+    }
     PMIX_INFO_LOAD(&ip[0], PMIX_ALLOC_FABRIC_ID, rks, PMIX_STRING);
     free(rks);
     PMIX_INFO_LOAD(&ip[1], PMIX_ALLOC_FABRIC_SEC_KEY, NULL, PMIX_BOOL);

--- a/test/simple/stability.c
+++ b/test/simple/stability.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -350,13 +351,19 @@ int main(int argc, char **argv)
         /* we have a single namespace for all clients */
         atmp = NULL;
         for (n = 0; n < nprocs; n++) {
-            asprintf(&tmp, "%d", n);
+            if (0 > asprintf(&tmp, "%d", n)) {
+                errno = ENOMEM;
+                abort();
+            }
             PMIx_Argv_append_nosize(&atmp, tmp);
             free(tmp);
         }
         tmp = PMIx_Argv_join(atmp, ',');
         PMIx_Argv_free(atmp);
-        asprintf(&nspace, "foobar%d", m);
+        if (0 > asprintf(&nspace, "foobar%d", m)) {
+            errno = ENOMEM;
+            abort();
+        }
         pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
         x = PMIX_NEW(myxfer_t);
         set_namespace(nprocs, tmp, nspace, opcbfunc, x);
@@ -526,7 +533,10 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
     iptr[3].value.type = PMIX_DATA_ARRAY;
     PMIX_DATA_ARRAY_CREATE(iptr[3].value.data.darray, 2, PMIX_INFO);
     ip = (pmix_info_t *) iptr[3].value.data.darray->array;
-    asprintf(&rks, "%s.net", nspace);
+    if (0 > asprintf(&rks, "%s.net", nspace)) {
+        errno = ENOMEM;
+        abort();
+    }
     PMIX_INFO_LOAD(&ip[0], PMIX_ALLOC_NETWORK_ID, rks, PMIX_STRING);
     free(rks);
     PMIX_INFO_LOAD(&ip[1], PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);


### PR DESCRIPTION
[Fix test builds with picky compiler options.](https://github.com/openpmix/openpmix/commit/d79d5b05f33de1b99f541f0446ff7b31b375d563)

Newer compilers don't accept the void cast of asprintf's return value,
so address those sites in test code.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/165cb3d56e673252d5a6bddf01b81e6c192c245c)

[Update the Python regex for doc build](https://github.com/openpmix/openpmix/commit/1839af8fd8fce886adc520b6dbce0a8ae7225391)

Python no longer accepts escape sequences in the
regex - need to use raw strings.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/449a8b6c62ca713a4496648b6ad9fd8fcdf4618b)
