### PR TITLE
configure: fix broken bashisms resulting in logic failure

### DIFF
--- a/src/mca/gds/shmem2/configure.m4
+++ b/src/mca/gds/shmem2/configure.m4
@@ -18,7 +18,7 @@ AC_DEFUN([MCA_pmix_gds_shmem2_CONFIG], [
     dnl address space is probably too small for the 'virtual memory hole'
     dnl finding that we do here. Below assumes support for only 32- and 64-bit
     dnl architectures.
-    AS_IF([test $ac_cv_sizeof_void_p -ne 4 && test $oac_have_apple == 0],
+    AS_IF([test $ac_cv_sizeof_void_p -ne 4 && test $oac_have_apple = 0],
           [$1
            pmix_gds_shmem2=yes],
           [$2


### PR DESCRIPTION
Some code which was only valid using GNU bash was included. Detected in Gentoo packaging via:

```
 * QA Notice: Abnormal configure code
 *
 * ./configure: 40936: test: 0: unexpected operator
```

Bash provides the standard `test XXX = YYY` or `[ XXX = YYY ]` utilities. It also provides the ability to spell the equals sign as a double equals. This does nothing whatsoever -- it adds no new functionality to bash, it forbids nothing, it is *literally* an exact alias.

It should never be used under any circumstances. All developers must immediately forget that it exists. Using it is non-portable and does not work in /bin/sh scripts such as configure scripts, and it results in dangerous muscle memory when used in bash scripts because it makes people unthinkingly use the double equals even in /bin/sh scripts. To add insult to injury, it makes scripts take up more disk space (by a whole byte! and sometimes even a few bytes...)

Delete this accidental bashism, and restore the ability to get correct ./configure behavior on systems where /bin/sh is something other than a symlink to GNU bash.