### PR TITLE
Correct group modex storage to avoid duplication

### DIFF
--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1027,6 +1027,8 @@ PMIX_EXPORT pmix_status_t pmix_bfrop_get_data_type(pmix_pointer_array_t *regtype
                                                    pmix_buffer_t *buffer, pmix_data_type_t *type);
 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
+
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_embed_payload(pmix_buffer_t *dest, pmix_byte_object_t *src);
 
 PMIX_EXPORT void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
                                              pmix_data_type_t type);

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -56,6 +56,11 @@ pmix_status_t pmix_bfrops_base_copy(pmix_pointer_array_t *regtypes, void **dest,
 pmix_status_t pmix_bfrops_base_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
 {
     return pmix_bfrops_base_tma_copy_payload(dest, src, NULL);
+}
+
+pmix_status_t pmix_bfrops_base_embed_payload(pmix_buffer_t *dest, pmix_byte_object_t *src)
+{
+    return pmix_bfrops_base_tma_embed_payload(dest, src, NULL);
 }
 
 /*

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -140,6 +140,36 @@ pmix_status_t pmix_bfrops_base_tma_copy_payload(pmix_buffer_t *dest,
     memcpy(ptr, src->unpack_ptr, to_copy);
     dest->bytes_used += to_copy;
     dest->pack_ptr += to_copy;
+    return PMIX_SUCCESS;
+}
+
+static inline
+pmix_status_t pmix_bfrops_base_tma_embed_payload(pmix_buffer_t *dest,
+                                                 pmix_byte_object_t *src,
+                                                 pmix_tma_t *tma)
+{
+    char *ptr;
+
+    /* deal with buffer type */
+    if (NULL == dest->base_ptr) {
+        /* destination buffer is empty - derive src buffer type */
+        dest->type = pmix_bfrops_globals.default_type;
+    }
+
+    /* if the src is empty, then there is
+     * nothing to do */
+    if (NULL == src->bytes) {
+        return PMIX_SUCCESS;
+    }
+
+    /* extend the dest if necessary */
+    if (NULL == (ptr = pmix_bfrops_base_tma_buffer_extend(dest, src->size, tma))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    memcpy(ptr, src->bytes, src->size);
+    dest->bytes_used += src->size;
+    dest->pack_ptr += src->size;
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
The loop to identify unique nspaces was unfortunately incorrect, thus resulting in not storing modex info that was needed, and sometimes duplicating storage for other nspaces. Ensure we provide the data only once for every nspace involved in the group.