### PR TITLE
Cleanup pfexec spawn operations

### DIFF
--- a/src/mca/pfexec/Makefile.am
+++ b/src/mca/pfexec/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,7 +27,8 @@ libmca_pfexec_la_SOURCES =
 dist_pmixdata_DATA =
 
 # local files
-headers = pfexec.h
+headers = pfexec.h \
+		  pfexec_types.h
 libmca_pfexec_la_SOURCES += $(headers)
 
 # install the header files

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -194,16 +194,31 @@ PMIX_CLASS_INSTANCE(pmix_pfexec_child_t,
 
 static void fccon(pmix_pfexec_fork_caddy_t *p)
 {
+    p->peer = NULL;
     p->jobinfo = NULL;
     p->njinfo = 0;
     p->apps = NULL;
     p->napps = 0;
+    p->channels = PMIX_FWD_NO_CHANNELS;
+    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
     p->frkfn = NULL;
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }
+static void fcdes(pmix_pfexec_fork_caddy_t *p)
+{
+   if (NULL != p->peer) {
+        PMIX_RELEASE(p->peer);
+    }
+    if (NULL != p->jobinfo) {
+        PMIX_INFO_FREE(p->jobinfo, p->njinfo);
+    }
+    if (NULL != p->apps) {
+        PMIX_APP_FREE(p->apps, p->napps);
+    }
+}
 PMIX_CLASS_INSTANCE(pmix_pfexec_fork_caddy_t,
-                    pmix_object_t, fccon, NULL);
+                    pmix_object_t, fccon, fcdes);
 
 PMIX_CLASS_INSTANCE(pmix_pfexec_signal_caddy_t,
                     pmix_object_t, NULL, NULL);

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -21,7 +21,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -127,8 +127,7 @@
 /*
  * Module functions (function pointers used in a struct)
  */
-static pmix_status_t spawn_job(const pmix_info_t job_info[], size_t ninfo, const pmix_app_t apps[],
-                               size_t napps, pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t spawn_job(pmix_pfexec_fork_caddy_t *fcd);
 static pmix_status_t kill_proc(pmix_proc_t *proc);
 static pmix_status_t signal_proc(pmix_proc_t *proc, int32_t signal);
 
@@ -630,8 +629,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
  * Launch all processes allocated to the current node.
  */
 
-static pmix_status_t spawn_job(const pmix_info_t job_info[], size_t ninfo, const pmix_app_t apps[],
-                               size_t napps, pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+static pmix_status_t spawn_job(pmix_pfexec_fork_caddy_t *fcd)
 {
      sigset_t unblock;
 
@@ -659,7 +657,8 @@ static pmix_status_t spawn_job(const pmix_info_t job_info[], size_t ninfo, const
         pmix_event_add(pmix_pfexec_globals.handler, NULL);
     }
 
-    PMIX_PFEXEC_SPAWN(job_info, ninfo, apps, napps, fork_proc, cbfunc, cbdata);
+    fcd->frkfn = fork_proc;
+    PMIX_PFEXEC_SPAWN(fcd);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pfexec/pfexec.h
+++ b/src/mca/pfexec/pfexec.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +35,7 @@
 #include "src/include/pmix_types.h"
 
 #include "src/mca/mca.h"
+#include "src/mca/pfexec/pfexec_types.h"
 
 BEGIN_C_DECLS
 
@@ -45,9 +46,7 @@ BEGIN_C_DECLS
 /**
  * Locally fork/exec the provided job
  */
-typedef pmix_status_t (*pmix_pfexec_base_module_spawn_job_fn_t)(
-    const pmix_info_t job_info[], size_t ninfo, const pmix_app_t apps[], size_t napps,
-    pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+typedef pmix_status_t (*pmix_pfexec_base_module_spawn_job_fn_t)(pmix_pfexec_fork_caddy_t *fcd);
 
 /**
  * Kill the local process we started

--- a/src/mca/pfexec/pfexec_types.h
+++ b/src/mca/pfexec/pfexec_types.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ */
+
+#ifndef MCA_PFEXEC_TYPES_H
+#define MCA_PFEXEC_TYPES_H
+
+/*
+ * includes
+ */
+#include "pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/common/pmix_iof.h"
+#include "src/mca/mca.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    int usepty;
+    bool connect_stdin;
+
+    /* private - callers should not modify these fields */
+    int p_stdin[2];
+    int p_stdout[2];
+    int p_stderr[2];
+} pmix_pfexec_base_io_conf_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_event_t ev;
+    pmix_proc_t proc;
+    pid_t pid;
+    bool completed;
+    int exitcode;
+    int keepalive[2];
+    pmix_pfexec_base_io_conf_t opts;
+    pmix_iof_sink_t stdinsink;
+    pmix_iof_read_event_t *stdoutev;
+    pmix_iof_read_event_t *stderrev;
+} pmix_pfexec_child_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_child_t);
+
+/* define a function that will fork/exec a local proc */
+typedef pmix_status_t (*pmix_pfexec_base_fork_proc_fn_t)(pmix_app_t *app,
+                                                         pmix_pfexec_child_t *child, char **env);
+
+/* define a function type for signaling a local proc */
+typedef pmix_status_t (*pmix_pfexec_base_signal_local_fn_t)(pid_t pd, int signum);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    pmix_peer_t *peer;
+    pmix_info_t *jobinfo;
+    size_t njinfo;
+    pmix_app_t *apps;
+    size_t napps;
+    pmix_iof_channel_t channels;
+    pmix_iof_flags_t flags;
+    pmix_pfexec_base_fork_proc_fn_t frkfn;
+    pmix_spawn_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_pfexec_fork_caddy_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_fork_caddy_t);
+
+END_C_DECLS
+#endif

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1474,118 +1474,137 @@ cleanup:
     return rc;
 }
 
