### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/gds/shmem2/gds_shmem2_fetch.c
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.c
@@ -444,7 +444,7 @@ xfer_sessioninfo(
             pmix_kval_t *kvi;
             PMIX_LIST_FOREACH(kvi, sessionlist, pmix_kval_t) {
                 pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);
-                kv->key = strdup(kv->key);
+                kv->key = strdup(kvi->key);
                 PMIX_VALUE_XFER(rc, kv->value, kvi->value);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_RELEASE(kv);


### PR DESCRIPTION
[Retry fetch with wildcard rank](https://github.com/openpmix/openpmix/commit/d94f37e3450e31f486b6cce5473d817029d9adc1)

If a request was made with rank=UNDEF, then retry the search
with rank=WILDCARD since the server may have returned the
data under that rank (depending upon version).

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7ba403b52bcbe26598728305c73a49c987478841)

[Fix typo in shmem2 fetch](https://github.com/openpmix/openpmix/commit/a0e589427d296229845a6110236f2b71455e0e6b)

Problem hit when asking for job-level info

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/bdc2562183823323768a0c1c08c7294e6c78e58d)