### PR TITLE
Prevent show-help from using IOF too soon

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -241,7 +241,8 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_client_globals.iof_output, "pmix:iof:PULL");
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof:PULL");
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,7 +119,7 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
 
 
     PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, cbfunc, cbdata);
-    
+
 #if 0
     /* check to see if there are any relevant directives */
     for (n = 0; n < ndirs; n++) {

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -683,7 +683,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         return PMIX_ERR_NOMEM;
     }
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: init called");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: init called");
 
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         /* if we are a client, then we need to pickup the

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -43,6 +43,7 @@ static time_t show_help_time_last_displayed = 0;
 static bool show_help_timer_set = false;
 static pmix_event_t show_help_timer_event;
 static int output_stream = -1;
+static bool pmix_show_help_initialized = false;
 
 /* How long to wait between displaying duplicate show_help notices */
 static struct timeval show_help_interval = {5, 0};
@@ -67,7 +68,9 @@ static void local_delivery(const char *file,
 {
     pmix_shift_caddy_t *cd;
 
-    if (!pmix_show_help_enabled || NULL == pmix_globals.evbase) {
+    if (!pmix_show_help_initialized ||
+        !pmix_show_help_enabled ||
+        NULL == pmix_globals.evbase) {
         /* the show help subsystem has not yet been enabled,
          * likely because we haven't gotten far enough thru
          * client/server/tool "init". In this case, we can
@@ -350,7 +353,7 @@ pmix_status_t pmix_show_help_init(void)
     pmix_output_stream_t lds;
     tuple_array_item_t *da;
 
-    if (pmix_show_help_enabled) {
+    if (pmix_show_help_initialized) {
         return PMIX_SUCCESS;
     }
 
@@ -365,14 +368,14 @@ pmix_status_t pmix_show_help_init(void)
     da->array = pmix_show_help_data;
     pmix_list_append(&data_arrays, &da->super);
 
-    pmix_show_help_enabled = true;
+    pmix_show_help_initialized = true;
 
     return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_show_help_finalize(void)
 {
-    if (!pmix_show_help_enabled) {
+    if (!pmix_show_help_initialized) {
         return PMIX_SUCCESS;
     }
 
@@ -381,7 +384,7 @@ pmix_status_t pmix_show_help_finalize(void)
 
     PMIX_LIST_DESTRUCT(&abd_tuples);
     PMIX_LIST_DESTRUCT(&data_arrays);
-    pmix_show_help_enabled = false;
+    pmix_show_help_initialized = false;
 
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
The show-help system is routed thru the IOF subsystem for local output. However, if a show-help is generated prior to the IOF being fully setup, then we need to output the message directly thru stderr. Manage the "enabled" flags to ensure that happens.