-void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
+pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
+                                      char nspace[],
+                                      pmix_iof_channel_t channels)
 {
-    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     pmix_iof_req_t *req;
     pmix_buffer_t *msg;
     pmix_status_t rc;
     pmix_iof_cache_t *iof, *ionext;
 
-    /* if it was successful, and there are IOF requests, then
-     * register them now */
-    if (PMIX_SUCCESS == status && PMIX_FWD_NO_CHANNELS != cd->channels) {
-        /* record the request */
-        req = PMIX_NEW(pmix_iof_req_t);
-        if (NULL == req) {
-            status = PMIX_ERR_NOMEM;
-            goto cleanup;
-        }
-        PMIX_RETAIN(cd->peer);
-        req->requestor = cd->peer;
-        req->nprocs = 1;
-        PMIX_PROC_CREATE(req->procs, req->nprocs);
-        PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
-        req->channels = cd->channels;
-        req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
-        /* process any cached IO */
-        PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
-            /* if the channels don't match, then ignore it */
-            if (!(iof->channel & req->channels)) {
-                continue;
-            }
-            /* if the source does not match the request, then ignore it */
-            if (!PMIX_CHECK_PROCID(&iof->source, &req->procs[0])) {
-                continue;
-            }
-            /* never forward back to the source! This can happen if the source
-             * is a launcher */
-            if (PMIX_CHECK_NAMES(&iof->source, &req->requestor->info->pname)) {
-                continue;
-            }
-            pmix_output_verbose(2, pmix_server_globals.iof_output,
-                                "PMIX:SERVER:SPAWN delivering cached IOF from %s to %s",
-                                PMIX_NAME_PRINT(&iof->source),
-                                PMIX_PNAME_PRINT(&req->requestor->info->pname));
-            /* setup the msg */
-            if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-                PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                rc = PMIX_ERR_OUT_OF_RESOURCE;
-                break;
-            }
-            /* provide the source */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->source, 1, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* provide the channel */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* provide their local id */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->remote_id, 1, PMIX_SIZE);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* provide any cached info */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->ninfo, 1, PMIX_SIZE);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            if (0 < iof->ninfo) {
-                PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->info, iof->ninfo, PMIX_INFO);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-            }
-            /* pack the data */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                break;
-            }
-            /* send it to the requestor */
-            PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-            }
-            /* remove it from the list since it has now been forwarded */
-            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
-            PMIX_RELEASE(iof);
-        }
+    // if no channels to forward, just return success
+    if (PMIX_FWD_NO_CHANNELS != channels) {
+        return PMIX_SUCCESS;
     }
 
