### PR TITLE
Cleanup ready-for-debug announcement

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -516,7 +516,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_buffer_t *req;
     pmix_cmd_t cmd = PMIX_REQ_CMD;
     pmix_proc_t wildcard;
-    pmix_info_t ginfo, evinfo[3];
+    pmix_info_t ginfo, evinfo[4];
     pmix_lock_t releaselock;
     size_t n;
     bool found;
@@ -956,12 +956,13 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
             PMIX_INFO_LOAD(&evinfo[1], PMIX_BREAKPOINT, "pmix-init", PMIX_STRING);
             PMIX_INFO_LOAD(&evinfo[2], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
+            PMIX_INFO_LOAD(&evinfo[3], PMIX_EVENT_CUSTOM_RANGE, pmix_client_globals.myserver, PMIX_PROC);
             scd = PMIX_NEW(pmix_shift_caddy_t);
             scd->status = PMIX_READY_FOR_DEBUG;
             scd->proc = &pmix_globals.myid;
-            scd->range = PMIX_RANGE_RM;
+            scd->range = PMIX_RANGE_CUSTOM;
             scd->info = evinfo;
-            scd->ninfo = 3;
+            scd->ninfo = 4;
             scd->cbfunc.opcbfn = NULL;
             scd->cbdata = NULL;
             PMIX_THREADSHIFT(scd, pmix_internal_notify_event);
@@ -971,6 +972,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_INFO_DESTRUCT(&evinfo[0]);
             PMIX_INFO_DESTRUCT(&evinfo[1]);
             PMIX_INFO_DESTRUCT(&evinfo[2]);
+            PMIX_INFO_DESTRUCT(&evinfo[3]);
             if (PMIX_SUCCESS != rc) {
                 // failed to notify ready-for-debug
                 PMIX_ERROR_LOG(rc);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1362,9 +1362,10 @@ bool pmix_notify_check_range(pmix_range_trkr_t *rng, const pmix_proc_t *proc)
 {
     size_t n;
 
-    if (PMIX_RANGE_UNDEF == rng->range || PMIX_RANGE_GLOBAL == rng->range
-        || PMIX_RANGE_SESSION == rng->range
-        || PMIX_RANGE_LOCAL == rng->range) { // assume RM took care of session & local for now
+    if (PMIX_RANGE_UNDEF == rng->range ||
+        PMIX_RANGE_GLOBAL == rng->range ||
+        PMIX_RANGE_SESSION == rng->range ||
+        PMIX_RANGE_LOCAL == rng->range) { // assume RM took care of session & local for now
         return true;
     }
     if (PMIX_RANGE_NAMESPACE == rng->range) {
@@ -1377,12 +1378,13 @@ bool pmix_notify_check_range(pmix_range_trkr_t *rng, const pmix_proc_t *proc)
     }
     if (PMIX_RANGE_PROC_LOCAL == rng->range) {
         for (n = 0; n < rng->nprocs; n++) {
-            if (PMIX_CHECK_PROCID(&rng->procs[n], proc)) {
+            if (PMIX_CHECK_PROCID(&rng->procs[n], &pmix_globals.myid)) {
                 return true;
             }
         }
         return false;
     }
+
     if (PMIX_RANGE_CUSTOM == rng->range) {
         /* see if this proc was included */
         for (n = 0; n < rng->nprocs; n++) {

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -134,7 +134,6 @@ static void nscon(pmix_namespace_t *p)
     memset(&p->version, 0, sizeof(p->version));
     p->nprocs = 0;
     p->nlocalprocs = SIZE_MAX;
-    p->num_waiting = 0;
     p->all_registered = false;
     p->version_stored = false;
     p->job_info_recvd = false;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -367,7 +367,6 @@ typedef struct {
     } version;
     pmix_rank_t nprocs; // num procs in this nspace
     size_t nlocalprocs;
-    size_t num_waiting;    // number of local procs waiting for debugger attach/release
     bool all_registered;   // all local ranks have been defined
     bool version_stored;   // the version string used by this nspace has been stored
     bool job_info_recvd;   // job-level info has been received

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -462,14 +462,6 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                     flags |= PMIX_HASH_NUM_NODES;
                 } else if (PMIX_CHECK_KEY(&info[n], PMIX_MAX_PROCS)) {
                     flags |= PMIX_HASH_MAX_PROCS;
-                } else if (PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_ON_EXEC) ||
-                           PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_IN_INIT) ||
-                           PMIX_CHECK_KEY(&info[n], PMIX_DEBUG_STOP_IN_APP)) {
-                    if (PMIX_RANK_WILDCARD == info[n].value.data.rank) {
-                        nptr->num_waiting = nptr->nlocalprocs;
-                    } else {
-                        nptr->num_waiting = 1;
-                    }
                 } else {
                     pmix_iof_check_flags(&info[n], &nptr->iof_flags);
                 }

--- a/src/mca/gds/hash/process_arrays.c
+++ b/src/mca/gds/hash/process_arrays.c
@@ -456,14 +456,6 @@ pmix_status_t pmix_gds_hash_process_job_array(pmix_info_t *info, pmix_job_t *trk
                     trk->nptr->nprocs = iptr[j].value.data.uint32;
                     *flags |= PMIX_HASH_JOB_SIZE;
                 }
-            } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_ON_EXEC) ||
-                       PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_INIT) ||
-                       PMIX_CHECK_KEY(&iptr[j], PMIX_DEBUG_STOP_IN_APP)) {
-                if (PMIX_RANK_WILDCARD == iptr[j].value.data.rank) {
-                    trk->nptr->num_waiting = trk->nptr->nlocalprocs;
-                } else {
-                    trk->nptr->num_waiting = 1;
-                }
             } else {
                 pmix_iof_check_flags(&iptr[j], &trk->nptr->iof_flags);
             }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -330,57 +330,6 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
     }
 }
 
