### PR TITLE
Add explicit test for Python >= v3.7 in configure

### DIFF
--- a/.github/workflows/run-xversion.yml
+++ b/.github/workflows/run-xversion.yml
@@ -1,59 +1,213 @@
 name: OpenPMIx Cross Version Testing
 
-on:
-  pull_request:
-    # We don't need this to be run on all types of PR behavior
-    # See
-    #  - https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
-    #  - https://frontside.com/blog/2020-05-26-github-actions-pull_request
-    types:
-      - opened
-      - synchronize
-      - edited
-      - reopened
-
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: docker.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: jjhursey/pmix-xver-tester
+on: [pull_request]
 
 jobs:
-  xversion-client:
+  xversion:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        versions: ['master', 'v5.0', 'v4.2', 'v4.1', 'v3.2']
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Check out the code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      # Run the container tester
-      - name: Cross-version Client
-        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/pmix-pr-to-test --env PR_TARGET_BRANCH=${GITHUB_BASE_REF} ${{ env.IMAGE_NAME }}:latest /bin/bash -c "/home/pmixer/bin/run-xversion.sh --path /home/pmixer/pmix-pr-to-test -- --skip-tool"
-        shell: bash
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
 
-  xversion-tool:
-    runs-on: ubuntu-latest
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Check out the code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      # Run the container tester
-      - name: Cross-version Tool
-        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/pmix-pr-to-test --env PR_TARGET_BRANCH=${GITHUB_BASE_REF} ${{ env.IMAGE_NAME }}:latest /bin/bash -c "/home/pmixer/bin/run-xversion.sh --path /home/pmixer/pmix-pr-to-test -- --skip-client"
-        shell: bash
+    - name: Git clone PR
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            path: pr
+    - name: Build PR
+      run: |
+        cd pr
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/prinstall --disable-debug --enable-static --disable-shared --disable-dlopen --disable-per-user-config-files
+        make -j
+        make install
+        cd test
+        make
+        cd simple
+        make
 
-  xversion-check:
-    runs-on: ubuntu-latest
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Check out the code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      # Run the container tester
-      - name: Cross-version Make Check
-        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/pmix-pr-to-test --env PR_TARGET_BRANCH=${GITHUB_BASE_REF} ${{ env.IMAGE_NAME }}:latest /bin/bash -c "/home/pmixer/bin/run-xversion.sh --path /home/pmixer/pmix-pr-to-test -- --skip-client --skip-tool --make-check"
-        shell: bash
+    - name: Git clone branch
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: checkbranch
+            ref: ${{ matrix.versions }}
+    - name: Build branch
+      run: |
+        cd checkbranch
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/branchinstall --disable-debug --enable-static --disable-shared --disable-dlopen --disable-per-user-config-files
+        make -j
+        make install
+        cd test
+        make
+        cd simple
+        make
+
+    - name: PR-to-branch simple
+      run:  pr/test/simple/simptest -n 2 -xversion -e checkbranch/test/simple/simpclient
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch tool
+      run:  pr/test/simple/simptest -n 1 -xversion -e checkbranch/test/simple/simptool
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check0
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check1
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check2
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:0]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check3
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check4
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[0:]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check5
+      run:  pr/test/pmix_test -n 4 --ns-dist 3:1 --fence "[b | 0:]" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check6
+      run:  pr/test/pmix_test -n 4 --job-fence -c -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check7
+      run:  pr/test/pmix_test -n 4 --job-fence -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check8
+      run:  pr/test/pmix_test -n 2 --test-publish -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check9
+      run:  pr/test/pmix_test -n 2 --test-spawn -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check10
+      run:  pr/test/pmix_test -n 2 --test-connect -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check11
+      run:  pr/test/pmix_test -n 5 --test-resolve-peers --ns-dist "1:2:2" -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check12
+      run:  pr/test/pmix_test -n 5 --test-replace 100:0,1,10,50,99 -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: PR-to-branch check13
+      run:  pr/test/pmix_test -n 5 --test-internal 10 -e checkbranch/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR simple
+      run:  checkbranch/test/simple/simptest -n 2 -xversion -e pr/test/simple/simpclient
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR tool
+      run:  checkbranch/test/simple/simptest -n 1 -xversion -e pr/test/simple/simptool
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check0
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check1
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check2
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:0]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check3
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check4
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[0:]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check5
+      run:  checkbranch/test/pmix_test -n 4 --ns-dist 3:1 --fence "[b | 0:]" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check6
+      run:  checkbranch/test/pmix_test -n 4 --job-fence -c -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check7
+      run:  checkbranch/test/pmix_test -n 4 --job-fence -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check8
+      run:  checkbranch/test/pmix_test -n 2 --test-publish -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check9
+      run:  checkbranch/test/pmix_test -n 2 --test-spawn -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check10
+      run:  checkbranch/test/pmix_test -n 2 --test-connect -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check11
+      run:  checkbranch/test/pmix_test -n 5 --test-resolve-peers --ns-dist "1:2:2" -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check12
+      run:  checkbranch/test/pmix_test -n 5 --test-replace 100:0,1,10,50,99 -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+    - name: branch-to-PR check13
+      run:  checkbranch/test/pmix_test -n 5 --test-internal 10 -e pr/test/pmix_client
+      if:   ${{ true }}
+      timeout-minutes: 5
+
+

