### PR TITLE
pctrl: fix exit code for help command line option

### DIFF
--- a/src/tools/pctrl/pctrl.c
+++ b/src/tools/pctrl/pctrl.c
@@ -142,6 +142,14 @@ int main(int argc, char **argv)
         }
     }
 
+    // check for help command line option
+    if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_HELP))) {
+        if (PMIX_OPERATION_SUCCEEDED == rc)
+            exit(0);
+        else
+            exit(rc);
+    }
+
     // handle relevant MCA params
     PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
         if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -148,6 +148,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 mystore(myoptions[option_index].name, optarg, results);
                 break;
             case 'h':
+                mystore(myoptions[option_index].name, str, results);
                 /* the "help" option can optionally take an argument. Since
                  * the argument _is_ optional, getopt will _NOT_ increment
                  * optind, so argv[optind] is the potential argument */


### PR DESCRIPTION
pctrl tool returns wrong exit code 1 for --help command line option.
It happens because of the --targets option check. But when --help is given, --targets is not required.

I tried to add a check for PMIX_CLI_HELP too, but pmix_cmd_line_parse() does not put this option to the results. Thats why I also added mystore() function call.

Please review this fix and give a feedback.
Thank you!