### PR TITLE
Parameterize client finalize timeout

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1047,7 +1047,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     pmix_status_t rc;
     size_t n;
     pmix_client_timeout_t tev;
-    struct timeval tv = {2, 0};
+    struct timeval tv;
     pmix_peer_t *peer;
     int i;
 
@@ -1105,6 +1105,8 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         pmix_event_assign(&tev.ev, pmix_globals.evbase, -1, 0, fin_timeout, &tev);
         tev.active = true;
         PMIX_POST_OBJECT(&tev);
+        tv.tv_sec = pmix_server_client_fintime;
+        tv.tv_usec = 0;
         pmix_event_add(&tev.ev, &tv);
         /* send to the server */
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -51,6 +51,7 @@ int pmix_event_caching_window = 1;
 char *pmix_progress_thread_cpus = NULL;
 bool pmix_bind_progress_thread_reqd = false;
 int pmix_maxfd = 1024;
+int pmix_server_client_fintime;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -276,6 +277,12 @@ pmix_status_t pmix_register_params(void)
                                       "In non-Linux environments, use this value as a maximum number of file descriptors to close when forking a new child process",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_maxfd);
+
+    pmix_server_client_fintime = 10;
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "finalize_timeout",
+                                      "Time in seconds to wait for server to ack client finalize request",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_server_client_fintime);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -50,6 +50,7 @@ PMIX_EXPORT extern int pmix_event_caching_window;
 PMIX_EXPORT extern char *pmix_progress_thread_cpus;
 PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
 PMIX_EXPORT extern int pmix_maxfd;
+PMIX_EXPORT extern int pmix_server_client_fintime;
 
 /** version string of pmix */
 extern const char pmix_version_string[];


### PR DESCRIPTION
The length of time we wait for client finalize to be ack'd by the server is pretty arbitrary - the timeout is there just to avoid having a client "hang" forever if the server is stuck. So let the user adjust the time via MCA param in the case where they need a long time, and set the default to something higher (i.e., 10 sec) than what we were using just in case they have a heavily loaded server.

Refs: https://github.com/open-mpi/ompi/issues/13344