### PR TITLE
Refcount the server_init calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ examples/monitor
 examples/monitor_remote
 examples/monitor_multi
 examples/simple
+examples/simple_server
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
-                  simple
+                  simple simple_server
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -191,6 +191,10 @@ simple_SOURCES = simple.c examples.h
 simple_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simple_LDADD = $(top_builddir)/src/libpmix.la
 
+simple_server_SOURCES = simple_server.c examples.h
+simple_server_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simple_server_LDADD = $(top_builddir)/src/libpmix.la
+
 distclean-local:
 	rm -f *.o alloc asyncgroup bad_exit client client2 \
         debugger debuggerd dmodex dynamic fault group \
@@ -199,4 +203,4 @@ distclean-local:
         async_group group_dmodex group_bootstrap client3 \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
-        simple
+        simple simple_server

--- a/examples/simple_server.c
+++ b/examples/simple_server.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+#include <pmix_server.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+        fprintf(stderr, "Server_init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    rc = PMIx_server_finalize();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Server finalize failed: %s\n", PMIx_Error_string(rc));
+    }
+
+    fprintf(stderr, "Pass one completed\n");
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+        fprintf(stderr, "Server_init second time failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+   /* finalize us */
+    rc = PMIx_server_finalize();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Server finalize second time failed: %s\n", PMIx_Error_string(rc));
+    }
+
+    fprintf(stderr, "Pass two completed\n");
+
+    fflush(stderr);
+    return (rc);
+}

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -13,7 +13,7 @@
 # Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
-# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# Copyright (c) 2025-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -80,10 +80,10 @@ attributes include:
 
 Please correct your program and try again.
 #
-[reentrant-init]
-An attempt was made to call an initialization routine, but the
-PMIx library has already been initialized:
+[module-set]
+A function call to %s was made that would have resulted in
+overwriting the function pointers in the PMIx server library's
+upcall module. This is not allowed - the server module can
+only be provided once and cannot be overwritten.
 
-  Function: %s
-
-Multiple calls to init are not supported. Please correct your program.
+Please correct your program and try again.

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -174,6 +174,7 @@ typedef struct {
 PMIX_CLASS_DECLARATION(pmix_pset_t);
 
 typedef struct {
+    bool module_set;    // pmix_host_server has been set
     pmix_list_t nspaces;          // list of pmix_nspace_t for the nspaces we know about
     pmix_pointer_array_t clients; // array of pmix_peer_t local clients
     pmix_list_t collectives;      // list of active pmix_server_trkr_t

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1449,7 +1449,14 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
 
 pmix_status_t PMIx_tool_set_server_module(pmix_server_module_t *module)
 {
+    if (pmix_server_globals.module_set) {
+        pmix_show_help("help-pmix-runtime.txt", "module-set", true,
+                       __func__);
+        return PMIX_ERR_INIT;
+    }
     pmix_host_server = *module;
+    pmix_server_globals.module_set = true;
+
     /* mark that we are now a server */
     PMIX_SET_PEER_TYPE(pmix_globals.mypeer, PMIX_PROC_SERVER);
     return PMIX_SUCCESS;

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -107,7 +107,7 @@ if PMIX_PICKY_COMPILERS
 	$(PMIX_V_GEN) $(PYTHON) $(abs_srcdir)/convert-help.py \
 		--root $(abs_top_srcdir) \
 		--out pmix_show_help_content.c \
-		--purge --verbose
+		--purge
 else
 	$(PMIX_V_GEN) $(PYTHON) $(abs_srcdir)/convert-help.py \
 		--root $(abs_top_srcdir) \


### PR DESCRIPTION
Allow someone to call PMIx_server_init multiple times so long as they only specify a server module once. Only the info array from the first call is traversed - the array is ignored on all subsequent calls.

Finalize once the refcount reaches zero.