### PR TITLE
Protect output files during cleanup

### DIFF
--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -177,7 +177,7 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
                 continue;
             }
         }
- 
+
         /* Create a pathname.  This is not always needed, but it makes
          * for cleaner code just to create it here.  Note that we are
          * allocating memory here, so we need to free it later on.


### PR DESCRIPTION
We protect any file in the session directory tree
whose name starts with "output-" so as to preserve diagnostic output.