### PR TITLE
Silence gcc15 warnings

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -143,7 +143,8 @@ typedef struct {
 static inline void examples_hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -817,7 +817,8 @@ PMIX_CLASS_INSTANCE(pmix_timer_t,
 void pmix_hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/get_put_example.c
+++ b/test/simple/get_put_example.c
@@ -11,7 +11,8 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/hybrid.c
+++ b/test/simple/hybrid.c
@@ -6,7 +6,8 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +40,8 @@ static pmix_proc_t myproc;
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/simpvni.c
+++ b/test/simple/simpvni.c
@@ -10,7 +10,8 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -12,7 +12,8 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    int __y = x;
+    __y = 2 * __y;
     va_start(ap, x);
     va_end(ap);
 }


### PR DESCRIPTION
Apparently, the gcc folks decided to declare passing a variable to va_start as not constituting being "used".