### PR TITLE
Raise min required HWLOC version to 2.1.0

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -95,38 +95,6 @@ jobs:
         make install
         make uninstall
 
-  ubuntu-oldHWLOC:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends software-properties-common libevent-dev
-    - name: Git clone HWLOC v1.x
-      uses: actions/checkout@v4
-      with:
-            repository: open-mpi/hwloc
-            ref: hwloc-1.11.13
-    - name: Build HWLOC
-      run: |
-        ./autogen.sh
-        ./configure --prefix=$RUNNER_TEMP/hwlocinstall
-        make -j install
-    - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
-      with:
-            submodules: recursive
-    - name: Build OpenPMIx
-      run: |
-        ./autogen.pl
-        ./configure --prefix=${PWD}/install --with-hwloc=$RUNNER_TEMP/hwlocinstall
-        make -j
-        cd test
-        make check
-        cd ..
-        make install
-        make uninstall
-
   distcheck:
     runs-on: ubuntu-latest
     steps:

--- a/VERSION
+++ b/VERSION
@@ -29,7 +29,7 @@ greek=a1
 # PMIx required dependency versions.
 # List in x.y.z format.
 
-hwloc_min_version=1.11.0
+hwloc_min_version=2.1.0
 event_min_version=2.0.21
 automake_min_version=1.13.4
 autoconf_min_version=2.69.0

--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -79,19 +79,6 @@ AC_DEFUN([PMIX_SETUP_HWLOC],[
                       [AC_MSG_RESULT(no)
                        AC_MSG_WARN([PMIx requires HWLOC v$pmix_hwloc_min_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
-
-    AC_MSG_CHECKING([if hwloc version is at least 2.0])
-    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                        #include <hwloc.h>
-                                        #if HWLOC_VERSION_MAJOR < 2
-                                        #error "hwloc version is less than 2.0"
-                                        #endif
-                                       ], [])],
-                        [AC_MSG_RESULT([yes])
-                         pmix_version_high=1],
-                        [AC_MSG_RESULT([no])
-                         pmix_version_high=0])
-    AM_CONDITIONAL([PMIX_HWLOC_VERSION_HIGH], [test $pmix_version_high -eq 1])
 
     AC_MSG_CHECKING([if hwloc version is greater than 2.x])
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -38,29 +38,6 @@
 #include "src/server/pmix_server_ops.h"
 
 BEGIN_C_DECLS
-
-#if HWLOC_API_VERSION < 0x20000
-
-#    ifndef HAVE_HWLOC_TOPOLOGY_DUP
-#        define HAVE_HWLOC_TOPOLOGY_DUP 0
-#    endif
-
-#    define HWLOC_OBJ_L3CACHE HWLOC_OBJ_CACHE
-#    define HWLOC_OBJ_L2CACHE HWLOC_OBJ_CACHE
-#    define HWLOC_OBJ_L1CACHE HWLOC_OBJ_CACHE
-
-#    if HWLOC_API_VERSION < 0x10b00
-#        define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
-#        define HWLOC_OBJ_PACKAGE  HWLOC_OBJ_SOCKET
-#    endif
-
-#    define HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC 0
-
-#else
-
-#    define HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC 1
-
-#endif
 
 /**
  * Register params

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,11 +20,7 @@
 # $HEADER$
 #
 
-noinst_PROGRAMS = numa
-
-if PMIX_HWLOC_VERSION_HIGH
-noinst_PROGRAMS += convert
-endif
+noinst_PROGRAMS = numa convert
 
 numa_SOURCES =  \
         numa.c


### PR DESCRIPTION
We no longer support all the way to pre-StoneAge
versions.