### PR TITLE
Multiple commits

### DIFF
--- a/examples/tool.c
+++ b/examples/tool.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -319,9 +319,12 @@ int main(int argc, char **argv)
                             }
                             iptr = (pmix_info_t *) dptr->array;
                             for (m = 0; m < dptr->size; m++) {
-                                fprintf(stderr, "\t%s", iptr[m].value.data.string);
+                                if (PMIX_CHECK_KEY(&iptr[m], PMIX_PROC_INFO_ARRAY)) {
+                                    fprintf(stderr, "\n");
+                                }
+                                fprintf(stderr, "\t%s", PMIx_Info_string(&iptr[m]));
                             }
-                            fprintf(stderr, "\n");
+                            fprintf(stderr, "\n\n");
                         }
                     }
                 }

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -38,7 +38,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1638,7 +1638,7 @@ PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
 
 /* load a process ID struct */
-PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p, 
+PMIX_EXPORT void PMIx_Load_procid(pmix_proc_t *p,
                                   const char *ns,
                                   pmix_rank_t rk);
 
@@ -1799,7 +1799,6 @@ PMIX_EXPORT void PMIx_Info_persistent(pmix_info_t *p);
 
 /* check if the info struct is persistent */
 PMIX_EXPORT bool PMIx_Info_is_persistent(const pmix_info_t *p);
-
 
 /* initialize a coord struct */
 PMIX_EXPORT void PMIx_Coord_construct(pmix_coord_t *m);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -256,7 +256,9 @@ typedef uint32_t pmix_rank_t;
                                                                     //        directives with a single call to PMIx_Get
 
 /* identification attributes */
+#define PMIX_REALUID                        "pmix.ruid"             // (uint32_t) real user id
 #define PMIX_USERID                         "pmix.euid"             // (uint32_t) effective user id
+#define PMIX_REALGID                        "pmix.rgid"             // (uint32_t) real group id
 #define PMIX_GRPID                          "pmix.egid"             // (uint32_t) effective group id
 #define PMIX_VERSION_INFO                   "pmix.version"          // (char*) PMIx version of contactor
 #define PMIX_REQUESTOR_IS_TOOL              "pmix.req.tool"         // (bool) requesting process is a tool

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -159,12 +159,20 @@ typedef uint32_t pmix_rank_t;
                                                                     //        functions (e.g., capturing signals) that would
                                                                     //        otherwise interfere with the host
 #define PMIX_SERVER_TOOL_SUPPORT            "pmix.srvr.tool"        // (bool) The host RM wants to declare itself as willing
-                                                                    //        to accept tool connection requests
+                                                                    //        to accept tool connection requests - rendezvous
+                                                                    //        files will be readable only by the host's user ID
+#define PMIX_SERVER_ALLOW_FOREIGN_TOOLS     "pmix.srvr.ftools"      // (bool) Mark the tool rendezvous files as readable
+                                                                    //        by all users and allow tools from user IDs other
+                                                                    //        than that of the server to connect. Note that the
+                                                                    //        host has ultimate authority over such connections,
+                                                                    //        and can restrict execution of tool requests as per
+                                                                    //        host policy (e.g., limit foreign tools to "queries")
 #define PMIX_SERVER_REMOTE_CONNECTIONS      "pmix.srvr.remote"      // (bool) Allow connections from remote tools (do not use
                                                                     //        loopback device)
 #define PMIX_SERVER_SYSTEM_SUPPORT          "pmix.srvr.sys"         // (bool) The host RM wants to declare itself as being
                                                                     //        the local system server for PMIx connection
-                                                                    //        requests
+                                                                    //        requests - rendezvous files will be readable
+                                                                    //        only by the host's user ID
 #define PMIX_SERVER_SESSION_SUPPORT         "pmix.srvr.sess"        // (bool) The host RM wants to declare itself as being
                                                                     //        the local session server for PMIx connection
                                                                     //        requests

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -450,6 +450,21 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
                                              const void *value,
                                              pmix_data_type_t type);
 
+PMIX_EXPORT pmix_status_t PMIx_Info_list_add_unique(void *ptr,
+                                                    const char *key,
+                                                    const void *value,
+                                                    pmix_data_type_t type,
+                                                    bool overwrite);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_add_value(void *ptr,
+                                                   const char *key,
+                                                   const pmix_value_t *value);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_add_value_unique(void *ptr,
+                                                          const char *key,
+                                                          const pmix_value_t *value,
+                                                          bool overwrite);
+
 PMIX_EXPORT pmix_status_t PMIx_Info_list_prepend(void *ptr,
                                                  const char *key,
                                                  const void *value,
@@ -459,6 +474,10 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr, pmix_info_t *info);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr,
                                               const pmix_info_t *info);
