### PR TITLE
Fix segfault in PMIx_Finalize due to NULL cls_destruct_array

### DIFF
--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -655,6 +655,7 @@ static inline void pmix_obj_run_constructors(pmix_object_t *object)
     assert(NULL != object->obj_class);
 
     cls_construct = object->obj_class->cls_construct_array;
+    if (NULL == cls_construct) return;
     while (NULL != *cls_construct) {
         (*cls_construct)(object);
         cls_construct++;
@@ -676,6 +677,7 @@ static inline void pmix_obj_run_destructors(pmix_object_t *object)
     assert(NULL != object->obj_class);
 
     cls_destruct = object->obj_class->cls_destruct_array;
+    if (NULL == cls_destruct) return;
     while (NULL != *cls_destruct) {
         (*cls_destruct)(object);
         cls_destruct++;


### PR DESCRIPTION
This fixes a crash in PMIx_Finalize when MPI programs are run under mpirun/prterun outside of singleton mode by adding NULL guards for cls_construct_array and cls_destruct_array in pmix_obj_run_constructors and pmix_obj_run_destructors..

pmix_object_t_class is statically preinitialized with cls_initialized matching pmix_class_init_epoch, causing pmix_class_initialize() to skip it. However, cls_construct_array and cls_destruct_array remain NULL since they are only populated by pmix_class_initialize().

Objects statically initialized via PMIX_OBJ_STATIC_INIT(pmix_object_t) (e.g., list sentinels within PMIX_LIST_STATIC_INIT) retain obj_class pointing to pmix_object_t_class. When PMIX_DESTRUCT is called on such an object, pmix_obj_run_destructors dereferences the NULL cls_destruct_array, causing a segfault.