### PR TITLE
Add a PMIX_FWD_ENVIRONMENT attribute

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -562,7 +562,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        first non-zero status returned by either primary or child jobs.
 #define PMIX_SPAWN_CHILD_SEP                "pmix.spchildsep"       // (bool) Treat the spawned job as independent from the parent - i.e, do not
                                                                     //        terminate the spawned job if the parent terminates.
-
+#define PMIX_FWD_ENVIRONMENT                "pmix.fwdenv"           // (bool) Forward the local environment to each spawned process
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */


### PR DESCRIPTION
Used in spawn to request that the entire environment at the launcher be forwarded to all processes being spawned. Note that we don't take the client's environ because it probably contains a bunch of proc-specific envars and we don't want to create confusion.