### PR TITLE
Do not shutdown libevent during finalize

### DIFF
--- a/src/include/pmix_types.h
+++ b/src/include/pmix_types.h
@@ -254,7 +254,6 @@ typedef struct event pmix_event_t;
 #define pmix_event_base_create() event_base_new()
 
 #define pmix_event_base_free(b) event_base_free(b)
-#define pmix_event_global_shutdown() libevent_global_shutdown()
 
 /* thread support APIs */
 #define pmix_event_use_threads() evthread_use_pthreads()

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -158,8 +158,6 @@ void pmix_rte_finalize(void)
 
     /* now safe to release the event base */
     (void) pmix_progress_thread_finalize(NULL);
-    // and finalize the library
-    pmix_event_global_shutdown();
 
     for (i = 0; i < PMIX_VAR_DUMP_COLOR_KEY_COUNT; i++) {
         free(pmix_var_dump_color[i]);


### PR DESCRIPTION
We cannot know who else might be using the libevent library, and the libevent shutdown routine shuts down the entire library. So we have no choice but to go ahead and leak the few bytes of memory libevent holds until shutdown in the case where we truly are the
only one using it.