### PR TITLE
Multiple commits

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1328,15 +1328,15 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
     AC_SUBST([PMIX_PYTHON_EGG_PATH], [$pmix_pythondir], [Path to installed Python egg])
 fi
 
-# If we didn't find a good Python and we don't have dictionary.h, then
+# If we didn't find a good Python and we don't have pmix_dictionary.h, then
 # see if we can find an older Python (because construct_dictionary.py
 # can use an older Python).
-AS_IF([test "$PYTHON" = "" && test ! -f $srcdir/include/dictionary.h],
+AS_IF([test "$PYTHON" = "" && test ! -f $srcdir/src/include/pmix_dictionary.h],
       [AC_MSG_CHECKING([python])
        PYTHON=
        AM_PATH_PYTHON
        # If we still can't find Python (and we don't have
-       # dictionary.h), then give up.
+       # pmix_dictionary.h), then give up.
        AC_MSG_RESULT([$PYTHON])
        AS_IF([test "$PYTHON" = ""],
              [AC_MSG_WARN([Could not find a modern enough Python])

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -14,6 +14,7 @@
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
 #                         reserved.
+# Copyright (c) 2024      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -94,13 +95,30 @@ Valid arguments:
   --distdir       Move the tarball(s) to this directory when done
   --dirtyok       Ok if the source tree is dirty
   --verok         Ignore result of autotools version checking
-  --macosx        Executing on Mac OSX, so do not check libtool version
+  --macosx        Allow execution on Mac OSX
 EOF
             exit 1
             ;;
     esac
     shift
 done
+
+# check for OS type - we do not allow building tarballs on
+# MacOSX by default as it can create problems when unpacking
+# the tarball on Linux. See
+# for details.
+if [[ $mac != 1 ]]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "\n*** Building a tarball on MacOSX results in a"
+        echo "*** tarball that includes undesirable artifacts"
+        echo "*** when unpacked on Linux systems. We therefore"
+        echo "*** do not support this operation by default.\n"
+        echo "*** If you do need to execute this on MacOSX, then"
+        echo "*** you can override this warning by setting the"
+        echo "*** --macosx option on the cmd line\n"
+        exit 1
+    fi
+fi
 
 # pmix needs libevent to build.  If $LIBEVENT is set in the
 # environment, automatically add it to the config_args.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0
+sphinx>=5.0.0
 recommonmark
-docutils
+docutils<0.19
 sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=5.0.0
 recommonmark
-docutils<0.19
+docutils
 sphinx-rtd-theme

--- a/src/mca/gds/shmem2/configure.m4
+++ b/src/mca/gds/shmem2/configure.m4
@@ -18,7 +18,7 @@ AC_DEFUN([MCA_pmix_gds_shmem2_CONFIG], [
     dnl address space is probably too small for the 'virtual memory hole'
     dnl finding that we do here. Below assumes support for only 32- and 64-bit
     dnl architectures.
-    AS_IF([test $ac_cv_sizeof_void_p -ne 4 && test $oac_have_apple == 0],
+    AS_IF([test $ac_cv_sizeof_void_p -ne 4 && test $oac_have_apple = 0],
           [$1
            pmix_gds_shmem2=yes],
           [$2


### PR DESCRIPTION
[Update the requirements for Sphinx](https://github.com/openpmix/openpmix/commit/cf6136e6b05da3cdda7915770ae2cc1528388a3b)

Getting into an odd situation where Sphinx is spewing
errors and warnings due to deprecated packages. Try to
find a path to something workable - somewhat frustrating
as the Sphinx site admits to the problems, but basically
saids they don't care, just poke around until you find
a "good" combination.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/27ab19f1f9be8b5d8c9d35a8ae0ed599c7cd8622)

[configure: fix broken bashisms resulting in logic failure](https://github.com/openpmix/openpmix/commit/7e8e5d685f5f9fb66fa212a5c64e9c3a5224e642)

Some code which was only valid using GNU bash was included. Detected in
Gentoo packaging via:

```
 * QA Notice: Abnormal configure code
 *
 * ./configure: 40936: test: 0: unexpected operator
```

Bash provides the standard `test XXX = YYY` or `[ XXX = YYY ]`
utilities. It also provides the ability to spell the equals sign as a
double equals. This does nothing whatsoever -- it adds no new
functionality to bash, it forbids nothing, it is *literally* an exact
alias.

It should never be used under any circumstances. All developers must
immediately forget that it exists. Using it is non-portable and does not
work in /bin/sh scripts such as configure scripts, and it results in
dangerous muscle memory when used in bash scripts because it makes
people unthinkingly use the double equals even in /bin/sh scripts. To
add insult to injury, it makes scripts take up more disk space (by a
whole byte! and sometimes even a few bytes...)

Delete this accidental bashism, and restore the ability to get correct
./configure behavior on systems where /bin/sh is something other than a
symlink to GNU bash.

Signed-off-by: Eli Schwartz <eschwartz@gentoo.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/0f63488540c83d4acef4df867632a4d4e67c23c8)

In commit https://github.com/openpmix/openpmix/commit/523497d119561af8e3f6358338ad13076e45abbb, some logic was added
to verify at configure time that a python interpreter is available. It's
required for a python script that generates a header, which is also
distributed via BUILT_SOURCES in dist tarballs, so it's only necessary
when building from git.

The configure check looks to see if the header file exists at configure
time to determine whether python is a requirement. But it accidentally
looked for the wrong file. The autoconf $srcdir variable looks similar
to the src/ directory, but actually refers to the directory that the
current ./configure script (or Makefile) is in. The actual src/
component of the path to the header went missing.

Later, in commit https://github.com/openpmix/openpmix/commit/b54565f8171856d0341fd1a52c9bc060b77df531, the header
file was renamed from dictionary.h to pmix_dictionary.h, which broke the
check a second way.

It's difficult to test a regression like this, because it is inherently
needed anyways when building from git, which CI does. To make matters
worse, some linux distros tend to have python3 installed for one reason
or another anyway (e.g. Gentoo's package manager is written in it) or
are building the bindings regardless, so the check will always pass even
if maybe it shouldn't.

Bug finally discovered via an entirely unrelated accident on Gentoo in a
CI which specifically removes the /usr/bin/python3 symlink and builds
random packages to check which ones fail to depend on Gentoo's python
wrapper. Even then, automake checks for version-specific names to
python, and python3.12 exists... but automake 1.16 only supports looking
for python 3.0 - 3.9, and automake 1.17 was released on July 11, 2024,
and is available nowhere.

Bug: https://bugs.gentoo.org/934234
Fixes: https://github.com/openpmix/openpmix/commit/b54565f8171856d0341fd1a52c9bc060b77df531
Fixes: https://github.com/openpmix/openpmix/commit/523497d119561af8e3f6358338ad13076e45abbb
Signed-off-by: Eli Schwartz <eschwartz@gentoo.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/ecc03ee1dd6acae9e8be074e1e1eb1072ea5fcc4)

[Warn against building tarball on MacOSX](https://github.com/openpmix/openpmix/commit/c5cd3a16b2c4cf70008a47cff7a1dc21cc57ad2a)

Building a tarball on MacOSX results in a
tarball that includes undesirable artifacts
when unpacked on Linux systems. We therefore
do not support this operation by default

Include an override path by passing --macosx on the cmd line

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/02b086e51cb25e74e473442a8261ac30aa426281)

[Revert Sphinx requirements](https://github.com/openpmix/openpmix/commit/b4d99ec9318f234444784ca829dda7c0f42c81b5)

Installing anaconda confused the system and led to
the problems. Uninstalling it resolved things and
we can therefore fall back to letting Python deal
with selecting the right combination of versions.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2811f52cf6c9e0c2a02fbc1c4a5a699276c2dd1b)
