### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,65 @@
+# The idea behind this Action is to prevent the situation where a user
+# files a Github Issue, someone asks for clarification / more
+# information, but the original poster never provides the information.
+# The issue then becomes forgotten and abondoned.
+#
+# Instead of that scenario, PMIx community members can assign a
+# label to Github Issues indicating that we're waiting for the user to
+# reply.  If too much time elapses with no reply, mark the Issue as
+# stale and emit a warning that we'll close the issue if we continue
+# to receive no reply.  If we timeout again with no reply after the
+# warning, close the Issue and emit a comment explaining why.
+#
+# If the user *does* reply, the label is removed, and this bot won't
+# touch the Issue.  Specifically: this bot will never mark stale /
+# close an Issue that doesn't have the specified label.
+#
+# Additionally, we are *only* marking stale / auto-closing Github
+# Issues -- not Pull Requests.
+#
+# This is a cron-based Action that runs a few times a day, just so
+# that we don't mark stale / close a bunch of issues all at once.
+#
+# While the actions/stale bot Action used here is capable of removing
+# the label when a user replies to the Issue, we actually use a 2nd
+# Action (removing-awaiting-user-info-label.yaml) to remove the label.
+# We do this because that 2nd Action runs whenever a comment is
+# created -- not via cron.  Hence, the 2nd Action will remove the
+# label effectively immediately when the user replies (vs. up to
+# several hours later).
+
+name: Close stale issues
+on:
+  schedule:
+    # Run it a few times a day so as not to necessarily mark stale /
+    # close a bunch of issues at once.
+    - cron: '0 1,5,9,13,17,21 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/close-stale-issues
+      - uses: actions/stale@v9
+        with:
+          # If there are no replies for 14 days, mark the issue as
+          # "stale" (and emit a warning).
+          days-before-stale: 14
+          # If there are no replies for 14 days after becoming stale,
+          # then close the issue (and emit a message explaining why).
+          days-before-close: 14
+
+          # Never close PRs
+          days-before-pr-close: -1
+
+          # We only close issues with this label
+          only-labels: "Awaiting response"
+          close-issue-label: Closed due to no reply
+
+          # Messages that we put in comments on issues
+          stale-issue-message: |
+            It looks like this issue is expecting a response, but hasn't gotten one yet.  If there are no responses in the next 2 weeks, we'll assume that the issue has been abandoned and will close it.
+          close-issue-message: |
+            Per the above comment, it has been a month with no reply on this issue.  It looks like this issue has been abandoned.
+
+            I'm going to close this issue.  If I'm wrong and this issue is *not* abandoned, please feel free to re-open it.  Thank you!

--- a/.github/workflows/remove-awaiting-user-info-label.yaml
+++ b/.github/workflows/remove-awaiting-user-info-label.yaml
@@ -1,0 +1,30 @@
+# This Action is run in conjunction with close-stale-issues.yaml.  See
+# that file for a more complete description of how they work together.
+
+name: 'Remove "Awaiting response" label when there has been a reply'
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # From
+    # https://github.com/marketplace/actions/close-issues-after-no-reply:
+    # only remove the label if someone replies to an issue who is not
+    # an owner or collaborator on the repo.
+    if: |
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    steps:
+      - name: 'Remove "Awaiting response" label'
+        uses: octokit/request-action@v2.x
+        continue-on-error: true
+        with:
+          route: DELETE /repos/:repository/issues/:issue/labels/:label
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          label: "Awaiting response"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -725,7 +725,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CHECK_FUNCS([pthread_setaffinity_np])
 
     # Setup HTML and man page processing
-    OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [])
+    OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [],
+                     [$srcdir/docs/requirements.txt])
 
     AS_IF([test -n "$OAC_MAKEDIST_DISABLE"],
           [AS_IF([test -n "$PMIX_MAKEDIST_DISABLE"],

--- a/src/mca/gds/shmem2/gds_shmem2_utils.h
+++ b/src/mca/gds/shmem2/gds_shmem2_utils.h
@@ -19,38 +19,38 @@
 
 #include "gds_shmem2.h"
 
-#define PMIX_GDS_SHMEM2_OUT(...)                                                \
+#define PMIX_GDS_SHMEM2_OUT(...)                                               \
 do {                                                                           \
-    pmix_output(0, "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);                \
+    pmix_output(0, "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);               \
 } while (0)
 
-#define PMIX_GDS_SHMEM2_VOUT(...)                                               \
+#define PMIX_GDS_SHMEM2_VOUT(...)                                              \
 do {                                                                           \
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,           \
-                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);           \
+                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);          \
 } while (0)
 
 #if PMIX_ENABLE_DEBUG
-#define PMIX_GDS_SHMEM2_VVOUT(...)                                              \
+#define PMIX_GDS_SHMEM2_VVOUT(...)                                             \
 do {                                                                           \
     pmix_output_verbose(8, pmix_gds_base_framework.framework_output,           \
-                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);           \
+                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);          \
 } while (0)
 
-#define PMIX_GDS_SHMEM2_VVVOUT(...)                                             \
+#define PMIX_GDS_SHMEM2_VVVOUT(...)                                            \
 do {                                                                           \
     pmix_output_verbose(9, pmix_gds_base_framework.framework_output,           \
-                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);           \
+                        "gds:" PMIX_GDS_SHMEM2_NAME ":" __VA_ARGS__);          \
 } while (0)
 #else
