### PR TITLE
Multiple commits

### DIFF
--- a/docs/news/news-v5.x.rst
+++ b/docs/news/news-v5.x.rst
@@ -4,6 +4,41 @@ PMIx v5.x series
 This file contains all the NEWS updates for the PMIx v5.x
 series, in reverse chronological order.
 
+5.0.4 -- TBD
+------------
+Detailed changes include:
+ - PR #3419: Add some missing attributes
+ - PR #3417: Multiple commits
+   - Fix typo in equality check
+   - Fix delayed get
+   - avoid warn-as-error for variable init
+   - Add support for libz-ng
+ - PR #3408: Update pmix_portable_platform_real.h from upstream gasnet
+ - PR #3404: Path must start with "src"
+ - PR #3402: Remove unused yaml
+ - PR #3400: add contrib/construct_event_strings.py to the dist tarball
+ - PR #3397: Multiple commits
+   - Add missing files
+   - mca/pif: fix pmix_found_linux typo
+   - Add cross-version compatibility to docs
+ - PR #3393: Multiple commits
+   - Add python directive
+   - Cleanup pfexec spawn operations
+   - Add missing function call
+ - PR #3387: Update OAC to latest HEAD
+ - PR #3385: Correctly check MCA params
+ - PR #3383: Protect against LTO optimizer
+ - PR #3381: Read The Docs updates
+ - PR #3379: Multiple commits
+   - Revert Sphinx requirements
+   - Warn against building tarball on MacOSX
+   - configure: fix regression that caused python to be mandatory to build
+   - configure: fix broken bashisms resulting in logic failure
+   - Update the requirements for Sphinx
+ - PR #3372: Multiple commits
+   - Update MLNX CI
+   - Apply prefix to copied version of the app array
+
 5.0.3 -- 8 Jul 2024
 -------------------
 Detailed changes include:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=5.0.0
+sphinx>=4.2.0
 recommonmark
 docutils
 sphinx-rtd-theme

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -128,7 +128,7 @@ static void localcbfunc(pmix_status_t status,
 
     // process IOF requests
     if (PMIX_SUCCESS == status) {
-        rc = pmix_server_process_iof(fcd->peer, nspace, fcd->channels);
+        rc = pmix_server_process_iof(fcd, nspace);
     }
 
     if (NULL != fcd->cbfunc) {

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -274,9 +274,13 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_proc_t *source,
                                                const pmix_byte_object_t *bo,
                                                const pmix_info_t *info, size_t ninfo,
-                                               const pmix_iof_req_t *req);
+                                               pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
+PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
+                                                     pmix_iof_flags_t *myflags,
+                                                     pmix_iof_channel_t stream,
+                                                     const pmix_byte_object_t *bo);
 
 END_C_DECLS
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -320,6 +320,7 @@ static void iofreqcon(pmix_iof_req_t *p)
     p->remote_id = 0;
     p->procs = NULL;
     p->nprocs = 0;
+    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
     p->regcbfunc = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -462,6 +462,7 @@ typedef struct {
     size_t remote_id;
     pmix_proc_t *procs;
     size_t nprocs;
+    pmix_iof_flags_t flags;
     pmix_iof_channel_t channels;
     pmix_iof_cbfunc_t cbfunc;
     pmix_hdlr_reg_cbfunc_t regcbfunc;

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -203,22 +203,6 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             goto complete;
         }
 
