### PR TITLE
Multiple commits

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -480,7 +480,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_HOSTFILE                       "pmix.hostfile"         // (char*) hostfile to use for spawned procs
 #define PMIX_ADD_HOST                       "pmix.addhost"          // (char*) comma-delimited list of hosts to add to allocation
 #define PMIX_ADD_HOSTFILE                   "pmix.addhostfile"      // (char*) hostfile to add to existing allocation
-#define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to use for starting spawned procs
+#define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to be used by an app to look for its
+                                                                    //         PMIx installation on remote nodes. A NULL
+                                                                    //         value indicates that no prefix is to be given
 #define PMIX_WDIR                           "pmix.wdir"             // (char*) working directory for spawned procs
 #define PMIX_WDIR_USER_SPECIFIED            "pmix.wdir.user"        // (bool) User specified the working directory
 #define PMIX_DISPLAY_MAP                    "pmix.dispmap"          // (bool) display placement map upon spawn


### PR DESCRIPTION
[Have show_help output all directories tried](https://github.com/openpmix/openpmix/commit/cf7e64f7646355171d9ccae5e95c8041a572968d)

When outputting a show_help message that fails to find
the specified topic file, output all locations attempted
so the user can see what was done.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Cleanup spawn and clarify attribute comment](https://github.com/openpmix/openpmix/commit/ca6a9a1d446b2d43c0f166e04d408baafcfb9739)

The use of PMIX_PREFIX in a spawn request was getting
confused, so add some text clarifying it in pmix_common.h.
```text
(char*) prefix to be used by an app to look for its
PMIx installation on remote nodes. A NULL
value indicates that no prefix is to be given
```
Cleanup the client spawn code to reflect that clarification.
Specifically, we are NOT prefixing the location of the
executable - we are instead asking the host to:

(a) setup the LD_LIBRARY_PATH to start with the prefix/lib
    location, and

(b) push `PMIX_PREFIX=<value given>` into the app's environment
    If the value given is NULL, then we want the host NOT to
    assign any prefix to the app, even if there is a default
    one at their level

Signed-off-by: Ralph Castain <rhc@pmix.org>
