### PR TITLE
support for non-blocking server funcs + small fixes in python bindings

### DIFF
--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -385,7 +385,10 @@ def harvest_constants(options, src, constants, definitions):
             defsrc = True
         definitions.write("\n    # TYPEDEFS\n")
         for t in typedefs:
-            definitions.write("    c" + t[0] + "\n")
+            if "cbfunc" in t[0] and len(t) == 1:
+                definitions.write("    c" + t[0] + " nogil\n")
+            else:
+                definitions.write("    c" + t[0] + "\n")
             if len(t) > 1:
                 # find the 2nd opening paren
                 idx = t[0].find("(") + 1
@@ -394,7 +397,10 @@ def harvest_constants(options, src, constants, definitions):
                     definitions.write("    ")
                     for m in range(idx):
                         definitions.write(" ")
-                    definitions.write(t[n] + "\n")
+                    if "cbfunc" in t[0] and n == len(t) - 1:
+                        definitions.write(t[n] + " nogil\n")
+                    else:
+                        definitions.write(t[n] + "\n")
             definitions.write("\n")
         # add some space
         definitions.write("\n")

--- a/bindings/python/tests/python/sched.py
+++ b/bindings/python/tests/python/sched.py
@@ -118,4 +118,6 @@ def main():
 if __name__ == '__main__':
     global killer
     killer = GracefulKiller()
+    start_event_loop()
     main()
+    stop_event_loop()

--- a/bindings/python/tests/python/server.py
+++ b/bindings/python/tests/python/server.py
@@ -99,4 +99,6 @@ def main():
 if __name__ == '__main__':
     global killer
     killer = GracefulKiller()
+    start_event_loop()
     main()
+    stop_event_loop()


### PR DESCRIPTION
The definition of the server function pointers in the python bindings are defined as blocking functions.
This has some limitations in certain scenarios.
 
This pull request adds support for non-blocking server functions in the Python bindings:

- Adds the paramters **cbfunc** and **cbdata** to the server function definitions, where

	**cbfunc**: is one of the following callables:
		+pypmix_op_cbfunc_t              =   Callable[[int, dict], int]
		+pypmix_info_cbfunc_t            =   Callable[[int, list, dict], int]
		+pypmix_modex_cbfunc_t           =   Callable[[int, bytearray, dict], int]
		+pypmix_lookup_cbfunc_t          =   Callable[[int, list, dict], int]
		+pypmix_spawn_cbfunc_t           =   Callable[[int, str, dict], int]
		+pypmix_tool_connection_cbfunc_t =   Callable[[int, dict, dict], None]
		+pypmix_credential_cbfunc_t      =   Callable[[int, dict, list, dict], None]
		+pypmix_validation_cbfunc_t      =   Callable[[int, list, dict], None]
	**cbdata**:  A python dictionary to be passed back to cbfunc

-  removed eventQueue (it seems to me that it is not needed anymore):
	- mark callback functions with no_gil (adapted in construct.py)
	- call callback functions directly within a with nogil block

- updated the server functions in server_upcalls.py in tests to call the cbfunc 

Additionaly, the pull request provides the following small fixes:
	

- add support for  PMIX_VALUE in pmix_load_darray/pmix_unload_darray

- remove memory releases in pmix_unload_darray (As as user I would not expect the unload function to release the darray.array)

- removed the proc INPUT argument in pmix_load_pdata, as the array argument is "a list of dictionaries, where each dictionary has a key, value, val_type, and proc keys". Hence, the proc info is already contained in the array argument

- add protection against and empty app['argv'] list passed to pmix_spawn (handle it similar to app['argv'] == None in pmix_load_apps)


The changes were tested with the server.py and sched.py scripts in the test directory and in my personal setup with PRRTE. 