### PR TITLE
Fix local group operations and cleanup to pass all examples.

### DIFF
--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +35,7 @@
 #include <sys/param.h>
 #include <time.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include "examples.h"
 #include <pmix.h>
@@ -44,13 +45,15 @@ static pmix_proc_t myproc;
 int main(int argc, char **argv)
 {
     int rc;
-    pmix_value_t *val = NULL;
-    pmix_proc_t proc;
+    pmix_value_t *val = NULL, value;
+    pmix_proc_t proc, *parray;
     uint32_t nprocs;
-    char nsp2[PMIX_MAX_NSLEN + 1];
+    size_t nall, n, maxprocs = 2;
+    char nsp2[PMIX_MAX_NSLEN + 1], *nsp;
     pmix_app_t *app;
     char hostname[1024], dir[1024];
-    size_t ntmp = 0;
+    pmix_info_t *results = NULL, info;
+    size_t nresults = 0;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -67,7 +70,7 @@ int main(int argc, char **argv)
                 rc);
         exit(0);
     }
-    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Running on host %s\n", myproc.nspace, myproc.rank, hostname);
 
     PMIX_PROC_CONSTRUCT(&proc);
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
@@ -90,66 +93,135 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    /* rank=0 calls spawn */
+    if (NULL == getenv("PMIX_ENV_VALUE")) {
+        // we are the parent
+        /* rank=0 calls spawn */
+        if (0 == myproc.rank) {
+            nsp = basename(argv[0]);
+            PMIX_APP_CREATE(app, 1);
+            app->cmd = strdup(argv[0]);
+            app->maxprocs = maxprocs;
+            app->argv = (char **) malloc(4 * sizeof(char *));
+            app->argv[0] = strdup(nsp);
+            app->argv[1] = strdup(myproc.nspace);
+            asprintf(&app->argv[2], "%d", nprocs);
+            app->argv[3] = NULL;
+            app->env = (char **) malloc(2 * sizeof(char *));
+            app->env[0] = strdup("PMIX_ENV_VALUE=3");
+            app->env[1] = NULL;
+
+            PMIX_INFO_LOAD(&info, PMIX_MAPBY, "node", PMIX_STRING);
+            fprintf(stderr, "Client ns %s rank %d: calling PMIx_Spawn\n", myproc.nspace, myproc.rank);
+            if (PMIX_SUCCESS != (rc = PMIx_Spawn(&info, 1, app, 1, nsp2))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Spawn failed: %d\n", myproc.nspace,
+                        myproc.rank, rc);
+                goto done;
+            }
+            PMIX_APP_FREE(app, 1);
+
+            // share the child namespace
+            value.type = PMIX_STRING;
+            value.data.string = nsp2;
+            if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, "child", &value))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Put child nspace failed: %s\n", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+                goto done;
+            }
+            PMIx_Commit();
+
+            // wait to sync with others
+            nsp = nsp2;
+            PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+            rc = PMIx_Fence(&proc, 1, NULL, 0);
+
+            // everybody calls connect
+            nall = nprocs + maxprocs;
+            PMIX_PROC_CREATE(parray, nall);
+            for (n=0; n < nprocs; n++) {
+                PMIX_LOAD_PROCID(&parray[n], myproc.nspace, n);
+            }
+            for (n=0; n < maxprocs; n++) {
+                PMIX_LOAD_PROCID(&parray[n+nprocs], nsp, n);
+            }
+
+        } else {
+            PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+            rc = PMIx_Fence(&proc, 1, NULL, 0);
+            // retrieve the child nspace
+            proc.rank = 0;
+            rc = PMIx_Get(&proc, "child", NULL, 0, &val);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get child nspace failed: %s\n", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+                goto done;
+            }
+            nsp = val->data.string;
+
+            // everybody calls connect
+            nall = nprocs + maxprocs;
+            PMIX_PROC_CREATE(parray, nall);
+            for (n=0; n < nprocs; n++) {
+                PMIX_LOAD_PROCID(&parray[n], myproc.nspace, n);
+            }
+            for (n=0; n < maxprocs; n++) {
+                PMIX_LOAD_PROCID(&parray[n+nprocs], nsp, n);
+            }
+        }
+    } else {
+        // we are the child job
+        nsp = argv[1];
+        maxprocs = atoi(argv[2]);
+        // everybody calls connect
+        nall = nprocs + maxprocs;
+        PMIX_PROC_CREATE(parray, nall);
+        for (n=0; n < maxprocs; n++) {
+            PMIX_LOAD_PROCID(&parray[n], nsp, n);
+        }
+        for (n=0; n < nprocs; n++) {
+            PMIX_LOAD_PROCID(&parray[n+maxprocs], myproc.nspace, n);
+        }
+    }
+
+
+    fprintf(stderr, "Client ns %s rank %d: calling PMIx_Connect\n", myproc.nspace, myproc.rank);
+    rc = PMIx_Connect(parray, nall, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Connect failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
     if (0 == myproc.rank) {
-        PMIX_APP_CREATE(app, 1);
-        if (0 > asprintf(&app->cmd, "%s/client", dir)) {
-            exit(1);
-        }
-        app->maxprocs = 2;
-        app->argv = (char **) malloc(2 * sizeof(char *));
-        if (0 > asprintf(&app->argv[0], "%s/client", dir)) {
-            exit(1);
-        }
-        app->argv[1] = NULL;
-        app->env = (char **) malloc(2 * sizeof(char *));
-        app->env[0] = strdup("PMIX_ENV_VALUE=3");
-        app->env[1] = NULL;
-
-        fprintf(stderr, "Client ns %s rank %d: calling PMIx_Spawn\n", myproc.nspace, myproc.rank);
-        if (PMIX_SUCCESS != (rc = PMIx_Spawn(NULL, 0, app, 1, nsp2))) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Spawn failed: %d\n", myproc.nspace,
-                    myproc.rank, rc);
-            goto done;
-        }
-        PMIX_APP_FREE(app, 1);
-
-        /* get their universe size */
-        val = NULL;
-        PMIX_LOAD_PROCID(&proc, nsp2, PMIX_RANK_WILDCARD);
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val)) || NULL == val) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
-                    myproc.rank, rc);
-            goto done;
-        }
-        ntmp = val->data.uint32;
-        PMIX_VALUE_RELEASE(val);
-        fprintf(stderr, "Client %s:%d job %s size %d\n", myproc.nspace, myproc.rank, nsp2,
-                (int) ntmp);
-
-        /* get a proc-specific value */
-        val = NULL;
-        proc.rank = 1;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_RANK, NULL, 0, &val)) || NULL == val) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %d\n", myproc.nspace,
-                    myproc.rank, rc);
-            goto done;
-        }
-        ntmp = (int) val->data.uint16;
-        PMIX_VALUE_RELEASE(val);
-        fprintf(stderr, "Client %s:%d job %s local rank %d\n", myproc.nspace, myproc.rank, nsp2,
-                (int) ntmp);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Connect GOOD\n", myproc.nspace, myproc.rank);
+    }
+    rc = PMIx_Disconnect(parray, nall, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Disonnect failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Disconnect GOOD\n", myproc.nspace, myproc.rank);
+    }
+    rc = PMIx_Group_construct("mygrp", parray, nall, NULL, 0, &results, &nresults);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct GOOD\n", myproc.nspace, myproc.rank);
+    }
+    rc = PMIx_Group_destruct("mygrp", NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (0 == myproc.rank) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct GOOD\n", myproc.nspace, myproc.rank);
     }
 
 done:
-    /* call fence to sync */
-    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank,
-                rc);
-        goto done;
-    }
-
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
 

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC.
  *                         All rights reserved.
  *
@@ -72,7 +72,7 @@ static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, v
 {
     mylock_t *lock = (mylock_t *) cbdata;
     EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
-    
+
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
 }
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
     uint32_t nprocs, n;
     mylock_t lock;
     pmix_info_t *results, *info, tinfo[2];
-    size_t nresults, cid, lcid, ninfo;
+    size_t nresults, cid, lcid, ninfo, m;
     pmix_data_array_t darray;
     void *grpinfo, *list;
 
@@ -184,10 +184,15 @@ int main(int argc, char **argv)
                 myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
-    /* we should have a single results object */
+    /* check the results for our global CID*/
     if (NULL != results) {
         cid = 0;
-        PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
+        for (m=0; m < nresults; m++) {
+            if (PMIX_CHECK_KEY(&results[m], PMIX_GROUP_CONTEXT_ID)) {
+                PMIX_VALUE_GET_NUMBER(rc, &results[m].value, cid, size_t);
+                break;
+            }
+        }
         fprintf(stderr, "Rank %d Group construct complete with status %s KEY %s CID %lu\n",
                 myproc.rank, PMIx_Error_string(rc), results[0].key, (unsigned long) cid);
     } else {

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -38,7 +38,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1182,6 +1182,7 @@ PMIX_EXPORT const char* PMIx_Get_attribute_name(const char *attrstring);
 PMIX_EXPORT const char* PMIx_Link_state_string(pmix_link_state_t state);
 PMIX_EXPORT const char* PMIx_Device_type_string(pmix_device_type_t type);
 PMIX_EXPORT const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp);
+PMIX_EXPORT const char* PMIx_Group_operation_string(pmix_group_operation_t op);
 
 /* the following print statements return ALLOCATED strings
  * that the user must release when done */
@@ -1658,7 +1659,7 @@ PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
 
 /* load a process ID struct */
-PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p, 
+PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p,
                                   const char *ns,
                                   pmix_rank_t rk);
 

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -502,4 +502,18 @@ char* PMIx_Resource_unit_string(const pmix_resource_unit_t *p)
 
     pmix_asprintf(&tmp, "TYPE: %s  COUNT: %" PRIsize_t "", PMIx_Device_type_string(p->type), p->count);
     return tmp;
+}
+
+const char* PMIx_Group_operation_string(pmix_group_operation_t op)
+{
+    switch(op) {
+        case PMIX_GROUP_CONSTRUCT:
+            return "CONSTRUCT";
+        case PMIX_GROUP_DESTRUCT:
+            return "DESTRUCT";
+        case PMIX_GROUP_NONE:
+            return "NONE";
+        default:
+            return "UNKNOWN VALUE";
+    }
 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1911,7 +1911,8 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     pmix_server_trkr_t *trk;
     struct timeval tv = {0, 0};
 
-    pmix_output_verbose(2, pmix_server_globals.connect_output, "recvd CONNECT from peer %s:%d",
+    pmix_output_verbose(2, pmix_server_globals.connect_output,
+                        "recvd CONNECT from peer %s:%d",
                         cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
 
     /* unpack the number of procs */


### PR DESCRIPTION
Group operations that are purely local go thru an
optimized path, but still need to return the
right set of info so the client can correctly
track the group.

Add a function to pretty-print the group operation.

Ensure that we get the communications between server and client correct so that all examples work.