### PR TITLE
Improve selection of interfaces

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -91,6 +91,7 @@ struct pmix_ptl_base_t {
     bool created_pid_filename;
     bool created_urifile;
     bool remote_connections;
+    bool connections_specified;
     bool system_tool;
     bool allow_foreign_tools;
     bool session_tool;

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -88,3 +88,36 @@ by the host runtime:
 
 This could be a security issue. Please check the situation and
 try again.
+#
+[no-remote-interfaces]
+You requested support for remote tool connections, but no non-loopback
+interfaces were found after applying any include or exclude directives:
+
+  Include:    %s
+  Exclude:    %s
+  Available:  %s
+
+Please adjust your include or exclude to allow selection of a
+non-loopback interface.
+#
+[no-loopback-interfaces]
+You requested support for only local tool connections, but no loopback
+interfaces were found after applying any include or exclude directives:
+
+  Include:    %s
+  Exclude:    %s
+  Available:  %s
+
+Please adjust your include or exclude to allow selection of a
+loopback interface.
+#
+[no-available-interfaces]
+You requested support for tool connections, but no available
+interfaces were found after applying any include or exclude directives:
+
+  Include:    %s
+  Exclude:    %s
+  Available:  %s
+
+Please adjust your include or exclude to allow selection of an
+available interface.

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -96,6 +96,7 @@ pmix_ptl_base_t pmix_ptl_base = {
     .created_pid_filename = false,
     .created_urifile = false,
     .remote_connections = false,
+    .connections_specified = false,
     .system_tool = false,
     .allow_foreign_tools = true,
     .session_tool = false,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -900,8 +900,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module, pmix_in
     }
 
     /* start listening for connections */
-    if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
-        pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
+    rc = pmix_ptl_base_start_listening(info, ninfo);
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_SILENT != rc) {
+            pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
+        }
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         PMIx_server_finalize();
         return PMIX_ERR_INIT;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1043,8 +1043,11 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         }
 
         /* start listening for connections */
-        if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
-            pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
+        rc = pmix_ptl_base_start_listening(info, ninfo);
+        if (PMIX_SUCCESS != rc) {
+            if (PMIX_ERR_SILENT != rc) {
+                pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
+            }
             return PMIX_ERR_INIT;
         }
     }


### PR DESCRIPTION
Default to using the loopback interface unless remote connections are specified - in which case, reject any loopback interfaces. Provide useful show-help messages when no valid interfaces are available. If no remote connection directive is given, and no loopback interfaces are available, then accept a non-loopback interface.