### PR TITLE
Add OPAL_* in the list of default envars

### DIFF
--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -59,7 +59,7 @@ static pmix_status_t component_register(void)
 {
     pmix_mca_base_component_t *component = &pmix_mca_pmdl_ompi_component.super;
 
-    pmix_mca_pmdl_ompi_component.incparms = "OMPI_*";
+    pmix_mca_pmdl_ompi_component.incparms = "OMPI_*,OPAL_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",


### PR DESCRIPTION
In SSH environment's app procs need to find the OMPI library, and so we need OPAL_PREFIX to be in their environment.
This avoids having to explicitely set OPAL_PREFIX with -x in OMPI.