### PR TITLE
Default output to file to nocopy

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -973,6 +973,12 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
     return NULL;
 }
 
+void pmix_iof_init_flags(pmix_iof_flags_t *flags)
+{
+    memset(flags, 0, sizeof(pmix_iof_flags_t));
+    flags->nocopy = true;
+}
+
 void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
 {
     if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT) ||

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -275,6 +275,7 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_byte_object_t *bo,
                                                const pmix_info_t *info, size_t ninfo,
                                                pmix_iof_req_t *req);
+PMIX_EXPORT void pmix_iof_init_flags(pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
 PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -52,6 +52,7 @@
 
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"
+#include "src/common/pmix_iof.h"
 #include "src/mca/bfrops/bfrops_types.h"
 #include "src/mca/bfrops/base/bfrop_base_tma.h"
 #include "src/threads/pmix_threads.h"
@@ -146,7 +147,7 @@ static void nscon(pmix_namespace_t *p)
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
     PMIX_CONSTRUCT(&p->setup_data, pmix_list_t);
-    memset(&p->iof_flags, 0, sizeof(p->iof_flags));
+    pmix_iof_init_flags(&p->iof_flags);
     PMIX_CONSTRUCT(&p->sinks, pmix_list_t);
 
 }
@@ -326,7 +327,7 @@ static void iofreqcon(pmix_iof_req_t *p)
     p->remote_id = 0;
     p->procs = NULL;
     p->nprocs = 0;
-    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&p->flags);
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->directives = NULL;
     p->ndirs = 0;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -348,7 +348,7 @@ typedef struct {
     .rank = false,                  \
     .file = NULL,                   \
     .directory = NULL,              \
-    .nocopy = false,                \
+    .nocopy = true,                 \
     .merge = false,                 \
     .local_output = false,          \
     .local_output_given = false,    \

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -242,7 +242,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 #endif
 
     pmix_init_called = true;
-    memset(&flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&flags);
 
     if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3080,7 +3080,7 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->copied = false;
     p->keys = NULL;
     p->channels = PMIX_FWD_NO_CHANNELS;
-    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&p->flags);
     p->bo = NULL;
     p->nbo = 0;
     p->cbfunc = NULL;


### PR DESCRIPTION
Don't copy output going to files to stdout/err
streams by default.