### PR TITLE
Extract the install prefix from the shared library.

### DIFF
--- a/src/mca/pinstalldirs/runtime/Makefile.am
+++ b/src/mca/pinstalldirs/runtime/Makefile.am
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_LTLIBRARIES = libpmix_mca_pinstalldirs_runtime.la
+
+libpmix_mca_pinstalldirs_runtime_la_SOURCES = \
+	pmix_pinstalldirs_runtime.c

--- a/src/mca/pinstalldirs/runtime/configure.m4
+++ b/src/mca/pinstalldirs/runtime/configure.m4
@@ -1,0 +1,44 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+AC_DEFUN([MCA_pmix_pinstalldirs_runtime_PRIORITY], [5])
+
+AC_DEFUN([MCA_pmix_pinstalldirs_runtime_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+# MCA_pinstalldirs_config_CONFIG(action-if-can-compile,
+#                        [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pinstalldirs_runtime_CONFIG], [
+    # Check if we are building a shared library or not. Disable if static
+    AC_MSG_CHECKING([if shared libraries are enabled])
+    AS_IF([test "$enable_shared" != "yes"],
+          [pinstalldirs_runtime_happy="no"],
+          [pinstalldirs_runtime_happy="yes"])
+    AC_MSG_RESULT([$pinstalldirs_runtime_happy])
+
+    # Check if dladdr is available
+    AS_IF([test "$pinstalldirs_runtime_happy" = "yes"],
+          [AC_CHECK_HEADERS([dlfcn.h],
+                            [],
+                            [pinstalldirs_runtime_happy="no"])])
+    AS_IF([test "$pinstalldirs_runtime_happy" = "yes"],
+          [AC_CHECK_LIB([dl], [dladdr],
+                        [],
+                        [pinstalldirs_runtime_happy="no"])
+          ])
+    #
+    AS_IF([test "$pinstalldirs_runtime_happy" = "yes"],
+          [AC_CONFIG_FILES([src/mca/pinstalldirs/runtime/Makefile])
+           $1], [$2])
+])
+

--- a/src/mca/pinstalldirs/runtime/pmix_pinstalldirs_runtime.c
+++ b/src/mca/pinstalldirs/runtime/pmix_pinstalldirs_runtime.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2025      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +17,7 @@
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include <dlfcn.h>
 #include "src/util/pmix_basename.h"
+#include "src/include/pmix_globals.h"
 
 
 static void pinstalldirs_runtime_init(pmix_info_t info[], size_t ninfo);
@@ -51,11 +53,13 @@ pmix_pinstalldirs_base_component_t pmix_mca_pinstalldirs_runtime_component = {
     },
     .init = pinstalldirs_runtime_init
 };
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pinstalldirs, runtime)
 
 static void pinstalldirs_runtime_init(pmix_info_t unused[], size_t ninfo)
 {
     Dl_info info;
     void* pmix_fct;
+    PMIX_HIDE_UNUSED_PARAMS(unused, ninfo);
 
     /* Casting from void* to fct pointer according to POSIX.1-2001 and POSIX.1-2008 */
     *(void **)&pmix_fct = dlsym(RTLD_DEFAULT, "pmix_init_util");

--- a/src/mca/pinstalldirs/runtime/pmix_pinstalldirs_runtime.c
+++ b/src/mca/pinstalldirs/runtime/pmix_pinstalldirs_runtime.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/pinstalldirs/pinstalldirs.h"
+#include <dlfcn.h>
+#include "src/util/pmix_basename.h"
+
+
+static void pinstalldirs_runtime_init(pmix_info_t info[], size_t ninfo);
+
+pmix_pinstalldirs_base_component_t pmix_mca_pinstalldirs_runtime_component = {
+    /* First, the mca_component_t struct containing meta information
+       about the component itself */
+    .component = {
+        PMIX_PINSTALLDIRS_BASE_VERSION_1_0_0,
+
+         /* Component name and version */
+         "runtime", PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION, PMIX_RELEASE_VERSION,
+    },
+
+    .install_dirs_data = {
+        .prefix = NULL,
+        .exec_prefix = NULL,
+        .bindir = NULL,
+        .sbindir = NULL,
+        .libexecdir = NULL,
+        .datarootdir = NULL,
+        .datadir = NULL,
+        .sysconfdir = NULL,
+        .sharedstatedir = NULL,
+        .localstatedir = NULL,
+        .libdir = NULL,
+        .includedir = NULL,
+        .infodir = NULL,
+        .mandir = NULL,
+        .pmixdatadir = NULL,
+        .pmixlibdir = NULL,
+        .pmixincludedir = NULL
+    },
+    .init = pinstalldirs_runtime_init
+};
+
+static void pinstalldirs_runtime_init(pmix_info_t unused[], size_t ninfo)
+{
+    Dl_info info;
+    void* pmix_fct;
+
+    /* Casting from void* to fct pointer according to POSIX.1-2001 and POSIX.1-2008 */
+    *(void **)&pmix_fct = dlsym(RTLD_DEFAULT, "pmix_init_util");
+
+    if( 0 != dladdr(pmix_fct, &info) ) {
+        char* dname = pmix_dirname(info.dli_fname);
+        char* prefix = pmix_dirname(dname);
+        free(dname);
+
+        pmix_mca_pinstalldirs_runtime_component.install_dirs_data.prefix = prefix;
+    }
+}


### PR DESCRIPTION
This is part of a multi-project effort, a similar PR will be created in OpenPMIX and OMPI. The goal of each of these changes is the same: instead of using build-time generated prefix that ignore a project rebase, take the prefix from the shared library of each project and derive the necessary paths from it. The user can however overwrite this using the environment variables, and the configuration files.