### PR TITLE
Improve description of PMIx_Compute_distances API

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1060,6 +1060,16 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric,
  * Returns an array of distances from the current process
  * location to each of the local devices of the specified type(s)
  *
+ * topo - the topology to use for the computation. If NULL,
+ *        then the local topology stored in PMIx itself will
+ *        be used
+ *
+ * cpuset - the cpus to which the process is bound
+ *
+ * info - an array of attributes directing the computation.
+ *
+ * ninfo - number of info in the array
+ *
  * distances - pointer to location where the array of
  *             distances is to be returned
  *


### PR DESCRIPTION
Include all the inputs. Note that a NULL topology input results in use of the PMIx libraries internal copy of the local topology.