-#define PMIX_GDS_SHMEM2_VVOUT(...)                                              \
+#define PMIX_GDS_SHMEM2_VVOUT(...)                                             \
 do { } while (0)
 
-#define PMIX_GDS_SHMEM2_VVVOUT(...)                                             \
+#define PMIX_GDS_SHMEM2_VVVOUT(...)                                            \
 do { } while (0)
 #endif
 
-#define PMIX_GDS_SHMEM2_VVOUT_HERE()                                            \
+#define PMIX_GDS_SHMEM2_VVOUT_HERE()                                           \
 PMIX_GDS_SHMEM2_VVOUT("HERE AT %s,%d", __func__, __LINE__)
 
 BEGIN_C_DECLS

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,6 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2023      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -68,3 +69,8 @@ PMIx detected a call to mkdir was unable to create the desired directory:
 
 Please check to ensure you have adequate permissions to perform
 the desired operation.
+[unlink-error]
+We attempted to remove a file, but were unable to do so:
+
+  Path:  %s
+  Error: %s

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -672,7 +672,8 @@ void pmix_hash_register_key(uint32_t inid,
     pmix_pointer_array_set_item(keyindex->table, inid, ptr);
 }
 
-// TODO(skg) We may have to add a TMA wrapper for this call.
+// skg: Note that one may have to add a TMA wrapper for this call if changes are
+// made to how pmix_hash operates. Something for developers to keep in mind.
 pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
                                            const char *key,
                                            pmix_keyindex_t *kidx)

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -145,11 +145,9 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
                             pmix_os_dirpath_destroy_callback_fn_t cbfunc)
 {
     int rc, exit_status = PMIX_SUCCESS;
-    bool is_dir = false;
     DIR *dp;
     struct dirent *ep;
     char *filenm;
-    struct stat buf;
 
     if (NULL == path) { /* protect against error */
         return PMIX_ERROR;
@@ -169,43 +167,6 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
             continue;
         }
 
-        /* Check to see if it is a directory */
-        is_dir = false;
-
-        /* Create a pathname.  This is not always needed, but it makes
-         * for cleaner code just to create it here.  Note that we are
-         * allocating memory here, so we need to free it later on.
-         */
-        filenm = pmix_os_path(false, path, ep->d_name, NULL);
-
-        /* coverity[TOCTOU] */
-        rc = stat(filenm, &buf);
-        if (0 > rc) {
-            /* Handle a race condition. filenm might have been deleted by an
-             * other process running on the same node. That typically occurs
-             * when one task is removing the job_session_dir and an other task
-             * is still removing its proc_session_dir.
-             */
-            free(filenm);
-            continue;
-        }
-        if (S_ISDIR(buf.st_mode)) {
-            is_dir = true;
-        }
-
-        /*
-         * If not recursively descending, then if we find a directory then fail
-         * since we were not told to remove it.
-         */
-        if (is_dir && !recursive) {
-            /* Set the error indicating that we found a directory,
-             * but continue removing files
-             */
-            exit_status = PMIX_ERROR;
-            free(filenm);
-            continue;
-        }
-
         /* Will the caller allow us to remove this file/directory? */
         if (NULL != cbfunc) {
             /*
@@ -213,7 +174,6 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
              * continue with the rest of the entries
              */
             if (!(cbfunc(path, ep->d_name))) {
-                free(filenm);
                 continue;
             }
         }
@@ -260,12 +220,6 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
                 exit_status = PMIX_ERROR;
                 break;
             }
-        } else {
-            /* Files are removed right here */
-            if (0 != (rc = unlink(filenm))) {
-                exit_status = PMIX_ERROR;
-            }
-            free(filenm);
         }
     }
 


### PR DESCRIPTION
[gds/shmem2: provide a useful error message on memory allocation failure.](https://github.com/openpmix/openpmix/commit/0422645304586b2eeded07b42a11bfc3412392fe)

Additionally, address some minor formatting issues and amend a comment
regarding TMA's use in pmix_hash.

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c7963e97ddd73abd0f705000b3b0b1d993b202d1)

[Add "close stale issues" actions](https://github.com/openpmix/openpmix/commit/c19e940a5c0f5d97046f26c7d738986a3da33734)

Ported from https://github.com/open-mpi/ompi/pull/12329

Thanks to @jsquyres!

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9e058d9e563b387eecec1685adb961b57cc8cc6d)

[oac: strengthen Sphinx check](https://github.com/openpmix/openpmix/commit/1cbca1946db43aca17fbb57e03ee57bf3ffb519c)

Update oac submodule pointer to pick up a stronger test for
Sphinx. Also add (new) optional 3rd param to OAC_SETUP_SPHINX.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7c587a16cf4680e838a94760e71e9e0895d839a5)

[Remove stat call when destroying a dirpath](https://github.com/openpmix/openpmix/pull/3299/commits/4b0d46beb356c5f67d30d9a1252afee1dcf0e58d)

Just respond to the unlink error.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/openpmix/commit/da23e309d3addf440712f25366f145b2c28a0801)

[Do not remove the system tmpdir during cleanup](https://github.com/openpmix/openpmix/pull/3299/commits/02e019c47c085ca79a07b769e463aeff22e6e81b)

Ensure os_dirpath_destroy protects the system tmpdir
from removal.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/openpmix/commit/6381f6c59094e231c179c7233a036bfbb6b42028)