### PR TITLE
Some minor cleanup

### DIFF
--- a/examples/simple.c
+++ b/examples/simple.c
@@ -46,9 +46,11 @@ int main(int argc, char **argv)
      * is included, then the process will be stopped in this call until
      * the "debugger release" notification arrives */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-       fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(1);
+        if (PMIX_ERR_UNREACH != rc) {
+           fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
     }
 
     rc = PMIx_Finalize(NULL, 0);
@@ -57,9 +59,11 @@ int main(int argc, char **argv)
     }
 
      if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-       fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(1);
+        if (PMIX_ERR_UNREACH != rc) {
+           fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
     }
 
    /* finalize us */

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -785,12 +785,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                sizeof(pmix_personality_t));
         /* mark that the server is unreachable */
         unreach = true;
-        /* we are a connected singleton */
-        rc = pmix_tool_init_info();
-        if (PMIX_SUCCESS != rc) {
-            free(suri);
-            return rc;
-        }
+
     } else {
         /* send a request for our job info - we do this as a non-blocking
          * transaction because some systems cannot handle very large

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -156,9 +156,6 @@ void pmix_rte_finalize(void)
     // release the topology
     pmix_hwloc_finalize();
 
-    /* now safe to release the event base */
-    (void) pmix_progress_thread_finalize(NULL);
-
     for (i = 0; i < PMIX_VAR_DUMP_COLOR_KEY_COUNT; i++) {
         free(pmix_var_dump_color[i]);
         pmix_var_dump_color[i] = NULL;


### PR DESCRIPTION
Allow simple example to run as singleton. Remove duplicate call to init info for singleton. Remove duplicate call to stop progress thread.