+
+PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer_unique(void *ptr,
+                                                     const pmix_info_t *info,
+                                                     bool overwrite);
 
 PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *par);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -710,6 +710,11 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
     PMIX_LOAD_PROCID(pmix_globals.myidval.data.proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
     pmix_globals.myrankval.data.rank = pmix_globals.myid.rank;
+    pmix_globals.mypeer->info->realuid = pmix_globals.realuid;
+    pmix_globals.mypeer->info->uid = pmix_globals.uid;
+    pmix_globals.mypeer->info->realgid = pmix_globals.realgid;
+    pmix_globals.mypeer->info->gid = pmix_globals.gid;
+    pmix_globals.mypeer->info->pid = pmix_globals.pid;
 
     /* select our psec compat module - the selection will be based
      * on the corresponding envars that should have been passed

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -546,8 +546,8 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    if (0 < pmix_globals.init_cntr
-        || (NULL != pmix_globals.mypeer && PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
+    if (0 < pmix_globals.init_cntr ||
+        (NULL != pmix_globals.mypeer && PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
         /* since we have been called before, the nspace and
          * rank should be known. So return them here if
          * requested */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -235,7 +235,11 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_keyindex_t,
 static void info_con(pmix_rank_info_t *info)
 {
     info->peerid = -1;
-    info->gid = info->uid = 0;
+    info->pid = -1;
+    info->realuid = 0;
+    info->uid = 0;
+    info->realgid = 0;
+    info->gid = 0;
     info->pname.nspace = NULL;
     info->pname.rank = PMIX_RANK_UNDEF;
     info->modex_recvd = false;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -258,6 +258,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_rank_info_t,
 
 static void pcon(pmix_peer_t *p)
 {
+    p->nptr = NULL;
     p->proc_type.type = PMIX_PROC_UNDEF;
     p->proc_type.major = PMIX_MAJOR_WILDCARD;
     p->proc_type.minor = PMIX_MINOR_WILDCARD;
@@ -282,6 +283,9 @@ static void pcon(pmix_peer_t *p)
 
 static void pdes(pmix_peer_t *p)
 {
+    if (NULL != p->nptr) {
+        PMIX_RELEASE(p->nptr);
+    }
     if (0 <= p->sd) {
         CLOSE_THE_SOCKET(p->sd);
     }
@@ -309,9 +313,6 @@ static void pdes(pmix_peer_t *p)
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
     PMIX_LIST_DESTRUCT(&p->epilog.ignores);
-    if (NULL != p->nptr) {
-        PMIX_RELEASE(p->nptr);
-    }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
                                 pmix_object_t,

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -766,6 +766,7 @@ typedef struct {
     gid_t realgid;       // real gid
     gid_t gid;           // my effective gid
     char *hostname;      // my hostname
+    char **aliases;      // aliases for my hostname
     uint32_t appnum;     // my appnum
     pid_t pid;           // my local pid
     uint32_t nodeid;     // my nodeid, if given

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -393,7 +393,10 @@ typedef struct pmix_rank_info_t {
     pmix_list_item_t super;
     int peerid; // peer object index into the local clients array on the server
     pmix_name_t pname;
+    pid_t pid;
+    uid_t realuid;
     uid_t uid;
+    gid_t realgid;
     gid_t gid;
     bool modex_recvd;
     int proc_cnt;        // #clones of this rank we know about
@@ -758,7 +761,9 @@ typedef struct {
     pmix_value_t myidval;
     pmix_value_t myrankval;
     pmix_peer_t *mypeer; // my own peer object
+    uid_t realuid;       // real uid
     uid_t uid;           // my effective uid
+    gid_t realgid;       // real gid
     gid_t gid;           // my effective gid
     char *hostname;      // my hostname
     uint32_t appnum;     // my appnum

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -40,6 +40,7 @@
 #include "src/mca/pmdl/pmdl.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
@@ -380,6 +381,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             if (NULL == nd) {
                 nd = PMIX_NEW(pmix_nodeinfo_t);
                 nd->hostname = strdup(pmix_globals.hostname);
+                pmix_set_aliases(&nd->aliases, nd->hostname);
                 pmix_list_append(&trk->nodeinfo, &nd->super);
             }
             /* ensure the value isn't already on the node info */

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -41,11 +41,13 @@
 #include "src/mca/pmdl/pmdl.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_hash.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -143,6 +145,10 @@ pmix_status_t pmix_gds_hash_process_node_array(pmix_value_t *val, pmix_list_t *t
         /* they forgot to pass us the ident for the node */
         PMIX_LIST_DESTRUCT(&cache);
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (NULL != nd->hostname) {
+        pmix_set_aliases(&nd->aliases, nd->hostname);
     }
 
     /* see if we already have this node on the

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,7 +104,7 @@ static pmix_status_t generate_node_regex(const char *input, char **regexp)
         len = strlen(vptr);
         startnum = -1;
         memset(prefix, 0, PMIX_MAX_NODE_PREFIX);
-        for (i = 0, j = 0; i < len; i++) {
+        for (i = 0, j = 0; i < len && j < (PMIX_MAX_NODE_PREFIX-1); i++) {
             if (!isalpha(vptr[i])) {
                 /* found a non-alpha char */
                 if (!isdigit(vptr[i])) {

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +37,7 @@ BEGIN_C_DECLS
 
 /******    MODULE DEFINITION    ******/
 
-#define PMIX_MAX_NODE_PREFIX 50
+#define PMIX_MAX_NODE_PREFIX 8192
 
 /* given a semicolon-separated list of input values, generate
  * a regex that can be passed down to a client for parsing.

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -93,6 +93,7 @@ struct pmix_ptl_base_t {
     bool created_urifile;
     bool remote_connections;
     bool system_tool;
+    bool allow_foreign_tools;
     bool session_tool;
     bool tool_support;
     char *if_include;

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -132,3 +132,13 @@ rendezvous file:
   Error:     %s
 
 Please correct the error and try again.
+#
+[mismatch-id]
+The %s ID of the client process does not match the ID registered
+by the host runtime:
+
+  Process:     %u
+  Registered:  %u
+
+This could be a security issue. Please check the situation and
+try again.

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -59,7 +59,6 @@ typedef struct {
     pmix_status_t status;
     pmix_status_t reply;
     pmix_pending_connection_t *pnd;
-    char *blob;
     pmix_peer_t *peer;
     pmix_info_t *info;
     size_t ninfo;
@@ -68,7 +67,6 @@ static void chcon(cnct_hdlr_t *p)
 {
     memset(&p->ev, 0, sizeof(pmix_event_t));
     p->pnd = NULL;
-    p->blob = NULL;
     p->peer = NULL;
     p->info = NULL;
     p->ninfo = 0;
@@ -77,9 +75,6 @@ static void chdes(cnct_hdlr_t *p)
 {
     if (NULL != p->pnd) {
         PMIX_RELEASE(p->pnd);
-    }
-    if (NULL != p->blob) {
-        free(p->blob);
     }
     if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
@@ -553,7 +548,6 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     ch->peer = peer;
     ch->pnd = pnd;
     ch->reply = reply;
-    ch->blob = blob;
 
     PMIx_Info_list_add(ilist, PMIX_USERID, &info->uid, PMIX_UINT32);
     PMIx_Info_list_add(ilist, PMIX_GRPID, &info->gid, PMIX_UINT32);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -495,10 +495,11 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     /* let the host server know that this client has connected */
     if (NULL != pmix_host_server.client_connected2) {
         PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
-        ch->ninfo = 2;
+        ch->ninfo = 3;
         PMIX_INFO_CREATE(ch->info, ch->ninfo);
         PMIX_INFO_LOAD(&ch->info[0], PMIX_USERID, &peer->info->uid, PMIX_UINT32);
         PMIX_INFO_LOAD(&ch->info[1], PMIX_GRPID, &peer->info->gid, PMIX_UINT32);
+        PMIX_INFO_LOAD(&ch->info[2], PMIX_PROC_PID, &peer->info->pid, PMIX_PID);
         rc = pmix_host_server.client_connected2(&proc, peer->info->server_object,
                                                 ch->info, ch->ninfo,
                                                 _connect_complete, ch);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -41,6 +41,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_getid.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_strnlen.h"
 
 #include "src/mca/ptl/base/base.h"
@@ -169,15 +170,19 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     pmix_peer_t *peer = NULL;
     pmix_status_t rc, reply;
     char *msg = NULL, *mg, *p, *blob = NULL;
-    size_t cnt;
+    size_t cnt, ncnt;
     size_t len = 0;
     pmix_namespace_t *nptr, *tmp;
     pmix_rank_info_t *info = NULL, *iptr;
     pmix_proc_t proc;
-    pmix_info_t ginfo;
+    pmix_info_t ginfo, *iblob;
     pmix_byte_object_t cred;
     uint8_t major, minor, release;
     cnct_hdlr_t *ch;
+    void *ilist;
+    pmix_data_array_t darray;
+    pmix_buffer_t buf;
+    int32_t i32;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -468,6 +473,60 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         nptr->version_stored = true;
     }
 
+    ilist = PMIx_Info_list_start();
+    // if a blob was provided, then unpack it
+    if (NULL != blob) {
+        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+        PMIX_LOAD_BUFFER_NON_DESTRUCT(peer, &buf, blob, len); // allocates no memory
+        i32 = 1;
+        PMIX_BFROPS_UNPACK(rc, peer, &buf, &cnt, &i32, PMIX_SIZE);
+        if (0 < cnt) {
+            PMIX_INFO_CREATE(iblob, cnt);
+            i32 = cnt;
+            PMIX_BFROPS_UNPACK(rc, peer, &buf, iblob, &i32, PMIX_INFO);
+            // process the data
+            for (ncnt=0; ncnt < cnt; ncnt++) {
+                if (PMIx_Check_key(iblob[ncnt].key, PMIX_PROC_PID)) {
+                    info->pid = iblob[ncnt].value.data.pid;
+                    PMIx_Info_list_add(ilist, PMIX_PROC_PID, &info->pid, PMIX_PID);
+
+                } else if (PMIx_Check_key(iblob[ncnt].key, PMIX_REALUID)) {
+                    info->realuid = iblob[ncnt].value.data.uint32;
+                    PMIx_Info_list_add(ilist, PMIX_REALUID, &info->realuid, PMIX_UINT32);
+
+                } else if (PMIx_Check_key(iblob[ncnt].key, PMIX_USERID)) {
+                    // check if the client is claiming to be someone other
+                    // than what they were registered as
+                    if (info->uid != iblob[ncnt].value.data.uint32) {
+                        // mismatch
+                        PMIx_Info_list_release(ilist);
+                        pmix_show_help("help-ptl-base.txt", "mismatch-id", true,
+                                       "user", iblob[ncnt].value.data.uint32, info->uid);
+                        goto error;
+                    }
+
+                } else if (PMIx_Check_key(iblob[ncnt].key, PMIX_REALGID)) {
+                    info->realgid = iblob[ncnt].value.data.uint32;
+                    PMIx_Info_list_add(ilist, PMIX_REALGID, &info->realgid, PMIX_UINT32);
+
+                } else if (PMIx_Check_key(iblob[ncnt].key, PMIX_GRPID)) {
+                    // check if the client is claiming to be someone other
+                    // than what they were registered as
+                    if (info->gid != iblob[ncnt].value.data.uint32) {
+                        // mismatch
+                        PMIx_Info_list_release(ilist);
+                        pmix_show_help("help-ptl-base.txt", "mismatch-id", true,
+                                       "group", iblob[ncnt].value.data.uint32, info->uid);
+                        goto error;
+                    }
+                }
+            }
+            PMIX_INFO_FREE(iblob, cnt);
+        }
+        free(blob);
+
+    }
+
     free(msg); // can now release the data buffer
     msg = NULL;
 
@@ -478,6 +537,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != reply) {
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "validation of client connection failed");
+        PMIx_Info_list_release(ilist);
         goto error;
     }
 
@@ -492,14 +552,16 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     ch->reply = reply;
     ch->blob = blob;
 
+    PMIx_Info_list_add(ilist, PMIX_USERID, &info->uid, PMIX_UINT32);
+    PMIx_Info_list_add(ilist, PMIX_GRPID, &info->gid, PMIX_UINT32);
+    PMIx_Info_list_convert(ilist, &darray);
+    ch->info = (pmix_info_t*)darray.array;
+    ch->ninfo = darray.size;
+    PMIx_Info_list_release(ilist);
+
     /* let the host server know that this client has connected */
     if (NULL != pmix_host_server.client_connected2) {
         PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
-        ch->ninfo = 3;
-        PMIX_INFO_CREATE(ch->info, ch->ninfo);
-        PMIX_INFO_LOAD(&ch->info[0], PMIX_USERID, &peer->info->uid, PMIX_UINT32);
-        PMIX_INFO_LOAD(&ch->info[1], PMIX_GRPID, &peer->info->gid, PMIX_UINT32);
-        PMIX_INFO_LOAD(&ch->info[2], PMIX_PROC_PID, &peer->info->pid, PMIX_PID);
         rc = pmix_host_server.client_connected2(&proc, peer->info->server_object,
                                                 ch->info, ch->ninfo,
                                                 _connect_complete, ch);
@@ -777,9 +839,12 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     pmix_namespace_t *nptr, *tmp;
     pmix_rank_info_t *info;
     bool found;
-    size_t n;
+    size_t n, sz;
     pmix_buffer_t buf;
     pmix_status_t rc;
+    void *ilist;
+    pmix_info_t *iptr;
+    pmix_data_array_t darray;
 
     peer = PMIX_NEW(pmix_peer_t);
     if (NULL == peer) {
@@ -870,43 +935,38 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     peer->nptr->compat.type = pnd->buffer_type;
     n = 0;
     /* if info structs need to be passed along, then unpack them */
+    ilist = PMIx_Info_list_start();
     if (0 < cnt) {
         int32_t foo;
         PMIX_CONSTRUCT(&buf, pmix_buffer_t);
         PMIX_LOAD_BUFFER_NON_DESTRUCT(peer, &buf, mg, cnt); // allocates no memory
         foo = 1;
-        PMIX_BFROPS_UNPACK(rc, peer, &buf, &pnd->ninfo, &foo, PMIX_SIZE);
+        PMIX_BFROPS_UNPACK(rc, peer, &buf, &sz, &foo, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(peer);
+            PMIx_Info_list_release(ilist);
             return rc;
         }
-        foo = (int32_t) pnd->ninfo;
-        /* if we have an identifier, then we leave room to pass it */
-        if (!pnd->need_id) {
-            pnd->ninfo += 5;
-        } else {
-            pnd->ninfo += 3;
-        }
-        PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
-        PMIX_BFROPS_UNPACK(rc, peer, &buf, pnd->info, &foo, PMIX_INFO);
+        foo = (int32_t) sz;
+        PMIX_INFO_CREATE(iptr, sz);
+        PMIX_BFROPS_UNPACK(rc, peer, &buf, iptr, &foo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(peer);
+            PMIX_INFO_FREE(iptr, sz);
+            PMIx_Info_list_release(ilist);
             return rc;
         }
-        n = foo;
-    } else {
-        if (!pnd->need_id) {
-            pnd->ninfo = 5;
-        } else {
-            pnd->ninfo = 3;
+        for (n=0; n < sz; n++) {
+            PMIx_Info_list_xfer(ilist, &iptr[n]);
         }
-        PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+        PMIX_INFO_FREE(iptr, sz);
     }
 
     /* does the server support tool connections? */
     if (NULL == pmix_host_server.tool_connected) {
+        PMIx_Info_list_release(ilist);
         if (pnd->need_id) {
             /* we need someone to provide the tool with an
              * identifier and they aren't available */
@@ -924,21 +984,28 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     /* setup the info array to pass the relevant info
      * to the server */
     /* provide the version */
-    PMIX_INFO_LOAD(&pnd->info[n], PMIX_VERSION_INFO, pnd->version, PMIX_STRING);
-    ++n;
+    PMIx_Info_list_add_unique(ilist, PMIX_VERSION_INFO,
+                              pnd->version, PMIX_STRING, true);
+
     /* provide the user id */
-    PMIX_INFO_LOAD(&pnd->info[n], PMIX_USERID, &pnd->uid, PMIX_UINT32);
-    ++n;
+    PMIx_Info_list_add_unique(ilist, PMIX_USERID,
+                              &pnd->uid, PMIX_UINT32, false);
+
     /* and the group id */
-    PMIX_INFO_LOAD(&pnd->info[n], PMIX_GRPID, &pnd->gid, PMIX_UINT32);
-    ++n;
+    PMIx_Info_list_add_unique(ilist, PMIX_GRPID,
+                              &pnd->gid, PMIX_UINT32, false);
+
     /* if we have it, pass along their ID */
     if (!pnd->need_id) {
-        PMIX_INFO_LOAD(&pnd->info[n], PMIX_NSPACE, pnd->proc.nspace, PMIX_STRING);
-        ++n;
-        PMIX_INFO_LOAD(&pnd->info[n], PMIX_RANK, &pnd->proc.rank, PMIX_PROC_RANK);
-        ++n;
+        PMIx_Info_list_add_unique(ilist, PMIX_NSPACE,
+                                  pnd->proc.nspace, PMIX_STRING, true);
+        PMIx_Info_list_add_unique(ilist, PMIX_RANK,
+                                  &pnd->proc.rank, PMIX_PROC_RANK, true);
     }
+    PMIx_Info_list_convert(ilist, &darray);
+    pnd->info = (pmix_info_t*)darray.array;
+    pnd->ninfo = darray.size;
+    PMIx_Info_list_release(ilist);
 
     /* pass it up for processing */
     pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -107,6 +107,7 @@ static void _cnct_complete(int sd, short args, void *cbdata)
         PMIX_ERROR_LOG(rc);
         goto error;
     }
+
     /* If needed, perform the handshake. The macro will update reply */
     PMIX_PSEC_SERVER_HANDSHAKE_IFNEED(ch->reply, ch->peer);
 
@@ -356,7 +357,8 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     }
 
     /* see if this is a tool connection request */
-    if (PMIX_SIMPLE_CLIENT != pnd->flag) {
+    if (PMIX_SIMPLE_CLIENT != pnd->flag &&
+        PMIX_SINGLETON_CLIENT != pnd->flag) {
         /* nope, it's for a tool, so process it
          * separately - it is a 2-step procedure */
         rc = process_tool_request(pnd, blob, len);
@@ -416,6 +418,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     if (NULL == peer) {
         goto error;
     }
+
     /* mark that this peer is a client of the given type */
     memcpy(&peer->proc_type, &pnd->proc_type, sizeof(pmix_proc_type_t));
     /* save the protocol */
@@ -575,6 +578,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
             PMIX_RELEASE(ch);
             goto error;
         }
+
     } else if (NULL != pmix_host_server.client_connected) {
         PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
         rc = pmix_host_server.client_connected(&proc, peer->info->server_object, _connect_complete, ch);
@@ -638,8 +642,8 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
     /* send this status so they don't hang */
     u32 = ntohl(cd->status);
-    if (PMIX_SUCCESS
-        != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t)))) {
+    rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t));
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
@@ -652,33 +656,33 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     /* if we got an identifier, send it back to the tool */
     if (pnd->need_id) {
         /* start with the nspace */
-        if (PMIX_SUCCESS
-            != (rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN + 1))) {
+        rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN + 1);
+        if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto error;
         }
 
         /* now the rank, suitably converted */
         u32 = ntohl(cd->proc.rank);
-        if (PMIX_SUCCESS
-            != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t)))) {
+        rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t));
+        if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto error;
         }
     }
 
     /* send my nspace back to the tool */
-    if (PMIX_SUCCESS
-        != (rc = pmix_ptl_base_send_blocking(pnd->sd, pmix_globals.myid.nspace,
-                                             PMIX_MAX_NSLEN + 1))) {
+    rc = pmix_ptl_base_send_blocking(pnd->sd, pmix_globals.myid.nspace,
+                                             PMIX_MAX_NSLEN + 1);
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
 
     /* send my rank back to the tool */
     u32 = ntohl(pmix_globals.myid.rank);
-    if (PMIX_SUCCESS
-        != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t)))) {
+    rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t));
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
@@ -835,7 +839,7 @@ static void cnct_cbfunc(pmix_status_t status, pmix_proc_t *proc, void *cbdata)
 static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
                                           char *mg, size_t cnt)
 {
-    pmix_peer_t *peer;
+    pmix_peer_t *peer, *p2;
     pmix_namespace_t *nptr, *tmp;
     pmix_rank_info_t *info;
     bool found;
@@ -846,27 +850,34 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     pmix_info_t *iptr;
     pmix_data_array_t darray;
 
+    if (!pmix_ptl_base.allow_foreign_tools) {
+        if (pnd->uid != pmix_globals.uid) {
+            // reject this connection
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+    }
+
     peer = PMIX_NEW(pmix_peer_t);
     if (NULL == peer) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
     }
     pnd->peer = peer;
+
+    /* see if we know this nspace - i.e., was it registered or did
+     * another tool within it already connect */
+    nptr = NULL;
+    PMIX_LIST_FOREACH (tmp, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (0 == strcmp(tmp->nspace, pnd->proc.nspace)) {
+            nptr = tmp;
+            break;
+        }
+    }
+
     /* if this is a tool we launched, then the host may
      * have already registered it as a client - so check
      * to see if we already have a peer for it */
     if (PMIX_TOOL_CLIENT == pnd->flag || PMIX_LAUNCHER_CLIENT == pnd->flag) {
-        /* registration only adds the nspace and a rank in that
-         * nspace - it doesn't add the peer object to our array
-         * of local clients. So let's start by searching for
-         * the nspace object */
-        nptr = NULL;
-        PMIX_LIST_FOREACH (tmp, &pmix_globals.nspaces, pmix_namespace_t) {
-            if (0 == strcmp(tmp->nspace, pnd->proc.nspace)) {
-                nptr = tmp;
-                break;
-            }
-        }
         if (NULL == nptr) {
             /* it is possible that this is a tool inside of
              * a job-script as part of a multi-spawn operation.
@@ -880,6 +891,7 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
             nptr = PMIX_NEW(pmix_namespace_t);
             if (NULL == nptr) {
                 PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                PMIX_RELEASE(peer);
                 return PMIX_ERR_NOMEM;
             }
             nptr->nspace = strdup(pnd->proc.nspace);
@@ -909,18 +921,62 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
         PMIX_RETAIN(info);
         peer->info = info;
         PMIX_RETAIN(nptr);
+
+    } else if (NULL != nptr) {
+        /* this is an non-client tool/launcher that already
+         * has a known nspace that wasn't defined by register_client.
+         * We must therefore already have a rank for it that connected
+         * (so we would know the nspace), and the uid/gid's of this proc
+         * must match those already registered */
+        info = (pmix_rank_info_t*)pmix_list_get_first(&nptr->ranks);
+        if (NULL == info) {
+            /* this cannot happen - the nspace can only exist because
+             * a prior instance of the tool already connected */
+            PMIX_RELEASE(peer);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+        if (-1 == info->peerid) {
+            /* this proc has not connected - this cannot happen
+             * for a tool as we otherwise would not know of it */
+            PMIX_RELEASE(peer);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+        p2 = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, info->peerid);
+        if (NULL == p2) {
+            // that's an error
+            PMIX_RELEASE(peer);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+            return PMIX_ERR_NOT_FOUND;
+        }
+        if (!PMIX_PEER_IS_TOOL(p2)) {
+            /* cannot happen - the entire nspace must be a tool if this proc claims
+             * to be a member of that nspace and is a tool */
+            PMIX_RELEASE(peer);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+        /* all members of an nspace must be from the same uid and gid */
+        if (info->uid != pnd->uid ||
+            info->gid != pnd->gid) {
+            PMIX_RELEASE(peer);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+            return PMIX_ERR_NOT_SUPPORTED;
+        }
+
     } else {
         nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             PMIX_RELEASE(peer);
-            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
         }
         /* save the version */
         nptr->version.major = pnd->proc_type.major;
         nptr->version.minor = pnd->proc_type.minor;
         nptr->version.release = pnd->proc_type.release;
+        /* we will add the info record later */
     }
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack
@@ -1002,10 +1058,16 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
         PMIx_Info_list_add_unique(ilist, PMIX_RANK,
                                   &pnd->proc.rank, PMIX_PROC_RANK, true);
     }
-    PMIx_Info_list_convert(ilist, &darray);
+    rc = PMIx_Info_list_convert(ilist, &darray);
+    PMIx_Info_list_release(ilist);
+    if (PMIX_SUCCESS  != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(peer);
+        return rc;
+    }
+
     pnd->info = (pmix_info_t*)darray.array;
     pnd->ninfo = darray.size;
-    PMIx_Info_list_release(ilist);
 
     /* pass it up for processing */
     pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -60,6 +60,8 @@ typedef struct {
     pmix_pending_connection_t *pnd;
     char *blob;
     pmix_peer_t *peer;
+    pmix_info_t *info;
+    size_t ninfo;
 } cnct_hdlr_t;
 static void chcon(cnct_hdlr_t *p)
 {
@@ -67,6 +69,8 @@ static void chcon(cnct_hdlr_t *p)
     p->pnd = NULL;
     p->blob = NULL;
     p->peer = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
 }
 static void chdes(cnct_hdlr_t *p)
 {
@@ -75,6 +79,9 @@ static void chdes(cnct_hdlr_t *p)
     }
     if (NULL != p->blob) {
         free(p->blob);
+    }
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
     }
 }
 static PMIX_CLASS_INSTANCE(cnct_hdlr_t,
@@ -87,6 +94,10 @@ static void _cnct_complete(int sd, short args, void *cbdata)
     uint32_t u32;
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    if (PMIX_SUCCESS != ch->status) {
+        goto error;
+    }
 
     /* tell the client all is good */
     u32 = htonl(ch->reply);
@@ -484,7 +495,12 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     /* let the host server know that this client has connected */
     if (NULL != pmix_host_server.client_connected2) {
         PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
-        rc = pmix_host_server.client_connected2(&proc, peer->info->server_object, NULL, 0,
+        ch->ninfo = 2;
+        PMIX_INFO_CREATE(ch->info, ch->ninfo);
+        PMIX_INFO_LOAD(&ch->info[0], PMIX_USERID, &peer->info->uid, PMIX_UINT32);
+        PMIX_INFO_LOAD(&ch->info[1], PMIX_GRPID, &peer->info->gid, PMIX_UINT32);
+        rc = pmix_host_server.client_connected2(&proc, peer->info->server_object,
+                                                ch->info, ch->ninfo,
                                                 _connect_complete, ch);
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             ch->status = PMIX_SUCCESS;
@@ -493,6 +509,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(ch);
             goto error;
         }
     } else if (NULL != pmix_host_server.client_connected) {
@@ -505,6 +522,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(ch);
             goto error;
         }
     } else {

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -322,8 +322,13 @@ pmix_status_t pmix_ptl_base_parse_uri_file(char *filename,
             /* otherwise, mark it as unreachable */
         }
         if (!optional) {
-            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                           filename, "could not be found");
+            if (EACCES == errno) {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "access denied");
+            } else {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "could not be found");
+            }
         }
         return PMIX_ERR_UNREACH;
     }
