### PR TITLE
Cleanup the group bootstrap operation

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -228,6 +228,8 @@ pmix_client_globals_t pmix_client_globals = {
     .iof_verbose = 0,
     .base_output = -1,
     .base_verbose = 0,
+    .group_output = -1,
+    .group_verbose = 0,
     .iof_stdout = PMIX_IOF_SINK_STATIC_INIT,
     .iof_stderr = PMIX_IOF_SINK_STATIC_INIT
 };

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -148,7 +148,7 @@ static void invite_hdlr(size_t evhdlr_registration_id, pmix_status_t status,
 
     PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, results, nresults);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "Client %s INVITED with status %s",
                         PMIX_NAME_PRINT(&pmix_globals.myid),
                         PMIx_Error_string(status));
@@ -248,7 +248,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_construct called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -267,6 +267,8 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
      * group creation operation - it will be included by invitation,
      * so we need to register the invite handler */
     if (NULL == procs) {
+        pmix_output_verbose(2, pmix_client_globals.group_output,
+                            "pmix: group_construct bootstrap operation");
         PMIX_CONSTRUCT_LOCK(&lock);
         rc = PMIX_GROUP_INVITED;
         // provide an object by which we get back the groupID and membership
@@ -348,7 +350,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_construct_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -367,6 +369,8 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
      * group creation operation - it will be included by invitation,
      * so we need to register the invite handler */
     if (NULL == procs) {
+        pmix_output_verbose(2, pmix_client_globals.group_output,
+                            "pmix: group_construct_nb bootstrap operation");
         PMIX_CONSTRUCT_LOCK(&lock);
         rc = PMIX_GROUP_INVITED;
         // provide an object by which we get back the groupID and membership
@@ -466,7 +470,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_destruct called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -498,7 +502,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
     rc = cb.status;
     PMIX_DESTRUCT(&cb);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group destruct completed");
 
     return rc;
@@ -516,7 +520,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_destruct_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -1008,7 +1012,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     rc = cb->status;
     PMIX_RELEASE(cb);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group construction completed");
 
     return rc;
@@ -1025,7 +1029,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     pmix_data_range_t range;
     PMIX_HIDE_UNUSED_PARAMS(grp, cbfunc);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "[%s:%d] pmix: join nb called",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
 
@@ -1085,7 +1089,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(cb);
     }
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "[%s:%d] pmix: group invite %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         (PMIX_GROUP_INVITE_ACCEPTED == code) ? "ACCEPTED" : "DECLINED");
@@ -1101,7 +1105,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output, "pmix: group_leave called");
+    pmix_output_verbose(2, pmix_client_globals.group_output, "pmix: group_leave called");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -1132,7 +1136,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
     rc = cb.status;
     PMIX_DESTRUCT(&cb);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group leave completed");
 
     return rc;
@@ -1149,7 +1153,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_leave_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -1267,7 +1271,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
 
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
 
@@ -1337,7 +1341,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     n = 0;
     if (0 < nmembers) {
         PMIX_INFO_LOAD(&iptr[n], PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
-        // do not destruct darray as the membership is being used
+        // data was copied into the info
         ++n;
     }
     if (gotctxid) {
@@ -1369,7 +1373,7 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
 
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output,
+    pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
 

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +54,9 @@ typedef struct {
     /* IOF output sinks */
     pmix_iof_sink_t iof_stdout;
     pmix_iof_sink_t iof_stderr;
+    // verbosity for client group operations
+    int group_output;
+    int group_verbose;
 } pmix_client_globals_t;
 
 PMIX_EXPORT extern pmix_client_globals_t pmix_client_globals;

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1295,7 +1295,8 @@ bool pmix_notify_check_range(pmix_range_trkr_t *rng, const pmix_proc_t *proc)
             if (0 != strncmp(rng->procs[n].nspace, proc->nspace, PMIX_MAX_NSLEN)) {
                 continue;
             }
-            if (PMIX_RANK_WILDCARD == rng->procs[n].rank || rng->procs[n].rank == proc->rank) {
+            if (PMIX_RANK_WILDCARD == rng->procs[n].rank ||
+                rng->procs[n].rank == proc->rank) {
                 return true;
             }
         }

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -890,7 +890,7 @@ pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next)
     return &active->info;
 }
 
-static pmix_status_t get_darray_size(pmix_data_array_t *array, 
+static pmix_status_t get_darray_size(pmix_data_array_t *array,
                                      size_t *sz)
 {
     pmix_status_t rc = PMIX_SUCCESS;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -385,6 +385,11 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
         /* set default output */
         pmix_client_globals.iof_output = pmix_output_open(NULL);
         pmix_output_set_verbosity(pmix_client_globals.iof_output, pmix_client_globals.iof_verbose);
+    }
+    if (0 < pmix_client_globals.group_verbose) {
+        /* set default output */
+        pmix_client_globals.group_output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(pmix_client_globals.group_output, pmix_client_globals.group_verbose);
     }
 
     /* get our effective id's */

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -23,7 +23,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,6 +157,11 @@ pmix_status_t pmix_register_params(void)
                                       "Verbosity for basic client operations",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_client_globals.base_verbose);
+
+    (void) pmix_mca_base_var_register("pmix", "pmix", "client", "group_verbose",
+                                      "Verbosity for server group operations",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_client_globals.group_verbose);
 
     /****   SERVER: VERBOSE OUTPUT PARAMS   ****/
     (void) pmix_mca_base_var_register("pmix", "pmix", "server", "get_verbose",


### PR DESCRIPTION
Add a client-level group verbosity parameter for better error tracking. Ensure we properly aggregate multiple group collective contributions to eliminate duplicate info entries.