### PR TITLE
Debug group operations

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -90,7 +90,6 @@ pmix_server_globals_t pmix_server_globals = {
     .gdata = PMIX_LIST_STATIC_INIT,
     .genvars = NULL,
     .events = PMIX_LIST_STATIC_INIT,
-    .failedgrps = NULL,
     .iof = PMIX_LIST_STATIC_INIT,
     .iof_residuals = PMIX_LIST_STATIC_INIT,
     .psets = PMIX_LIST_STATIC_INIT,
@@ -1067,9 +1066,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
          * abnormal termination, then the nspace object may not be
          * at zero refcount */
         pmix_execute_epilog(&ns->epilog);
-    }
-    if (NULL != pmix_server_globals.failedgrps) {
-        PMIX_ARGV_FREE(pmix_server_globals.failedgrps);
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -183,7 +183,6 @@ typedef struct {
     pmix_list_t gdata;  // cache of data given to me for passing to all clients
     char **genvars;     // argv array of envars given to me for passing to all clients
     pmix_list_t events; // list of pmix_regevents_info_t registered events
-    char **failedgrps;    // group IDs that failed to construct
     pmix_list_t iof;    // IO to be forwarded to clients
     pmix_list_t iof_residuals;  // leftover bytes waiting for newline
     pmix_list_t psets;  // list of known psets and memberships


### PR DESCRIPTION
Simplify the code by removing the local completion optimization - it isn't clear that is a good thing to do anyway. The host still needs to know about it, and probably needs global knowledge of the group's existence, so it isn't clear that it was even feasible/good to do.

Remove some other cruft. Also, group proc array doesn't have to be in any particular order, which means we cannot require that all participants provide the array in the _same_ order.