### PR TITLE
Fix function declaration

### DIFF
--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -420,13 +420,14 @@ bool pmix_net_islocalhost(const struct sockaddr *addr)
     return false;
 }
 
-bool pmix_net_samenetwork(const struct sockaddr *addr1, const struct sockaddr *addr2,
+bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
+                          const struct sockaddr_storage *addr2,
                           uint32_t prefixlen)
 {
     return false;
 }
 
-bool bool pmix_net_addr_isipv6linklocal(const struct sockaddr *addr)
+bool pmix_net_addr_isipv6linklocal(const struct sockaddr *addr)
 {
     return false;
 }


### PR DESCRIPTION
We almost never encounter it, so this error has gone undetected for quite some time. When the system lacks a sockaddr structure, we have to provide a "no-op" function. What remains unclear is how that can compile when the function parameters include a sockaddr structure - but that mystery will have to remain unsolved.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 889b1234cdab34d9884c4a5e54b51f6b90685912)