@@ -332,8 +337,13 @@ process:
     fp = fopen(filename, "r");
     if (NULL == fp) {
         if (!optional) {
-            pmix_show_help("help-ptl-base.txt", "file-not-found", true,
-                           filename, "could not be opened");
+            if (EACCES == errno) {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "access denied");
+            } else {
+                pmix_show_help("help-ptl-base.txt", "file-not-found", true,
+                               filename, "could not be found");
+            }
         }
         return PMIX_ERR_UNREACH;
     }
@@ -596,9 +606,9 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
     }
     reply = ntohl(u32);
 
-    if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer) &&
-        !PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) {
+    if ((PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+         PMIX_PEER_IS_SINGLETON(pmix_globals.mypeer)) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         rc = pmix_ptl_base_client_handshake(peer, reply);
     } else { // we are a tool
         rc = pmix_ptl_base_tool_handshake(peer, reply);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -98,6 +98,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .created_urifile = false,
     .remote_connections = false,
     .system_tool = false,
+    .allow_foreign_tools = false,
     .session_tool = false,
     .tool_support = false,
     .if_include = NULL,

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -195,10 +195,11 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
 static pmix_status_t write_rndz_file(char *filename, char *uri,
                                      bool *dir_created, bool *file_created)
 {
-    FILE *fp;
-    char *dirname;
+    int fd;
+    char *dirname, *tmp;
     time_t mytime;
     int rc;
+    mode_t mode = 0;
 
     dirname = pmix_dirname(filename);
     if (NULL != dirname) {
@@ -223,32 +224,42 @@ static pmix_status_t write_rndz_file(char *filename, char *uri,
         free(dirname);
     }
 
-    fp = fopen(filename, "w");
-    if (NULL == fp) {
+    /* set the file mode */
+    mode = S_IRUSR | S_IWUSR | S_IRGRP;
+    if (pmix_ptl_base.allow_foreign_tools) {
+        mode |= S_IROTH;
+    }
+    fd = open(filename, O_RDWR | O_CREAT | O_EXCL, mode);
+    if (0 > fd) {
+        if (EEXIST == errno) {
+            // the file already exists
+            *file_created = false;
+            return PMIX_ERR_EXISTS;
+        }
         pmix_output(0, "Impossible to open the file %s in write mode\n", filename);
         PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
         *file_created = false;
         return PMIX_ERR_FILE_OPEN_FAILURE;
     }
 
-    /* output the URI */
-    fprintf(fp, "%s\n", uri);
-    /* add the version */
-    fprintf(fp, "%s\n", PMIX_VERSION);
-    /* output our pid */
-    fprintf(fp, "%lu\n", (unsigned long) getpid());
-    /* output our effective uid and gid */
-    fprintf(fp, "%lu:%lu\n", (unsigned long) geteuid(), (unsigned long) getegid());
-    /* output the time */
+    /* output the information */
     mytime = time(NULL);
-    fprintf(fp, "%s\n", ctime(&mytime));
-    fclose(fp);
-    *file_created = true;
-    /* set the file mode */
-    if (0 != chmod(filename, S_IRUSR | S_IWUSR | S_IRGRP)) {
-        PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
-        return PMIX_ERR_FILE_OPEN_FAILURE;
+    pmix_asprintf(&tmp, "%s\n%s\n%lu\n%lu:%lu\n%s\n",
+                  uri, PMIX_VERSION, (unsigned long)pmix_globals.pid,
+                  (unsigned long)pmix_globals.uid,
+                  (unsigned long)pmix_globals.gid,
+                  ctime(&mytime));
+    rc = write(fd, tmp, strlen(tmp));
+    if (0 > rc) {
+        PMIX_ERROR_LOG(PMIX_ERR_FILE_WRITE_FAILURE);
+        *file_created = false;
+        pmix_free(tmp);
+        close(fd);
+        return PMIX_ERR_FILE_WRITE_FAILURE;
     }
+    pmix_free(tmp);
+    close(fd);
+    *file_created = true;
     return PMIX_SUCCESS;
 }
 
@@ -294,34 +305,49 @@ pmix_status_t pmix_ptl_base_setup_listener(pmix_info_t info[], size_t ninfo)
     for (n = 0; n < ninfo; n++) {
         if (0 == strcmp(info[n].key, PMIX_SERVER_SESSION_SUPPORT)) {
             pmix_ptl_base.session_tool = PMIX_INFO_TRUE(&info[n]);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SYSTEM_SUPPORT)) {
             pmix_ptl_base.system_tool = PMIX_INFO_TRUE(&info[n]);
+
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_ALLOW_FOREIGN_TOOLS)) {
+            pmix_ptl_base.allow_foreign_tools = PMIX_INFO_TRUE(&info[n]);
+
         } else if (0 == strcmp(info[n].key, PMIX_SERVER_TOOL_SUPPORT)) {
             pmix_ptl_base.tool_support = PMIX_INFO_TRUE(&info[n]);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_REMOTE_CONNECTIONS)) {
             pmix_ptl_base.remote_connections = PMIX_INFO_TRUE(&info[n]);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_INCLUDE)) {
             pmix_ptl_base.if_include = strdup(info[n].value.data.string);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_EXCLUDE)) {
             pmix_ptl_base.if_exclude = strdup(info[n].value.data.string);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV4_PORT)) {
             pmix_ptl_base.ipv4_port = info[n].value.data.integer;
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV6_PORT)) {
             pmix_ptl_base.ipv6_port = info[n].value.data.integer;
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV4)) {
             pmix_ptl_base.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
             pmix_ptl_base.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_REPORT_URI)) {
             if (NULL != pmix_ptl_base.report_uri) {
                 free(pmix_ptl_base.report_uri);
             }
             pmix_ptl_base.report_uri = strdup(info[n].value.data.string);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
             if (NULL != pmix_ptl_base.session_tmpdir) {
                 free(pmix_ptl_base.session_tmpdir);
             }
             pmix_ptl_base.session_tmpdir = strdup(info[n].value.data.string);
+
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
             if (NULL != pmix_ptl_base.system_tmpdir) {
                 free(pmix_ptl_base.system_tmpdir);

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -203,7 +203,11 @@ static pmix_status_t write_rndz_file(char *filename, char *uri,
 
     dirname = pmix_dirname(filename);
     if (NULL != dirname) {
-        rc = pmix_os_dirpath_create(dirname, 0755);
+        mode = S_IRWXU;
+        if (pmix_ptl_base.allow_foreign_tools) {
+            mode |= S_IXGRP | S_IRGRP | S_IXOTH | S_IROTH;
+        }
+        rc = pmix_os_dirpath_create(dirname, mode);
         if (PMIX_ERR_SILENT == rc) {
             // error has already been reported
             return rc;
@@ -225,9 +229,9 @@ static pmix_status_t write_rndz_file(char *filename, char *uri,
     }
 
     /* set the file mode */
-    mode = S_IRUSR | S_IWUSR | S_IRGRP;
+    mode = S_IRUSR | S_IWUSR ;
     if (pmix_ptl_base.allow_foreign_tools) {
-        mode |= S_IROTH;
+        mode |= S_IRGRP | S_IROTH;
     }
     fd = open(filename, O_RDWR | O_CREAT | O_EXCL, mode);
     if (0 > fd) {

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -143,6 +143,10 @@ void pmix_rte_finalize(void)
     if (NULL != pmix_globals.hostname) {
         free(pmix_globals.hostname);
         pmix_globals.hostname = NULL;
+    }
+    if (NULL != pmix_globals.aliases) {
+        PMIx_Argv_free(pmix_globals.aliases);
+        pmix_globals.aliases = NULL;
     }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -36,6 +36,9 @@
 #endif
 
 #include "src/include/pmix_globals.h"
+#include "src/include/pmix_dictionary.h"
+#include "src/include/pmix_types.h"
+
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/bfrops/base/base.h"
@@ -49,6 +52,9 @@
 #include "src/mca/psec/base/base.h"
 #include "src/mca/psquash/base/base.h"
 #include "src/mca/ptl/base/base.h"
+
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
@@ -58,10 +64,6 @@
 #include "src/client/pmix_client_ops.h"
 #include "src/common/pmix_attributes.h"
 #include "src/event/pmix_event.h"
-#include "src/include/pmix_dictionary.h"
-#include "src/include/pmix_types.h"
-#include "src/util/pmix_error.h"
-#include "src/util/pmix_keyval_parse.h"
 
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
@@ -87,6 +89,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .realgid = 0,
     .gid = 0,
     .hostname = NULL,
+    .aliases = NULL,
     .appnum = 0,
     .pid = 0,
     .nodeid = UINT32_MAX,
@@ -226,7 +229,6 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     char hostname[PMIX_MAXHOSTNAMELEN] = {0};
     pmix_info_t *iptr;
     size_t minfo;
-    bool keepfqdn = false;
     pmix_iof_flags_t flags;
 
 #if PMIX_NO_LIB_DESTRUCTOR
@@ -283,7 +285,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_EXTERNAL_AUX_EVENT_BASE)) {
                 pmix_globals.evauxbase = (pmix_event_base_t*)info[n].value.data.ptr;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME_KEEP_FQDN)) {
-                keepfqdn = PMIX_INFO_TRUE(&info[n]);
+                pmix_keep_fqdn_hostnames = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_BIND_PROGRESS_THREAD)) {
                 if (NULL != pmix_progress_thread_cpus) {
                     free(pmix_progress_thread_cpus);
@@ -435,12 +437,9 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             /* if we weren't previously given a hostname, then
              * use the OS one */
             gethostname(hostname, PMIX_MAXHOSTNAMELEN - 1);
-            /* strip the FQDN unless told to keep it */
-            if (!keepfqdn && !pmix_net_isaddr(hostname) && NULL != (evar = strchr(hostname, '.'))) {
-                *evar = '\0';
-            }
             pmix_globals.hostname = strdup(hostname);
         }
+        pmix_set_aliases(&pmix_globals.aliases, pmix_globals.hostname);
     }
 
     /* the choice of modules to use when communicating with a peer
@@ -581,4 +580,24 @@ int pmix_finalize_util(void)
 {
     util_initialized = false;
     return PMIX_SUCCESS;
+}
+
+void pmix_set_aliases(char ***aliases, char *hostname)
+{
+    char *ptr;
+
+    if (!pmix_net_isaddr(hostname) &&
+        NULL != (ptr = strchr(hostname, '.'))) {
+        if (pmix_keep_fqdn_hostnames) {
+            /* retain the non-fqdn name as an alias */
+            *ptr = '\0';
+            PMIx_Argv_append_unique_nosize(aliases, hostname);
+            *ptr = '.';
+        } else {
+            /* add the fqdn name as an alias */
+            PMIx_Argv_append_unique_nosize(aliases, hostname);
+            /* retain the non-fqdn name as the node's name */
+            *ptr = '\0';
+        }
+    }
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -82,7 +82,9 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .myidval = PMIX_VALUE_STATIC_INIT,
     .myrankval = PMIX_VALUE_STATIC_INIT,
     .mypeer = NULL,
