### PR TITLE
Multiple commits

### DIFF
--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020-2022 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -363,15 +363,12 @@ const pmix_regattr_input_t pmix_dictionary[] = {
         return 1
 
     # mark the end of the array
-    constants.write(""",\n
-    {.index = UINT32_MAX, .name = "", .string = "", .type = PMIX_POINTER, .description = (char *[]){"NONE", NULL}}
-};
-""")
+    constants.write("""\n};""")
     constants.write("\n")
     constants.close()
 
     # write the header
-    return _write_header(options, build_src_include_dir, index + 1)
+    return _write_header(options, build_src_include_dir, index)
 
 
 if __name__ == '__main__':

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -518,7 +518,7 @@ cleanup:
 pmix_status_t PMIx_Init(pmix_proc_t *proc,
                         pmix_info_t info[], size_t ninfo)
 {
-    char *evar;
+    char *evar, *suri;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_cb_t cb;
     pmix_buffer_t *req;
@@ -557,11 +557,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
          * to connect if are currently unconnected */
         if (!pmix_globals.connected) {
             rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver, info,
-                                          ninfo);
+                                          ninfo, &suri);
             if (PMIX_SUCCESS == rc) {
                 PMIX_ACQUIRE_THREAD(&pmix_global_lock);
                 pmix_init_result = rc;
                 pmix_client_globals.singleton = false;
+                free(suri);
                 PMIX_RELEASE_THREAD(&pmix_global_lock);
             }
         }
@@ -778,7 +779,8 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     PMIX_INFO_DESTRUCT(&ginfo);
 
     /* attempt to connect to a server */
-    rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver, info, ninfo);
+    rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver,
+                                   info, ninfo, &suri);
     if (PMIX_SUCCESS != rc) {
         /* mark that we couldn't connect to a server */
         pmix_client_globals.singleton = true;
@@ -800,6 +802,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         if (PMIX_SUCCESS != rc) {
             pmix_init_result = rc;
             PMIX_RELEASE_THREAD(&pmix_global_lock);
+            free(suri);
             return rc;
         }
     } else {
@@ -813,6 +816,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_RELEASE(req);
             pmix_init_result = rc;
             PMIX_RELEASE_THREAD(&pmix_global_lock);
+            free(suri);
             return rc;
         }
         /* send to the server */
@@ -821,6 +825,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         if (PMIX_SUCCESS != rc) {
             pmix_init_result = rc;
             PMIX_RELEASE_THREAD(&pmix_global_lock);
+            free(suri);
             return rc;
         }
         /* wait for the data to return */
@@ -829,6 +834,47 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_DESTRUCT(&cb);
     }
     pmix_init_result = rc;
+
+    /* store our server's ID */
+    if (NULL != pmix_client_globals.myserver &&
+        NULL != pmix_client_globals.myserver->info) {
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_SERVER_NSPACE);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup(pmix_client_globals.myserver->info->pname.nspace);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_SERVER_RANK);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_PROC_RANK;
+        kptr->value->data.rank = pmix_client_globals.myserver->info->pname.rank;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+        PMIX_RELEASE(kptr); // maintain accounting
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+
+        /* store the URI for subsequent lookups */
+        PMIX_KVAL_NEW(kptr, PMIX_SERVER_URI);
+        kptr->value->type = PMIX_STRING;
+        pmix_asprintf(&kptr->value->data.string, "%s.%u;%s",
+                      pmix_client_globals.myserver->info->pname.nspace,
+                      pmix_client_globals.myserver->info->pname.rank, suri);
+        free(suri);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+        PMIX_RELEASE(kptr); // maintain accounting
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+    }
 
     // enable show_help subsystem
     pmix_show_help_enabled = true;
