### PR TITLE
Cleanup and abstract pmix_info support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 # Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -54,6 +54,8 @@ AC_CONFIG_MACRO_DIRS([./config config/oac])
 
 AC_PROG_SED
 
+PMIX_CAPTURE_CONFIGURE_CLI([PMIX_CONFIGURE_CLI])
+
 AC_CHECK_PROG([PERL],[perl],[perl],[no])
 AS_IF([test "X$PERL" = "Xno"],
       [AC_MSG_ERROR([OpenPMIx requires perl to build. Aborting.])])
@@ -73,7 +75,6 @@ for val in $CFLAGS; do
 done
 CFLAGS=$PMIX_CFLAGS_pass
 
-PMIX_CAPTURE_CONFIGURE_CLI([PMIX_CONFIGURE_CLI])
 
 # Get our platform support file.  This has to be done very, very early
 # because it twiddles random bits of autoconf

--- a/docs/man/man1/pmix_info.1.rst
+++ b/docs/man/man1/pmix_info.1.rst
@@ -62,7 +62,7 @@ OPTIONS
   is given, then all components will be reported).
 
 * ``--path <type>``: Show paths that PMIx was configured
-  with. Accepts the following parameters: ``prefix``, ``bindir``,
+  with. Accepts the following parameters: ``all``, ``prefix``, ``bindir``,
   ``libdir``, ``incdir``, ``pkglibdir``, ``sysconfdir``.
 
 * ``--pretty-print``: When used in conjunction with other parameters, the output is

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -26,6 +26,22 @@
 
 EXTRA_DIST += runtime/help-pmix-runtime.txt
 
+AM_CFLAGS = \
+            -DPMIX_CONFIGURE_USER="\"@PMIX_CONFIGURE_USER@\"" \
+            -DPMIX_CONFIGURE_HOST="\"@PMIX_CONFIGURE_HOST@\"" \
+            -DPMIX_CONFIGURE_DATE="\"@PMIX_CONFIGURE_DATE@\"" \
+            -DPMIX_BUILD_USER="\"$$USER\"" \
+            -DPMIX_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
+            -DPMIX_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
+            -DPMIX_BUILD_CFLAGS="\"@CFLAGS@\"" \
+            -DPMIX_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
+            -DPMIX_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
+            -DPMIX_BUILD_LIBS="\"@LIBS@\"" \
+            -DPMIX_CC_ABSOLUTE="\"@PMIX_CC_ABSOLUTE@\"" \
+            -DPMIX_GREEK_VERSION="\"@PMIX_GREEK_VERSION@\"" \
+            -DPMIX_REPO_REV="\"@PMIX_REPO_REV@\"" \
+            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
+
 headers += \
         runtime/pmix_rte.h \
         runtime/pmix_progress_threads.h \

--- a/src/runtime/pmix_info_support.h
+++ b/src/runtime/pmix_info_support.h
@@ -16,11 +16,12 @@
 #ifndef PMIX_INFO_REGISTER_H
 #define PMIX_INFO_REGISTER_H
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/mca/pinstalldirs/pinstalldirs_types.h"
 #include "src/util/pmix_cmd_line.h"
 
 BEGIN_C_DECLS
@@ -44,11 +45,17 @@ extern const char *pmix_info_ver_mca;
 extern const char *pmix_info_ver_type;
 extern const char *pmix_info_ver_component;
 
