### PR TITLE
configure: fix regression that caused python to be mandatory to build

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1328,15 +1328,15 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
     AC_SUBST([PMIX_PYTHON_EGG_PATH], [$pmix_pythondir], [Path to installed Python egg])
 fi
 
-# If we didn't find a good Python and we don't have dictionary.h, then
+# If we didn't find a good Python and we don't have pmix_dictionary.h, then
 # see if we can find an older Python (because construct_dictionary.py
 # can use an older Python).
-AS_IF([test "$PYTHON" = "" && test ! -f $srcdir/include/dictionary.h],
+AS_IF([test "$PYTHON" = "" && test ! -f $srcdir/src/include/pmix_dictionary.h],
       [AC_MSG_CHECKING([python])
        PYTHON=
        AM_PATH_PYTHON
        # If we still can't find Python (and we don't have
-       # dictionary.h), then give up.
+       # pmix_dictionary.h), then give up.
        AC_MSG_RESULT([$PYTHON])
        AS_IF([test "$PYTHON" = ""],
              [AC_MSG_WARN([Could not find a modern enough Python])


### PR DESCRIPTION
In commit 523497d119561af8e3f6358338ad13076e45abbb, some logic was added to verify at configure time that a python interpreter is available. It's required for a python script that generates a header, which is also distributed via BUILT_SOURCES in dist tarballs, so it's only necessary when building from git.

The configure check looks to see if the header file exists at configure time to determine whether python is a requirement. But it accidentally looked for the wrong file. The autoconf $srcdir variable looks similar to the src/ directory, but actually refers to the directory that the current ./configure script (or Makefile) is in. The actual src/ component of the path to the header went missing.

Later, in commit b54565f8171856d0341fd1a52c9bc060b77df531, the header file was renamed from dictionary.h to pmix_dictionary.h, which broke the check a second way.

It's difficult to test a regression like this, because it is inherently needed anyways when building from git, which CI does. To make matters worse, some linux distros tend to have python3 installed for one reason or another anyway (e.g. Gentoo's package manager is written in it) or are building the bindings regardless, so the check will always pass even if maybe it shouldn't.

Bug finally discovered via an entirely unrelated accident on Gentoo in a CI which specifically removes the /usr/bin/python3 symlink and builds random packages to check which ones fail to depend on Gentoo's python wrapper. Even then, automake checks for version-specific names to python, and python3.12 exists... but automake 1.16 only supports looking for python 3.0 - 3.9, and automake 1.17 was released on July 11, 2024, and is available nowhere.

Bug: https://bugs.gentoo.org/934234
Fixes: b54565f8171856d0341fd1a52c9bc060b77df531
Fixes: 523497d119561af8e3f6358338ad13076e45abbb