### PR TITLE
Revert Sphinx requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=5.0.0
 recommonmark
-docutils<0.19
+docutils
 sphinx-rtd-theme


### PR DESCRIPTION
Installing anaconda confused the system and led to the problems. Uninstalling it resolved things and
we can therefore fall back to letting Python deal
with selecting the right combination of versions.