### PR TITLE
Path must start with "src"

### DIFF
--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -15,7 +15,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -422,7 +422,7 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 
 #    if !defined(HAVE_ASPRINTF) || !defined(HAVE_SNPRINTF) || !defined(HAVE_VASPRINTF) \
         || !defined(HAVE_VSNPRINTF)
-#        include "util/pmix_printf.h"
+#        include "src/util/pmix_printf.h"
 #    endif
 
 #    ifndef HAVE_ASPRINTF


### PR DESCRIPTION
Configure test for pmix_argv.h fails when pmix_config_bottom.h tries to include pmix_printf.h as it is missing part of its relative path

Thanks to @ksalerno99 for the patch!

Refs https://github.com/open-mpi/ompi/issues/12814