### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=6
 minor=0
-release=0
+release=1
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -120,7 +120,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=20:0:18
+libpmix_so_version=20:1:18
 
 # "Common" components install standalone libraries that are run-time
 # # linked by one or more components.  So they need to be versioned as

--- a/VERSION
+++ b/VERSION
@@ -35,7 +35,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
-python_min_version=3.7
+python_min_version=3.6
 
 # PMIx Standard Compliance Level
 # The major and minor numbers indicate the version

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -703,14 +703,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     #
     PMIX_CONFIG_THREADS
 
-    CFLAGS="$CFLAGS $THREAD_CFLAGS"
-    CPPFLAGS="$CPPFLAGS $THREAD_CPPFLAGS"
-    LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
-    LIBS="$LIBS $THREAD_LIBS"
-
-    PMIX_WRAPPER_FLAGS_ADD([CFLAGS], [$THREAD_CFLAGS])
-    PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$THREAD_LDFLAGS])
-
     #
     # What is the local equivalent of "ln -s"
     #
@@ -720,9 +712,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Check for some common system programs that we need
     AC_PROG_GREP
     AC_PROG_EGREP
-
-    # This check must come after PMIX_CONFIG_THREADS
-    AC_CHECK_FUNCS([pthread_setaffinity_np])
 
     # Setup HTML and man page processing
     OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [],

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1264,6 +1264,7 @@ AS_IF([test "$pmix_need_python" = "yes"],
       [AM_PATH_PYTHON([$pmix_python_min_version],
                       [pmix_have_good_python=1],
                       [AC_MSG_ERROR([OpenPMIx requires Python >= $pmix_python_min_version to build. Aborting.])])
+       PMIX_SUMMARY_ADD([[Required Packages]], [Python], [], [yes ($[PYTHON_VERSION])])
       ])
 
 AS_IF([test "$pmix_want_python_bindings" = "yes" && test $pmix_have_good_python -eq 0],

--- a/config/pmix_config_threads.m4
+++ b/config/pmix_config_threads.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2025      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -62,7 +63,22 @@ THREAD_LIBS="$PTHREAD_LIBS"
 
 PMIX_CHECK_PTHREAD_PIDS
 
-AC_DEFINE_UNQUOTED([PMIX_ENABLE_MULTI_THREADS], [1],
-                   [Whether we should enable thread support within the PMIX code base])
+#update the flags
+CFLAGS="$CFLAGS $THREAD_CFLAGS"
+CPPFLAGS="$CPPFLAGS $THREAD_CPPFLAGS"
+LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
+LIBS="$LIBS $THREAD_LIBS"
+
+PMIX_WRAPPER_FLAGS_ADD([CFLAGS], [$THREAD_CFLAGS])
+PMIX_WRAPPER_FLAGS_ADD([LDFLAGS], [$THREAD_LDFLAGS])
+
+# Check for the setaffinity function - must come after
+# we update the flags
+AC_CHECK_FUNCS([pthread_setaffinity_np])
+
+# Some folks apparently split that function definition
+# into a separate header, even though they leave the
+# function in pthreads.h. Go figure.
+AC_CHECK_HEADERS([pthread_np.h])
 
 ])dnl

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -562,7 +562,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        first non-zero status returned by either primary or child jobs.
 #define PMIX_SPAWN_CHILD_SEP                "pmix.spchildsep"       // (bool) Treat the spawned job as independent from the parent - i.e, do not
                                                                     //        terminate the spawned job if the parent terminates.
-
+#define PMIX_FWD_ENVIRONMENT                "pmix.fwdenv"           // (bool) Forward the local environment to each spawned process
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -101,3 +101,6 @@ $(libpmixglobal_gen): $(abs_top_srcdir)/include/pmix_common.h.in \
 	        $(PMIX_V_GEN) $(PYTHON) $(abs_top_srcdir)/contrib/construct_event_strings.py
 
 MAINTAINERCLEANFILES = $(libpmixglobal_gen)
+
+clean-local:
+	rm -f pmix_dictionary.h pmix_dictionary.c pmix_event_strings.h pmix_event_strings.c

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -20,6 +20,9 @@
 #    include <unistd.h>
 #endif
 #include <pthread.h>
+#ifdef HAVE_PTHREAD_NP_H
+#    include <pthread_np.h>
+#endif
 #include <string.h>
 #include <event.h>
 

--- a/src/tools/wrapper/help-pmixcc.txt
+++ b/src/tools/wrapper/help-pmixcc.txt
@@ -39,6 +39,7 @@ PMIx wrapper compiler
   --showme:libdirs         Show list of library dirs added when linking
   --showme:libdirs_static  Show list of static library dirs added when linking
   --showme:libs            Show list of libraries added when linking
+  --showme:libs_static     Show list of static libraries added when linking
   --showme:version         Show version of %s
   --showme:help            This help message
 
@@ -93,6 +94,10 @@ Show list of static library dirs added when linking
 [showme:libs]
 
 Show list of libraries added when linking
+#
+[showme:libs_static]
+
+Show list of static libraries added when linking
 #
 [showme:version]
 

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -124,6 +124,9 @@ libpmix_util_la_DEPENDENCIES = \
 pmixdir = $(pmixincludedir)/$(subdir)
 pmix_HEADERS = $(headers)
 
+clean-local:
+	rm -f pmix_show_help_content.c pmix_show_help_content.lo
+
 MAINTAINERCLEANFILES = \
 	pmix_show_help_content.c
 

--- a/src/util/convert-help.py
+++ b/src/util/convert-help.py
@@ -45,7 +45,7 @@ def find_files(root, verbose=False):
     # Check for existence of root directory - otherwise, we just
     # fall through with no error output
     if not os.path.isdir(root):
-        sys.stderr.write("Root directory " + root + " does not exist\nCannot continue")
+        sys.stderr.write("Root directory " + root + " does not exist\nCannot continue\n")
         exit(1)
 
     # Search for help-*.txt files across the source tree, skipping
@@ -133,7 +133,7 @@ def parse_help_files(file_paths, data, citations, verbose=False):
                     sections[current_section].append(line)
 
         if file_path in data:
-            sys.stderr.write("ERROR: path", file_path, "already exists in data dictionary")
+            sys.stderr.write("ERROR: path " + file_path + " already exists in data dictionary\n")
         else:
             data[file_path] = sections
         if verbose:
@@ -197,7 +197,7 @@ def parse_src_files(source_files, citations, verbose=False):
                             continue
                         else:
                             cont_filename = False
-                            sys.stderr.write("ERROR: Missing end of filename")
+                            sys.stderr.write("ERROR: Missing end of filename\n")
                             continue
 
                 if "pmix_show_help(" in line or "pmix_show_help_string(" in line:
@@ -312,7 +312,7 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                             cli.append(lsrc[start:end])
 
         if not found:
-            sys.stderr.write("WARNING: No corresponding source code found for help file ", hlp)
+            sys.stderr.write("WARNING: No corresponding source code found for help file " + hlp + "\n")
             exit(1)
 
         # convert the CLI to strings so we can check the options and topics
@@ -334,7 +334,7 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                         break
             if not found:
                 # unrecognized option
-                sys.stderr.write("WARNING: Unrecognized command line option ", c, "in source code", os.path.basename(src))
+                sys.stderr.write("WARNING: Unrecognized command line option " + c + " in source code " + os.path.basename(src) + "\n")
                 exit(1)
 
         # check the cli and options to ensure they match
@@ -346,7 +346,7 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                     found = True
                     break
             if not found:
-                sys.stderr.write("WARNING: Option", option, "has no corresponding CLI defined for", tool)
+                sys.stderr.write("WARNING: Option " + option + " has no corresponding CLI defined for " + tool + "\n")
                 exit(1)
 
         # reverse must also be true
@@ -362,7 +362,7 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                     found = True
                     break
             if not found:
-                sys.stderr.write("WARNING: CLI definition", c, "has no corresponding help entry in", os.path.basename(hlp))
+                sys.stderr.write("WARNING: CLI definition " + c + " has no corresponding help entry in " + os.path.basename(hlp) + "\n")
                 exit(1)
 
         # also require that there be a topic for each option so that
@@ -382,7 +382,7 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                     citations.append((os.path.basename(hlp), option))
                     break
             if not found:
-                sys.stderr.write("WARNING: Option", option, "has no topic entry in", os.path.basename(hlp))
+                sys.stderr.write("WARNING: Option " + option + " has no topic entry in " + os.path.basename(hlp) + "\n")
 
 
 def purge(parsed_data, citations):
@@ -408,11 +408,11 @@ def purge(parsed_data, citations):
                     if sec == section:
                         if content == cnt:
                             # these are the same
-                            sys.stderr.write("DUPLICATE FOUND - SECTION: ", section, "FILES: ", filename, file2)
+                            sys.stderr.write("DUPLICATE FOUND - SECTION: " + section + "\nFILES: " + filename + "\n       " + file2 + "\n")
                             errorFound = True
                         else:
                             # same topic, different content
-                            sys.stderr.write("DUPLICATE SECTION WITH DIFFERENT CONTENT: ", section, "FILES: ", filename, file2)
+                            sys.stderr.write("DUPLICATE SECTION WITH DIFFERENT CONTENT: " + section, "\nFILES: " + filename + "\n       " + file2 + "\n")
                             errorFound = True
             # search code files for usage
             # protect special values
@@ -429,16 +429,16 @@ def purge(parsed_data, citations):
                     used = True
                     break;
             if not used:
-                sys.stderr.write("** WARNING: Unused help topic")
-                sys.stderr.write("    File: ", filename)
-                sys.stderr.write("    Section: ", section)
+                sys.stderr.write("** WARNING: Unused help topic\n")
+                sys.stderr.write("    File: " + filename + "\n")
+                sys.stderr.write("    Section: " + section + "\n")
                 errorFound = True
         # see if anything is left
         if 0 < len(result_sections):
             # don't retain the file if no citations for it are left
             result_data[filename] = result_sections
         else:
-            sys.stderr.write("File ", filename, "has no used topics - omitting")
+            sys.stderr.write("File " + filename + "has no used topics - omitting\n")
             errorFound = True
 
     if errorFound:
@@ -510,7 +510,7 @@ def main():
     # the options are in root/util/pmix_cmd_line.h
     path = os.path.join(rootdir, "util", "pmix_cmd_line.h")
     if not os.path.exists(path):
-        sys.stderr.write("File " + path + " does not exist\nCannot continue")
+        sys.stderr.write("File " + path + " does not exist\nCannot continue\n")
         exit(1)
     # obtain a list of (option name, string) tuples
     cli_options = parse_cmd_line_options(path, args.verbose)


### PR DESCRIPTION
[Update VERSION to v6.0.1](https://github.com/openpmix/openpmix/commit/4da127c31ab856f68f90c147d8f88dfe3681fe6e)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick

[Fix the wrapper compiler](https://github.com/openpmix/openpmix/commit/2960805584c016b3e1ba7d57a38c124ba3456f44)

Cannot use the cmd line parser as the wrapper compiler must
accept all options for the underlying system compiler. Also
cleanup a bunch of formatting crud

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/824058daae3449e02dacda9f4d0abe94db544d60)

[Decrease min Py version to 3.6](https://github.com/openpmix/openpmix/commit/2116dd7df4521b6697c17562244826054db982c1)

Decrease the minimum required Python version to 3.6.
Ensure we cleanup the pmix_show_help_content.c file
when executing "make clean".

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/b50dfb18ac6a28128a97b96f2ce0b4d86bf17ef8)

[Delete built files on "make clean"](https://github.com/openpmix/openpmix/commit/5e769353c68060e7898b25de65fa7614adca6b6b)

Missed a few files

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/cab097fcc585a3bbcd205c2a2368a5aaf7b4126c)

[Add a PMIX_FWD_ENVIRONMENT attribute](https://github.com/openpmix/openpmix/commit/9d9b797244cf8ab2d003d110172c041a4b688263)

Used in spawn to request that the entire environment
at the launcher be forwarded to all processes being
spawned. Note that we don't take the client's environ
because it probably contains a bunch of proc-specific
envars and we don't want to create confusion.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7e9b1cdca47cc03fbab058de8efc3715aa83b521)

[Check for pthread_np.h header](https://github.com/openpmix/openpmix/commit/54951ace6c600149cdb6674ca0eccbd61b569f5f)

We use the pthread_setaffinity_np function if it is
found in the standard pthread library. Apparently,
however, some folks split the definition of that function
from pthreads.h into a separate header, even though they
leave the function itself in the pthread library. Go figure.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/829f0bb5b06e460633bff7572a17dd47b48d88da)
