### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -1,0 +1,49 @@
+name: PRRTE
+
+on: [pull_request]
+
+jobs:
+  dvm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+    - name: Build OpenPMIx
+      run: |
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/prrte
+            path: prrte/master
+            ref: master
+    - name: Build PRRTE
+      run: |
+        cd prrte/master
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Tweak PRRTE
+      run:  |
+         # Tweak PRRTE
+         mca_params="$HOME/.prte/mca-params.conf"
+         mkdir -p "$(dirname "$mca_params")"
+         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+    - name: Run simple test
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         prte --daemonize --no-ready-msg
+         prun -n 4 ./examples/hello
+         pterm

--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -25,11 +25,11 @@ jobs:
       with:
             submodules: recursive
             repository: openpmix/prrte
-            path: prrte/master
-            ref: master
+            path: prrte/v3.0
+            ref: v3.0
     - name: Build PRRTE
       run: |
-        cd prrte/master
+        cd prrte/v3.0
         ./autogen.pl
         ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
         make -j

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -63,6 +63,7 @@ else
 fi
 
 greekonly=0
+nogreek=0
 autogen_args=
 config_args=
 distdir=".."
@@ -70,6 +71,7 @@ for i in "$@"; do
     case $i in
         -greekonly) greekonly=1 ;;
         --greekonly) greekonly=1 ;;
+        --nogreek) nogreek=1 ;;
         -highok) highok=1 ;;
         --highok) highok=1 ;;
         -autogen-args=*) autogen_args="${i#*=}"; shift ;;
@@ -89,6 +91,7 @@ Unrecognized argument: $1
 
 Valid arguments:
   --greekonly     Only build the greek tarball (vs. both tarballs)
+  --nogreek       Only build the non-greek tarball
   --highok        Ok if Autotools versions are too high
   --autogen-args  Arguments to pass to autogen
   --config-args   Arguments to pass to configure (e.g., --with-libevent=<foo>)
@@ -415,8 +418,12 @@ done
 
 # First, make greek tarball
 
-echo "*** Making greek tarball"
-make_tarball
+if test "$nogreek" = "1"; then
+    echo "*** Skipping greek tarball"
+else
+    echo "*** Making greek tarball"
+    make_tarball
+fi
 
 # Now if ! --greekonly, make the non-greek tarball
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -80,6 +80,7 @@ struct pmix_ptl_base_t {
     char *nspace_filename;
     char *pid_filename;
     char *rendezvous_filename;
+    bool created_rendezvous_dir;
     bool created_rendezvous_file;
     bool created_session_tmpdir;
     bool created_system_tmpdir;
@@ -137,7 +138,6 @@ PMIX_EXPORT void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
 
 PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
-PMIX_EXPORT pmix_status_t pmix_base_write_rndz_file(char *filename, char *uri, bool *created);
 
 /* base support functions */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_check_server_uris(pmix_peer_t *peer, char **evar);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4464,6 +4464,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
                     return PMIX_SUCCESS;
                 }
                 /* remove the tracker from the list */
+                pmix_list_remove_item(&trk->local_cbs, &cd->super);
                 pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
                 PMIX_RELEASE(trk);
                 return rc;
@@ -4486,6 +4487,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
     /* check if our host supports group operations */
     if (NULL == pmix_host_server.group) {
         /* cannot support it */
+        pmix_list_remove_item(&trk->local_cbs, &cd->super);
         pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
         PMIX_RELEASE(trk);
         return PMIX_ERR_NOT_SUPPORTED;
@@ -4501,6 +4503,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
         rc = _collect_data(trk, &bucket);
         if (PMIX_SUCCESS != rc) {
             /* remove the tracker from the list */
+            pmix_list_remove_item(&trk->local_cbs, &cd->super);
             pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
             PMIX_RELEASE(trk);
             PMIX_DESTRUCT(&bucket);
@@ -4582,6 +4585,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd, pmix_buffer_t *b
             return PMIX_SUCCESS;
         }
         /* remove the tracker from the list */
+        pmix_list_remove_item(&trk->local_cbs, &cd->super);
         pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
         PMIX_RELEASE(trk);
         return rc;

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
-# Copyright (c) 2023      Nanook Consulting  All rights reserved.
+# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -69,6 +69,7 @@ PMIx detected a call to mkdir was unable to create the desired directory:
 
 Please check to ensure you have adequate permissions to perform
 the desired operation.
+#
 [unlink-error]
 We attempted to remove a file, but were unable to do so:
 


### PR DESCRIPTION
[Repair the file removal code](https://github.com/openpmix/openpmix/commit/35ec1bd74579c9ec12067bd39ef372c0bd695818)

We made some changes to the os_dirpath_create code a while back
to resolve some of the "test-before-use" warnings and other
things. However, this opened a hole in the logic of the PTL
code that used it. Specifically, we weakened the connection
between when a file and directory were being created by the
tool itself, and when those things already existed. So we could
inadvertently stomp on files.

Do a better job of tracking precisely which directories and
files are being created by a given process...and then ONLY
remove those that were created by it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/445d4af7dfc0305d6bfc54c0703e4adf11e8ad98)

[Add a --nogreek option to make tarball](https://github.com/openpmix/openpmix/commit/d6d5953a606d39fc4bc2b83af3558ddc57645c4a)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3c65fc8e88c21aeb28133b5848a07c69d369da09)

[Update PRRTE CI to point at PRRTE v3.0 branch](https://github.com/openpmix/openpmix/pull/3479/commits/fbde4937c663802a684c01987796f44b65bba661)
[fbde493](https://github.com/openpmix/openpmix/pull/3479/commits/fbde4937c663802a684c01987796f44b65bba661)

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Cleanup a segfault when the host refuses group construct support](https://github.com/openpmix/openpmix/pull/3479/commits/eca9633b1f902cf439a1272da07676996c2b4f8f)

Signed-off-by: Ralph Castain <rhc@pmix.org>

bot:notacherrypick