### PR TITLE
Flush namespace sinks' residuals before destroying namespace

### DIFF
--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -277,7 +277,6 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
-PMIX_EXPORT void pmix_iof_flush_sink(pmix_iof_sink_t *sink);
 PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                                                      pmix_iof_flags_t *myflags,
                                                      pmix_iof_channel_t stream,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1142,6 +1142,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
+    // the list will be destructed in rte_finalize, but do the
+    // epilog here
     PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
         /* ensure that we do the specified cleanup - if this is an
          * abnormal termination, then the nspace object may not be
@@ -1672,13 +1674,6 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
 
     /* perform any epilog */
     pmix_execute_epilog(&nptr->epilog);
-
-    // flush any residuals on this namespace's sinks, and dump their output
-    pmix_iof_sink_t *sink;
-    PMIX_LIST_FOREACH(sink, &nptr->sinks, pmix_iof_sink_t){
-        pmix_iof_flush_sink(sink);
-        pmix_iof_static_dump_output(sink);
-    }
 
     /* remove and release it */
     pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);


### PR DESCRIPTION
I was getting intermittent hangs during PMIx_server_finalize when running MPI jobs with the `--output file=<filename>` option. The problem is that sinks get destroyed when the namespace is destroyed, but any residuals on those sinks keep a pointer to the `pmix_iof_write_event_t` object in those sinks. Flushing the residuals during finalize causes PMIx to add invalid events to the event base, which then hangs when being closed by libevent.