### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -2,6 +2,9 @@ name: Build tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: macos-latest

--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -2,6 +2,9 @@ name: Debuggers
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   dbg:
     runs-on: ubuntu-latest

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -2,6 +2,9 @@ name: GROUP
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   group-testsuite:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   mlnx:
     runs-on: ubuntu-latest

--- a/.github/workflows/pmix_mpi4py.yaml
+++ b/.github/workflows/pmix_mpi4py.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -2,6 +2,9 @@ name: PRRTE
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   dvm:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-bindings.yaml
+++ b/.github/workflows/python-bindings.yaml
@@ -13,6 +13,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-xversion.yml
+++ b/.github/workflows/run-xversion.yml
@@ -2,6 +2,9 @@ name: OpenPMIx Cross Version Testing
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   xversion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Per Copilot:

To fix the problem, explicitly declare a permissions block so that the GITHUB_TOKEN is limited to the minimal rights required. Since this workflow only checks out code and builds/tests it, it only needs read access to repository contents; no job appears to require write permissions or access to other scopes (issues, pull requests, packages, etc.).

The most straightforward fix that doesn’t alter existing behavior is to add a single, workflow-wide permissions block at the top level (same indentation as on: and jobs:) and set contents: read. This applies to all jobs that don’t override permissions, covering macos, ubuntu, and distcheck in one place. Concretely, in .github/workflows/builds.yaml, insert:

permissions:
  contents: read

between the on: [pull_request] line and the jobs: line. No additional imports, methods, or other changes are required.