### PR TITLE
Multiple commits

### DIFF
--- a/.github/actions/mlnx/Dockerfile
+++ b/.github/actions/mlnx/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9
+FROM almalinux:latest
 
 RUN \
     dnf install -y perl perl-Data-Dumper \

--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=6
 minor=1
-release=0
+release=1
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -24,7 +24,7 @@ release=0
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=
+greek=a1
 
 # PMIx required dependency versions.
 # List in x.y.z format.
@@ -120,7 +120,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=25:0:23
+libpmix_so_version=25:1:23
 
 # "Common" components install standalone libraries that are run-time
 # # linked by one or more components.  So they need to be versioned as

--- a/docs/man/man1/pmixcc.1.rst
+++ b/docs/man/man1/pmixcc.1.rst
@@ -1,132 +1,160 @@
 .. _man1-pmixcc:
 
-pmixcc
-=========
+PMIx Wrapper Compiler
+=====================
 
 .. include_body
 
-pmixcc |mdash| wrapper compiler for PMIx-based applications or tools
+pmixcc |mdash| PMIx wrapper compiler
 
-SYNOPSIS
---------
+SYNTAX
+------
 
-``pmixcc [options] <file>``
-
-
-DESCRIPTION
------------
-
-``pmixcc`` is a wrapper compiler that can be used to build PMIx-based
-applications or tools.
+``pmixcc [--showme | --showme:compile | --showme:link] ...``
 
 
 OPTIONS
 -------
 
-``pmixcc`` accepts the following options:
+The options include:
 
-* ``-h`` | ``--help``: Show help message
+* ``--showme``: This option comes in several different variants (see
+  below). None of the variants invokes the underlying compiler; they
+  all provide information on how the underlying compiler would have
+  been invoked had ``--showme`` not been used. The basic ``--showme``
+  option outputs the command line that would be executed to compile
+  the program.
 
-* ``--help={common|optimizers|params|target|warnings|[^]{joined|separate|undocumented}}[,...].``: Display specific types of command line options
+  .. note:: If a non-filename argument is passed on the command line,
+            the ``--showme`` option will *not* display any additional
+            flags. For example, both ``"pmixcc --showme`` and
+            ``pmixcc --showme my_source.c`` will show all the
+            wrapper-supplied flags. But ``pmixcc
+            --showme -v`` will only show the underlying compiler name
+            and ``-v``.
 
-* ``-v`` | ``--verbose``: Enable debug output.
+* ``--showme:compile``: Output the compiler flags that would have been
+  supplied to the underlying compiler.
 
-* ``-V`` | ``--version``: Print version and exit.
+* ``--showme:link``: Output the linker flags that would have been
+  supplied to the underlying compiler.
 
-* ``-dumpspecs``: Display all of the built in spec strings.
+* ``--showme:command``: Outputs the underlying compiler
+  command (which may be one or more tokens).
 
-* ``-dumpversion``: Display the version of the compiler.
+* ``--showme:incdirs``: Outputs a space-delimited (but otherwise
+  undecorated) list of directories that the wrapper compiler would
+  have provided to the underlying compiler to indicate
+  where relevant header files are located.
 
-* ``-dumpmachine``: Display the compiler's target processor.
+* ``--showme:libdirs``: Outputs a space-delimited (but otherwise
+  undecorated) list of directories that the wrapper compiler would
+  have provided to the underlying linker to indicate where relevant
+  libraries are located.
 
-* ``-foffload=<targets>``: Specify offloading targets.
+* ``--showme:libs`` Outputs a space-delimited (but otherwise
+  undecorated) list of library names that the wrapper compiler would
+  have used to link an application. For example: ``pmix util``.
 
-* ``-print-search-dirs``: Display the directories in the compiler's search path.
+* ``--showme:version``: Outputs the version number of PMIx.
 
-* ``-print-libgcc-file-name``: Display the name of the compiler's companion library.
+* ``--showme:help``: Output a brief usage help message.
 
