### PR TITLE
add dummy slurm_notify function to prm_slurm module

### DIFF
--- a/src/mca/prm/slurm/prm_slurm.c
+++ b/src/mca/prm/slurm/prm_slurm.c
@@ -33,10 +33,14 @@
 #include "prm_slurm.h"
 
 static pmix_status_t get_remaining_time(uint32_t *timeleft);
+static pmix_status_t slurm_notify(pmix_status_t status, const pmix_proc_t *source,
+                               pmix_data_range_t range, const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 pmix_prm_module_t pmix_prm_slurm_module = {
     .name = "slurm",
-    .get_remaining_time = get_remaining_time
+    .get_remaining_time = get_remaining_time,
+    .notify = slurm_notify
 };
 
 static pmix_status_t get_remaining_time(uint32_t *timeleft)
@@ -91,4 +95,12 @@ static pmix_status_t get_remaining_time(uint32_t *timeleft)
 
     *timeleft = tleft;
     return PMIX_SUCCESS;
+}
+
+static pmix_status_t slurm_notify(pmix_status_t status, const pmix_proc_t *source,
+                               pmix_data_range_t range, const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, source, range, info, ninfo, cbfunc, cbdata);
+    return PMIX_ERR_NOT_SUPPORTED;
 }


### PR DESCRIPTION
The prm_slurm module does not yet provide a function pointer for the `.notify ` member.
This has resulted in a segfault when using `PMIx_Notify_event` inside of a Slurm allocation as the PMIx server tries to call a NULL pointer.
The pull request adds a dummy slurm_notify function that returns `PMIX_ERR_NOT_SUPPORTED`.

I'm not sure if I fully understand the intentions of the prm framework but I was wondering if it would make sense to default to calling the `host_server.notify` function if the active module returns `PMIX_ERR_NOT_SUPPORTED`? E.g. when running PRRTE inside of a Slurm allocation. 