### PR TITLE
Read The Docs updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,15 @@ key = 'READTHEDOCS'
 if key in os.environ and os.environ[key] == 'True':
     print("OpenPMIx: found ReadTheDocs build environment")
 
+    # Tell Jinja2 templates the build is running on Read the Docs
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
+    # Define the canonical URL if you are using a custom domain on
+    # Read the Docs
+    html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
     rtd_v = os.environ['READTHEDOCS_VERSION']
     if os.environ['READTHEDOCS_VERSION_TYPE'] == 'external':
         # Make "release" be shorter than the full "opmix_ver" value.


### PR DESCRIPTION
RTD is rolling out some changes.  Per
https://about.readthedocs.com/blog/2024/07/addons-by-default/, these are the changes we need to make.

Port of https://github.com/open-mpi/ompi/pull/12687

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit fe988a64077dc6a276f7a3c66894e76642f70333)