### PR TITLE
Cleanup some group docs

### DIFF
--- a/docs/how-things-work/sets_groups/group_construct.rst
+++ b/docs/how-things-work/sets_groups/group_construct.rst
@@ -144,10 +144,11 @@ API, and are *required* to include the
 ``PMIX_GROUP_BOOTSTRAP`` attribute in their array of ``pmix_info_t``
 directives, with the value in that attribute set to equal the number
 of leaders in the group construct operation. They may also provide the
-``PMIX_ADD_MEMBERS`` attribute with an array of process IDs that are to
+``PMIX_GROUP_ADD_MEMBERS`` attribute with an array of process IDs that are to
 belong to the final group - each of those processes will also call the group
 construct, but with a ``NULL`` process ID to indicate they are joining
-as "add members" and not leaders.
+as "add members" and not leaders. Construction will complete once all
+leaders and "add members" have participated.
 
 An example of the bootstrap method can be seen in the
 :ref:`group_bootstrap.c <group-bootstrap-example-label>` example taken from the PMIx library.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1151,10 +1151,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_GROUP_ADD_MEMBERS              "pmix.grp.add"          // (pmix_data_array_t*) Array of pmix_proc_t identifying procs that are not
                                                                     //        included in the membership specified in the procs array passed to
                                                                     //        the PMIx_Group_construct[_nb] call, but are to be included in the
-                                                                    //        final group. The identified procs will be sent an invitation to
-                                                                    //        join the group during the construction procedure. This is used when
-                                                                    //        some members of the proposed group do not know the full membership
-                                                                    //        and therefore cannot include all members in the call to construct.
+                                                                    //        final group. See PMIX_GROUP_BOOTSTRAP for description of this operation.
 #define PMIX_GROUP_BOOTSTRAP                "pmix.grp.btstrp"       // (size_t) Group construct call will not include all members as individual
                                                                     //        participants don't know the entire list. The provided number indicates
                                                                     //        the number of procs that will start the construction. Additional


### PR DESCRIPTION
Correct the group bootstrap procedure descriptions to indicate that "add members" must call group_construct.