### PR TITLE
Work on enabling "pty" behaviors

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -563,6 +563,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SPAWN_CHILD_SEP                "pmix.spchildsep"       // (bool) Treat the spawned job as independent from the parent - i.e, do not
                                                                     //        terminate the spawned job if the parent terminates.
 #define PMIX_FWD_ENVIRONMENT                "pmix.fwdenv"           // (bool) Forward the local environment to each spawned process
+#define PMIX_SPAWN_PTY                      "pmix.spawn.pty"        // (bool) Spawn a pseudo-terminal
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */

--- a/src/mca/pmdl/base/pmdl_base_stubs.c
+++ b/src/mca/pmdl/base/pmdl_base_stubs.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,8 +106,7 @@ pmix_status_t pmix_pmdl_base_harvest_envars(char *nspace, const pmix_info_t info
         pmix_list_append(ilist, &kv->super);
     }
 
-    if (NULL != nspace) {
-        nptr = NULL;
+    if (NULL != nspace && 0 < strlen(nspace)) {
         /* find this nspace - note that it may not have
          * been registered yet */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {


### PR DESCRIPTION
Fix a spot where we incorrectly add a zero-length nspace to the global nspace list. Ensure "raw" output doesn't get exposed to the residual line-buffering logic. Add an attribute to indicate that the user is requesting spawning of a PTY - not used yet, but will be wired in a little later.