### PR TITLE
Decrease min Py version to 3.6

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -35,7 +35,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
-python_min_version=3.7
+python_min_version=3.6
 
 # PMIx Standard Compliance Level
 # The major and minor numbers indicate the version

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1264,6 +1264,7 @@ AS_IF([test "$pmix_need_python" = "yes"],
       [AM_PATH_PYTHON([$pmix_python_min_version],
                       [pmix_have_good_python=1],
                       [AC_MSG_ERROR([OpenPMIx requires Python >= $pmix_python_min_version to build. Aborting.])])
+       PMIX_SUMMARY_ADD([[Required Packages]], [Python], [], [yes ($[PYTHON_VERSION])])
       ])
 
 AS_IF([test "$pmix_want_python_bindings" = "yes" && test $pmix_have_good_python -eq 0],

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -124,6 +124,9 @@ libpmix_util_la_DEPENDENCIES = \
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)
 
+clean-local:
+	rm -f pmix_show_help_content.c pmix_show_help_content.lo
+
 MAINTAINERCLEANFILES = \
 	pmix_show_help_content.c
 


### PR DESCRIPTION
Decrease the minimum required Python version to 3.6. Ensure we cleanup the pmix_show_help_content.c file when executing "make clean".