### PR TITLE
Potential double free and use after free (alerts 13,14)

### DIFF
--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -894,24 +894,28 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
 
         pmix_argv_append(num_env, env, str);
         free(str);
+        str = NULL;
 
         ret = PMIX_SUCCESS;
         switch (var->mbv_source) {
-        case PMIX_MCA_BASE_VAR_SOURCE_FILE:
-        case PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE:
-            ret = asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix, var->mbv_full_name,
-                           pmix_mca_base_var_source_file(var));
-            break;
-        case PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE:
-            ret = asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix, var->mbv_full_name);
-            break;
-        case PMIX_MCA_BASE_VAR_SOURCE_ENV:
-        case PMIX_MCA_BASE_VAR_SOURCE_SET:
-        case PMIX_MCA_BASE_VAR_SOURCE_DEFAULT:
-            str = NULL;
-            break;
-        case PMIX_MCA_BASE_VAR_SOURCE_MAX:
-            goto cleanup;
+            case PMIX_MCA_BASE_VAR_SOURCE_FILE:
+            case PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE:
+                ret = asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix, var->mbv_full_name,
+                               pmix_mca_base_var_source_file(var));
+                break;
+
+            case PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE:
+                ret = asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix, var->mbv_full_name);
+                break;
+
+            case PMIX_MCA_BASE_VAR_SOURCE_ENV:
+            case PMIX_MCA_BASE_VAR_SOURCE_SET:
+            case PMIX_MCA_BASE_VAR_SOURCE_DEFAULT:
+                str = NULL;
+                break;
+
+            case PMIX_MCA_BASE_VAR_SOURCE_MAX:
+                goto cleanup;
         }
 
         if (NULL != str) {


### PR DESCRIPTION
Deallocating memory more than once can lead to a double-free vulnerability. This can be exploited to corrupt the allocator's internal data structures, which can lead to denial-of-service attacks by crashing the program, or security vulnerabilities, by allowing an attacker to overwrite arbitrary memory locations.

This rule finds accesses through a pointer of a memory location that has already been freed (i.e. through a dangling pointer). Such memory blocks have already been released to the dynamic memory manager, and modifying them can lead to anything from a segfault to memory corruption that would cause subsequent calls to the dynamic memory manager to behave erratically, to a possible security vulnerability.