--- a/VERSION
+++ b/VERSION
@@ -35,6 +35,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
+python_min_version=3.7
 
 # PMIx Standard Compliance Level
 # The major and minor numbers indicate the version

--- a/autogen.pl
+++ b/autogen.pl
@@ -749,6 +749,11 @@ sub get_and_define_min_versions() {
                   export_version("FLEX", $fields[1]);
               }
           }
+          elsif($fields[0] eq "python_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PYTHON", $fields[1]);
+              }
+          }
     }
     close(IN);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 # Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -53,6 +53,11 @@ AC_CONFIG_AUX_DIR(./config)
 AC_CONFIG_MACRO_DIRS([./config config/oac])
 
 AC_PROG_SED
+
+AC_CHECK_PROG([PERL],[perl],[perl],[no])
+AS_IF([test "X$PERL" = "Xno"],
+      [AC_MSG_ERROR([OpenPMIx requires perl to build. Aborting.])])
+
 
 # autotools expects to perform tests without interference
 # from user-provided CFLAGS, particularly -Werror flags.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ automake_min_version = f"{opmix_data['automake_min_version']}"
 autoconf_min_version = f"{opmix_data['autoconf_min_version']}"
 libtool_min_version = f"{opmix_data['libtool_min_version']}"
 flex_min_version = f"{opmix_data['flex_min_version']}"
+python_min_version = f"{opmix_data['python_min_version']}"
 
 # "release" is a sphinx config variable: assign it to the computed
 # OpenPMIx version number.  The opmix_ver string begins with a "v"; the
@@ -205,6 +206,7 @@ rst_prolog = f"""
 .. |autoconf_min_version| replace:: {autoconf_min_version}
 .. |libtool_min_version| replace:: {libtool_min_version}
 .. |flex_min_version| replace:: {flex_min_version}
+.. |python_min_version| replace:: {python_min_version}
 
 """
 

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -43,6 +43,24 @@ build them manually, see the :ref:`how to build and install GNU
 Autotools section <developers-installing-autotools-label>` for much
 more detail.
 
+Python
+------
+
+When building from a Git clone, Python >= |python_min_version| is
+required for several tasks during the PMIx build, such as (but not
+limited to):
+
+  * Generating the "show help" messages
+
+  * Generating the attribute dictionary
+
+  * Building the Open MPI documentation and man pages
+
+All of these are necessary when building from a Git clone.  Most of
+these can be accomplished with core Python; only building the full
+OpenPMIx documentation and man pages requires additional Python
+packages (:ref:`see below <developers-requirements-sphinx-label>`).
+
 Perl
 ----
 
@@ -84,8 +102,10 @@ MacPorts on MacOS), see `the Flex Github repository
 <https://github.com/westes/flex>`_.
 
 
-Sphinx (and therefore Python)
------------------------------
+.. _developers-requirements-sphinx-label:
+
+Sphinx
+------
 
 `Sphinx <https://www.sphinx-doc.org/>`_ is a Python-based tool used to
 generate both the HTML version of the documentation (that you are

--- a/docs/installing-pmix/quickstart.rst
+++ b/docs/installing-pmix/quickstart.rst
@@ -25,6 +25,9 @@ to support its `autoconf` logic. You can, however, omit the explicit
 submodule update step `if` you cloned the Git repository with the
 ``--recursive`` flag.
 
+OpenPMIx requires Perl and Python >= |python_min_version| to build
+from a Git clone.
+
 You will need very recent versions of GNU Autoconf, Automake, and
 Libtool.  If ``autogen.pl`` fails, read the :doc:`Developer's Guide
 </developers/index>`.  If anything else fails, read the


### PR DESCRIPTION
PMIx now requires Python to build when:

  * in a Git clone for building:
    * the attribute dictionary (pmix_dictionary.h)
    * the show-help in-memory text (pmix_show_help_content.c)

  * Python bindings are requested

Check for an adequate Python version for these cases.