### PR TITLE
bindings: Fix get with None key

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -706,18 +706,21 @@ cdef class PMIxClient:
             pmix_copy_nspace(p.nspace, proc['nspace'])
             p.rank = proc['rank']
 
-        # convert key,val to pmix_value_t and pmix_key_t
-        pmix_copy_key(key, ky)
-
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
 
         val = None
 
-        # pass it into the get API
-        with nogil:
-            rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
+        # None key - pass NULL to return all data
+        if ky is None:
+            with nogil:
+                rc = PMIx_Get(&p, NULL, info, ninfo, &val_ptr)
+        else:
+            # convert key,val to pmix_value_t and pmix_key_t
+            pmix_copy_key(key, ky)
+            with nogil:
+                rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
         if PMIX_SUCCESS == rc:
             val = pmix_unload_value(val_ptr)
             pmix_free_value(self, val_ptr)

--- a/bindings/python/tests/python/client.py
+++ b/bindings/python/tests/python/client.py
@@ -117,6 +117,7 @@ def main():
 
     # put value into keystore
     test_put(foo, PMIX_GLOBAL, "mykey", {'value':1, 'val_type':PMIX_INT32})
+    test_put(foo, PMIX_GLOBAL, "secondkey", {'value':2, 'val_type':PMIX_INT32})
 
     # commit it
     test_commit(foo)
@@ -128,6 +129,9 @@ def main():
 
     info = []
     test_get(foo, {'nspace':"testnspace", 'rank': 0}, "mykey", info)
+
+    # Get all keys for this proc
+    test_get(foo, {'nspace':"testnspace", 'rank': 0}, None, info)
 
     # test a fence that should return not_supported because
     # we pass a required attribute that doesn't exist


### PR DESCRIPTION
This PR fixes the Python bindings' `get()` method by properly capturing `None` key and translating it into `NULL`, so that client can retrieve all the keys.

Current behavior:
```
stderr: Traceback (most recent call last):
stderr:   File "/openpmix/bindings/python/tests/python/./client.py", line 186, in <module>
stderr:     main()
stderr:   File "/openpmix/bindings/python/tests/python/./client.py", line 134, in main
stderr:     test_get(foo, {'nspace':"testnspace", 'rank': 0}, None, info)
stderr:   File "/openpmix/bindings/python/tests/python/./client.py", line 44, in test_get
stderr:     rc, get_val = client.get(proc, ky, dicts)
stderr:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
stderr:   File "pmix.pyx", line 710, in pmix.PMIxClient.get
stderr:   File "pmix.pxi", line 892, in pmix.pmix_copy_key
stderr: TypeError: object of type 'NoneType' has no len()
```

After fix:
```
stdout: GET_VAL RETURNED:  {'value': {'type': 24, 'array': [{'key': 'pmix.hname', 'flags': 0, 'value': 'test000', 'val_type': 3}, {'key': 'pmix.nodeid', 'flags': 0, 'value': 0, 'val_type': 14}, {'key': 'pmix.lrank', 'flags': 0, 'value': 0, 'val_type': 13}, {'key': 'pmix.nrank', 'flags': 0, 'value': 0, 'val_type': 13}]}, 'val_type': 39}
```