### PR TITLE
Cleanup inii/finalize cycle

### DIFF
--- a/examples/simple.c
+++ b/examples/simple.c
@@ -51,7 +51,18 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    /* finalize us */
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Finalize failed: %s\n", PMIx_Error_string(rc));
+    }
+
+     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+       fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+   /* finalize us */
     rc = PMIx_Finalize(NULL, 0);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Finalize failed: %s\n", PMIx_Error_string(rc));

--- a/src/include/pmix_types.h
+++ b/src/include/pmix_types.h
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -254,6 +254,7 @@ typedef struct event pmix_event_t;
 #define pmix_event_base_create() event_base_new()
 
 #define pmix_event_base_free(b) event_base_free(b)
+#define pmix_event_global_shutdown() libevent_global_shutdown()
 
 /* thread support APIs */
 #define pmix_event_use_threads() evthread_use_pthreads()

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -158,7 +158,16 @@ void pmix_rte_finalize(void)
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_finalize(NULL);
+    // and finalize the library
+    pmix_event_global_shutdown();
+
+    for (i = 0; i < PMIX_VAR_DUMP_COLOR_KEY_COUNT; i++) {
+        free(pmix_var_dump_color[i]);
+        pmix_var_dump_color[i] = NULL;
+    }
     pmix_tsd_keys_destruct();
 
     pmix_finalize_util();
+    // release the event base
+    pmix_progress_thread_stop(NULL);
 }

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -120,6 +120,7 @@ pmix_status_t pmix_register_params(void)
         return ret;
     }
 
+    pmix_event_caching_window = 1;
     (void) pmix_mca_base_var_register(
         "pmix", "pmix", NULL, "event_caching_window",
         "Time (in seconds) to aggregate events before reporting them - this "
@@ -443,7 +444,7 @@ static int parse_color_string(char *color_string, char **key_names,
         }
     }
 
-    end:
+end:
 
     PMIx_Argv_free(tokens);
     PMIx_Argv_free(kv);


### PR DESCRIPTION
Reset variables to NULL after free. Finalize the event library so it can clean up. Always destroy the topology because hwloc does the right thing for shmem under the covers.