### PR TITLE
Multiple commits

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -141,6 +141,7 @@ static void nscon(pmix_namespace_t *p)
     p->num_waiting = 0;
     p->all_registered = false;
     p->version_stored = false;
+    p->job_info_recvd = false;
     p->jobbkt = NULL;
     p->ndelivered = 0;
     p->nfinalized = 0;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -349,6 +349,7 @@ typedef struct {
     size_t num_waiting;    // number of local procs waiting for debugger attach/release
     bool all_registered;   // all local ranks have been defined
     bool version_stored;   // the version string used by this nspace has been stored
+    bool job_info_recvd;   // job-level info has been received
     pmix_buffer_t *jobbkt; // packed version of jobinfo
     size_t ndelivered;     // count of #local clients that have received the jobinfo
     size_t nfinalized;     // count of #local clients that have finalized

--- a/src/mca/gds/shmem2/gds_shmem2_fetch.c
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.c
@@ -444,7 +444,7 @@ xfer_sessioninfo(
             pmix_kval_t *kvi;
             PMIX_LIST_FOREACH(kvi, sessionlist, pmix_kval_t) {
                 pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-                kv->key = strdup(kv->key);
+                kv->key = strdup(kvi->key);
                 PMIX_VALUE_XFER(rc, kv->value, kvi->value);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_RELEASE(kv);


### PR DESCRIPTION
[Fix typo in shmem2 fetch](https://github.com/openpmix/openpmix/commit/b3e9d659ef03ced06fab30bbe28146b33accaea7)

Problem hit when asking for job-level info

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Include job-level info in PMIx_Connect exchange](https://github.com/openpmix/openpmix/commit/dcb4fee20cae2b1829a2ed1cd995ac4555529471)

Need to ensure that all participants end up with access
to the job-level info for all other participants. Protect
against "re-adding" the info if the PMIx server already
has it. Only have one member of each participating nspace
provide the info to avoid unnecessary duplication.

Signed-off-by: Ralph Castain <rhc@pmix.org>
