### PR TITLE
Use remote scope for endpt collection

### DIFF
--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -179,13 +179,13 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     }
 
     /* get our endpt info, if some was posted. We use
-     * the global scope here as connect may involve
-     * cross-nspace, and so the local endpts may
-     * be relevant */
+     * "remote" scope as all local procs have access
+     * to info posted by all other local procs, regardless
+     * of their namespace */
     PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
     PMIX_CONSTRUCT(&cb2, pmix_cb_t);
     cb2.proc = &pmix_globals.myid;
-    cb2.scope = PMIX_GLOBAL;
+    cb2.scope = PMIX_REMOTE;
     cb2.copy = true;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
     if (PMIX_SUCCESS == rc) {

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -378,12 +378,12 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
     }
 
     /* get our endpt info, if some was posted. We use
-     * global in case the construct operation involves
-     * multiple nspaces and local connection
-     * between them is allowed. */
+     * "remote" scope as all local procs have access
+     * to info posted by all other local procs, regardless
+     * of their namespace */
     sz = ninfo;
     lclendpts = false;
-    rc = get_endpts(&local_endpts, PMIX_GLOBAL, &lclendpts);
+    rc = get_endpts(&local_endpts, PMIX_REMOTE, &lclendpts);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;


### PR DESCRIPTION
When performing connect or group construct operations, only collect and share "remote" info. Local procs already have access to all posted "local" info, regardless of namespace, and sharing the local info on other nodes leads to confusion.