+    .realuid = 0,
     .uid = 0,
+    .realgid = 0,
     .gid = 0,
     .hostname = NULL,
     .appnum = 0,
@@ -388,9 +390,14 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
         pmix_output_set_verbosity(pmix_client_globals.iof_output, pmix_client_globals.iof_verbose);
     }
 
+    /* get our real id's */
+    pmix_globals.realuid = getuid();
+    pmix_globals.realgid = getgid();
+
     /* get our effective id's */
     pmix_globals.uid = geteuid();
     pmix_globals.gid = getegid();
+
     /* see if debug is requested */
     if (NULL != (evar = getenv("PMIX_DEBUG"))) {
         debug_level = strtol(evar, NULL, 10);

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -53,6 +53,7 @@ char *pmix_progress_thread_cpus = NULL;
 bool pmix_bind_progress_thread_reqd = false;
 int pmix_maxfd = 1024;
 int pmix_server_client_fintime;
+bool pmix_keep_fqdn_hostnames = false;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -286,6 +287,12 @@ pmix_status_t pmix_register_params(void)
                                       "Time in seconds to wait for server to ack client finalize request",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &pmix_server_client_fintime);
+
+    pmix_keep_fqdn_hostnames = false;
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "keep_fqdn_hostnames",
+                                      "Whether or not to keep FQDN hostnames [default: no]",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &pmix_keep_fqdn_hostnames);
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -52,6 +52,7 @@ PMIX_EXPORT extern char *pmix_progress_thread_cpus;
 PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
 PMIX_EXPORT extern int pmix_maxfd;
 PMIX_EXPORT extern int pmix_server_client_fintime;
