### PR TITLE
Further cleanup of "resolve" functions

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4823,7 +4823,8 @@ static void respeers_cbfunc(pmix_status_t status, pmix_info_t info[], size_t nin
     pmix_value_t *val;
     pmix_proc_t *pa = NULL;
     size_t np = 0;
-    PMIX_ACQUIRE_OBJECT(cb);
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     ret = status;
     if (PMIX_SUCCESS == ret) {
@@ -4842,6 +4843,16 @@ static void respeers_cbfunc(pmix_status_t status, pmix_info_t info[], size_t nin
         }
         pa = (pmix_proc_t*)val->data.darray->array;
         np = val->data.darray->size;
+    } else {
+        /* we are in the host's progress thread, so we
+         * must threadshift to our own thread to
+         * attempt to locally resolve the request */
+        PMIX_THREADSHIFT(cd, pmix_server_locally_resolve_peers);
+        // give the host its release
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
+        return;
     }
 
 done:
@@ -4879,6 +4890,8 @@ complete:
         PMIX_RELEASE(reply);
     }
     PMIX_RELEASE(cd);
+
+    // give the host its release
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
@@ -4892,6 +4905,8 @@ static void resnodes_cbfunc(pmix_status_t status, pmix_info_t info[], size_t nin
     pmix_status_t rc, ret;
     pmix_value_t *val;
     char *nodelist = NULL;
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     ret = status;
     if (PMIX_SUCCESS == ret) {
@@ -4907,17 +4922,23 @@ static void resnodes_cbfunc(pmix_status_t status, pmix_info_t info[], size_t nin
             ret = PMIX_ERR_INVALID_VAL;
             goto done;
         }
-        nodelist = strdup(val->data.string);
+        nodelist = val->data.string;
+    } else {
+        /* we are in the host's progress thread, so we
+         * must threadshift to our own thread to
+         * attempt to locally resolve the request */
+        PMIX_THREADSHIFT(cd, pmix_server_locally_resolve_node);
+        // give the host its release
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
+        return;
     }
 
 done:
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        PMIX_RELEASE(cd);
-        if (NULL != nodelist) {
-            free(nodelist);
-        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -4927,7 +4948,7 @@ done:
         goto complete;
     }
 
-    if (PMIX_SUCCESS == status) {
+    if (PMIX_SUCCESS == ret) {
         PMIX_BFROPS_PACK(rc, cd->peer, reply, &nodelist, 1, PMIX_STRING);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -4941,10 +4962,9 @@ complete:
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(reply);
     }
-    if (NULL != nodelist) {
-        free(nodelist);
-    }
     PMIX_RELEASE(cd);
+
+    // give the caller their release
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1344,8 +1344,7 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
 
-  //  pmix_output_verbose(2, pmix_server_globals.base_output,
-    pmix_output(0,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd query from client");
 
     cd = PMIX_NEW(pmix_query_caddy_t);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -379,10 +379,13 @@ PMIX_EXPORT pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
                                                     pmix_buffer_t *buf,
                                                     pmix_info_cbfunc_t cbfunc);
 
+PMIX_EXPORT void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata);
+
 PMIX_EXPORT pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
                                                    pmix_buffer_t *buf,
                                                    pmix_info_cbfunc_t cbfunc);
 
+PMIX_EXPORT void pmix_server_locally_resolve_node(int sd, short args, void *cbdata);
 
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -80,20 +80,11 @@ pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
                                         pmix_buffer_t *buf,
                                         pmix_info_cbfunc_t cbfunc)
 {
-    pmix_cb_t cb;
     int32_t cnt;
     pmix_status_t rc;
     char *nodename = NULL;
-    pmix_nspace_t nspace;
-    pmix_info_t info[3], *iptr;
-    pmix_proc_t proc;
-    pmix_kval_t *kv;
-    char **p, **tmp = NULL, *prs;
-    pmix_proc_t *pa = NULL;
-    size_t m, n, np = 0, ninfo = 3;
-    pmix_namespace_t *ns;
     char *nd, *str;
-    pmix_data_array_t darray;
+    pmix_info_t *iptr;
 
     /* unpack the nodename */
     cnt = 1;
@@ -101,6 +92,14 @@ pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
+    }
+
+    // if the nodename is NULL, then they are asking for our
+    // local host
+    if (NULL == nodename) {
+        nd = pmix_globals.hostname;
+    } else {
+        nd = nodename;
     }
 
     /* unpack the nspace */
