### PR TITLE
Repair the file removal code

### DIFF
--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -1,0 +1,49 @@
+name: PRRTE
+
+on: [pull_request]
+
+jobs:
+  dvm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+    - name: Build OpenPMIx
+      run: |
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/prrte
+            path: prrte/master
+            ref: master
+    - name: Build PRRTE
+      run: |
+        cd prrte/master
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Tweak PRRTE
+      run:  |
+         # Tweak PRRTE
+         mca_params="$HOME/.prte/mca-params.conf"
+         mkdir -p "$(dirname "$mca_params")"
+         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+    - name: Run simple test
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         prte --daemonize --no-ready-msg
+         prun -n 4 ./examples/hello
+         pterm

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -79,6 +79,7 @@ struct pmix_ptl_base_t {
     char *nspace_filename;
     char *pid_filename;
     char *rendezvous_filename;
+    bool created_rendezvous_dir;
     bool created_rendezvous_file;
     bool created_session_tmpdir;
     bool created_system_tmpdir;
@@ -136,7 +137,6 @@ PMIX_EXPORT void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
 
 PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
-PMIX_EXPORT pmix_status_t pmix_base_write_rndz_file(char *filename, char *uri, bool *created);
 
 /* base support functions */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **evar);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -45,6 +45,7 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/mca.h"
 #include "src/server/pmix_server_ops.h"
+#include "src/util/pmix_basename.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_os_dirpath.h"
 #include "src/util/pmix_os_path.h"
@@ -83,6 +84,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .nspace_filename = NULL,
     .pid_filename = NULL,
     .rendezvous_filename = NULL,
+    .created_rendezvous_dir = false,
     .created_rendezvous_file = false,
     .created_session_tmpdir = false,
     .created_system_tmpdir = false,
@@ -249,6 +251,7 @@ static bool _check_file(const char *root, const char *path)
 static pmix_status_t pmix_ptl_close(void)
 {
     int rc;
+    char *tmp;
 
     if (!pmix_ptl_base.initialized) {
         return PMIX_SUCCESS;
@@ -340,6 +343,11 @@ static pmix_status_t pmix_ptl_close(void)
         free(pmix_ptl_base.pid_filename);
     }
     if (NULL != pmix_ptl_base.rendezvous_filename) {
+        if (pmix_ptl_base.created_rendezvous_dir) {
+            tmp = pmix_dirname(pmix_ptl_base.rendezvous_filename);
+            pmix_os_dirpath_destroy(tmp, true, _check_file);
+            free(tmp);
+        }
         if (pmix_ptl_base.created_rendezvous_file) {
             rc = remove(pmix_ptl_base.rendezvous_filename);
             if (0 != rc) {

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
-# Copyright (c) 2023      Nanook Consulting  All rights reserved.
+# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -69,6 +69,7 @@ PMIx detected a call to mkdir was unable to create the desired directory:
 
 Please check to ensure you have adequate permissions to perform
 the desired operation.
+#
 [unlink-error]
 We attempted to remove a file, but were unable to do so:
 


### PR DESCRIPTION
We made some changes to the os_dirpath_create code a while back to resolve some of the "test-before-use" warnings and other things. However, this opened a hole in the logic of the PTL code that used it. Specifically, we weakened the connection between when a file and directory were being created by the tool itself, and when those things already existed. So we could inadvertently stomp on files.

Do a better job of tracking precisely which directories and files are being created by a given process...and then ONLY remove those that were created by it.