### PR TITLE
Only notify if tool didn't finalize, add new cli option

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -203,21 +203,13 @@ static void lost_connection(pmix_peer_t *peer)
             /* cleanup any sensors that are monitoring them */
             pmix_psensor.stop(peer, NULL);
         }
-        if (!pmix_globals.mypeer->finalized) {
-            /* if the peer is a tool, then we always generate the
-             * lost connection event so that the host can know the
-             * tool departed */
-            if (PMIX_PEER_IS_TOOL(peer) && !PMIX_PEER_IS_CLIENT(peer)) {
-                PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION, peer,
-                                  PMIX_RANGE_PROC_LOCAL, _notify_complete);
-            } else if (!peer->finalized) {
-                /* if this peer already called finalize, then
-                 * we are just seeing their connection go away
-                 * when they terminate - so do not generate
-                 * an event. If an abnormal termination, then we do */
-                PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION, peer,
-                                  PMIX_RANGE_PROC_LOCAL, _notify_complete);
-            }
+        if (!pmix_globals.mypeer->finalized && !peer->finalized) {
+            /* if this peer already called finalize, then
+             * we are just seeing their connection go away
+             * when they terminate - so do not generate
+             * an event. If an abnormal termination, then we do */
+            PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION, peer,
+                              PMIX_RANGE_PROC_LOCAL, _notify_complete);
         }
 
     } else if (peer == pmix_client_globals.myserver) {

--- a/src/tools/palloc/help-palloc.txt
+++ b/src/tools/palloc/help-palloc.txt
@@ -51,6 +51,7 @@ PMIx Allocation Request tool
    --system-server-first             First look for a system server and connect to it if found
    --system-server-only              Connect only to a system-level server
    --system-controller               Connect to the system controller
+   --scheduler                       Connect to the scheduler
    --tmpdir <arg0>                   Set the root for the session directory tree
    --connect-order <arg0>            Specify search order for server connections - e.g., scheduler,
                                      system controller, system-level server, or local server
@@ -160,6 +161,9 @@ Connect only to a system-level server - abort if one is not found
 #
 [system-controller]
 Look for a system controller and connect to it if found
+#
+[scheduler]
+Look for the scheduler on this node and connect to it if found
 #
 [tmpdir]
 Define the root location for the session directory tree where the

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,6 +64,7 @@ static struct option pallocptions[] = {
     PMIX_OPTION_DEFINE(PMIX_CLI_TMPDIR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_CONNECTION_ORDER, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_SYS_CONTROLLER, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PMIX_CLI_SCHEDULER, PMIX_ARG_NONE),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_REQ_ID, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_QUEUE, PMIX_ARG_REQD, 'q'),
@@ -298,6 +299,9 @@ int main(int argc, char **argv)
 
     } else if (pmix_cmd_line_is_taken(&results, PMIX_CLI_SYS_CONTROLLER)) {
         PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SYS_CONTROLLER, NULL, PMIX_BOOL);
+
+    } else if (pmix_cmd_line_is_taken(&results, PMIX_CLI_SCHEDULER)) {
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
 
     } else {
         /* if none of the above, setup a common "order" to check */

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -127,6 +127,7 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 #define PMIX_CLI_TMPDIR                 "tmpdir"                    // required
 #define PMIX_CLI_CONNECTION_ORDER       "connect-order"             // required
 #define PMIX_CLI_SYS_CONTROLLER         "system-controller"         // none
+#define PMIX_CLI_SCHEDULER              "scheduler"                 // none
 
 // Allocation request options
 #define PMIX_CLI_REQ_ID                 "request-id"                // required


### PR DESCRIPTION
Only notify the host if a tool disconnects without first calling finalize - the host will be notified of the finalize call and doesn't need an event as well.

Add a "scheduler" connection option for palloc.