### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -55,3 +55,10 @@ jobs:
          prun -n 1 --system-server sleep 10000 &
          ./examples/toolqry --system-server
          pterm --system-server
+    - name: Run pubstress check
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         prterun -n 5 ./examples/pubstress 30
+      if:   ${{ true }}
+      timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ examples/pset
 examples/resolve
 examples/toolqry
 examples/simple_resolve
+examples/pubstress
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -23,7 +23,7 @@ dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
@@ -226,6 +226,16 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     pmix_show_title "Compiler and preprocessor tests"
 
     PMIX_SETUP_CC
+    # We do not currently support the "lto" optimizer as it
+    # aggregates all the headers from our plugins, resulting
+    # in a configuration that generates warnings/errors when
+    # passed through their optimizer phase. We therefore check
+    # for the flag, and if found, output a message explaining
+    # the situation and aborting configure
+    _PMIX_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
+    _PMIX_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
+    _PMIX_CHECK_LTO_FLAG($LIBS, LIBS)
 
     #
     # Check for some types
@@ -874,18 +884,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     fi
     CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$pmix_cc_iquote"'&/g')"
     CPPFLAGS="$CPP_INCLUDES -I$PMIX_top_srcdir/include $CPPFLAGS"
-
-
-    # We do not currently support the "lto" optimizer as it
-    # aggregates all the headers from our plugins, resulting
-    # in a configuration that generates warnings/errors when
-    # passed through their optimizer phase. We therefore check
-    # for the flag, and if found, output a message explaining
-    # the situation and aborting configure
-    _PMIX_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
-    _PMIX_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
-    _PMIX_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
-    _PMIX_CHECK_LTO_FLAG($LIBS, LIBS)
 
 
     ############################################################################

--- a/config/pmix_check_cflags.m4
+++ b/config/pmix_check_cflags.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -42,12 +42,20 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
 ])
 
 AC_DEFUN([_PMIX_CHECK_LTO_FLAG], [
-    chkflg=`echo $1 | grep -- -flto`
+    chkflg=`echo $1 | grep -- lto`
     if test -n "$chkflg"; then
-        AC_MSG_WARN([Configure has detected the presence of the -flto])
-        AC_MSG_WARN([compiler directive in $2. PMIx does not currently])
-        AC_MSG_WARN([support this flag as it conflicts with the])
-        AC_MSG_WARN([plugin architecture of the PMIx library.])
-        AC_MSG_ERROR([Please remove this directive and re-run configure.])
+        AC_MSG_WARN([Configure has detected the presence of one or more])
+        AC_MSG_WARN([compiler directives involving the lto optimizer])
+        AC_MSG_WARN([$2. PMIx does not currently support such directives])
+        AC_MSG_WARN([as they conflict with the plugin architecture of the])
+        AC_MSG_WARN([PMIx library. The directive is being ignored.])
+        newflg=
+        for item in $1; do
+            chkflg=`echo $item | grep -- lto`
+            if test ! -n "$chkflg"; then
+                newflg+="$item "
+            fi
+        done
+        $2="$newflg"
     fi
 ])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -27,7 +27,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_buildd
 noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   tool debugger debuggerd alloc jctrl group group_dmodex asyncgroup \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
-                  client3 launcher resolve toolqry simple_resolve
+                  client3 launcher resolve toolqry simple_resolve pubstress
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -148,6 +148,10 @@ toolqry_LDADD = $(top_builddir)/src/libpmix.la
 simple_resolve_SOURCES = simple_resolve.c examples.h
 simple_resolve_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simple_resolve_LDADD = $(top_builddir)/src/libpmix.la
+
+pubstress_SOURCES = pubstress.c examples.h
+pubstress_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+pubstress_LDADD = $(top_builddir)/src/libpmix.la
 
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \

--- a/examples/pubstress.c
+++ b/examples/pubstress.c
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <libgen.h>
+
+#include <pmix.h>
+
+#include "examples.h"
+
+#define NITER 10
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    int rc, n;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+    pmix_info_t info[2], lkinfo[2];
+    pmix_pdata_t pdata;
+    pmix_persistence_t firstread = PMIX_PERSIST_FIRST_READ;
+    int timeout=10;
+    char *tmp;
+    int iters;
+    size_t ninfo, bcount=0;
+    char *keys[3];
+
+    if (1 < argc) {
+        iters = strtol(argv[1], NULL, 10);
+    } else {
+        iters = NITER;
+    }
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        exit(0);
+    }
+
+    /* get our job size */
+    PMIX_PROC_CONSTRUCT(&proc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    // require at least 4 procs
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "%s requires at least 4 processes\n", basename(argv[0]));
+        }
+        exit(1);
+    }
+
+    PMIX_INFO_LOAD(&info[1], PMIX_PERSISTENCE, &firstread, PMIX_PERSIST);
+    PMIX_INFO_LOAD(&lkinfo[0], PMIX_WAIT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&lkinfo[1], PMIX_TIMEOUT, &timeout, PMIX_INT);
+
+    if (myproc.rank < 2) {
+        ninfo = 2;
+        for (n=0; n < iters; n++) {
+            if (0 == myproc.rank) {
+                if (n % 2) { // delay us a bit so other ranks get ahead
+                    sleep(1);
+                }
+                /* publish something */
+                if (0 > asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, myproc.rank, n)) {
+                    goto done;
+                }
+                PMIX_INFO_LOAD(&info[0], tmp, &n, PMIX_INT);
+                free(tmp);
+                if (PMIX_SUCCESS != (rc = PMIx_Publish(info, ninfo))) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Publish failed: %d\n", myproc.nspace,
+                            myproc.rank, rc);
+                    goto done;
+                }
+                PMIX_INFO_DESTRUCT(&info[0]);
+
+                /* lookup other rank's value */
+                PMIX_PDATA_CONSTRUCT(&pdata);
+                if (0 > asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, 1, n)) {
+                    goto done;
+                }
+                PMIX_LOAD_KEY(pdata.key, tmp);
+                free(tmp);
+                // lookup value
+                if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, lkinfo, 2))) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup failed: %d\n", myproc.nspace,
+                            myproc.rank, rc);
+                    goto done;
+                }
+                /* check the return for value and source */
+                if (0 != strncmp(myproc.nspace, pdata.proc.nspace, PMIX_MAX_NSLEN)) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong nspace: %s\n",
+                            myproc.nspace, myproc.rank, pdata.proc.nspace);
+                    goto done;
+                }
+                if (1 != pdata.proc.rank) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong rank: %d\n",
+                            myproc.nspace, myproc.rank, pdata.proc.rank);
+                    goto done;
+                }
+                if (PMIX_INT != pdata.value.type) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong type: %d\n",
+                            myproc.nspace, myproc.rank, pdata.value.type);
+                    goto done;
+                }
+                if (n != pdata.value.data.integer) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong value: %d\n",
+                            myproc.nspace, myproc.rank, (int) pdata.value.data.uint8);
+                    goto done;
+                }
+                PMIX_PDATA_DESTRUCT(&pdata);
+                fprintf(stderr, "PUBLISH-LOOKUP SUCCEEDED: %d\n", n);
+                ninfo = 2;
+            } else if (1 == myproc.rank) {
+                if (0 == n) {
+                    sleep(1);
+                }
+                /* lookup other rank's value */
+                PMIX_PDATA_CONSTRUCT(&pdata);
+                if (0 > asprintf(&tmp, "FOOBAR:%s.%u:%d", myproc.nspace, 0, n)) {
+                    goto done;
+                }
+                PMIX_LOAD_KEY(pdata.key, tmp);
+                free(tmp);
+                // check value
+                if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, lkinfo, 2))) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup failed: %d\n", myproc.nspace,
+                            myproc.rank, rc);
+                    goto done;
+                }
+                /* check the return for value and source */
+                if (0 != strncmp(myproc.nspace, pdata.proc.nspace, PMIX_MAX_NSLEN)) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong nspace: %s\n",
+                            myproc.nspace, myproc.rank, pdata.proc.nspace);
+                    goto done;
+                }
+                if (0 != pdata.proc.rank) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong rank: %d\n",
+                            myproc.nspace, myproc.rank, pdata.proc.rank);
+                    goto done;
+                }
+                if (PMIX_INT != pdata.value.type) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong type: %d\n",
+                            myproc.nspace, myproc.rank, pdata.value.type);
+                    goto done;
+                }
+                if (n != pdata.value.data.integer) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong value: %d\n",
+                            myproc.nspace, myproc.rank, (int) pdata.value.data.uint8);
+                    goto done;
+                }
+                PMIX_PDATA_DESTRUCT(&pdata);
+                /* publish something */
+                if (0 > asprintf(&tmp, "BAZ:%s.%u:%d", myproc.nspace, myproc.rank, n)) {
+                    goto done;
+                }
+                PMIX_INFO_LOAD(&info[0], tmp, &n, PMIX_INT);
+                free(tmp);
+                if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 2))) {
+                    fprintf(stderr, "Client ns %s rank %d: PMIx_Publish failed: %d\n", myproc.nspace,
+                            myproc.rank, rc);
+                    goto done;
+                }
+                PMIX_INFO_DESTRUCT(&info[0]);
+            }
+        }
+        goto done;
+    }
+
+    // we cannot participate in the "firstread" cases as only
+    // one other proc can read the value
+    /* lookup other rank's value */
+    for (n=0; n < iters; n++) {
+        if (2 == myproc.rank) {
+            if (n % 2) { // delay us a bit so other ranks get ahead
+                sleep(1);
+            }
+            // publish something
+            if (0 > asprintf(&tmp, "BIGTEST:%s.%u:%d", myproc.nspace, myproc.rank, n)) {
+                goto done;
+            }
+            bcount = 1234 + n;
+            PMIX_INFO_LOAD(&info[0], tmp, &bcount, PMIX_SIZE);
+            free(tmp);
+                fprintf(stderr, "Client ns %s rank %d: Published: %lu\n", myproc.nspace,
+                        myproc.rank, (unsigned long)bcount);
+            if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 1))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Publish failed: %d\n", myproc.nspace,
+                        myproc.rank, rc);
+                goto done;
+            }
+            PMIX_INFO_DESTRUCT(&info[0]);
+        } else {
+            // everyone else retrieves it
+            PMIX_PDATA_CONSTRUCT(&pdata);
+            if (0 > asprintf(&tmp, "BIGTEST:%s.%u:%d", myproc.nspace, 2, n)) {
+                goto done;
+            }
+            PMIX_LOAD_KEY(pdata.key, tmp);
+            free(tmp);
+            // check value
+            if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, lkinfo, 2))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup failed: %d\n", myproc.nspace,
+                        myproc.rank, rc);
+                goto done;
+            }
+            /* check the return for value and source */
+            if (!PMIX_CHECK_NSPACE(myproc.nspace, pdata.proc.nspace)) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong nspace: %s\n",
+                        myproc.nspace, myproc.rank, pdata.proc.nspace);
+                goto done;
+            }
+            if (2 != pdata.proc.rank) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong rank: %d\n",
+                        myproc.nspace, myproc.rank, pdata.proc.rank);
+                goto done;
+            }
+            if (PMIX_SIZE != pdata.value.type) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong type: %s\n",
+                        myproc.nspace, myproc.rank, PMIx_Data_type_string(pdata.value.type));
+                goto done;
+            }
+            bcount = pdata.value.data.size;
+            if (bcount != (size_t)(1234 + n)) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong value: %lu\n",
+                        myproc.nspace, myproc.rank, (unsigned long)bcount);
+                goto done;
+            }
+            PMIX_PDATA_DESTRUCT(&pdata);
+            fprintf(stderr, "Client ns %s rank %d: PUBLISH-LOOKUP BIGTEST SUCCEEDED: %d\n",
+                    myproc.nspace, myproc.rank, n);
+        }
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Fence(&proc, 1, NULL, 0);
+    if (2 == myproc.rank) {
+        if (0 > asprintf(&keys[0], "BIGTEST:%s.%u:%d", myproc.nspace, myproc.rank, 0)) {
+            goto done;
+        }
+        if (0 > asprintf(&keys[1], "BIGTEST:%s.%u:%d", myproc.nspace, myproc.rank, 1)) {
+            goto done;
+        }
+        keys[2] = NULL;
+        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(keys, NULL, 0))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish failed: %d\n", myproc.nspace,
+                    myproc.rank, rc);
+            goto done;
+        }
+        // purge the rest
+        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(NULL, NULL, 0))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish purge failed: %d\n", myproc.nspace,
+                    myproc.rank, rc);
+            goto done;
+        }
+        // verify the purge
+        if (0 > asprintf(&tmp, "BIGTEST:%s.%u:%d", myproc.nspace, 2, 2)) {
+            goto done;
+        }
+        PMIX_LOAD_KEY(pdata.key, tmp);
+        free(tmp);
+        // check value
+        rc = PMIx_Lookup(&pdata, 1, NULL, 0);
+        // should not be found
+        if (PMIX_SUCCESS == rc) {
+            fprintf(stderr, "Client ns %s rank %d: Purge failed\n",
+                    myproc.nspace, myproc.rank);
+            goto done;
+        } else {
+            fprintf(stderr, "Client ns %s rank %d: Purge succeeded: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        }
+    }
+
+done:
+    /* finalize us */
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
+                myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return (0);
+}

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -471,7 +471,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_HOSTFILE                       "pmix.hostfile"         // (char*) hostfile to use for spawned procs
 #define PMIX_ADD_HOST                       "pmix.addhost"          // (char*) comma-delimited list of hosts to add to allocation
 #define PMIX_ADD_HOSTFILE                   "pmix.addhostfile"      // (char*) hostfile to add to existing allocation
