### PR TITLE
Fix segfault on error in shmem2

### DIFF
--- a/src/mca/gds/shmem2/gds_shmem2.c
+++ b/src/mca/gds/shmem2/gds_shmem2.c
@@ -1053,7 +1053,6 @@ shmem2_attach(
             );
             rc = PMIX_ERROR;
         }
-        PMIX_ERROR_LOG(rc);
         goto out;
     }
     PMIX_GDS_SHMEM2_VOUT(
@@ -1062,6 +1061,9 @@ shmem2_attach(
 out:
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(shmem2);
+        // remove the job from the tracker
+        pmix_list_remove_item(&pmix_mca_gds_shmem2_component.jobs, &job->super);
+        PMIX_RELEASE(job);
     }
     else {
         pmix_gds_shmem2_set_status(
@@ -1126,7 +1128,6 @@ shmem2_segment_attach_and_init(
     const uintptr_t req_addr = (uintptr_t)seginfo->seg_hadr;
     rc = shmem2_attach(job, seginfo->smid, req_addr);
     if (PMIX_UNLIKELY(rc != PMIX_SUCCESS)) {
-        PMIX_ERROR_LOG(rc);
         return rc;
     }
     // Now we can safely initialize our shared data structures.
@@ -2518,7 +2519,6 @@ unpack_shmem2_seg_blob_and_attach_if_necessary(
         // Looks like we have to attach and initialize it.
         rc = shmem2_segment_attach_and_init(job, &usb);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-            PMIX_ERROR_LOG(rc);
             break;
         }
     } while (false);
@@ -2550,7 +2550,6 @@ client_connect_to_shmem2_from_buffi(
         if (PMIX_CHECK_KEY(&kval, SHMEM2_SEG_BLOB_KEY)) {
             rc = unpack_shmem2_seg_blob_and_attach_if_necessary(&kval);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-                PMIX_ERROR_LOG(rc);
                 break;
             }
         }
@@ -2575,9 +2574,7 @@ client_connect_to_shmem2_from_buffi(
     PMIX_DESTRUCT(&kval);
 
     if (PMIX_UNLIKELY(PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc)) {
-        PMIX_ERROR_LOG(rc);
         rc = PMIX_ERR_UNPACK_FAILURE;
-        PMIX_ERROR_LOG(rc);
         return rc;
     }
     return PMIX_SUCCESS;
@@ -2642,7 +2639,7 @@ server_store_modex_cb(pmix_proc_t *proc,
     int32_t cnt;
     pmix_kval_t kv;
     pmix_gds_shmem2_job_t *job;
-    
+
     rc = pmix_gds_shmem2_get_job_tracker(proc->nspace, false, &job);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
-# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2023-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -75,3 +75,13 @@ We attempted to remove a file, but were unable to do so:
 
   Path:  %s
   Error: %s
+#
+[failed-file-open]
+An attempt was made to open a shared memory backing file, but the
+attempt failed:
+
+  File:  %s
+  Error: %s
+
+The PMIx shared memory subsystem will be disabled, but your job will
+continue by using the "hash" subsystem.

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,9 @@
 #include "pmix_common.h"
 #include "pmix_output.h"
 #include "src/include/pmix_globals.h"
+#include "src/mca/gds/base/base.h"
 #include "src/util/pmix_error.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
 
 #ifdef HAVE_FCNTL_H
@@ -62,6 +64,10 @@ segment_attach(
     const int fd = open(shmem->backing_path, O_RDWR);
     if (fd == -1) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
+        if (0 < pmix_output_get_verbosity(pmix_gds_base_framework.framework_output)) {
+            pmix_show_help("help-pmix-util.txt", "failed-file-open", true,
+                           shmem->backing_path, strerror(errno));
+        }
         goto out;
     }
 
@@ -88,7 +94,6 @@ out:
     }
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(shmem);
-        PMIX_ERROR_LOG(rc);
     }
     else {
         shmem->attached = true;


### PR DESCRIPTION
If someone mistakenly provides an incorrect path for the directory where we will be storing the shmem backing file (e.g., pass a relative directory and then change the working directory), then we segfault in shmem2 because of a stale job object in the tracking system. So ensure we cleanup the job object when that happens so we can cleanly fallover to "hash".

Remove a bunch of error logs when this happens since we are not going to fail, but instead continue running. Add some debug output to report which file was attempted to be opened.

Fixes #3560 