### PR TITLE
Multiple commits

### DIFF
--- a/examples/abi_with_init.c
+++ b/examples/abi_with_init.c
@@ -48,8 +48,10 @@ int main(int argc, char **argv) {
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "PMIx_Init failed: %d\n", rc);
-        exit(rc);
+        if (PMIX_ERR_UNREACH != rc) {
+            fprintf(stderr, "PMIx_Init failed: %d\n", rc);
+            exit(rc);
+        }
     }
 
     nqueries = 3;

--- a/examples/client.c
+++ b/examples/client.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      ParTec AG.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -149,9 +149,15 @@ int main(int argc, char **argv)
      * is included, then the process will be stopped in this call until
      * the "debugger release" notification arrives */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(0);
+        if (PMIX_ERR_UNREACH == rc) {
+            fprintf(stderr, "Client ns %s rank %d: Cannot operate as singleton\n",
+                    myproc.nspace, myproc.rank);
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                    myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+        }
+        exit(1);
     }
     fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
             (unsigned long) pid);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -562,6 +562,7 @@ typedef struct {
     pmix_peer_t *peer;
     pmix_info_t *info;
     size_t ninfo;
+    pmix_query_t *query;
 } pmix_server_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
 

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -321,16 +321,20 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
             } while (retries < pmix_ptl_base.max_retries);
             /* otherwise, mark it as unreachable */
         }
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be found");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be found");
+        }
         return PMIX_ERR_UNREACH;
     }
 
 process:
     fp = fopen(filename, "r");
     if (NULL == fp) {
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be opened");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be opened");
+        }
         return PMIX_ERR_UNREACH;
     }
     /* get the URI - might seem crazy, but there is actually
@@ -357,8 +361,10 @@ process:
         }
     }
     if (NULL == srvr) {
-        pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                       filename, "could not be read");
+        if (!optional) {
+            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                           filename, "could not be read");
+        }
         fclose(fp);
         return PMIX_ERR_UNREACH;
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4470,6 +4470,143 @@ complete:
     }
 }
 
+static void respeers_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo, void *cbdata,
+                            pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t rc, ret;
+    pmix_value_t *val;
+    pmix_proc_t *pa = NULL;
+    size_t np = 0;
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    ret = status;
+    if (PMIX_SUCCESS == ret) {
+        // array return should be in first info
+        if (0 == ninfo) {
+            // they didn't return anything
+            ret = PMIX_ERR_NOT_FOUND;
+            goto done;
+        }
+        val = &info[0].value;
+        if (PMIX_DATA_ARRAY != val->type ||
+            PMIX_PROC != val->data.darray->type) {
+            PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
+            ret = PMIX_ERR_INVALID_VAL;
+            goto done;
+        }
+        pa = (pmix_proc_t*)val->data.darray->array;
+        np = val->data.darray->size;
+    }
+
+done:
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
+    }
+
+    if (PMIX_SUCCESS == ret) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, &np, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto complete;
+        }
+        if (0 < np) {
+            PMIX_BFROPS_PACK(rc, cd->peer, reply, pa, np, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto complete;
+            }
+        }
+    }
+
+complete:
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+    }
+    PMIX_RELEASE(cd);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
+static void resnodes_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo, void *cbdata,
+                            pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t rc, ret;
+    pmix_value_t *val;
+    char *nodelist = NULL;
+
+    ret = status;
+    if (PMIX_SUCCESS == ret) {
+        // array return should be in first info
+        if (0 == ninfo) {
+            // they didn't return anything
+            ret = PMIX_ERR_NOT_FOUND;
+            goto done;
+        }
+        val = &info[0].value;
+        if (PMIX_STRING != val->type) {
+            PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
+            ret = PMIX_ERR_INVALID_VAL;
+            goto done;
+        }
+        nodelist = strdup(val->data.string);
+    }
+
+done:
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
+        if (NULL != nodelist) {
+            free(nodelist);
+        }
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto complete;
+    }
+
+    if (PMIX_SUCCESS == status) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, &nodelist, 1, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto complete;
+        }
+    }
+
+complete:
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+    }
+    if (NULL != nodelist) {
+        free(nodelist);
+    }
+    PMIX_RELEASE(cd);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
+
 /* the switchyard is the primary message handling function. It's purpose
  * is to take incoming commands (packed into a buffer), unpack them,
  * and then call the corresponding host server's function to execute
@@ -4842,7 +4979,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_RESOLVE_PEERS_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        if (PMIX_SUCCESS != (rc = pmix_server_resolve_peers(cd, buf))) {
+        if (PMIX_SUCCESS != (rc = pmix_server_resolve_peers(cd, buf, respeers_cbfunc))) {
             PMIX_RELEASE(cd);
         }
         return rc;
@@ -4850,7 +4987,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_RESOLVE_NODE_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        if (PMIX_SUCCESS != (rc = pmix_server_resolve_node(cd, buf))) {
+        if (PMIX_SUCCESS != (rc = pmix_server_resolve_node(cd, buf, resnodes_cbfunc))) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -5339,6 +5339,7 @@ static void cdcon(pmix_server_caddy_t *cd)
     cd->peer = NULL;
     cd->info = NULL;
     cd->ninfo = 0;
+    cd->query = NULL;
 }
 static void cddes(pmix_server_caddy_t *cd)
 {
@@ -5353,6 +5354,9 @@ static void cddes(pmix_server_caddy_t *cd)
     }
     if (NULL != cd->info) {
         PMIX_INFO_FREE(cd->info, cd->ninfo);
+    }
+    if (NULL != cd->query) {
+        PMIX_QUERY_FREE(cd->query, 1);
     }
 }
 PMIX_CLASS_INSTANCE(pmix_server_caddy_t,

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2638,8 +2638,7 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
 
-  //  pmix_output_verbose(2, pmix_server_globals.base_output,
-    pmix_output(0,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd query from client");
 
     cd = PMIX_NEW(pmix_query_caddy_t);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -367,10 +367,12 @@ PMIX_EXPORT pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
                                                     pmix_op_cbfunc_t cbfunc);
 
 PMIX_EXPORT pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
-                                                    pmix_buffer_t *buf);
+                                                    pmix_buffer_t *buf,
+                                                    pmix_info_cbfunc_t cbfunc);
 
 PMIX_EXPORT pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
-                                                   pmix_buffer_t *buf);
+                                                   pmix_buffer_t *buf,
+                                                   pmix_info_cbfunc_t cbfunc);
 
 
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -370,10 +370,13 @@ PMIX_EXPORT pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
                                                     pmix_buffer_t *buf,
                                                     pmix_info_cbfunc_t cbfunc);
 
+PMIX_EXPORT void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata);
+
 PMIX_EXPORT pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
                                                    pmix_buffer_t *buf,
                                                    pmix_info_cbfunc_t cbfunc);
 
+PMIX_EXPORT void pmix_server_locally_resolve_node(int sd, short args, void *cbdata);
 
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;


### PR DESCRIPTION
[Do not block in query upcall](https://github.com/openpmix/openpmix/commit/25fabcb3081100758ca576e36e0714b488ec4643)

We cannot block in an upcall into the host, so do the right
thing and allow the host to callback asynchronously when
servicing a "resolve" request

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/ce3f5a464c5565cd2432682180e9a2daff5ad22d)

[Further cleanup of "resolve" functions](https://github.com/openpmix/openpmix/commit/2943c22625e876aa2b6118c7312582fe0f53c0fa)

If the host supports the "query" upcall interface, they
will return SUCCESS to mean that they are servicing the
request. It does not mean that they will understand the
key(s) being passed to them - in which case, they will
issue the callback with some status other than SUCCESS.

Should that happen, we still want the server to attempt
to resolve the request to the best of its ability. So
provide a mechanism by which the server gets a second
shot at providing the answer.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/76bd8626f801fd58968d1dadc62ab62a6fbe50d7)

[Silence error output when running as singleton](https://github.com/openpmix/openpmix/commit/b53ed165b69b9349b859233313a8b37d7286dff0)

When executed as a singleton, we automatically search
for available connections, just like a tool would do.
However, if they are not found, we should not emit an
error message if we were not specifically directed
to find one - e.g., a system-level server.

Also fix the query operation to return any partial
results it was able to find when operating as
a singleton.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2a762fff71d0aa57b286f4a3be15bc3cb87421fd)
