### PR TITLE
Add scheduler integration "how-things-work" docs and few attributes

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -41,6 +41,7 @@ RST_SOURCE_FILES   = \
         $(srcdir)/building-apps/*.rst \
         $(srcdir)/developers/*.rst \
         $(srcdir)/how-things-work/*.rst \
+        $(srcdir)/how-things-work/schedulers/*.rst \
         $(srcdir)/installing-pmix/*.rst \
         $(srcdir)/installing-pmix/configure-cli-options/*.rst \
         $(srcdir)/man/*.rst \

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -11,3 +11,4 @@ find information on that subject here.
 
    session_dirs.rst
    distances.rst
+   schedulers/index.rst

--- a/docs/how-things-work/schedulers/index.rst
+++ b/docs/how-things-work/schedulers/index.rst
@@ -1,0 +1,12 @@
+
+Scheduler Integration
+=====================
+
+This section describes PMIx support for interactions
+between schedulers and their runtimes, applications,
+and tools. 
+
+.. toctree::
+   :maxdepth: 2
+
+   overview.rst

--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -1,0 +1,23 @@
+Overview
+========
+
+Describe general layout for operation. Tools and apps can potentially
+communicate directly to the scheduler, passing requests and getting
+responses. Or, more commonly, they can communicate such requests to
+their local runtime environment (RTE), which can then act as a relay
+between the requestor and the scheduler.
+
+In addition, the RTE itself can use its connection to the scheduler
+for coordinating their interactions. For example, the scheduler may
+use PMIx to inform the RTE of a new session it should instantiate.
+Likewise, the RTE can use PMIx to inform the scheduler that a session
+has terminated and thus all its resources are available for reuse.
+
+While the PMIx scheduler integration support can be used for the
+more common operations (e.g., submitting allocation requests,
+RTE-scheduler coordination), the primary intent of the support is
+to enable dynamic environments - i.e., the ability for an application
+to request on-the-fly modifications of its session. 
+
+Support is provided via a few APIs, attributes, and events.
+

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -549,6 +549,9 @@ typedef uint32_t pmix_rank_t;
                                                                     //        separately. If false, then the final exit status reported will be
                                                                     //        zero if the primary job and all spawned jobs exit normally, or the
                                                                     //        first non-zero status returned by either primary or child jobs.
+#define PMIX_SPAWN_CHILD_SEP                "pmix.spchildsep"       // (bool) Treat the spawned job as independent from the parent - i.e, do not
+                                                                    //        terminate the spawned job if the parent terminates.
+
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */
@@ -924,6 +927,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //         of the MAU so the information can be passed along. Alternatively,
                                                                     //         a host can pass the information into its PMIx server. Array consists
                                                                     //         of pmix_resource_unit_t structs.
+#define PMIX_ALLOC_CHILD_SEP                "pmix.alloc.sep"        // (bool) Treat the resulting allocation as independent from its parent - i.e.,
+                                                                    //        do not terminate the allocation upon termination of the parent.
 
 
 /* job control attributes */
@@ -958,6 +963,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CLEANUP_LEAVE_TOPDIR           "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove
                                                                     //        the top-level directory (the one given in the
                                                                     //        cleanup request)
+#define PMIX_JOB_CTRL_SEP                   "pmix.jctrl.sep"        // (bool) Separate the specified nspace from its parent - i.e., allow
+                                                                    //        the two to independently terminate.
+
+
 /* session control attributes */
 #define PMIX_SESSION_CTRL_ID                "pmix.ssnctrl.id"       // (char*) provide a string identifier for this request
 
@@ -992,6 +1001,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        all their resources. If no PMIX_NSPACE is specified, then restore
                                                                     //        all jobs in the session.
 #define PMIX_SESSION_SIGNAL                 "pmix.ssn.sig"          // (int) send given signal to all processes of every job in the session
+#define PMIX_SESSION_SEP                    "pmix.ssn.sep"          // (bool) Separate the specified session from its parent - i.e., allow
+                                                                    //        the two to independently terminate.
 
 /* session operational attributes - called by RTE */
 #define PMIX_SESSION_COMPLETE               "pmix.ssn.complete"     // (bool) specified session has completed, all resources have been


### PR DESCRIPTION
Add new docs explaining how PMIx handles scheduler integration - still a work-in-progress. Add a few attributes indicating that an allocation and/or job is to be independent of its parent.