### PR TITLE
Enable use of loopback interface

### DIFF
--- a/src/mca/pif/base/pif_base_components.c
+++ b/src/mca/pif/base/pif_base_components.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,7 +24,6 @@
 /* instantiate the global list of interfaces */
 pmix_list_t pmix_if_list = PMIX_LIST_STATIC_INIT;
 bool pmix_if_do_not_resolve = false;
-bool pmix_if_retain_loopback = false;
 
 static int pmix_pif_base_register(pmix_mca_base_register_flag_t flags);
 static int pmix_pif_base_open(pmix_mca_base_open_flag_t flags);
@@ -48,12 +47,6 @@ static int pmix_pif_base_register(pmix_mca_base_register_flag_t flags)
                                                 "If nonzero, do not attempt to resolve interfaces",
                                                 PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                                 &pmix_if_do_not_resolve);
-
-    pmix_if_retain_loopback = false;
-    (void) pmix_mca_base_framework_var_register(&pmix_pif_base_framework, "retain_loopback",
-                                                "If nonzero, retain loopback interfaces",
-                                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                                &pmix_if_retain_loopback);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -126,12 +126,7 @@ static int if_bsdx_open(void)
             continue;
         }
 
-        /* skip interface if it is a loopback device (IFF_LOOPBACK set) */
-        if (!pmix_if_retain_loopback && 0 != (cur_ifaddrs->ifa_flags & IFF_LOOPBACK)) {
-            continue;
-        }
-
-        /* or if it is a point-to-point interface */
+        /* skip if it is a point-to-point interface */
         /* TODO: do we really skip p2p? */
         if (0 != (cur_ifaddrs->ifa_flags & IFF_POINTOPOINT)) {
             continue;

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -120,14 +120,7 @@ static int if_bsdx_ipv6_open(void)
             continue;
         }
 
-        /* skip interface if it is a loopback device (IFF_LOOPBACK set) */
-        if (!pmix_if_retain_loopback && 0 != (cur_ifaddrs->ifa_flags & IFF_LOOPBACK)) {
-            pmix_output_verbose(1, pmix_pif_base_framework.framework_output,
-                                "skipping loopback interface %s.\n", cur_ifaddrs->ifa_name);
-            continue;
-        }
-
-        /* or if it is a point-to-point interface */
+        /* skip if it is a point-to-point interface */
         /* TODO: do we really skip p2p? */
         if (0 != (cur_ifaddrs->ifa_flags & IFF_POINTOPOINT)) {
             pmix_output_verbose(1, pmix_pif_base_framework.framework_output,

--- a/src/mca/pif/pif.h
+++ b/src/mca/pif/pif.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +76,6 @@ extern pmix_list_t pmix_if_list;
 
 /* global flags */
 extern bool pmix_if_do_not_resolve;
-extern bool pmix_if_retain_loopback;
 
 /**
  * Structure for if components.

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -227,11 +227,6 @@ static int if_posix_open(void)
             continue;
         }
 #endif
-#if 0
-        if (!pmix_if_retain_loopback && (ifr->ifr_flags & IFF_LOOPBACK) != 0) {
-            continue;
-        }
-#endif
 
         intf = PMIX_NEW(pmix_pif_t);
         if (NULL == intf) {

--- a/src/util/pmix_if.h
+++ b/src/util/pmix_if.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,7 +77,6 @@ PMIX_EXPORT extern pmix_list_t pmix_if_list;
 
 /* global flags */
 PMIX_EXPORT extern bool pmix_if_do_not_resolve;
-PMIX_EXPORT extern bool pmix_if_retain_loopback;
 
 /**
  *  Lookup an interface by address and return its name.


### PR DESCRIPTION
We used to have support for both Unix sockets and TCP interfaces, so we explicitly ignored all loopback devices (leaving local operations to the Unix sockets).

However, at some point years back we removed the Unix socket support, transitioning solely over to TCP interfaces. Nobody remembered the TCP support ignoring loopbacks, and we always picked up public interfaces - so nobody realized the limitation.

Now that we have a directive to not allow remote connections, translating into wanting a loopback device, we cannot continue to reject loopbacks. So we need to fix that bug to enable selection of the loopback.