### PR TITLE
Ensure cleanup of allocated pmix_info_t

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -147,6 +147,7 @@ static void pdiedfn(int fd, short flags, void *arg)
     PMIX_INFO_CREATE(cb->info, cb->ninfo);
     PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
+    cb->infocopy = true; // ensure cleanup
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
                       PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
                       _pdiedcb, (void*)cb);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -100,6 +100,7 @@ static void pdiedfn(int fd, short flags, void *arg)
     PMIX_INFO_CREATE(cb->info, cb->ninfo);
     PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
+    cb->infocopy = true;  // ensure cleanup
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
                       PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
                       _pdiedcb, (void*)cb);


### PR DESCRIPTION
The pmix_cb_t destructor will release the info
array if the infocopy field is set to true.