### PR TITLE
Apply prefix to copied version of the app array

### DIFF
--- a/.github/actions/mlnx/Dockerfile
+++ b/.github/actions/mlnx/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos:7.6.1810
+FROM almalinux:9
 
 RUN \
-    yum install -y perl perl-Data-Dumper \
-        python3 python3-pip python-virtualenv \
+    dnf install -y perl perl-Data-Dumper \
+        python3 python3-pip zlib \
         automake libtool flex make bzip2 git which rpm-build libevent-devel hwloc hwloc-devel
 
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/mlnx/entrypoint.sh
+++ b/.github/actions/mlnx/entrypoint.sh
@@ -3,6 +3,8 @@
 rel_path=$(dirname $0)
 abs_path=$(readlink -f $rel_path)
 
+git config --global --add safe.directory /github/workspace
+
 if [ "$1" = "build" ]; then
     jenkins_test_build="yes"
     jenkins_test_check="no"
@@ -167,12 +169,9 @@ if [ "$jenkins_test_src_rpm" = "yes" ]; then
         echo "Do not support PMIX on debian"
     else
         # Install Sphinx so that we can "make dist"
-        virtualenv --python=python3 venv
+        python3 -m venv venv
         . ./venv/bin/activate
-        # This job runs in a CentOS 7 docker container, which does not
-        # understand the "--use-feature" pip CLI argument.
-        grep -v use-feature docs/requirements.txt > docs/r2.txt
-        pip install -r docs/r2.txt
+        pip install -r docs/requirements.txt
 
         echo ./configure --prefix=$pmix_dir $configure_args | bash -xeE || exit 11
         echo "Building PMIX src.rpm"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,9 +37,8 @@ with open("../VERSION") as fp:
 
 opmix_data = dict()
 for opmix_line in opmix_lines:
-    if '#' in opmix_line:
-        parts = opmix_line.split("#")
-        opmix_line = parts[0]
+    if '#' in opmix_line or 0 == len(opmix_line):
+        continue
     opmix_line = opmix_line.strip()
 
     if '=' not in opmix_line:

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -319,14 +319,22 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         // adjust the cmd prefix if required
         if (NULL != prefix) {
             // prefix the command
-            pmix_asprintf(&tmp, "%s/%s", prefix, aptr->cmd);
-            free(aptr->cmd);
-            aptr->cmd = tmp;
+            pmix_asprintf(&tmp, "%s/%s", prefix, appsptr[n].cmd);
+            free(appsptr[n].cmd);
+            appsptr[n].cmd = tmp;
+            // prefix argv[0]
+            pmix_asprintf(&tmp, "%s/%s", prefix, appsptr[n].argv[0]);
+            free(appsptr[n].argv[0]);
+            appsptr[n].argv[0] = tmp;
         } else if (NULL != defprefix) {
             // prefix the command
-            pmix_asprintf(&tmp, "%s/%s", defprefix, aptr->cmd);
-            free(aptr->cmd);
-            aptr->cmd = tmp;
+            pmix_asprintf(&tmp, "%s/%s", defprefix, appsptr[n].cmd);
+            free(appsptr[n].cmd);
+            appsptr[n].cmd = tmp;
+            // prefix argv[0]
+            pmix_asprintf(&tmp, "%s/%s", defprefix, appsptr[n].argv[0]);
+            free(appsptr[n].argv[0]);
+            appsptr[n].argv[0] = tmp;
         }
 
         if (!jobenvars) {


### PR DESCRIPTION
When applying a specified prefix, apply the change to the copy of the incoming app array and not the incoming array elements themselves in case they were statically defined.

Thanks to @dgloe-hpe for the report!

Fixes #3370 