### PR TITLE
define default MAXPATHLEN if not defined by system

### DIFF
--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -88,6 +88,10 @@
 #include "src/common/pmix_pfexec.h"
 #include "src/server/pmix_server_ops.h"
 
+#ifndef MAXPATHLEN /* Hurd */
+#define MAXPATHLEN 1024
+#endif
+
 static pmix_status_t setup_prefork(pmix_pfexec_child_t *child);
 static pmix_status_t register_nspace(char *nspace, pmix_setup_caddy_t *fcd);
 static void wait_signal_callback(int fd, short event, void *arg);

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -52,6 +52,10 @@
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
+#ifndef MAXPATHLEN /* Hurd */
+#define MAXPATHLEN 1024
+#endif
+
 /*
  * global variables
  */


### PR DESCRIPTION
A definition of `MAXPATHLEN` is not a mandatory part of the POSIX standard, and is not defined for [GNU hurd](https://www.gnu.org/software/hurd/) operating system, where `<sys/param.h>` is not available.

cf. https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html
for further context.

But it is difficult to use `getcwd` without `MAXPATHLEN`, so set a default value if it has not been defined in `<sys/param.h>`.

This allows openpmix to build for hurd.

The patch is taken from debian,
https://salsa.debian.org/science-team/pmix/-/blob/e29db6a5b8e523a3b5e0d80922d5958a0d8e0d07/debian/patches/hurd-fix.patch
and has been successfully tested in debian hurd builds, e.g.
https://buildd.debian.org/status/fetch.php?pkg=pmix&arch=hurd-amd64&ver=6.0.0-3&stamp=1756199722&raw=0

Closes: #3671 