### PR TITLE
Protect against NULL fields

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -836,7 +836,8 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_init_result = rc;
 
     /* store our server's ID */
-    if (NULL != pmix_client_globals.myserver &&
+    if (!pmix_client_globals.singleton &&
+        NULL != pmix_client_globals.myserver &&
         NULL != pmix_client_globals.myserver->info) {
         kptr = PMIX_NEW(pmix_kval_t);
         kptr->key = strdup(PMIX_SERVER_NSPACE);

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,11 +100,14 @@ static pmix_value_cmp_t cmp_proc_info(pmix_proc_info_t *pi1,
     } else if (NULL != pi1->hostname && NULL == pi2->hostname) {
         return PMIX_VALUE1_GREATER;
     }
-    ret = strcmp(pi1->hostname, pi2->hostname);
-    if (ret < 0) {
-        return PMIX_VALUE2_GREATER;
-    } else if (0 < ret) {
-        return PMIX_VALUE1_GREATER;
+    // both can be NULL
+    if (NULL != pi1->hostname && NULL != pi2->hostname) {
+        ret = strcmp(pi1->hostname, pi2->hostname);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
     }
     /* hostnames match */
 
@@ -113,11 +116,14 @@ static pmix_value_cmp_t cmp_proc_info(pmix_proc_info_t *pi1,
     } else if (NULL != pi1->executable_name && NULL == pi2->executable_name) {
         return PMIX_VALUE1_GREATER;
     }
-    ret = strcmp(pi1->executable_name, pi2->executable_name);
-    if (ret < 0) {
-        return PMIX_VALUE2_GREATER;
-    } else if (0 < ret) {
-        return PMIX_VALUE1_GREATER;
+    // both can be NULL
+    if (NULL != pi1->executable_name && NULL != pi2->executable_name) {
+        ret = strcmp(pi1->executable_name, pi2->executable_name);
+        if (ret < 0) {
+            return PMIX_VALUE2_GREATER;
+        } else if (0 < ret) {
+            return PMIX_VALUE1_GREATER;
+        }
     }
     /* executables match */
 

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1158,7 +1158,9 @@ pmix_status_t pmix_bfrops_base_print_pinfo(char **output, char *prefix,
                      "%sData type: PMIX_PROC_INFO\tValue:\n%s\n%sHostname: %s\tExecutable: "
                      "%s\n%sPid: %lu\tExit code: %d\tState: %s",
                      (NULL == prefix) ? " " : prefix, tmp, p2,
-                     src->hostname, src->executable_name, p2,
+                     (NULL == src->hostname) ? "NULL" : src->hostname,
+                     (NULL == src->executable_name) ? "NULL" : src->executable_name,
+                     p2,
                      (unsigned long) src->pid, src->exit_code,
                      PMIx_Proc_state_string(src->state))) {
         free(p2);


### PR DESCRIPTION
Protect a couple of places from NULL fields in pmix_proc_info_t

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 2a7d9e13dc4e88a661e42a633ff25f5898f20401)

[Fix singletons](https://github.com/openpmix/openpmix/pull/3363/commits/5599f9fcf059d9ba787a03e1117eddabe90745df)

Don't try to save the server URL if we are operating
as a singleton since we won't have one.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 930d4bc5af1cbf7a2674ed51a88984c299824eea)
