### PR TITLE
Fix indirect debugger launch

### DIFF
--- a/src/common/pmix_pfexec.h
+++ b/src/common/pmix_pfexec.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,6 +136,7 @@ typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
     pmix_pfexec_child_t *child;
+    pmix_info_t info[2];
 } pmix_pfexec_cmpl_caddy_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_cmpl_caddy_t);
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -49,8 +49,8 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status, const pmix_pro
         return PMIX_ERR_INIT;
     }
 
-    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
-        PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+    if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
 
         pmix_output_verbose(2, pmix_server_globals.event_output,

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -1079,6 +1079,10 @@ static pmix_status_t process_tool_request(pmix_pending_connection_t *pnd,
 
     }
 
+    if (!pnd->nspace_created) {
+        // this was already on the nspace list, so protect it
+        PMIX_RETAIN(nptr);
+    }
     peer->nptr = nptr;
     /* select their bfrops compat module so we can unpack
      * any provided pmix_info_t structs */


### PR DESCRIPTION
Do not block on event notification as we are already in an event. Correctly track ref count for nspace object created when we fork/exec the launcher.


(cherry picked from commit 667b23a771bc6746f1772dabeb40a4831bf4b36b)