-#define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to use for starting spawned procs
+#define PMIX_PREFIX                         "pmix.prefix"           // (char*) prefix to be used by an app to look for its
+                                                                    //         PMIx installation on remote nodes. A NULL
+                                                                    //         value indicates that no prefix is to be given
 #define PMIX_WDIR                           "pmix.wdir"             // (char*) working directory for spawned procs
 #define PMIX_WDIR_USER_SPECIFIED            "pmix.wdir.user"        // (bool) User specified the working directory
 #define PMIX_DISPLAY_MAP                    "pmix.dispmap"          // (bool) display placement map upon spawn


### PR DESCRIPTION
[Add new pub-lookup stress example](https://github.com/openpmix/openpmix/commit/11d4fe3e81b37a0d1bd9a27224422afa39d3633e)

Try to more fully explore the publish-lookup race
condition

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c6cf013cfe960a0992d9b70503dd0bba7f492544)

[Just ignore any lto settings](https://github.com/openpmix/openpmix/commit/ddcf33ea0e3ef5eb75b18686165de012e4359f94)

Rather than exiting configure with an error, print a warning
if lto-based directives are detected and ignore those flags.
This may help resolve rpm problems.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/af25b7cd9e39574b06e66dd3c308743329b5c9ee)

[Have show_help output all directories tried](https://github.com/openpmix/openpmix/commit/025d8fbcf425279339bbe8a832f13021b8784c0d)

When outputting a show_help message that fails to find
the specified topic file, output all locations attempted
so the user can see what was done.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/f0466252e25840733c42b736aa5cdea3331c9a1b)

