### PR TITLE
Protect callbacks from threadshift when progress thread is stopped

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      ParTec AG.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -289,7 +289,8 @@ int main(int argc, char **argv)
         goto done;
     }
     if (0 == myproc.rank) {
-        sleep(2);
+        fprintf(stderr, "Rank 0 sleeping\n");
+        sleep(5);
     }
 
     /* call fence to synchronize with our peers - instruct

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -165,9 +165,14 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
         }
     }
 
+    if (NULL == name || 0 == strcmp(name, shared_thread_tracker->name)) {
+        // mark progress thread as stopped to prevent new entries from being
+        // added via PMIx API
+        pmix_atomic_set_bool(&pmix_globals.progress_thread_stopped);
+    }
+
     PMIX_LIST_FOREACH (trk, &tracking, pmix_progress_tracker_t) {
         if (NULL == name || 0 == strcmp(name, trk->name)) {
-
             /* If the progress thread is active, stop it */
             if (trk->ev_active) {
                 if (flush) {
@@ -184,11 +189,6 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
         }
     }
 
-    if (NULL == name || 0 == strcmp(name, shared_thread_tracker->name)) {
-        // mark progress thread as stopped to prevent new entries from being
-        // added via PMIx API
-        pmix_atomic_set_bool(&pmix_globals.progress_thread_stopped);
-    }
 }
 
 static int start_progress_engine(pmix_progress_tracker_t *trk)

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1255,6 +1255,15 @@ static void dmdx_cbfunc(pmix_status_t status, const char *data, size_t ndata, vo
                         pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
     pmix_dmdx_reply_caddy_t *caddy;
+    pmix_dmdx_local_t *lcd = (pmix_dmdx_local_t *) cbdata;
+
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
+        PMIX_RELEASE(lcd);
+        return;
+    }
 
     /* because the host RM is calling us from their own thread, we
      * need to thread-shift into our local progress thread before

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -483,6 +483,11 @@ static void grpcbfunc(pmix_status_t status,
 {
     grp_block_t *blk = (grp_block_t *) cbdata;
     grp_shifter_t *scd;
+
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        PMIX_RELEASE(blk);
+        return;
+    }
 
     pmix_output_verbose(2, pmix_server_globals.group_output,
                         "server:grpcbfunc called with %d info", (int) ninfo);

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -85,6 +85,10 @@ pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
     char *nodename = NULL;
     char *nd, *str;
     pmix_info_t *iptr;
+
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
 
     /* unpack the nodename */
     cnt = 1;
@@ -424,6 +428,10 @@ pmix_status_t pmix_server_resolve_node(pmix_server_caddy_t *cd,
     pmix_status_t rc;
     pmix_info_t *iptr;
     char *str;
+
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
 
     /* unpack the nspace */
     cnt = 1;


### PR DESCRIPTION
Ensure we don't add events to the stopped progress thread while we are trying to flush it.