### PR TITLE
Provide job-level info to all group construct members

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -462,6 +462,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_TIMESTAMP                "pmix.evtstamp"         // (time_t) System time when the associated event occurred.
 #define PMIX_EVENT_ONESHOT                  "pmix.evone"            // (bool) when registering, indicate that this event handler is to be deleted
                                                                     //        after being invoked
+#define PMIX_EVENT_STAYS_LOCAL              "pmix.evlocal"          // (bool) Event is not to be passed up to the host environment - used
+                                                                    //        when the range is custom to also indicate range=local and prevent
+                                                                    //        infinite loops with the host
 
 /* fault tolerance-related events */
 #define PMIX_EVENT_TERMINATE_SESSION        "pmix.evterm.sess"      // (bool) RM intends to terminate session
@@ -469,6 +472,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_TERMINATE_NODE           "pmix.evterm.node"      // (bool) RM intends to terminate all procs on this node
 #define PMIX_EVENT_TERMINATE_PROC           "pmix.evterm.proc"      // (bool) RM intends to terminate just this process
 #define PMIX_EVENT_ACTION_TIMEOUT           "pmix.evtimeout"        // (int) time in sec before RM will execute error response
+
 
 /* attributes used to describe "spawn" directives */
 #define PMIX_PERSONALITY                    "pmix.pers"             // (char*) name of personality to use
@@ -1140,6 +1144,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        with a NULL for the procs parameter. This indicates that the caller
                                                                     //        wishes to be included via a group invite, and so the library will
                                                                     //        handle the necessary event registrations on behalf of the caller.
+#define PMIX_GROUP_JOB_INFO                 "pmix.grp.jinfo"        // (pmix_byte_object_t) Job-level info for group construction
 
 
 /* Storage-Related Attributes */

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -939,10 +939,10 @@ static void _notify_client_event(int sd, short args, void *cbdata)
         /* check for caching instructions */
         for (n = 0; n < cd->ninfo; n++) {
             if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_DO_NOT_CACHE)) {
-                if (PMIX_INFO_TRUE(&cd->info[n])) {
-                    holdcd = false;
-                }
-                break;
+                holdcd = !PMIX_INFO_TRUE(&cd->info[n]);
+
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_STAYS_LOCAL)) {
+                cd->staylocal = PMIX_INFO_TRUE(&cd->info[n]);
             }
         }
     }
@@ -1185,6 +1185,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
         }
         PMIX_LIST_DESTRUCT(&trk);
         if (PMIX_RANGE_LOCAL != cd->range &&
+            !cd->staylocal &&
             PMIX_CHECK_PROCID(&cd->source, &pmix_globals.myid)) {
             /* if we are the source, then we need to post this upwards as
              * well so the host RM can broadcast it as necessary */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -528,6 +528,7 @@ static void ncon(pmix_notify_caddy_t *p)
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN + 1);
     p->source.rank = PMIX_RANK_UNDEF;
     p->range = PMIX_RANGE_UNDEF;
+    p->staylocal = false;
     p->targets = NULL;
     p->ntargets = 0;
     p->nleft = SIZE_MAX;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -700,6 +700,7 @@ typedef struct {
     pmix_status_t status;
     pmix_proc_t source;
     pmix_data_range_t range;
+    bool staylocal;  // do not pass up to host environment
     /* For notification, we use the targets field to track
      * any custom range of procs that are to receive the
      * event.


### PR DESCRIPTION
Ensure that everyone gets the job-level info, including all add-member participants. Add a couple of attributes to help with that operation. Generate the event for add-member participants from the PMIx server instead of the host.