### PR TITLE
Change default show-load-errors to "none"

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -791,8 +791,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                 mca_base_component_show_load_errors (but
                                 can be overridden at run time by the usual
                                 MCA-variable-setting mechansism).
-                                (default: "all")])])
-
+                                (default: "none")])],
+                                [], [with_show_load_errors=no])
     if test -z "$with_show_load_errors" || \
        test "$with_show_load_errors" = "yes"; then
         with_show_load_errors=all


### PR DESCRIPTION
We treat a NULL string as boolean "true", which means that the show-load-errors param was defaulting to "all". Change the default configuration option --with-show-load-errors to be "none" so we avoid that behavior.

Refs https://github.com/open-mpi/ompi/issues/13314