### PR TITLE
Continue work on pty support

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -630,6 +630,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     # Darwin doesn't need -lutil, as it's something other than this -lutil.
     PMIX_SEARCH_LIBS_CORE([openpty], [util])
+    PMIX_SEARCH_LIBS_CORE([forkpty], [util])
 
     PMIX_SEARCH_LIBS_CORE([gethostbyname], [nsl])
 
@@ -644,7 +645,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # -lrt might be needed for clock_gettime
     PMIX_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty setenv fork execve waitpid atexit])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty setenv fork execve waitpid atexit forkpty posix_openpt fileno_unlocked])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -564,6 +564,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        terminate the spawned job if the parent terminates.
 #define PMIX_FWD_ENVIRONMENT                "pmix.fwdenv"           // (bool) Forward the local environment to each spawned process
 #define PMIX_SPAWN_PTY                      "pmix.spawn.pty"        // (bool) Spawn a pseudo-terminal
+#define PMIX_PTY_TERMIO                     "pmix.pty.termio"       // (pmix_byte_object_t) Contents of a termio structure
+#define PMIX_PTY_WSIZE                      "pmix.pty.wsize"        // (pmix_byte_object_t) Contents of a window size structure
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -66,10 +66,10 @@
 #include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_environ.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
-#include "src/util/pmix_environ.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -67,7 +67,8 @@ headers = \
         pmix_pty.h \
         pmix_few.h \
         pmix_string_copy.h \
-        pmix_getcwd.h
+        pmix_getcwd.h \
+        pmix_tty.h
 
 sources = \
         pmix_alfg.c \
@@ -98,7 +99,8 @@ sources = \
         pmix_pty.c \
         pmix_few.c \
         pmix_string_copy.c \
-        pmix_getcwd.c
+        pmix_getcwd.c \
+        pmix_tty.c
 
 pmix_show_help_content.c: convert-help.py
 if PMIX_PICKY_COMPILERS

--- a/src/util/pmix_fd.c
+++ b/src/util/pmix_fd.c
@@ -282,3 +282,31 @@ slow:
         }
     }
 }
+
+int pmix_fd_dup2(int src, int target)
+{
+    int ret;
+
+#ifdef HAVE_FILENO_UNLOCKED
+    if (0 == target) {
+        ret = dup2(src, fileno_unlocked(stdin));
+    } else if (1 == target) {
+        ret = dup2(src, fileno_unlocked(stdout));
+    } else if (2 == target) {
+        ret = dup2(src, fileno_unlocked(stderr));
+    } else {
+        ret = dup2(src, target);
+    }
+#else
+    if (0 == target) {
+        ret = dup2(src, fileno(stdin));
+    } else if (1 == target) {
+        ret = dup2(src, fileno(stdout));
+    } else if (2 == target) {
+        ret = dup2(src, fileno(stderr));
+    } else {
+        ret = dup2(src, target);
+    }
+#endif
+    return ret;
+}

--- a/src/util/pmix_fd.h
+++ b/src/util/pmix_fd.h
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,6 +105,8 @@ PMIX_EXPORT bool pmix_fd_is_blkdev(int fd);
 PMIX_EXPORT void pmix_close_open_file_descriptors(int protected_fd);
 
 PMIX_EXPORT const char *pmix_fd_get_peer_name(int fd);
+
+PMIX_EXPORT int pmix_fd_dup2(int src, int target);
 
 END_C_DECLS
 