-* ``-print-file-name=<lib>``: Display the full path to library <lib>.
-
-* ``-print-prog-name=<prog>``: Display the full path to compiler component <prog>.
-
-* ``-print-multiarch``: Display the target's normalized GNU triplet, used as a component in the library path.
-
-* ``-print-multi-directory``: Display the root directory for versions of libgcc.
-
-* ``-print-multi-lib``: Display the mapping between command line options and multiple library search directories.
-
-* ``-print-multi-os-directory``: Display the relative path to OS libraries.
-
-* ``-print-sysroot``: Display the target libraries directory.
-
-* ``-print-sysroot-headers-suffix``: Display the sysroot suffix used to find headers.
-
-* ``-Wa,<options>``: Pass comma-separated <options> on to the assembler.
-
-* ``-Wp,<options>``: Pass comma-separated <options> on to the preprocessor.
-* ``-Wl,<options>``: Pass comma-separated <options> on to the linker.
-
-* ``-Xassembler <arg>``: Pass <arg> on to the assembler.
-
-* ``-Xpreprocessor <arg>``: Pass <arg> on to the preprocessor.
-
-* ``-Xlinker <arg>``: Pass <arg> on to the linker.
-
-* ``-save-temps``: Do not delete intermediate files.
-
-* ``-save-temps=<arg>``: Do not delete intermediate files.
-
-* ``-no-canonical-prefixes``: Do not canonicalize paths when building relative prefixes to other gcc components.
-
-* ``-pipe``: Use pipes rather than intermediate files.
-
-* ``-time``: Time the execution of each subprocess.
-
-* ``-specs=<file>``: Override built-in specs with the contents of <file>.
-
-* ``-std=<standard>``: Assume that the input sources are for <standard>.
-
-* ``--sysroot=<directory>``: Use <directory> as the root directory for headers and libraries.
-
-* ``-B <directory>``: Add <directory> to the compiler's search paths.
-
-* ``-v``: Display the programs invoked by the compiler.
-
-* ``-###``: Like -v but options quoted and commands not executed.
-
-* ``-E``: Preprocess only; do not compile, assemble or link.
-
-* ``-S``: Compile only; do not assemble or link.
-
-* ``-c``: Compile and assemble, but do not link.
-
-* ``-o <file>``: Place the output into <file>.
-
-* ``-pie``: Create a dynamically linked position independent executable.
-
-* ``-shared``: Create a shared library.
-
-* ``-x <language>``: Specify the language of the following input files.
-  Permissible languages include: c c++ assembler none
-  'none' means revert to the default behavior of
-  guessing the language based on the file's extension.
+See the man page for your underlying compiler for other options that
+can be passed through pmixcc.
 
 
-Options starting with ``-g``, ``-f``, ``-m``, ``-O``, ``-W``, or ``--param`` are automatically
-passed on to the various sub-processes invoked by the compiler.  In order to pass
-other options on to these processes the ``-W<letter>`` options must be used.
-
-
-EXIT STATUS
+DESCRIPTION
 -----------
 
-Returns 0 if build is successful, a non-zero error code if otherwise.
+Conceptually, the role of these commands is quite simple:
+transparently add relevant compiler and linker flags to the user's
+command line that are necessary to compile / link PMIx-based programs,
+and then invoke the underlying compiler to actually perform the
+command.
+
+As such, these commands are frequently referred to as "wrapper"
+compilers because they do not actually compile or link applications
+themselves; they only add in command line flags and invoke the
+back-end compiler.
 
 
-EXAMPLES
+Overview
 --------
 
-Examples of using this command.
+``pmixcc`` is a convenience wrapper for the underlying C compiler.
+Translation of a PMIx-based program requires the linkage of the
+PMIx-specific libraries which may not reside in one of the standard
+search directories of ``ld(1)``. It also often requires the inclusion
+of header files what may also not be found in a standard location.
 
