### PR TITLE
ptl support for connection to multiple servers

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -274,6 +274,9 @@ static void pcon(pmix_peer_t *p)
     PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
+    p->dyn_tags_start = PMIX_PTL_TAG_DYNAMIC;
+    p->dyn_tags_current = PMIX_PTL_TAG_DYNAMIC;
+    p->dyn_tags_end = UINT32_MAX;
 }
 
 static void pdes(pmix_peer_t *p)

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -453,6 +453,9 @@ typedef struct pmix_peer_t {
     int commit_cnt;
     pmix_epilog_t epilog; /**< things to be performed upon
                                termination of this peer */
+    uint32_t dyn_tags_start; // lower limit of valid tags for sendrecvs to this peer
+    uint32_t dyn_tags_current; // current tag for sendrecvs to this peer
+    uint32_t dyn_tags_end; // upper limit of valid tags for sendrecvs to this peer
 } pmix_peer_t;
 PMIX_CLASS_DECLARATION(pmix_peer_t);
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -66,7 +66,6 @@ struct pmix_ptl_base_t {
     pmix_list_t unexpected_msgs;
     pmix_listener_t listener;
     struct sockaddr_storage *connection;
-    uint32_t current_tag;
     size_t max_msg_size;
     char *session_tmpdir;
     char *system_tmpdir;

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -300,6 +300,10 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     if (NULL == peer) {
         goto error;
     }
+    /* Assign the upper half of the tag space for sendrecvs */
+    peer->dyn_tags_start    = PMIX_PTL_TAG_DYNAMIC + (UINT32_MAX - PMIX_PTL_TAG_DYNAMIC)/2 + 1;
+    peer->dyn_tags_end      = UINT32_MAX;
+    peer->dyn_tags_current  = peer->dyn_tags_start;
     /* mark that this peer is a client of the given type */
     memcpy(&peer->proc_type, &pnd->proc_type, sizeof(pmix_proc_type_t));
     /* save the protocol */
@@ -693,6 +697,10 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
     }
+    /* Assign the upper half of the tag space for sendrecvs */
+    peer->dyn_tags_start    = PMIX_PTL_TAG_DYNAMIC + (UINT32_MAX - PMIX_PTL_TAG_DYNAMIC)/2 + 1;
+    peer->dyn_tags_end      = UINT32_MAX;
+    peer->dyn_tags_current  = peer->dyn_tags_start;
     pnd->peer = peer;
     /* if this is a tool we launched, then the host may
      * have already registered it as a client - so check

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -660,6 +660,10 @@ retry:
         }
         return rc;
     }
+    /* Assign the lower half of the tag space for sendrecvs */
+    peer->dyn_tags_start    = PMIX_PTL_TAG_DYNAMIC;
+    peer->dyn_tags_current  = PMIX_PTL_TAG_DYNAMIC;
+    peer->dyn_tags_end      = PMIX_PTL_TAG_DYNAMIC + (UINT32_MAX - PMIX_PTL_TAG_DYNAMIC)/2;
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -70,7 +70,6 @@ pmix_ptl_base_t pmix_ptl_base = {
     .unexpected_msgs = PMIX_LIST_STATIC_INIT,
     .listener = PMIX_LISTENER_STATIC_INIT,
     .connection = NULL,
-    .current_tag = 0,
     .max_msg_size = 0,
     .session_tmpdir = NULL,
     .system_tmpdir = NULL,
@@ -394,7 +393,6 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     PMIX_CONSTRUCT(&pmix_ptl_base.posted_recvs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_ptl_base.unexpected_msgs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_ptl_base.listener, pmix_listener_t);
-    pmix_ptl_base.current_tag = PMIX_PTL_TAG_DYNAMIC;
     pmix_ptl_base.connection = (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
     if (NULL == pmix_ptl_base.connection) {
         return PMIX_ERR_NOMEM;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -728,12 +728,12 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
         return;
     }
 
-    /* take the next tag in the sequence */
-    pmix_ptl_base.current_tag++;
-    if (UINT32_MAX == pmix_ptl_base.current_tag) {
-        pmix_ptl_base.current_tag = PMIX_PTL_TAG_DYNAMIC;
+    /* take the next tag in the sequence of tags for this peer */
+    ms->peer->dyn_tags_current++;
+    if (ms->peer->dyn_tags_current == ms->peer->dyn_tags_end) {
+        ms->peer->dyn_tags_current = ms->peer->dyn_tags_start;
     }
-    tag = pmix_ptl_base.current_tag;
+    tag = ms->peer->dyn_tags_current;
 
     if (NULL != ms->cbfunc) {
         /* if a callback msg is expected, setup a recv for it */


### PR DESCRIPTION
The current ptl implementation assigns dynamic tags for sendrecvs using a single, global cur_tag counter from the range [PMIX_PTL_TAG_DYNAMIC, UINT32_MAX].
This can lead to collisions, e.g., when a tool acts simultaneously as a server.

The solution proposed in this pull request uses a per-peer counter and range for the current tag to be used for sendrecvs to this peer.
The range of valid tags for a particular peer is either [PMIX_PTL_TAG_DYNAMIC, (UINT32_MAX - PMIX_PTL_TAG_DYNAMIC)/2] when we first connected to the peer and  [(UINT32_MAX - PMIX_PTL_TAG_DYNAMIC)/2, UINT32_MAX] if the peer connected to us.