### PR TITLE
Reverse the default "squash" setting

### DIFF
--- a/src/mca/bfrops/base/Makefile.include
+++ b/src/mca/bfrops/base/Makefile.include
@@ -13,7 +13,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -39,4 +39,5 @@ sources += \
         base/bfrop_base_print.c \
         base/bfrop_base_unpack.c \
         base/bfrop_base_stubs.c \
-        base/bfrop_base_macro_backers.c
+        base/bfrop_base_macro_backers.c \
+        base/bfrop_base_squash.c

--- a/src/mca/bfrops/base/bfrop_base_squash.c
+++ b/src/mca/bfrops/base/bfrop_base_squash.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "pmix_common.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_output.h"
+
+#include <unistd.h>
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+
+#include "src/mca/bfrops/base/base.h"
+
+/* Flexible packing constants */
+#define FLEX_BASE7_MAX_BUF_SIZE (SIZEOF_SIZE_T + 1)
+#define FLEX_BASE7_MASK         ((1 << 7) - 1)
+#define FLEX_BASE7_SHIFT        7
+#define FLEX_BASE7_CONT_FLAG    (1 << 7)
+
+/**
+ * Packing conversion of a signed integer value to a flexible representation.
+ * The main idea is to split a signed negative value onto an absolute value
+ * and a sign bit stored in the special location.
+ * This allows efficient representetion of negative values in the
+ * flexible form.
+ *
+ * type - type (pmix_data_type_t) of integer value
+ * ptr - pointer to the signed integer value
+ *       with the type defined as (type)
+ * out - flexible representation of *ptr,
+ *       extended to uint64_t if needed
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_PACK_CONVERT_SIGNED(type, ptr, out)            \
+    do {                                                       \
+        type __tbuf = 0;                                       \
+        size_t __tmp;                                          \
+        int __sign = 0;                                        \
+        memcpy(&__tbuf, (ptr), sizeof(type));                  \
+        __tmp = __tbuf;                                        \
+        (out) = (size_t) __tmp;                                \
+        if (__tmp & (1UL << (sizeof(__tmp) * CHAR_BIT - 1))) { \
+            __sign = 1;                                        \
+            out = ~(out);                                      \
+        }                                                      \
+        (out) = ((out) << 1) + __sign;                         \
+    } while (0)
+
+/**
+ * Packing conversion of a signed integer value to a flexible representation.
+ * For unsigned types it is reduced to a memcopy.
+ *
+ * type - usual integer C-type of integer value
+ * ptr - pointer to the signed integer value
+ *       with the type defined as (type)
+ * out - flexible representation of *ptr,
+ *       extended to uint64_t if needed
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_PACK_CONVERT_UNSIGNED(type, ptr, out) \
+    do {                                              \
+        type __tbuf = 0;                              \
+        memcpy(&__tbuf, (ptr), sizeof(type));         \
+        out = __tbuf;                                 \
+    } while (0)
+
+/**
+ * Packing conversion from integer value to a flexible representation.
+ *
+ * r - return status code
+ * t - type (pmix_data_type_t) of integer value, it is determines
+ *     which type of integer is converted
+ * s - pointer to the integer value with the type defined as (t)
+ * d - flexible representation output value (uin64_t)
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_PACK_CONVERT(r, t, s, d)                   \
+    do {                                                   \
+        (r) = PMIX_SUCCESS;                                \
+        switch (t) {                                       \
+        case PMIX_INT16:                                   \
+            FLEX128_PACK_CONVERT_SIGNED(int16_t, s, d);    \
+            break;                                         \
+        case PMIX_UINT16:                                  \
+            FLEX128_PACK_CONVERT_UNSIGNED(uint16_t, s, d); \
+            break;                                         \
+        case PMIX_INT:                                     \
+        case PMIX_INT32:                                   \
+            FLEX128_PACK_CONVERT_SIGNED(int32_t, s, d);    \
+            break;                                         \
+        case PMIX_UINT:                                    \
+        case PMIX_UINT32:                                  \
+            FLEX128_PACK_CONVERT_UNSIGNED(uint32_t, s, d); \
+            break;                                         \
+        case PMIX_INT64:                                   \
+            FLEX128_PACK_CONVERT_SIGNED(int64_t, s, d);    \
+            break;                                         \
+        case PMIX_SIZE:                                    \
+            FLEX128_PACK_CONVERT_UNSIGNED(size_t, s, d);   \
+            break;                                         \
+        case PMIX_UINT64:                                  \
+            FLEX128_PACK_CONVERT_UNSIGNED(uint64_t, s, d); \
+            break;                                         \
+        default:                                           \
+            (r) = PMIX_ERR_BAD_PARAM;                      \
+        }                                                  \
+    } while (0)
+
+/**
+ * Unpacking conversion from a flexible representation to a
+ * signed integer value.
+ *
+ * type - C-type of a signed integer value
+ * val - flexible representation (uint64_t)
+ * ptr - pointer to a 64-bit output buffer for the upacked value
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_UNPACK_CONVERT_SIGNED(type, val, ptr) \
+    do {                                              \
+        type __tbuf = 0;                              \
+        size_t __tmp = val;                           \
+        int sign = (__tmp) &1;                        \
+        __tmp >>= 1;                                  \
+        if (sign) {                                   \
+            __tmp = ~__tmp;                           \
+        }                                             \
+        __tbuf = (type) __tmp;                        \
+        memcpy(ptr, &__tbuf, sizeof(type));           \
+    } while (0)
+
+/**
+ * Unpacking conversion of a flexible representation value
+ * to an unsigned integer.
+ *
+ * type - C-type of unsigned integer value
+ * val - flexible representation value (uint64_t)
+ * ptr - pointer to a 64-bit output buffer for the upacked value
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_UNPACK_CONVERT_UNSIGNED(type, val, ptr) \
+    do {                                                \
+        type __tbuf = 0;                                \
+        __tbuf = (type) val;                            \
+        memcpy(ptr, &__tbuf, sizeof(type));             \
+    } while (0)
+
+/**
+ * Unpacking conversion of a flexible representation value
+ * to an integer.
+ *
+ * r - return status code
+ * t - type (pmix_data_type_t) of integer value, it is determines
+ *     which type of integer is converted
+ * s - flex-representation value (uin64_t)
+ * d - pointer to a 64-bit output buffer for the upacked value
+ * (see a comment to `pmix_bfrops_pack_flex` for additional details)
+ */
+#define FLEX128_UNPACK_CONVERT(r, t, s, d)                   \
+    do {                                                     \
+        (r) = PMIX_SUCCESS;                                  \
+        switch (t) {                                         \
+        case PMIX_INT16:                                     \
+            FLEX128_UNPACK_CONVERT_SIGNED(int16_t, s, d);    \
+            break;                                           \
+        case PMIX_UINT16:                                    \
+            FLEX128_UNPACK_CONVERT_UNSIGNED(uint16_t, s, d); \
+            break;                                           \
+        case PMIX_INT:                                       \
+        case PMIX_INT32:                                     \
+            FLEX128_UNPACK_CONVERT_SIGNED(int32_t, s, d);    \
+            break;                                           \
+        case PMIX_UINT:                                      \
+        case PMIX_UINT32:                                    \
+            FLEX128_UNPACK_CONVERT_UNSIGNED(uint32_t, s, d); \
+            break;                                           \
+        case PMIX_INT64:                                     \
+            FLEX128_UNPACK_CONVERT_SIGNED(int64_t, s, d);    \
+            break;                                           \
+        case PMIX_SIZE:                                      \
+            FLEX128_UNPACK_CONVERT_UNSIGNED(size_t, s, d);   \
+            break;                                           \
+        case PMIX_UINT64:                                    \
+            FLEX128_UNPACK_CONVERT_UNSIGNED(uint64_t, s, d); \
+            break;                                           \
+        default:                                             \
+            (r) = PMIX_ERR_BAD_PARAM;                        \
+        }                                                    \
+    } while (0)
+
+
+static size_t flex_pack_integer(size_t val, uint8_t out_buf[FLEX_BASE7_MAX_BUF_SIZE]);
+
+static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size, size_t *out_val,
+                                  size_t *out_val_size);
+
+pmix_status_t pmix_bfrops_base_get_max_size(pmix_data_type_t type, size_t *size)
+{
+    pmix_status_t rc;
+    PMIX_SQUASH_TYPE_SIZEOF(rc, type, *size);
+    /* the size of the packed value can be 1B larger
+     * because of continuation flags */
+    *size += 1;
+    return rc;
+}
+
+pmix_status_t pmix_bfrops_base_encode_int(pmix_data_type_t type, void *src,
+                                          void *dst, size_t *size)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    uint8_t tmp_buf[FLEX_BASE7_MAX_BUF_SIZE];
+    uint64_t tmp;
+
+    FLEX128_PACK_CONVERT(rc, type, (uint8_t *) src, tmp);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    *size = flex_pack_integer(tmp, tmp_buf);
+    memcpy(dst, tmp_buf, *size);
+
+    return rc;
+}
+
+pmix_status_t pmix_bfrops_base_decode_int(pmix_data_type_t type, void *src, size_t src_len,
+                                          void *dest, size_t *dst_size)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t tmp;
+    size_t val_size, unpack_val_size;
+
+    PMIX_SQUASH_TYPE_SIZEOF(rc, type, val_size);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    *dst_size = flex_unpack_integer(src, src_len, &tmp, &unpack_val_size);
+
+    if (val_size < unpack_val_size) { // sanity check
+        rc = PMIX_ERR_UNPACK_FAILURE;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    FLEX128_UNPACK_CONVERT(rc, type, tmp, (uint8_t *) dest);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    return rc;
+}
+
+/*
+ * Typical representation of a number in computer systems is:
+ * A[0]*B^0 + A[1]*B^1 + A[2]*B^2 + ... + A[n]*B^n
+ * where B called a base and B == 256 (one byte)
+ *
+ * This encoding changes the default representation by introducing an additional
+ * bit per each byte to store a "continuation flag". So integers are now encoded
+ * with the same representation, but the base B = 128 and the remaining bit is
+ * used to indicate whether or not the next byte contains more bits of this value.
+ */
+static size_t flex_pack_integer(size_t val, uint8_t out_buf[FLEX_BASE7_MAX_BUF_SIZE])
+{
+    size_t tmp = val;
+    size_t idx = 0;
+
+    do {
+        uint8_t encoding = tmp & FLEX_BASE7_MASK;
+        tmp >>= FLEX_BASE7_SHIFT;
+        if (PMIX_UNLIKELY(tmp)) {
+            encoding |= FLEX_BASE7_CONT_FLAG;
+        }
+        out_buf[idx++] = encoding;
+    } while (tmp && idx < SIZEOF_SIZE_T);
+
+    /* If we have leftover (VERY unlikely) */
+    if (PMIX_UNLIKELY(SIZEOF_SIZE_T == idx && tmp)) {
+        out_buf[idx++] = tmp;
+    }
+
+    return idx;
+}
+
+/*
+ * See a comment to `pmix_bfrops_pack_flex` for additional details.
+ */
+static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size, size_t *out_val,
+                                  size_t *out_val_size)
+{
+    size_t value = 0, shift = 0, shift_last = 0;
+    size_t idx = 0;
+    uint8_t val = 0, val_last = 0;
+    uint8_t hi_bit = 0;
+    size_t flex_size = buf_size;
+
+    /* restrict the buf size to max flex size */
+    if (buf_size > FLEX_BASE7_MAX_BUF_SIZE) {
+        flex_size = FLEX_BASE7_MAX_BUF_SIZE;
+    }
+
+    do {
+        val = in_buf[idx++];
+        val_last = val;
+        shift_last = shift;
+        value = value + (((uint64_t) val & FLEX_BASE7_MASK) << shift);
+        shift += FLEX_BASE7_SHIFT;
+    } while (PMIX_UNLIKELY((val & FLEX_BASE7_CONT_FLAG) && (idx < (flex_size - 1))));
+    /* If we have leftover (VERY unlikely) */
+    if (PMIX_UNLIKELY((flex_size - 1) == idx && (val & FLEX_BASE7_CONT_FLAG))) {
+        val = in_buf[idx++];
+        val_last = val;
+        value = value + ((uint64_t) val << shift);
+        shift_last = shift;
+    }
+    /* compute the most significant bit of val */
+    while (val_last != 0) {
+        val_last >>= 1;
+        hi_bit++;
+    }
+    /* compute the real val size */
+    *out_val_size = (hi_bit + shift_last) / CHAR_BIT + !!((hi_bit + shift_last) & (CHAR_BIT - 1));
+    *out_val = value;
+
+    return idx;
+}

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,6 +68,34 @@ typedef struct pmix_modex_data {
     size_t size;
 } pmix_modex_data_t;
 