@@ -113,8 +112,58 @@ pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
         }
         return rc;
     }
-    PMIX_LOAD_NSPACE(nspace, str);
-    free(str);
+
+    PMIX_QUERY_CREATE(cd->query, 1);
+    PMIX_ARGV_APPEND(rc, cd->query->keys, PMIX_QUERY_RESOLVE_PEERS);
+    PMIX_INFO_CREATE(iptr, 2);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING);
+    if (NULL != str) {
+        free(str);
+    }
+    PMIX_INFO_SET_QUALIFIER(&iptr[0]);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_HOSTNAME, nd, PMIX_STRING);
+    if (NULL != nodename) {
+        free(nodename);
+    }
+    PMIX_INFO_SET_QUALIFIER(&iptr[1]);
+    cd->query->qualifiers = iptr;
+    cd->query->nqual = 2;
+
+    // if the host supports the "query" interface, then
+    // pass this up to the host for processing as it has
+    // the latest information
+    if (NULL != pmix_host_server.query) {
+        rc = pmix_host_server.query(&pmix_globals.myid,
+                                    cd->query, 1,
+                                    cbfunc, (void*)cd);
+        if (PMIX_SUCCESS == rc) {
+            return PMIX_SUCCESS;
+        }
+    }
+
+    // they either don't support this query, or have
+    // nothing to contribute - so use what we know
+
+    PMIX_THREADSHIFT(cd, pmix_server_locally_resolve_peers);
+    // indicate that the switchyard is not to send a response
+    return PMIX_SUCCESS;
+}
+
+void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+    pmix_cb_t cb;
+    pmix_status_t rc, ret=PMIX_SUCCESS;
+    pmix_info_t info[3];
+    pmix_proc_t proc;
+    pmix_kval_t *kv;
+    char **p, **tmp = NULL, *prs;
+    char *nspace, *nd;
+    pmix_proc_t *pa = NULL;
+    size_t m, n, np = 0, ninfo = 3;
+    pmix_namespace_t *ns;
+    pmix_buffer_t *reply;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     // construct these so we don't have to worry about
     // destruct later
@@ -122,44 +171,15 @@ pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
         PMIX_INFO_CONSTRUCT(&info[n]);
     }
 
-    // if the host supports the "query" interface, then
-    // pass this up to the host for processing as it has
-    // the latest information
-    if (NULL != pmix_host_server.query) {
-        PMIX_QUERY_CREATE(cd->query, 1);
-        PMIX_ARGV_APPEND(rc, cd->query->keys, PMIX_QUERY_RESOLVE_PEERS);
-        PMIX_INFO_CREATE(iptr, 2);
-        str = (char*)nspace;
-        PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING);
-        PMIX_INFO_SET_QUALIFIER(&iptr[0]);
-        PMIX_INFO_LOAD(&iptr[1], PMIX_HOSTNAME, nodename, PMIX_STRING);
-        PMIX_INFO_SET_QUALIFIER(&iptr[1]);
-        cd->query->qualifiers = iptr;
-        cd->query->nqual = 2;
-        rc = pmix_host_server.query(&pmix_globals.myid,
-                                    cd->query, 1,
-                                    cbfunc, (void*)cd);
-        if (PMIX_SUCCESS != rc) {
-            // they either don't support this query, or have
-            // nothing to contribute - so use what we know
-            PMIX_QUERY_FREE(cd->query, 1);
-            cd->query = NULL;
-            goto local;
-        }
-        return PMIX_SUCCESS;
-    }
+    // first qualifier in the query has the nspace in it
+    nspace = cd->query->qualifiers[0].value.data.string;
 
