### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -47,7 +47,8 @@ jobs:
 
         $c --prefix=${PWD}/install $sphinx \
             CPPFLAGS=$libevent_cppflags \
-            LDFLAGS=$libevent_ldflags
+            LDFLAGS=$libevent_ldflags \
+            --enable-devel-check
         make -j
         make install
         cd test
@@ -87,7 +88,7 @@ jobs:
             c=../configure
         fi
 
-        $c --prefix=${PWD}/install $sphinx
+        $c --prefix=${PWD}/install $sphinx --enable-devel-check
         make -j
         cd test
         make check
@@ -110,5 +111,5 @@ jobs:
       run: |
         pip install -r docs/requirements.txt
         ./autogen.pl
-        ./configure --prefix=${PWD}/install --enable-sphinx
+        ./configure --prefix=${PWD}/install --enable-sphinx --enable-devel-check
         make distcheck AM_DISTCHECK_MAKEFLAGS=-j

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Build PMIx
       run: |
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall --enable-devel-check
         make -j
         make install
     - name: Git clone PRRTE

--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Build OpenPMIx
       run: |
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall --enable-devel-check
         make -j
         make install
     - name: Git clone PRRTE

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,7 +104,9 @@ int main(int argc, char **argv)
             app->argv = (char **) malloc(4 * sizeof(char *));
             app->argv[0] = strdup(nsp);
             app->argv[1] = strdup(myproc.nspace);
-            asprintf(&app->argv[2], "%d", nprocs);
+            if (0 > asprintf(&app->argv[2], "%d", nprocs)) {
+                goto done;
+            }
             app->argv[3] = NULL;
             app->env = (char **) malloc(2 * sizeof(char *));
             app->env[0] = strdup("PMIX_ENV_VALUE=3");

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,6 +85,7 @@ typedef struct {
 typedef struct {
     volatile bool active;
     mylock_t lock;
+    pmix_status_t status;
     pmix_info_t *info;
     size_t ninfo;
 } myquery_data_t;
@@ -93,6 +94,7 @@ typedef struct {
     do {                                    \
         (q)->active = false;                \
         DEBUG_CONSTRUCT_LOCK(&((q)->lock)); \
+        (q)->status = PMIX_ERROR;           \
         (q)->info = NULL;                   \
         (q)->ninfo = 0;                     \
     } while (0)

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC.
  *                         All rights reserved.
  *
@@ -136,14 +136,18 @@ int main(int argc, char **argv)
     }
 
     // put some "modex" data
-    asprintf(&value.data.string, "btl-tcp-%u", myproc.rank);
+    if (0 > asprintf(&value.data.string, "btl-tcp-%u", myproc.rank)) {
+        goto done;
+    }
     value.type = PMIX_STRING;
     rc = PMIx_Put(PMIX_GLOBAL, "modex-btl", &value);
     free(value.data.string);
     if (PMIX_SUCCESS != rc) {
         goto done;
     }
-    asprintf(&value.data.string, "btl-smcuda-%u", myproc.rank);
+    if (0 > asprintf(&value.data.string, "btl-smcuda-%u", myproc.rank)) {
+        goto done;
+    }
     rc = PMIx_Put(PMIX_GLOBAL, "modex-btl", &value);
     free(value.data.string);
     if (PMIX_SUCCESS != rc) {

--- a/examples/multi_nspace_group.c
+++ b/examples/multi_nspace_group.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,7 +87,10 @@ int main(int argc, char **argv)
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     gethostname(hostname, 1024);
-    getcwd(dir, 1024);
+    if (NULL == getcwd(dir, 1024)) {
+        fprintf(stderr, "Getcwd failure\n");
+        exit(1);
+    }
     pid = getpid();
 
     if (1 < argc) {
@@ -310,6 +313,7 @@ int main(int argc, char **argv)
     /* we should have a single results object */
     if (NULL != results) {
         cid = 0;
+        pptr = NULL;
         for (n=0; n < nresults; n++) {
             if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
                 PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
@@ -324,6 +328,13 @@ int main(int argc, char **argv)
                 }
             }
         }
+        if (NULL == pptr) {
+            fprintf(stderr, "%s:%d Membership not returned\n", myproc.nspace, myproc.rank);
+            goto done;
+        }
+    } else {
+        fprintf(stderr, "%s:%d No returned results\n", myproc.nspace, myproc.rank);
+        goto done;
     }
 
     // check for modex data to have been exchanged

--- a/examples/pub2.c
+++ b/examples/pub2.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,7 +91,9 @@ int main(int argc, char **argv)
     for (n=0; n < iters; n++) {
         if (0 == myproc.rank) {
             /* publish something */
-            asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, myproc.rank, n);
+            if (0 > asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, myproc.rank, n)) {
+                goto done;
+            }
             PMIX_INFO_LOAD(&info[0], tmp, &n, PMIX_INT);
             free(tmp);
             if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 2))) {
@@ -103,7 +105,9 @@ int main(int argc, char **argv)
 
             /* lookup other rank's value */
             PMIX_PDATA_CONSTRUCT(&pdata);
-            asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, 1, n);
+            if (0 > asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, 1, n)) {
+                goto done;
+            }
             PMIX_LOAD_KEY(pdata.key, tmp);
             free(tmp);
             // lookup value
@@ -137,7 +141,9 @@ int main(int argc, char **argv)
             fprintf(stderr, "PUBLISH-LOOKUP SUCCEEDED: %d\n", n);
         } else {
             /* publish something */
-            asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, myproc.rank, n);
+            if (0 > asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, myproc.rank, n)) {
+                goto done;
+            }
             PMIX_INFO_LOAD(&info[0], tmp, &n, PMIX_INT);
             free(tmp);
             if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 2))) {
@@ -149,7 +155,9 @@ int main(int argc, char **argv)
 
             /* lookup other rank's value */
             PMIX_PDATA_CONSTRUCT(&pdata);
-            asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, 0, n);
+            if (0 > asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, 0, n)) {
+                goto done;
+            }
             PMIX_LOAD_KEY(pdata.key, tmp);
             free(tmp);
             // check value

