### PR TITLE
Provide better FQDN support

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -794,6 +794,7 @@ typedef struct {
     uid_t uid;           // my effective uid
     gid_t gid;           // my effective gid
     char *hostname;      // my hostname
+    char **aliases;      // aliases for my hostname
     uint32_t appnum;     // my appnum
     pid_t pid;           // my local pid
     uint32_t nodeid;     // my nodeid, if given

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -40,6 +40,7 @@
 #include "src/mca/pmdl/pmdl.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
@@ -379,6 +380,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
                 nd->hostname = strdup(pmix_globals.hostname);
+                pmix_set_aliases(&nd->aliases, nd->hostname);
                 pmix_list_append(&trk->nodeinfo, &nd->super);
             }
             /* ensure the value isn't already on the node info */

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -41,11 +41,13 @@
 #include "src/mca/pmdl/pmdl.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -143,6 +145,10 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
         /* they forgot to pass us the ident for the node */
         PMIX_LIST_DESTRUCT(&cache);
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (NULL != nd->hostname) {
+        pmix_set_aliases(&nd->aliases, nd->hostname);
     }
 
     /* see if we already have this node on the

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -138,6 +138,10 @@ void pmix_rte_finalize(void)
     if (NULL != pmix_globals.hostname) {
         free(pmix_globals.hostname);
         pmix_globals.hostname = NULL;
+    }
+    if (NULL != pmix_globals.aliases) {
+        PMIx_Argv_free(pmix_globals.aliases);
+        pmix_globals.aliases = NULL;
     }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -52,6 +52,7 @@ char *pmix_progress_thread_cpus = NULL;
 bool pmix_bind_progress_thread_reqd = false;
 int pmix_maxfd = 1024;
 int pmix_server_client_fintime;
+bool pmix_keep_fqdn_hostnames = false;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -283,6 +284,12 @@ pmix_status_t pmix_register_params(void)
                                       "Time in seconds to wait for server to ack client finalize request",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_server_client_fintime);
+
+    pmix_keep_fqdn_hostnames = false;
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "keep_fqdn_hostnames",
+                                      "Whether or not to keep FQDN hostnames [default: no]",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &pmix_keep_fqdn_hostnames);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -51,6 +51,7 @@ PMIX_EXPORT extern char *pmix_progress_thread_cpus;
 PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
 PMIX_EXPORT extern int pmix_maxfd;
 PMIX_EXPORT extern int pmix_server_client_fintime;
+PMIX_EXPORT extern bool pmix_keep_fqdn_hostnames;
 
 /** version string of pmix */
 extern const char pmix_version_string[];
@@ -76,6 +77,8 @@ PMIX_EXPORT void pmix_rte_finalize(void);
  */
 PMIX_EXPORT pmix_status_t pmix_register_params(void);
 PMIX_EXPORT pmix_status_t pmix_deregister_params(void);
+
+PMIX_EXPORT void pmix_set_aliases(char ***aliases, char *hostname);
 
 END_C_DECLS
 

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -177,10 +177,6 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
     // second qualifier in the query has the nodename
     nd = cd->query->qualifiers[1].value.data.string;
 
-    // restrict our search to already available info
-    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, NULL, PMIX_BOOL);
-
-
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     proc.rank = PMIX_RANK_UNDEF;
     cb.proc = &proc;


### PR DESCRIPTION
We strip FQDNs by default because of the inherent problem of interacting with users, who generally don't like typing all that extra stuff. However, that creates a problem when being provided FQDN input during things like nspace registration.

So add an MCA param to control the strip operation instead of only switching it on/off via info directing during init. Add logic to the nspace registration process to perform the strip and add aliases (for the case where the host failed to provide them).

Refs #3652 