-.. seealso::
-   :ref:`openpmix(5) <man5-openpmix>`
+``pmixcc`` passes its arguments to the underlying C compiler along with
+the ``-I``, ``-L`` and ``-l`` options required by PMIx-based programs.
+
+The PMIx Team *strongly* encourages using the wrapper compiler
+instead of attempting to link to the PMIx library manually. This
+allows the specific implementation of PMIx to change without
+forcing changes to linker directives in users' Makefiles. Indeed, the
+specific set of flags and libraries used by the wrapper compiler
+depends on how PMIx was configured and built; the values can change
+between different installations of the same version of PMIx.
+
+Indeed, since the wrappers are simply thin shells on top of an
+underlying compiler, there are very, very few compelling reasons *not*
+to use PMIx's wrapper compiler. When it is not possible to use
+the wrapper directly, the ``--showme:compile`` and ``--showme:link``
+options should be used to determine what flags the wrapper would have
+used. For example:
+
+.. code:: sh
+
+   shell$ cc -c file1.c `pmixcc --showme:compile`
+
+   shell$ cc -c file2.c `pmixcc --showme:compile`
+
+   shell$ cc file1.o file2.o `pmixcc --showme:link` -o my_program
+
+.. _man1-pmix-wrapper-compiler-files:
+
+FILES
+-----
+
+The strings that the wrapper compiler inserts into the command line
+before invoking the underlying compiler are stored in a text file
+created by PMIx and installed to
+``$pkgdata/pmixcc-wrapper-data.txt``, where:
+
+* ``$pkgdata`` is typically ``$prefix/share/pmix``
+* ``$prefix`` is the top installation directory of PMIx
+
+It is rarely necessary to edit this file, but it can be examined to
+gain insight into what flags the wrapper is placing on the command
+line.
+
+
+ENVIRONMENT VARIABLES
+---------------------
+
+By default, the wrapper uses the compiler that was selected when
+PMIx was configured. This compiler was either found
+automatically by PMIx's "configure" script, or was selected by
+the user via the ``CC`` environment variable
+before ``configure`` was invoked. Additionally, other arguments specific
+to the compiler may have been selected by configure.
+
+These values can be selectively overridden by either editing the text
+files containing this configuration information (see the :ref:`FILES
+<man1-pmix-wrapper-compiler-files>` section), or by setting selected
+environment variables of the form ``pmix_value``.
+
+Valid value names are:
+
+* ``CPPFLAGS``: Flags added when invoking the preprocessor
+
+* ``LDFLAGS``: Flags added when invoking the linker
+
+* ``LIBS``: Libraries added when invoking the linker
+
+* ``CC``: C compiler
+
+* ``CFLAGS``: C compiler flags

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx>=4.2.0
 recommonmark
 docutils
 sphinx-rtd-theme
+requests>=2.33.0
+pygments>=2.20.0

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -46,9 +46,11 @@ int main(int argc, char **argv)
      * is included, then the process will be stopped in this call until
      * the "debugger release" notification arrives */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-       fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(1);
+        if (PMIX_ERR_UNREACH != rc) {
+           fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
     }
 
     rc = PMIx_Finalize(NULL, 0);
@@ -57,9 +59,11 @@ int main(int argc, char **argv)
     }
 
      if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-       fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(1);
+        if (PMIX_ERR_UNREACH != rc) {
+           fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
     }
 
    /* finalize us */

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -785,12 +785,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                sizeof(pmix_personality_t));
         /* mark that the server is unreachable */
         unreach = true;