--- a/examples/resolve.c
+++ b/examples/resolve.c
@@ -259,16 +259,16 @@ int get_node_list(char ***nodelist)
         if (i == 0) {
             /* Resolve nodes of own/ parent nspace */
             if (is_spawned) {
-                strncpy(nspace, parent_proc.nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(nspace, parent_proc.nspace);
             } else {
-                strncpy(nspace, own_proc.nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(nspace, own_proc.nspace);
             }
         } else {
             /* Resolve nodes of child/ own nspace */
             if (is_spawned) {
-                strncpy(nspace, own_proc.nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(nspace, own_proc.nspace);
             } else {
-                strncpy(nspace, child_nspace, PMIX_MAX_NSLEN);
+                PMIX_LOAD_NSPACE(nspace, child_nspace);
             }
         }
         rc = PMIx_Resolve_nodes(nspace, &nodes);
@@ -363,19 +363,19 @@ int create_node_map(void)
             if (n == 0) {
                 /* Resolve peers of own/ parent nspace on node*/
                 if (is_spawned) {
-                    strncpy(nspace, parent_proc.nspace, PMIX_MAX_NSLEN);
+                    PMIX_LOAD_NSPACE(nspace, parent_proc.nspace);
                 } else {
-                    strncpy(nspace, own_proc.nspace, PMIX_MAX_NSLEN);
+                    PMIX_LOAD_NSPACE(nspace, own_proc.nspace);
                 }
             } else {
                 /* Resolve peers of child/ own nspace on node*/
                 if (is_spawned) {
-                    strncpy(nspace, own_proc.nspace, PMIX_MAX_NSLEN);
+                    PMIX_LOAD_NSPACE(nspace, own_proc.nspace);
                 } else {
                     if (0 == strlen(child_nspace)) {
                         break;
                     }
-                    strncpy(nspace, child_nspace, PMIX_MAX_NSLEN);
+                    PMIX_LOAD_NSPACE(nspace, child_nspace);
                 }
             }
             pmix_proc_t * node_procs = NULL;

--- a/examples/spawn_group.c
+++ b/examples/spawn_group.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,7 +87,10 @@ int main(int argc, char **argv)
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     gethostname(hostname, 1024);
-    getcwd(dir, 1024);
+    if (NULL == getcwd(dir, 1024)) {
+        fprintf(stderr, "Getcwd failure\n");
+        exit(1);
+    }
 
     if (1 < argc) {
         maxprocs = atoi(argv[1]);
@@ -280,6 +283,7 @@ int main(int argc, char **argv)
     /* we should have a single results object */
     if (NULL != results) {
         cid = 0;
+        parray = NULL;
         for (n=0; n < nresults; n++) {
             if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
                 PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
@@ -294,6 +298,13 @@ int main(int argc, char **argv)
                 }
             }
         }
+        if (NULL == parray) {
+            fprintf(stderr, "%s:%d Membership not returned\n", myproc.nspace, myproc.rank);
+            goto done;
+        }
+    } else {
+        fprintf(stderr, "%s:%d No returned results\n", myproc.nspace, myproc.rank);
+        goto done;
     }
 
     // check for modex data to have been exchanged

--- a/examples/toolqry.c
+++ b/examples/toolqry.c
@@ -146,9 +146,15 @@ int main(int argc, char **argv)
     DEBUG_DESTRUCT_MYQUERY(&mydata);
 
     rc = PMIx_Get(&proc, PMIX_APPNUM, NULL, 0, &val);
-    fprintf(stderr, "RETURN: %s\n", PMIx_Error_string(rc));
+    fprintf(stderr, "APPNUM RETURN: %s\n\n\n", PMIx_Error_string(rc));
     if (PMIX_SUCCESS == rc) {
     	fprintf(stderr, "\t%s\n", PMIx_Value_string(val));
+    }
+
+    rc = PMIx_Get(&proc, PMIX_LOCALLDR, NULL, 0, &val);
+    fprintf(stderr, "LOCALLDR RETURN: %s\n", PMIx_Error_string(rc));
+    if (PMIX_SUCCESS == rc) {
+        fprintf(stderr, "\t%s\n", PMIx_Value_string(val));
     }
 
 done:

--- a/src/common/pmix_attributes.h
+++ b/src/common/pmix_attributes.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,7 +66,9 @@ PMIX_EXPORT void pmix_attributes_print_attrs(char ***ans, char *function, pmix_r
                                              size_t nattrs);
 PMIX_EXPORT void pmix_attributes_print_headers(char ***ans, char *level);
 
-PMIX_EXPORT void pmix_attrs_query_support(int sd, short args, void *cbdata);
+PMIX_EXPORT void pmix_attrs_query_support(pmix_query_caddy_t *cd,
+                                          pmix_query_t *qry,
+                                          pmix_list_t *unresolved);
 PMIX_EXPORT const char *pmix_attributes_lookup(const char *name);
 PMIX_EXPORT const char *pmix_attributes_reverse_lookup(const char *name);
 PMIX_EXPORT const pmix_regattr_input_t *pmix_attributes_lookup_term(char *attr);

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -36,72 +36,9 @@
 #include "src/include/pmix_globals.h"
 #include "src/server/pmix_server_ops.h"
 
-/*
- * Support structure for locally resolving some keys
- * outside of what we send to the server
- */
-typedef struct {
-    pmix_query_caddy_t super;
-
-    /** Number of locally resolved keys */
-    size_t num_local;
-    /** Original query list */
-    pmix_query_t *orig_queries;
-    size_t orig_nqueries;
-    /** Original cbfunc/data */
-    pmix_info_cbfunc_t orig_cbfunc;
-    void *orig_cbdata;
-    /** Info returned to the user **/
-    pmix_info_t *info;
-    size_t num_info;
-} pmix_local_query_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_local_query_caddy_t);
-
-static void qlcon(pmix_local_query_caddy_t *p) {
-    p->num_local = 0;
-    p->orig_cbfunc = NULL;
-    p->orig_cbdata = NULL;
-    p->orig_queries = NULL;
-    p->orig_nqueries = 0;
-    p->info = NULL;
-    p->num_info = 0;
-}
-static void qldes(pmix_local_query_caddy_t *p) {
-    if (NULL != p->super.queries) {
-        PMIX_QUERY_RELEASE(p->super.queries);
-        p->super.queries = NULL;
-    }
-
-    p->num_local = 0;
-    p->orig_cbfunc = NULL;
-    p->orig_cbdata = NULL;
-    p->orig_queries = NULL;
-    p->orig_nqueries = 0;
-    if (NULL != p->info) {
-        PMIX_INFO_FREE(p->info, p->num_info);
-    }
-    p->info = NULL;
-    p->num_info = 0;
-}
-PMIX_CLASS_INSTANCE(pmix_local_query_caddy_t, pmix_query_caddy_t, qlcon, qldes);
-
-static bool pmix_query_check_is_local_resolve(const char *key);
-static size_t pmix_query_get_num_local_resolve(pmix_query_t queries[], size_t nqueries);
-static int pmix_query_resolve_all_pre_init(pmix_query_t queries[], size_t nqueries,
-                                           pmix_info_t **results, size_t *nresults);
-void pmix_query_local_resolve_cbfunc(pmix_status_t status,
-                                     pmix_info_t *cb_info, size_t ninfo,
-                                     void *cbdata,
-                                     pmix_release_cbfunc_t release_fn,
-                                     void *release_cbdata);
-static pmix_query_t * pmix_query_strip_local_keys(pmix_query_t orig_queries[],
-                                                  size_t orig_nqueries,
-                                                  size_t nqueries);
-
-
 static void relcbfunc(void *cbdata)
 {
-    pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                 "pmix:query release callback");
@@ -116,10 +53,10 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
-    pmix_status_t rc;
-    pmix_shift_caddy_t *results;
+    pmix_status_t rc, status;
     int cnt;
-    size_t n;
+    pmix_info_t *info;
+    size_t n, ninfo;
     pmix_kval_t *kv;
     PMIX_HIDE_UNUSED_PARAMS(hdr);
 
@@ -132,92 +69,99 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         return;
     }
 
