### PR TITLE
Use pthread_np.h on platforms where it is required

### DIFF
--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -19,7 +19,12 @@
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
 #endif
+
 #include <pthread.h>
+#if (defined(__FreeBSD__) || defined(__OpenBSD__)) && defined(HAVE_PTHREAD_SETAFFINITY_NP)
+#    include <pthread_np.h>
+#endif
+    
 #include <string.h>
 #include <event.h>
 


### PR DESCRIPTION
I encountered an error attempting to cross compile for FreeBSD. On some of the BSDs pthread extensions are not found in `pthread.h` but in `pthread.np.h`. For reference here is that error:

```
runtime/pmix_progress_threads.c:176:14: error: call to undeclared function 'pthread_setaffinity_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  176 |         rc = pthread_setaffinity_np(trk->engine.t_handle, sizeof(cpu_set_t), &cpuset);
      |              ^
2 errors generated.
make[2]: *** [Makefile:1235: runtime/pmix_progress_threads.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Adding `#include <pthread_np.h>` seems to get compilation working. Note I haven't tested this on an actual FreeBSD machine, however perusing GitHub this seems like a very common pattern to enable pthreads on FreeBSD, and the FreeBSD manpages indicate this is correct.