### PR TITLE
Silence error output when running as singleton

### DIFF
--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -48,8 +48,10 @@ int main(int argc, char **argv) {
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "PMIx_Init failed: %d\n", rc);
-        exit(rc);
+        if (PMIX_ERR_UNREACH != rc) {
+            fprintf(stderr, "PMIx_Init failed: %d\n", rc);
+            exit(rc);
+        }
     }
 
     nqueries = 3;

--- a/examples/client.c
+++ b/examples/client.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      ParTec AG.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -149,9 +149,15 @@ int main(int argc, char **argv)
      * is included, then the process will be stopped in this call until
      * the "debugger release" notification arrives */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(0);
+        if (PMIX_ERR_UNREACH == rc) {
+            fprintf(stderr, "Client ns %s rank %d: Cannot operate as singleton\n",
+                    myproc.nspace, myproc.rank);
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                    myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+        }
+        exit(1);
     }
     fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
             (unsigned long) pid);

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -340,16 +340,20 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
             } while (retries < pmix_ptl_base.max_retries);
             /* otherwise, mark it as unreachable */
         }
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be found");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be found");
+        }
         return PMIX_ERR_UNREACH;
     }
 
 process:
     fp = fopen(filename, "r");
     if (NULL == fp) {
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be opened");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be opened");
+        }
         return PMIX_ERR_UNREACH;
     }
     /* get the URI - might seem crazy, but there is actually
@@ -376,8 +380,10 @@ process:
         }
     }
     if (NULL == srvr) {
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be read");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be read");
+        }
         fclose(fp);
         return PMIX_ERR_UNREACH;
     }


### PR DESCRIPTION
When executed as a singleton, we automatically search for available connections, just like a tool would do. However, if they are not found, we should not emit an error message if we were not specifically directed to find one - e.g., a system-level server.

Also fix the query operation to return any partial results it was able to find when operating as
a singleton.

Fixes https://github.com/open-mpi/ompi/issues/13114