### PR TITLE
Copy the source procID instead of pointing at it

### DIFF
--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -182,7 +182,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
                     timestamp = time(NULL);
                 }
             } else if (0 == strncmp(directives[n].key, PMIX_LOG_SOURCE, PMIX_MAX_KEYLEN)) {
-                source = directives[n].value.data.proc;
+                memcpy(source, directives[n].value.data.proc, sizeof(pmix_proc_t));
             }
         }
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1028,7 +1028,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     int i;
     pmix_peer_t *peer;
     pmix_namespace_t *ns;
- 
+
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
@@ -3394,7 +3394,6 @@ static void _opcbfunc(int sd, short args, void *cbdata)
      * it still being present - send a copy to the originator */
     PMIX_PTL_SEND_ONEWAY(rc, cd->peer, reply, cd->hdr.tag);
     if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(reply);
     }
 


### PR DESCRIPTION
Need to memcpy the source of the PMIx_Log request instead of pointing at it so we don't crash when it is free'd.