### PR TITLE
Prevent memory overrun in regx calculation

### DIFF
--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,7 +104,7 @@ static pmix_status_t generate_node_regex(const char *input, char **regexp)
         len = strlen(vptr);
         startnum = -1;
         memset(prefix, 0, PMIX_MAX_NODE_PREFIX);
-        for (i = 0, j = 0; i < len; i++) {
+        for (i = 0, j = 0; i < len && j < (PMIX_MAX_NODE_PREFIX-1); i++) {
             if (!isalpha(vptr[i])) {
                 /* found a non-alpha char */
                 if (!isdigit(vptr[i])) {

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +37,7 @@ BEGIN_C_DECLS
 
 /******    MODULE DEFINITION    ******/
 
-#define PMIX_MAX_NODE_PREFIX 50
+#define PMIX_MAX_NODE_PREFIX 8192
 
 /* given a semicolon-separated list of input values, generate
  * a regex that can be passed down to a client for parsing.


### PR DESCRIPTION
If we do use the native regx component, ensure we don't overrun the prefix array when assemplix the prefix on long hostnames