--- a/src/util/pmix_tty.c
+++ b/src/util/pmix_tty.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#ifdef HAVE_SYS_CDEFS_H
+#    include <sys/cdefs.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_IOCTL_H
+#    include <sys/ioctl.h>
+#endif
+#ifdef HAVE_TERMIOS_H
+#    include <termios.h>
+#else
+#    ifdef HAVE_TERMIO_H
+#        include <termio.h>
+#    endif
+#endif
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#ifdef HAVE_UTIL_H
+#    include <util.h>
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_tty.h"
+
+pmix_status_t pmix_gettermios(int fd, struct termios *terms)
+{
+    int rc;
+
+    rc = tcgetattr(fd, terms);
+    if (0 == rc) {
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+pmix_status_t pmix_getwinsz(int fd, struct winsize *ws)
+{
+    int rc;
+
+    rc = ioctl(fd, TIOCGWINSZ, (char*) ws);
+    if (0 == rc) {
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+pmix_status_t pmix_settermios(int fd, struct termios *terms)
+{
+    struct termios old, check;
+    int rc, err;
+
+    rc = pmix_gettermios(fd, &old);
+
+    if (0 != rc) {
+        return PMIX_ERROR;
+    }
+
+    rc = tcsetattr(fd, TCSAFLUSH, terms);
+    if (0 != rc) {
+        // attempt to reset it
+        err = errno;  // preserve original error
+        tcsetattr(fd, TCSAFLUSH, &old);
+        errno = err;
+
+    } else {
+
+        /* check that it was fully successful - tcsetattr returns
+         * success if ANY change succeeded */
+        rc = pmix_gettermios(fd, &check);
+        if (0 != rc) {
+            return PMIX_ERROR;
+        }
+        rc = memcmp(terms, &check, sizeof(struct termios));
+        if (0 != rc) {
+            errno = EINVAL;
+            return PMIX_ERROR;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_setwinsz(int fd, struct winsize *ws)
+{
+    int rc;
+
+    rc = ioctl(fd, TIOCSWINSZ, (char*) ws);
+    if (0 == rc) {
+        return PMIX_SUCCESS;
+    }
+    return PMIX_ERROR;
+}
+
+pmix_status_t pmix_setraw(int fd, struct termios *prior)
+{
+    struct termios terms;
+    int rc;
+
+    rc = pmix_gettermios(fd, &terms);
+
+    if (0 != rc) {
+        return PMIX_ERROR;
+    }
+
+    if (NULL != prior) {
+        memcpy(prior, &terms, sizeof(struct termios));
+    }
+
+    terms.c_lflag &= ~(ICANON | ISIG | IEXTEN | ECHO);
+                        /* Noncanonical mode, disable signals, extended
+                           input processing, and echoing */
+
+    terms.c_iflag &= ~(BRKINT | ICRNL | IGNBRK | IGNCR | INLCR |
+                       INPCK | ISTRIP | IXON | PARMRK);
+                        /* Disable special handling of CR, NL, and BREAK.
+                           No 8th-bit stripping or parity error handling.
+                           Disable START/STOP output flow control. */
+
+    terms.c_oflag &= ~OPOST;                /* Disable all output processing */
+
+    terms.c_cc[VMIN] = 1;                   /* Character-at-a-time input */
+    terms.c_cc[VTIME] = 0;                  /* with blocking */
+
+    rc = pmix_settermios(fd, &terms);
+    return rc;
+}

--- a/src/util/pmix_tty.h
+++ b/src/util/pmix_tty.h
@@ -18,18 +18,12 @@
  * $HEADER$
  */
 
-#ifndef PMIX_UTIL_PTY_H
-#define PMIX_UTIL_PTY_H
+#ifndef PMIX_UTIL_TTY_H
+#define PMIX_UTIL_TTY_H
 
 #include "src/include/pmix_config.h"
 #include "pmix_common.h"
 
-#ifdef HAVE_UTIL_H
-#    include <util.h>
-#endif
-#ifdef HAVE_LIBUTIL_H
-#    include <libutil.h>
-#endif
 #ifdef HAVE_TERMIOS_H
 #    include <termios.h>
 #else
@@ -37,36 +31,22 @@
 #        include <termio.h>
 #    endif
 #endif
+#ifdef HAVE_SYS_IOCTL_H
+#    include <sys/ioctl.h>
+#endif
 
 BEGIN_C_DECLS
 
-#if PMIX_ENABLE_PTY_SUPPORT
+PMIX_EXPORT pmix_status_t pmix_gettermios(int fd, struct termios *terms);
 
-PMIX_EXPORT int pmix_openpty(int *amaster, int *aslave, char *name,
-                             struct termios *termp, struct winsize *winp);
+PMIX_EXPORT pmix_status_t pmix_getwinsz(int fd, struct winsize *ws);
 
-PMIX_EXPORT int pmix_ptymopen(char *pts_name, size_t maxlen);
+PMIX_EXPORT pmix_status_t pmix_settermios(int fd, struct termios *terms);
 
-PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name);
+PMIX_EXPORT pmix_status_t pmix_setwinsz(int fd, struct winsize *ws);
 
-PMIX_EXPORT pid_t pmix_forkpty(int *master, char *slave,
-                               const struct termios *sterm,
-                               const struct winsize *sws);
-
-#else
-
-PMIX_EXPORT int pmix_openpty(int *amaster, int *aslave, char *name,
-                             void *termp, void *winpp);
-
-PMIX_EXPORT int pmix_ptymopen(char *pts_name, size_t maxlen);
-
-PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name);
-
-PMIX_EXPORT pid_t pmix_forkpty(int *master, char *slave,
-                               const void *sterm, const void *sws);
-
-#endif
+PMIX_EXPORT pmix_status_t pmix_setraw(int fd, struct termios *prior);
 
 END_C_DECLS
 
-#endif /* PMIX_UTIL_PTY_H */
+#endif /* PMIX_UTIL_TTY_H */


### PR DESCRIPTION
Add some common tty support functions for handling terminal attributes and window sizes. Expose atomistic utilities for pty creation. Add a dup2 abstracion to remove clutter elsewhere.