### PR TITLE
Silence Coverity complaints

### DIFF
--- a/examples/group.c
+++ b/examples/group.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
             cid = 0;
             for (n=0; n < nresults; n++) {
                 if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
-                    PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
+                    rc = PMIx_Value_get_number(&results[n].value, &cid, PMIX_SIZE);
                     fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
                             myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);
                 } else if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_MEMBERSHIP)) {

--- a/examples/group_bootstrap.c
+++ b/examples/group_bootstrap.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -175,6 +175,7 @@ int main(int argc, char **argv)
             cid = 0;
             for (n=0; n < nresults; n++) {
                 if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
+                    rc = PMIx_Value_get_number(&results[n].value, &cid, PMIX_SIZE);
                     PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
                     fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %lu\n",
                             myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);

--- a/examples/group_dmodex.c
+++ b/examples/group_dmodex.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC.
  *                         All rights reserved.
  *
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     if (NULL != results) {
         for (n=0; n < nresults; n++) {
             if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
+                rc = PMIx_Value_get_number(&results[n].value, &cid, PMIX_SIZE);
                 fprintf(stderr, "%d Group construct complete with status %s CID %lu\n",
                         myproc.rank, PMIx_Error_string(rc), cid);
                 break;

--- a/examples/group_lcl_cid.c
+++ b/examples/group_lcl_cid.c
@@ -227,7 +227,7 @@ int main(int argc, char **argv)
         cid = 0;
         for (m=0; m < nresults; m++) {
             if (PMIX_CHECK_KEY(&results[m], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &results[m].value, cid, size_t);
+                rc = PMIx_Value_get_number(&results[m].value, &cid, PMIX_SIZE);
                 idassigned = true;
                 break;
             }

--- a/examples/multi_nspace_group.c
+++ b/examples/multi_nspace_group.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
         pptr = NULL;
         for (n=0; n < nresults; n++) {
             if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
+                rc = PMIx_Value_get_number(&results[n].value, &cid, PMIX_SIZE);
                 fprintf(stderr, "%s:%d Group construct complete with status %s KEY %s CID %lu\n",
                         myproc.nspace, myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);
             } else if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_MEMBERSHIP)) {

--- a/examples/spawn_group.c
+++ b/examples/spawn_group.c
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
         parray = NULL;
         for (n=0; n < nresults; n++) {
             if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &results[n].value, cid, size_t);
+                rc = PMIx_Value_get_number(&results[n].value, &cid, PMIX_SIZE);
                 fprintf(stderr, "%s:%d Group construct complete with status %s KEY %s CID %lu\n",
                         myproc.nspace, myproc.rank, PMIx_Error_string(rc), results[n].key, (unsigned long) cid);
             } else if (PMIX_CHECK_KEY(&results[n], PMIX_GROUP_MEMBERSHIP)) {

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -325,51 +325,44 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 #define PMIX_VALUE_XFER_DIRECT(r, v, s)     \
     (r) = PMIx_Value_xfer((v), (s))
 
-#define PMIX_VALUE_GET_NUMBER(r, m, n, t)                                   \
-do {                                                                        \
-        char* _s = #t ;                                                     \
-        (r) = PMIX_SUCCESS;                                                 \
-        if (0 == strcmp(_s, "size_t")) {                                    \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_SIZE);       \
-        } else if (0 == strcmp(_s, "int")) {                                \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_INT);        \
-        } else if (0 == strcmp(_s, "int8_t")) {                             \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_INT8);       \
-        } else if (0 == strcmp(_s, "int16_t")) {                            \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_INT16);      \
-        } else if (0 == strcmp(_s, "int32_t")) {                            \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_INT32);      \
-        } else if (0 == strcmp(_s, "int64_t")) {                            \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_INT64);      \
-        } else if (0 == strcmp(_s, "uint")) {                               \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT);       \
-        } else if (0 == strcmp(_s, "unsigned int")) {                       \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT);       \
-        } else if (0 == strcmp(_s, "uint8_t")) {                            \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT8);      \
-        } else if (0 == strcmp(_s, "uint16_t")) {                           \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT16);     \
-        } else if (0 == strcmp(_s, "uint32_t")) {                           \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT32);     \
-        } else if (0 == strcmp(_s, "uint64_t")) {                           \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT64);     \
-        } else if (0 == strcmp(_s, "float")) {                              \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_FLOAT);      \
-        } else if (0 == strcmp(_s, "double")) {                             \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_DOUBLE);     \
-        } else if (0 == strcmp(_s, "pid_t")) {                              \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_PID);        \
-        } else if (0 == strcmp(_s, "pmix_rank_t")) {                        \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_PROC_RANK);  \
-        } else if (0 == strcmp(_s, "pmix_status_t")) {                      \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_STATUS);     \
-        } else if (0 == strcmp(_s, "uid_t")) {                              \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT32);     \
-        } else if (0 == strcmp(_s, "gid_t")) {                              \
-            (r) = PMIx_Value_get_number((m), (void*)&(n), PMIX_UINT32);     \
-        } else {                                                            \
-            (r) = PMIX_ERR_BAD_PARAM;                                       \
-        }                                                                   \
+#define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
+do {                                                    \
+        (s) = PMIX_SUCCESS;                             \
+        if (PMIX_SIZE == (m)->type) {                   \
+            (n) = (t)((m)->data.size);                  \
+        } else if (PMIX_INT == (m)->type) {             \
+            (n) = (t)((m)->data.integer);               \
+        } else if (PMIX_INT8 == (m)->type) {            \
+            (n) = (t)((m)->data.int8);                  \
+        } else if (PMIX_INT16 == (m)->type) {           \
+            (n) = (t)((m)->data.int16);                 \
+        } else if (PMIX_INT32 == (m)->type) {           \
+            (n) = (t)((m)->data.int32);                 \
+        } else if (PMIX_INT64 == (m)->type) {           \
+            (n) = (t)((m)->data.int64);                 \
+        } else if (PMIX_UINT == (m)->type) {            \
+            (n) = (t)((m)->data.uint);                  \
+        } else if (PMIX_UINT8 == (m)->type) {           \
+            (n) = (t)((m)->data.uint8);                 \
+        } else if (PMIX_UINT16 == (m)->type) {          \
+            (n) = (t)((m)->data.uint16);                \
+        } else if (PMIX_UINT32 == (m)->type) {          \
+            (n) = (t)((m)->data.uint32);                \
+        } else if (PMIX_UINT64 == (m)->type) {          \
+            (n) = (t)((m)->data.uint64);                \
+        } else if (PMIX_FLOAT == (m)->type) {           \
+            (n) = (t)((m)->data.fval);                  \
+        } else if (PMIX_DOUBLE == (m)->type) {          \
+            (n) = (t)((m)->data.dval);                  \
+        } else if (PMIX_PID == (m)->type) {             \
+            (n) = (t)((m)->data.pid);                   \
+        } else if (PMIX_PROC_RANK == (m)->type) {       \
+            (n) = (t)((m)->data.rank);                  \
+        } else if (PMIX_STATUS == (m)->type) {          \
+            (n) = (t)((m)->data.status);                \
+        } else {                                        \
+            (s) = PMIX_ERR_BAD_PARAM;                   \
+        }                                               \
 } while(0)
 
 

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -112,7 +112,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                             PMIX_LIST_DESTRUCT(&cache);
                             return PMIX_ERR_NOT_FOUND;
                         }
