### PR TITLE
Properly trigger the "keepalive failed" event

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -126,22 +126,30 @@ static char *gds_mode = NULL;
 static pid_t mypid;
 static pmix_proc_t myparent;
 
+static void _pdiedcb(pmix_status_t status, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_RELEASE(cb);
+}
+
 static void pdiedfn(int fd, short flags, void *arg)
 {
-    pmix_info_t info[2];
     pmix_proc_t keepalive;
-
+    pmix_cb_t *cb;
     PMIX_HIDE_UNUSED_PARAMS(fd, flags, arg);
 
     PMIX_LOAD_PROCID(&keepalive, "PMIX_KEEPALIVE_PIPE", PMIX_RANK_UNDEF);
 
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
-
     /* generate a job-terminated event */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->ninfo = 2;
+    PMIX_INFO_CREATE(cb->info, cb->ninfo);
+    PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
-                      PMIX_RANGE_PROC_LOCAL, info, 2,
-                      NULL, NULL);
+                      PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
+                      _pdiedcb, (void*)cb);
 }
 
 static void server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,


### PR DESCRIPTION
Need to retain the info structs passed to
PMIx_Notify_event until the callback is
executed.