### PR TITLE
Toughen the submodule checks in autogen.pl

### DIFF
--- a/docs/news/news-v5.x.rst
+++ b/docs/news/news-v5.x.rst
@@ -14,6 +14,7 @@ series, in reverse chronological order.
                v5.0.1 and v5.0.0 releases.
 
 Detailed changes include:
+ - PR #3319: Toughen the submodule checks in autogen.pl
  - PR #3317 Correct group modex storage to avoid duplication
  - PR #3314 Fix memory leak in storing of modex data
  - PR #3311 More cleanup of group operations and local client array


### PR DESCRIPTION
Based off of https://github.com/open-mpi/ompi/pull/12406. Modified to cover the case where the submodule's ".git" file exists, but the directory is actually unpopulated. Admittedly a "borked" installation, but surprisingly does happen.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 528b4bc19febe3d2d58341042f664045adcbec39)