### PR TITLE
Add support for libz-ng

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -392,7 +392,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       crt_externs.h signal.h \
                       ioLib.h sockLib.h hostLib.h limits.h \
                       sys/fcntl.h sys/statfs.h sys/statvfs.h \
-                      netdb.h ucred.h zlib.h sys/auxv.h \
+                      netdb.h ucred.h sys/auxv.h \
                       sys/sysctl.h termio.h termios.h pty.h \
                       libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h \
                       sys/utsname.h stdatomic.h mntent.h])

--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 dnl Copyright (c) 2018-2021 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -55,7 +55,7 @@ AC_DEFUN([PMIX_MCA],[
     AC_ARG_ENABLE([mca-no-build],
         [AS_HELP_STRING([--enable-mca-no-build=LIST],
                         [Comma-separated list of <type>-<component> pairs
-                         that will not be built.  Example: "--enable-mca-no-build=pgpu,pcompress-zlib" will disable building all pgpu components and the "zlib" pcompress components.])])
+                         that will not be built.  Example: "--enable-mca-no-build=pgpu,pcompress-zlib" will disable building all pgpu components and the "zlib" pcompress component.])])
     AC_ARG_ENABLE(mca-dso,
         AS_HELP_STRING([--enable-mca-dso=LIST],
                        [Comma-separated list of types and/or
@@ -63,7 +63,7 @@ AC_DEFUN([PMIX_MCA],[
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
                         platform.]),
-                        [], [enable_mca_dso=pcompress-zlib,pnet-sshot,prm])
+                        [], [enable_mca_dso=pcompress,pnet-sshot,prm])
     AC_ARG_ENABLE(mca-static,
         AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or

--- a/src/mca/pcompress/zlib/configure.m4
+++ b/src/mca/pcompress/zlib/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -42,24 +42,11 @@ AC_DEFUN([MCA_pmix_pcompress_zlib_CONFIG],[
     fi
 
     AC_MSG_CHECKING([will zlib support be built])
-    if test "$pmix_zlib_support" != "1"; then
-        AC_MSG_RESULT([no])
-        AC_MSG_WARN([*************************************************])
-        AC_MSG_WARN([* PMIx was unable to find a usable version      *])
-        AC_MSG_WARN([* of zlib and zlib-devel on the system. We will *])
-        AC_MSG_WARN([* be unable to compress large data streams.     *])
-        AC_MSG_WARN([* This may result in longer-than-normal startup *])
-        AC_MSG_WARN([* times and larger memory footprints. We will   *])
-        AC_MSG_WARN([* continue, but strongly recommend installing   *])
-        AC_MSG_WARN([* zlib for better user experience.              *])
-        AC_MSG_WARN([*************************************************])
-    else
-        AC_MSG_RESULT([yes])
-    fi
-
     AS_IF([test "$pmix_zlib_support" = "1"],
-          [$1],
-          [$2])
+          [$1
+           AC_MSG_RESULT([yes])],
+          [$2
+           AC_MSG_RESULT([no])])
 
     PMIX_SUMMARY_ADD([External Packages], [ZLIB], [], [${pcompress_zlib_SUMMARY}])
 

--- a/src/mca/pcompress/zlibng/Makefile.am
+++ b/src/mca/pcompress/zlibng/Makefile.am
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2004-2010 The Trustees of Indiana University.
+#                         All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(pcompress_zlibng_CPPFLAGS)
+
+sources = \
+        compress_zlibng.h \
+        compress_zlibng_component.c \
+        compress_zlibng.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pcompress_zlibng_DSO
+component_noinst =
+component_install = pmix_mca_pcompress_zlibng.la
+else
+component_noinst = libpmix_mca_pcompress_zlibng.la
+component_install =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+pmix_mca_pcompress_zlibng_la_SOURCES = $(sources)
+pmix_mca_pcompress_zlibng_la_LDFLAGS = -module -avoid-version $(pcompress_zlibng_LDFLAGS)
+pmix_mca_pcompress_zlibng_la_LIBADD = $(pcompress_zlibng_LIBS)
+if NEED_LIBPMIX
+pmix_mca_pcompress_zlibng_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(component_noinst)
+libpmix_mca_pcompress_zlibng_la_SOURCES = $(sources)
+libpmix_mca_pcompress_zlibng_la_LDFLAGS = -module -avoid-version $(pcompress_zlibng_LDFLAGS)
+libpmix_mca_pcompress_zlibng_la_LIBADD = $(pcompress_zlibng_LIBS)

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ *
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#if HAVE_UNISTD_H
+#    include <unistd.h>
+#endif /* HAVE_UNISTD_H */
+#include <zlib-ng.h>
+
+#include "src/include/pmix_stdint.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
+
+#include "pmix_common.h"
+#include "src/util/pmix_basename.h"
+
+#include "src/mca/pcompress/base/base.h"
+
+#include "compress_zlibng.h"
+
+static bool zlibng_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen);
+
+static bool zlibng_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *inbytes, size_t inlen);
+
+static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes);
+
+static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len);
+
+pmix_compress_base_module_t pmix_pcompress_zlibng_module = {
+    .compress = zlibng_compress,
+    .decompress = zlibng_decompress,
+    .compress_string = compress_string,
+    .decompress_string = decompress_string,
+};
+
+static bool zlibng_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen)
+{
+    zng_stream strm;
+    size_t len, len2;
+    uint8_t *tmp, *ptr;
+    uint32_t len3;
+    int rc;
+
+    /* set default output */
+    *outbytes = NULL;
+    *outlen = 0;
+
+    if (inlen < pmix_compress_base.compress_limit || inlen >= UINT32_MAX) {
+        return false;
+    }
+    len3 = inlen;
+
+    /* setup the stream */
+    memset(&strm, 0, sizeof(strm));
+    if (Z_OK != zng_deflateInit(&strm, 9)) {
+        return false;
+    }
+
+    /* get an upper bound on the required output storage */
+    len = zng_deflateBound(&strm, inlen);
+    /* if this isn't going to result in a smaller footprint,
+     * then don't do it */
+    if (len >= inlen) {
+        (void) zng_deflateEnd(&strm);
+        return false;
+    }
+
+    if (NULL == (tmp = (uint8_t *) malloc(len))) {
+        (void) zng_deflateEnd(&strm);
+        return false;
+    }
+    strm.next_in = (uint8_t*)inbytes;
+    strm.avail_in = inlen;
+
+    /* allocating the upper bound guarantees zlibng will
+     * always successfully compress into the available space */
+    strm.avail_out = len;
+    strm.next_out = tmp;
+
+    rc = zng_deflate(&strm, Z_FINISH);
+    (void) zng_deflateEnd(&strm);
+    if (Z_STREAM_END != rc) {
+        free(tmp);
+        return false;
+    }
+
+    /* allocate 4 bytes beyond the size reqd by zlibng so we
+     * can pass the size of the uncompressed block to the
+     * decompress side */
+    len2 = len - strm.avail_out + sizeof(uint32_t);
+    ptr = (uint8_t *) malloc(len2);
+    if (NULL == ptr) {
+        free(tmp);
+        return false;
+    }
+    *outbytes = ptr;
+    *outlen = len2;
+
+    /* fold the uncompressed length into the buffer */
+    memcpy(ptr, &len3, sizeof(uint32_t));
+    ptr += sizeof(uint32_t);
+    /* bring over the compressed data */
+    memcpy(ptr, tmp, len2 - sizeof(uint32_t));
+    free(tmp);
+    pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                        "COMPRESS INPUT BLOCK OF LEN %" PRIsize_t " OUTPUT SIZE %" PRIsize_t "",
+                        inlen, len2 - sizeof(uint32_t));
+    return true; // we did the compression
+}
+
+static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes)
+{
+    uint32_t inlen;
+
+    /* setup the stream */
+    inlen = strlen(instring);
+
+    /* compress the string */
+    return zlibng_compress((uint8_t *) instring, inlen, outbytes, nbytes);
+}
+
+static bool doit(uint8_t **outbytes, size_t len2, const uint8_t *inbytes, size_t inlen)
+{
+    uint8_t *dest;
+    zng_stream strm;
+    int rc;
+
+    /* set the default error answer */
+    *outbytes = NULL;
+
+    /* setting destination to the fully decompressed size */
+    dest = (uint8_t *) malloc(len2);
+    if (NULL == dest) {
+        return false;
+    }
+    memset(dest, 0, len2);
+
+    memset(&strm, 0, sizeof(strm));
+    if (Z_OK != zng_inflateInit(&strm)) {
+        free(dest);
+        return false;
+    }
+    strm.avail_in = inlen;
+    strm.next_in = (uint8_t*)inbytes;
+    strm.avail_out = len2;
+    strm.next_out = dest;
+
+    rc = zng_inflate(&strm, Z_FINISH);
+    zng_inflateEnd(&strm);
+    if (Z_STREAM_END == rc) {
+        *outbytes = dest;
+        return true;
+    }
+    free(dest);
+    return false;
+}
+static bool zlibng_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *inbytes, size_t inlen)
+{
+    uint32_t len2;
+    bool rc;
+    uint8_t *input;
+
+    /* set the default error answer */
+    *outlen = 0;
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+
+    pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                        "DECOMPRESSING INPUT OF LEN %" PRIsize_t " OUTPUT %u", inlen, len2);
+
+    input = (uint8_t *) (inbytes + sizeof(uint32_t)); // step over the size
+    rc = doit(outbytes, len2, input, inlen);
+    if (rc) {
+        *outlen = len2;
+        return true;
+    }
+    return false;
+}
+
+static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
+{
+    uint32_t len2;
+    bool rc;
+    uint8_t *input;
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+    if (len2 == UINT32_MAX) {
+        /* set the default error answer */
+        *outstring = NULL;
+        return false;
+    }
+    /* add one to hold the NUL terminator */
+    ++len2;
+
+    /* decompress the bytes */
+    input = (uint8_t *) (inbytes + sizeof(uint32_t)); // step over the size
+    rc = doit((uint8_t **) outstring, len2, input, len);
+
+    if (rc) {
+        /* ensure this is NUL terminated! */
+        *outstring[len2 - 1] = '\0';
+        return true;
+    }
+
+    /* set the default error answer */
+    *outstring = NULL;
+    return false;
+}

--- a/src/mca/pcompress/zlibng/compress_zlibng.h
+++ b/src/mca/pcompress/zlibng/compress_zlibng.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * ZLIBNG COMPRESS component
+ *
+ * Uses the zlib-ng library
+ */
+
+#ifndef MCA_COMPRESS_ZLIBNG_EXPORT_H
+#define MCA_COMPRESS_ZLIBNG_EXPORT_H
+
+#include "pmix_config.h"
+
+#include "src/util/pmix_output.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/pcompress/pcompress.h"
+
+#if defined(c_plusplus) || defined(__cplusplus)
+extern "C" {
+#endif
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_pcompress_zlibng_component;
+extern pmix_compress_base_module_t pmix_pcompress_zlibng_module;
+
+#if defined(c_plusplus) || defined(__cplusplus)
+}
+#endif
+
+#endif /* MCA_COMPRESS_ZLIBNG_EXPORT_H */

--- a/src/mca/pcompress/zlibng/compress_zlibng_component.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng_component.c
@@ -1,0 +1,58 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include "compress_zlibng.h"
+#include "pmix_common.h"
+#include "src/mca/pcompress/base/base.h"
+
+/*
+ * Public string for version number
+ */
+const char *pmix_compress_zlibng_component_version_string
+    = "PMIX COMPRESS zlibng MCA component version " PMIX_VERSION;
+
+/*
+ * Local functionality
+ */
+static int compress_zlibng_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointer to our public functions in it
+ */
+PMIX_EXPORT pmix_mca_base_component_t pmix_mca_pcompress_zlibng_component = {
+    /* Handle the general mca_component_t struct containing
+     *  meta information about the component zlibng
+     */
+    PMIX_COMPRESS_BASE_VERSION_2_0_0,
+
+    /* Component name and version */
+    .pmix_mca_component_name = "zlibng",
+    PMIX_MCA_BASE_MAKE_VERSION(component, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
+                               PMIX_RELEASE_VERSION),
+
+    /* Component open and close functions */
+    .pmix_mca_query_component = compress_zlibng_query
+};
+
+static int compress_zlibng_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = (pmix_mca_base_module_t *) &pmix_pcompress_zlibng_module;
+    *priority = 75;
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pcompress/zlibng/configure.m4
+++ b/src/mca/pcompress/zlibng/configure.m4
@@ -1,0 +1,62 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pcompress_zlibng_CONFIG([action-if-can-compile],
+#                           [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pcompress_zlibng_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pcompress/zlibng/Makefile])
+
+    AC_ARG_WITH([zlibng],
+                [AS_HELP_STRING([--with-zlibng=DIR],
+                                [Search for zlib-ng headers and libraries in DIR ])])
+    AC_ARG_WITH([zlibng-libdir],
+                [AS_HELP_STRING([--with-zlibng-libdir=DIR],
+                                [Search for zlib-ng libraries in DIR ])])
+
+    pmix_zlibng_support=0
+
+    OAC_CHECK_PACKAGE([zlibng],
+                      [pcompress_zlibng],
+                      [zlib-ng.h],
+                      [z-ng],
+                      [zng_deflate],
+                      [pmix_zlibng_support=1],
+                      [pmix_zlibng_support=0])
+
+    if test ! -z "$with_zlibng" && test "$with_zlibng" != "no" && test "$pmix_zlibng_support" != "1"; then
+        AC_MSG_WARN([ZLIB-NG SUPPORT REQUESTED AND NOT FOUND])
+        AC_MSG_ERROR([CANNOT CONTINUE])
+    fi
+
+    AC_MSG_CHECKING([will zlib-ng support be built])
+    AS_IF([test "$pmix_zlibng_support" = "1"],
+          [$1
+           AC_MSG_RESULT([yes])],
+          [$2
+           AC_MSG_RESULT([no])])
+
+    PMIX_SUMMARY_ADD([External Packages], [ZLIBNG], [], [${pcompress_zlibng_SUMMARY}])
+
+    # substitute in the things needed to build pcompress/zlibng
+    AC_SUBST([pcompress_zlibng_CPPFLAGS])
+    AC_SUBST([pcompress_zlibng_LDFLAGS])
+    AC_SUBST([pcompress_zlibng_LIBS])
+
+    PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS $pcompress_zlibng_LIBS"
+    PMIX_EMBEDDED_LDFLAGS="$PMIX_EMBEDDED_LDFLAGS $pcompress_zlibng_LDFLAGS"
+    PMIX_EMBEDDED_CPPFLAGS="$PMIX_EMBEDDED_CPPFLAGS $pcompress_zlibng_CPPFLAGS"
+
+])dnl

--- a/src/mca/pcompress/zlibng/owner.txt
+++ b/src/mca/pcompress/zlibng/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance


### PR DESCRIPTION
People have created a "next-gen" version of libz that contains some enhancements and performance improvements based on features available in newer chipsets. If we see it present and/or are directed to it, preferentially use it over the traditional libz.

Fixes #3351 