-local:
+    // second qualifier in the query has the nodename
+    nd = cd->query->qualifiers[1].value.data.string;
+
     // restrict our search to already available info
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, NULL, PMIX_BOOL);
 
-    // if the nodename is NULL, then they are asking for our
-    // local host
-    if (NULL == nodename) {
-        nd = pmix_globals.hostname;
-    } else {
-        nd = nodename;
-    }
 
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     proc.rank = PMIX_RANK_UNDEF;
@@ -237,7 +257,7 @@ local:
             /* allocate the proc array */
             PMIX_PROC_CREATE(pa, np);
             if (NULL == pa) {
-                rc = PMIX_ERR_NOMEM;
+                ret = PMIX_ERR_NOMEM;
                 PMIx_Argv_free(tmp);
                 np = 0;
                 PMIX_DESTRUCT(&cb);
@@ -250,7 +270,7 @@ local:
                 prs = strchr(tmp[n], ':');
                 if (NULL == prs) {
                     /* should never happen, but silence a Coverity warning */
-                    rc = PMIX_ERR_BAD_PARAM;
+                    ret = PMIX_ERR_BAD_PARAM;
                     PMIx_Argv_free(tmp);
                     PMIX_PROC_FREE(pa, np);
                     pa = NULL;
@@ -269,7 +289,7 @@ local:
                 PMIx_Argv_free(p);
             }
             PMIx_Argv_free(tmp);
-            rc = PMIX_SUCCESS;
+            ret = PMIX_SUCCESS;
         }
         PMIX_DESTRUCT(&cb);
         goto done;
@@ -278,24 +298,24 @@ local:
     /* get the list of local peers for this nspace and node */
     PMIX_LOAD_PROCID(&proc, nspace, PMIX_RANK_UNDEF);
 