-                        PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
+                        rc = PMIx_Value_get_number(kv->value, &jsize, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
                             PMIX_LIST_DESTRUCT(&cache);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -174,19 +174,19 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
             lg->hostname = info[n].value.data.string;
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->nodeid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &lg->nodeid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->appnum, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &lg->appnum, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, lg->sessionid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &lg->sessionid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
@@ -837,7 +837,7 @@ static void get_data(int sd, short args, void *cbdata)
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
                         if (NULL != kv) {  // will never be NULL
-                            PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->nodeid, uint32_t);
+                            rc = PMIx_Value_get_number(kv->value, &lg->nodeid, PMIX_UINT32);
                             PMIX_RELEASE(kv);
                         } else {
                             rc = PMIX_ERROR;
@@ -940,7 +940,7 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->appnum, uint32_t);
+                        rc = PMIx_Value_get_number(kv->value, &lg->appnum, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
                             cb->status = rc;
@@ -1015,7 +1015,7 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        PMIX_VALUE_GET_NUMBER(rc, kv->value, lg->sessionid, uint32_t);
+                        rc = PMIx_Value_get_number(kv->value, &lg->sessionid, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
                             cb->status = rc;

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -594,7 +594,7 @@ static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
             affected = info[n].value.data.proc;
 
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_CONTEXT_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, contextid, size_t);
+            rc = PMIx_Value_get_number(&info[n].value, &contextid, PMIX_SIZE);
             gotctxid = true;
         }
     }
