### PR TITLE
Terminate an array and return correct size

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -393,7 +393,9 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         PMIX_ALLOC_DIRECTIVE,
         PMIX_LINK_STATE,
         PMIX_LOCTYPE,
-        PMIX_DEVTYPE
+        PMIX_DEVTYPE,
+
+        PMIX_UNDEF
     };
 
     rc = PMIX_SUCCESS;
@@ -503,7 +505,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
             if (NULL != kv->data.bo.bytes && 0 < kv->data.bo.size) {
                 rc = pmix_bfrops_base_copy_bo((pmix_byte_object_t**)data, &kv->data.bo, PMIX_BYTE_OBJECT);
                 if (PMIX_SUCCESS == rc) {
-                    *sz = kv->data.bo.size;
+                    *sz = sizeof(pmix_byte_object_t);
                 } else {
                     *data = NULL;
                     *sz = 0;


### PR DESCRIPTION
The `PMIx_Value_unload` function follows the format of the data in the `pmix_value_t` structure. If the data type in the `pmix_value_t`:

   * is a simple data field (e.g., a `size_t`), then the function just copies the data across. The caller needs to provide the storage for the data.

   * is a pointer (e.g., the pmix_envar_t field), then the function malloc's the storage for the value, copies the fields into the new storage, and returns that storage to the caller. The caller needs to provide storage for the pointer to the returned value.

So in other words, the caller needs to provide storage (and a pointer to) the place where the final data is to be put. If it's a simple data field, the value will be placed in the provided storage. If it's a complex data field (e.g., a struct), then the function will place the pointer to that malloc'd data in the provided storage.

Note that this has an unusual side effect. For example, consider the case where the ``pmix_value_t`` contains a ``pmix_byte_object_t``. In this case, the caller would need to pass a ``pmix_byte_object_t`` to the `PMIx_Value_unload` function since the byte object (and not its data) is what is being unloaded. The returned size, therefore, is the size of a ``pmix_byte_object_t``, *not* the number of bytes in the ``bytes`` field of the object.