### PR TITLE
Complete implementation of group construct "bootstrap"

### DIFF
--- a/docs/how-things-work/sets_groups/group_construct.rst
+++ b/docs/how-things-work/sets_groups/group_construct.rst
@@ -1,21 +1,53 @@
 Group Construction
 ==================
 
-PMIx supports two methods for constructing PMIx groups. The
+For purposes of constructing PMIx groups, PMIx defines two
+classes of group members:
+
+*leaders* have some global view of the group at time of
+construction. This might consist of knowing the number of
+leaders in the group, or knowing the process IDs of all
+group leaders.
+
+*members* know only that they are to participate in a given
+group ID, but have no other knowledge of the group. For example,
+a member may not know how many processes will be in the group
+or any of their process IDs. The only requirement for membership
+is that the process know the group ID to which they are to belong.
+
+Within that context,
+PMIx supports three methods for constructing PMIx groups. The
 *collective* method is considered the more traditional form
-of the operation but requires all members of the group
-invoking the ``PMIx_Group_construct`` to know the proc ID
-of all other members prior to calling the API.
+of the operation but requires all group leaders to know the process ID
+of all other leaders prior to calling the API.
 
 In contrast,
-the *bootstrap* method is a more dynamic form of the operation
-that assumes only a core subset of participants know of each other
-prior to calling the API - but that some or all of those
-participants know of _additional_ processes that need to be
-included in the final group. Bootstrap also requires that
-those additional processes know (a) that they need to join
-the group, and (b) the group ID of the group they need
-to join.
+the *bootstrap* method is a somewhat more dynamic form of the operation
+that assumes each leader only knows the number of group leaders,
+but does not know their process IDs.
+
+In either of these two methods, additional group members can be
+specified by any leader via the ``PMIX_GROUP_ADD_MEMBERS``
+attribute. The PMIx server library and host are jointly responsible
+for aggregating the
+additional group members specified across leaders. Processes that are on the
+"additional member" list must call ``PMIx_Group_construct``
+with ``NULL`` in the  ``procs`` argument - this
+indicates that the process is to
+be added to the group when the group construct operation has completed.
+
+Note that the group construct operation _cannot_ complete until all
+"add members" have
+called ``PMIx_Group_construct``. This is required so that any group
+and/or endpoint information
+provided by the added members can be included in the returned
+``pmix_info_t`` array.
+
+
+Finally, the *invite* method represents the most dynamic form
+of group construction as it is executed in an ad hoc manner that
+revolves around a single leader that asynchronously invites
+processes to join a group.
 
 Each of these methods is explained further below.
 
@@ -23,11 +55,10 @@ Each of these methods is explained further below.
 Collective Method
 -----------------
 
-All participants know the ID of all other participants, and thus call
-``PMIx_Group_construct`` with the array of all participating proc IDs.
-Note that in this method, _all_ participants _must_ call the API
-with the array of participating proc IDs. No participants can be
-added using the ``PMIX_GROUP_ADD_MEMBERS`` attribute.
+All leaders know the ID of all other leaders, and thus call
+``PMIx_Group_construct`` with the array of all leader process IDs.
+Note that in this method, _all_ leaders _must_ call the API
+with the array of process IDs.
 
 
 Host responsibilities
@@ -44,32 +75,14 @@ has access to posted information.
 
 Bootstrap Method
 ----------------
-Bootstrap is used when the processes involved in group construct do
-not know the identity of all other processes that will be participating.
-It is required, however, that all participants at least know how many
-processes will be participating.
-
-In this context, participants equate to processes that call ``PMIx_Group_construct`` (or
-its non-blocking equivalent) and pass _only_ their own process identifier
-to the ``procs`` argument. Participants are _required_ to include the
+Bootstrap is used when the processes leading group construct do
+not know the identity of all other processes that will be participating, but at least
+know how may leaders will be participating. Leaders provide only their
+own process ID in the ``procs`` parameter to the ``PMIx_Group_construct``
+API, and are _required_ to include the
 ``PMIX_GROUP_BOOTSTRAP`` attribute in their array of ``pmix_info_t``
 directives, with the value in that attribute set to equal the number