@@ -816,7 +816,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                 PMIX_DESTRUCT(&cb2);
                 if (NULL != kv) {  // should never be NULL
-                    PMIX_VALUE_GET_NUMBER(rc, kv->value, jsize, uint32_t);
+                    rc = PMIx_Value_get_number(kv->value, &jsize, PMIX_UINT32);
                     PMIX_RELEASE(kv);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_RELEASE(cb);
@@ -1405,7 +1405,7 @@ static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
                 grpid = info[n].value.data.string;
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &info[n].value, ctxid, size_t);
+                rc = PMIx_Value_get_number(&info[n].value, &ctxid, PMIX_SIZE);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                 }

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1195,7 +1195,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                 if (NULL != kv) { // should never be NULL
-                    PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
+                    rc = PMIx_Value_get_number(kv->value, &pid, PMIX_PID);
                     PMIX_RELEASE(kv);
                     if (PMIX_SUCCESS != rc) {
                         pidstring = strdup("unknown");
@@ -1284,7 +1284,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                PMIX_VALUE_GET_NUMBER(rc, kv->value, pid, pid_t);
+                rc = PMIx_Value_get_number(kv->value, &pid, PMIX_PID);
                 PMIX_RELEASE(kv);
                 if (PMIX_SUCCESS != rc) {
                     pidstring = strdup("unknown");

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -137,7 +137,7 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
             procs = (pmix_proc_t*)cb->directives[n].value.data.darray->array;
             sz = cb->directives[n].value.data.darray->size;
             for (m=0; !local && !remote && m < sz; m++) {
-                for (k=0; !local && !remote && k < pmix_server_globals.clients.size; k++) {
+                for (k=0; (!local || !remote) && k < pmix_server_globals.clients.size; k++) {
                     ptr = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
                     if (NULL == ptr) {
                         continue;
@@ -168,7 +168,7 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
             // is our node included?
             hostnames = (char**)cb->directives[n].value.data.darray->array;
             sz = cb->directives[n].value.data.darray->size;
-            for (m=0; !local && !remote && m < sz; m++) {
+            for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
                 if (0 == strcmp(hostnames[m], pmix_globals.hostname)) {
                     local = true;
@@ -194,7 +194,7 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
             // is our node included?
             nids = (uint32_t*)cb->directives[n].value.data.darray->array;
             sz = cb->directives[n].value.data.darray->size;
-            for (m=0; !local && !remote && m < sz; m++) {
+            for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
                 if (nids[m] == pmix_globals.nodeid) {
                     local = true;
@@ -220,7 +220,7 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
             // is our node included?
             ppid = (pmix_node_pid_t*)cb->directives[n].value.data.darray->array;
             sz = cb->directives[n].value.data.darray->size;
-            for (m=0; !local && !remote && m < sz; m++) {
+            for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
                 if (ppid[m].nodeid == pmix_globals.nodeid ||
                     0 == strcmp(ppid[m].hostname, pmix_globals.hostname)) {

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -782,7 +782,7 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
                 grpid = chain->info[n].value.data.string;
 
             } else if (PMIX_CHECK_KEY(&chain->info[n], PMIX_GROUP_CONTEXT_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &chain->info[n].value, ctxid, size_t);
+                rc = PMIx_Value_get_number(&chain->info[n].value, &ctxid, PMIX_SIZE);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                 }

--- a/src/mca/bfrops/base/bfrop_base_get_number.c
+++ b/src/mca/bfrops/base/bfrop_base_get_number.c
@@ -91,7 +91,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 {
     if (PMIX_SIZE == value->type) {
         if (PMIX_SIZE == type) {
-            memcpy(dest, &value->data.size, sizeof(size_t));
+            size_t *sz;
+            sz = (size_t*)dest;
+            *sz = value->data.size;
             return PMIX_SUCCESS;
         } else {
             return check_size(value, dest, type);
@@ -100,7 +102,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_INT == value->type) {
         if (PMIX_INT == type) {
-            memcpy(dest, &value->data.integer, sizeof(int));
+            int *i;
+            i = (int*)dest;
+            *i = value->data.integer;
             return PMIX_SUCCESS;
         } else {
             return check_int(value, dest, type);
@@ -109,7 +113,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_INT8 == value->type) {
         if (PMIX_INT8 == type) {
-            memcpy(dest, &value->data.int8, sizeof(int8_t));
+            int8_t *i8;
+            i8 = (int8_t*)dest;
+            *i8 = value->data.int8;
             return PMIX_SUCCESS;
         } else {
             return check_int8(value, dest, type);
@@ -118,7 +124,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_INT16 == value->type) {
         if (PMIX_INT16 == type) {
-            memcpy(dest, &value->data.int16, sizeof(int16_t));
+            int16_t *i16;
+            i16 = (int16_t*)dest;
+            *i16 = value->data.int16;
             return PMIX_SUCCESS;
         } else {
             return check_int16(value, dest, type);
@@ -127,7 +135,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_INT32 == value->type) {
         if (PMIX_INT32 == type) {
-            memcpy(dest, &value->data.int32, sizeof(int32_t));
+            int32_t *i32;
+            i32 = (int32_t*)dest;
+            *i32 = value->data.int32;
             return PMIX_SUCCESS;
         } else {
             return check_int32(value, dest, type);
@@ -136,7 +146,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_INT64 == value->type) {
         if (PMIX_INT64 == type) {
-            memcpy(dest, &value->data.int8, sizeof(int64_t));
+            int64_t *i64;
+            i64 = (int64_t*)dest;
+            *i64 = value->data.int64;
             return PMIX_SUCCESS;
         } else {
             return check_int64(value, dest, type);
@@ -145,7 +157,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_UINT == value->type) {
         if (PMIX_UINT == type) {
-            memcpy(dest, &value->data.uint, sizeof(unsigned int));
+            unsigned int *ui;
+            ui = (unsigned int*)dest;
+            *ui = value->data.uint;
             return PMIX_SUCCESS;
         } else {
             return check_uint(value, dest, type);
@@ -154,7 +168,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_UINT8 == value->type) {
         if (PMIX_UINT8 == type) {
-            memcpy(dest, &value->data.uint8, sizeof(uint8_t));
+            uint8_t *u8;
+            u8 = (uint8_t*)dest;
+            *u8 = value->data.uint8;
             return PMIX_SUCCESS;
         } else {
             return check_uint8(value, dest, type);
@@ -163,7 +179,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_UINT16 == value->type) {
         if (PMIX_UINT16 == type) {
-            memcpy(dest, &value->data.uint16, sizeof(uint16_t));
+            uint16_t *u16;
+            u16 = (uint16_t*)dest;
+            *u16 = value->data.uint16;
             return PMIX_SUCCESS;
         } else {
             return check_uint16(value, dest, type);
@@ -172,7 +190,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_UINT32 == value->type) {
         if (PMIX_UINT32 == type) {
-            memcpy(dest, &value->data.uint32, sizeof(uint32_t));
+            uint32_t *u32;
+            u32 = (uint32_t*)dest;
+            *u32 = value->data.uint32;
             return PMIX_SUCCESS;
         } else {
             return check_uint32(value, dest, type);
@@ -181,7 +201,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_UINT64 == value->type) {
         if (PMIX_UINT64 == type) {
-            memcpy(dest, &value->data.uint64, sizeof(uint64_t));
+            uint64_t *u64;
+            u64 = (uint64_t*)dest;
+            *u64 = value->data.uint64;
             return PMIX_SUCCESS;
         } else {
             return check_uint64(value, dest, type);
@@ -190,7 +212,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_FLOAT == value->type) {
         if (PMIX_FLOAT == type) {
-            memcpy(dest, &value->data.fval, sizeof(float));
+            float *f;
+            f = (float*)dest;
+            *f = value->data.fval;
             return PMIX_SUCCESS;
         } else {
             return check_float(value, dest, type);
@@ -199,7 +223,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_DOUBLE == value->type) {
         if (PMIX_DOUBLE == type) {
-            memcpy(dest, &value->data.dval, sizeof(double));
+            double *d;
+            d = (double*)dest;
+            *d = value->data.dval;
             return PMIX_SUCCESS;
         } else {
             return check_double(value, dest, type);
@@ -208,14 +234,18 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_PID == value->type) {
         if (PMIX_PID == type) {
-            memcpy(dest, &value->data.pid, sizeof(pid_t));
+            pid_t *p;
+            p = (pid_t*)dest;
+            *p = value->data.pid;
             return PMIX_SUCCESS;
         }
     }
 
     if (PMIX_PROC_RANK == value->type) {
         if (PMIX_PROC_RANK == type) {
-            memcpy(dest, &value->data.rank, sizeof(pmix_rank_t));
+            pmix_rank_t *r;
+            r = (pmix_rank_t*)dest;
+            *r = value->data.rank;
             return PMIX_SUCCESS;
         } else {
             return check_rank(value, dest, type);
@@ -224,7 +254,9 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
 
     if (PMIX_STATUS == value->type) {
         if (PMIX_STATUS== type) {
-            memcpy(dest, &value->data.status, sizeof(pmix_status_t));
+            pmix_status_t *s;
+            s = (pmix_status_t*)dest;
+            *s = value->data.status;
             return PMIX_SUCCESS;
         } else {
             return check_status(value, dest, type);
@@ -495,15 +527,6 @@ static pmix_status_t check_int(const pmix_value_t *value,
         return PMIX_SUCCESS;
     }
     if (PMIX_INT32 == type) {
-        if (0 < value->data.integer) {
-            if (INT32_MAX < value->data.integer) {
-                return PMIX_ERR_LOST_PRECISION;
-            }
-        } else {
-            if (INT32_MIN > value->data.integer) {
-                return PMIX_ERR_LOST_PRECISION;
-            }
-        }
         i32 = (int32_t*)dest;
         *i32 = (int32_t)value->data.integer;
         return PMIX_SUCCESS;

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -137,7 +137,7 @@ pmix_status_t pmix_gds_hash_fetch_sessioninfo(pmix_peer_t *peer,
      * which session they are asking about */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, sid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &sid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
@@ -178,7 +178,7 @@ pmix_status_t pmix_gds_hash_fetch_nodeinfo(pmix_peer_t *peer,
      * which node they are asking about */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, nid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &nid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
@@ -395,7 +395,7 @@ pmix_status_t pmix_gds_hash_fetch_appinfo(pmix_peer_t *peer,
      * which app they are asking about */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, appnum, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &appnum, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -196,7 +196,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                             "%s gds:hash:cache_job_info for key %s",
                             PMIX_NAME_PRINT(&pmix_globals.myid), info[n].key);
         if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, sid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &sid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 goto release;
@@ -856,9 +856,9 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 }
                 if (myproc) {
                     if (PMIX_CHECK_KEY(&kp2, PMIX_APPNUM)) {
-                        PMIX_VALUE_GET_NUMBER(rc, kp2.value, pmix_globals.appnum, uint32_t);
+                        rc = PMIx_Value_get_number(kp2.value, &pmix_globals.appnum, PMIX_UINT32);
                     } else if (PMIX_CHECK_KEY(&kp2, PMIX_NODEID)) {
-                        PMIX_VALUE_GET_NUMBER(rc, kp2.value, pmix_globals.nodeid, uint32_t);
+                        rc = PMIx_Value_get_number(kp2.value, &pmix_globals.nodeid, PMIX_UINT32);
                     } else if (PMIX_CHECK_KEY(&kp2, PMIX_HOSTNAME)) {
                         pmix_globals.hostname = strdup(kp2.value->data.string);
                     }
@@ -981,7 +981,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
             /* cleanup */
             PMIX_DESTRUCT(&buf2);
         } else if (PMIX_CHECK_KEY(&kptr, PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, kptr.value, sid, uint32_t);
+            rc = PMIx_Value_get_number(kptr.value, &sid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -93,7 +93,7 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
             }
-            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, nd->nodeid, uint32_t);
+            rc = PMIx_Value_get_number(&iptr[j].value, &nd->nodeid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(nd);
@@ -261,7 +261,7 @@ pmix_status_t pmix_gds_hash_process_app_array(pmix_value_t *val, pmix_job_t *trk
                             PMIX_NAME_PRINT(&pmix_globals.myid),
                             PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
-            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);
+            rc = PMIx_Value_get_number(&iptr[j].value, &appnum, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 goto release;
@@ -500,7 +500,7 @@ pmix_status_t pmix_gds_hash_process_session_array(pmix_value_t *val, pmix_job_t 
                             PMIX_NAME_PRINT(&pmix_globals.myid),
                             PMIx_Get_attribute_name(iptr[j].key));
         if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
+            rc = PMIx_Value_get_number(&iptr[j].value, &sid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_LIST_DESTRUCT(&ncache);

--- a/src/mca/gds/shmem2/gds_shmem2.c
+++ b/src/mca/gds/shmem2/gds_shmem2.c
@@ -2203,7 +2203,7 @@ get_local_job_data_info(
             // See if this is the job's session ID. If so, capture it.
             pmix_info_t *info = (pmix_info_t *)kvi->value->data.darray->array;
             if (PMIX_CHECK_KEY(&info[0], PMIX_SESSION_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &info[0].value, sid, uint32_t);
+                rc = PMIx_Value_get_number(&info[0].value, &sid, PMIX_UINT32);
                 if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     goto out;

--- a/src/mca/gds/shmem2/gds_shmem2_fetch.c
+++ b/src/mca/gds/shmem2/gds_shmem2_fetch.c
@@ -187,7 +187,7 @@ fetch_nodeinfo(
     // which node they are asking about.
     for (size_t n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, nid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &nid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
@@ -360,7 +360,7 @@ fetch_appinfo(
         if (!PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
             continue;
         }
-        PMIX_VALUE_GET_NUMBER(rc, &info[n].value, appnum, uint32_t);
+        rc = PMIx_Value_get_number(&info[n].value, &appnum, PMIX_UINT32);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }
@@ -511,7 +511,7 @@ fetch_sessioninfo(
     uint32_t sid = UINT32_MAX;
     for (size_t n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, sid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &sid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }

--- a/src/mca/gds/shmem2/gds_shmem2_store.c
+++ b/src/mca/gds/shmem2/gds_shmem2_store.c
@@ -121,9 +121,7 @@ cache_node_info(
         );
         if (PMIX_CHECK_KEY(&info[j], PMIX_NODEID)) {
             have_node_id_info = true;
-            PMIX_VALUE_GET_NUMBER(
-                rc, &info[j].value, iinfo->nodeid, uint32_t
-            );
+            rc = PMIx_Value_get_number(&info[j].value, &iinfo->nodeid, PMIX_UINT32);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 goto out;
@@ -285,7 +283,7 @@ store_app_array(
         );
         if (PMIX_CHECK_KEY(&info[j], PMIX_APPNUM)) {
             uint32_t appnum;
-            PMIX_VALUE_GET_NUMBER(rc, &info[j].value, appnum, uint32_t);
+            rc = PMIx_Value_get_number(&info[j].value, &appnum, PMIX_UINT32);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 goto out;
@@ -448,7 +446,7 @@ store_session_array(
     }
 
     uint32_t sid;
-    PMIX_VALUE_GET_NUMBER(rc, &info[0].value, sid, uint32_t);
+    rc = PMIx_Value_get_number(&info[0].value, &sid, PMIX_UINT32);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -310,7 +310,7 @@ harvest:
     /* see if the user has a default MCA param file */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_USERID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, uid, uint32_t);
+            rc = PMIx_Value_get_number(&info[n].value, &uid, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -376,7 +376,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             }
             plane = requests[n].value.data.string;
         } else if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_FABRIC_ENDPTS, PMIX_MAX_KEYLEN)) {
-            PMIX_VALUE_GET_NUMBER(rc, &requests[n].value, ports_per_node, int);
+            rc = PMIx_Value_get_number(&requests[n].value, &ports_per_node, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -67,13 +67,17 @@ pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char **evar)
 
     vrs = getenv("PMIX_VERSION");
 
-    if (NULL != evar && NULL != *evar) {
+    if (NULL == evar) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (NULL == *evar) {
+        eval = NULL;
+        evalgiven = false;
+    } else {
         // they are passing in the bfrops module to use
         eval = *evar;
         evalgiven = true;
-    } else {
-        eval = NULL;
-        evalgiven = false;
     }
 
     PMIX_LIST_FOREACH(mod, &pmix_bfrops_globals.actives, pmix_bfrops_base_active_module_t) {
@@ -169,12 +173,12 @@ pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo)
             }
             pmix_ptl_base.system_tmpdir = strdup(info[n].value.data.string);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_MAX_RETRIES)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, pmix_ptl_base.max_retries, int);
+            rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.max_retries, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_RETRY_DELAY)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, pmix_ptl_base.wait_to_connect, int);
+            rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.wait_to_connect, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 return rc;
             }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -256,7 +256,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                 }
                 pmix_globals.hostname = strdup(info[n].value.data.string);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
-                PMIX_VALUE_GET_NUMBER(ret, &info[n].value, pmix_globals.nodeid, uint32_t);
+                ret = PMIx_Value_get_number(&info[n].value, &pmix_globals.nodeid, PMIX_UINT32);
                 if (PMIX_SUCCESS != ret) {
                     goto return_error;
                 }
@@ -271,7 +271,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                         }
                         pmix_globals.hostname = strdup(iptr[m].value.data.string);
                     } else if (PMIX_CHECK_KEY(&iptr[m], PMIX_NODEID)) {
-                        PMIX_VALUE_GET_NUMBER(ret, &iptr[m].value, pmix_globals.nodeid, uint32_t);
+                        ret = PMIx_Value_get_number(&iptr[m].value, &pmix_globals.nodeid, PMIX_UINT32);
                         if (PMIX_SUCCESS != ret) {
                             goto return_error;
                         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1759,7 +1759,7 @@ static void _register_resources(int sd, short args, void *cbdata)
             pmix_list_append(&endpts, &ept->super);
 
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_CONTEXT_ID)) {
-            PMIX_VALUE_GET_NUMBER(rc, &cd->info[n].value, ctxid, size_t);
+            rc = PMIx_Value_get_number(&cd->info[n].value, &ctxid, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             } else {

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -948,7 +948,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             if (PMIX_CHECK_KEY(&info[n], PMIX_COLLECT_DATA)) {
                 collect_data = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
-                PMIX_VALUE_GET_NUMBER(rc, &info[n].value, tv.tv_sec, uint32_t);
+                rc = PMIx_Value_get_number(&info[n].value, &tv.tv_sec, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_PROC_FREE(procs, nprocs);
                     PMIX_INFO_FREE(info, ninfo);

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -380,7 +380,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
     /* see if this group was assigned a context ID or collected data */
     for (n = 0; n < scd->ninfo; n++) {
         if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_CONTEXT_ID)) {
-            PMIX_VALUE_GET_NUMBER(ret, &scd->info[n].value, ctxid, size_t);
+            ret = PMIx_Value_get_number(&scd->info[n].value, &ctxid, PMIX_SIZE);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
             } else {
@@ -601,12 +601,12 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
 
                     } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_BOOTSTRAP)) {
                         // the numbers must match
-                        PMIX_VALUE_GET_NUMBER(rc, &blk->info[m].value, bt, size_t);
+                        rc = PMIx_Value_get_number(&blk->info[m].value, &bt, PMIX_SIZE);
                         if (PMIX_SUCCESS != rc) {
                             PMIX_LIST_DESTRUCT(&ilist);
                             return rc;
                         }
-                        PMIX_VALUE_GET_NUMBER(rc, &trk->info[n].value, bt2, size_t);
+                        rc = PMIx_Value_get_number(&trk->info[n].value, &bt2, PMIX_SIZE);
                         if (PMIX_SUCCESS != rc) {
                             PMIX_LIST_DESTRUCT(&ilist);
                             return rc;

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -108,7 +108,7 @@ static void cbfunc(pmix_status_t status,
         for (n=0; n < ninfo; n++) {
             PMIX_INFO_XFER(&req->info[n], &info[n]);
             if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
-                PMIX_VALUE_GET_NUMBER(rc, &info[n].value, req->sessionid, uint32_t);
+                rc = PMIx_Value_get_number(&info[n].value, &req->sessionid, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     req->status = rc;
                 }

--- a/test/sshot/testcoord.c
+++ b/test/sshot/testcoord.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
                     PMIx_Error_string(rc));
         goto done;
     }
-    PMIX_VALUE_GET_NUMBER(rc, val, tclass, int);
+    rc = PMIx_Value_get_number(val, &tclass, PMIX_INT);
     if (PMIX_SUCCESS != rc) {
         pmix_output(0, "[%s:%d] Get of traffic class returned non-number", __FILE__, __LINE__);
         goto done;

--- a/test/test_v2/test_clientapp_funcs.c
+++ b/test/test_v2/test_clientapp_funcs.c
@@ -6,7 +6,7 @@
  *                         All rights reserved.
  * Copyright (c) 2020-2021 Triad National Security, LLC
  *                         All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -301,7 +301,7 @@ void pmixt_validate_predefined(pmix_proc_t *myproc, const char *key, pmix_value_
     switch (value->type) {
     case PMIX_UINT16: {
         uint16_t uint16data = UINT16_MAX;
-        PMIX_VALUE_GET_NUMBER(rc, value, uint16data, uint16_t);
+        rc = PMIx_Value_get_number(value, &uint16data, PMIX_UINT16);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR_EXIT(
                 ("Failed to retrieve value correctly. Key: %s Type: %u", key, value->type));
@@ -312,7 +312,7 @@ void pmixt_validate_predefined(pmix_proc_t *myproc, const char *key, pmix_value_
     }
     case PMIX_UINT32: {
         uint32_t uint32data = UINT32_MAX;
-        PMIX_VALUE_GET_NUMBER(rc, value, uint32data, uint32_t);
+        rc = PMIx_Value_get_number(value, &uint32data, PMIX_UINT32);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR_EXIT(
                 ("Failed to retrieve value correctly. Key: %s Type: %u", key, value->type));
@@ -325,7 +325,7 @@ void pmixt_validate_predefined(pmix_proc_t *myproc, const char *key, pmix_value_
     }
     case PMIX_PROC_RANK: {
         pmix_rank_t rankdata = UINT32_MAX;
-        PMIX_VALUE_GET_NUMBER(rc, value, rankdata, pmix_rank_t);
+        rc = PMIx_Value_get_number(value, &rankdata, PMIX_PROC_RANK);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("Failed to retrieve value correctly. Key: %s Type: %u", key, value->type));
             pmixt_exit(1);

--- a/test/test_v2/test_fence_partial.c
+++ b/test/test_v2/test_fence_partial.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2021-2022 Triad National Security, LLC.
  *                         All rights reserved.
  *
- * Copyright (c) 2021      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,11 +91,11 @@ int main(int argc, char *argv[]) {
     job_proc.rank = PMIX_RANK_WILDCARD;
 
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_JOB_SIZE, NULL, 0, &val), params, v_params);
-    PMIX_VALUE_GET_NUMBER(rc, val, num_procs, uint32_t);
+    rc = PMIx_Value_get_number(val, &num_procs, PMIX_UINT32);
     free(val);
 
     PMIXT_CHECK(PMIx_Get(&job_proc, PMIX_NUM_NODES, NULL, 0, &val), params, v_params);
-    PMIX_VALUE_GET_NUMBER(rc, val, num_nodes, uint32_t);
+    rc = PMIx_Value_get_number(val, &num_nodes, PMIX_UINT32);
     free(val);
 
     if (params.time_fence) {


### PR DESCRIPTION
Fix an unitialized variable. Try to resolve some complaints about data alignment when using the PMIX_VALUE_GET_NUMBER macro backed by the function.