-cleanup:
+    /* record the request */
+    req = PMIX_NEW(pmix_iof_req_t);
+    if (NULL == req) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(peer);
+    req->requestor = peer;
+    req->nprocs = 1;
+    PMIX_PROC_CREATE(req->procs, req->nprocs);
+    PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
+    req->channels = channels;
+    req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    /* process any cached IO */
+    PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
+        /* if the channels don't match, then ignore it */
+        if (!(iof->channel & channels)) {
+            continue;
+        }
+        /* if the source does not match the request, then ignore it */
+        if (!PMIX_CHECK_PROCID(&iof->source, &req->procs[0])) {
+            continue;
+        }
+        /* never forward back to the source! This can happen if the source
+         * is a launcher */
+        if (PMIX_CHECK_NAMES(&iof->source, &req->requestor->info->pname)) {
+            continue;
+        }
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIX:SERVER:SPAWN delivering cached IOF from %s to %s",
+                            PMIX_NAME_PRINT(&iof->source),
+                            PMIX_PNAME_PRINT(&req->requestor->info->pname));
+        /* setup the msg */
+        if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        /* provide the source */
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->source, 1, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        /* provide the channel */
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        /* provide their local id */
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->remote_id, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        /* provide any cached info */
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->ninfo, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        if (0 < iof->ninfo) {
+            PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->info, iof->ninfo, PMIX_INFO);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                return rc;
+            }
+        }
+        /* pack the data */
+        PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        /* send it to the requestor */
+        PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+        }
+        /* remove it from the list since it has now been forwarded */
+        pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+        PMIX_RELEASE(iof);
+    }
+    return PMIX_SUCCESS;
+}
+
+void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
+    pmix_status_t rc;
+
+    // pass along default status
+    rc = status;
+
+    /* if it was successful, and there are IOF requests, then
+     * register them now */
+    if (PMIX_SUCCESS == status) {
+        rc = pmix_server_process_iof(cd->peer, nspace, cd->channels);
+    }
+
     if (NULL != cd->spcbfunc) {
-        cd->spcbfunc(status, nspace, cd->cbdata);
+        cd->spcbfunc(rc, nspace, cd->cbdata);
     }
     PMIX_RELEASE(cd);
 }
 
