### PR TITLE
Update log support to conform to Standard

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -359,8 +359,10 @@ static void scon(pmix_shift_caddy_t *p)
     p->data = NULL;
     p->ndata = 0;
     p->key = NULL;
+    p->infocopy = false;
     p->info = NULL;
     p->ninfo = 0;
+    p->dircopy = false;
     p->directives = NULL;
     p->ndirs = 0;
     p->pdata = NULL;
@@ -389,6 +391,12 @@ static void scdes(pmix_shift_caddy_t *p)
     }
     if (NULL != p->pname.nspace) {
         free(p->pname.nspace);
+    }
+    if (p->infocopy) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    if (p->dircopy) {
+        PMIX_INFO_FREE(p->directives, p->ndirs);
     }
     if (NULL != p->kv) {
         PMIX_RELEASE(p->kv);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -630,8 +630,10 @@ typedef struct {
     const char *data;
     size_t ndata;
     const char *key;
+    bool infocopy;
     pmix_info_t *info;
     size_t ninfo;
+    bool dircopy;
     pmix_info_t *directives;
     size_t ndirs;
     pmix_pdata_t *pdata;

--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,6 +110,10 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                        "%s: plog:stdfd called",
+                        PMIX_NAME_PRINT(&pmix_globals.myid));
+
 #if 0
     /* check to see if there are any relevant directives */
     for (n = 0; n < ndirs; n++) {
@@ -129,6 +133,10 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
             continue;
         }
         if (0 == strncmp(data[n].key, PMIX_LOG_STDERR, PMIX_MAX_KEYLEN)) {
+            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                                "%s: plog:stdfd delivering to stderr for source %s",
+                                PMIX_NAME_PRINT(&pmix_globals.myid),
+                                (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
             p = PMIX_NEW(pmix_iof_deliver_t);
             PMIX_XFER_PROCID(&p->source, source);
             p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
@@ -140,6 +148,10 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
                 PMIX_RELEASE(p);
             }
         } else if (0 == strncmp(data[n].key, PMIX_LOG_STDOUT, PMIX_MAX_KEYLEN)) {
+            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                                "%s: plog:stdfd delivering to stdout for source %s",
+                                PMIX_NAME_PRINT(&pmix_globals.myid),
+                                (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
             p = PMIX_NEW(pmix_iof_deliver_t);
             PMIX_XFER_PROCID(&p->source, source);
             p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -65,7 +65,7 @@
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
-#include "src/mca/plog/plog.h"
+#include "src/mca/plog/base/base.h"
 #include "src/mca/pnet/pnet.h"
 #include "src/mca/psensor/psensor.h"
 #include "src/mca/ptl/base/base.h"
@@ -1428,8 +1428,8 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
     time_t timestamp;
     PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
 
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "recvd log from client");
+    pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                        "pmix:server recvd log from client");
 
     /* setup the requesting peer name */
     pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
@@ -1503,9 +1503,13 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
     /* if we are not the gateway, then pass this up to the host
      * for transfer to the gateway, if available */
     if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
+        pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                            "pmix:server not gateway");
         cd->cbfunc.opcbfn = cbfunc;
         cd->cbdata = cbdata;
         if (NULL != pmix_host_server.log2) {
+            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                                "pmix:server using log2 upcall");
             rc = pmix_host_server.log2(&proc, cd->info, cd->ninfo,
                                        cd->directives, cd->ndirs,
                                        localcbfn, (void *) cd);
@@ -1515,6 +1519,8 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
             }
 
         } else if (NULL != pmix_host_server.log) {
+            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                                "pmix:server using log upcall");
             pmix_host_server.log(&proc, cd->info, cd->ninfo,
                                  cd->directives, cd->ndirs,
                                  localcbfn, (void *) cd);
@@ -1527,6 +1533,8 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
 
 local:
     /* pass it down */
+    pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                        "pmix:server processing locally");
     rc = pmix_plog.log(&proc, cd->info, cd->ninfo, cd->directives, cd->ndirs);
     if (PMIX_SUCCESS == rc) {
         // mark that it was done atomically


### PR DESCRIPTION
The Standard requires that the PMIx_Log_nb function call its callback function after it completes if it returned success to the caller. It is to return operation_succeeded if it atomically completes the operation, and an error if it cannot perform the operation. So properly handle those cases and support the callback handshake with the server and host.