### PR TITLE
Cleanup for show-help system

### DIFF
--- a/src/util/convert-help.py
+++ b/src/util/convert-help.py
@@ -56,9 +56,9 @@ def find_files(root, verbose=False):
     source_files = []
     tool_help_files = []
     tool_source_files = []
-    # the tools need special treatment, so skip them here
+    # skip infrastructure directories
     skip_dirs = ['.git', '.libs', '.deps']
-    # there are some help files we want to ignore
+    # there may also be some help files we want to ignore
     skip_files = []
     for root_dir, dirs, files in os.walk(root):
         for sd in skip_dirs:
@@ -121,8 +121,12 @@ def parse_help_files(file_paths, data, citations, verbose=False):
                     continue
                 if current_section is None and not stripped:
                     continue
-                if stripped.startswith('[') and stripped.endswith(']'):
-                    current_section = stripped[1:-1]
+                if stripped.startswith('['):
+                    # find the end of the section name
+                    end = stripped.find(']', 1)
+                    if -1 == end:
+                        continue
+                    current_section = stripped[1:end]
                     sections[current_section] = list()
                 elif current_section is not None:
                     line = line.rstrip()

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -162,6 +162,17 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_APPEND_ENVAR           "append-env"                // required
 #define PMIX_CLI_UNSET_ENVAR            "unset-env"                 // required
 
+// Info options
+#define PMIX_CLI_INFO_ALL               "all"                       // none
+#define PMIX_CLI_INFO_ARCH              "arch"                      // none
+#define PMIX_CLI_INFO_CONFIG            "config"                    // none
+#define PMIX_CLI_INFO_HOSTNAME          "hostname"                  // none
+#define PMIX_CLI_INFO_INTERNAL          "internal"                  // none
+#define PMIX_CLI_INFO_PARAM             "param"                     // required
+#define PMIX_CLI_INFO_PATH              "path"                      // required
+#define PMIX_CLI_INFO_VERSION           "show-version"              // required
+
+
 typedef void (*pmix_cmd_line_store_fn_t)(const char *name, const char *option,
                                          pmix_cli_result_t *results);
 

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -574,12 +574,6 @@ pmix_status_t pmix_show_help_add_data(const char *project,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_show_help_add_dir(const char *directory)
-{
-    PMIX_HIDE_UNUSED_PARAMS(directory);
-    return PMIX_ERR_NOT_SUPPORTED;
-}
-
 pmix_status_t pmix_show_help_norender(const char *filename,
                                       const char *topic,
                                       const char *output)

--- a/src/util/pmix_show_help.h
+++ b/src/util/pmix_show_help.h
@@ -165,9 +165,6 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename,
 PMIX_EXPORT pmix_status_t pmix_show_help_add_data(const char *project,
                                                   pmix_show_help_file_t *array);
 
-// DEPRECATED
-PMIX_EXPORT pmix_status_t pmix_show_help_add_dir(const char *directory);
-
 // check for duplicate entries
 PMIX_EXPORT pmix_status_t pmix_help_check_dups(const char *filename,
                                                const char *topic);


### PR DESCRIPTION
Add cmd line definitions for use by pmix-info. Remove deprecated function to ensure that older versions of PRRTE don't mistakenly try to build against newer
versions of PMIx as the show-help system is incompatible.