### PR TITLE
Ensure IOF respects formatting requests

### DIFF
--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -128,7 +128,7 @@ static void localcbfunc(pmix_status_t status,
 
     // process IOF requests
     if (PMIX_SUCCESS == status) {
-        rc = pmix_server_process_iof(fcd->peer, nspace, fcd->channels);
+        rc = pmix_server_process_iof(fcd, nspace);
     }
 
     if (NULL != fcd->spcbfunc) {

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -274,9 +274,13 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_proc_t *source,
                                                const pmix_byte_object_t *bo,
                                                const pmix_info_t *info, size_t ninfo,
-                                               const pmix_iof_req_t *req);
+                                               pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
+PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
+                                                     pmix_iof_flags_t *myflags,
+                                                     pmix_iof_channel_t stream,
+                                                     const pmix_byte_object_t *bo);
 
 END_C_DECLS
 

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -323,22 +323,6 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             goto complete;
         }
 
-        /* process any job-info */
-        if (NULL != fcd->info) {
-            for (k = 0; k < fcd->ninfo; k++) {
-                if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_SET_ENVAR)) {
-
-                } else if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_ADD_ENVAR)) {
-
-                } else if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_UNSET_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_PREPEND_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_APPEND_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->info[k], PMIX_NOHUP)) {
-                    nohup = PMIX_INFO_TRUE(&fcd->info[k]);
-                }
-            }
-        }
-
         /* check for a fork/exec agent we should use */
         if (NULL != app->info) {
             for (k = 0; k < app->ninfo; k++) {

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -323,6 +323,7 @@ static void iofreqcon(pmix_iof_req_t *p)
     p->remote_id = 0;
     p->procs = NULL;
     p->nprocs = 0;
+    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
     p->regcbfunc = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -468,6 +468,7 @@ typedef struct {
     size_t remote_id;
     pmix_proc_t *procs;
     size_t nprocs;
+    pmix_iof_flags_t flags;
     pmix_iof_channel_t channels;
     pmix_iof_cbfunc_t cbfunc;
     pmix_hdlr_reg_cbfunc_t regcbfunc;

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -596,6 +596,8 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     PMIX_PROC_CREATE(req->procs, req->nprocs);
     PMIX_LOAD_PROCID(&req->procs[0], pmix_globals.myid.nspace, pmix_globals.myid.rank);
     req->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
+    // default to formatting output as we were directed to do
+    req->flags = pmix_globals.iof_flags;
     req->remote_id = 0; // default ID for tool during init
     req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -220,6 +220,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_info_t *iptr;
     size_t minfo;
     bool keepfqdn = false;
+    pmix_iof_flags_t flags;
 
 #if PMIX_NO_LIB_DESTRUCTOR
     if (pmix_init_called) {
@@ -234,6 +235,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 #endif
 
     pmix_init_called = true;
+    memset(&flags, 0, sizeof(pmix_iof_flags_t));
 
     if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;
@@ -289,7 +291,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_BIND_REQUIRED)) {
                 pmix_bind_progress_thread_reqd = PMIX_INFO_TRUE(&info[n]);
             } else {
-                pmix_iof_check_flags(&info[n], &pmix_globals.iof_flags);
+                pmix_iof_check_flags(&info[n], &flags);
             }
         }
     }
@@ -342,7 +344,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
     /* setup the stdin forwarding target list */
     PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
