### PR TITLE
Provide a better error message to user

### DIFF
--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -123,3 +123,12 @@ of a rendezvous file.
 
 Some connection handles have been read from files named pmix.*
 in subdirectories of $TMPDIR; delete them if they are stale.
+#
+[file-not-found]
+There was an error when attempting to access the specified server
+rendezvous file:
+
+  Filename:  %s
+  Error:     %s
+
+Please correct the error and try again.

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -340,12 +340,16 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
             } while (retries < pmix_ptl_base.max_retries);
             /* otherwise, mark it as unreachable */
         }
+        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                       filename, "could not be found");
         return PMIX_ERR_UNREACH;
     }
 
 process:
     fp = fopen(filename, "r");
     if (NULL == fp) {
+        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                       filename, "could not be opened");
         return PMIX_ERR_UNREACH;
     }
     /* get the URI - might seem crazy, but there is actually
@@ -372,7 +376,8 @@ process:
         }
     }
     if (NULL == srvr) {
-        PMIX_ERROR_LOG(PMIX_ERR_FILE_READ_FAILURE);
+        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                       filename, "could not be read");
         fclose(fp);
         return PMIX_ERR_UNREACH;
     }


### PR DESCRIPTION
When the specified server rendezvous file cannot be accessed, provide a nicer error message and reason.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 11244254362b74d91d882239e27221c8dce60c00)