### PR TITLE
Fix the dictionary transfer in shmem2

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -15,7 +15,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -104,6 +104,38 @@ typedef struct {
     pmix_data_type_t type;
     char **description;
 } pmix_regattr_input_t;
+#define PMIX_REGATTR_INPUT_NEW(a, i, n, s, t, d)                            \
+do {                                                                        \
+    (a) = (pmix_regattr_input_t*)pmix_malloc(sizeof(pmix_regattr_input_t)); \
+    if (NULL != (a)) {                                                      \
+        memset((a), 0, sizeof(pmix_regattr_input_t));                       \
+        (a)->index = (i);                                                   \
+        if (NULL != (n)) {                                                    \
+            (a)->name = strdup((n));                                       \
+        }                                                                   \
+        if (NULL != (s)) {                                                    \
+            (a)->string = strdup((s));                                        \
+        }                                                                   \
+        (a)->type = (t);                                                    \
+        if (NULL != (d)) {                                                    \
+            (a)->description = PMIx_Argv_copy((d));                           \
+        }                                                                   \
+    }                                                                       \
+} while(0)
+#define PMIX_REGATTR_INPUT_FREE(a)      \
+do {                                    \
+    if (NULL != (a)) {                  \
+        if (NULL != (a)->name) {        \
+            free((a)->name);            \
+        }                               \
+        if (NULL != (a)->string)        \
+            free((a)->string);          \
+        }                               \
+        if (NULL != (a)->description) { \
+            free((a)->description);     \
+        }                               \
+    }                                   \
+} while(0)
 
 /* define a struct for holding entries in the
  * dictionary of event strings */

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -686,21 +686,7 @@ pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
             /* they have to give us something! */
             return NULL;
         }
-        if (PMIX_CHECK_RESERVED_KEY(key)) {
-            /* reserved keys are in the front of the table */
-            for (id = 0; id < PMIX_INDEX_BOUNDARY; id++) {
-                ptr = pmix_pointer_array_get_item(keyindex->table, id);
-                if (NULL != ptr) {
-                    if (0 == strcmp(key, ptr->string)) {
-                        return ptr;
-                    }
-                }
-            }
-            /* reserved keys must already have been registered */
-            return NULL;
-        }
-        /* unreserved keys are at the back of the table */
-        for (id = PMIX_INDEX_BOUNDARY; id < keyindex->table->size; id++) {
+        for (id = 0; id < keyindex->table->size; id++) {
             ptr = pmix_pointer_array_get_item(keyindex->table, id);
             if (NULL != ptr) {
                 if (0 == strcmp(key, ptr->string)) {
@@ -708,6 +694,7 @@ pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
                 }
             }
         }
+
         /* we didn't find it - register it */
         ptr = (pmix_regattr_input_t*)pmix_malloc(sizeof(pmix_regattr_input_t));
         ptr->name = strdup(key);


### PR DESCRIPTION
We can _never_ assume that the indices in our dictionary match the ones in the server's dictionary. Even if the number of entries is the same, there is no guarantee that they are in the same order - and thus, the index of a particular entry can be different, causing errors on our side. Likewise, even if we have more entries than they do, there is no guarantee that their entries are in the same order as ours. So we have to rebuild the dictionary to match what they have - and if we have additional entries, then we add them back at the end of the new dictionary.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 6163f2127e6058815998bc934be63a69cb87383e)