+PMIX_EXPORT extern bool pmix_info_color;
+PMIX_EXPORT extern bool pmix_info_pretty;
+PMIX_EXPORT extern pmix_mca_base_register_flag_t pmix_info_register_flags;
+
+
 /*
  * Component-related functions
  */
 typedef struct {
     pmix_list_item_t super;
+    char *project;
     char *type;
     pmix_list_t *components;
     pmix_list_t *failed_components;
@@ -62,12 +69,18 @@ PMIX_EXPORT int pmix_info_init(int argc, char **argv,
 
 PMIX_EXPORT void pmix_info_finalize(void);
 
-PMIX_EXPORT void pmix_info_register_types(pmix_pointer_array_t *mca_types);
+PMIX_EXPORT void pmix_info_register_types(pmix_pointer_array_t *mca_types,
+                                          bool frames_only);
 
 PMIX_EXPORT int pmix_info_register_framework_params(pmix_pointer_array_t *component_map);
 
 PMIX_EXPORT void pmix_info_close_components(void);
 PMIX_EXPORT void pmix_info_err_params(pmix_pointer_array_t *component_map);
+
+PMIX_EXPORT void pmix_info_show_package(char *pkgstring);
+PMIX_EXPORT void pmix_info_show_pmix_package(void);
+
+PMIX_EXPORT void pmix_info_do_pmix_config(bool want_all);
 
 PMIX_EXPORT void pmix_info_do_config(bool want_all, char *user, char *date, char *host,
                                      char *cli, char *builduser, char *builddate,
@@ -76,33 +89,40 @@ PMIX_EXPORT void pmix_info_do_config(bool want_all, char *user, char *date, char
                                      char *ldflags, char *libs, bool enabledebug,
                                      bool havedl, bool havevi);
 
-PMIX_EXPORT void pmix_info_do_params(bool want_all_in, bool want_internal,
-                                       pmix_pointer_array_t *mca_type,
-                                       pmix_pointer_array_t *component_map,
-                                       pmix_cli_result_t *pmix_info_cmd_line);
+PMIX_EXPORT void pmix_info_do_params(const char *project,
+                                     bool want_all_in, bool want_internal,
+                                     pmix_pointer_array_t *mca_type,
+                                     pmix_pointer_array_t *component_map,
+                                     pmix_cli_result_t *pmix_info_cmd_line);
 
 PMIX_EXPORT void pmix_info_show_path(const char *type, const char *value);
+PMIX_EXPORT void pmix_info_show_pmix_path(void);
 
-PMIX_EXPORT void pmix_info_do_path(bool want_all, pmix_cli_result_t *cmd_line);
+PMIX_EXPORT void pmix_info_do_path(bool want_all, pmix_cli_result_t *cmd_line,
+                                   pmix_pinstall_dirs_t *dirs);
+PMIX_EXPORT void pmix_info_do_pmix_path(bool wall, pmix_cli_result_t *cmd_line);
 
 PMIX_EXPORT void pmix_info_show_mca_params(const char *type, const char *component,
                                            bool want_internal);
 
 PMIX_EXPORT void pmix_info_show_mca_version(const pmix_mca_base_component_t *component,
-                                              const char *scope, const char *ver_type);
+                                            const char *scope, const char *ver_type);
 
-PMIX_EXPORT void pmix_info_show_component_version(pmix_pointer_array_t *mca_types,
-                                                    pmix_pointer_array_t *component_map,
-                                                    const char *type_name,
-                                                    const char *component_name, const char *scope,
-                                                    const char *ver_type);
+PMIX_EXPORT void pmix_info_show_component_version(const char *project,
+                                                  pmix_pointer_array_t *mca_types,
+                                                  pmix_pointer_array_t *component_map,
+                                                  const char *type_name,
+                                                  const char *component_name, const char *scope,
+                                                  const char *ver_type);
 
 PMIX_EXPORT char *pmix_info_make_version_str(const char *scope, int major, int minor, int release,
                                              const char *greek, const char *repo);
 
-PMIX_EXPORT void pmix_info_show_pmix_version(const char *project, const char *scope, int major, int minor,
-                                             int release, const char *greek, const char *repo,
-                                             const char *rdate);
+PMIX_EXPORT void pmix_info_show_version(const char *project, const char *scope, int major, int minor,
+                                        int release, const char *greek, const char *repo,
+                                        const char *rdate);
+
+PMIX_EXPORT void pmix_info_show_pmix_version(void);
 
 PMIX_EXPORT void pmix_info_do_arch(void);
 
@@ -111,14 +131,14 @@ PMIX_EXPORT void pmix_info_do_hostname(void);
 PMIX_EXPORT void pmix_info_do_type(pmix_cli_result_t *pmix_info_cmd_line);
 
 PMIX_EXPORT void pmix_info_out(const char *pretty_message, const char *plain_message,
-                                 const char *value);
+                               const char *value);
 
 PMIX_EXPORT void pmix_info_out_int(const char *pretty_message, const char *plain_message,
-                                     int value);
+                                   int value);
 
 PMIX_EXPORT int pmix_info_register_project_frameworks(const char *project_name,
-                                                        pmix_mca_base_framework_t **frameworks,
-                                                        pmix_pointer_array_t *component_map);
+                                                      pmix_mca_base_framework_t **frameworks,
+                                                      pmix_pointer_array_t *component_map);
 
 END_C_DECLS
 

