### PR TITLE
More cleanup of group operations and local client array

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1740,7 +1740,8 @@ typedef enum {
 
 typedef enum {
     PMIX_GROUP_CONSTRUCT,
-    PMIX_GROUP_DESTRUCT
+    PMIX_GROUP_DESTRUCT,
+    PMIX_GROUP_NONE
 } pmix_group_operation_t;
 
 /* define storage medium values

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -543,6 +543,7 @@ typedef struct {
     pmix_info_t *info;      // array of info structs
     size_t ninfo;           // number of info structs in array
     pmix_list_t grpinfo;    // list of group info to be distributed
+    int grpop;              // the group operation being tracked
     pmix_collect_t collect_type; // whether or not data is to be returned at completion
     pmix_modex_cbfunc_t modexcbfunc;
     pmix_op_cbfunc_t op_cbfunc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3017,13 +3017,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 /* we need to find the precise peer - we can only
                  * do cleanup for a local client */
                 for (m = 0; m < pmix_server_globals.clients.size; m++) {
-                    if (NULL
-                        == (pr = (pmix_peer_t *)
-                                pmix_pointer_array_get_item(&pmix_server_globals.clients, m))) {
+                    pr = (pmix_peer_t *)pmix_pointer_array_get_item(&pmix_server_globals.clients, m);
+                    if (NULL == pr) {
                         continue;
                     }
-                    if (0
-                        != strncmp(pr->info->pname.nspace, cd->targets[n].nspace, PMIX_MAX_NSLEN)) {
+                    if (!PMIX_CHECK_NSPACE(pr->info->pname.nspace, cd->targets[n].nspace)) {
                         continue;
                     }
                     if (pr->info->pname.rank == cd->targets[n].rank) {
@@ -4300,6 +4298,7 @@ static void tcon(pmix_server_trkr_t *t)
     t->info = NULL;
     t->ninfo = 0;
     PMIX_CONSTRUCT(&t->grpinfo, pmix_list_t);
+    t->grpop = PMIX_GROUP_NONE;
     /* this needs to be set explicitly */
     t->collect_type = PMIX_COLLECT_INVALID;
     t->modexcbfunc = NULL;


### PR DESCRIPTION
Ensure we remove clients from the local client array when deregistered, and that all clients get cleaned up when the nspace is deregistered as some people may not have deregistered clients prior to the nspace.

Do not reuse the "hybrid" field of the tracker to track the group operation as it is used for other purposes and should not be overwritten. Add a new PMIX_GROUP_NONE operation tag for initializing the new tracker field - put it at the end of the enum to avoid causing errors with existing users.