### PR TITLE
.gitignore: add configure~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ autom4te.cache
 aclocal.m4
 compile
 configure
+configure~
 configure.log.*
 make.log.*
 make.install.log.*


### PR DESCRIPTION
The file "configure~" is generated when building OpenPMIx as part of Open MPI.  This causes an annoying git submodule "untracked content" notification.  So let's just add "configure~" to .gitignore so that it's properly ignored by git / git submodules.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit 24593f714ead151c443d67b47b7be20b3d74c274)