### PR TITLE
Protect static variable

### DIFF
--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -363,6 +363,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
             /* find the parent's peer object */
             fcd->peer = pmix_get_peer_object(&parent);
             if (NULL == fcd->peer) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
                 PMIX_RELEASE(fcd);
                 return PMIX_ERR_NOT_FOUND;
             }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -897,7 +897,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         /* save our parent ID */
         PMIX_KVAL_NEW(kptr, PMIX_PARENT_ID);
         kptr->value->type = PMIX_PROC;
-        kptr->value->data.proc = &myparent;
+        PMIX_PROC_CREATE(kptr->value->data.proc, 1);
+        PMIx_Proc_load(kptr->value->data.proc, myparent.nspace, myparent.rank);
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
         PMIX_RELEASE(kptr); // maintain accounting
         if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
Cannot point the value to the static myparent variable as the release function will attempt to free it.