### PR TITLE
Modify the return from PMIx_Resolve_peers for clarity

### DIFF
--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -13,3 +13,4 @@ find information on that subject here.
    distances.rst
    schedulers/index.rst
    sets_groups/index.rst
+   resolve.rst

--- a/examples/resolve.c
+++ b/examples/resolve.c
@@ -379,13 +379,18 @@ int create_node_map(void)
             }
             pmix_proc_t * node_procs = NULL;
             size_t nnode_procs = 0;
-
             rc = PMIx_Resolve_peers(node, nspace,  &node_procs, &nnode_procs);
-            if (rc == PMIX_ERR_NOT_FOUND) {
+            if (rc == PMIX_ERR_INVALID_NAMESPACE) {
+                printf("[%s:%d] resolving peers: nspace %s is unknown\n",
+                        own_proc.nspace, own_proc.rank, nspace);
+            } else if (rc == PMIX_ERR_NOT_FOUND || NULL == node_procs) {
                 printf("[%s:%d] resolving peers: nspace %s has no procs on node %s\n",
                         own_proc.nspace, own_proc.rank, nspace, node);
             } else if (rc != PMIX_SUCCESS) {
                 CHECK_PMIX_ERR(rc, "PMIx_Resolve_peers", own_proc);
+            } else {
+                printf("[%s:%d] resolving peers: nspace %s has %lu procs on node %s\n",
+                        own_proc.nspace, own_proc.rank, nspace, nnode_procs, node);
             }
 
             if (nnode_procs > 0) {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1150,7 +1150,7 @@ doget:
         pmix_output_verbose(2, pmix_client_globals.get_output,
                             "PMIx_Get key=%s for rank = %u, namespace = %s was not found - request was optional",
                             cb->key, cb->pname.rank, cb->pname.nspace);
-        cb->status = PMIX_ERR_NOT_FOUND;
+        cb->status = rc;
         goto done;
     }
 


### PR DESCRIPTION
We return an error (e.g., "not found") if the nspace or node are not found. However, if they _are_ found but there are no peers from that nspace on the specified node, then return "success" (instead of "not found") with NULL for the array of peers.

Add a docs page that walks thru the "resolve" procedure and explains the various return status codes.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit a083d8f9caf0f6171917da9fd9bbd9bd56ec0c23)