### PR TITLE
Correct error in retrieval of node and app info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ bindings/python/tests/python/__pycache__/
 examples/alloc
 examples/client
 examples/client2
+examples/client3
 examples/debugger
 examples/debuggerd
 examples/dmodex

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -27,7 +27,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
-                  group_bootstrap
+                  group_bootstrap client3
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -42,6 +42,10 @@ client_LDADD =  $(top_builddir)/src/libpmix.la
 client2_SOURCES = client2.c examples.h
 client2_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 client2_LDADD =  $(top_builddir)/src/libpmix.la
+
+client3_SOURCES = client3.c examples.h
+client3_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client3_LDADD =  $(top_builddir)/src/libpmix.la
 
 debugger_SOURCES = debugger.c examples.h
 debugger_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -138,4 +142,4 @@ distclean-local:
         debugger debuggerd dmodex dynamic fault group \
         hello jctrl launcher log pub pubi server tool \
         abi_no_init abi_with_init group_lcl_cid pset \
-        async_group group_dmodex group_bootstrap
+        async_group group_dmodex group_bootstrap client3

--- a/examples/client3.c
+++ b/examples/client3.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022      ParTec AG.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                myproc.nspace, myproc.rank, status, (unsigned long) evhandler_ref);
+    }
+    lock->status = status;
+    lock->evhandler_ref = evhandler_ref;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL, *val2 = NULL;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    mylock_t mylock;
+    pid_t pid;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    pid = getpid();
+    fprintf(stderr, "Client %lu: Running\n", (unsigned long) pid);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
+            (unsigned long) pid);
+
+    /* register our default event handler - again, this isn't strictly
+     * required, but is generally good practice */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace,
+                myproc.rank);
+        goto done;
+    }
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get the number of procs in our job - univ size is the total number of allocated
+     * slots, not the number of procs in the job */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d num procs %d\n", myproc.nspace, myproc.rank, nprocs);
+
+     /* get a list of our local procs - some may not be in our job */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PROCS, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs with WILDCARD rank failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    // get the list using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_PROCS, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+    /* get our nodeID in various ways */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(NULL, PMIX_NODEID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID with NULL proc failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    // get the nodeID using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NODEID, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != val && NULL != val2 && PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+    /* get our hostname in various ways */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(NULL, PMIX_HOSTNAME, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname with NULL proc failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    // get the nodeID using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -195,7 +195,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     }
 
     /* see if they just want their own process ID */
-    if (NULL == proc && 0 == strncmp(key, PMIX_PROCID, PMIX_MAX_KEYLEN)) {
+    if (NULL == proc && PMIx_Check_key(key, PMIX_PROCID)) {
         if (lg->stval) {
             ival = *val;
             ival->type = PMIX_PROC;
@@ -217,7 +217,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     }
 
     /* see if they just want our version */
-    if (NULL != key && 0 == strncmp(key, PMIX_VERSION_NUMERIC, PMIX_MAX_KEYLEN)) {
+    if (NULL != key && PMIx_Check_key(key, PMIX_VERSION_NUMERIC)) {
         if (lg->stval) {
             ival = *val;
             ival->type = PMIX_UINT32;
@@ -245,7 +245,12 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
      * must be globally unique, so communicate this to the hash
      * functions with the UNDEF rank */
     if (NULL == proc) {
-        lg->p.rank = PMIX_RANK_UNDEF;
+        // if they want node or app info, then use our rank
+        if (lg->nodeinfo || lg->appinfo) {
+            lg->p.rank = pmix_globals.myid.rank;
+        } else {
+            lg->p.rank = PMIX_RANK_UNDEF;
+        }
     } else {
         lg->p.rank = proc->rank;
     }
@@ -254,7 +259,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
      * for PMIX_RANK, then they are asking for our process rank */
     if (PMIX_RANK_INVALID == lg->p.rank &&
         PMIX_CHECK_NSPACE(lg->p.nspace, pmix_globals.myid.nspace) &&
-        NULL != key && 0 == strncmp(key, PMIX_RANK, PMIX_MAX_KEYLEN)) {
+        NULL != key && PMIx_Check_key(key, PMIX_RANK)) {
         if (lg->stval) {
             ival = *val;
             ival->type = PMIX_PROC_RANK;
@@ -273,7 +278,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         return PMIX_OPERATION_SUCCEEDED;
     }
 
-    /* if they passed a group in the nspace of proc, 
+    /* if they passed a group in the nspace of proc,
      * replace it with the translated proc. */
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         proc != NULL && 0 != strlen(proc->nspace)) {
@@ -755,17 +760,26 @@ static void get_data(int sd, short args, void *cbdata)
             /* if they didn't specify the target node, then see if they
              * specified a proc */
             if (PMIX_RANK_IS_VALID(cb->proc->rank)) {
-                /* if this is us, then we know our info */
+                /* if this is us, then see if we know our info */
                 if (PMIX_CHECK_PROCID(cb->proc, &pmix_globals.myid)) {
-                    lg->hostname = strdup(pmix_globals.hostname);
-                    lg->nodeid = pmix_globals.nodeid;
-                } else {
+                    if (NULL != pmix_globals.hostname) {
+                        lg->hostname = strdup(pmix_globals.hostname);
+                    }
+                    if (UINT32_MAX != pmix_globals.nodeid) {
+                        lg->nodeid = pmix_globals.nodeid;
+                    }
+                }
+                if (NULL == lg->hostname) {
                     PMIX_CONSTRUCT(&cb2, pmix_cb_t);
                     cb2.proc = cb->proc;
                     cb2.key = PMIX_HOSTNAME;
                     cb2.info = &optional;
                     cb2.ninfo = 1;
-                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
+                        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb2);
+                    } else {
+                        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    }
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
@@ -775,30 +789,38 @@ static void get_data(int sd, short args, void *cbdata)
                         } else {
                             lg->hostname = strdup("unknown");
                         }
+                    }
+                }
+                if (UINT32_MAX == lg->nodeid) {
+                    /* try for the nodeid */
+                    PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+                    cb2.proc = cb->proc;
+                    cb2.key = PMIX_NODEID;
+                    cb2.info = &optional;
+                    cb2.ninfo = 1;
+                    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
+                        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb2);
                     } else {
-                        /* try for the nodeid */
-                        cb2.key = PMIX_NODEID;
                         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-                        if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
-                            kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                            PMIX_DESTRUCT(&cb2);
-                            if (NULL != kv) {  // will never be NULL
-                                PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
-                                PMIX_RELEASE(kv);
-                            } else {
-                                rc = PMIX_ERROR;
-                            }
-                            if (PMIX_SUCCESS != rc) {
-                                cb->status = rc;
-                                goto done;
-                            }
+                    }
+                    if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+                        kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
+                        PMIX_DESTRUCT(&cb2);
+                        if (NULL != kv) {  // will never be NULL
+                            PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
+                            PMIX_RELEASE(kv);
                         } else {
-                            /* could not find hostname or nodeid, so we cannot do anything */
-                            cb->status = PMIX_ERR_NOT_FOUND;
+                            rc = PMIX_ERROR;
+                        }
+                        if (PMIX_SUCCESS != rc) {
+                            cb->status = rc;
                             goto done;
                         }
                     }
                 }
