### PR TITLE
Protect against LTO optimizer

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -890,6 +890,19 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
     CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
 
+
+    # We do not currently support the "lto" optimizer as it
+    # aggregates all the headers from our plugins, resulting
+    # in a configuration that generates warnings/errors when
+    # passed through their optimizer phase. We therefore check
+    # for the flag, and if found, output a message explaining
+    # the situation and aborting configure
+    _PMIX_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
+    _PMIX_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LIBS, LIBS)
+
+
     ############################################################################
     # final wrapper compiler config
     ############################################################################

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -39,4 +39,15 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
             else
                 AC_MSG_RESULT([yes])
             fi
+])
+
+AC_DEFUN([_PMIX_CHECK_LTO_FLAG], [
+    chkflg=`echo $1 | grep -- -flto`
+    if test -n "$chkflg"; then
+        AC_MSG_WARN([Configure has detected the presence of the -flto])
+        AC_MSG_WARN([compiler directive in $2. PMIx does not currently])
+        AC_MSG_WARN([support this flag as it conflicts with the])
+        AC_MSG_WARN([plugin architecture of the PMIx library.])
+        AC_MSG_ERROR([Please remove this directive and re-run configure.])
+    fi
 ])


### PR DESCRIPTION
We currently do not support the LTO optimizer
as it is incompatible with our plugin component
architecture. So detect it has been specified
in configure and error out with an explanation.

Includes suggestions from @jsquyres

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit e44dd27cb386e9abe3a0af0d2486c096c2ebd28d)