### PR TITLE
fix for failure to call MPI_Session_init twice

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1075,6 +1075,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
 
     // mark we are no longer initialized
     pmix_atomic_unset_bool(&pmix_globals.initialized);
+    pmix_globals.init_called = false;
 
     pmix_output_verbose(2, pmix_client_globals.base_output,
                         "%s:%d pmix:client finalize called",


### PR DESCRIPTION
Commit 56b3b87d562185cb069bfb6a315958db696ab015 broke support for the following MPI sessions use case:

MPI_Session_init(&a);
MPI_Session_finalize(&a);
MPI_Session_init(&a);
MPI_Session_finalize(&);

A test that illustrates the problem is at
https://github.com/open-mpi/ompi-tests/blob/master/ibm/sessions/sessions_init_twice.c

This patch fixes that problem.