-static void debugger_aggregator(size_t evhdlr_registration_id, pmix_status_t status,
-                                const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
-                                pmix_info_t results[], size_t nresults,
-                                pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
-{
-    pmix_proc_t proc;
-    pmix_status_t rc;
-    pmix_namespace_t *ns, *nptr;
-
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "%s DEBUGGER AGGREGATOR CALLED FOR SOURCE %s",
-                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(source));
-
-    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, results, nresults);
-
-    /* find the nspace tracker for this namespace */
-    nptr = NULL;
-    PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
-        if (0 == strcmp(ns->nspace, source->nspace)) {
-            nptr = ns;
-            break;
-        }
-    }
-    if (NULL == nptr) {
-        /* only can happen if there is an error - nothing we can do*/
-        goto done;
-    }
-
-    /* track the number of waiting-for-notify alerts we get */
-    nptr->num_waiting--;
-
-    /* if the server has provided the notify_event function
-     * entry, then pass it up */
-    if (nptr->num_waiting <= 0 && NULL != pmix_host_server.notify_event) {
-        PMIX_LOAD_PROCID(&proc, source->nspace, PMIX_RANK_LOCAL_PEERS);
-        /* pass an event to our host */
-        rc = pmix_host_server.notify_event(status, &proc, PMIX_RANGE_RM,
-                                           (pmix_info_t *) info, ninfo,
-                                           NULL, NULL);
-        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc &&
-            PMIX_ERR_NOT_SUPPORTED != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
-    }
-
-done:
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
-    }
-}
-
 static pmix_status_t register_singleton(char *name)
 {
     char *tmp, *ptr;
@@ -918,30 +867,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
 
     // enable show_help subsystem
     pmix_atomic_store_int(&pmix_show_help_enabled, 1);
-
-    /* register a handler to catch/aggregate PMIX_EVENT_WAITING_FOR_NOTIFY
-     * events prior to passing them to our host */
-    PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_HDLR_NAME, "DEBUGGER-AGGREGATOR", PMIX_STRING);
-    cd = PMIX_NEW(pmix_rshift_caddy_t);
-    cd->codes = malloc(sizeof(int));
-    cd->codes[0] = PMIX_DEBUG_WAITING_FOR_NOTIFY;
-    cd->ncodes = 1;
-    cd->info = evinfo;
-    cd->ninfo = 1;
-    cd->evhdlr = debugger_aggregator;
-    cd->evregcbfn = evhandler_reg_callbk;
-    cd->cbdata = cd;
-    PMIX_RETAIN(cd); // so pmix_internal_reg_event_hdlr doesn't wind up releasing it
-    PMIX_THREADSHIFT(cd, pmix_internal_reg_event_hdlr);
-    PMIX_WAIT_THREAD(&cd->lock);
-    rc = cd->status;
-    PMIX_RELEASE(cd);
-    PMIX_INFO_DESTRUCT(&evinfo[0]);
-
-    if (0 >rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
 
     /* see if they gave us a rendezvous URI to which we are to call back */
     evar = getenv("PMIX_LAUNCHER_RNDZ_URI");

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1410,7 +1410,7 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
 static void localcbfn(pmix_status_t status, void *cbdata)
 {
     pmix_shift_caddy_t *cb = (pmix_shift_caddy_t *) cbdata;
-    
+
     if (NULL != cb->cbfunc.opcbfn) {
         cb->cbfunc.opcbfn(status, cb->cbdata);
     }


### PR DESCRIPTION
Don't attempt to aggregate the local announcements as we don't know how many will participate given the various options one can specify for stop-in-init and friends. Ensure the announcement only goes to the local server so it can be upcalled to the host. The other local procs don't need to see it.