### PR TITLE
More cleanup of group operations and local client array

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1660,7 +1660,8 @@ typedef enum {
 
 typedef enum {
     PMIX_GROUP_CONSTRUCT,
-    PMIX_GROUP_DESTRUCT
+    PMIX_GROUP_DESTRUCT,
+    PMIX_GROUP_NONE
 } pmix_group_operation_t;
 
 /* define storage medium values

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -540,6 +540,7 @@ typedef struct {
     pmix_info_t *info;      // array of info structs
     size_t ninfo;           // number of info structs in array
     pmix_list_t grpinfo;    // list of group info to be distributed
+    int grpop;              // the group operation being tracked
     pmix_collect_t collect_type; // whether or not data is to be returned at completion
     pmix_modex_cbfunc_t modexcbfunc;
     pmix_op_cbfunc_t op_cbfunc;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -9,7 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1383,10 +1383,76 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
     }
 }
 
+static void remove_client(pmix_namespace_t *nptr, pmix_proc_t *p)
+{
+    pmix_rank_info_t *info, *inext;
+    pmix_peer_t *peer;
+    pmix_proc_t proc;
+
+    PMIX_LIST_FOREACH_SAFE(info, inext, &nptr->ranks, pmix_rank_info_t) {
+        if (NULL == p || info->pname.rank == p->rank) {
+            if (NULL == p) {
+                PMIX_LOAD_PROCID(&proc, info->pname.nspace, info->pname.rank);
+            } else {
+                memcpy(&proc, p, sizeof(pmix_proc_t));
+            }
+            /* if this client failed to call finalize, we still need
+             * to restore any allocations that were given to it */
+            peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, info->peerid);
+            if (NULL == peer) {
+                /* this peer never connected, and hence it won't finalize,
+                 * so account for it here */
+                nptr->nfinalized++;
+                /* even if they never connected, resources were allocated
+                 * to them, so we need to ensure they are properly released */
+                pmix_pnet.child_finalized(&proc);
+            } else {
+                if (!peer->finalized) {
+                    /* this peer connected to us, but is being deregistered
+                     * without having finalized. This usually means an
+                     * abnormal termination that was picked up by
+                     * our host prior to our seeing the connection drop.
+                     * It is also possible that we missed the dropped
+                     * connection, so mark the peer as finalized so
+                     * we don't duplicate account for it and take care
+                     * of it here */
+                    peer->finalized = true;
+                    nptr->nfinalized++;
+                }
+                /* resources may have been allocated to them, so
+                 * ensure they get cleaned up - this isn't true
+                 * for tools, so don't clean them up */
+                if (!PMIX_PEER_IS_TOOL(peer)) {
+                    pmix_pnet.child_finalized(&proc);
+                    pmix_psensor.stop(peer, NULL);
+                }
+                /* honor any registered epilogs */
+                pmix_execute_epilog(&peer->epilog);
+                /* ensure we close the socket to this peer so we don't
+                 * generate "connection lost" events should it be
+                 * subsequently "killed" by the host */
+                CLOSE_THE_SOCKET(peer->sd);
+                // remove it from our client array
+                pmix_pointer_array_set_item(&pmix_server_globals.clients, info->peerid, NULL);
+                PMIX_RELEASE(peer);
+            }
+            if (nptr->nlocalprocs == nptr->nfinalized) {
+                pmix_pnet.local_app_finalized(nptr);
+            }
+            pmix_list_remove_item(&nptr->ranks, &info->super);
+            PMIX_RELEASE(info);
+            if (NULL != p) {
+                break;
+            }
+        }
+    }
+    return;
+}
+
 static void _deregister_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
-    pmix_namespace_t *tmp;
+    pmix_namespace_t *tmp, *nptr;
     pmix_status_t rc;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -1414,18 +1480,30 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
      * cached notifications targeting procs from this nspace */
     pmix_server_purge_events(NULL, &cd->proc);
 