+PMIX_EXPORT extern bool pmix_keep_fqdn_hostnames;
 
 /** version string of pmix */
 extern const char pmix_version_string[];
@@ -77,6 +78,8 @@ PMIX_EXPORT void pmix_rte_finalize(void);
  */
 PMIX_EXPORT pmix_status_t pmix_register_params(void);
 PMIX_EXPORT pmix_status_t pmix_deregister_params(void);
+
+PMIX_EXPORT void pmix_set_aliases(char ***aliases, char *hostname);
 
 END_C_DECLS
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -574,20 +574,27 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
                 pmix_server_globals.system_tmpdir = strdup(info[n].value.data.string);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_NSPACE)) {
                 nspace = info[n].value.data.string;
                 nspace_given = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_RANK)) {
                 rank = info[n].value.data.rank;
                 rank_given = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SHARE_TOPOLOGY)) {
                 share_topo = true;
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_IOF_LOCAL_OUTPUT)) {
                 outputio = PMIX_INFO_TRUE(&info[n]);
+
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SINGLETON)) {
                 singleton = info[n].value.data.string;
+
             }
         }
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -400,7 +400,9 @@ static pmix_status_t register_singleton(char *name)
     }
     rinfo->pname.nspace = strdup(tmp);
     rinfo->pname.rank = rank;