@@ -894,33 +940,6 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* check to see if we need to notify anyone */
     if (NULL != info) {
         _check_for_notify(info, ninfo);
-    }
-
-    /* store our server's ID */
-    if (NULL != pmix_client_globals.myserver &&
-        NULL != pmix_client_globals.myserver->info) {
-        kptr = PMIX_NEW(pmix_kval_t);
-        kptr->key = strdup(PMIX_SERVER_NSPACE);
-        PMIX_VALUE_CREATE(kptr->value, 1);
-        kptr->value->type = PMIX_STRING;
-        kptr->value->data.string = strdup(pmix_client_globals.myserver->info->pname.nspace);
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-        PMIX_RELEASE(kptr); // maintain accounting
-        kptr = PMIX_NEW(pmix_kval_t);
-        kptr->key = strdup(PMIX_SERVER_RANK);
-        PMIX_VALUE_CREATE(kptr->value, 1);
-        kptr->value->type = PMIX_PROC_RANK;
-        kptr->value->data.rank = pmix_client_globals.myserver->info->pname.rank;
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-        PMIX_RELEASE(kptr); // maintain accounting
     }
 
     /* register the client supported attrs */

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -73,7 +73,8 @@ PMIX_EXPORT void pmix_init_registered_attrs(void)
 
         /* cycle across the dictionary and load a hash
          * table with translations of key -> index */
-        for (n=0; UINT32_MAX != pmix_dictionary[n].index; n++) {
+        pmix_pointer_array_set_size(pmix_globals.keyindex.table, PMIX_INDEX_BOUNDARY);  // minimize realloc's
+        for (n=0; n < PMIX_INDEX_BOUNDARY; n++) {
             p = (pmix_regattr_input_t*)pmix_malloc(sizeof(pmix_regattr_input_t));
             p->index = pmix_dictionary[n].index;
             p->name = strdup(pmix_dictionary[n].name);
@@ -82,6 +83,7 @@ PMIX_EXPORT void pmix_init_registered_attrs(void)
             p->description = PMIx_Argv_copy(pmix_dictionary[n].description);
             pmix_hash_register_key(p->index, p, &pmix_globals.keyindex);
         }
+        pmix_globals.keyindex.next_id = PMIX_INDEX_BOUNDARY;
         initialized = true;
     }
 }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -201,7 +201,9 @@ static void keyindex_construct(pmix_keyindex_t *ki)
     pmix_tma_t *const tma = pmix_obj_get_tma(&ki->super);
 
     ki->table = PMIX_NEW(pmix_pointer_array_t, tma);
-    ki->next_id = PMIX_INDEX_BOUNDARY;
+    pmix_pointer_array_init(ki->table, 1024, INT_MAX, 128);
+
+    ki->next_id = 0;
 }
 
 static void keyindex_destruct(pmix_keyindex_t *ki)

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -270,11 +270,13 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_names
  *
  * t - pointer to the modex server tracker
  */
-#define PMIX_GDS_STORE_MODEX(r, n, b, t)                                                          \
-    do {                                                                                          \
-        pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS STORE MODEX WITH %s", __FILE__, \
-                            __LINE__, (n)->compat.gds->name);                                     \
-        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t *) n, b, t);                  \
+#define PMIX_GDS_STORE_MODEX(r, n, b, t)                                    \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_output_verbose(1, pmix_gds_base_output,                        \
+                            "[%s:%d] GDS STORE MODEX WITH %s", __FILE__,    \
+                            __LINE__, _g->name);                            \
+        (r) = _g->store_modex((struct pmix_namespace_t *)n, b, t);          \
     } while (0)
 
 typedef pmix_status_t (*pmix_gds_base_module_mark_modex_complete_fn_t)(struct pmix_peer_t *peer,
@@ -282,7 +284,7 @@ typedef pmix_status_t (*pmix_gds_base_module_mark_modex_complete_fn_t)(struct pm
                                                                        pmix_buffer_t *buff);
 #define PMIX_GDS_MARK_MODEX_COMPLETE(r, p, l, b)                            \
     do {                                                                    \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                 \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS MARK MODEX COMPLETE WITH %s",      \
                             __FILE__, __LINE__, _g->name);                  \
@@ -292,7 +294,7 @@ typedef pmix_status_t (*pmix_gds_base_module_mark_modex_complete_fn_t)(struct pm
 typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buffer_t *buff);
 #define PMIX_GDS_RECV_MODEX_COMPLETE(r, p, b)                               \
     do {                                                                    \
-        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                 \
+        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS RECV MODEX COMPLETE WITH %s",      \
                             __FILE__, __LINE__, _g->name);                  \

--- a/src/mca/gds/shmem2/gds_shmem2.c
+++ b/src/mca/gds/shmem2/gds_shmem2.c
@@ -1807,19 +1807,6 @@ unpack_shmem2_connection_info(
     return rc;
 }
 
-static inline int
-parray_nelem(
-    pmix_pointer_array_t *array
-) {
-    int i = 0;
-    for ( ; i < array->size; ++i) {
-        if (!pmix_pointer_array_get_item(array, i)) {
-            break;
-        }
-    }
-    return i;
-}
-
 static inline void
 regattr_list_free(
     pmix_regattr_input_t *ra,

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -122,7 +122,8 @@ PMIX_CLASS_DECLARATION(pmix_connection_t);
 /* API stubs */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *peer,
-                                                        pmix_info_t info[], size_t ninfo);
+                                                        pmix_info_t info[], size_t ninfo,
+                                                        char **suri);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
                                                        bool optional,
                                                        pmix_list_t *connections);
@@ -167,7 +168,7 @@ PMIX_EXPORT pmix_rnd_flag_t pmix_ptl_base_set_flag(size_t *sz);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,
                                                         pmix_info_t *iptr, size_t niptr);
 PMIX_EXPORT void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace,
