### PR TITLE
Fully support return of static values

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -365,8 +365,12 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
         rc = PMIX_SUCCESS;
     }
     if (PMIX_SUCCESS == rc && NULL != cb->value) {
-        *val = cb->value;
-        cb->value = NULL;
+        if (lg->stval) {
+            PMIx_Value_xfer(*val, cb->value);
+        } else {
+            *val = cb->value;
+            cb->value = NULL;
+        }
     } else {
         *val = NULL;
     }
@@ -425,6 +429,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
         cb->cbfunc.valuefn = cbfunc;
         cb->cbdata = cbdata;
         PMIX_THREADSHIFT(cb, gcbfn);
+        PMIX_RELEASE(lg);
         return PMIX_SUCCESS;
     } else if (PMIX_SUCCESS != rc) {
         /* it's a true error */


### PR DESCRIPTION
If someone provides backing storage and request we return a static value, then return the value in their location. Note this is only available via the blocking form of PMIx_Get as there is no way to pass the address of the backing storage to the non-blocking function.

Fixes #3782 