### PR TITLE
Fix resolve peers for other nspaces

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -337,7 +337,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     pmix_output_verbose(2, pmix_server_globals.get_output,
                         "%s EXECUTE GET FOR %s:%d WITH KEY %s ON BEHALF OF %s",
                         PMIX_NAME_PRINT(&pmix_globals.myid), nspace, rank,
-                        (NULL == key) ? "NULL" : key, PMIX_PNAME_PRINT(&cd->peer->info->pname));
+                        (NULL == key) ? "NULL" : PMIx_Get_attribute_name(key),
+                        PMIX_PNAME_PRINT(&cd->peer->info->pname));
 
     /* This call flows upward from a local client. If we don't
      * know about this nspace, then it cannot refer to the


### PR DESCRIPTION
When calling PMIx_Resolve_peers, the client may not be able to find the job-level info for the specified nspace. In this case, it requests the info from the server. The server's copy of the info is sometimes stored as rank=UNDEF, but can also be stored as rank=WILDCARD (depending on the server's version). So the client has to check both rank values to ensure the data is found.

Fortunately, it only requires one exchange with the server regardless of which rank is being used.