### PR TITLE
Add attribute to direct app library's GPU support

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -46,7 +46,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -940,6 +940,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        do not terminate the allocation upon termination of the parent.
 #define PMIX_MEM_ALLOC_KIND                 "pmix.alloc.mkind"      // (char*) Comma-delimited list of memory kinds
                                                                     //         being allocated (e.g., system,mpi,rocm:device)
+#define PMIX_GPU_SUPPORT                    "pmix.gpu.support"      // (bool) Direct application to either enable (true) or
+                                                                    //        disable (false) its internal library's GPU support
 
 
 /* job control attributes */

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
@@ -596,10 +596,16 @@ pmix_boolean_t pmix_bfrops_base_tma_value_true(const pmix_value_t *value,
                 return PMIX_BOOL_TRUE;
             }
         } else if (0 == strncasecmp(ptr, "yes", 3) ||
-                   0 == strncasecmp(ptr, "true", 4)) {
+                   0 == strncasecmp(ptr, "true", 4) ||
+                   0 == strcasecmp(ptr, "y") ||
+                   0 == strcasecmp(ptr, "t") ||
+                   0 == strncasecmp(ptr, "enable", 6)) {
             return PMIX_BOOL_TRUE;
         } else if (0 == strncasecmp(ptr, "no", 2) ||
-                   0 == strncasecmp(ptr, "false", 5)) {
+                   0 == strncasecmp(ptr, "false", 5) ||
+                   0 == strcasecmp(ptr, "n") ||
+                   0 == strcasecmp(ptr, "f") ||
+                   0 == strncasecmp(ptr, "disable", 7)) {
             return PMIX_BOOL_FALSE;
         }
     }


### PR DESCRIPTION
There apparently are some circumstances when an application can benefit from disabling the internal GPU support in one or more of its libraries. Let's assume that a library might also provide a mechanism by which that support can be defaulted to enabled or disabled.

Add a spawn attribute by which a user/launcher can specify whether to enable of disable such support. Also extend the "info true" utility to accept a broader range of common entries for designating "true" or "false".

Refs https://github.com/openpmix/prrte/pull/2134