-    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-    if (PMIX_SUCCESS == rc) {
+    PMIX_GDS_FETCH_KV(ret, pmix_globals.mypeer, &cb);
+    if (PMIX_SUCCESS == ret) {
         goto process;
     }
-    if (PMIX_ERR_INVALID_NAMESPACE == rc) {
+    if (PMIX_ERR_INVALID_NAMESPACE == ret) {
         // this namespace is unknown
         PMIX_DESTRUCT(&cb);
         goto done;
     }
-    if (PMIX_ERR_NOT_FOUND == rc) {
+    if (PMIX_ERR_NOT_FOUND == ret) {
         // found the namespace, but the node is
         // not present on that namespace - the
         // default response is correct
-        rc = PMIX_SUCCESS;
+        ret = PMIX_SUCCESS;
         PMIX_DESTRUCT(&cb);
         goto done;
     }
-    if (PMIX_ERR_DATA_VALUE_NOT_FOUND == rc) {
+    if (PMIX_ERR_DATA_VALUE_NOT_FOUND == ret) {
         // found the namespace and node, but the
         // host did not provide the information
         PMIX_DESTRUCT(&cb);
@@ -305,15 +325,15 @@ local:
     if (PMIX_RANK_UNDEF == proc.rank) {
         // try again with wildcard
         proc.rank = PMIX_RANK_WILDCARD;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        if (PMIX_SUCCESS == rc) {
+        PMIX_GDS_FETCH_KV(ret, pmix_globals.mypeer, &cb);
+        if (PMIX_SUCCESS == ret) {
             goto process;
         }
-        if (PMIX_ERR_NOT_FOUND == rc) {
+        if (PMIX_ERR_NOT_FOUND == ret) {
             // found the namespace, but the node is
             // not present on that namespace - the
             // default response is correct
-            rc = PMIX_SUCCESS;
+            ret = PMIX_SUCCESS;
         }
         // couldn't find it
         PMIX_DESTRUCT(&cb);
@@ -323,13 +343,13 @@ local:
 process:
     /* sanity check */
     if (0 == pmix_list_get_size(&cb.kvs)) {
-        rc = PMIX_ERR_INVALID_VAL;
+        ret = PMIX_ERR_INVALID_VAL;
         PMIX_DESTRUCT(&cb);
         goto done;
     }
     kv = (pmix_kval_t*)pmix_list_get_first(&cb.kvs);
     if (PMIX_STRING != kv->value->type || NULL == kv->value->data.string) {
-        rc = PMIX_ERR_INVALID_VAL;
+        ret = PMIX_ERR_INVALID_VAL;
         PMIX_DESTRUCT(&cb);
         goto done;
     }
@@ -341,7 +361,7 @@ process:
     /* allocate the proc array */
     PMIX_PROC_CREATE(pa, np);
     if (NULL == pa) {
-        rc = PMIX_ERR_NOMEM;
+        ret = PMIX_ERR_NOMEM;
         PMIx_Argv_free(p);
         PMIX_DESTRUCT(&cb);
         goto done;
@@ -352,48 +372,62 @@ process:
         pa[n].rank = strtoul(p[n], NULL, 10);
     }
     PMIx_Argv_free(p);
-    rc = PMIX_SUCCESS;
+    ret = PMIX_SUCCESS;
     PMIX_DESTRUCT(&cb);
 
 done:
     for (n=0; n < ninfo; n++) {
         PMIX_INFO_DESTRUCT(&info[n]);
     }
-    if (NULL != nodename) {
-        free(nodename);
+
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
     }
 
-    if (PMIX_SUCCESS == rc) {
-        // put the answer in an info
-        cd->ninfo = 1;
-        PMIX_INFO_CREATE(cd->info, cd->ninfo);
-        // key doesn't matter here
-        darray.type = PMIX_PROC;
-        darray.array = pa;
-        darray.size = np;
-        PMIX_INFO_LOAD(&cd->info[0], PMIX_QUERY_RESOLVE_NODE, &darray, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS == ret) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, &np, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto complete;
+        }
+        if (0 < np) {
+            PMIX_BFROPS_PACK(rc, cd->peer, reply, pa, np, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto complete;
+            }
+        }
+    }
+
+complete:
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+    }
+    PMIX_RELEASE(cd);
+
+    if (NULL != pa) {
         PMIX_PROC_FREE(pa, np);
     }
-
-    cbfunc(rc, cd->info, cd->ninfo, cd, NULL, NULL);
-    return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
                                        pmix_buffer_t *buf,
                                        pmix_info_cbfunc_t cbfunc)
 {
-    pmix_cb_t cb;
     int32_t cnt;
     pmix_status_t rc;
-    pmix_nspace_t nspace;
-    pmix_info_t info, *iptr;
-    pmix_proc_t proc;
-    pmix_kval_t *kv;
-    pmix_value_t *val;
-    char **p, **tmp = NULL, *nodelist = NULL, *str;
-    pmix_namespace_t *ns;
-    size_t n;
+    pmix_info_t *iptr;
+    char *str;
 
     /* unpack the nspace */
     cnt = 1;
@@ -402,35 +436,54 @@ pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    PMIX_LOAD_NSPACE(nspace, str);
-    free(str);
+
+    PMIX_QUERY_CREATE(cd->query, 1);
+    PMIX_ARGV_APPEND(rc, cd->query->keys, PMIX_QUERY_RESOLVE_NODE);
+    PMIX_INFO_CREATE(iptr, 1);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING);
+    if (NULL != str) {
+        free(str);
+    }
+    PMIX_INFO_SET_QUALIFIER(&iptr[0]);
+    cd->query->qualifiers = iptr;
+    cd->query->nqual = 1;
 
     // if the host supports the "query" interface, then
     // pass this up to the host for processing as it has
     // the latest information
     if (NULL != pmix_host_server.query) {
-        PMIX_QUERY_CREATE(cd->query, 1);
-        PMIX_ARGV_APPEND(rc, cd->query->keys, PMIX_QUERY_RESOLVE_NODE);
-        PMIX_INFO_CREATE(iptr, 1);
-        str = (char*)nspace;
-        PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING);
-        PMIX_INFO_SET_QUALIFIER(&iptr[0]);
-        cd->query->qualifiers = iptr;
-        cd->query->nqual = 1;
         rc = pmix_host_server.query(&pmix_globals.myid,
                                     cd->query, 1,
                                     cbfunc, (void*)cd);
-        if (PMIX_SUCCESS != rc) {
-            // they either don't support this query, or have
-            // nothing to contribute - so use what we know
-            PMIX_QUERY_FREE(cd->query, 1);
-            cd->query = NULL;
-            goto local;
+        if (PMIX_SUCCESS == rc) {
+            return PMIX_SUCCESS;
         }
-        return PMIX_SUCCESS;
     }
 
-local:
+    // they either don't support this query, or have
+    // nothing to contribute - so use what we know
+
+    PMIX_THREADSHIFT(cd, pmix_server_locally_resolve_node);
+    // indicate that the switchyard is not to send a response
+    return PMIX_SUCCESS;
+}
+
+void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+    pmix_cb_t cb;
+    pmix_status_t rc, ret = PMIX_SUCCESS;
+    pmix_nspace_t nspace;
+    pmix_info_t info;
+    pmix_proc_t proc;
+    pmix_kval_t *kv;
+    pmix_value_t *val;
+    char **p, **tmp = NULL, *nodelist = NULL;
+    pmix_namespace_t *ns;
+    size_t n;
+    pmix_buffer_t *reply;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
     // restrict our search to already available info
     PMIX_INFO_LOAD(&info, PMIX_OPTIONAL, NULL, PMIX_BOOL);
 
@@ -482,7 +535,7 @@ local:
             nodelist = PMIx_Argv_join(tmp, ',');
             PMIx_Argv_free(tmp);
         }
-        rc = PMIX_SUCCESS;
+        ret = PMIX_SUCCESS;
         PMIX_DESTRUCT(&cb);
         goto done;
     }
@@ -492,6 +545,7 @@ local:
     PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_DESTRUCT(&cb);
+        ret = rc;
         goto done;
     }
 
@@ -504,7 +558,7 @@ local:
     val = kv->value;
     if (PMIX_STRING != val->type || NULL == val->data.string) {
         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
-        rc = PMIX_ERR_INVALID_VAL;
+        ret = PMIX_ERR_INVALID_VAL;
         PMIX_DESTRUCT(&cb);
         goto done;
     }
@@ -512,14 +566,34 @@ local:
     PMIX_DESTRUCT(&cb);
 
 done:
-    if (PMIX_SUCCESS == rc) {
-        // put the nodelist in an info
-        cd->ninfo = 1;
-        PMIX_INFO_CREATE(cd->info, cd->ninfo);
-        // key doesn't matter here
-        PMIX_INFO_LOAD(&cd->info[0], PMIX_QUERY_RESOLVE_NODE, &nodelist, PMIX_STRING);
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
     }
 
-    cbfunc(rc, cd->info, cd->ninfo, cd, NULL, NULL);
-    return PMIX_SUCCESS;
+    if (PMIX_SUCCESS == ret) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, &nodelist, 1, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto complete;
+        }
+    }
+
+complete:
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+    }
+    if (NULL != nodelist) {
+        free(nodelist);
+    }
+    PMIX_RELEASE(cd);
 }


### PR DESCRIPTION
If the host supports the "query" upcall interface, they will return SUCCESS to mean that they are servicing the request. It does not mean that they will understand the key(s) being passed to them - in which case, they will issue the callback with some status other than SUCCESS.

Should that happen, we still want the server to attempt to resolve the request to the best of its ability. So provide a mechanism by which the server gets a second shot at providing the answer.