-        /* we are a connected singleton */
-        rc = pmix_tool_init_info();
-        if (PMIX_SUCCESS != rc) {
-            free(suri);
-            return rc;
-        }
+
     } else {
         /* send a request for our job info - we do this as a non-blocking
          * transaction because some systems cannot handle very large

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -156,9 +156,6 @@ void pmix_rte_finalize(void)
     // release the topology
     pmix_hwloc_finalize();
 
-    /* now safe to release the event base */
-    (void) pmix_progress_thread_finalize(NULL);
-
     for (i = 0; i < PMIX_VAR_DUMP_COLOR_KEY_COUNT; i++) {
         free(pmix_var_dump_color[i]);
         pmix_var_dump_color[i] = NULL;

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -148,7 +148,7 @@ static void stop_progress_engine(pmix_progress_tracker_t *trk)
 static void checkev(int fd, short args, void *cbdata)
 {
     pmix_lock_t *lock = (pmix_lock_t*)cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(fd, args, cbdata);
+    PMIX_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_WAKEUP_THREAD(lock);
 }

--- a/src/tools/wrapper/help-pmixcc.txt
+++ b/src/tools/wrapper/help-pmixcc.txt
@@ -13,7 +13,7 @@
 # Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2012-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# Copyright (c) 2025-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,7 +40,7 @@ PMIx wrapper compiler
   --showme:libdirs_static  Show list of static library dirs added when linking
   --showme:libs            Show list of libraries added when linking
   --showme:libs_static     Show list of static libraries added when linking
-  --showme:version         Show version of %s
+  --showme:version         Show version of PMIx library
   --showme:help            This help message
 
 where "args" consists of compiler flags and sources that are to

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -594,6 +594,7 @@ int main(int argc, char *argv[])
     bool disable_flags = true;
     bool real_flag = false;
     char hostname[PMIX_PATH_MAX];
+    char *str;
     PMIX_HIDE_UNUSED_PARAMS(options);
 
     /* init globals */
@@ -708,13 +709,6 @@ int main(int argc, char *argv[])
     user_argc = PMIx_Argv_count(user_argv);
 
     for (i = 0; i < user_argc; ++i) {
-        if (0 == strcmp(user_argv[i], "--help") ||
-            0 == strcmp(user_argv[i], "-h")) {
-            pmix_show_help("help-pmixcc.txt", "usage", false,
-                            "pmixcc");
-            exit_status = 0;
-            goto cleanup;
-        }
         if (0 == strncmp(user_argv[i], "-showme", strlen("-showme")) ||
             0 == strncmp(user_argv[i], "--showme", strlen("--showme")) ||
             0 == strncmp(user_argv[i], "-show", strlen("-show")) ||
@@ -784,7 +778,6 @@ int main(int argc, char *argv[])
 
             } else if (0 == strncmp(user_argv[i], "-showme:version", strlen("-showme:version")) ||
                        0 == strncmp(user_argv[i], "--showme:version", strlen("--showme:version"))) {
-                char *str;
                 str = pmix_show_help_string("help-pmixcc.txt", "version", false, base_argv0,
                                             options_data[user_data_idx].project,
                                             options_data[user_data_idx].version,
@@ -797,13 +790,10 @@ int main(int argc, char *argv[])
 
             } else if (0 == strncmp(user_argv[i], "-showme:help", strlen("-showme:help")) ||
                        0 == strncmp(user_argv[i], "--showme:help", strlen("--showme:help"))) {
-                char *str;
-                fprintf(stderr, "BUG %s\n", PMIX_PROXY_BUGREPORT);
                 str = pmix_show_help_string("help-pmixcc.txt", "usage", false, base_argv0,
                                             options_data[user_data_idx].project,
                                             options_data[user_data_idx].version,
-                                            base_argv0, options_data[parse_options_idx].compiler,
-                                            pmix_tool_msg);
+                                            base_argv0, pmix_tool_msg);
                 if (NULL != str) {
                     printf("%s", str);
                     free(str);


### PR DESCRIPTION
[Fix reporting of help from pmixcc](https://github.com/openpmix/openpmix/commit/c7f5d8224eeff568c364c1826c43ec78ccf37fab)

Avoid a segfault when requesting usage help.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/03e066fbf2f002f167904f7bed4a54cd4b26f17b)

[Correct the wrapper compiler man page](https://github.com/openpmix/openpmix/commit/00c6014a3ef7712f41371a9fbae97c25dd8d580a)

It was garbage copy from some unclear source, so let's
make it actually be relevant to PMIx.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d40c0f038af72625c1f6306978b5c3a5251b1517)

[Some minor cleanup](https://github.com/openpmix/openpmix/commit/02027f47d62b60de59024754ea76ba919780d2fe)

Allow simple example to run as singleton. Remove duplicate
call to init info for singleton. Remove duplicate call to
stop progress thread.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/55197dc7e500e4e3bb76eec1f4808d8aaf3f79b2)

[Nit - don't hide used param](https://github.com/openpmix/openpmix/commit/d3486d27e22f144bd61f2527038037029ba62148)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/002b1f05f86911c31d38a7f373c026a42934b1a8)

[Update docs dependencies](https://github.com/openpmix/openpmix/commit/54b4d9544e75d591baa9d711b18bbf1fd5b46254)

Per dgloe-hpe, Synk feels there are some security issues in
a couple of secondary dependencies in the docs required
packages

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/0a1ab4360ec5fdcbc3109f3fd6ccfcb28b67f256)

[Update Mellanox CI](https://github.com/openpmix/openpmix/commit/7f0ada03ac15f1d5d99c15637d297c9965c25269)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/be491d1e91eba06dc5cbfb5ed907ad29de5fe587)

[Roll VERSION to v6.1.1](https://github.com/openpmix/openpmix/commit/9e44db0042a6e63f777f6df9ef14eb32e6336ec1)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick