### PR TITLE
fixes for pr 3329

### DIFF
--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1138,6 +1138,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
         gotctxid = true;
     }
 
+
     /* since the group construction has finished, we can add
      * the group to out list of groups. Always sort the
      * the array to maintain the same view across participants.*/
@@ -1153,12 +1154,16 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     darray.type = PMIX_PROC;
     ++ninfo;
 
+    ++ninfo; // account for the grpID
+
     if (gotctxid) {
         ++ninfo;
     }
 
     PMIX_INFO_CREATE(iptr, ninfo);
     n = 0;
+    PMIX_INFO_LOAD(&iptr[n], PMIX_GROUP_ID, cb->grpid, PMIX_STRING);
+    ++n;
     if (0 < nmembers) {
         PMIX_INFO_LOAD(&iptr[n], PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
         // do not destruct darray as the membership is being used

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -582,9 +582,11 @@ static void grdes(pmix_group_t *p)
 {
     if (NULL != p->grpid) {
         free(p->grpid);
+        p->grpid = NULL;
     }
     if (NULL != p->members) {
         PMIX_PROC_FREE(p->members, p->nmbrs);
+        p->members = NULL;
     }
 }
 PMIX_CLASS_INSTANCE(pmix_group_t,


### PR DESCRIPTION
PR 3329 introduced a regression which causes Open MPI's MPI_Intercomm_from_groups method to fail.

Related to https://github.com/open-mpi/ompi/pull/12449

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 213956cf00ff164230de06b9887a9412bf1e1dad)