-    results = PMIX_NEW(pmix_shift_caddy_t);
-
     /* unpack the status */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &results->status, &cnt, PMIX_STATUS);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        results->status = rc;
         goto complete;
     }
-    if (PMIX_SUCCESS != results->status &&
-        PMIX_ERR_PARTIAL_SUCCESS != results->status) {
+    if (PMIX_SUCCESS != status &&
+        PMIX_ERR_PARTIAL_SUCCESS != status) {
+        rc = status;
         goto complete;
     }
 
     /* unpack any returned data */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        results->status = rc;
+        status = rc;
         goto complete;
     }
-    if (0 < results->ninfo) {
-        PMIX_INFO_CREATE(results->info, results->ninfo);
-        cnt = results->ninfo;
-        PMIX_BFROPS_UNPACK(rc, peer, buf, results->info, &cnt, PMIX_INFO);
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            results->status = rc;
+            PMIX_INFO_FREE(info, ninfo);
+            status = rc;
             goto complete;
         }
-        /* locally cache the results */
-        for (n = 0; n < results->ninfo; n++) {
-            kv = PMIX_NEW(pmix_kval_t);
-            kv->key = strdup(results->info[n].key);
-            PMIX_VALUE_CREATE(kv->value, 1);
-            PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, &results->info[n].value);
-
-            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kv);
-            PMIX_RELEASE(kv); // maintain accounting
+        /* add the results to our cache */
+        for (n = 0; n < ninfo; n++) {
+            PMIX_KVAL_NEW(kv, info[n].key);
+            PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, &info[n].value);
+            pmix_list_append(&cd->results, &kv->super);
         }
+        PMIX_INFO_FREE(info, ninfo);
     }
 
 complete:
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:query cback from server releasing with status %s",
-                        PMIx_Error_string(results->status));
+                        PMIx_Error_string(status));
     /* release the caller */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(results->status, results->info, results->ninfo, cd->cbdata, relcbfunc, results);
+        if (0 < pmix_list_get_size(&cd->results)) {
+            cd->ninfo = pmix_list_get_size(&cd->results);
+            PMIX_INFO_CREATE(cd->info, cd->ninfo);
+            n = 0;
+            PMIX_LIST_FOREACH(kv, &cd->results, pmix_kval_t) {
+                PMIX_LOAD_KEY(cd->info[n].key, kv->key);
+                PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, &cd->info[n].value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    status = rc;
+                }
+                ++n;
+            }
+        }
+        cd->cbfunc(status, cd->info, cd->ninfo, cd->cbdata, relcbfunc, cd);
+    } else {
+        PMIX_RELEASE(cd);
     }
-    PMIX_RELEASE(cd);
 }
 
 static void qinfocb(pmix_status_t status, pmix_info_t info[], size_t ninfo, void *cbdata,
                     pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
-    pmix_query_caddy_t *cb = (pmix_query_caddy_t *) cbdata;
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t *) cbdata;
     size_t n;
 
-    cb->status = status;
-    if (NULL != info) {
-        cb->ninfo = ninfo;
-        PMIX_INFO_CREATE(cb->info, cb->ninfo);
-        for (n = 0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&cb->info[n], &info[n]);
+    // transfer the results
+    cd->status = status;
+    if (0 < ninfo) {
+        cd->ninfo = ninfo;
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&cd->info[n], &info[n]);
         }
     }
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
-    PMIX_WAKEUP_THREAD(&cb->lock);
+
+    PMIX_WAKEUP_THREAD(&cd->lock);
 }
 
-static pmix_status_t send_for_help(pmix_query_t queries[], size_t nqueries,
-                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+static pmix_status_t send_for_help(pmix_query_caddy_t *cd)
 {
-    pmix_query_caddy_t *cd;
     pmix_cmd_t cmd = PMIX_QUERY_CMD;
     pmix_buffer_t *msg;
     pmix_status_t rc;
 
-    cd = PMIX_NEW(pmix_query_caddy_t);
-    cd->cbfunc = cbfunc;  // the final callback function
-    cd->cbdata = cbdata;  // the user's cbdata
     msg = PMIX_NEW(pmix_buffer_t);
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
     if (PMIX_SUCCESS != rc) {
@@ -226,27 +170,22 @@ static pmix_status_t send_for_help(pmix_query_t queries[], size_t nqueries,
         PMIX_RELEASE(cd);
         return rc;
     }
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nqueries, 1, PMIX_SIZE);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cd->nqueries, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
-        PMIX_RELEASE(cd);
         return rc;
     }
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, queries, nqueries, PMIX_QUERY);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, cd->queries, cd->nqueries, PMIX_QUERY);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
-        PMIX_RELEASE(cd);
         return rc;
     }
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:query sending to server");
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, query_cbfunc, (void *) cd);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(cd);
-    }
     return rc;
 }
 
@@ -254,44 +193,44 @@ static void finalstep(pmix_status_t status, pmix_info_t info[], size_t ninfo, vo
                       pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
     pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
-    pmix_status_t rc;
+    pmix_status_t rc, lstat = status;
+    size_t n;
+    pmix_kval_t *kv;
 
-    /* if the host satisfied the request, then we are done */
-    if (PMIX_SUCCESS == status) {
-        if (NULL != cd->cbfunc) {
-            cd->cbfunc(status, info, ninfo, cd->cbdata, release_fn, release_cbdata);
-            PMIX_RELEASE(cd);
-        }
-        return;
-    } else {
-        /* if we are connected, let our server have a try */
-        PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-        if (!pmix_globals.connected) {
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            /* nothing more we can do */
-            if (NULL != cd->cbfunc) {
-                cd->cbfunc(status, info, ninfo, cd->cbdata, release_fn, release_cbdata);
-                PMIX_RELEASE(cd);
-            } else {
-                rc = send_for_help(cd->queries, cd->nqueries, cd->cbfunc, cd->cbdata);
-                if (PMIX_SUCCESS != rc) {
-                    if (NULL != cd->cbfunc) {
-                        cd->cbfunc(rc, NULL, 0, cd->cbdata, release_fn, release_cbdata);
-                        PMIX_RELEASE(cd);
-                    }
-                }
-            }
-            return;
-        }
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    // transfer any returned answers
+    for (n = 0; n < ninfo; n++) {
+        PMIX_KVAL_NEW(kv, info[n].key);
+        PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, &info[n].value);
+        pmix_list_append(&cd->results, &kv->super);
     }
+
+    /* construct the final response */
+    if (NULL != cd->cbfunc) {
+        if (0 < pmix_list_get_size(&cd->results)) {
+            cd->ninfo = pmix_list_get_size(&cd->results);
+            PMIX_INFO_CREATE(cd->info, cd->ninfo);
+            n = 0;
+            PMIX_LIST_FOREACH(kv, &cd->results, pmix_kval_t) {
+                PMIX_LOAD_KEY(cd->info[n].key, kv->key);
+                PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, &cd->info[n].value, kv->value);
+                if (PMIX_SUCCESS != rc) {
+                    lstat = rc;
+                }
+                ++n;
+            }
+        }
+        cd->cbfunc(lstat, cd->info, cd->ninfo, cd->cbdata, relcbfunc, cd);
+    }
+
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    return;
 }
 
 static pmix_status_t request_help(pmix_query_caddy_t *cd)
 {
-    pmix_local_query_caddy_t *local_cd;
     pmix_status_t rc;
-    size_t num_local;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -302,6 +241,7 @@ static pmix_status_t request_help(pmix_query_caddy_t *cd)
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:query handed to RM");
+        cd->host_called = true;
         rc = pmix_host_server.query(&pmix_globals.myid,
                                     cd->queries, cd->nqueries,
                                     finalstep, (void*)cd);
@@ -315,39 +255,7 @@ static pmix_status_t request_help(pmix_query_caddy_t *cd)
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-    num_local = pmix_query_get_num_local_resolve(cd->queries, cd->nqueries);
-    if( 0 == num_local ) {
-        // No locally resolved keys, so send directly to the server
-        rc = send_for_help(cd->queries,cd->nqueries, cd->cbfunc, cd->cbdata);
-    } else {
-        // Some locally resolved keys, so send the subset of non-locally resolved
-        // keys to the server. We will patch up the results with the locally
-        // resolved keys when they come back from the server in our callback.
-        local_cd = PMIX_NEW(pmix_local_query_caddy_t);
-        // Save original values
-        local_cd->orig_cbfunc = cd->cbfunc;
-        local_cd->orig_cbdata = cd->cbdata;
-        local_cd->orig_queries = cd->queries;
-        local_cd->orig_nqueries = cd->nqueries;
-        local_cd->num_local = num_local;
-        // Values we are going to send to the server
-        local_cd->super.nqueries = cd->nqueries - num_local;
-        if (0 < local_cd->super.nqueries) {
-            local_cd->super.queries = pmix_query_strip_local_keys(cd->queries, cd->nqueries, cd->nqueries - num_local);
-        } else {
-            local_cd->super.queries = NULL;
-        }
-        local_cd->super.cbfunc = pmix_query_local_resolve_cbfunc;
-        local_cd->super.cbdata = &local_cd;
-
-        if (0 == local_cd->super.nqueries) {
-            // Skip calling the server and just resolve locally
-            rc = PMIX_SUCCESS;
-            pmix_query_local_resolve_cbfunc(PMIX_SUCCESS, NULL, 0, local_cd, NULL, NULL);
-        } else {
-            rc = send_for_help(local_cd->super.queries, local_cd->super.nqueries, pmix_query_local_resolve_cbfunc, local_cd);
-        }
-    }
+    rc = send_for_help(cd);
 
     return rc;
 }
@@ -369,17 +277,18 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
     size_t nqueries = cd->nqueries;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_cb_t cb;
-    size_t n, p;
-    pmix_list_t results;
+    size_t n, p, m;
+    pmix_list_t unresolved;
     pmix_kval_t *kv, *kvnxt;
     pmix_proc_t proc;
-    bool rank_given = false;
+    bool rank_given;
+    pmix_querylist_t *qry;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* setup the list of local results */
-    PMIX_CONSTRUCT(&results, pmix_list_t);
-
+    // setup the list of unresolved queries
+    PMIX_CONSTRUCT(&unresolved, pmix_list_t);
     for (n = 0; n < nqueries; n++) {
+        rank_given = false;
         PMIX_LOAD_PROCID(&proc, NULL, PMIX_RANK_INVALID);
         for (p = 0; p < queries[n].nqual; p++) {
             if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
@@ -394,7 +303,7 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
             }
         }
 
