### PR TITLE
Check for pthread_np.h header

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -703,14 +703,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     #
     PMIX_CONFIG_THREADS
 
-    CFLAGS="$CFLAGS $THREAD_CFLAGS"
-    CPPFLAGS="$CPPFLAGS $THREAD_CPPFLAGS"
-    LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
-    LIBS="$LIBS $THREAD_LIBS"
-
-    PMIX_WRAPPER_FLAGS_ADD([CFLAGS], [$THREAD_CFLAGS])
-    PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$THREAD_LDFLAGS])
-
     #
     # What is the local equivalent of "ln -s"
     #
@@ -720,9 +712,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Check for some common system programs that we need
     AC_PROG_GREP
     AC_PROG_EGREP
-
-    # This check must come after PMIX_CONFIG_THREADS
-    AC_CHECK_FUNCS([pthread_setaffinity_np])
 
     # Setup HTML and man page processing
     OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [],

--- a/config/pmix_config_threads.m4
+++ b/config/pmix_config_threads.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2025      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -62,7 +63,22 @@ THREAD_LIBS="$PTHREAD_LIBS"
 
 PMIX_CHECK_PTHREAD_PIDS
 
-AC_DEFINE_UNQUOTED([PMIX_ENABLE_MULTI_THREADS], [1],
-                   [Whether we should enable thread support within the PMIX code base])
+#update the flags
+CFLAGS="$CFLAGS $THREAD_CFLAGS"
+CPPFLAGS="$CPPFLAGS $THREAD_CPPFLAGS"
+LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
+LIBS="$LIBS $THREAD_LIBS"
+
+PMIX_WRAPPER_FLAGS_ADD([CFLAGS], [$THREAD_CFLAGS])
+PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$THREAD_LDFLAGS])
+
+# Check for the setaffinity function - must come after
+# we update the flags
+AC_CHECK_FUNCS([pthread_setaffinity_np])
+
+# Some folks apparently split that function definition
+# into a separate header, even though they leave the
+# function in pthreads.h. Go figure.
+AC_CHECK_HEADERS([pthread_np.h])
 
 ])dnl

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -20,6 +20,9 @@
 #    include <unistd.h>
 #endif
 #include <pthread.h>
+#ifdef HAVE_PTHREAD_NP_H
+#    include <pthread_np.h>
+#endif
 #include <string.h>
 #include <event.h>
 


### PR DESCRIPTION
We use the pthread_setaffinity_np function if it is found in the standard pthread library. Apparently, however, some folks split the definition of that function from pthreads.h into a separate header, even though they leave the function itself in the pthread library. Go figure.