### PR TITLE
Multiple commits

### DIFF
--- a/docs/news/news-v5.x.rst
+++ b/docs/news/news-v5.x.rst
@@ -12,7 +12,19 @@ series, in reverse chronological order.
                answers.
 
 Detailed changes include:
- - PR #3547: Update NEWS and headers for release
+ - PR #3568: Update NEWS for release
+ - PR #3567: Multiple commits
+    - Add new pub-lookup stress example
+    - Just ignore any lto settings
+    - Have show_help output all directories tried
+    - Extend the pubstress test and add it to CI
+    - Cleanup spawn and clarify attribute comment
+    - Properly handle OPAL_PREFIX
+ - PR #3562: Update OAC submodule
+ - PR #3556: Multiple commits
+    - Do not block in query upcall
+    - Further cleanup of "resolve" functions
+    - Silence error output when running as singleton - PR #3547: Update NEWS and headers for release
  - PR #3545: Multiple commits
     - Exit with correct status after displaying help or version
     - Revamp the query implementation

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Oak Ridge National Laboratory.  All rights reserved.
-# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2023-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -75,3 +75,13 @@ We attempted to remove a file, but were unable to do so:
 
   Path:  %s
   Error: %s
+#
+[failed-file-open]
+An attempt was made to open a shared memory backing file, but the
+attempt failed:
+
+  File:  %s
+  Error: %s
+
+The PMIx shared memory subsystem will be disabled, but your job will
+continue by using the "hash" subsystem.

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,7 +13,9 @@
 #include "pmix_common.h"
 #include "pmix_output.h"
 #include "src/include/pmix_globals.h"
+#include "src/mca/gds/base/base.h"
 #include "src/util/pmix_error.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
 
 #ifdef HAVE_FCNTL_H
@@ -62,6 +64,10 @@ segment_attach(
     const int fd = open(shmem->backing_path, O_RDWR);
     if (fd == -1) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
+        if (0 < pmix_output_get_verbosity(pmix_gds_base_framework.framework_output)) {
+            pmix_show_help("help-pmix-util.txt", "failed-file-open", true,
+                           shmem->backing_path, strerror(errno));
+        }
         goto out;
     }
 
@@ -88,7 +94,6 @@ out:
     }
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(shmem);
-        PMIX_ERROR_LOG(rc);
     }
     else {
         shmem->attached = true;


### PR DESCRIPTION
[Fix segfault on error in shmem2](https://github.com/openpmix/openpmix/commit/c79c06ee27321c8a4269c68cb56771e7ad2d5eb6)

If someone mistakenly provides an incorrect path for the
directory where we will be storing the shmem backing file
(e.g., pass a relative directory and then change the
working directory), then we segfault in shmem2 because
of a stale job object in the tracking system. So ensure
we cleanup the job object when that happens so we can
cleanly fallover to "hash".

Remove a bunch of error logs when this happens since we are
not going to fail, but instead continue running. Add some
debug output to report which file was attempted to be opened.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d8d8b69da85cc54e450373f61be1066e5b6345a2)


[Update NEWS](https://github.com/openpmix/openpmix/commit/d6fda007697115d0a958fd2399f0496fadec34e3)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick
