### PR TITLE
Multiple commits

### DIFF
--- a/.github/actions/build-python-bindings/action.yaml
+++ b/.github/actions/build-python-bindings/action.yaml
@@ -1,0 +1,58 @@
+#-----------------------------------------------------------------
+# File: build-python-bindings/action.yaml
+#
+# Descr: Actions file used by the workflow CI for reusable items
+#        performed across the different python-versions tested.
+#
+# See also: .github/workflows/python-bindings.yaml
+#-----------------------------------------------------------------
+name: Build PMIx Python Bindings
+description: Configure, build, and install OpenPMIx with Python bindings
+
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
+      shell: bash
+
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        clean: false
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+      shell: bash
+
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r bindings/python/requirements.txt
+      shell: bash
+
+    - name: Display Cython version
+      run: cython --version
+      shell: bash
+
+    - name: Build OpenPMIx
+      run: |
+        ./autogen.pl
+        ./configure --enable-python-bindings --prefix=$RUNNER_TEMP/pmixinstall
+        make -j $(nproc)
+        make install
+      shell: bash
+

--- a/.github/workflows/python-bindings.yaml
+++ b/.github/workflows/python-bindings.yaml
@@ -1,0 +1,42 @@
+#-----------------------------------------------------------------
+# File: python-bindings.yaml
+#
+# Descr: Tests for PMIx Python bindings across different python versions.
+#        Uses common actions to reduce repetition in this file.
+#
+# See also: .github/actions/build-python-bindings/action.yaml)
+#-----------------------------------------------------------------
+name: OpenPMIx-bindings Python Versions
+
+# Run only on pull-requests -or- via manual 'Run workflow' option.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Add additional Python versions to test below:
+          # Each item should include 'name' and 'python-version'
+          # (Note: Make sure to quote versions to avoid 3.10 => 3.1)
+          - name: "CPython 3.9"
+            python-version: "3.9"
+          - name: "CPython 3.10"
+            python-version: "3.10"
+          - name: "CPython 3.11"
+            python-version: "3.11"
+          - name: "CPython 3.12"
+            python-version: "3.12"
+          - name: "CPython 3.13"
+            python-version: "3.13"
+    name: ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/build-python-bindings
+        with:
+          python-version: ${{ matrix.python-version }}
+

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -872,7 +872,10 @@ def pmix_bool_convert(f):
 
     return int_bool
 
-pmix_int_types = (int, long)
+# Tuple of integer types.
+#  Python 2.x distinguished int/long, but in
+#  Python 3.x dropped long and just uses int or width specific variants.
+pmix_int_types = (int,)
 
 # provide a safe way to copy a Python nspace into
 # the pmix_nspace_t structure that guarantees the

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -825,8 +825,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                 mca_base_component_show_load_errors (but
                                 can be overridden at run time by the usual
                                 MCA-variable-setting mechansism).
-                                (default: "all")])])
-
+                                (default: "none")])],
+                                [], [with_show_load_errors=no])
     if test -z "$with_show_load_errors" || \
        test "$with_show_load_errors" = "yes"; then
         with_show_load_errors=all

--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -130,6 +130,9 @@ def harvest_constants(options, path, constants):
                             datatype = "TBD"
                         elif tokens[3] == "(time_t)":
                             datatype = "PMIX_TIME"
+                        elif tokens[3] == "(struct" and tokens[4] == "timeval)":
+                            datatype = "PMIX_TIMEVAL"
+                            dstart = 5
                         elif tokens[3] == "(pmix_envar_t*)":
                             datatype = "PMIX_ENVAR"
                         elif tokens[3] == "(pid_t)":

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1046,7 +1046,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     pmix_status_t rc;
     size_t n;
     pmix_client_timeout_t tev;
-    struct timeval tv = {2, 0};
+    struct timeval tv;
     pmix_peer_t *peer;
     int i;
 
@@ -1104,6 +1104,8 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         pmix_event_assign(&tev.ev, pmix_globals.evbase, -1, 0, fin_timeout, &tev);
         tev.active = true;
         PMIX_POST_OBJECT(&tev);
+        tv.tv_sec = pmix_server_client_fintime;
+        tv.tv_usec = 0;
         pmix_event_add(&tev.ev, &tv);
         /* send to the server */
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -836,7 +836,7 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         /* ensure the directory exists */
         rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
         free(outdir);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
             PMIX_ERROR_LOG(rc);
             return NULL;
         }

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -114,8 +114,10 @@ static int process_repository_item(const char *filename, void *data)
     if (0 != strncmp(base, prefix, strlen(prefix)) &&
         0 != strncmp(base, type, strlen(type))) {
         if (pmix_mca_base_show_load_errors(NULL, NULL)) {
-            pmix_output(0, "mca:base:process_repository_item filename %s has bad prefix - expected:\n\t%s\nor\n\t%s",
-                        filename, prefix, type);
+            pmix_output_verbose(
+                PMIX_MCA_BASE_VERBOSE_INFO, 0,
+                "mca:base:process_repository_item filename %s has unexpected prefix - expected:\n\t%s\nor\n\t%s",
+                filename, prefix, type);
         }
         free(base);
         free(prefix);

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -52,6 +52,7 @@ bool pmix_suppress_missing_data_warning = false;
 char *pmix_progress_thread_cpus = NULL;
 bool pmix_bind_progress_thread_reqd = false;
 int pmix_maxfd = 1024;
+int pmix_server_client_fintime;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -279,6 +280,12 @@ pmix_status_t pmix_register_params(void)
                                       "In non-Linux environments, use this value as a maximum number of file descriptors to close when forking a new child process",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_maxfd);
+
+    pmix_server_client_fintime = 10;
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "finalize_timeout",
+                                      "Time in seconds to wait for server to ack client finalize request",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_server_client_fintime);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -51,6 +51,7 @@ PMIX_EXPORT extern bool pmix_suppress_missing_data_warning;
 PMIX_EXPORT extern char *pmix_progress_thread_cpus;
 PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
 PMIX_EXPORT extern int pmix_maxfd;
+PMIX_EXPORT extern int pmix_server_client_fintime;
 
 /** version string of pmix */
 extern const char pmix_version_string[];

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -147,6 +147,7 @@ static void pdiedfn(int fd, short flags, void *arg)
     PMIX_INFO_CREATE(cb->info, cb->ninfo);
     PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
+    cb->infocopy = true; // ensure cleanup
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
                       PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
                       _pdiedcb, (void*)cb);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -329,8 +329,8 @@ static void debugger_aggregator(size_t evhdlr_registration_id, pmix_status_t sta
     pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "[%s:%d] DEBUGGER AGGREGATOR CALLED FOR NSPACE %s",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank, source->nspace);
+                        "%s DEBUGGER AGGREGATOR CALLED FOR SOURCE %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(source));
 
     PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, results, nresults);
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -126,22 +126,30 @@ static char *gds_mode = NULL;
 static pid_t mypid;
 static pmix_proc_t myparent;
 
+static void _pdiedcb(pmix_status_t status, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_RELEASE(cb);
+}
+
 static void pdiedfn(int fd, short flags, void *arg)
 {
-    pmix_info_t info[2];
     pmix_proc_t keepalive;
-
+    pmix_cb_t *cb;
     PMIX_HIDE_UNUSED_PARAMS(fd, flags, arg);
 
     PMIX_LOAD_PROCID(&keepalive, "PMIX_KEEPALIVE_PIPE", PMIX_RANK_UNDEF);
 
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
-
     /* generate a job-terminated event */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->ninfo = 2;
+    PMIX_INFO_CREATE(cb->info, cb->ninfo);
+    PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
-                      PMIX_RANGE_PROC_LOCAL, info, 2,
-                      NULL, NULL);
+                      PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
+                      _pdiedcb, (void*)cb);
 }
 
 static void server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -100,6 +100,7 @@ static void pdiedfn(int fd, short flags, void *arg)
     PMIX_INFO_CREATE(cb->info, cb->ninfo);
     PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_AFFECTED_PROC, &keepalive, PMIX_PROC);
+    cb->infocopy = true;  // ensure cleanup
     PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid,
                       PMIX_RANGE_PROC_LOCAL, cb->info, cb->ninfo,
                       _pdiedcb, (void*)cb);


