### PR TITLE
Cleanup the server's group ops a bit

### DIFF
--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -85,8 +85,14 @@ typedef struct {
     pmix_event_t ev;
     bool event_active;
     bool need_cxtid;
+    pmix_proc_t *pcs;
+    size_t npcs;
+    pmix_info_t *info;
+    size_t ninfo;
     pmix_list_t mbrs;  // list of grp_trk_t
-    pmix_list_t nslist;  // list of involved nspaces
+    bool def_complete;      // all local procs have been registered and the trk definition is complete
+    uint32_t nlocal;        // number of local participants
+    uint32_t local_cnt;     // number of local participants who have contributed
 } grp_block_t;
 static void gbcon(grp_block_t *p)
 {
@@ -94,16 +100,27 @@ static void gbcon(grp_block_t *p)
     p->grpop = PMIX_GROUP_NONE;
     p->event_active = false;
     p->need_cxtid = false;
+    p->pcs = NULL;
+    p->npcs = 0;
+    p->info = NULL;
+    p->ninfo = 0;
     PMIX_CONSTRUCT(&p->mbrs, pmix_list_t);
-    PMIX_CONSTRUCT(&p->nslist, pmix_list_t);
+    p->def_complete = false;
+    p->nlocal = 0;
+    p->local_cnt = 0;
 }
 static void gbdes(grp_block_t *p)
 {
     if (NULL != p->id) {
         free(p->id);
     }
+    if (NULL != p->pcs) {
+        PMIX_PROC_FREE(p->pcs, p->npcs);
+    }
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
     PMIX_LIST_DESTRUCT(&p->mbrs);
-    PMIX_LIST_DESTRUCT(&p->nslist);
 }
 static PMIX_CLASS_INSTANCE(grp_block_t,
                            pmix_list_item_t,
@@ -122,14 +139,7 @@ typedef struct {
     size_t npcs;
     pmix_info_t *info;
     size_t ninfo;
-    bool def_complete;      // all local procs have been registered and the trk definition is complete
     pmix_list_t local_cbs;  // list of pmix_server_caddy_t for sending result to the local participants
-                            //    Note: there may be multiple entries for a given proc if that proc
-                            //    has fork/exec'd clones that are also participating
-    uint32_t nlocal;        // number of local participants
-    uint32_t local_cnt;     // number of local participants who have contributed
-    pmix_info_cbfunc_t cbfunc;
-    void *cbdata;
 } grp_trk_t;
 static void gtcon(grp_trk_t *t)
 {
@@ -143,12 +153,7 @@ static void gtcon(grp_trk_t *t)
     t->npcs = 0;
     t->info = NULL;
     t->ninfo = 0;
-    t->def_complete = false;
     PMIX_CONSTRUCT(&t->local_cbs, pmix_list_t);
-    t->nlocal = 0;
-    t->local_cnt = 0;
-    t->cbfunc = NULL;
-    t->cbdata = NULL;
 }
 static void gtdes(grp_trk_t *t)
 {
@@ -193,145 +198,94 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(grp_shifter_t,
 
 
 /* DEFINE LOCAL FUNCTIONS */
-static pmix_status_t aggregate_info(grp_trk_t *trk,
-                                    pmix_info_t *info,
-                                    size_t ninfo);
+static pmix_status_t aggregate_info(grp_block_t *blk);
 
-static void check_completion(grp_trk_t *trk,
-                             pmix_proc_t *procs, size_t nprocs)
+static void check_definition_complete(grp_block_t *blk)
 {
-    bool all_def, found;
-    pmix_nspace_t first;
     pmix_namespace_t *ns, *nptr;
-    pmix_nspace_caddy_t *nm;
     pmix_rank_info_t *info;
     size_t i;
+    uint32_t nlocal = 0;
+    grp_trk_t *trk;
 
-    if (trk->def_complete) {
+    if (blk->def_complete) {
         return;
     }
 
-    all_def = true;
-    PMIX_LOAD_NSPACE(first, NULL);
-    for (i = 0; i < nprocs; i++) {
-        /* is this nspace known to us? */
-        nptr = NULL;
-        PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
-            if (0 == strcmp(procs[i].nspace, ns->nspace)) {
-                nptr = ns;
-                break;
+    PMIX_LIST_FOREACH(trk, &blk->mbrs, grp_trk_t) {
+        for (i = 0; i < trk->npcs; i++) {
+            /* is this nspace known to us? */
+            nptr = NULL;
+            PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
+                if (0 == strcmp(trk->pcs[i].nspace, ns->nspace)) {
+                    nptr = ns;
+                    break;
+                }
             }
-        }
-        /* check if multiple nspaces are involved in this operation */
-        if (0 == strlen(first)) {
-            PMIX_LOAD_NSPACE(first, procs[i].nspace);
-        } else if (!PMIX_CHECK_NSPACE(first, procs[i].nspace)) {
-            trk->hybrid = true;
-        }
-        if (NULL == nptr) {
-            /* we don't know about this nspace. If there is going to
-             * be at least one local process participating in a fence,
-             * they we require that either at least one process must already
-             * have been registered (via "register client") or that the
-             * nspace itself have been regisered. So either the nspace
-             * wasn't registered because it doesn't include any local
-             * procs, or our host has not been told about this nspace
-             * because it won't host any local procs. We therefore mark
-             * this tracker as including non-local participants.
-             *
-             * NOTE: It is conceivable that someone might want to review
-             * this constraint at a future date. I believe it has to be
-             * required (at least for now) as otherwise we wouldn't have
-             * a way of knowing when all local procs have participated.
-             * It is possible that a new nspace could come along at some
-             * later time and add more local participants - but we don't
-             * know how long to wait.
-             *
-             * The only immediately obvious alternative solutions would
-             * be to either require that RMs always inform all daemons
-             * about the launch of nspaces, regardless of whether or
-             * not they will host local procs; or to drop the aggregation
-             * of local participants and just pass every fence call
-             * directly to the host. Neither of these seems palatable
-             * at this time. */
-            continue;
-        }
-        /* it is possible we know about this nspace because the host
-         * has registered one or more clients via "register_client",
-         * but the host has not yet called "register_nspace". There is
-         * a very tiny race condition whereby this can happen due
-         * to event-driven processing, but account for it here */
-        if (SIZE_MAX == nptr->nlocalprocs) {
-            /* delay processing until this nspace is registered */
-            all_def = false;
-            continue;
-        }
-        if (0 == nptr->nlocalprocs) {
-            /* the host has informed us that this nspace has no local procs */
-            pmix_output_verbose(5, pmix_server_globals.fence_output,
-                                "pmix_server_new_tracker: nspace %s has no local procs",
-                                procs[i].nspace);
-            continue;
-        }
-
-        /* check and add uniq ns into nslist for this group operation block */
-        found = false;
-        PMIX_LIST_FOREACH (nm, &trk->blk->nslist, pmix_nspace_caddy_t) {
-            if (0 == strcmp(nptr->nspace, nm->ns->nspace)) {
-                found = true;
-                break;
+            if (NULL == nptr) {
+                /* we don't know about this nspace - we need to
+                 * wait until it has been registered */
+                return;
             }
-        }
-        if (!found) {
-            nm = PMIX_NEW(pmix_nspace_caddy_t);
-            PMIX_RETAIN(nptr);
-            nm->ns = nptr;
-            pmix_list_append(&trk->blk->nslist, &nm->super);
-        }
-
-        /* if they want all the local members of this nspace, then
-         * add them in here. They told us how many procs will be
-         * local to us from this nspace, but we don't know their
-         * ranks. So as long as they want _all_ of them, we can
-         * handle that case regardless of whether the individual
-         * clients have been "registered" */
-        if (PMIX_RANK_WILDCARD == procs[i].rank) {
-            trk->nlocal += nptr->nlocalprocs;
-            continue;
-        }
-
-        /* They don't want all the local clients, or they are at
-         * least listing them individually. Check if all the clients
-         * for this nspace have been registered via "register_client"
-         * so we know the specific ranks on this node */
-        if (!nptr->all_registered) {
-            /* nope, so no point in going further on this one - we'll
-             * process it once all the procs are known */
-            all_def = false;
-            pmix_output_verbose(5, pmix_server_globals.fence_output,
-                                "pmix_server_new_tracker: all clients not registered nspace %s",
-                                procs[i].nspace);
-            continue;
-        }
-        /* is this one of my local ranks? */
-        found = false;
-        PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
-            if (procs[i].rank == info->pname.rank) {
+            /* it is possible we know about this nspace because the host
+             * has registered one or more clients via "register_client",
+             * but the host has not yet called "register_nspace". There is
+             * a very tiny race condition whereby this can happen due
+             * to event-driven processing, but account for it here */
+            if (SIZE_MAX == nptr->nlocalprocs) {
+                /* delay processing until this nspace is registered */
+                return;
+            }
+            if (0 == nptr->nlocalprocs) {
+                /* the host has informed us that this nspace has no local procs */
                 pmix_output_verbose(5, pmix_server_globals.fence_output,
-                                    "adding local proc %s.%d to tracker", info->pname.nspace,
-                                    info->pname.rank);
-                found = true;
-                /* track the count */
-                trk->nlocal++;
-                break;
+                                    "pmix_server_new_tracker: nspace %s has no local procs",
+                                    trk->pcs[i].nspace);
+                continue;
+            }
+
+            /* if they want all the local members of this nspace, then
+             * add them in here. They told us how many procs will be
+             * local to us from this nspace, but we don't know their
+             * ranks. So as long as they want _all_ of them, we can
+             * handle that case regardless of whether the individual
+             * clients have been "registered" */
+            if (PMIX_RANK_WILDCARD == trk->pcs[i].rank) {
+                nlocal += nptr->nlocalprocs;
+                continue;
+            }
+
+            /* They don't want all the local clients, or they are at
+             * least listing them individually. Check if all the clients
+             * for this nspace have been registered via "register_client"
+             * so we know the specific ranks on this node */
+            if (!nptr->all_registered) {
+                /* nope, so no point in going further on this one - we'll
+                 * process it once all the procs are known */
+                pmix_output_verbose(5, pmix_server_globals.fence_output,
+                                    "pmix_server_new_tracker: all clients not registered nspace %s",
+                                    trk->pcs[i].nspace);
+                return;
+            }
+            /* is this one of my local ranks? */
+            PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
+                if (trk->pcs[i].rank == info->pname.rank) {
+                    pmix_output_verbose(5, pmix_server_globals.fence_output,
+                                        "adding local proc %s.%d to tracker", info->pname.nspace,
+                                        info->pname.rank);
+                    /* track the count */
+                    nlocal++;
+                    break;
+                }
             }
         }
     }
 
-    if (all_def) {
-        trk->def_complete = true;
-    }
+    // if we get here, then we have completed definition of the block
+    blk->def_complete = true;
+    blk->nlocal = nlocal;
 }
+
 static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
                                  pmix_proc_t *procs, size_t nprocs,
                                  pmix_info_t *info, size_t ninfo,
@@ -339,61 +293,20 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
 {
     grp_block_t *blk;
     grp_trk_t *trk;
-    pmix_status_t rc;
-    size_t m, n, match;
+
+
+    if (follower || bootstrap) {
+        // bootstrap operations maintain independent trackers
+        // since we don't know who is going to participate as
+        // a leader
+        goto newblock;
+    }
 
     // see if we already have a block for this ID
     PMIX_LIST_FOREACH(blk, &pmix_server_globals.grp_collectives, grp_block_t) {
         if (0 == strcmp(grpid, blk->id)) {
             // we do - pass it back
             *block = blk;
-            // if this is part of a bootstrap, then it always gets its own tracker.
-            // we don't attempt to locally collect participants as we don't
-            // know who the other group construct leaders and/or add-members are - we
-            // only know how many leaders there will be
-            if (follower || bootstrap) {
-                trk = PMIX_NEW(grp_trk_t);
-                PMIX_RETAIN(blk);
-                trk->blk = blk;
-                // there can be only one proc in the array, but copy it anyway
-                trk->npcs = nprocs;
-                if (NULL != procs) {
-                    PMIX_PROC_CREATE(trk->pcs, trk->npcs);
-                    memcpy(trk->pcs, procs, nprocs * sizeof(pmix_proc_t));
-                }
-                trk->info = info;
-                trk->ninfo = ninfo;
-                // bootstraps are sent as separate participants
-                trk->def_complete = true;
-                pmix_list_append(&blk->mbrs, &trk->super);
-                *tracker = trk;
-                return PMIX_SUCCESS;
-            }
-            // check if this participant's signature is already present
-            PMIX_LIST_FOREACH(trk, &blk->mbrs, grp_trk_t) {
-                if (trk->npcs != nprocs) {
-                    continue;
-                }
-                // the procs are not required to be in the same order!
-                match = 0;
-                for (n=0; n < trk->npcs; n++) {
-                    for (m=0; m < nprocs; m++) {
-                        if (PMIX_CHECK_PROCID(&trk->pcs[n], &procs[m])) {
-                            match++;
-                            break;
-                        }
-                    }
-                }
-                if (match == nprocs) {
-                    // matching tracker - pass it back
-                    *tracker = trk;
-                    // check for completion
-                    check_completion(trk, procs, nprocs);
-                    // aggregate info
-                    rc = aggregate_info(trk, info, ninfo);
-                    return rc;
-                }
-            }
             // new signature, so create a tracker for it
             trk = PMIX_NEW(grp_trk_t);
             PMIX_RETAIN(blk);
@@ -405,11 +318,12 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
             trk->ninfo = ninfo;
             pmix_list_append(&blk->mbrs, &trk->super);
             *tracker = trk;
-            check_completion(trk, procs, nprocs);
+            check_definition_complete(blk);
             return PMIX_SUCCESS;
         }
     }
 
+newblock:
     // new block
     blk = PMIX_NEW(grp_block_t);
     blk->id = strdup(grpid);
@@ -428,9 +342,9 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
     trk->ninfo = ninfo;
     pmix_list_append(&blk->mbrs, &trk->super);
     if (follower || bootstrap) {
-        trk->def_complete = true;
+        blk->def_complete = true;
     } else {
-        check_completion(trk, procs, nprocs);
+        check_definition_complete(blk);
     }
     *tracker = trk;
     return PMIX_SUCCESS;
@@ -439,7 +353,9 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
 static void _grpcbfunc(int sd, short args, void *cbdata)
 {
     grp_shifter_t *scd = (grp_shifter_t *) cbdata;
-    grp_block_t *blk = scd->blk;
+    grp_block_t *blk = scd->blk, *bk;
+    char *id;
+    pmix_group_operation_t op;
     grp_trk_t *trk;
     pmix_server_caddy_t *cd;
     pmix_buffer_t *reply;
@@ -477,71 +393,81 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
         }
     }
 
-    PMIX_LIST_FOREACH(trk, &blk->mbrs, grp_trk_t) {
-        pmix_output_verbose(2, pmix_server_globals.group_output,
-                            "server:grpcbfunc processing WITH %d CALLBACKS",
-                            (int) pmix_list_get_size(&trk->local_cbs));
+    // preserve the group id
+    id = strdup(blk->id);
+    op = blk->grpop;
 
-
-        /* loop across all procs in the tracker, sending them the reply */
-        PMIX_LIST_FOREACH (cd, &trk->local_cbs, pmix_server_caddy_t) {
-            reply = PMIX_NEW(pmix_buffer_t);
-            if (NULL == reply) {
-                break;
-            }
-            /* setup the reply, starting with the returned status */
-            PMIX_BFROPS_PACK(ret, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_ERROR_LOG(ret);
-                PMIX_RELEASE(reply);
-                break;
-            }
-            if (PMIX_SUCCESS == scd->status && PMIX_GROUP_CONSTRUCT == blk->grpop) {
-                /* add the final membership */
-                PMIX_BFROPS_PACK(ret, cd->peer, reply, &nmembers, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != ret) {
-                    PMIX_ERROR_LOG(ret);
-                    PMIX_RELEASE(reply);
-                    break;
-                }
-                if (0 < nmembers) {
-                    PMIX_BFROPS_PACK(ret, cd->peer, reply, members, nmembers, PMIX_PROC);
-                    if (PMIX_SUCCESS != ret) {
-                        PMIX_ERROR_LOG(ret);
-                        PMIX_RELEASE(reply);
-                        break;
-                    }
-                }
-                /* if a ctxid was provided, pass it along */
-                PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid_given, 1, PMIX_BOOL);
-                if (PMIX_SUCCESS != ret) {
-                    PMIX_ERROR_LOG(ret);
-                    PMIX_RELEASE(reply);
-                    break;
-                }
-                if (ctxid_given) {
-                    PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid, 1, PMIX_SIZE);
-                    if (PMIX_SUCCESS != ret) {
-                        PMIX_ERROR_LOG(ret);
-                        PMIX_RELEASE(reply);
-                        break;
-                    }
-                }
-            }
-
+    // because bootstrap will have added multiple blocks to the collectives
+    // for each bootstrap operation, cycle across the list to find them all
+    PMIX_LIST_FOREACH(bk, &pmix_server_globals.grp_collectives, grp_block_t) {
+        if (0 != strcmp(id, bk->id)) {
+            continue;
+        }
+        PMIX_LIST_FOREACH(trk, &bk->mbrs, grp_trk_t) {
             pmix_output_verbose(2, pmix_server_globals.group_output,
-                                "server:grp_cbfunc reply being sent to %s:%u",
-                                cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
-            PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_RELEASE(reply);
+                                "server:grpcbfunc processing WITH %d CALLBACKS",
+                                (int) pmix_list_get_size(&trk->local_cbs));
+
+
+            /* loop across all procs in the tracker, sending them the reply */
+            PMIX_LIST_FOREACH (cd, &trk->local_cbs, pmix_server_caddy_t) {
+                reply = PMIX_NEW(pmix_buffer_t);
+                if (NULL == reply) {
+                    break;
+                }
+                /* setup the reply, starting with the returned status */
+                PMIX_BFROPS_PACK(ret, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
+                if (PMIX_SUCCESS != ret) {
+                    PMIX_ERROR_LOG(ret);
+                    PMIX_RELEASE(reply);
+                    break;
+                }
+                if (PMIX_SUCCESS == scd->status && PMIX_GROUP_CONSTRUCT == op) {
+                    /* add the final membership */
+                    PMIX_BFROPS_PACK(ret, cd->peer, reply, &nmembers, 1, PMIX_SIZE);
+                    if (PMIX_SUCCESS != ret) {
+                        PMIX_ERROR_LOG(ret);
+                        PMIX_RELEASE(reply);
+                        break;
+                    }
+                    if (0 < nmembers) {
+                        PMIX_BFROPS_PACK(ret, cd->peer, reply, members, nmembers, PMIX_PROC);
+                        if (PMIX_SUCCESS != ret) {
+                            PMIX_ERROR_LOG(ret);
+                            PMIX_RELEASE(reply);
+                            break;
+                        }
+                    }
+                    /* if a ctxid was provided, pass it along */
+                    PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid_given, 1, PMIX_BOOL);
+                    if (PMIX_SUCCESS != ret) {
+                        PMIX_ERROR_LOG(ret);
+                        PMIX_RELEASE(reply);
+                        break;
+                    }
+                    if (ctxid_given) {
+                        PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid, 1, PMIX_SIZE);
+                        if (PMIX_SUCCESS != ret) {
+                            PMIX_ERROR_LOG(ret);
+                            PMIX_RELEASE(reply);
+                            break;
+                        }
+                    }
+                }
+
+                pmix_output_verbose(2, pmix_server_globals.group_output,
+                                    "server:grp_cbfunc reply being sent to %s:%u",
+                                    cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
+                PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
+                if (PMIX_SUCCESS != ret) {
+                    PMIX_RELEASE(reply);
+                }
             }
         }
+        /* remove the block from the list */
+        pmix_list_remove_item(&pmix_server_globals.grp_collectives, &bk->super);
+        PMIX_RELEASE(bk);
     }
-
-    /* remove the block from the list */
-    pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-    PMIX_RELEASE(blk);
 
     /* we are done */
     if (NULL != scd->relfn) {
@@ -586,130 +512,165 @@ static void grpcbfunc(pmix_status_t status,
     PMIX_THREADSHIFT(scd, _grpcbfunc);
 }
 
-static pmix_status_t aggregate_info(grp_trk_t *trk,
-                                    pmix_info_t *info,
-                                    size_t ninfo)
+static pmix_status_t aggregate_info(grp_block_t *blk)
 {
-    pmix_list_t ilist, nmlist;
+    grp_trk_t *trk;
+    pmix_list_t ilist, nmlist, plist;
     size_t n, m, j, k, niptr;
     pmix_info_t *iptr;
     bool found, nmfound;
     pmix_info_caddy_t *icd;
     pmix_proclist_t *nm;
-    pmix_proc_t *nmarray, *trkarray;
+    pmix_proc_t *nmarray, *trkarray, *tmp;
     size_t nmsize, trksize, bt, bt2;
     pmix_status_t rc;
 
-    if (NULL == trk->info) {
-        trk->info = info;
-        trk->ninfo = ninfo;
-        return PMIX_EXISTS;
-    }
-
     // only keep unique entries
     PMIX_CONSTRUCT(&ilist, pmix_list_t);
-    for (m=0; m < ninfo; m++) {
-        found = false;
-        for (n=0; n < trk->ninfo; n++) {
-            if (PMIX_CHECK_KEY(&trk->info[n], info[m].key)) {
+    PMIX_CONSTRUCT(&plist, pmix_list_t);
 
-                // check a few critical keys
-                if (PMIX_CHECK_KEY(&info[m], PMIX_GROUP_ADD_MEMBERS)) {
-                    // aggregate the members
-                    nmarray = (pmix_proc_t*)info[m].value.data.darray->array;
-                    nmsize = info[m].value.data.darray->size;
-                    trkarray = (pmix_proc_t*)trk->info[n].value.data.darray->array;
-                    trksize = trk->info[n].value.data.darray->size;
-                    PMIX_CONSTRUCT(&nmlist, pmix_list_t);
-                    // sadly, an exhaustive search
-                    for (j=0; j < nmsize; j++) {
-                        nmfound = false;
-                        for (k=0; k < trksize; k++) {
-                            if (PMIX_CHECK_PROCID(&nmarray[j], &trkarray[k])) {
-                                // if the new one is rank=WILDCARD, then ensure
-                                // we keep it as wildcard
-                                if (PMIX_RANK_WILDCARD == nmarray[j].rank) {
-                                    trkarray[k].rank = PMIX_RANK_WILDCARD;
-                                }
-                                nmfound = true;
-                                break;
-                            }
-                        }
-                        if (!nmfound) {
-                            nm = PMIX_NEW(pmix_proclist_t);
-                            memcpy(&nm->proc, &nmarray[j], sizeof(pmix_proc_t));
-                            pmix_list_append(&nmlist, &nm->super);
-                        }
+    PMIX_LIST_FOREACH(trk, &blk->mbrs, grp_trk_t) {
+        // aggregate procs
+        for (n=0; n < trk->npcs; n++) {
+            found = false;
+            for (m=0; m < blk->npcs; m++) {
+                if (PMIX_CHECK_PROCID(&trk->pcs[n], &blk->pcs[m])) {
+                    found = true;
+                    // preserve WILDCARD rank
+                    if (PMIX_RANK_WILDCARD == trk->pcs[n].rank) {
+                        blk->pcs[m].rank = PMIX_RANK_WILDCARD;
                     }
-                    // create the replacement array, if needed
-                    if (0 < pmix_list_get_size(&nmlist)) {
-                        nmsize = trksize + pmix_list_get_size(&nmlist);
-                        PMIX_PROC_CREATE(nmarray, nmsize);
-                        memcpy(nmarray, trkarray, trksize * sizeof(pmix_proc_t));
-                        j = trksize;
-                        PMIX_LIST_FOREACH(nm, &nmlist, pmix_proclist_t) {
-                            memcpy(&nmarray[j], &nm->proc, sizeof(pmix_proc_t));
-                            ++j;
-                        }
-                        PMIX_PROC_FREE(trkarray, trksize);
-                        trk->info[n].value.data.darray->array = nmarray;
-                        trk->info[n].value.data.darray->size = nmsize;
-                    }
-                    PMIX_LIST_DESTRUCT(&nmlist);
-
-                } else if (PMIX_CHECK_KEY(&info[m], PMIX_GROUP_BOOTSTRAP)) {
-                    // the numbers must match
-                    PMIX_VALUE_GET_NUMBER(rc, &info[m].value, bt, size_t);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_LIST_DESTRUCT(&ilist);
-                        return rc;
-                    }
-                    PMIX_VALUE_GET_NUMBER(rc, &trk->info[n].value, bt2, size_t);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_LIST_DESTRUCT(&ilist);
-                        return rc;
-                    }
-                    if (bt != bt2) {
-                        PMIX_LIST_DESTRUCT(&ilist);
-                        return PMIX_ERR_BAD_PARAM;
-                    }
-                } else if (PMIX_CHECK_KEY(&info[m], PMIX_PROC_DATA) ||
-                           PMIX_CHECK_KEY(&info[m], PMIX_GROUP_INFO)) {
-                    // keep the duplicates
-                    icd = PMIX_NEW(pmix_info_caddy_t);
-                    icd->info = &info[m];
-                    icd->ninfo = 1;
-                    pmix_list_append(&ilist, &icd->super);
+                    break;
                 }
-                found = true;
-                break;
+            }
+            if (!found) {
+                nm = PMIX_NEW(pmix_proclist_t);
+                memcpy(&nm->proc, &trk->pcs[n], sizeof(pmix_proc_t));
+                pmix_list_append(&plist, &nm->super);
             }
         }
-        if (!found) {
-            // add this one in
-            icd = PMIX_NEW(pmix_info_caddy_t);
-            icd->info = &info[m];
-            icd->ninfo = 1;
-            pmix_list_append(&ilist, &icd->super);
+        // aggregate info structs
+        for (n=0; n < trk->ninfo; n++) {
+            found = false;
+            for (m=0; m < blk->ninfo; m++) {
+                // if the keys match, then aggregate the values
+                if (PMIX_CHECK_KEY(&trk->info[n], blk->info[m].key)) {
+                    // check a few critical keys
+                    if (PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_ADD_MEMBERS)) {
+                        // aggregate the members
+                        nmarray = (pmix_proc_t*)blk->info[m].value.data.darray->array;
+                        nmsize = blk->info[m].value.data.darray->size;
+                        trkarray = (pmix_proc_t*)trk->info[n].value.data.darray->array;
+                        trksize = trk->info[n].value.data.darray->size;
+                        PMIX_CONSTRUCT(&nmlist, pmix_list_t);
+                        // sadly, an exhaustive search
+                        for (k=0; k < trksize; k++) {
+                            nmfound = false;
+                            for (j=0; j < nmsize; j++) {
+                                if (PMIX_CHECK_PROCID(&nmarray[j], &trkarray[k])) {
+                                    // if the new one is rank=WILDCARD, then ensure
+                                    // we keep it as wildcard
+                                    if (PMIX_RANK_WILDCARD == trkarray[k].rank) {
+                                        nmarray[j].rank = PMIX_RANK_WILDCARD;
+                                    }
+                                    nmfound = true;
+                                    break;
+                                }
+                            }
+                            if (!nmfound) {
+                                nm = PMIX_NEW(pmix_proclist_t);
+                                memcpy(&nm->proc, &trkarray[k], sizeof(pmix_proc_t));
+                                pmix_list_append(&nmlist, &nm->super);
+                            }
+                        }
+                        // create the replacement array, if needed
+                        if (0 < pmix_list_get_size(&nmlist)) {
+                            bt = nmsize + pmix_list_get_size(&nmlist);
+                            PMIX_PROC_CREATE(tmp, bt);
+                            memcpy(tmp, nmarray, nmsize * sizeof(pmix_proc_t));
+                            j = nmsize;
+                            PMIX_LIST_FOREACH(nm, &nmlist, pmix_proclist_t) {
+                                memcpy(&tmp[j], &nm->proc, sizeof(pmix_proc_t));
+                                ++j;
+                            }
+                            PMIX_PROC_FREE(nmarray, nmsize);
+                            blk->info[m].value.data.darray->array = tmp;
+                            blk->info[m].value.data.darray->size = bt;
+                        }
+                        PMIX_LIST_DESTRUCT(&nmlist);
+
+                    } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_BOOTSTRAP)) {
+                        // the numbers must match
+                        PMIX_VALUE_GET_NUMBER(rc, &blk->info[m].value, bt, size_t);
+                        if (PMIX_SUCCESS != rc) {
+                            PMIX_LIST_DESTRUCT(&ilist);
+                            return rc;
+                        }
+                        PMIX_VALUE_GET_NUMBER(rc, &trk->info[n].value, bt2, size_t);
+                        if (PMIX_SUCCESS != rc) {
+                            PMIX_LIST_DESTRUCT(&ilist);
+                            return rc;
+                        }
+                        if (bt != bt2) {
+                            PMIX_LIST_DESTRUCT(&ilist);
+                            return PMIX_ERR_BAD_PARAM;
+                        }
+                    } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_PROC_DATA) ||
+                               PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_INFO)) {
+                        // keep the duplicates
+                        icd = PMIX_NEW(pmix_info_caddy_t);
+                        icd->info = &trk->info[n];
+                        icd->ninfo = 1;
+                        pmix_list_append(&ilist, &icd->super);
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                // add this one in
+                icd = PMIX_NEW(pmix_info_caddy_t);
+                icd->info = &trk->info[n];
+                icd->ninfo = 1;
+                pmix_list_append(&ilist, &icd->super);
+            }
         }
     }
-    if (0 < pmix_list_get_size(&ilist)) {
-        niptr = trk->ninfo + pmix_list_get_size(&ilist);
-        PMIX_INFO_CREATE(iptr, niptr);
-        for (n=0; n < trk->ninfo; n++) {
-            PMIX_INFO_XFER(&iptr[n], &trk->info[n]);
+    if (0 < pmix_list_get_size(&plist)) {
+        m = blk->npcs + pmix_list_get_size(&plist);
+        PMIX_PROC_CREATE(tmp, m);
+        if (NULL != blk->pcs) {
+            memcpy(tmp, blk->pcs, blk->npcs * sizeof(pmix_proc_t));
         }
-        n = trk->ninfo;
+        n = blk->npcs;
+        PMIX_LIST_FOREACH(nm, &plist, pmix_proclist_t) {
+            memcpy(&tmp[n], &nm->proc, sizeof(pmix_proc_t));
+            n++;
+        }
+        if (NULL != blk->pcs) {
+            PMIX_PROC_FREE(blk->pcs, blk->npcs);
+        }
+        blk->pcs = tmp;
+        blk->npcs = m;
+    }
+    if (0 < pmix_list_get_size(&ilist)) {
+        niptr = blk->ninfo + pmix_list_get_size(&ilist);
+        PMIX_INFO_CREATE(iptr, niptr);
+        for (n=0; n < blk->ninfo; n++) {
+            PMIX_INFO_XFER(&iptr[n], &blk->info[n]);
+        }
+        n = blk->ninfo;
         PMIX_LIST_FOREACH(icd, &ilist, pmix_info_caddy_t) {
             PMIX_INFO_XFER(&iptr[n], icd->info);
             ++n;
         }
-        PMIX_INFO_FREE(trk->info, trk->ninfo);
-        trk->info = iptr;
-        trk->ninfo = niptr;
+        PMIX_INFO_FREE(blk->info, blk->ninfo);
+        blk->info = iptr;
+        blk->ninfo = niptr;
         /* cleanup */
     }
     PMIX_LIST_DESTRUCT(&ilist);
+    PMIX_LIST_DESTRUCT(&plist);
     return PMIX_SUCCESS;
 }
 
@@ -851,7 +812,7 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     }
 
     /* are we locally complete? */
-    if (!trk->def_complete || pmix_list_get_size(&trk->local_cbs) != trk->nlocal) {
+    if (!blk->def_complete || pmix_list_get_size(&blk->mbrs) != blk->nlocal) {
         /* if we are not locally complete, then we are done */
         return PMIX_SUCCESS;
     }
@@ -860,8 +821,16 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
                         "local group op complete with %d procs",
                         (int) trk->npcs);
 
+    rc = aggregate_info(blk);
+    if (PMIX_SUCCESS != rc) {
+        pmix_list_remove_item(&trk->local_cbs, &cd->super);
+        // the trk will be released when we release the blk
+        pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
+        PMIX_RELEASE(blk);
+        return rc;
+    }
     rc = pmix_host_server.group(op, blk->id, trk->pcs, trk->npcs,
-                                trk->info, trk->ninfo, grpcbfunc, blk);
+                                blk->info, blk->ninfo, grpcbfunc, blk);
     if (PMIX_SUCCESS != rc) {
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             /* let the grpcbfunc threadshift the result */


### PR DESCRIPTION
Need to aggregate the procs from the various participants and include those in the upcall to the server. Since bootstrap results in multiple "block" trackers for the same ID being put on the collective tracking list, be sure to scan the list for matches so everyone gets notified.