### PR TITLE
Correct group modex storage to avoid duplication

### DIFF
--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -992,6 +992,8 @@ PMIX_EXPORT pmix_status_t pmix_bfrop_get_data_type(pmix_pointer_array_t *regtype
                                                    pmix_buffer_t *buffer, pmix_data_type_t *type);
 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
+
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_embed_payload(pmix_buffer_t *dest, pmix_byte_object_t *src);
 
 PMIX_EXPORT void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
                                              pmix_data_type_t type);

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -56,6 +56,11 @@ pmix_status_t pmix_bfrops_base_copy(pmix_pointer_array_t *regtypes, void **dest,
 pmix_status_t pmix_bfrops_base_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
 {
     return pmix_bfrops_base_tma_copy_payload(dest, src, NULL);
+}
+
+pmix_status_t pmix_bfrops_base_embed_payload(pmix_buffer_t *dest, pmix_byte_object_t *src)
+{
+    return pmix_bfrops_base_tma_embed_payload(dest, src, NULL);
 }
 
 /*

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -140,6 +140,36 @@ pmix_status_t pmix_bfrops_base_tma_copy_payload(pmix_buffer_t *dest,
     memcpy(ptr, src->unpack_ptr, to_copy);
     dest->bytes_used += to_copy;
     dest->pack_ptr += to_copy;
+    return PMIX_SUCCESS;
+}
+
+static inline
+pmix_status_t pmix_bfrops_base_tma_embed_payload(pmix_buffer_t *dest,
+                                                 pmix_byte_object_t *src,
+                                                 pmix_tma_t *tma)
+{
+    char *ptr;
+
+    /* deal with buffer type */
+    if (NULL == dest->base_ptr) {
+        /* destination buffer is empty - derive src buffer type */
+        dest->type = pmix_bfrops_globals.default_type;
+    }
+
+    /* if the src is empty, then there is
+     * nothing to do */
+    if (NULL == src->bytes) {
+        return PMIX_SUCCESS;
+    }
+
+    /* extend the dest if necessary */
+    if (NULL == (ptr = pmix_bfrops_base_tma_buffer_extend(dest, src->size, tma))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    memcpy(ptr, src->bytes, src->size);
+    dest->bytes_used += src->size;
+    dest->pack_ptr += src->size;
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -61,7 +61,7 @@
 #include "src/common/pmix_attributes.h"
 #include "src/common/pmix_iof.h"
 #include "src/hwloc/pmix_hwloc.h"
-#include "src/mca/bfrops/bfrops.h"
+#include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
 #include "src/mca/plog/plog.h"
 #include "src/mca/pnet/pnet.h"
@@ -3793,14 +3793,13 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
         PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
         PMIX_LOAD_BUFFER(pmix_globals.mypeer, &xfer, bo->bytes, bo->size);
         PMIX_CONSTRUCT(&nslist, pmix_list_t);
-        /* Collect the nptr list with uniq GDS components of all local
-         * participants. It does not allow multiple storing to the
-         * same GDS if participants have mutual GDS. */
+        /* Collect the nptr list with unique nspaces */
         PMIX_LIST_FOREACH (cd, &trk->local_cbs, pmix_server_caddy_t) {
             // see if we already have this nspace
             found = false;
             PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
-                if (0 == strcmp(nptr->ns->compat.gds->name, cd->peer->nptr->compat.gds->name)) {
+                // if we already have this nspace, ignore this entry
+                if (PMIX_CHECK_NSPACE(nptr->ns->nspace, cd->peer->nptr->nspace)) {
                     found = true;
                     break;
                 }
@@ -3836,18 +3835,24 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                 PMIX_DESTRUCT(&xfer);
                 goto release;
             }
-            PMIX_CONSTRUCT(&dblob, pmix_buffer_t);
-            PMIX_LOAD_BUFFER(pmix_globals.mypeer, &dblob, pbo.bytes, pbo.size);
-            PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
 
             if (index == endptidx) {
                 PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
+                    PMIX_CONSTRUCT(&dblob, pmix_buffer_t);
+                    ret = pmix_bfrops_base_embed_payload(&dblob, &pbo);  // does NOT alter the pbo
+                    if (PMIX_SUCCESS != ret) {
+                        PMIX_ERROR_LOG(ret);
+                        break;
+                    }
                     PMIX_GDS_STORE_MODEX(ret, nptr->ns, &dblob, trk);
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
                         break;
                     }
+                    PMIX_DESTRUCT(&dblob);
                 }
+                PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+
             } else if (index == infoidx) {
                 /* this is packed differently, at least for now, so we have
                  * to unpack it and process it directly */
@@ -3856,6 +3861,9 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                      * of the contributing proc followed by the pmix_info_t they
                      * provided */
                     ret = PMIX_SUCCESS;
+                    PMIX_CONSTRUCT(&dblob, pmix_buffer_t);
+                    PMIX_LOAD_BUFFER(pmix_globals.mypeer, &dblob, pbo.bytes, pbo.size);
+                    PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
                     while (PMIX_SUCCESS == ret) {
                         cnt = 1;
                         PMIX_BFROPS_UNPACK(ret, pmix_globals.mypeer, &dblob, &pbo, &cnt, PMIX_BYTE_OBJECT);
@@ -3933,9 +3941,9 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                         PMIX_DESTRUCT(&rankblob);
                         ret = PMIX_SUCCESS;
                     }
+                    PMIX_DESTRUCT(&dblob);
                 }
             }
-            PMIX_DESTRUCT(&dblob);
             /* get the next blob */
             cnt = 1;
             PMIX_BFROPS_UNPACK(ret, pmix_globals.mypeer, &xfer, &index, &cnt, PMIX_UINT32);


### PR DESCRIPTION
The loop to identify unique nspaces was unfortunately incorrect, thus resulting in not storing modex info that was needed, and sometimes duplicating storage for other nspaces. Ensure we provide the data only once for every nspace involved in the group.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ce7a58fd423c706852f305ad3609b0786bfc9531)