-                                                   pmix_rank_t rank, char *uri);
+                                                   pmix_rank_t rank);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_timeout(pmix_peer_t *peer, struct timeval *save,
                                                     pmix_socklen_t *sz, bool *sockopt);
 PMIX_EXPORT void pmix_ptl_base_setup_socket(pmix_peer_t *peer);
@@ -175,8 +176,6 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_client_handshake(pmix_peer_t *peer, pmix
 PMIX_EXPORT pmix_status_t pmix_ptl_base_tool_handshake(pmix_peer_t *peer, pmix_status_t rp);
 PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(const char *orig_str,
                                                    const char *name);
-PMIX_EXPORT pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info,
-                                                        size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char *evar);
 PMIX_EXPORT char *pmix_ptl_base_get_cmd_line(void);
 

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -433,7 +433,9 @@ static pmix_status_t trysearch(pmix_peer_t *peer, char **nspace,
     return rc;
 }
 
-pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info, size_t ninfo)
+pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
+                                            pmix_info_t *info, size_t ninfo,
+                                            char **suriout)
 {
     char *suri = NULL, *st, *evar;
     char *filename, *nspace = NULL;
@@ -796,9 +798,10 @@ complete:
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "tool_peer_try_connect: Connection across to server succeeded");
 
-    pmix_ptl_base_complete_connection(peer, nspace, rank, suri);
+    pmix_ptl_base_complete_connection(peer, nspace, rank);
 
 cleanup:
+    *suriout = suri;
     if (NULL != nspace) {
         free(nspace);
     }
@@ -807,9 +810,6 @@ cleanup:
     }
     if (NULL != rendfile) {
         free(rendfile);
-    }
-    if (NULL != suri) {
-        free(suri);
     }
     if (NULL != server_nspace) {
         free(server_nspace);

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -645,12 +645,8 @@ retry:
     return PMIX_SUCCESS;
 }
 
-void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace, pmix_rank_t rank,
-                                       char *suri)
+void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace, pmix_rank_t rank)
 {
-    pmix_kval_t *urikv;
-    pmix_status_t rc;
-
     pmix_globals.connected = true;
 
     /* setup the server info */
@@ -670,16 +666,6 @@ void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace, pmix_ran
     }
     peer->info->pname.nspace = strdup(peer->nptr->nspace);
     peer->info->pname.rank = rank;
-
-    /* store the URI for subsequent lookups */
-    PMIX_KVAL_NEW(urikv, PMIX_SERVER_URI);
-    urikv->value->type = PMIX_STRING;
-    pmix_asprintf(&urikv->value->data.string, "%s.%u;%s", nspace, rank, suri);
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, urikv);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-    }
-    PMIX_RELEASE(urikv); // maintain accounting
 
     pmix_ptl_base_set_nonblocking(peer->sd);
 

--- a/src/mca/ptl/client/ptl_client.c
+++ b/src/mca/ptl/client/ptl_client.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,14 +62,18 @@
 #include "ptl_client.h"
 #include "src/mca/ptl/base/base.h"
 
-static pmix_status_t connect_to_peer(struct pmix_peer_t *peer, pmix_info_t *info, size_t ninfo);
+static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
+                                     pmix_info_t *info, size_t ninfo,
+                                     char **suri);
 
 pmix_ptl_module_t pmix_ptl_client_module = {
     .name = "client",
     .connect_to_peer = connect_to_peer
 };
 