-        /* first try a local "get" on the data to see if we already have it */
+        /* setup to try a local "get" on the data to see if we already have it */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         cb.copy = false;
         /* if they are querying about node or app values not directly
@@ -421,54 +330,68 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
             }
         }
 
-        /* first see if we already have this info */
+        /* see if we already have this info */
         for (p = 0; NULL != queries[n].keys[p]; p++) {
             cb.key = queries[n].keys[p];
             // Locally resolvable keys
             if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
                 PMIX_KVAL_NEW(kv, cb.key);
                 PMIx_Value_load(kv->value, PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
-                pmix_list_append(&cb.kvs, &kv->super);
+                pmix_list_append(&cd->results, &kv->super);
+
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
                 PMIX_KVAL_NEW(kv, cb.key);
                 PMIx_Value_load(kv->value, PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
-                pmix_list_append(&cb.kvs, &kv->super);
+                pmix_list_append(&cd->results, &kv->super);
+
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
-                PMIX_THREADSHIFT(cd, pmix_attrs_query_support);
-                return;
+                // supported attrs will be appended to cd->results
+                // any that must be sent for help will be appended to unresolved
+                pmix_attrs_query_support(cd, &queries[n], &unresolved);
+
             /* check for request to scan the local node for available
              * servers the caller could connect to */
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_AVAIL_SERVERS)) {
                 PMIX_THREADSHIFT(cd, pmix_ptl_base_query_servers);
                 return;
+
             } else {
                 PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-                if (PMIX_SUCCESS != rc) {
-                    /* not in our gds */
-                    PMIX_DESTRUCT(&cb);
-                    goto complete;
+                if (PMIX_SUCCESS == rc) {
+                    /* need to retain this result */
+                    PMIX_LIST_FOREACH_SAFE (kv, kvnxt, &cb.kvs, pmix_kval_t) {
+                        pmix_list_remove_item(&cb.kvs, &kv->super);
+                        pmix_list_append(&cd->results, &kv->super);
+                    }
+
+                } else {
+                    // cache this as unresolved
+                    qry = PMIX_NEW(pmix_querylist_t);
+                    PMIX_ARGV_APPEND(rc, qry->query.keys, queries[n].keys[p]);
+                    if (0 < queries[n].nqual) {
+                        qry->query.nqual = queries[n].nqual;
+                        PMIX_INFO_CREATE(qry->query.qualifiers, qry->query.nqual);
+                        for (m=0; m < queries[n].nqual; m++) {
+                            PMIX_INFO_XFER(&qry->query.qualifiers[m], &queries[n].qualifiers[m]);
+                        }
+                    }
+                    pmix_list_append(&unresolved, &qry->super);
                 }
             }
-            /* need to retain this result */
-            PMIX_LIST_FOREACH_SAFE (kv, kvnxt, &cb.kvs, pmix_kval_t) {
-                pmix_list_remove_item(&cb.kvs, &kv->super);
-                pmix_list_append(&results, &kv->super);
-            }
-            PMIX_DESTRUCT(&cb);
-            goto complete;
+            cb.key = NULL;  // protect the key
         }
+        PMIX_DESTRUCT(&cb);
     }
 
