### PR TITLE
Enable fetch of job-level data for another nspace

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1103,7 +1103,7 @@ doget:
     /* we didn't find the data in either the server or the internal hash
      * components. If this is a NULL or reserved key, then we do NOT go
      * up to the server unless special circumstances require it */
-    if (NULL == cb->key || PMIX_CHECK_RESERVED_KEY(cb->key)) {
+    if (NULL == cb->key) {
         /* if the server is pre-v3.2, or we are asking about the
          * job-level info from another namespace, then we have to
          * request the data */
@@ -1111,18 +1111,18 @@ doget:
             !PMIX_CHECK_NSPACE(lg->p.nspace, pmix_globals.myid.nspace)) {
             /* flag that we want all of the job-level info */
             proc.rank = PMIX_RANK_WILDCARD;
-        } else if (NULL != cb->key) {
-            /* this is a reserved key - we should have had this info, but
-             * it is possible that some system don't provide it, thereby
-             * causing the app to manually distribute it. We will therefore
-             * request it from the server, but do so under the "immediate"
-             * use-case, adding that flag if they didn't already include it
-             */
-            pmix_output_verbose(5, pmix_client_globals.get_output,
-                                "pmix:client reserved key not locally found");
-            if (!lg->immediate) {
-                lg->add_immediate = true;
-            }
+        }
+    } else if (PMIX_CHECK_RESERVED_KEY(cb->key)) {
+        /* this is a reserved key - we should have had this info, but
+         * it is possible that some system don't provide it, thereby
+         * causing the app to manually distribute it. We will therefore
+         * request it from the server, but do so under the "immediate"
+         * use-case, adding that flag if they didn't already include it
+         */
+        pmix_output_verbose(5, pmix_client_globals.get_output,
+                            "pmix:client reserved key not locally found");
+        if (!lg->immediate) {
+            lg->add_immediate = true;
         }
     }
 

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -712,6 +712,11 @@ doover:
     } else {
         rc = pmix_hash_fetch(ht, proc->rank, key, qualifiers, nqual, kvs, NULL);
     }
+    if (NULL != key && PMIX_CHECK_RESERVED_KEY(key)) {
+        // there is no need to check other scopes for
+        // reserved keys - they are always on "internal"
+        return rc;
+    }
     if (PMIX_SUCCESS == rc) {
         if (PMIX_GLOBAL == scope) {
             if (ht == &trk->local) {
@@ -770,6 +775,12 @@ doover:
         } else {
             rc = PMIX_ERR_NOT_FOUND;
         }
+    } else {
+        // since we found something, the fetch is a success.
+        // We need to set the status here because the fetch on the
+        // last scope we tried might not have succeeded, but
+        // we found things in an earlier scope we tried
+        rc = PMIX_SUCCESS;
     }
 
     return rc;

--- a/src/mca/gds/shmem2/gds_shmem2_fetch.c
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.c
@@ -791,7 +791,11 @@ doover:
             rc = PMIX_ERR_NOT_FOUND;
         }
     }
-
+    if (NULL != key && PMIX_CHECK_RESERVED_KEY(key)) {
+        // there is no need to check other scopes for
+        // reserved keys - they are always on "internal"
+        return rc;
+    }
     if (PMIX_SUCCESS == rc) {
         if (PMIX_GLOBAL == scope) {
             if (ht == local_ht) {
@@ -812,9 +816,49 @@ doover:
     }
 
     if (0 == pmix_list_get_size(kvs)) {
-        // If we didn't find it and the rank was
-        // valid, then let hash deal with it.
-        rc = PMIX_ERR_NOT_FOUND;
+        /* if we didn't find it and the rank was valid, then
+         * check to see if the data exists in a different scope.
+         * This is done to avoid having the process go into a
+         * timeout wait when the data will never appear within
+         * the specified scope */
+        if (PMIX_RANK_IS_VALID(proc->rank)) {
+            pmix_kval_t *kv;
+            if (PMIX_LOCAL == scope) {
+                if (NULL != remote_ht) {
+                    /* check the remote scope */
+                    rc = pmix_hash_fetch(remote_ht, proc->rank, key, qualifiers, nqual, kvs, NULL);
+                    if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
+                        while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
+                            PMIX_RELEASE(kv);
+                        }
+                        rc = PMIX_ERR_EXISTS_OUTSIDE_SCOPE;
+                    } else {
+                        rc = PMIX_ERR_NOT_FOUND;
+                    }
+                } else {
+                    rc = PMIX_ERR_NOT_FOUND;
+                }
+            } else if (PMIX_REMOTE == scope) {
+                /* check the local scope */
+                rc = pmix_hash_fetch(local_ht, proc->rank, key, qualifiers, nqual, kvs, NULL);
+                if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
+                    while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
+                        PMIX_RELEASE(kv);
+                    }
+                    rc = PMIX_ERR_EXISTS_OUTSIDE_SCOPE;
+                } else {
+                    rc = PMIX_ERR_NOT_FOUND;
+                }
+            }
+        } else {
+            rc = PMIX_ERR_NOT_FOUND;
+        }
+    } else {
+        // since we found something, the fetch is a success.
+        // We need to set the status here because the fetch on the
+        // last scope we tried might not have succeeded, but
+        // we found things in an earlier scope we tried
+        rc = PMIX_SUCCESS;
     }
     return rc;
 }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -479,10 +479,14 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         cb.proc = &proc;
         if (scope_given) {
             cb.scope = scope;
-        } else if (local) {
-            cb.scope = PMIX_LOCAL;
         } else {
-            cb.scope = PMIX_REMOTE;
+            if (NULL != key && PMIX_CHECK_RESERVED_KEY(key)) {
+                cb.scope = PMIX_INTERNAL;
+            } else if (local) {
+                cb.scope = PMIX_LOCAL;
+            } else {
+                cb.scope = PMIX_REMOTE;
+            }
         }
         cb.copy = false;
         cb.info = cd->info;


### PR DESCRIPTION
If a proc (e.g., a tool) wants to fetch a piece of job-level data for a namespace other than their own, then it is likely that the proc won't already have a copy of that data. If they have done a PMIx_Connect or PMIx_Group_construct operation that included the other namespace, then they should have it - but otherwise, they likely don't. This is normally the case for tools, as an example.

Ensure we flow the request up to the server for processing. Given that it is job-level info (i.e., it is a request for a reserved key), then we only want to flow thru the fetch process once. If it is found, then no need to search further in other scopes - if it isn't found in the initial "internal" scope, then it definitely won't be found on some other scope.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 1933e428af8ff4d7b9ce1c79d9836dbb8ad6296b)