### PR TITLE
Don't fail when PMIX_IOF_OUTPUT_TO_FILE directory exists

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -837,7 +837,7 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         /* ensure the directory exists */
         rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
         free(outdir);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
             PMIX_ERROR_LOG(rc);
             return NULL;
         }


### PR DESCRIPTION
Currently, setting an output file successfully creates the directory on one process, but the rest then detect an already existing directory. PMIX reports the error and continues, but the output from those processes is lost (even to the standard shared output).