### PR TITLE
Add new PMIX_GROUP_FINAL_MEMBERSHIP_ORDER attribute

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1328,6 +1328,11 @@ typedef uint32_t pmix_rank_t;
                                                                     //        wishes to be included via a group invite, and so the library will
                                                                     //        handle the necessary event registrations on behalf of the caller.
 #define PMIX_GROUP_JOB_INFO                 "pmix.grp.jinfo"        // (pmix_byte_object_t) Job-level info for group construction
+#define PMIX_GROUP_FINAL_MEMBERSHIP_ORDER   "pmix.grp.finord"       // (pmix_data_array_t*) Array of pmix_proc_t specifying the order of processes
+                                                                    //        in the group membership. This can be specified by individual processes
+                                                                    //        or by namespace (with a wildcard rank). If multiple participants
+                                                                    //        provide this attribute, then the values must match - i.e., the
+                                                                    //        desired final membership order must be identical.
 
 
 /* Storage-Related Attributes */


### PR DESCRIPTION
The PMIx_Group_construct API itself is not order sensitive in the provided proc array - i.e., we ignore that order when executing the operation. This allows each caller to provide the proc array in arbitrary order - which is advantageous for most libraries.

However, some users may need us to return a specific order of the procs in the final membership. Allow them to specify the order in a new attribute, This can be specified by individual processes or by namespace (with a wildcard rank). If multiple participants provide this attribute, then the values must match - i.e., the desired final membership order must be identical.