-    /* release this nspace */
+    // find the nspace object
+    nptr = NULL;
     PMIX_LIST_FOREACH (tmp, &pmix_globals.nspaces, pmix_namespace_t) {
         if (PMIX_CHECK_NSPACE(tmp->nspace, cd->proc.nspace)) {
-            /* perform any nspace-level epilog */
-            pmix_execute_epilog(&tmp->epilog);
-            /* remove and release it */
-            pmix_list_remove_item(&pmix_globals.nspaces, &tmp->super);
-            PMIX_RELEASE(tmp);
+            nptr = tmp;
             break;
         }
     }
+    if (NULL == nptr) {
+        /* nothing to do */
+        goto cleanup;
+    }
 
+    // ensure all local clients have been deregistered
+    remove_client(nptr, NULL);
+
+    /* perform any epilog */
+    pmix_execute_epilog(&nptr->epilog);
+
+    /* remove and release it */
+    pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
+    PMIX_RELEASE(nptr);
+
+cleanup:
     /* release the caller */
     cd->opcbfunc(rc, cd->cbdata);
     PMIX_RELEASE(cd);
@@ -2024,9 +2102,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc, u
 static void _deregister_client(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
-    pmix_rank_info_t *info;
     pmix_namespace_t *nptr, *tmp;
-    pmix_peer_t *peer;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -2047,54 +2123,9 @@ static void _deregister_client(int sd, short args, void *cbdata)
         /* nothing to do */
         goto cleanup;
     }
+
     /* find and remove this client */
-    PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
-        if (info->pname.rank == cd->proc.rank) {
-            /* if this client failed to call finalize, we still need
-             * to restore any allocations that were given to it */
-            peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, info->peerid);
-            if (NULL == peer) {
-                /* this peer never connected, and hence it won't finalize,
-                 * so account for it here */
-                nptr->nfinalized++;
-                /* even if they never connected, resources were allocated
-                 * to them, so we need to ensure they are properly released */
-                pmix_pnet.child_finalized(&cd->proc);
-            } else {
-                if (!peer->finalized) {
-                    /* this peer connected to us, but is being deregistered
-                     * without having finalized. This usually means an
-                     * abnormal termination that was picked up by
-                     * our host prior to our seeing the connection drop.
-                     * It is also possible that we missed the dropped
-                     * connection, so mark the peer as finalized so
-                     * we don't duplicate account for it and take care
-                     * of it here */
-                    peer->finalized = true;
-                    nptr->nfinalized++;
-                }
-                /* resources may have been allocated to them, so
-                 * ensure they get cleaned up - this isn't true
-                 * for tools, so don't clean them up */
-                if (!PMIX_PEER_IS_TOOL(peer)) {
-                    pmix_pnet.child_finalized(&cd->proc);
-                    pmix_psensor.stop(peer, NULL);
-                }
-                /* honor any registered epilogs */
-                pmix_execute_epilog(&peer->epilog);
-                /* ensure we close the socket to this peer so we don't
-                 * generate "connection lost" events should it be
-                 * subsequently "killed" by the host */
-                CLOSE_THE_SOCKET(peer->sd);
-            }
-            if (nptr->nlocalprocs == nptr->nfinalized) {
-                pmix_pnet.local_app_finalized(nptr);
-            }
-            pmix_list_remove_item(&nptr->ranks, &info->super);
-            PMIX_RELEASE(info);
-            break;
-        }
-    }
+    remove_client(nptr, &cd->proc);
 
 cleanup:
     cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);


### PR DESCRIPTION
Ensure we remove clients from the local client array when deregistered, and that all clients get cleaned up when the nspace is deregistered as some people may not have deregistered clients prior to the nspace.

Do not reuse the "hybrid" field of the tracker to track the group operation as it is used for other purposes and should not be overwritten. Add a new PMIX_GROUP_NONE operation tag for initializing the new tracker field - put it at the end of the enum to avoid causing errors with existing users.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 6be456b6b2a5280065a7e11a348a0188ae9ed518)