### PR TITLE
Do not remove nspace from global list on rejected connection

### DIFF
--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -250,14 +250,16 @@ static pmix_status_t validate_cred(struct pmix_peer_t *peer, const pmix_info_t d
     /* check uid */
     if (euid != pr->info->uid) {
         pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
-                            "psec: socket cred contains invalid uid %u", euid);
+                            "psec: socket cred contains invalid uid %u - required uid %u",
+                            euid, pr->info->uid);
         return PMIX_ERR_INVALID_CRED;
     }
 
     /* check gid */
     if (egid != pr->info->gid) {
         pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
-                            "psec: socket cred contains invalid gid %u", egid);
+                            "psec: socket cred contains invalid gid %u - required gid %u",
+                            egid, pr->info->gid);
         return PMIX_ERR_INVALID_CRED;
     }
 

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -622,9 +622,10 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     pmix_pending_connection_t *pnd = (pmix_pending_connection_t *) cd->cbdata;
     pmix_namespace_t *nptr = NULL;
     pmix_rank_info_t *info;
-    pmix_peer_t *peer = NULL;
+    pmix_peer_t *peer = NULL, *pr2;
     pmix_status_t rc, reply;
     uint32_t u32;
+    int n;
     pmix_info_t ginfo;
     pmix_byte_object_t cred;
     pmix_iof_req_t *req = NULL;
@@ -685,12 +686,36 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     peer = (pmix_peer_t *) pnd->peer;
     nptr = peer->nptr;
 
+    /* if this tool is a client, then check against our list of
+     * local clients to verify they are the same */
+    if (PMIX_TOOL_CLIENT == pnd->flag || PMIX_LAUNCHER_CLIENT == pnd->flag) {
+        for (n=0; n < pmix_server_globals.clients.size; n++) {
+            pr2 = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n);
+            if (NULL == pr2) {
+                continue;
+            }
+            if (PMIx_Check_nspace(pr2->info->pname.nspace, cd->proc.nspace) &&
+                pr2->info->pname.rank == cd->proc.rank) {
+                // this matches the existing client record - check uid/gid
+                if (pr2->info->uid != pnd->uid) {
+                    reply = PMIX_ERR_INVALID_CRED;
+                    u32 = htonl(reply);
+                    rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t));
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                    }
+                    goto error;
+                }
+            }
+        }
+    }
     /* if this tool wasn't initially registered as a client,
      * then add some required structures */
     if (PMIX_TOOL_CLIENT != pnd->flag && PMIX_LAUNCHER_CLIENT != pnd->flag) {
-        PMIX_RETAIN(nptr);
+        if (NULL != nptr->nspace) {
+            free(nptr->nspace);
+        }
         nptr->nspace = strdup(cd->proc.nspace);
-        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
         info = PMIX_NEW(pmix_rank_info_t);
         info->pname.nspace = strdup(nptr->nspace);
         info->pname.rank = cd->proc.rank;
@@ -699,6 +724,10 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         pmix_list_append(&nptr->ranks, &info->super);
         PMIX_RETAIN(info);
         peer->info = info;
+        pnd->rinfo_created = true;
+    } else if (pnd->nspace_created) {
+        // must add it to the global list
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
 
     /* mark the peer proc type */
@@ -756,11 +785,16 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     cred.bytes = pnd->cred;
     cred.size = pnd->len;
     PMIX_PSEC_VALIDATE_CONNECTION(reply, peer, NULL, 0, NULL, NULL, &cred);
+    if (PMIX_SUCCESS != reply) {
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "validation of tool credentials failed: %s",
+                            PMIx_Error_string(reply));
+    }
+
     /* communicate the result to the other side */
     u32 = htonl(reply);
-    if (PMIX_SUCCESS
-        != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t)))) {
-        PMIX_ERROR_LOG(rc);
+    rc = pmix_ptl_base_send_blocking(pnd->sd, (char *) &u32, sizeof(uint32_t));
+    if (PMIX_SUCCESS != rc || PMIX_SUCCESS != reply) {
         goto error;
     }
 
@@ -770,7 +804,8 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     /* If verification wasn't successful - stop here */
     if (PMIX_SUCCESS != reply) {
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "validation of tool credentials failed: %s", PMIx_Error_string(rc));
+                            "security handshake for tool failed: %s",
+                            PMIx_Error_string(reply));
         goto error;
     }
 
@@ -801,19 +836,23 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
 error:
     CLOSE_THE_SOCKET(pnd->sd);
-    PMIX_RELEASE(pnd);
+    if (NULL != peer->info && pnd->rinfo_created) {
+        pmix_list_remove_item(&peer->nptr->ranks, &peer->info->super);
+        // the info object will be released along with the peer
+    }
+    if (NULL != peer->nptr && pnd->nspace_created) {
+        pmix_list_remove_item(&pmix_globals.nspaces, &peer->nptr->super);
+        // the nptr will be released along with the peer
+    }
     if (NULL != peer) {
         PMIX_RELEASE(peer);
-    }
-    if (NULL != nptr) {
-        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
-        PMIX_RELEASE(nptr); // will release the info object
     }
     PMIX_RELEASE(cd);
     if (NULL != req) {
         pmix_pointer_array_set_item(&pmix_globals.iof_requests, req->local_id, NULL);
         PMIX_RELEASE(req);
     }
