### PR TITLE
Just ignore any lto settings

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -23,7 +23,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
@@ -226,6 +226,16 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     pmix_show_title "Compiler and preprocessor tests"
 
     PMIX_SETUP_CC
+    # We do not currently support the "lto" optimizer as it
+    # aggregates all the headers from our plugins, resulting
+    # in a configuration that generates warnings/errors when
+    # passed through their optimizer phase. We therefore check
+    # for the flag, and if found, output a message explaining
+    # the situation and aborting configure
+    _PMIX_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
+    _PMIX_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LIBS, LIBS)
 
     #
     # Check for some types
@@ -850,18 +860,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     fi
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
     CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
-
-
-    # We do not currently support the "lto" optimizer as it
-    # aggregates all the headers from our plugins, resulting
-    # in a configuration that generates warnings/errors when
-    # passed through their optimizer phase. We therefore check
-    # for the flag, and if found, output a message explaining
-    # the situation and aborting configure
-    _PMIX_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
-    _PMIX_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
-    _PMIX_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
-    _PMIX_CHECK_LTO_FLAG($LIBS, LIBS)
 
 
     ############################################################################

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -42,12 +42,20 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
 ])
 
 AC_DEFUN([_PMIX_CHECK_LTO_FLAG], [
-    chkflg=`echo $1 | grep -- -flto`
+    chkflg=`echo $1 | grep -- lto`
     if test -n "$chkflg"; then
-        AC_MSG_WARN([Configure has detected the presence of the -flto])
-        AC_MSG_WARN([compiler directive in $2. PMIx does not currently])
-        AC_MSG_WARN([support this flag as it conflicts with the])
-        AC_MSG_WARN([plugin architecture of the PMIx library.])
-        AC_MSG_ERROR([Please remove this directive and re-run configure.])
+        AC_MSG_WARN([Configure has detected the presence of one or more])
+        AC_MSG_WARN([compiler directives involving the lto optimizer])
+        AC_MSG_WARN([$2. PMIx does not currently support such directives])
+        AC_MSG_WARN([as they conflict with the plugin architecture of the])
+        AC_MSG_WARN([PMIx library. The directive is being ignored.])
+        newflg=
+        for item in $1; do
+            chkflg=`echo $item | grep -- lto`
+            if test ! -n "$chkflg"; then
+                newflg+="$item "
+            fi
+        done
+        $2="$newflg"
     fi
 ])


### PR DESCRIPTION
Rather than exiting configure with an error, print a warning
if lto-based directives are detected and ignore those flags.
This may help resolve rpm problems.