-complete:
-    if (PMIX_OPERATION_SUCCEEDED == rc) {
+    if (0 == pmix_list_get_size(&unresolved)) {
         /* if we get here, then all queries were locally
          * resolved, so construct the results for return */
         cd->status = PMIX_SUCCESS;
-        cd->ninfo = pmix_list_get_size(&results);
+        cd->ninfo = pmix_list_get_size(&cd->results);
         if (0 < cd->ninfo) {
             PMIX_INFO_CREATE(cd->info, cd->ninfo);
             n = 0;
-            PMIX_LIST_FOREACH_SAFE (kv, kvnxt, &results, pmix_kval_t) {
+            PMIX_LIST_FOREACH(kv, &cd->results, pmix_kval_t) {
                 PMIX_LOAD_KEY(cd->info[n].key, kv->key);
                 rc = PMIx_Value_xfer(&cd->info[n].value, kv->value);
                 if (PMIX_SUCCESS != rc) {
@@ -479,27 +402,42 @@ complete:
                 ++n;
             }
         }
-        /* done with the list of results */
-        PMIX_LIST_DESTRUCT(&results);
+        /* done with the list of unresolved queries */
+        PMIX_LIST_DESTRUCT(&unresolved);
 
         if (NULL != cd->cbfunc) {
             cd->cbfunc(cd->status, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
         }
-    } else if (PMIX_SUCCESS != rc) {
-        /* ask for help */
-        rc = request_help(cd);
-        if (PMIX_SUCCESS != rc) {
-            /* we have to return the error to the caller */
-            if (NULL != cd->cbfunc) {
-                cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
-            }
-            cd->queries = NULL;
-            cd->nqueries = 0;
-        }
         return;
     }
 
-    /* get here if the query returned PMIX_SUCCESS, which means
+    // move the unresolved queries into the queries cache
+    PMIX_QUERY_FREE(cd->queries, cd->nqueries);
+    cd->nqueries = pmix_list_get_size(&unresolved);
+    PMIX_QUERY_CREATE(cd->queries, cd->nqueries);
+    n = 0;
+    PMIX_LIST_FOREACH(qry, &unresolved, pmix_querylist_t) {
+        cd->queries[n].keys = PMIx_Argv_copy(qry->query.keys);
+        if (0 < qry->query.nqual) {
+            cd->queries[n].nqual = qry->query.nqual;
+            PMIX_INFO_CREATE(cd->queries[n].qualifiers, cd->queries[n].nqual);
+            for (m=0; m < qry->query.nqual; m++) {
+                PMIX_INFO_XFER(&cd->queries[n].qualifiers[m], &qry->query.qualifiers[m]);
+            }
+        }
+        ++n;
+    }
+    /* ask for help */
+    rc = request_help(cd);
+    if (PMIX_SUCCESS != rc) {
+        /* we have to return the error to the caller */
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(rc, NULL, 0, cd->cbdata, _local_relcb, cd);
+        }
+    }
+    return;
+
+    /* get here if the request returned PMIX_SUCCESS, which means
      * that the query is being processed and will call the cbfunc
      * when complete */
 }
@@ -509,56 +447,18 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nquerie
 {
     pmix_query_caddy_t *cd;
     pmix_status_t rc;
-    size_t n, p;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    // setup default response
+    *results = NULL;
+    *nresults = 0;
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        rc = pmix_query_resolve_all_pre_init(queries, nqueries, results, nresults);
-        if (PMIX_SUCCESS == rc) {
-            pmix_output_verbose(2, pmix_globals.debug_output,
-                                "pmix:query completed - locally, pre-init");
-            return rc;
-        } else {
-            return PMIX_ERR_INIT;
-        }
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "%s pmix:query",
-                        PMIX_NAME_PRINT(&pmix_globals.myid));
-
-    if (0 == nqueries || NULL == queries) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    /* do a quick check of the qualifiers arrays to ensure
-     * the nqual field has been set */
-    for (n = 0; n < nqueries; n++) {
-        if (NULL != queries[n].qualifiers && 0 == queries[n].nqual) {
-            /* look for the info marked as "end" */
-            p = 0;
-            while (!(PMIX_INFO_IS_END(&queries[n].qualifiers[p])) && p < SIZE_MAX) {
-                ++p;
-            }
-            if (SIZE_MAX == p) {
-                /* nothing we can do */
-                return PMIX_ERR_BAD_PARAM;
-            }
-            queries[n].nqual = p;
-        }
-    }
-
-    /* we get here if a refresh isn't required - need to
-     * threadshift this to access our internal data */
+    /* pass this to the non-blocking version for processing */
     cd = PMIX_NEW(pmix_query_caddy_t);
-    cd->host_called = true;
-    cd->queries = queries;
-    cd->nqueries = nqueries;
-    cd->cbfunc = qinfocb;
-    cd->cbdata = cd;
-    PMIX_THREADSHIFT(cd, pmix_parse_localquery);
+    rc = PMIx_Query_info_nb(queries, nqueries, qinfocb, (void*)cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
+        return rc;
+    }
 
     /* wait for the operation to complete */
     PMIX_WAIT_THREAD(&cd->lock);
@@ -598,6 +498,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     if (0 == nqueries || NULL == queries) {
         return PMIX_ERR_BAD_PARAM;
     }
+
     /* do a quick check of the qualifiers arrays to ensure
      * the nqual field has been set */
     for (n = 0; n < nqueries; n++) {
@@ -618,9 +519,20 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     /* we get here if a refresh isn't required - need to
      * threadshift this to access our internal data */
     cd = PMIX_NEW(pmix_query_caddy_t);
-    cd->host_called = true;
-    cd->queries = queries;
+    cd->host_called = false;
+    // copy the queries as we will modify them
     cd->nqueries = nqueries;
+    PMIX_QUERY_CREATE(cd->queries, cd->nqueries);
+    for (n=0; n < nqueries; n++) {
+        cd->queries[n].keys = PMIx_Argv_copy(queries[n].keys);
+        if (0 < queries[n].nqual) {
+            cd->queries[n].nqual = queries[n].nqual;
+            PMIX_INFO_CREATE(cd->queries[n].qualifiers, cd->queries[n].nqual);
+            for (p=0; p < queries[n].nqual; p++) {
+                PMIX_INFO_XFER(&cd->queries[n].qualifiers[p], &queries[n].qualifiers[p]);
+            }
+        }
+    }
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
     PMIX_THREADSHIFT(cd, pmix_parse_localquery);
@@ -629,175 +541,4 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
      * was accepted for processing */
 
     return PMIX_SUCCESS;
-}
-
-/*
- * Determine if the keysis meant to be locally resolved
- */
-static bool pmix_query_check_is_local_resolve(const char *key)
-{
-    if (0 == strcmp(key, PMIX_QUERY_STABLE_ABI_VERSION)) {
-        return true;
-    }
-    else if (0 == strcmp(key, PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
-        return true;
-    }
-    return false;
-}
-
-/*
- * Count the number of keys that are locally resolvable
- */
-static size_t pmix_query_get_num_local_resolve(pmix_query_t queries[], size_t nqueries)
-{
-    size_t num_local = 0;
-    size_t n, p;
-
-    for (n = 0; n < nqueries; n++) {
-        for (p = 0; NULL != queries[n].keys[p]; p++) {
-            if (pmix_query_check_is_local_resolve(queries[n].keys[p])) {
-                ++num_local;
-            }
-        }
-    }
-
-    return num_local;
-}
-
-/*
- * Called outside of init/finalize. Check to see if we are allowed to resolve
- * the query entirely locally.
- * Query must contain only those keys allowed to be called before init.
- */
-static int pmix_query_resolve_all_pre_init(pmix_query_t queries[], size_t nqueries,
-                                           pmix_info_t **results, size_t *nresults)
-{
-    size_t n, p;
-    size_t cur_info = 0, num_info = 0;
-
-    // Check to see if this query qualifies.
-    num_info = pmix_query_get_num_local_resolve(queries, nqueries);
-
-    // If it does not qualify then reject
-    if( num_info != nqueries ) {
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix:query Found %d queries of %d queries that cannot be handled before init.",
-                            (int)(nqueries - num_info), (int)nqueries);
-        return PMIX_ERROR;
-    }
-
-    // If it does qualify then fill in the results
-    *nresults = num_info;
-    PMIX_INFO_CREATE((*results), (*nresults));
-    cur_info = 0;
-    for (n = 0; n < nqueries; n++) {
-        for (p = 0; NULL != queries[n].keys[p]; p++) {
-            if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
-                PMIx_Info_load(&((*results)[cur_info]), PMIX_QUERY_STABLE_ABI_VERSION, PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
-                ++cur_info;
-            }
-            else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
-                PMIx_Info_load(&((*results)[cur_info]), PMIX_QUERY_PROVISIONAL_ABI_VERSION, PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
-                ++cur_info;
-            }
-        }
-    }
-
-    return PMIX_SUCCESS;
-}
-
-static void local_resolve_release_cbfunc(void *cbdata)
-{
-    pmix_local_query_caddy_t *local_cd = (pmix_local_query_caddy_t*)cbdata;
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:query local release callback");
-
-    if (NULL != local_cd) {
-        PMIX_RELEASE(local_cd);
-    }
-}
-
-void pmix_query_local_resolve_cbfunc(pmix_status_t status,
-                                     pmix_info_t *info, size_t ninfo,
-                                     void *cbdata,
-                                     pmix_release_cbfunc_t release_fn,
-                                     void *release_cbdata)
-{
-    pmix_local_query_caddy_t *local_cd = (pmix_local_query_caddy_t*)cbdata;
-    size_t n, p, n_idx, p_idx;
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:query local resolve callback (ninfo %d, local %d)",
-                        (int)ninfo, (int)local_cd->num_local);
-
-    local_cd->num_info = ninfo + local_cd->num_local;
-    PMIX_INFO_CREATE(local_cd->info, local_cd->num_info);
-
-    // Copy values from the server
-    for (n_idx = 0; n_idx < ninfo; ++n_idx) {
-        PMIx_Info_xfer(&local_cd->info[n_idx], &info[n_idx]);
-    }
-
-    // Append the locally resolved values
-    for (n = 0; n < local_cd->orig_nqueries; n++) {
-        p_idx = 0;
-        for (p = 0; NULL != local_cd->orig_queries[n].keys[p]; p++) {
-            if (0 == strcmp(local_cd->orig_queries[n].keys[p], PMIX_QUERY_STABLE_ABI_VERSION)) {
-                PMIx_Info_load(&local_cd->info[n_idx], local_cd->orig_queries[n].keys[p],
-                               PMIX_STD_ABI_STABLE_VERSION, PMIX_STRING);
-                ++p_idx;
-            }
-            else if (0 == strcmp(local_cd->orig_queries[n].keys[p], PMIX_QUERY_PROVISIONAL_ABI_VERSION)) {
-                PMIx_Info_load(&local_cd->info[n_idx], local_cd->orig_queries[n].keys[p],
-                               PMIX_STD_ABI_PROVISIONAL_VERSION, PMIX_STRING);
-                ++p_idx;
-            }
-        }
-        if( p_idx > 0 ) {
-            ++n_idx;
-        }
-    }
-
-    // We copied the server contents into a new info list, so
-    // release what was passed to us.
-    if( NULL != release_fn ) {
-        release_fn(release_cbdata);
-    }
-
-    local_cd->orig_cbfunc(status, local_cd->info, local_cd->num_info,
-                          local_cd->orig_cbdata, local_resolve_release_cbfunc, cbdata);
-}
-
-static pmix_query_t * pmix_query_strip_local_keys(pmix_query_t orig_queries[],
-                                                  size_t orig_nqueries,
-                                                  size_t nqueries)
-{
-    int rc = PMIX_SUCCESS;
-    size_t n, p, n_idx, p_idx;
-    pmix_query_t *queries;
-
-    PMIX_QUERY_CREATE(queries, nqueries);
-    n_idx = 0;
-    for (n = 0; n < orig_nqueries; n++) {
-        p_idx = 0;
-        for (p = 0; NULL != orig_queries[n].keys[p]; p++) {
-            if (!pmix_query_check_is_local_resolve(orig_queries[n].keys[p])) {
-                PMIX_ARGV_APPEND(rc, queries[n_idx].keys, orig_queries[n].keys[p]);
-                if (PMIX_SUCCESS != rc) {
-                    goto out;
-                }
-                ++p_idx;
-            }
-        }
-        if( p_idx > 0 ) {
-            ++n_idx;
-        }
-    }
-out:
-    if (PMIX_SUCCESS != rc) {
-        PMIX_QUERY_RELEASE(queries);
-        // Note that queries is set to NULL by PMIX_QUERY_RELEASE.
-    }
-    return queries;
 }

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -300,6 +300,11 @@ typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buff
  * scope. A NULL key returns all values committed by the given peer
  * for that scope.
  *
+ * @param peer    peer object of the proc requesting the info - needed
+ *                because the server can request info on behalf of another
+ *                process, and the fetch response has to be formatted
+ *                to match the _requesting_ process
+ *
  * @param proc    namespace and rank whose info is being requested
  *
  * @param key     key.
@@ -337,7 +342,8 @@ typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buff
  *
  * Data stored with PMIX_INTERNAL scope can be retrieved with that scope.
  */
-typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(const pmix_proc_t *proc,
+typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(struct pmix_peer_t *peer,
+                                                         const pmix_proc_t *proc,
                                                          pmix_scope_t scope, bool copy,
                                                          const char *key, pmix_info_t info[],
                                                          size_t ninfo, pmix_list_t *kvs);
@@ -347,10 +353,11 @@ typedef pmix_status_t (*pmix_gds_base_module_fetch_fn_t)(const pmix_proc_t *proc
 #define PMIX_GDS_FETCH_KV(s, p, c)                                                             \
     do {                                                                                       \
         pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                                    \
-        pmix_output_verbose(1, pmix_gds_base_output, "[%s:%d] GDS FETCH KV WITH %s", __FILE__, \
-                            __LINE__, _g->name);                                               \
-        (s) = _g->fetch((c)->proc, (c)->scope, (c)->copy, (c)->key, (c)->info, (c)->ninfo,     \
-                        &(c)->kvs);                                                            \
+        pmix_output_verbose(1, pmix_gds_base_output,                                           \
+                            "[%s:%d] GDS FETCH KV WITH %s",                                    \
+                            __FILE__,  __LINE__, _g->name);                                    \
+        (s) = _g->fetch((p), (c)->proc, (c)->scope, (c)->copy, (c)->key,                       \
+                        (c)->info, (c)->ninfo, &(c)->kvs);                                     \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -557,7 +557,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any session-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_sessioninfo(NULL, trk, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_sessioninfo(peer, NULL, trk, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -571,7 +571,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         sptr = pmix_gds_hash_check_session(NULL, UINT32_MAX, false);
         if (NULL != sptr) {
             PMIX_CONSTRUCT(&results, pmix_list_t);
-            rc = pmix_gds_hash_xfer_sessioninfo(sptr, trk, NULL, &results);
+            rc = pmix_gds_hash_xfer_sessioninfo(peer, sptr, NULL, &results);
             if (PMIX_SUCCESS == rc) {
                 PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
                     PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -583,7 +583,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any node-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_nodeinfo(NULL, trk, &trk->nodeinfo, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_nodeinfo(peer, NULL, &trk->nodeinfo, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             /* if the peer is earlier than v3.2.x, it is expecting
@@ -624,7 +624,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 
     /* get any app-level info for this job */
     PMIX_CONSTRUCT(&results, pmix_list_t);
-    rc = pmix_gds_hash_fetch_appinfo(NULL, trk, &trk->apps, NULL, 0, &results);
+    rc = pmix_gds_hash_fetch_appinfo(peer, NULL, &trk->apps, NULL, 0, &results);
     if (PMIX_SUCCESS == rc) {
         PMIX_LIST_FOREACH (kvptr, &results, pmix_kval_t) {
             PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
@@ -1167,7 +1167,8 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "%s gds:hash:hash_store for proc %s key %s type %s scope %s",
-                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(proc), kv->key,
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(proc),
+                        PMIx_Get_attribute_name(kv->key),
                         PMIx_Data_type_string(kv->value->type), PMIx_Scope_string(scope));
 
     if (NULL == kv->key) {

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,8 +101,8 @@ extern pmix_job_t *pmix_gds_hash_get_tracker(const pmix_nspace_t nspace, bool cr
 extern pmix_session_t* pmix_gds_hash_check_session(pmix_job_t *trk,
                                                    uint32_t sid,
                                                    bool create);
-extern pmix_status_t pmix_gds_hash_xfer_sessioninfo(pmix_session_t *sptr,
-                                                    pmix_job_t *trk,
+extern pmix_status_t pmix_gds_hash_xfer_sessioninfo(pmix_peer_t *peer,
+                                                    pmix_session_t *sptr,
                                                     const char *key,
                                                     pmix_list_t *kvs);
 
@@ -115,20 +115,24 @@ extern pmix_nodeinfo_t* pmix_gds_hash_check_nodename(pmix_list_t *nodes, char *h
 extern pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
                                              uint32_t flags);
 
-extern pmix_status_t pmix_gds_hash_fetch(const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
+extern pmix_status_t pmix_gds_hash_fetch(struct pmix_peer_t *peer,
+                                         const pmix_proc_t *proc, pmix_scope_t scope, bool copy,
                                          const char *key, pmix_info_t qualifiers[], size_t nqual,
                                          pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_sessioninfo(const char *key,
+extern pmix_status_t pmix_gds_hash_fetch_sessioninfo(pmix_peer_t *peer,
+                                                     const char *key,
                                                      pmix_job_t *trk,
                                                      pmix_info_t *info, size_t ninfo,
                                                      pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_nodeinfo(const char *key, pmix_job_t *trk,
+extern pmix_status_t pmix_gds_hash_fetch_nodeinfo(pmix_peer_t *peer,
+                                                  const char *key,
                                                   pmix_list_t *tgt, pmix_info_t *info, size_t ninfo,
                                                   pmix_list_t *kvs);
 
-extern pmix_status_t pmix_gds_hash_fetch_appinfo(const char *key, pmix_job_t *trk, pmix_list_t *tgt,
+extern pmix_status_t pmix_gds_hash_fetch_appinfo(pmix_peer_t *peer,
+                                                 const char *key,  pmix_list_t *tgt,
                                                  pmix_info_t *info, size_t ninfo, pmix_list_t *kvs);
 
 extern pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc, pmix_scope_t scope,

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -85,7 +85,8 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
     for (j = 0; j < size; j++) {
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
                             "%s gds:hash:node_array for key %s",
-                            PMIX_NAME_PRINT(&pmix_globals.myid), iptr[j].key);
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODEID)) {
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
@@ -252,7 +253,7 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
                             "%s gds:hash:app_array for key %s",
                             PMIX_NAME_PRINT(&pmix_globals.myid),
-                            iptr[j].key);
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);
             if (PMIX_SUCCESS != rc) {
@@ -386,6 +387,10 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
     iptr = (pmix_info_t *) info->value.data.darray->array;
     PMIX_CONSTRUCT(&cache, pmix_list_t);
     for (j = 0; j < size; j++) {
+        pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
+                            "%s gds:hash:job_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APP_INFO_ARRAY)) {
             if (PMIX_SUCCESS != (rc = pmix_gds_hash_process_app_array(&iptr[j].value, trk))) {
                 return rc;
@@ -484,10 +489,10 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
     PMIX_CONSTRUCT(&scache, pmix_list_t);
 
     for (j = 0; j < size; j++) {
-         pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
-                    "%s gds:hash:session_array for key %s",
-                    PMIX_NAME_PRINT(&pmix_globals.myid),
-                    iptr[j].key);
+        pmix_output_verbose(12, pmix_gds_base_framework.framework_output,
+                            "%s gds:hash:session_array for key %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
             PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
             if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/shmem2/gds_shmem2_fetch.h
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2024      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +15,7 @@
 
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem2_fetch(
+    struct pmix_peer_t *peer,
     const pmix_proc_t *proc,
     pmix_scope_t scope,
     bool copy,

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -769,6 +769,10 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
         }
+        /* save the version */
+        nptr->version.major = pnd->proc_type.major;
+        nptr->version.minor = pnd->proc_type.minor;
+        nptr->version.release = pnd->proc_type.release;
     }
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +33,17 @@
 
 bool pmix_ptl_base_peer_is_earlier(pmix_peer_t *peer, uint8_t major, uint8_t minor, uint8_t release)
 {
+    if (0 == PMIX_PEER_MAJOR_VERSION(peer)) {
+        /* the peer's version was never assigned. This happens
+         * when the application never calls PMIx_Init - we
+         * cannot assign the version because the client never
+         * told us what they are using. Normally, this indicates
+         * that the application is not a PMIx one. All we can do
+         * is assume the peer is NOT earlier
+         */
+        return false;
+    }
+
     /* if they don't care, then don't check */
     if (PMIX_MAJOR_WILDCARD != major) {
         if (PMIX_PEER_MAJOR_VERSION(peer) == PMIX_MAJOR_WILDCARD) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1344,7 +1344,8 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output,
+  //  pmix_output_verbose(2, pmix_server_globals.base_output,
+    pmix_output(0,
                         "recvd query from client");
 
     cd = PMIX_NEW(pmix_query_caddy_t);

--- a/src/tools/pctrl/pctrl.c
+++ b/src/tools/pctrl/pctrl.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -133,13 +133,13 @@ int main(int argc, char **argv)
                              NULL, &results, "help-pctrl.txt");
 
     if (PMIX_SUCCESS != rc) {
-        if (PMIX_ERR_SILENT == rc) {
-            exit(rc);
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            exit(0);
         }
-        if (PMIX_OPERATION_SUCCEEDED != rc) {
+        if (PMIX_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", argv[0], PMIx_Error_string(rc));
-            exit(rc);
         }
+        exit(rc);
     }
 
     // handle relevant MCA params


### PR DESCRIPTION
[Exit with correct status after displaying help or version](https://github.com/openpmix/openpmix/commit/82aab5777def6f24ef2d347ee0211722810fdfa7)

Update the "pctrl" tool so it correctly exits with zero
status when asked for "help" or "version".

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/1424b4f2b6417380cb51423051a87965255f39d5)

[Revamp the query implementation](https://github.com/openpmix/openpmix/commit/1d3a9b3a3041ddab236641999e2b42b64a5216e3)

Resolve the hang in the blocking query API. Strip out the
unnecessary code. Cache results as we go so we don't lose
initial results when we go to the server and/or the host.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7c0165eeb858fb1d3ab404d2866267bc3b7b2ca1)

[Update CI workflows](https://github.com/openpmix/openpmix/commit/098cffcbccfabaea69ae87ef4179164b7a9b60df)

Add `--enable-devel-check` to all configure lines

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/fafe63ca3cd05f564818b5cafdd52a739aa41199)

[Silence warnings exposed by updated CI](https://github.com/openpmix/openpmix/commit/59e6c31c41ad5eacaff36ba10cc05187c4f03d30)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/da99e5e9db601cfb8fc64d97953456dbaf5bde77)

[Fix format of fetch response for peer's version](https://github.com/openpmix/openpmix/commit/b7b9af8f7d551ad7456d314bcbf1ddfa4d70026a)

When a client asks the server for information, the server
must format the response to match the PMIx version employed
by the client. We were incorrectly formatting the response
on the basis of the version declared by the process whose
data was being requested - as opposed to the version of
the _requestor_.

In the case of tools, this led to an incorrectly formatted
response, particularly for node-level data where earlier
PMIx versions didn't support the node-info array.

Looking at this also exposed that the client's version
was defaulting to 0.0.0, and would remain that way if
the client application did not call PMIx_Init. Needed
to adjust the macro that checks for PMIx version level
to deal with non-PMIx clients.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/a140bd79bd93b45c70f966ca39f5ce4e0b269226)
