### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=5
 minor=0
-release=7
+release=8
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -118,5 +118,5 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=15:7:13
+libpmix_so_version=15:8:13
 

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,6 +157,10 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_TARGETS                "targets"                   // required
 #define PMIX_CLI_TERMINATE              "terminate"                 // none
 #define PMIX_CLI_PSET_NAME              "pset"                      // required
+#define PMIX_CLI_FWD_ENVAR              "x"                         // required
+#define PMIX_CLI_PREPEND_ENVAR          "prepend-env"               // required
+#define PMIX_CLI_APPEND_ENVAR           "append-env"                // required
+#define PMIX_CLI_UNSET_ENVAR            "unset-env"                 // required
 
 typedef void (*pmix_cmd_line_store_fn_t)(const char *name, const char *option,
                                          pmix_cli_result_t *results);


### PR DESCRIPTION
[Extend cmd line processor to deal with envar ops](https://github.com/openpmix/openpmix/commit/2b4434e2ee49ed7ed6948e40ae2663605782a6ff)

PMIx supports forward/set, unset, append, and prepend of
environmental variables. However, the cmd line processor
wasn't setup to handle cmd line options for that purpose.
Extend it to provide such support.

Forward (-x) of envars can be just the envar name (to pickup
the local value and forward it), or can be envar=value to
set the envar to a specific value.

Unset (--unset) takes just the name of the envar.

Append (--append-env) takes two arguments:
   * the name of the envar, appended with a "[c]" where
     the 'c' is the character to be used as the separator
     between envar values
   * the value to be appended
So it looks like "--append-env FOO[:] 20"

Prepend (--prepend-env) behaves exactly like append except
it prepends the value to whatever current envar value it finds

Multiple instances of any of these options may be present on
the cmd line. Each instance will have its arguments appended
to the parameter's pmix_cli_item_t's values argv-array.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c4694cbdf4252d7b6041de32504eb4b5e04f714e)

[Roll version to v5.0.8](https://github.com/openpmix/openpmix/commit/da4844dc551ca08d2734e52906b072008db9986c)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick