### PR TITLE
Provide better singleton support and support blocking event notify

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -788,6 +788,13 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         /* set our server ID to be ourselves */
         pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
         pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
+        pmix_client_globals.myserver->nptr->nspace = strdup(pmix_globals.myid.nspace);
+        pmix_client_globals.myserver->info->uid = pmix_globals.uid;
+        pmix_client_globals.myserver->info->gid = pmix_globals.gid;
+        // set the compat entries to the same as mine
+        memcpy(&pmix_client_globals.myserver->nptr->compat,
+               &pmix_globals.mypeer->nptr->compat,
+               sizeof(pmix_personality_t));
         /* mark that the server is unreachable */
         rc = PMIX_ERR_UNREACH;
     } else if (PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -273,9 +273,19 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
             cb2.copy = false;
             PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb2);
             if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&cb2);
-                goto moveon;
+                if (!PMIX_GDS_CHECK_COMPONENT(pmix_client_globals.myserver, "hash")) {
+                    /* check the data in my hash module */
+                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_DESTRUCT(&cb2);
+                        goto moveon;
+                    }
+                } else {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DESTRUCT(&cb2);
+                    goto moveon;
+                }
             }
             if (0 < pmix_list_get_size(&cb2.kvs)) {
                 // pack to send it along


### PR DESCRIPTION
Set a few more server fields when client is operating as a singleton. When the connect function is attempting to retrieve job-level info, check both the server and local GDS components if necessary. Calling PMIx_Notify_event with a NULL callback function indicates the user is requesting a blocking operation, so support that request.