+    rinfo->realuid = getuid();
     rinfo->uid = geteuid();
+    rinfo->realgid = getgid();
     rinfo->gid = getegid();
     pmix_list_append(&nptr->ranks, &rinfo->super);
     nptr->all_registered = true;
@@ -720,7 +722,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     pmix_globals.mypeer->nptr->nspace = strdup(pmix_globals.myid.nspace);
     rinfo->pname.nspace = strdup(pmix_globals.mypeer->nptr->nspace);
     rinfo->pname.rank = pmix_globals.myid.rank;
+    rinfo->realuid = pmix_globals.realuid;
     rinfo->uid = pmix_globals.uid;
+    rinfo->realgid = pmix_globals.realgid;
     rinfo->gid = pmix_globals.gid;
     pmix_client_globals.myserver->info = pmix_globals.mypeer->info;
 

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -177,10 +177,6 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
     // second qualifier in the query has the nodename
     nd = cd->query->qualifiers[1].value.data.string;
 
-    // restrict our search to already available info
-    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, NULL, PMIX_BOOL);
-
-
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     proc.rank = PMIX_RANK_UNDEF;
     cb.proc = &proc;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -679,19 +679,24 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix: init called");
 
+    /* setup a rank_info object for us */
+    pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
+    if (NULL == pmix_globals.mypeer->info) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOMEM;
+    }
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer)) {
         /* if we are a client, then we need to pickup the
          * rest of the envar-based server assignments */
         pmix_globals.pindex = -1;
-        /* setup a rank_info object for us */
-        pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
-        if (NULL == pmix_globals.mypeer->info) {
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return PMIX_ERR_NOMEM;
-        }
         pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
         pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
     }
