### PR TITLE
Extend listener thread port specification to support ranges

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1358,13 +1358,16 @@ AC_ARG_ENABLE([ipv6],
 if test "$enable_ipv6" = "yes"; then
     AC_MSG_RESULT([yes])
     pmix_want_ipv6=1
+    pmix_ipv6_enabled="enabled"
 else
     AC_MSG_RESULT([no])
     pmix_want_ipv6=0
+    pmix_ipv6_enabled="disabled"
 fi
 AC_DEFINE_UNQUOTED([PMIX_ENABLE_IPV6], [$pmix_want_ipv6],
                    [Enable IPv6 support, but only if the underlying system supports it])
 
+PMIX_SUMMARY_ADD([Miscellaneous], [IPv6 Support], [], [$pmix_ipv6_enabled])
 
 ])dnl
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -98,9 +98,9 @@ struct pmix_ptl_base_t {
     bool tool_support;
     char *if_include;
     char *if_exclude;
-    int ipv4_port;
+    char **ipv4_ports;
     bool disable_ipv4_family;
-    int ipv6_port;
+    char **ipv6_ports;
     bool disable_ipv6_family;
     int max_retries;
     int wait_to_connect;
@@ -141,7 +141,6 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
 
 /* base support functions */
-PMIX_EXPORT pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env);
 PMIX_EXPORT void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata);
 PMIX_EXPORT void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata);

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -457,12 +457,6 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:base: connecting to server");
 
-    /* check for common directives */
-    rc = pmix_ptl_base_check_directives(info, ninfo);
-    if (PMIX_SUCCESS != rc) {
-        return rc;
-    }
-
     /* check any provided directives
      * to see where they want us to connect to */
     PMIX_CONSTRUCT(&ilist, pmix_list_t);
@@ -546,6 +540,37 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_CONNECT_OPTIONAL)) {
                 optional = PMIX_INFO_TRUE(&info[n]);
+
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_URI)
+                       || PMIX_CHECK_KEY(&info[n], PMIX_SERVER_URI)) {
+                if (NULL != pmix_ptl_base.uri) {
+                    free(pmix_ptl_base.uri);
+                }
+                pmix_ptl_base.uri = strdup(info[n].value.data.string);
+
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
+                if (NULL != pmix_ptl_base.session_tmpdir) {
+                    free(pmix_ptl_base.session_tmpdir);
+                }
+                pmix_ptl_base.session_tmpdir = strdup(info[n].value.data.string);
+
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
+                if (NULL != pmix_ptl_base.system_tmpdir) {
+                    free(pmix_ptl_base.system_tmpdir);
+                }
+                pmix_ptl_base.system_tmpdir = strdup(info[n].value.data.string);
+
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_MAX_RETRIES)) {
+                rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.max_retries, PMIX_INT);
+                if (PMIX_SUCCESS != rc) {
+                    return rc;
+                }
+
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_RETRY_DELAY)) {
+                rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.wait_to_connect, PMIX_INT);
+                if (PMIX_SUCCESS != rc) {
+                    return rc;
+                }
 
             } else {
                 /* need to pass this to server */

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -132,61 +132,6 @@ pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char **evar)
     return PMIX_ERR_UNREACH;
 }
 
-pmix_status_t pmix_ptl_base_check_directives(pmix_info_t *info, size_t ninfo)
-{
-    size_t n;
-    pmix_status_t rc;
-
-    for (n = 0; n < ninfo; n++) {
-        if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_INCLUDE)) {
-            if (NULL != pmix_ptl_base.if_include) {
-                free(pmix_ptl_base.if_include);
-            }
-            pmix_ptl_base.if_include = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_EXCLUDE)) {
-            if (NULL != pmix_ptl_base.if_exclude) {
-                free(pmix_ptl_base.if_exclude);
-            }
-            pmix_ptl_base.if_exclude = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV4_PORT)) {
-            pmix_ptl_base.ipv4_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV6_PORT)) {
-            pmix_ptl_base.ipv6_port = info[n].value.data.integer;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV4)) {
-            pmix_ptl_base.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
-            pmix_ptl_base.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_URI)
-                   || PMIX_CHECK_KEY(&info[n], PMIX_SERVER_URI)) {
-            if (NULL != pmix_ptl_base.uri) {
-                free(pmix_ptl_base.uri);
-            }
-            pmix_ptl_base.uri = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
-            if (NULL != pmix_ptl_base.session_tmpdir) {
-                free(pmix_ptl_base.session_tmpdir);
-            }
-            pmix_ptl_base.session_tmpdir = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
-            if (NULL != pmix_ptl_base.system_tmpdir) {
-                free(pmix_ptl_base.system_tmpdir);
-            }
-            pmix_ptl_base.system_tmpdir = strdup(info[n].value.data.string);
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_MAX_RETRIES)) {
-            rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.max_retries, PMIX_INT);
-            if (PMIX_SUCCESS != rc) {
-                return rc;
-            }
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_RETRY_DELAY)) {
-            rc = PMIx_Value_get_number(&info[n].value, &pmix_ptl_base.wait_to_connect, PMIX_INT);
-            if (PMIX_SUCCESS != rc) {
-                return rc;
-            }
-        }
-    }
-    return PMIX_SUCCESS;
-}
-
 pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env)
 {
     PMIX_HIDE_UNUSED_PARAMS(proc);


### PR DESCRIPTION
Particularly when the host system is closing ports for security purposes, we can face a situation where we know the range of ports available for the server's listener thread, but not necessarily the specific port to be used. So extend the port specification interface to allow passing of a comma-delimited set of port ranges, and then try those until we find the first one that works.

Note that the MCA param method for passing the port did not require any change as that is always just a string that we parse to extract the port number(s). However, we have extended the value for the PMIX_TCP_IPV4_PORT and PMIX_TCP_IPV6_PORT attributes so that:

* if the value is of type PMIX_INT, then treat the value as a distinct port number to be used

* if the value is of type PMIX_STRING, then treat it as a comma-delimited list of port ranges (e.g., "2,13-25,32")

In other words, those two attributes can now contain either a PMIX_INT or a PMIX_STRING value.