### PR TITLE
Fix indirect debugger launch

### DIFF
--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -119,16 +119,23 @@ int pmix_pfexec_base_close(void)
     return PMIX_SUCCESS;
 }
 
+static void _ntfy_done(pmix_status_t status, void *cbdata)
+{
+    pmix_pfexec_cmpl_caddy_t *cd = (pmix_pfexec_cmpl_caddy_t*)cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
+    PMIX_RELEASE(cd->child);
+    PMIX_RELEASE(cd);
+}
+
 void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
 {
-    (void) sd;
-    (void) args;
     pmix_pfexec_cmpl_caddy_t *cd = (pmix_pfexec_cmpl_caddy_t *) cbdata;
-    pmix_info_t info[2];
     pmix_status_t rc;
     pmix_pfexec_child_t *child;
     bool stillalive = false;
     pmix_proc_t wildcard;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_list_remove_item(&pmix_pfexec_globals.children, &cd->child->super);
     /* see if any more children from this nspace are alive */
@@ -139,17 +146,17 @@ void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
     }
     if (!stillalive) {
         /* generate a local event indicating job terminated */
-        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&cd->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
         PMIX_LOAD_NSPACE(wildcard.nspace, cd->child->proc.nspace);
-        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &wildcard, PMIX_PROC);
+        PMIX_INFO_LOAD(&cd->info[1], PMIX_EVENT_AFFECTED_PROC, &wildcard, PMIX_PROC);
         rc = PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL,
-                               info, 2, NULL, NULL);
+                               cd->info, 2, _ntfy_done, cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(cd->child);
+            PMIX_RELEASE(cd);
         }
     }
-    PMIX_RELEASE(cd->child);
-    PMIX_RELEASE(cd);
 }
 
 int pmix_pfexec_register(void)
@@ -1345,7 +1352,9 @@ PMIX_CLASS_INSTANCE(pmix_pfexec_child_t,
                     chcon, chdes);
 
 PMIX_CLASS_INSTANCE(pmix_pfexec_signal_caddy_t,
-                    pmix_object_t, NULL, NULL);
+                    pmix_object_t,
+                    NULL, NULL);
 
 PMIX_CLASS_INSTANCE(pmix_pfexec_cmpl_caddy_t,
-                    pmix_object_t, NULL, NULL);
+                    pmix_object_t,
+                    NULL, NULL);

--- a/src/common/pmix_pfexec.h
+++ b/src/common/pmix_pfexec.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,6 +136,7 @@ typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
     pmix_pfexec_child_t *child;
+    pmix_info_t info[2];
 } pmix_pfexec_cmpl_caddy_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_cmpl_caddy_t);
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -53,8 +53,8 @@ void pmix_internal_notify_event(int sd, short args, void *cbdata)
     pmix_proc_t *source = scd->proc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
-        PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
 
         pmix_output_verbose(2, pmix_server_globals.event_output,
                             "pmix_server_notify_event source = %s:%d event_status = %s",
@@ -76,6 +76,7 @@ void pmix_internal_notify_event(int sd, short args, void *cbdata)
             // let the completion function cleanup
             return;
         }
+        return;
     }
 
     /* if we aren't connected, don't attempt to send */

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -1090,6 +1090,10 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
 
     }
 
+    if (!pnd->nspace_created) {
+        // this was already on the nspace list, so protect it
+        PMIX_RETAIN(nptr);
+    }
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack
      * any provided pmix_info_t structs */


### PR DESCRIPTION
Do not block on event notification as we are already in an event. Correctly track ref count for nspace object created when we fork/exec the launcher.