### PR TITLE
Silence some warnings

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2609,7 +2609,7 @@ cdef int query(pmix_proc_t *source,
 
 cdef void toolconnected(pmix_info_t *info, size_t ninfo,
                         pmix_tool_connection_cbfunc_t cbfunc,
-                        void *cbdata) with gil:
+                        void *cbdata) noexcept with gil:
     keys = pmixservermodule.keys()
     ret_proc = {'nspace': "UNDEF", 'rank': PMIX_RANK_UNDEF}
     if 'toolconnected' in keys:
@@ -2624,7 +2624,7 @@ cdef void toolconnected(pmix_info_t *info, size_t ninfo,
 cdef void log(const pmix_proc_t *client,
               const pmix_info_t data[], size_t ndata,
               const pmix_info_t directives[], size_t ndirs,
-              pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+              pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
     keys = pmixservermodule.keys()
     if 'log' in keys:
         args = {}

--- a/examples/spawn_group.c
+++ b/examples/spawn_group.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
     pmix_value_t value;
     mylock_t lock;
     pmix_info_t *results = NULL, info[3], tinfo;
-    size_t nresults, cid, n, m, psize, maxprocs = 2;
+    size_t nresults, cid, n, m, psize=0, maxprocs = 2;
     pmix_data_array_t dry;
     char hostname[1024], dir[1024];
     char tmp[1024];


### PR DESCRIPTION
[Silence Cython warning](https://github.com/openpmix/openpmix/commit/ae47c349f61860ca24d7781c4893c348388b67d6)

Consistent performance warning about the need to always take
the gil if allowing exceptions to be generated by these
two functions since they don't return a value.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Silence warnings](https://github.com/openpmix/openpmix/commit/1d2ae55cd5467e7b2ddbde44e6b6a1b583f35601)

Signed-off-by: Ralph Castain <rhc@pmix.org>
