### PR TITLE
Switch to atomics for tracking initialization

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -379,7 +379,24 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         ])],
         [AC_MSG_RESULT([found])],
         [AC_MSG_RESULT([not found])
-         AC_MSG_ERROR([PMIx requires some minimal C11 atomic support. This was])
+         AC_MSG_WARN([PMIx requires some minimal C11 atomic support. This was])
+         AC_MSG_WARN([not found in the current compiler. Please select a compiler])
+         AC_MSG_WARN([with the required support])
+         AC_MSG_ERROR([Cannot continue])]
+    )
+
+    AC_MSG_CHECKING([for atomic_store])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([
+            #include <stdatomic.h>
+            void test_atomic_store() {
+                atomic_bool value = 0;
+                atomic_store(&value, 1);
+            }
+        ])],
+        [AC_MSG_RESULT([found])],
+        [AC_MSG_RESULT([not found])
+         AC_MSG_WARN([PMIx requires some minimal C11 atomic support. This was])
          AC_MSG_WARN([not found in the current compiler. Please select a compiler])
          AC_MSG_WARN([with the required support])
          AC_MSG_ERROR([Cannot continue])]
@@ -396,7 +413,41 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         ])],
         [AC_MSG_RESULT([found])],
         [AC_MSG_RESULT([not found])
-         AC_MSG_ERROR([PMIx requires some minimal C11 atomic support. This was])
+         AC_MSG_WARN([PMIx requires some minimal C11 atomic support. This was])
+         AC_MSG_WARN([not found in the current compiler. Please select a compiler])
+         AC_MSG_WARN([with the required support])
+         AC_MSG_ERROR([Cannot continue])]
+    )
+
+    AC_MSG_CHECKING([for __atomic_fetch_add])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([
+            #include <stdatomic.h>
+            void test_atomic_fetch_add() {
+                int value = 0;
+                __atomic_fetch_add(&value, 1, __ATOMIC_SEQ_CST);
+            }
+        ])],
+        [AC_MSG_RESULT([found])],
+        [AC_MSG_RESULT([not found])
+         AC_MSG_WARN([PMIx requires some minimal C11 atomic support. This was])
+         AC_MSG_WARN([not found in the current compiler. Please select a compiler])
+         AC_MSG_WARN([with the required support])
+         AC_MSG_ERROR([Cannot continue])]
+    )
+
+    AC_MSG_CHECKING([for __atomic_test_and_set])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([
+            #include <stdatomic.h>
+            void test_atomic_test_and_set() {
+                _Bool flag = 0;
+                __atomic_test_and_set(&flag, __ATOMIC_SEQ_CST);
+            }
+        ])],
+        [AC_MSG_RESULT([found])],
+        [AC_MSG_RESULT([not found])
+         AC_MSG_WARN([PMIx requires some minimal C11 atomic support. This was])
          AC_MSG_WARN([not found in the current compiler. Please select a compiler])
          AC_MSG_WARN([with the required support])
          AC_MSG_ERROR([Cannot continue])]

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -68,21 +68,17 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix: connect called");
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output, "pmix: connect called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -125,21 +121,17 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     pmix_rank_t minrank;
     pmix_proc_t proc;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix:connect_nb called");
 
-    pmix_output_verbose(2, pmix_client_globals.connect_output, "pmix:connect_nb called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == procs || 0 >= nprocs) {
@@ -340,18 +332,14 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t npro
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -382,9 +370,8 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: disconnect called");
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: disconnect called");
 
     size_t cnt;
     for (cnt = 0; cnt < nprocs; cnt++) {
@@ -393,17 +380,14 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
         }
     }
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == procs || 0 >= nprocs) {

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -295,22 +295,17 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_construct called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -348,22 +343,17 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_construct_nb called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     // send any data to our server
     msg = PMIX_NEW(pmix_buffer_t);
@@ -399,22 +389,17 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
     pmix_status_t rc;
     pmix_group_tracker_t cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_destruct called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -449,22 +434,17 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     pmix_group_tracker_t *cb = NULL;
     pmix_group_t *grp, *pgrp;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_destruct_nb called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == grpid) {
@@ -676,18 +656,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
     size_t n;
     pmix_data_array_t darray;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == grp || NULL == procs) {
@@ -775,18 +751,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
     pmix_kval_t *kv;
     uint32_t jsize;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == grp || NULL == procs) {
@@ -921,18 +893,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     PMIX_HIDE_UNUSED_PARAMS(results, nresults);
 
@@ -973,18 +941,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
                         "[%s:%d] pmix: join nb called",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which lock to release when
@@ -1044,21 +1008,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
     pmix_status_t rc;
     pmix_group_tracker_t cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output, "pmix: group_leave called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -1092,22 +1051,17 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_leave_nb called");
 
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
     if (NULL == grp) {

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,21 +67,17 @@ PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo)
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: publish called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: publish called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object to let us know when it is done */
     cb = PMIX_NEW(pmix_cb_t);
