### PR TITLE
Extend authentication support

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -159,12 +159,20 @@ typedef uint32_t pmix_rank_t;
                                                                     //        functions (e.g., capturing signals) that would
                                                                     //        otherwise interfere with the host
 #define PMIX_SERVER_TOOL_SUPPORT            "pmix.srvr.tool"        // (bool) The host RM wants to declare itself as willing
-                                                                    //        to accept tool connection requests
+                                                                    //        to accept tool connection requests - rendezvous
+                                                                    //        files will be readable only by the host's user ID
+#define PMIX_SERVER_ALLOW_FOREIGN_TOOLS     "pmix.srvr.ftools"      // (bool) Mark the tool rendezvous files as readable
+                                                                    //        by all users and allow tools from user IDs other
+                                                                    //        than that of the server to connect. Note that the
+                                                                    //        host has ultimate authority over such connections,
+                                                                    //        and can restrict execution of tool requests as per
+                                                                    //        host policy (e.g., limit foreign tools to "queries")
 #define PMIX_SERVER_REMOTE_CONNECTIONS      "pmix.srvr.remote"      // (bool) Allow connections from remote tools (do not use
                                                                     //        loopback device)
 #define PMIX_SERVER_SYSTEM_SUPPORT          "pmix.srvr.sys"         // (bool) The host RM wants to declare itself as being
                                                                     //        the local system server for PMIx connection
-                                                                    //        requests
+                                                                    //        requests - rendezvous files will be readable
+                                                                    //        only by the host's user ID
 #define PMIX_SERVER_SESSION_SUPPORT         "pmix.srvr.sess"        // (bool) The host RM wants to declare itself as being
                                                                     //        the local session server for PMIx connection
                                                                     //        requests

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -546,8 +546,8 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    if (0 < pmix_globals.init_cntr
-        || (NULL != pmix_globals.mypeer && PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
+    if (0 < pmix_globals.init_cntr ||
+        (NULL != pmix_globals.mypeer && PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
         /* since we have been called before, the nspace and
          * rank should be known. So return them here if
          * requested */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -259,6 +259,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_rank_info_t,
 
 static void pcon(pmix_peer_t *p)
 {
+    p->nptr = NULL;
     p->proc_type.type = PMIX_PROC_UNDEF;
     p->proc_type.major = PMIX_MAJOR_WILDCARD;
     p->proc_type.minor = PMIX_MINOR_WILDCARD;
@@ -286,6 +287,9 @@ static void pcon(pmix_peer_t *p)
 
 static void pdes(pmix_peer_t *p)
 {
+    if (NULL != p->nptr) {
+        PMIX_RELEASE(p->nptr);
+    }
     if (0 <= p->sd) {
         CLOSE_THE_SOCKET(p->sd);
     }
@@ -313,9 +317,6 @@ static void pdes(pmix_peer_t *p)
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
     PMIX_LIST_DESTRUCT(&p->epilog.ignores);
-    if (NULL != p->nptr) {
-        PMIX_RELEASE(p->nptr);
-    }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
                                 pmix_object_t,

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -92,6 +92,7 @@ struct pmix_ptl_base_t {
     bool created_urifile;
     bool remote_connections;
     bool system_tool;
+    bool allow_foreign_tools;
     bool session_tool;
     bool tool_support;
     char *if_include;

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -287,8 +287,13 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
             /* otherwise, mark it as unreachable */
         }
         if (!optional) {
-            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                           filename, "could not be found");
+            if (EACCES == errno) {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "access denied");
+            } else {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "could not be found");
+            }
         }
         return PMIX_ERR_UNREACH;
     }
@@ -297,8 +302,13 @@ process:
     fp = fopen(filename, "r");
     if (NULL == fp) {
         if (!optional) {
-            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                           filename, "could not be opened");
+            if (EACCES == errno) {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "access denied");
+            } else {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "could not be found");
+            }
         }
         return PMIX_ERR_UNREACH;
     }
@@ -561,9 +571,9 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     }
     reply = ntohl(u32);
 
-    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
+    if ((PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+         PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         rc = pmix_ptl_base_client_handshake(peer, reply);
     } else { // we are a tool
         rc = pmix_ptl_base_tool_handshake(peer, reply);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -97,6 +97,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .created_urifile = false,
     .remote_connections = false,
     .system_tool = false,
+    .allow_foreign_tools = false,
     .session_tool = false,
     .tool_support = false,
     .if_include = NULL,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -589,27 +589,36 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
                     free(pmix_server_globals.tmpdir);
                 }
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
                 if (NULL != pmix_server_globals.system_tmpdir) {
                     free(pmix_server_globals.system_tmpdir);
                 }
                 pmix_server_globals.system_tmpdir = strdup(info[n].value.data.string);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_NSPACE)) {
                 nspace = info[n].value.data.string;
                 nspace_given = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_RANK)) {
                 rank = info[n].value.data.rank;
                 rank_given = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SHARE_TOPOLOGY)) {
                 share_topo = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_IOF_LOCAL_OUTPUT)) {
                 outputio = PMIX_INFO_TRUE(&info[n]);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SINGLETON)) {
                 singleton = info[n].value.data.string;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_MAU)) {
                 mau = info[n].value.data.darray;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_CONNECT_OPTIONAL)) {
                 connect_optional = PMIX_INFO_TRUE(&info[n]);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_TO_SYSTEM)) {
                 if (PMIX_INFO_TRUE(&info[n])) {
                     connect_directed = true;


### PR DESCRIPTION
Provide the ability to include/exclude connections from tools whose user IDs are different from that of the server (i.e., "foreign" tools). Add an attribute to direct that behavior, default to "exclude". If we allow foreign tools, then modify the rendezvous file permissions to allow read by others. Track both the real user/group IDs vs the effective ones in case someone wants to check both. Pass more information up to the server client_connected2 and tool_connection upcalls so the server can make more informed decisions.