### PR TITLE
Seal memory leak

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -389,6 +389,7 @@ static void _check_for_notify(pmix_info_t info[], size_t ninfo)
             PMIX_RELEASE(scd);
             return;
         }
+        scd->infocopy = true;
         scd->ninfo = m + 1;
         n = 0;
         if (NULL != model) {


### PR DESCRIPTION
When someone calls PMIx_Init again and passes info objects, we shift to a function to see if that info requires notification. The shift caddy copies the info, so we need to indicate it has been copied so that the destructor will release them.