+    PMIX_RELEASE(pnd);
 }
 
 /* receive a callback from the host RM with an nspace
@@ -886,8 +925,8 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
      * have already registered it as a client - so check
      * to see if we already have a peer for it */
     if (PMIX_TOOL_CLIENT == pnd->flag || PMIX_LAUNCHER_CLIENT == pnd->flag) {
-        if (NULL == nptr) {
-            /* it is possible that this is a tool inside of
+       if (NULL == nptr) {
+           /* it is possible that this is a tool inside of
              * a job-script as part of a multi-spawn operation.
              * Since each tool invocation may have finalized and
              * terminated, the tool will appear to "terminate", thus
@@ -907,6 +946,8 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
             nptr->version.major = pnd->proc_type.major;
             nptr->version.minor = pnd->proc_type.minor;
             nptr->version.release = pnd->proc_type.release;
+            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+            pnd->nspace_created = true;
         }
         /* now look for the rank */
         info = NULL;
@@ -917,14 +958,25 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
                 break;
             }
         }
-        if (!found) {
-            /* see above note about not finding nspace */
+        if (found) {
+            /* check that the uid/gid of the connecting tool
+             * matches the expected values */
+            if (info->uid != pnd->uid ||
+                info->gid != pnd->gid) {
+                PMIX_RELEASE(peer);
+                PMIX_ERROR_LOG(PMIX_ERR_INVALID_CRED);
+                return PMIX_ERR_INVALID_CRED;
+            }
+
+        } else {
+           /* see above note about not finding nspace */
             info = PMIX_NEW(pmix_rank_info_t);
             info->pname.nspace = strdup(pnd->proc.nspace);
             info->pname.rank = pnd->proc.rank;
             info->uid = pnd->uid;
             info->gid = pnd->gid;
             pmix_list_append(&nptr->ranks, &info->super);
+            pnd->rinfo_created = true;
         }
         PMIX_RETAIN(info);
         peer->info = info;
@@ -984,19 +1036,25 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
         nptr->version.major = pnd->proc_type.major;
         nptr->version.minor = pnd->proc_type.minor;
         nptr->version.release = pnd->proc_type.release;
-        /* we will add the info record later */
+        pnd->nspace_created = true;
+        /* must add the nspace to the global list after we return
+         * from the host's upcall since they can/will assign the
+         * tool with a namespace */
+        PMIX_RETAIN(nptr);
     }
+
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack
      * any provided pmix_info_t structs */
     peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(pnd->bfrops);
     if (NULL == peer->nptr->compat.bfrops) {
-        PMIX_RELEASE(peer);
-        PMIX_ERROR_LOG(PMIX_ERR_NOT_AVAILABLE);
-        return PMIX_ERR_NOT_AVAILABLE;
+        rc = PMIX_ERR_NOT_AVAILABLE;
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
     }
     /* set the buffer type */
     peer->nptr->compat.type = pnd->buffer_type;
+
     n = 0;
     /* if info structs need to be passed along, then unpack them */
     ilist = PMIx_Info_list_start();
@@ -1035,8 +1093,8 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
             /* we need someone to provide the tool with an
              * identifier and they aren't available */
             /* send an error reply to the client */
-            PMIX_RELEASE(peer);
-            return PMIX_ERR_NOT_SUPPORTED;
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            goto cleanup;
         } else {
             /* just process it locally */
             cnct_cbfunc(PMIX_SUCCESS, &pnd->proc, (void *) pnd);
@@ -1070,8 +1128,7 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     PMIx_Info_list_release(ilist);
     if (PMIX_SUCCESS  != rc) {
         PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(peer);
-        return rc;
+        goto cleanup;
     }
 
     pnd->info = (pmix_info_t*)darray.array;
@@ -1080,6 +1137,25 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
     /* pass it up for processing */
     pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);
     return PMIX_SUCCESS;
+
+cleanup:
+    if (pnd->rinfo_created) {
+        pmix_list_remove_item(&nptr->ranks, &peer->info->super);
+        PMIX_RELEASE(pnd->info);
+    } else {
+        peer->info = NULL;
+    }
+
+    if (pnd->nspace_created) {
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
+        PMIX_RELEASE(nptr);
+    } else {
+        peer->nptr = NULL;  // protect it
+    }
+
+    PMIX_RELEASE(peer);
+    return rc;
+
 }
 
 static void _check_cached_events(pmix_peer_t *peer)

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -587,7 +587,7 @@ static pmix_status_t recv_connect_ack(pmix_peer_t *peer)
         }
     }
 
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 pmix_status_t pmix_ptl_base_make_connection(pmix_peer_t *peer, char *suri,

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -523,6 +523,8 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_sr_t,
 static void pccon(pmix_pending_connection_t *p)
 {
     p->need_id = false;
+    p->nspace_created = false;
+    p->rinfo_created = false;
     PMIX_LOAD_PROCID(&p->proc, NULL, PMIX_RANK_UNDEF);
     p->info = NULL;
     p->ninfo = 0;

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -306,6 +306,8 @@ typedef struct {
     pmix_listener_protocol_t protocol;
     int sd;
     bool need_id;
+    bool nspace_created;
+    bool rinfo_created;
     pmix_rnd_flag_t flag;
     pmix_proc_t proc;
     pmix_info_t *info;


### PR DESCRIPTION
Depending on tool type, we may not want to remove the tool's nspace tracker from the global list if the connection is rejected. Improve the checks for different connection scenarios.