+static pmix_status_t pack_int(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer, const void *src,
+                              int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pack_sizet(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, const void *src,
+                                int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pack_int16(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer, const void *src,
+                              int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pack_int32(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer, const void *src,
+                              int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pack_int64(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer, const void *src,
+                              int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t unpack_int(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, void *dest,
+                                int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t unpack_sizet(pmix_pointer_array_t *regtypes,
+                                  pmix_buffer_t *buffer, void *dest,
+                                  int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t unpack_int16(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t unpack_int32(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t unpack_int64(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type);
+
 static pmix_status_t pmix3_bfrop_pack_array(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                             const void *src, int32_t num_vals,
                                             pmix_data_type_t type);
@@ -103,15 +131,15 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_print_string, &pmix_mca_bfrops_v3_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
-    PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pmix_bfrops_base_pack_sizet,
-                       pmix_bfrops_base_unpack_sizet, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE, pack_sizet,
+                       unpack_sizet, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_size, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID, pmix_bfrops_base_pack_pid, pmix_bfrops_base_unpack_pid,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_pid,
                        &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pmix_bfrops_base_pack_int, pmix_bfrops_base_unpack_int,
+    PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT, pack_int, unpack_int,
                        pmix_bfrops_base_std_copy, pmix_bfrops_base_print_int,
                        &pmix_mca_bfrops_v3_component.types);
 
@@ -120,36 +148,36 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pack_int16, unpack_int16,
+                       pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pack_int32,
+                       unpack_int32, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pack_int64,
+                       unpack_int64, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
-                       pmix_bfrops_base_unpack_int, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pack_int,
+                       unpack_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8, pmix_bfrops_base_pack_byte,
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pack_int16,
+                       unpack_int16, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pack_int32,
+                       unpack_int32, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v3_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pack_int64,
+                       unpack_int64, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v3_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,
@@ -326,6 +354,260 @@ static pmix_status_t pmix3_print(char **output, char *prefix, void *src, pmix_da
 static const char *data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&pmix_mca_bfrops_v3_component.types, type);
+}
+
+static pmix_status_t pack_int(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer, const void *src,
+                              int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    /* System types need to always be described so we can properly
+       unpack them */
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
+        return ret;
+    }
+
+    /* Turn around and pack the real type */
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, BFROP_TYPE_INT, regtypes);
+    return ret;
+}
+
+static pmix_status_t pack_sizet(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, const void *src,
+                                int32_t num_vals, pmix_data_type_t type)
+{
+    int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    /* System types need to always be described so we can properly
+       unpack them. */
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
+        return ret;
+    }
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, BFROP_TYPE_SIZE_T, regtypes);
+    return ret;
+}
+
+static pmix_status_t pack_int16(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint16_t tmp, *srctmp = (uint16_t *) src;
+    char *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int16 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0; i < num_vals; ++i) {
+        tmp = pmix_htons(srctmp[i]);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += num_vals * sizeof(tmp);
+    buffer->bytes_used += num_vals * sizeof(tmp);
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t pack_int32(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint32_t tmp, *srctmp = (uint32_t *) src;
+    char *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int32 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals * sizeof(tmp)))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    for (i = 0; i < num_vals; ++i) {
+        tmp = htonl(srctmp[i]);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += num_vals * sizeof(tmp);
+    buffer->bytes_used += num_vals * sizeof(tmp);
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t pack_int64(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint64_t tmp, tmp2;
+    char *dst;
+    size_t bytes_packed = num_vals * sizeof(tmp);
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int64 * %d\n", num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0; i < num_vals; ++i) {
+        memcpy(&tmp2, (char *) src + i * sizeof(uint64_t), sizeof(uint64_t));
+        tmp = pmix_hton64(tmp2);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += bytes_packed;
+    buffer->bytes_used += bytes_packed;
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t unpack_int(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, void *dest,
+                                int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+    pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
+        return ret;
+    }
+    if (remote_type == BFROP_TYPE_INT) {
+        /* fast path it if the sizes are the same */
+        /* Turn around and unpack the real type */
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, BFROP_TYPE_INT, regtypes);
+    } else {
+        /* slow path - types are different sizes */
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, int, remote_type, ret);
+    }
+
+    return ret;
+}
+
+static pmix_status_t unpack_sizet(pmix_pointer_array_t *regtypes,
+                                  pmix_buffer_t *buffer, void *dest,
+                                  int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+    pmix_data_type_t remote_type;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
+        PMIX_ERROR_LOG(ret);
+        return ret;
+    }
+    if (remote_type == BFROP_TYPE_SIZE_T) {
+        /* fast path it if the sizes are the same */
+        /* Turn around and unpack the real type */
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, BFROP_TYPE_SIZE_T, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+        }
+    } else {
+        /* slow path - types are different sizes */
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, size_t, remote_type, ret);
+    }
+    return ret;
+}
+
+static pmix_status_t unpack_int16(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint16_t tmp, *desttmp = (uint16_t *) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack_int16 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy(&(tmp), buffer->unpack_ptr, sizeof(tmp));
+        tmp = pmix_ntohs(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t unpack_int32(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint32_t tmp, *desttmp = (uint32_t *) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack_int32 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy(&(tmp), buffer->unpack_ptr, sizeof(tmp));
+        tmp = ntohl(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t unpack_int64(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                  void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint64_t tmp, *desttmp = (uint64_t *) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack_int64 * %d\n", (int) *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
+
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals) * sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy(&(tmp), buffer->unpack_ptr, sizeof(tmp));
+        tmp = pmix_ntoh64(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
 }
 
 /**** DEPRECATED ****/

--- a/src/mca/bfrops/v4/bfrop_pmix4.c
+++ b/src/mca/bfrops/v4/bfrop_pmix4.c
@@ -91,16 +91,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
@@ -111,16 +111,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v4_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v4_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,

--- a/src/mca/bfrops/v41/bfrop_pmix41.c
+++ b/src/mca/bfrops/v41/bfrop_pmix41.c
@@ -91,16 +91,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
@@ -111,16 +111,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v41_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v41_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,

--- a/src/mca/bfrops/v51/bfrop_pmix51.c
+++ b/src/mca/bfrops/v51/bfrop_pmix51.c
@@ -90,16 +90,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int8, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int16, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int32, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_int64, &pmix_mca_bfrops_v51_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT, pmix_bfrops_base_pack_int,
@@ -110,16 +110,16 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_byte, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint8, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint16, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint32, &pmix_mca_bfrops_v51_component.types);
 
-    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64, pmix_bfrops_base_std_copy,
+    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64, pmix_bfrops_base_pack_general_int,
+                       pmix_bfrops_base_unpack_general_int, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_uint64, &pmix_mca_bfrops_v51_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT, pmix_bfrops_base_pack_float,


### PR DESCRIPTION
Unfortunately, the implementation of the "psquash" framework violated the PMIx design rules - and was not caught at the time it was released. The code _assumes_ that both sides of the communication are using the same psquash component, which is definitely not guaranteed.

I've tried several remedies, but nothing is particularly satisfying. Adding the psquash active component to the connection handshake doesn't solve the backward compatibility issue and just further complicates an already complex operation. Simply defaulting to always using either psquash component breaks backward compatibility as prior releases will continue to dynamically select the active one.

Given the default settings in that framework, the least breakage results from defaulting to using the "squashed" component. Not the ideal solution as that adds code complexity for what appears to be minimal gain, but forcing all prior releases to set an MCA param directing that they use the "native" component is a user-unfriendly solution.

So bite the old tongue and make the "squash" behavior be the only one supported going forward. This doesn't fully solve the problem for prior releases - nothing we can do about it, we screwed up and should never have released the code in its current form.