### PR TITLE
Include notes about submodules in docs

### DIFF
--- a/docs/developers/autogen.rst
+++ b/docs/developers/autogen.rst
@@ -22,6 +22,19 @@ shell startup files)::
    # For csh/tcsh:
    set AUTOMAKE_JOBS 4
 
+.. important:: ``autogen.pl`` will fail and report an error if you
+   forgot to install the required submodule prior to running the
+   autogen script. You can either do this by adding the ``--recursive``
+   flag to your Git ``clone`` command, or by manually populating the
+   submodule by running:
+
+   .. code-block:: sh
+
+      shell$ git submodule update --init
+
+   prior to executing ``autogen.pl``.
+
+
 .. important:: You generally need to run ``autogen.pl`` whenever the
    top-level file ``configure.ac`` changes, or any files in the
    ``config/`` or ``<project>/config/`` directories change (these

--- a/docs/installing-pmix/quickstart.rst
+++ b/docs/installing-pmix/quickstart.rst
@@ -17,7 +17,13 @@ must then run:
 
 .. code-block:: sh
 
+   shell$ git submodule update --init
    shell$ ./autogen.pl
+
+The ``submodule update`` is required as PMIx incorporates a submodule
+to support its `autoconf` logic. You can, however, omit the explicit
+submodule update step `if` you cloned the Git repository with the
+``--recursive`` flag.
 
 You will need very recent versions of GNU Autoconf, Automake, and
 Libtool.  If ``autogen.pl`` fails, read the :doc:`Developer's Guide


### PR DESCRIPTION
The installation docs didn't mention that PMIx now incorporates a submodule. Add appropriate words
about that so people realize they need to initialize the submodule before trying to build a Git clone.