-    memset(&pmix_globals.iof_flags, 0, sizeof(pmix_iof_flags_t));
+    memcpy(&pmix_globals.iof_flags, &flags, sizeof(pmix_iof_flags_t));
 
     /* Setup client verbosities as all procs are allowed to
      * access client APIs */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4434,9 +4434,9 @@ static void _iofreg(int sd, short args, void *cbdata)
                                                              cd->ncodes);
         if (NULL != req) {
             PMIX_LIST_FOREACH_SAFE (iof, inxt, &pmix_server_globals.iof, pmix_iof_cache_t) {
-                if (PMIX_OPERATION_SUCCEEDED
-                    == pmix_iof_process_iof(iof->channel, &iof->source, iof->bo, iof->info,
-                                            iof->ninfo, req)) {
+                rc = pmix_iof_process_iof(iof->channel, &iof->source, iof->bo, iof->info,
+                                            iof->ninfo, req);
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
                     pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
                     PMIX_RELEASE(iof);
                 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1474,17 +1474,15 @@ cleanup:
     return rc;
 }
 
-pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
-                                      char nspace[],
-                                      pmix_iof_channel_t channels)
+pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
+                                      char nspace[])
 {
     pmix_iof_req_t *req;
-    pmix_buffer_t *msg;
     pmix_status_t rc;
     pmix_iof_cache_t *iof, *ionext;
 
     // if no channels to forward, just return success
-    if (PMIX_FWD_NO_CHANNELS == channels) {
+    if (PMIX_FWD_NO_CHANNELS == cd->channels) {
         return PMIX_SUCCESS;
     }
 
@@ -1493,89 +1491,23 @@ pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
     if (NULL == req) {
         return PMIX_ERR_NOMEM;
     }
-    PMIX_RETAIN(peer);
-    req->requestor = peer;
+    PMIX_RETAIN(cd->peer);
+    req->requestor = cd->peer;
     req->nprocs = 1;
     PMIX_PROC_CREATE(req->procs, req->nprocs);
     PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
-    req->channels = channels;
+    req->channels = cd->channels;
+    req->flags = cd->flags;
     req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
     /* process any cached IO */
     PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
-        /* if the channels don't match, then ignore it */
-        if (!(iof->channel & channels)) {
-            continue;
+        rc = pmix_iof_process_iof(iof->channel, &iof->source, iof->bo,
+                                  iof->info, iof->ninfo, req);
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* remove it from the list since it has now been forwarded */
+            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+            PMIX_RELEASE(iof);
         }
-        /* if the source does not match the request, then ignore it */
-        if (!PMIX_CHECK_PROCID(&iof->source, &req->procs[0])) {
-            continue;
-        }
-        /* never forward back to the source! This can happen if the source
-         * is a launcher */
-        if (PMIX_CHECK_NAMES(&iof->source, &req->requestor->info->pname)) {
-            continue;
-        }
-        pmix_output_verbose(2, pmix_server_globals.iof_output,
-                            "PMIX:SERVER:SPAWN delivering cached IOF from %s to %s",
-                            PMIX_NAME_PRINT(&iof->source),
-                            PMIX_PNAME_PRINT(&req->requestor->info->pname));
-        /* setup the msg */
-        if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-            return PMIX_ERR_OUT_OF_RESOURCE;
-        }
-        /* provide the source */
-        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->source, 1, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            return rc;
-        }
-        /* provide the channel */
-        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            return rc;
-        }
-        /* provide their local id */
-        PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->remote_id, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            return rc;
-        }
-        /* provide any cached info */
-        PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            return rc;
-        }
-        if (0 < iof->ninfo) {
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->info, iof->ninfo, PMIX_INFO);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return rc;
-            }
-        }
-        /* pack the data */
-        PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            return rc;
-        }
-        /* send it to the requestor */
-        PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-        }
-        /* remove it from the list since it has now been forwarded */
-        pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
-        PMIX_RELEASE(iof);
     }
     return PMIX_SUCCESS;
 }
@@ -1591,7 +1523,7 @@ void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
     /* if it was successful, and there are IOF requests, then
      * register them now */
     if (PMIX_SUCCESS == status) {
-        rc = pmix_server_process_iof(cd->peer, nspace, cd->channels);
+        rc = pmix_server_process_iof(cd, nspace);
     }
 
     if (NULL != cd->spcbfunc) {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -277,9 +277,8 @@ PMIX_EXPORT void pmix_server_spawn_parser(pmix_peer_t *peer,
                                           pmix_iof_flags_t *flags,
                                           pmix_info_t *info,
                                           size_t ninfo);
-PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
-                                                  char nspace[],
-                                                  pmix_iof_channel_t channels);
+PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
+                                                  char nspace[]);
 
 PMIX_EXPORT void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata);
 


### PR DESCRIPTION
When a tool starts a launcher and the launcher cmd line includes IO formatting requests, we want the tool to receive relayed output in the specified format. So ensure that formatting directives for a spawned job are not only applied to the direct output of the launcher, but also to all output forwarded to a requestor.

Fixes https://github.com/openpmix/openpmix/issues/3405