### PR TITLE
Enforce cherry picks on release branch

### DIFF
--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -26,3 +26,4 @@ jobs:
         uses: open-mpi/pr-git-commit-checker@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"
+          cherry-pick-required: true


### PR DESCRIPTION
v6.0 is a release branch; set the parameter on the Github action to enforce cherry picks.

bot:notacherrypick