-static pmix_status_t connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info, size_t ninfo)
+static pmix_status_t connect_to_peer(struct pmix_peer_t *pr,
+                                     pmix_info_t *info, size_t ninfo,
+                                     char **suriout)
 {
     char *evar = NULL, *suri = NULL;
     char *nspace = NULL;
@@ -215,13 +219,11 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *pr, pmix_info_t *info, 
 
 complete:
     /* mark the connection as made */
-    pmix_ptl_base_complete_connection(peer, nspace, rank, suri);
+    pmix_ptl_base_complete_connection(peer, nspace, rank);
+    *suriout = suri;
 
     if (NULL != nspace) {
         free(nspace);
-    }
-    if (NULL != suri) {
-        free(suri);
     }
     return rc;
 }

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,8 +83,10 @@ typedef pmix_status_t (*pmix_ptl_cancel_fn_t)(struct pmix_peer_t *peer, pmix_ptl
 
 /* connect to a peer - this is a blocking function
  * to establish a connection to a peer*/
-typedef pmix_status_t (*pmix_ptl_connect_to_peer_fn_t)(struct pmix_peer_t *peer, pmix_info_t info[],
-                                                       size_t ninfo);
+typedef pmix_status_t (*pmix_ptl_connect_to_peer_fn_t)(struct pmix_peer_t *peer,
+                                                       pmix_info_t info[],
+                                                       size_t ninfo,
+                                                       char **suri);
 
 /* query available servers on the local node */
 typedef void (*pmix_ptl_query_servers_fn_t)(char *dirname, pmix_list_t *servers);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -494,7 +494,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     bool nspace_given = false, rank_given = false;
     bool share_topo = false;
     pmix_info_t ginfo, *iptr, evinfo[3];
-    char *evar, *nspace = NULL, *suri;
+    char *evar, *nspace = NULL;
     pmix_rank_t rank = PMIX_RANK_INVALID;
     pmix_rank_info_t *rinfo;
     pmix_proc_type_t ptype = PMIX_PROC_TYPE_STATIC_INIT;
@@ -507,8 +507,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     pmix_ptl_posted_recv_t *rcv;
     bool outputio;
     char *singleton = NULL;
-    pmix_data_array_t *mau = NULL;
-    pmix_kval_t *kptr;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -910,26 +908,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
         /* wait for release to arrive */
         PMIX_WAIT_THREAD(&releaselock);
         PMIX_DESTRUCT_LOCK(&releaselock);
-    } else if (connect_directed) {
-        /* connect to another server, if the info's direct us to */
-        rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver,
-                                      info, ninfo, &suri);
-        if (PMIX_SUCCESS != rc && !connect_optional) {
-            return rc;
-        }
-        /* store the URI for subsequent lookups */
-        PMIX_KVAL_NEW(kptr, PMIX_SERVER_URI);
-        kptr->value->type = PMIX_STRING;
-        pmix_asprintf(&kptr->value->data.string, "%s.%u;%s",
-                      pmix_client_globals.myserver->info->pname.nspace,
-                      pmix_client_globals.myserver->info->pname.rank, suri);
-        free(suri);
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
-        PMIX_RELEASE(kptr); // maintain accounting
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
     }
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
[Ensure server and client indices are in sync](https://github.com/openpmix/openpmix/commit/cd2bd9da96d527e826f447cdf47d25b338a4a9b9)

Do not include a terminator element in the pmix_dictionary, but
instead rely on the defined number of entries as the length
of the array. Since user-defined keys can be different on
each process, and/or appear in different order, we cannot
define a unique index for them. Each process will assign
their own index when those keys are "put", and we currently
have no way to go back into the hash storage to "reset"
those values. So we have to push all returned modex values
into the local hash for now.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c38aef6ba5f657b72cd98e47ea38857cceb7b5c1)
Signed-off-by: Ralph Castain <rhc@pmix.org>

[Remove unused function in shmem2.](https://github.com/openpmix/openpmix/commit/73664171e3fa31b9195ac89ebe6612468ee7fbba)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c3ae2d05485eae3cb86d0cd625d896beb5a02715)
