### PR TITLE
Multiple commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ bindings/python/tests/python/__pycache__/
 examples/alloc
 examples/client
 examples/client2
+examples/client3
 examples/debugger
 examples/debuggerd
 examples/dmodex

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -26,7 +26,8 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
-                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log
+                  hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
+                  client3
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -41,6 +42,10 @@ client_LDADD =  $(top_builddir)/src/libpmix.la
 client2_SOURCES = client2.c examples.h
 client2_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 client2_LDADD =  $(top_builddir)/src/libpmix.la
+
+client3_SOURCES = client3.c examples.h
+client3_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client3_LDADD =  $(top_builddir)/src/libpmix.la
 
 debugger_SOURCES = debugger.c examples.h
 debugger_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -132,4 +137,5 @@ distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
         hello jctrl launcher log pub pubi server tool \
-        abi_no_init abi_with_init group_lcl_cid
+        abi_no_init abi_with_init group_lcl_cid pset \
+        async_group group_dmodex client3

--- a/examples/client3.c
+++ b/examples/client3.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022      ParTec AG.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                myproc.nspace, myproc.rank, status, (unsigned long) evhandler_ref);
+    }
+    lock->status = status;
+    lock->evhandler_ref = evhandler_ref;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL, *val2 = NULL;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    mylock_t mylock;
+    pid_t pid;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    pid = getpid();
+    fprintf(stderr, "Client %lu: Running\n", (unsigned long) pid);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
+            (unsigned long) pid);
+
+    /* register our default event handler - again, this isn't strictly
+     * required, but is generally good practice */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace,
+                myproc.rank);
+        goto done;
+    }
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    /* get the number of procs in our job - univ size is the total number of allocated
+     * slots, not the number of procs in the job */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d num procs %d\n", myproc.nspace, myproc.rank, nprocs);
+
+     /* get a list of our local procs - some may not be in our job */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PROCS, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs with WILDCARD rank failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    // get the list using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_PROCS, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local procs mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+    /* get our nodeID in various ways */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(NULL, PMIX_NODEID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID with NULL proc failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    // get the nodeID using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NODEID, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != val && NULL != val2 && PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get nodeID mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+    /* get our hostname in various ways */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(NULL, PMIX_HOSTNAME, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname with NULL proc failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    // get the nodeID using our proc ID
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_HOSTNAME, NULL, 0, &val2))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname with my ID failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_EQUAL == PMIx_Value_compare(val, val2)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname GOOD\n", myproc.nspace, myproc.rank);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get hostname mismatch\n", myproc.nspace, myproc.rank);
+    }
+    PMIX_VALUE_RELEASE(val);
+    PMIX_VALUE_RELEASE(val2);
+
+done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1260,6 +1260,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_PROVISIONAL_ABI_VERSION  "pmix.qry.prabiver"    // (char*) The PMIx Standard Provisional ABI version supported returned in the form of a comma separated "MAJOR.MINOR"
                                                                    //         This attribute can be used with PMIx_Query_info outside of the init/finalize region.
 
+#define PMIX_VERSION_NUMERIC                "pmix.vers.num"        // (uint32_t) Numeric representation of the version of the PMIx library
+                                                                   //            being used
+
+
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;
 #define PMIX_PROC_STATE_UNDEF                    0  /* undefined process state */

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -239,8 +239,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
             tmp = pmix_basename(aptr->cmd);
             t2 = pmix_basename(aptr->argv[0]);
             if (0 != strcmp(tmp, t2)) {
-                free(appsptr[n].argv[0]);
-                appsptr[n].argv[0] = strdup(tmp);
+                // assume that the user may have put the argv
+                // for their cmd in the argv array, but not
+                // started with the actual cmd - so add it
+                // to the front of the array
+                PMIx_Argv_prepend_nosize(&appsptr[n].argv, tmp);
             }
             free(tmp);
             free(t2);

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -565,7 +565,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         }
     }
     PMIX_LIST_DESTRUCT(&results);
-\
+
     /* if the job's tracker points to a non-default session ID,
      * then we add the default session information to it */
     if (NULL != trk->session && UINT32_MAX != trk->session->session) {


### PR DESCRIPTION
[Correctly set the app cmd and argv0 fields](https://github.com/openpmix/openpmix/commit/75bbd7be7e41168897aeb9ef998413afa28d2320)

Ensure that the cmd field always gets set, or return
an error if it wasn't provided and neither was argv.
If cmd is not set, then take it from argv0.

Ensure that argv0 is always the basename of cmd so
that the spawned app sees the expected name in
that location.

Fix a bug in the transferrence of the app's argv
to the internal structure.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6473f4c7698f3980e9acd64b3eadd5a024fb50c4)

[Don't overwrite user's args](https://github.com/openpmix/openpmix/commit/8728d1fa385814493e4a5f507faf1f021c91c738)

If the cmd provided to spawn doesn't match
argv0, then assume that the user may have put the argv
for their cmd in the argv array, but not
started with the actual cmd - so add it
to the front of the array

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/8733b7acd0f9fd2c755e909ebcbb4b6fa947a2df)

[Correct error in retrieval of node and app info](https://github.com/openpmix/openpmix/commit/d1e16d76bacad6a5eaedc319228dc2e455fb90ce)

Per the Standard, PMIx_Get of node and app info
is to ignore the procID argument. Ensure that we
correctly do so. Add a new test client3 example.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/8a5bee6e83cf3d3b9830da6f14227f5003cf35c7)
