### PR TITLE
Fix the asyncgroup example

### DIFF
--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -73,17 +73,17 @@ static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, v
     DEBUG_WAKEUP_THREAD(lock);
 }
 
-static void grpcomplete(size_t evhdlr_registration_id, pmix_status_t status, const pmix_proc_t *source,
-                        pmix_info_t info[], size_t ninfo, pmix_info_t results[], size_t nresults,
+static void grpcomplete(size_t evhdlr_registration_id, pmix_status_t status,
+                        const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                        pmix_info_t results[], size_t nresults,
                         pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
-    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
 
     DEBUG_WAKEUP_THREAD(&invitedlock);
-
-    // progress the event thread
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
@@ -252,8 +252,8 @@ int main(int argc, char **argv)
         PMIX_PROC_LOAD(&proc, "ourgroup", PMIX_RANK_WILDCARD);
         rc = PMIx_Fence(&proc, 1, NULL, 0);
         if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %d\n",
-                    myproc.nspace, myproc.rank, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %s(%d)\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc), rc);
             goto done;
         }
         fprintf(stderr, "%d Executing Group_destruct\n", myproc.rank);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,7 +77,9 @@ static void rsdes(pmix_rshift_caddy_t *p)
         PMIX_RELEASE(p->cd);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_rshift_caddy_t, pmix_object_t, rscon, rsdes);
+PMIX_CLASS_INSTANCE(pmix_rshift_caddy_t,
+                    pmix_object_t,
+                    rscon, rsdes);
 
 static void check_cached_events(pmix_rshift_caddy_t *cd);
 
@@ -252,7 +254,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     if (NULL == cd->codes) {
         registered = false;
         PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-            if (PMIX_MAX_ERR_CONSTANT == active->code && 
+            if (PMIX_MAX_ERR_CONSTANT == active->code &&
                 (NULL != active->peer && active->peer == pmix_client_globals.myserver)) {
                 /* we have registered a default */
                 registered = true;
@@ -273,7 +275,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
         for (n = 0; n < cd->ncodes; n++) {
             registered = false;
             PMIX_LIST_FOREACH (active, &pmix_globals.events.actives, pmix_active_code_t) {
-                if (active->code == cd->codes[n] && 
+                if (active->code == cd->codes[n] &&
                     (NULL != active->peer && active->peer == pmix_client_globals.myserver)) {
                     registered = true;
                     ++active->nregs;


### PR DESCRIPTION
We need to catch the "group complete" event so we can add the group and its membership to the client's list of known groups. This enables the client to then reference the group for operations like "fence" instead of the individual procs.