-of participants in the group construct operation.
+of leaders in the group construct operation.
 
 
-Add Members
------------
-Additional group members can be specified by any participant via the ``PMIX_GROUP_ADD_MEMBERS``
-attribute. The PMIx server library and host are jointly responsible for aggregating the
-additional group members specified across participants. Processes that are on the
-"additional member" list must call ``PMIx_Group_construct``
-with a ``NULL`` ``procs`` argument - this indicates that the process is to
-be added to the group (via PMIx event, internal to the ``PMIx_Group_construct`` function)
-when the group construct operation has completed.
 
-Participant in this context equates to any process that calls ``PMIx_Group_construct``,
-whether bootstrapping or not.
-
-Note that the group construct operation _cannot_ complete until all "add members" have
-called ``PMIx_Group_construct``. This is required so that any group and/or endpoint information
-provided by the added members can be included in the returned ``pmix_info_t`` array.

--- a/examples/group_bootstrap.c
+++ b/examples/group_bootstrap.c
@@ -72,10 +72,10 @@ int main(int argc, char **argv)
     int rc;
     pmix_value_t *val = NULL;
     uint32_t nprocs;
-    pmix_proc_t proc, *parray;
+    pmix_proc_t proc, *parray = NULL;
     mylock_t lock;
     pmix_info_t *results = NULL, info[3];
-    size_t nresults, cid, n, m, psize;
+    size_t nresults, cid, n, m, psize = 0;
     pmix_data_array_t dry;
     char hostname[1024];
 
@@ -157,6 +157,7 @@ int main(int argc, char **argv)
         }
     } else if (4 == myproc.rank || 5 == myproc.rank) {
         fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+        fflush(stderr);
         rc = PMIx_Group_construct("ourgroup", NULL, 0, NULL, 0, &results, &nresults);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
@@ -164,6 +165,8 @@ int main(int argc, char **argv)
             goto done;
         }
     }
+    fprintf(stderr, "%d GROUP CONSTRUCT COMPLETE\n", myproc.rank);
+    fflush(stderr);
 
     if (0 == myproc.rank || 3 == myproc.rank ||
         4 == myproc.rank || 5 == myproc.rank) {
@@ -184,9 +187,12 @@ int main(int argc, char **argv)
                     }
                 }
             }
-            PMIX_INFO_FREE(results, nresults);
         } else {
             fprintf(stderr, "%d Group construct complete, but no results returned\n", myproc.rank);
+        }
+        if (NULL == parray) {
+            fprintf(stderr, "%d NULL proc array\n", myproc.rank);
+            goto done;
         }
 
         fprintf(stderr, "%d Executing group fence\n", myproc.rank);

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4939,7 +4939,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
     }
 
     if (PMIX_FINALIZE_CMD == cmd) {
-        pmix_output_verbose(2, pmix_server_globals.base_output, "recvd FINALIZE");
         peer->nptr->nfinalized++;
         /* purge events */
         pmix_server_purge_events(peer, NULL);

--- a/test/group/run.sh
+++ b/test/group/run.sh
@@ -1,0 +1,8 @@
+#/bin/bash
+
+echo "Test group"
+prterun -n 4 ../../examples/group >& /dev/null
+
+echo "Test group_lcl_cid"
+prterun -n 4 ../../examples/group_lcl_cid >& /dev/null
+


### PR DESCRIPTION
In some scenarios, a limited number of group members will know the processIDs of other group members - but some group members will not. In this case, we want to still construct a group from all the members, but cannot execute it with every member calling PMIx_Group_construct and passing a complete array of participants.

So reduce the constraints by allowing a "leader" to call group construct and pass (a) its own process ID as the sole entry in the "procs" array; (b) the number of "leaders" that will be participating; and (c) an optional attribute identifying additional processIDs for procs that want to join the group, but don't know anything about it beyond the group ID.

All "additional members" must call PMIx_Group_construct with the group ID and a NULL entry for the procs array.

Upon completion, the "results" array will include a complete list of members (including all additional members) plus any other related info (e.g., a requested context ID). The operation will also result in all "put" info from members being available via PMIx_Get, along with the job-level info for all participating namespaces.