-        /* process any job-info */
-        if (NULL != fcd->jobinfo) {
-            for (k = 0; k < fcd->njinfo; k++) {
-                if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_SET_ENVAR)) {
-
-                } else if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_ADD_ENVAR)) {
-
-                } else if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_UNSET_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_PREPEND_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_APPEND_ENVAR)) {
-                } else if (PMIX_CHECK_KEY(&fcd->jobinfo[k], PMIX_NOHUP)) {
-                    nohup = PMIX_INFO_TRUE(&fcd->jobinfo[k]);
-                }
-            }
-        }
-
         /* check for a fork/exec agent we should use */
         if (NULL != app->info) {
             for (k = 0; k < app->ninfo; k++) {

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -592,6 +592,8 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     PMIX_PROC_CREATE(req->procs, req->nprocs);
     PMIX_LOAD_PROCID(&req->procs[0], pmix_globals.myid.nspace, pmix_globals.myid.rank);
     req->channels = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL;
+    // default to formatting output as we were directed to do
+    req->flags = pmix_globals.iof_flags;
     req->remote_id = 0; // default ID for tool during init
     req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -227,6 +227,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_info_t *iptr;
     size_t minfo;
     bool keepfqdn = false;
+    pmix_iof_flags_t flags;
 
 #if PMIX_NO_LIB_DESTRUCTOR
     if (pmix_init_called) {
@@ -241,6 +242,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 #endif
 
     pmix_init_called = true;
+    memset(&flags, 0, sizeof(pmix_iof_flags_t));
 
     if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;
@@ -290,7 +292,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_BIND_REQUIRED)) {
                 pmix_bind_progress_thread_reqd = PMIX_INFO_TRUE(&info[n]);
             } else {
-                pmix_iof_check_flags(&info[n], &pmix_globals.iof_flags);
+                pmix_iof_check_flags(&info[n], &flags);
             }
         }
     }
@@ -344,7 +346,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
     /* setup the stdin forwarding target list */
     PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
-    memset(&pmix_globals.iof_flags, 0, sizeof(pmix_iof_flags_t));
+    memcpy(&pmix_globals.iof_flags, &flags, sizeof(pmix_iof_flags_t));
 
     /* Setup client verbosities as all procs are allowed to
      * access client APIs */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4318,9 +4318,9 @@ static void _iofreg(int sd, short args, void *cbdata)
                                                              cd->ncodes);
         if (NULL != req) {
             PMIX_LIST_FOREACH_SAFE (iof, inxt, &pmix_server_globals.iof, pmix_iof_cache_t) {
-                if (PMIX_OPERATION_SUCCEEDED
-                    == pmix_iof_process_iof(iof->channel, &iof->source, iof->bo, iof->info,
-                                            iof->ninfo, req)) {
+                rc = pmix_iof_process_iof(iof->channel, &iof->source, iof->bo, iof->info,
+                                            iof->ninfo, req);
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
                     pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
                     PMIX_RELEASE(iof);
                 }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -275,9 +275,8 @@ PMIX_EXPORT void pmix_server_spawn_parser(pmix_peer_t *peer,
                                           pmix_iof_flags_t *flags,
                                           pmix_info_t *info,
                                           size_t ninfo);
-PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_peer_t *peer,
-                                                  char nspace[],
-                                                  pmix_iof_channel_t channels);
+PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
+                                                  char nspace[]);
 
 PMIX_EXPORT void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata);
 


### PR DESCRIPTION
[Ensure IOF respects formatting requests](https://github.com/openpmix/openpmix/commit/112c94e1db829220afc010ae754347618bcef539)

When a tool starts a launcher and the launcher cmd line
includes IO formatting requests, we want the tool to receive
relayed output in the specified format. So ensure that
formatting directives for a spawned job are not only
applied to the direct output of the launcher, but also
to all output forwarded to a requestor.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/054d296b7016a1d9f64aa6bb54de60f7ba8f5306)

[Drop the sphinx required level to match PRRTE](https://github.com/openpmix/openpmix/commit/016dcdd40991472bac1e8bb9940763dee896f4a9)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/756015637d663d9d80839c443c9d37757f22251f)

[Update NEWS to include v5.0 branch](https://github.com/openpmix/openpmix/commit/13fe6abf19cb838271e54be73903ec88d998dfa7)

Sync the news with the branch doc

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/a2e527a097d206dabe66ac283492e80c00fbe82c)
