### PR TITLE
Add fn to print peer type

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -177,6 +177,8 @@ PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(const char *orig_str,
                                                    const char *name);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char **evar);
 PMIX_EXPORT char *pmix_ptl_base_get_cmd_line(void);
+
+PMIX_EXPORT char *pmix_ptl_base_peer_type(pmix_peer_t *peer);
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -643,6 +643,22 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         kv = PMIX_NEW(pmix_info_caddy_t);
         PMIX_INFO_LOAD(&launcher, PMIX_LAUNCHER, NULL, PMIX_BOOL);
+        kv->info = &launcher;
+        pmix_list_append(&ilist, &kv->super);
+    }
+
+    /* if I am a system controller, tell them so */
+    if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
+        kv = PMIX_NEW(pmix_info_caddy_t);
+        PMIX_INFO_LOAD(&launcher, PMIX_SERVER_SYS_CONTROLLER, NULL, PMIX_BOOL);
+        kv->info = &launcher;
+        pmix_list_append(&ilist, &kv->super);
+    }
+
+    /* if I am a scheduler, tell them so */
+    if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
+        kv = PMIX_NEW(pmix_info_caddy_t);
+        PMIX_INFO_LOAD(&launcher, PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
         kv->info = &launcher;
         pmix_list_append(&ilist, &kv->super);
     }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -1405,3 +1405,37 @@ char **pmix_ptl_base_split_and_resolve(const char *orig_str,
     PMIx_Argv_free(argv);
     return interfaces;
 }
+
+char *pmix_ptl_base_peer_type(pmix_peer_t *peer)
+{
+    char **types = NULL;
+    char *ans;
+
+    if (PMIX_PEER_IS_CLIENT(peer)) {
+        PMIx_Argv_append_nosize(&types, "CLIENT");
+    }
+    if (PMIX_PEER_IS_SINGLETON(peer)) {
+        PMIx_Argv_append_nosize(&types, "SINGLETON");
+    }
+    if (PMIX_PEER_IS_SERVER(peer)) {
+        PMIx_Argv_append_nosize(&types, "SERVER");
+    }
+    if (PMIX_PEER_IS_TOOL(peer)) {
+        PMIx_Argv_append_nosize(&types, "TOOL");
+    }
+    if (PMIX_PEER_IS_LAUNCHER(peer)) {
+        PMIx_Argv_append_nosize(&types, "LAUNCHER");
+    }
+    if (PMIX_PEER_IS_GATEWAY(peer)) {
+        PMIx_Argv_append_nosize(&types, "GATEWAY");
+    }
+    if (PMIX_PEER_IS_SCHEDULER(peer)) {
+        PMIx_Argv_append_nosize(&types, "SCHEDULER");
+    }
+    if (PMIX_PEER_IS_SYS_CTRLR(peer)) {
+        PMIx_Argv_append_nosize(&types, "SYSCTRLR");
+    }
+    ans = PMIx_Argv_join(types, ',');
+    PMIx_Argv_free(types);
+    return ans;
+}


### PR DESCRIPTION
Add a helper function to print the peer type. Include info indicating the proc is a scheduler or sys controller to the connection handshake.