--- a/src/tools/pmix_info/help-pmix_info.txt
+++ b/src/tools/pmix_info/help-pmix_info.txt
@@ -165,7 +165,7 @@ Aborting...
 #
 [developer warning: field too long]
 **************************************************************************
-*** DEVELOPER WARNING: A field in pmix-info output is too long and
+*** DEVELOPER WARNING: A field in pmix_info output is too long and
 *** will appear poorly in the prettyprint output.
 ***
 ***   Value:      "%s"
@@ -188,3 +188,13 @@ The %s option requires %d values, but fewer were provided:
   Value:   %s
 
 Please correct this and try again.
+#
+[no-args]
+
+The %s command does not accept arguments other than those specifically
+defined by the command. The following were not recognized:
+
+   Args: %s
+
+Please see "%s --help" for a description of all accepted command
+options.

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -15,7 +15,7 @@
 # Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -107,7 +107,7 @@ if PMIX_PICKY_COMPILERS
 	$(PMIX_V_GEN) $(PYTHON) $(abs_srcdir)/convert-help.py \
 		--root $(abs_top_srcdir) \
 		--out pmix_show_help_content.c \
-		--purge
+		--purge --verbose
 else
 	$(PMIX_V_GEN) $(PYTHON) $(abs_srcdir)/convert-help.py \
 		--root $(abs_top_srcdir) \

--- a/src/util/convert-help.py
+++ b/src/util/convert-help.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
-# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# Copyright (c) 2025-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -242,12 +242,16 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
         options = []
         cli = []
         local_cli = []
+        insection = False
         # scan the help file to find cmd line options that
         # are referenced in the help file itself
         with open(hlp) as file:
             for line in file:
                 line = line.strip()
-                if line.startswith('#') or not line:
+                if not line:
+                    continue
+                if line.startswith('#'):
+                    insection = False
                     continue
                 if line.startswith('[') and line.endswith(']'):
                     # topic - save it
@@ -255,17 +259,20 @@ def parse_tool_files(help_files, source_files, cli_options, citations, verbose=F
                     end = line.find(']')
                     topic = line[start:end]
                     topics.append(topic)
+                    if topic != "usage":
+                        insection = True
                     continue
-                # scan the line for the "--" that indicates a cmd line option
-                opt = line.find("--")
-                if -1 == opt:
-                    continue
-                # opt now points to the "--" in front of the option
-                opt += 2
-                optend = line.find(' ', opt+1)
-                option = line[opt:optend]
-                # track the option
-                options.append(option)
+                if not insection:
+                    # scan the line for the "--" that indicates a cmd line option
+                    opt = line.find("--")
+                    if -1 == opt:
+                        continue
+                    # opt now points to the "--" in front of the option
+                    opt += 2
+                    optend = line.find(' ', opt+1)
+                    option = line[opt:optend]
+                    # track the option
+                    options.append(option)
         # get the name of the tool this help file belongs to
         d = os.path.basename(hlp)
         # find the start of the tool name


### PR DESCRIPTION
Ensure we report the correct cmd line. Abstract the support functions so a 3rd party can call and get
the PMIx configuration, and still be able to use
the basic functions to report their own config.