@@ -108,21 +104,17 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: publish called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: publish called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo cases */
     if (NULL == info) {
@@ -190,21 +182,17 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata, const 
     char **keys = NULL;
     size_t i;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: lookup called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: lookup called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* bozo protection */
     if (NULL == pdata) {
@@ -250,21 +238,17 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     pmix_cb_t *cb;
     size_t nkeys, n;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: lookup_nb called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: lookup_nb called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo cases */
     if (NULL == keys) {
@@ -345,21 +329,17 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish(char **keys, const pmix_info_t info[], 
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: unpublish called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: unpublish called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -389,21 +369,17 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     pmix_cb_t *cb;
     size_t i, j;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: unpublish called");
 
-    pmix_output_verbose(2, pmix_globals.debug_output, "pmix: unpublish called");
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* create the unpublish cmd */
     msg = PMIX_NEW(pmix_buffer_t);

--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -185,13 +185,9 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request(pmix_alloc_directive_t directi
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_globals.debug_output, "%s pmix:allocate",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
@@ -280,16 +276,12 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: allocate called");
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we are hosted by the scheduler, then this makes no sense */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -301,7 +293,6 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
     /* if we are the system controller, then nothing we can do
      * since the scheduler is not attached */
     if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -313,7 +304,6 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
         NULL != pmix_host_server.allocate) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:allocate handed to host");
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         // need to be in our thread context to perform the upcall
         acd = PMIX_NEW(pmix_alloc_caddy_t);
         acd->directive = directive;
@@ -328,11 +318,9 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 sendit:
     /* for all other cases, we need to send this to someone
      * if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* all other cases, relay this request to our server, which
      * might (for a tool) actually be the scheduler itself */
@@ -458,13 +446,9 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t di
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "%s pmix:resource block op",
@@ -524,16 +508,12 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: allocate called");
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
     /* if we are hosted by the scheduler, then this makes no sense */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -545,7 +525,6 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t
     /* if we are the system controller, then nothing we can do
      * since the scheduler is not attached */
     if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -557,7 +536,6 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t
         NULL != pmix_host_server.resource_block) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:resource_block handed to host");
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
         cd = PMIX_NEW(pmix_rb_caddy_t);
         cd->directive = directive;
         cd->block = block;
@@ -574,11 +552,9 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t
 sendit:
     /* for all other cases, we need to send this to someone
      *  if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* all other cases, relay this request to our server */
     msg = PMIX_NEW(pmix_buffer_t);

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -143,12 +143,9 @@ PMIX_EXPORT pmix_status_t PMIx_Register_attributes(char *function, char *attrs[]
 
     pmix_status_t rc;
 
-    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
-    if (pmix_globals.init_cntr <= 0) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     scd = PMIX_NEW(pmix_setup_caddy_t);
     scd->nspace = function;

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -165,6 +165,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target, pmix_data_bu
     pmix_peer_t *peer;
     pmix_shift_caddy_t scd;
 
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     // if the target is a member of my own nspace, then use our own peer
     if (NULL == target ||
         PMIx_Check_nspace(target->nspace, pmix_globals.myid.nspace)) {
@@ -234,6 +238,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *target, pmix_data_
     pmix_peer_t *peer;
     pmix_shift_caddy_t scd;
 
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     // if the target is a member of my own nspace, then use our own peer
     if (NULL == target ||
         PMIx_Check_nspace(target->nspace, pmix_globals.myid.nspace)) {
@@ -290,6 +298,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_copy(void **dest, void *src, pmix_data_type_
 {
     pmix_status_t rc;
 
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     /* copy the value */
     PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, dest, src, type);
 
@@ -301,7 +313,11 @@ PMIX_EXPORT pmix_status_t PMIx_Data_print(char **output, char *prefix, void *src
 {
     pmix_status_t rc;
 
-    /* print the value */
+     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
+   /* print the value */
     PMIX_BFROPS_PRINT(rc, pmix_globals.mypeer, output, prefix, src, type);
 
     return rc;
@@ -311,6 +327,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest, pmix_
 {
     pmix_status_t rc;
     pmix_buffer_t buf1, buf2;
+
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
 
     if (NULL == src) {
         return PMIX_SUCCESS;
@@ -337,6 +357,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest, pmix_
 
 pmix_status_t PMIx_Data_unload(pmix_data_buffer_t *buffer, pmix_byte_object_t *payload)
 {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     /* check that buffer is not null */
     if (!buffer) {
         return PMIX_ERR_BAD_PARAM;
@@ -384,6 +408,10 @@ cleanup:
 
 pmix_status_t PMIx_Data_load(pmix_data_buffer_t *buffer, pmix_byte_object_t *payload)
 {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     /* check to see if the buffer has been initialized */
     if (NULL == buffer) {
         return PMIX_ERR_BAD_PARAM;
@@ -422,6 +450,10 @@ pmix_status_t PMIx_Data_embed(pmix_data_buffer_t *buffer, const pmix_byte_object
     pmix_data_buffer_t src;
     pmix_status_t rc;
 
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     /* check to see if the buffer has been initialized */
     if (NULL == buffer) {
         return PMIX_ERR_BAD_PARAM;
@@ -452,6 +484,10 @@ pmix_status_t PMIx_Data_embed(pmix_data_buffer_t *buffer, const pmix_byte_object
 
 bool PMIx_Data_compress(const uint8_t *inbytes, size_t size, uint8_t **outbytes, size_t *nbytes)
 {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     if (NULL == inbytes) {
         return PMIX_ERR_BAD_PARAM;
     }
@@ -462,6 +498,10 @@ bool PMIx_Data_compress(const uint8_t *inbytes, size_t size, uint8_t **outbytes,
 bool PMIx_Data_decompress(const uint8_t *inbytes, size_t size,
                           uint8_t **outbytes, size_t *nbytes)
 {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     if (NULL == inbytes) {
         return PMIX_ERR_BAD_PARAM;
     }

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +69,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log(const pmix_info_t data[], size_t ndata,
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    if (pmix_globals.init_cntr <= 0) {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
@@ -170,7 +170,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:log non-blocking");
 
-    if (pmix_globals.init_cntr <= 0) {
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
@@ -197,7 +197,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
      * always pass this request to our server for execution */
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* if we aren't connected, don't attempt to send */
-        if (!pmix_globals.connected) {
+        if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
             return PMIX_ERR_UNREACH;
         }
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -65,10 +65,6 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd,
                             pmix_epilog_t *epi);
 static bool dirpath_is_empty(const char *path);
 
-PMIX_EXPORT pmix_lock_t pmix_global_lock = {.mutex = PMIX_MUTEX_STATIC_INIT,
-                                            .cond = PMIX_CONDITION_STATIC_INIT,
-                                            .active = false};
-
 static void nsenvcon(pmix_nspace_env_cache_t *p)
 {
     PMIX_CONSTRUCT(&p->envars, pmix_list_t);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -804,7 +804,8 @@ PMIX_CLASS_DECLARATION(pmix_keyindex_t);
  * between various parts of the code library. The client, tool,
  * and server libraries must instance this structure */
 typedef struct {
-    int init_cntr; // #times someone called Init - #times called Finalize
+    bool init_called;
+    atomic_bool initialized;
     pmix_proc_t myid;
     pmix_value_t myidval;
     pmix_value_t myrankval;
@@ -824,7 +825,7 @@ typedef struct {
     pmix_event_base_t *evauxbase;
     int debug_output;
     pmix_events_t events; // my event handler registrations.
-    bool connected;
+    atomic_bool connected;
     bool commits_pending;
     struct timeval event_window;
     pmix_list_t cached_events;         // events waiting in the window prior to processing
@@ -854,7 +855,6 @@ PMIX_EXPORT void pmix_execute_epilog(pmix_epilog_t *ep);
 PMIX_EXPORT pmix_status_t pmix_notify_event_cache(pmix_notify_caddy_t *cd);
 
 PMIX_EXPORT extern pmix_globals_t pmix_globals;
-PMIX_EXPORT extern pmix_lock_t pmix_global_lock;
 PMIX_EXPORT extern const char* PMIX_PROXY_VERSION;
 PMIX_EXPORT extern const char* PMIX_PROXY_BUGREPORT;
 

--- a/src/include/pmix_stdatomic.h
+++ b/src/include/pmix_stdatomic.h
@@ -39,9 +39,18 @@ typedef _Atomic ssize_t pmix_atomic_ssize_t;
 typedef _Atomic intptr_t pmix_atomic_intptr_t;
 typedef _Atomic uintptr_t pmix_atomic_uintptr_t;
 
-#define pmix_atomic_store_int(addr , val) __atomic_store_n(addr, val, __ATOMIC_RELAXED)
+#define pmix_atomic_store_int(addr, val) __atomic_store_n(addr, val, __ATOMIC_RELAXED)
 
 #define pmix_atomic_load_int(addr) __atomic_load_n(addr, __ATOMIC_RELAXED)
 
+#define pmix_atomic_set_bool(addr) atomic_store(addr, true)
+
+#define pmix_atomic_unset_bool(addr) atomic_store(addr, false)
+
+#define pmix_atomic_check_bool(addr) atomic_load(addr)
+
+#define pmix_atomic_fetch_add(addr, val) __atomic_fetch_add(addr, val, __ATOMIC_SEQ_CST)
+
+#define pmix_atomic_test_and_set(addr) __atomic_test_and_set(addr, __ATOMIC_SEQ_CST)
 
 #endif

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -583,7 +583,7 @@ retry:
 
 void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace, pmix_rank_t rank)
 {
-    pmix_globals.connected = true;
+    pmix_atomic_set_bool(&pmix_globals.connected);
 
     /* setup the server info */
     if (NULL == peer->info) {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -196,7 +196,7 @@ static void lost_connection(pmix_peer_t *peer)
 
         if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
             /* only connection I can lose is to my server, so mark it */
-            pmix_globals.connected = false;
+            pmix_atomic_unset_bool(&pmix_globals.connected);
         } else {
             /* cleanup any sensors that are monitoring them */
             pmix_psensor.stop(peer, NULL);
@@ -221,7 +221,7 @@ static void lost_connection(pmix_peer_t *peer)
     } else if (peer == pmix_client_globals.myserver) {
         /* if this was the server to which I am connected,
          * then we need to exit */
-        pmix_globals.connected = false;
+        pmix_atomic_unset_bool(&pmix_globals.connected);
         /* it is possible that we have sendrecv's in progress where
          * we are waiting for a response to arrive. Since we have
          * lost connection to the server, that will never happen.

--- a/src/mca/ptl/tool/ptl_tool.c
+++ b/src/mca/ptl/tool/ptl_tool.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,7 +53,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo)
     }
 
     /* if we are connected, then register any rendezvous files for cleanup */
-    if (pmix_globals.connected) {
+    if (pmix_atomic_check_bool(&pmix_globals.connected)) {
         if (NULL != pmix_ptl_base.nspace_filename) {
             PMIx_Argv_append_nosize(&clnup, pmix_ptl_base.nspace_filename);
         }

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -79,3 +79,11 @@ attributes include:
       the given pid
 
 Please correct your program and try again.
+#
+[reentrant-init]
+An attempt was made to call an initialization routine, but the
+PMIx library has already been initialized:
+
+  Function: %s
+
+Multiple calls to init are not supported. Please correct your program.

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -78,7 +78,8 @@ PMIX_EXPORT bool pmix_init_called = false;
 /* we have to export the pmix_globals object so
  * all plugins can access it. */
 PMIX_EXPORT pmix_globals_t pmix_globals = {
-    .init_cntr = 0,
+    .init_called = false,
+    .initialized = false,
     .myid = PMIX_PROC_STATIC_INIT,
     .myidval = PMIX_VALUE_STATIC_INIT,
     .myrankval = PMIX_VALUE_STATIC_INIT,

--- a/src/tool/pmix_tool_ops.c
+++ b/src/tool/pmix_tool_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,7 +81,7 @@ pmix_status_t pmix_tool_relay_op(pmix_cmd_t cmd, pmix_peer_t *peer,
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    if (!pmix_globals.connected) {
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
 

--- a/src/tool/pmix_tool_ops.h
+++ b/src/tool/pmix_tool_ops.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -15,5 +15,10 @@
 
 PMIX_EXPORT pmix_status_t pmix_tool_relay_op(pmix_cmd_t cmd, pmix_peer_t *peer, pmix_buffer_t *bfr,
                                              uint32_t tag);
+
+PMIX_EXPORT void pmix_tool_retry_set(int sd, short args, void *cbdata);
+
+PMIX_EXPORT void pmix_tool_retry_attach(int sd, short args, void *cbdata);
+
 
 #endif // PMIX_TOOL_OPS_H


### PR DESCRIPTION
Rather than using mutex and condition variables, let's just use atomics for tracking if the library has been initialized, and which init entry point was used. Check for and reject attempts to call multiple mismatched entry points.

First stage in a multi-stage process.