### PR TITLE
First set of API updates

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -435,6 +435,8 @@ static void cbcon(pmix_cb_t *p)
     p->nprocs = 0;
     p->info = NULL;
     p->ninfo = 0;
+    p->directives = NULL;
+    p->ndirs = 0;
     p->dist = NULL;
     p->infocopy = false;
     p->nvals = 0;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -688,6 +688,8 @@ typedef struct {
     size_t nprocs;
     pmix_info_t *info;
     size_t ninfo;
+    pmix_info_t *directives;
+    size_t ndirs;
     pmix_device_distance_t *dist;
     bool infocopy;
     size_t nvals;


### PR DESCRIPTION
Ensure that any upcall from the API is executed in the PMIx progress thread context. Protect any callback to process it in that context (as opposed to the host's).

Covers alloc, resblock, attribute, control, monitor, and event registration functions.