### PR TITLE
Use somehwat simpler method to silence gcc15

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -143,8 +143,7 @@ typedef struct {
 static inline void examples_hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -817,8 +817,7 @@ PMIX_CLASS_INSTANCE(pmix_timer_t,
 void pmix_hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/get_put_example.c
+++ b/test/simple/get_put_example.c
@@ -11,8 +11,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/hybrid.c
+++ b/test/simple/hybrid.c
@@ -6,8 +6,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -40,8 +40,7 @@ static pmix_proc_t myproc;
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/simpvni.c
+++ b/test/simple/simpvni.c
@@ -10,8 +10,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -12,8 +12,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
-    int __y = x;
-    __y = 2 * __y;
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }


### PR DESCRIPTION
Use the (void)x trick instead of a faux computation. No guarantees that future gcc won't declare that also to be "unused", but...shrug.

Thanks to Felip Moll for the suggestion.