-void pmix_server_spawn_parser(pmix_peer_t *peer, pmix_setup_caddy_t *cd)
+void pmix_server_spawn_parser(pmix_peer_t *peer,
+                              pmix_iof_channel_t *channels,
+                              pmix_iof_flags_t *flags,
+                              pmix_info_t *info,
+                              size_t ninfo)
 {
     size_t n;
     bool stdout_found = false, stderr_found = false, stddiag_found = false;
@@ -1594,29 +1613,29 @@ void pmix_server_spawn_parser(pmix_peer_t *peer, pmix_setup_caddy_t *cd)
      * requests were included so we can set that up now - helps
      * to catch any early output - and a request for notification
      * of job termination so we can setup the event registration */
-    cd->channels = PMIX_FWD_NO_CHANNELS;
-    for (n = 0; n < cd->ninfo; n++) {
-        if (PMIX_CHECK_KEY(&cd->info[n], PMIX_FWD_STDIN)) {
-            if (PMIX_INFO_TRUE(&cd->info[n])) {
-                cd->channels |= PMIX_FWD_STDIN_CHANNEL;
+    *channels = PMIX_FWD_NO_CHANNELS;
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_FWD_STDIN)) {
+            if (PMIX_INFO_TRUE(&info[n])) {
+                *channels |= PMIX_FWD_STDIN_CHANNEL;
             }
-        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_FWD_STDOUT)) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_FWD_STDOUT)) {
             stdout_found = true;
-            if (PMIX_INFO_TRUE(&cd->info[n])) {
-                cd->channels |= PMIX_FWD_STDOUT_CHANNEL;
+            if (PMIX_INFO_TRUE(&info[n])) {
+                *channels |= PMIX_FWD_STDOUT_CHANNEL;
             }
-        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_FWD_STDERR)) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_FWD_STDERR)) {
             stderr_found = true;
-            if (PMIX_INFO_TRUE(&cd->info[n])) {
-                cd->channels |= PMIX_FWD_STDERR_CHANNEL;
+            if (PMIX_INFO_TRUE(&info[n])) {
+                *channels |= PMIX_FWD_STDERR_CHANNEL;
             }
-        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_FWD_STDDIAG)) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_FWD_STDDIAG)) {
             stddiag_found = true;
-            if (PMIX_INFO_TRUE(&cd->info[n])) {
-                cd->channels |= PMIX_FWD_STDDIAG_CHANNEL;
+            if (PMIX_INFO_TRUE(&info[n])) {
+                *channels |= PMIX_FWD_STDDIAG_CHANNEL;
             }
         } else {
-            pmix_iof_check_flags(&cd->info[n], &cd->flags);
+            pmix_iof_check_flags(&info[n], flags);
         }
     }
     /* we will construct any required iof request tracker upon completion of the spawn
@@ -1626,13 +1645,13 @@ void pmix_server_spawn_parser(pmix_peer_t *peer, pmix_setup_caddy_t *cd)
         /* if the requestor is a tool, we default to forwarding all
          * output IO channels */
         if (!stdout_found) {
-            cd->channels |= PMIX_FWD_STDOUT_CHANNEL;
+            *channels |= PMIX_FWD_STDOUT_CHANNEL;
         }
         if (!stderr_found) {
-            cd->channels |= PMIX_FWD_STDERR_CHANNEL;
+            *channels |= PMIX_FWD_STDERR_CHANNEL;
         }
         if (!stddiag_found) {
-            cd->channels |= PMIX_FWD_STDDIAG_CHANNEL;
+            *channels |= PMIX_FWD_STDDIAG_CHANNEL;
         }
     }
 }
@@ -1688,7 +1707,8 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
          * requests were included so we can set that up now - helps
          * to catch any early output - and a request for notification
          * of job termination so we can setup the event registration */
-        pmix_server_spawn_parser(peer, cd);
+        pmix_server_spawn_parser(peer, &cd->channels, &cd->flags,
+                                 cd->info, cd->ninfo);
     }
 
     /* unpack the number of apps */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -272,7 +272,15 @@ PMIX_EXPORT pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t
 
 PMIX_EXPORT pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_spawn_cbfunc_t cbfunc, void *cbdata);
-PMIX_EXPORT void pmix_server_spawn_parser(pmix_peer_t *peer, pmix_setup_caddy_t *cd);
+PMIX_EXPORT void pmix_server_spawn_parser(pmix_peer_t *peer,
+                                          pmix_iof_channel_t *channels,
+                                          pmix_iof_flags_t *flags,
+                                          pmix_info_t *info,
+                                          size_t ninfo);
+PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
+                                                  char nspace[],
+                                                  pmix_iof_channel_t channels);
+
 PMIX_EXPORT void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata);
 
 PMIX_EXPORT pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd, pmix_buffer_t *buf,


### PR DESCRIPTION
Ensure we don't release the created app array copy prior to processing it. Do a much better job of
memory cleanup as we were leaking like a sieve.
Ensure we properly process any IOF directives
associated with the local fork/exec operation.

Refs #3390 