### PR TITLE
Restore support for HWLOC truly ancient

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -350,9 +350,9 @@ tryxml:
         return rc;
     }
 
+tryv1:
 #endif
 
-tryv1:
     /* try to get the v1 XML string */
     pmix_output_verbose(2, pmix_hwloc_output,
                         "%s:%s checking v1 xml",
@@ -733,7 +733,7 @@ pmix_status_t pmix_hwloc_parse_cpuset_string(const char *cpuset_string, pmix_cpu
 {
     char *src;
     int hrc;
-    
+
     /* if we aren't the source, then pass */
     src = strchr(cpuset_string, ':');
     if (NULL == src) {
@@ -1404,13 +1404,18 @@ static int set_flags(hwloc_topology_t topo, unsigned int flags)
     if (0 != hwloc_topology_set_flags(topo, flags)) {
         return PMIX_ERR_INIT;
     }
+#ifdef HWLOC_VERSION_MAJOR
     // Blacklist the "gl" component due to potential conflicts.
     // See "https://github.com/open-mpi/ompi/issues/10025" for
-    // an explanation
+    // an explanation. Sadly, HWLOC doesn't define version numbers
+    // until v2.0, so we cannot check versions here. Fortunately,
+    // the blacklist ability was added in HWLOC v2.1, so we can't
+    // do it for earlier versions anyway.
 #if HWLOC_VERSION_MAJOR > 2
     hwloc_topology_set_components(topo, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
 #elif HWLOC_VERSION_MAJOR == 2 && HWLOC_VERSION_MINOR >= 1
     hwloc_topology_set_components(topo, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#endif
 #endif
 
     return PMIX_SUCCESS;

--- a/test/simple/simpdist.c
+++ b/test/simple/simpdist.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,22 +85,7 @@ static void output_usage(void)
 
 static hwloc_obj_type_t convert_type(const char *name, char **strname)
 {
-    if (0 == strncasecmp(name, "L3", 2)) {
-        if (NULL != strname) {
-            *strname = "L3CACHE";
-        }
-        return HWLOC_OBJ_L3CACHE;
-    } else if (0 == strncasecmp(name, "L2", 2)) {
-        if (NULL != strname) {
-            *strname = "L2CACHE";
-        }
-        return HWLOC_OBJ_L2CACHE;
-    } else if (0 == strncasecmp(name, "L1", 2)) {
-        if (NULL != strname) {
-            *strname = "L1CACHE";
-        }
-        return HWLOC_OBJ_L1CACHE;
-    } else if (0 == strncasecmp(name, "C", 1)) {
+    if (0 == strncasecmp(name, "C", 1)) {
         if (NULL != strname) {
             *strname = "CORE";
         }
@@ -121,6 +106,31 @@ static hwloc_obj_type_t convert_type(const char *name, char **strname)
             *strname = "PACKAGE";
         }
         return HWLOC_OBJ_PACKAGE;
+#if HWLOC_API_VERSION >= 0x20000
+    } else if (0 == strncasecmp(name, "L3", 2)) {
+        if (NULL != strname) {
+            *strname = "L3CACHE";
+        }
+        return HWLOC_OBJ_L3CACHE;
+    } else if (0 == strncasecmp(name, "L2", 2)) {
+        if (NULL != strname) {
+            *strname = "L2CACHE";
+        }
+        return HWLOC_OBJ_L2CACHE;
+    } else if (0 == strncasecmp(name, "L1", 2)) {
+        if (NULL != strname) {
+            *strname = "L1CACHE";
+        }
+        return HWLOC_OBJ_L1CACHE;
+#else
+    } else if (0 == strncasecmp(name, "L3", 2) ||
+               0 == strncasecmp(name, "L2", 2) ||
+               0 == strncasecmp(name, "L1", 2)) {
+        if (NULL != strname) {
+            *strname = "CACHE";
+        }
+        return HWLOC_OBJ_CACHE;
+#endif
     } else {
         fprintf(stderr, "UNRECOGNIZED HWLOC TYPE: %s\n", name);
         return HWLOC_OBJ_TYPE_MAX;


### PR DESCRIPTION
Ancient HWLOC does not provide version information, so we have to protect some areas against missing definitions.