### PR TITLE
v5.0: Add OPAL_* in the list of default envars

### DIFF
--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -59,7 +59,7 @@ static pmix_status_t component_register(void)
 {
     pmix_mca_base_component_t *component = &pmix_mca_pmdl_ompi_component.super;
 
-    pmix_mca_pmdl_ompi_component.incparms = "OMPI_*";
+    pmix_mca_pmdl_ompi_component.incparms = "OMPI_*,OPAL_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",


### PR DESCRIPTION
Signed-off-by: Tomislav Janjusic <tomislavj@nvidia.com>
(cherry picked from commit 1eb98ce241c13ec29d563b742f6f661fee0f304b)