+                // set the rank to undefined since this request is
+                // required to ignore the procID
+                cb->proc->rank = PMIX_RANK_UNDEF;
             } else {
                 /* it's an invalid rank - assume they are asking about this node.
                  * This is consistent with prior releases */
@@ -807,20 +829,26 @@ static void get_data(int sd, short args, void *cbdata)
                 lg->nodeid = pmix_globals.nodeid;
             }
         }
-        /* if we have a hostname and that is what they were
-         * asking for, then we are done */
-        if (NULL != lg->hostname && 0 == strcmp(cb->key, PMIX_HOSTNAME)) {
-            cb->status = PMIX_SUCCESS;
-            PMIX_VALUE_CREATE(cb->value, 1);
-            PMIX_VALUE_LOAD(cb->value, lg->hostname, PMIX_STRING);
+        /* if they were asking for hostname, then we are done */
+        if (PMIx_Check_key(cb->key, PMIX_HOSTNAME)) {
+            if (NULL != lg->hostname) {
+                cb->status = PMIX_SUCCESS;
+                PMIX_VALUE_CREATE(cb->value, 1);
+                PMIX_VALUE_LOAD(cb->value, lg->hostname, PMIX_STRING);
+            } else {
+                cb->status = PMIX_ERR_NOT_FOUND;
+            }
             goto done;
         }
-        /* if we have a nodeid and that is what they were
-         * asking for, then we are done */
-        if (UINT32_MAX != lg->nodeid && 0 == strcmp(cb->key, PMIX_NODEID)) {
-            cb->status = PMIX_SUCCESS;
-            PMIX_VALUE_CREATE(cb->value, 1);
-            PMIX_VALUE_LOAD(cb->value, &lg->nodeid, PMIX_UINT32);
+        /* if they were asking for nodeid, then we are done */
+        if (PMIx_Check_key(cb->key, PMIX_NODEID)) {
+            if (UINT32_MAX != lg->nodeid) {
+                cb->status = PMIX_SUCCESS;
+                PMIX_VALUE_CREATE(cb->value, 1);
+                PMIX_VALUE_LOAD(cb->value, &lg->nodeid, PMIX_UINT32);
+            } else {
+                cb->status = PMIX_ERR_NOT_FOUND;
+            }
             goto done;
         }
         /* we have to look for the info, so we need to tell the GDS
@@ -836,7 +864,7 @@ static void get_data(int sd, short args, void *cbdata)
             if (NULL != lg->hostname) {
                 PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_HOSTNAME, lg->hostname, PMIX_STRING);
             } else {
-                PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_HOSTNAME, &lg->nodeid, PMIX_UINT32);
+                PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_NODEID, &lg->nodeid, PMIX_UINT32);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
             cb->infocopy = true;
@@ -874,7 +902,11 @@ static void get_data(int sd, short args, void *cbdata)
                     cb2.key = PMIX_APPNUM;
                     cb2.info = &optional;
                     cb2.ninfo = 1;
-                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
+                        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb2);
+                    } else {
+                        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    }
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
@@ -890,6 +922,9 @@ static void get_data(int sd, short args, void *cbdata)
                         goto done;
                     }
                 }
+                // set the rank to undefined since this request is
+                // required to ignore the procID
+                cb->proc->rank = PMIX_RANK_UNDEF;
             } else {
                 /* rank is invalid - assume they want info about our app.
                  * This is consistent with prior releases */

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -565,7 +565,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         }
     }
     PMIX_LIST_DESTRUCT(&results);
-\
+
     /* if the job's tracker points to a non-default session ID,
      * then we add the default session information to it */
     if (NULL != trk->session && UINT32_MAX != trk->session->session) {


### PR DESCRIPTION
Per the Standard, PMIx_Get of node and app info
is to ignore the procID argument. Ensure that we
correctly do so. Add a minor test in the client
example.

Thanks to Hessam Mirsadeghi for pointing it out.