### PR TITLE
Fix format of fetch response for peer's version

### DIFF
--- a/examples/toolqry.c
+++ b/examples/toolqry.c
@@ -146,9 +146,15 @@ int main(int argc, char **argv)
     DEBUG_DESTRUCT_MYQUERY(&mydata);
 
     rc = PMIx_Get(&proc, PMIX_APPNUM, NULL, 0, &val);
-    fprintf(stderr, "RETURN: %s\n", PMIx_Error_string(rc));
+    fprintf(stderr, "APPNUM RETURN: %s\n\n\n", PMIx_Error_string(rc));
     if (PMIX_SUCCESS == rc) {
     	fprintf(stderr, "\t%s\n", PMIx_Value_string(val));
+    }
+
+    rc = PMIx_Get(&proc, PMIX_LOCALLDR, NULL, 0, &val);
+    fprintf(stderr, "LOCALLDR RETURN: %s\n", PMIx_Error_string(rc));
+    if (PMIX_SUCCESS == rc) {
+        fprintf(stderr, "\t%s\n", PMIx_Value_string(val));
     }
 
 done:

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -300,6 +300,11 @@ typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buff
  * scope. A NULL key returns all values committed by the given peer
  * for that scope.
  *
+ * @param peer    peer object of the proc requesting the info - needed
+ *                because the server can request info on behalf of another
+ *                process, and the fetch response has to be formatted
+ *                to match the _requesting_ process
+ *
  * @param proc    namespace and rank whose info is being requested
  *
  * @param key     key.
@@ -337,7 +342,8 @@ typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buff
  *
  * Data stored with PMIX_INTERNAL scope can be retrieved with that scope.
  */
-typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(const pmix_proc_t *proc,
+typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(struct pmix_peer_t *peer,
+                                                         const pmix_proc_t *proc,
                                                          pmix_scope_t scope, bool copy,
                                                          const char *key, pmix_info_t info[],
                                                          size_t ninfo, pmix_list_t *kvs);
@@ -347,10 +353,11 @@ typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(const pmix_proc_t *proc
 #define PMIX_GDS_FETCH_KV(s, p, c)                                                             \
     do {                                                                                       \
         pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                    \
-        pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS FETCH KV WITH %s", __FILE__, \
-                            __LINE__, _g->name);                                               \
-        (s) = _g->fetch((c)->proc, (c)->scope, (c)->copy, (c)->key, (c)->info, (c)->ninfo,     \
-                        &(c)->kvs);                                                            \
+        pmix_output_verbose(1, pmix_gds_base_output,                                           \
+                            "[%s:%d] GDS FETCH KV WITH %s",                                    \
+                            __FILE__,  __LINE__, _g->name);                                    \
+        (s) = _g->fetch((p), (c)->proc, (c)->scope, (c)->copy, (c)->key,                       \
+                        (c)->info, (c)->ninfo, &(c)->kvs);                                     \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -557,7 +557,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any session-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_sessioninfo(NULL, trk, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_sessioninfo(peer, NULL, trk, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -571,7 +571,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         sptr = pmix_gds_hash_check_session(NULL, UINT32_MAX, false);
         if (NULL != sptr) {
             PMIX_CONSTRUCT(&results, pmix_list_t);
-            rc = pmix_gds_hash_xfer_sessioninfo(sptr, trk, NULL, &results);
+            rc = pmix_gds_hash_xfer_sessioninfo(peer, sptr, NULL, &results);
             if (PMIX_SUCCESS == rc) {
                 PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
                     PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -583,7 +583,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any node-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_nodeinfo(NULL, trk, &trk->nodeinfo, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_nodeinfo(peer, NULL, &trk->nodeinfo, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             /* if the peer is earlier than v3.2.x, it is expecting
@@ -624,7 +624,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any app-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_appinfo(NULL, trk, &trk->apps, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_appinfo(peer, NULL, &trk->apps, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -1167,7 +1167,8 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "%s gds:hash:hash_store for proc %s key %s type %s scope %s",
-                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(proc), kv->key,
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(proc),
+                        PMIx_Get_attribute_name(kv->key),
                         PMIx_Data_type_string(kv->value->type), PMIx_Scope_string(scope));
 
     if (NULL == kv->key) {

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,8 +101,8 @@ extern pmix_job_t *pmix_gds_hash_get_tracker(const pmix_nspace_t nspace, bool cr
 extern pmix_session_t* pmix_gds_hash_check_session(pmix_job_t *trk,
                                                    uint32_t sid,
                                                    bool create);
-extern pmix_status_t pmix_gds_hash_xfer_sessioninfo(pmix_session_t *sptr,
-                                                    pmix_job_t *trk,
+extern pmix_status_t pmix_gds_hash_xfer_sessioninfo(pmix_peer_t *peer,
+                                                    pmix_session_t *sptr,
                                                     const char *key,
                                                     pmix_list_t *kvs);
 
@@ -115,20 +115,24 @@ extern pmix_nodeinfo_t* pmix_gds_hash_check_nodename(pmix_list_t *nodes, char *h
 extern pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                              uint32_t flags);
 
-extern pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
+extern pmix_status_t pmix_gds_hash_fetch(struct pmix_peer_t *peer,
+                                         const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
                                          const char *key, pmix_info_t qualifiers[], size_t nqual,
                                          pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_sessioninfo(const char *key,
+extern pmix_status_t pmix_gds_hash_fetch_sessioninfo(pmix_peer_t *peer,
+                                                     const char *key,
                                                      pmix_job_t *trk,
                                                      pmix_info_t *info, size_t ninfo,
                                                      pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk,
+extern pmix_status_t pmix_gds_hash_fetch_nodeinfo(pmix_peer_t *peer,
+                                                  const char *key,
                                                   pmix_list_t *tgt, pmix_info_t *info, size_t ninfo,
                                                   pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *trk, pmix_list_t *tgt,
+extern pmix_status_t pmix_gds_hash_fetch_appinfo(pmix_peer_t *peer,
+                                                 const char *key,  pmix_list_t *tgt,
                                                  pmix_info_t *info, size_t ninfo, pmix_list_t *kvs);
 
 extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t scope,

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -85,7 +85,8 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
     for (j = 0; j < size; j++) {
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
                             "%s gds:hash:node_array for key %s",
-                            PMIX_NAME_PRINT(&pmix_globals.myid), iptr[j].key);
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODEID)) {
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
@@ -252,7 +253,7 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
                             "%s gds:hash:app_array for key %s",
                             PMIX_NAME_PRINT(&pmix_globals.myid),
-                            iptr[j].key);
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);
             if (PMIX_SUCCESS != rc) {
@@ -386,6 +387,10 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
     iptr = (pmix_info_t *) info->value.data.darray->array;
     PMIX_CONSTRUCT(&cache, pmix_list_t);
     for (j = 0; j < size; j++) {
+        pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
+                            "%s gds:hash:job_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APP_INFO_ARRAY)) {
             if (PMIX_SUCCESS != (rc = pmix_gds_hash_process_app_array(&iptr[j].value, trk))) {
                 return rc;
@@ -484,10 +489,10 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
     PMIX_CONSTRUCT(&scache, pmix_list_t);
 
     for (j = 0; j < size; j++) {
-         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
-                    "%s gds:hash:session_array for key %s",
-                    PMIX_NAME_PRINT(&pmix_globals.myid),
-                    iptr[j].key);
+        pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
+                            "%s gds:hash:session_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
             if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/shmem2/gds_shmem2_fetch.h
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2024      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +15,7 @@
 
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem2_fetch(
+    struct pmix_peer_t *peer,
     const pmix_proc_t *proc,
     pmix_scope_t scope,
     bool copy,

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -769,6 +769,10 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
         }
+        /* save the version */
+        nptr->version.major = pnd->proc_type.major;
+        nptr->version.minor = pnd->proc_type.minor;
+        nptr->version.release = pnd->proc_type.release;
     }
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +33,17 @@
 
 bool pmix_ptl_base_peer_is_earlier(pmix_peer_t *peer, uint8_t major, uint8_t minor, uint8_t release)
 {
+    if (0 == PMIX_PEER_MAJOR_VERSION(peer)) {
+        /* the peer's version was never assigned. This happens
+         * when the application never calls PMIx_Init - we
+         * cannot assign the version because the client never
+         * told us what they are using. Normally, this indicates
+         * that the application is not a PMIx one. All we can do
+         * is assume the peer is NOT earlier
+         */
+        return false;
+    }
+
     /* if they don't care, then don't check */
     if (PMIX_MAJOR_WILDCARD != major) {
         if (PMIX_PEER_MAJOR_VERSION(peer) == PMIX_MAJOR_WILDCARD) {


### PR DESCRIPTION
When a client asks the server for information, the server must format the response to match the PMIx version employed by the client. We were incorrectly formatting the response on the basis of the version declared by the process whose data was being requested - as opposed to the version of the _requestor_.

In the case of tools, this led to an incorrectly formatted response, particularly for node-level data where earlier PMIx versions didn't support the node-info array.

Looking at this also exposed that the client's version was defaulting to 0.0.0, and would remain that way if the client application did not call PMIx_Init. Needed to adjust the macro that checks for PMIx version level to deal with non-PMIx clients.