[Extend the pubstress test and add it to CI](https://github.com/openpmix/openpmix/commit/415cc916d01ee1533f57f6aa02b0dd3b5a308972)

Check that we correctly unpublish data for given
persistence levels. Add the pubstress test to
the CI.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/b19f050777edeba7aa8fc45942993a1118afc64a)

[Cleanup spawn and clarify attribute comment](https://github.com/openpmix/openpmix/commit/4684de702cafe5de47e3dd303770e75d3a715340)

The use of PMIX_PREFIX in a spawn request was getting
confused, so add some text clarifying it in pmix_common.h.
```text
(char*) prefix to be used by an app to look for its
PMIx installation on remote nodes. A NULL
value indicates that no prefix is to be given
```
Cleanup the client spawn code to reflect that clarification.
Specifically, we are NOT prefixing the location of the
executable - we are instead asking the host to:

(a) setup the LD_LIBRARY_PATH to start with the prefix/lib
    location, and

(b) push `PMIX_PREFIX=<value given>` into the app's environment
    If the value given is NULL, then we want the host NOT to
    assign any prefix to the app, even if there is a default
    one at their level

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/fc0a55b88374c7fb274cea8e4158ae2b14910a7e)

[Properly handle OPAL_PREFIX](https://github.com/openpmix/openpmix/commit/db59fa6c9fe0a89453041d46a9adc9742a641479)

When we see the OPAL_PREFIX envar, we need to not only
propagate it, but we also need to modify LD_LIBRARY_PATH
accordingly so that the app can find its components.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c445afed668e5802c676d53c964142639cd13ecc)
