### PR TITLE
support event registration at multiple  servers

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -119,6 +119,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_status_t code;
     size_t nregs;
+    void *peer; // (pmix_peer_t *)
 } pmix_active_code_t;
 PMIX_CLASS_DECLARATION(pmix_active_code_t);
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1460,6 +1460,7 @@ PMIX_CLASS_INSTANCE(pmix_event_hdlr_t, pmix_list_item_t, sevcon, sevdes);
 static void accon(pmix_active_code_t *p)
 {
     p->nregs = 0;
+    p->peer = NULL;
 }
 PMIX_CLASS_INSTANCE(pmix_active_code_t, pmix_list_item_t, accon, NULL);
 

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -252,7 +252,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     if (NULL == cd->codes) {
         registered = false;
         PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-            if (PMIX_MAX_ERR_CONSTANT == active->code) {
+            if (PMIX_MAX_ERR_CONSTANT == active->code && 
+                (NULL != active->peer && active->peer == pmix_client_globals.myserver)) {
                 /* we have registered a default */
                 registered = true;
                 ++active->nregs;
@@ -263,6 +264,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
             active = PMIX_NEW(pmix_active_code_t);
             active->code = PMIX_MAX_ERR_CONSTANT;
             active->nregs = 1;
+            active->peer = pmix_client_globals.myserver;
             pmix_list_append(&pmix_globals.events.actives, &active->super);
             /* ensure we register it */
             need_register = true;
@@ -271,7 +273,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
         for (n = 0; n < cd->ncodes; n++) {
             registered = false;
             PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-                if (active->code == cd->codes[n]) {
+                if (active->code == cd->codes[n] && 
+                    (NULL != active->peer && active->peer == pmix_client_globals.myserver)) {
                     registered = true;
                     ++active->nregs;
                     break;
@@ -281,6 +284,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
                 active = PMIX_NEW(pmix_active_code_t);
                 active->code = cd->codes[n];
                 active->nregs = 1;
+                active->peer = pmix_client_globals.myserver;
                 pmix_list_append(&pmix_globals.events.actives, &active->super);
                 /* ensure we register it */
                 need_register = true;


### PR DESCRIPTION
The current implementation does not support tools registering event_handlers at different servers.
This is because the `_add_hdlr` in pmix_event_registration.c does not call `_send_to_server` if there was already a handler registered for the same code.

This pull request stores a pointer to the currently active server peer in the `pmix_active_code_t` struct when adding it to the list of active events. 
In subsequent registrations, the current server peer is compared against the peer stored in the active event to ensure `_send_to_server` is called if the tool switched to another server. 

Unfortunately, we cannot use a pmix_peer_t pointer here, as the peer struct is defined in pmix_globals.h:

```
/* define an object for tracking status codes we are actively registered to receive */
typedef struct {
    pmix_list_item_t super;
    pmix_status_t code;
    size_t nregs;
    void *peer; // (pmix_peer_t *)
} pmix_active_code_t;
```