+    pmix_globals.mypeer->info->realuid = pmix_globals.realuid;
+    pmix_globals.mypeer->info->uid = pmix_globals.uid;
+    pmix_globals.mypeer->info->realgid = pmix_globals.realgid;
+    pmix_globals.mypeer->info->gid = pmix_globals.gid;
+    pmix_globals.mypeer->info->pid = pmix_globals.pid;
 
     /* select our bfrops compat module */
     pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);


### PR DESCRIPTION
[Provide better FQDN support](https://github.com/openpmix/openpmix/commit/a0703b1c)

We strip FQDNs by default because of the inherent problem
of interacting with users, who generally don't like typing
all that extra stuff. However, that creates a problem when
being provided FQDN input during things like nspace registration.

So add an MCA param to control the strip operation instead of
only switching it on/off via info directing during init.
Add logic to the nspace registration process to perform the
strip and add aliases (for the case where the host failed
to provide them).

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/c36cae08d0e37ad93644bc82810c2a3052b886f1)

[Pass the uid/gid for client connections](https://github.com/openpmix/openpmix/commit/cfa3021082ee81104aca8d70a7560de20f2892a5)

We added the client_connected2 server module upcall so we
could pass information to the host about the connecting client.
User it to pass the uid and gid of the client. Terminate
the connection attempt if the host rejects it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/633068a906db22e1532c7cfff1fa4f74b52f9fed)

[Prevent memory overrun in regx calculation](https://github.com/openpmix/openpmix/commit/e34e4b41b924acb6998b5c2935c531137f1461a6)

If we do use the native regx component, ensure we don't
overrun the prefix array when assemplix the prefix
on long hostnames

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/37ff4df80844fe4c479e4f2072ceea15ba3f76a5)

[Pass the client's pid as well](https://github.com/openpmix/openpmix/commit/39dee25d01844ee5a200ff92cdbf28bbc58c6f0d)

Include the client's pid in the info passed to
the host via client_connected2.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/e0e2974788582c1406e4e3d35c4bc6099db4b001)

[Provide more info on connections](https://github.com/openpmix/openpmix/commit/b86f602aeead71afb7e38edf246b96a279ae974a)

When a client connects to the server, pass the proc's
pid plus the  real user and group IDs in addition to
the effective ones. When a tool connects, pass those
values plus the pid, cmd line, and PMIx version info.

Add attributes for the real user and group IDs to
distinguish them from the effective values.

Add new info-list APIs for uniquely moving values
onto the list. Provide an "overwrite" flag to indicate
that the current value it to be overwritten by the
new one.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3162ba55463fbcca3aade455917394b0845ab4d8)

[Extend authentication support](https://github.com/openpmix/openpmix/commit/5d9b7a1c53edd65c9cfa60c7c1df64a241cd0594)

Provide the ability to include/exclude connections from
tools whose user IDs are different from that of the server
(i.e., "foreign" tools). Add an attribute to direct that
behavior, default to "exclude". If we allow foreign tools,
then modify the rendezvous file permissions to allow read
by others. Track both the real user/group IDs vs the
effective ones in case someone wants to check both. Pass
more information up to the server client_connected2 and
tool_connection upcalls so the server can make more
informed decisions.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d5773968432d96cbc359d6e8a9c54c367209ff0b)

[Update listener thread setting of permissions on connection files.](https://github.com/openpmix/openpmix/commit/9ced680392029fba5a1984c575719d9df4d1bc15)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/cc49332fdf1242669d08a63e48ffae28b48e04b9)