### PR DESCRIPTION
[github: add python-version checks for bindings](https://github.com/openpmix/openpmix/commit/855663ed9680fff0e198a7a85eed83270e5db4ec)

* OpenPMIx-bindings Python Versions CI checks
   - Builds OpenPMIx Python bindings across different Python versions
   - Uses reusable actions that are driven by python-bindings workflow
       o Actions:   .github/actions/build-python-bindings/action.yaml
       o Workflows: .github/workflows/python-bindings.yaml
   - Setup to get Python per-version results
   - Split actions/workflow to reduce duplicate code, and
     easily add new Python versions (in workflows matrix).
   - Currently only test CPython
   - CI runs limited to pull-requests only (on: pull_request)
   - CI manually trigger on main repo via 'Run Workflow' (on: workflow_dispatch)

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c690de9a30ae73ba95bf49edbb8cee34a52a0626)

[bindings: fix Python 3.x error for 'long' integer](https://github.com/openpmix/openpmix/commit/9ac9e9fad6663f14877346a8848ef2715db7225b)

* Fix Cython 'long' integer error:
   - Avoids issue for now deprecated use of 'long' integer.
   - As of Python 3.x no longer make this distinction.
   - See also: https://wiki.python.org/moin/PortingExtensionModulesToPy3k#long-int-unification

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/684e9282d2f963a87216defc93c923466ff604e1)

[Properly trigger the "keepalive failed" event](https://github.com/openpmix/openpmix/commit/e37f19783fe21a1ba20d414fef7d5aa1b9aae077)

Need to retain the info structs passed to
PMIx_Notify_event until the callback is
executed.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/57d71b6e748abb6dd403962da074e3666bdcaca3)

[Ensure cleanup of allocated pmix_info_t](https://github.com/openpmix/openpmix/commit/20adf69778c6de0faaab0dee055f402827693862)

The pmix_cb_t destructor will release the info
array if the infocopy field is set to true.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/51a4b6725450eb486df37587dacd60a3b6af8d74)

[Change default show-load-errors to "none"](https://github.com/openpmix/openpmix/commit/d829ffb7f7f687fa9fa246817f684cec571deac4)

We treat a NULL string as boolean "true", which means that
the show-load-errors param was defaulting to "all". Change
the default configuration option --with-show-load-errors
to be "none" so we avoid that behavior.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3657e41340f934e0ff2dd5286b26e556fb1eda2c)

[Only report bad prefix if verbose requested](https://github.com/openpmix/openpmix/commit/ffe954e466d036b81a5de06860e0b7b95dfed00b)

Hide the warnings about bad prefixes behind a verbosity
check - only active if show-load-errors is set as well.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/f28cdd74468bbd3299460b225aa78b0735e5ee3d)

[Correct client notify of ready for debugger](https://github.com/openpmix/openpmix/commit/6c7f5dd8baff1bf6c68ef608f7100328d6731a54)

Need to provide a callback function so that the notify
procedure can correctly release the code for the next
step in debugger rendezvous

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/6eb0177c9a13ff94636db9f8711c21d3559e8e19)

[Check return code for notify ready-for-debug](https://github.com/openpmix/openpmix/commit/59356165d6be1491382fdf4bcd46997344c90fa1)

Check the return code to see if we need to wait
for thread release.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/69f7e7e22f01b4963e4fd24ea0eb82d7bd702013)

[Parameterize client finalize timeout](https://github.com/openpmix/openpmix/commit/d7c35f7e572299eeb7dec64f078eb376c1f3f453)

The length of time we wait for client finalize to be
ack'd by the server is pretty arbitrary - the timeout
is there just to avoid having a client "hang" forever
if the server is stuck. So let the user adjust the time
via MCA param in the case where they need a long time,
and set the default to something higher (i.e., 10 sec)
than what we were using just in case they have a heavily
loaded server.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/85bc673d5860158623b3eaebf6996d2e2d59e860)

[IOF output file bugfix](https://github.com/openpmix/openpmix/commit/3deb7fae056ea9df4318c2429b27aa459098fb8f)

Allow pmix.iof.file to output to an existing directory

Signed-off-by: Matthew Whitlock <mwhitlo@sandia.gov>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/5995438c0925560ed2c9c43d9b6416e899f99ce4)
