### PR TITLE
Fix messaging problem in ptl recv

### DIFF
--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -134,9 +134,6 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_connection(char *uri,
                                                          struct sockaddr_storage *connection,
                                                          size_t *len);
 
-PMIX_EXPORT void pmix_ptl_base_post_recv(int fd, short args, void *cbdata);
-PMIX_EXPORT void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
-
 PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
 

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -121,3 +121,12 @@ interfaces were found after applying any include or exclude directives:
 
 Please adjust your include or exclude to allow selection of an
 available interface.
+#
+[unexpected-message]
+The PMIx messaging system has received an unexpected message:
+
+  Peer: %s
+  Tag:  %u
+
+The message cannot be processed and will be ignored. Please
+report this error to the PMIx developers.

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -325,7 +325,6 @@ static pmix_status_t pmix_ptl_close(void)
     }
     /* the component will cleanup when closed */
     PMIX_LIST_DESTRUCT(&pmix_ptl_base.posted_recvs);
-    PMIX_LIST_DESTRUCT(&pmix_ptl_base.unexpected_msgs);
     PMIX_DESTRUCT(&pmix_ptl_base.listener);
 
     if (NULL != pmix_ptl_base.scheduler_filename) {
@@ -462,7 +461,6 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     /* initialize globals */
     pmix_ptl_base.initialized = true;
     PMIX_CONSTRUCT(&pmix_ptl_base.posted_recvs, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_ptl_base.unexpected_msgs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_ptl_base.listener, pmix_listener_t);
     pmix_ptl_base.connection = (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
     if (NULL == pmix_ptl_base.connection) {
@@ -557,6 +555,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_recv_t,
 
 static void prcon(pmix_ptl_posted_recv_t *p)
 {
+    p->peer = NULL;
     p->tag = UINT32_MAX;
     p->cbfunc = NULL;
     p->cbdata = NULL;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -706,7 +706,8 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(ms);
 
-    if (NULL == ms->peer || ms->peer->sd < 0 || NULL == ms->peer->info || NULL == ms->peer->nptr) {
+    if (NULL == ms->peer || ms->peer->sd < 0 ||
+        NULL == ms->peer->info || NULL == ms->peer->nptr) {
         /* this peer has lost connection */
         if (NULL != ms->bfr) {
             PMIX_RELEASE(ms->bfr);
@@ -731,11 +732,13 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     if (NULL != ms->cbfunc) {
         /* if a callback msg is expected, setup a recv for it */
         req = PMIX_NEW(pmix_ptl_posted_recv_t);
+        req->peer = ms->peer;
         req->tag = tag;
         req->cbfunc = ms->cbfunc;
         req->cbdata = ms->cbdata;
 
-        pmix_output_verbose(5, pmix_ptl_base_framework.framework_output, "posting recv on tag %d",
+        pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
+                            "posting recv on tag %d",
                             req->tag);
         /* add it to the list of recvs - we cannot have unexpected messages
          * in this subsystem as the server never sends us something that
@@ -804,15 +807,21 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
     PMIX_ACQUIRE_OBJECT(msg);
 
     pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                        "%s:%d message received %d bytes for tag %u on socket %d",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank, (int) msg->hdr.nbytes,
-                        msg->hdr.tag, msg->sd);
+                        "%s message received from %s with %d bytes for tag %u on socket %d",
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_PEER_PRINT(msg->peer),
+                        (int) msg->hdr.nbytes, msg->hdr.tag, msg->sd);
 
     /* see if we have a waiting recv for this message */
     PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
         pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                            "checking msg on tag %u for tag %u", msg->hdr.tag, rcv->tag);
+                            "checking msg from %s on tag %u for peer %s tag %u",
+                            (NULL == msg->peer) ? "NULL" : PMIX_PEER_PRINT(msg->peer), msg->hdr.tag,
+                            (NULL == rcv->peer) ? "NULL" : PMIX_PEER_PRINT(rcv->peer), rcv->tag);
 
+        // if the msg and rcv peers don't match, then skip this rcv
+        if (NULL != rcv->peer && msg->peer != rcv->peer && UINT_MAX != rcv->tag) {
+            continue;
+        }
         if (msg->hdr.tag == rcv->tag || UINT_MAX == rcv->tag) {
             if (NULL != rcv->cbfunc) {
                 /* construct and load the buffer */
@@ -845,20 +854,9 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
         }
     }
 
-    /* if the tag in this message is above the dynamic marker, then
-     * that is an error */
-    if (PMIX_PTL_TAG_DYNAMIC <= msg->hdr.tag) {
-        pmix_output(0, "UNEXPECTED MESSAGE tag = %d from source %s:%d", msg->hdr.tag,
-                    msg->peer->info->pname.nspace, msg->peer->info->pname.rank);
-        PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
-        PMIX_RELEASE(msg);
-        return;
-    }
-
-    /* it is possible that someone may post a recv for this message
-     * at some point, so we have to hold onto it */
-    pmix_list_append(&pmix_ptl_base.unexpected_msgs, &msg->super);
-    /* ensure we post the modified object before another thread
-     * picks it back up */
-    PMIX_POST_OBJECT(msg);
+    /* we should never see an unexpected msg */
+    pmix_show_help("help-ptl-base.txt", "unexpected-message", true,
+                   PMIX_PEER_PRINT(msg->peer), msg->hdr.tag);
+    PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
+    PMIX_RELEASE(msg);
 }

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,59 +106,4 @@ pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc)
      * we didn't previously request */
     pmix_list_prepend(&pmix_ptl_base.posted_recvs, &req->super);
     return PMIX_SUCCESS;
-}
-
-void pmix_ptl_base_post_recv(int fd, short args, void *cbdata)
-{
-    (void) fd;
-    (void) args;
-    pmix_ptl_posted_recv_t *req = (pmix_ptl_posted_recv_t *) cbdata;
-    pmix_ptl_recv_t *msg, *nmsg;
-    pmix_buffer_t buf;
-
-    pmix_output_verbose(5, pmix_ptl_base_framework.framework_output, "posting recv on tag %d",
-                        req->tag);
-
-    /* add it to the list of recvs */
-    pmix_list_append(&pmix_ptl_base.posted_recvs, &req->super);
-
-    /* now check the unexpected msg queue to see if we already
-     * recvd something for it */
-    PMIX_LIST_FOREACH_SAFE (msg, nmsg, &pmix_ptl_base.unexpected_msgs, pmix_ptl_recv_t) {
-        if (msg->hdr.tag == req->tag || UINT_MAX == req->tag) {
-            if (NULL != req->cbfunc) {
-                /* construct and load the buffer */
-                PMIX_CONSTRUCT(&buf, pmix_buffer_t);
-                if (NULL != msg->data) {
-                    buf.base_ptr = (char *) msg->data;
-                    buf.bytes_allocated = buf.bytes_used = msg->hdr.nbytes;
-                    buf.unpack_ptr = buf.base_ptr;
-                    buf.pack_ptr = ((char *) buf.base_ptr) + buf.bytes_used;
-                }
-                msg->data = NULL; // protect the data region
-                req->cbfunc(msg->peer, &msg->hdr, &buf, req->cbdata);
-                PMIX_DESTRUCT(&buf); // free's the msg data
-            }
-            pmix_list_remove_item(&pmix_ptl_base.unexpected_msgs, &msg->super);
-            PMIX_RELEASE(msg);
-        }
-    }
-}
-
-void pmix_ptl_base_cancel_recv(int fd, short args, void *cbdata)
-{
-    (void) fd;
-    (void) args;
-    pmix_ptl_posted_recv_t *req = (pmix_ptl_posted_recv_t *) cbdata;
-    pmix_ptl_posted_recv_t *rcv;
-
-    PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
-        if (rcv->tag == req->tag) {
-            pmix_list_remove_item(&pmix_ptl_base.posted_recvs, &rcv->super);
-            PMIX_RELEASE(rcv);
-            PMIX_RELEASE(req);
-            return;
-        }
-    }
-    PMIX_RELEASE(req);
 }

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,42 +160,10 @@ typedef struct pmix_ptl_module_t pmix_ptl_module_t;
         }                                            \
     } while (0)
 
-#define PMIX_PTL_RECV(r, c, t)                                               \
-    do {                                                                     \
-        pmix_ptl_posted_recv_t *req;                                         \
-        req = PMIX_NEW(pmix_ptl_posted_recv_t);                              \
-        if (NULL == req) {                                                   \
-            (r) = PMIX_ERR_NOMEM;                                            \
-        } else {                                                             \
-            req->tag = (t);                                                  \
-            req->cbfunc = (c);                                               \
-            pmix_event_assign(&(req->ev), pmix_globals.evbase, -1, EV_WRITE, \
-                              pmix_ptl_base_post_recv, req);                 \
-            pmix_event_active(&(req->ev), EV_WRITE, 1);                      \
-            (r) = PMIX_SUCCESS;                                              \
-        }                                                                    \
-    } while (0)
-
-#define PMIX_PTL_CANCEL(r, t)                                                \
-    do {                                                                     \
-        pmix_ptl_posted_recv_t *req;                                         \
-        req = PMIX_NEW(pmix_ptl_posted_recv_t);                              \
-        if (NULL == req) {                                                   \
-            (r) = PMIX_ERR_NOMEM;                                            \
-        } else {                                                             \
-            req->tag = (t);                                                  \
-            pmix_event_assign(&(req->ev), pmix_globals.evbase, -1, EV_WRITE, \
-                              pmix_ptl_base_cancel_recv, req);               \
-            pmix_event_active(&(req->ev), EV_WRITE, 1);                      \
-            (r) = PMIX_SUCCESS;                                              \
-        }                                                                    \
-    } while (0)
-
 /* expose functions used by the macros */
 PMIX_EXPORT extern void pmix_ptl_base_send(int sd, short args, void *cbdata);
 PMIX_EXPORT extern void pmix_ptl_base_send_recv(int sd, short args, void *cbdata);
 PMIX_EXPORT extern void pmix_ptl_base_register_recv(int sd, short args, void *cbdata);
-PMIX_EXPORT extern void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
 
 /****    COMPONENT STRUCTURE DEFINITION    ****/
 

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -264,6 +264,7 @@ PMIX_CLASS_DECLARATION(pmix_ptl_recv_t);
 typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
+    struct pmix_peer_t *peer;
     uint32_t tag;
     pmix_ptl_cbfunc_t cbfunc;
     void *cbdata;


### PR DESCRIPTION
Posted receives need to be separated out by expected peer. As things stand, a proc could send a message to a server and post a recv on the corresponding tag. If another proc (say a tool) then sends a message on that same tag (since all dynamic tags start at the same value), the recv processor would incorrectly match the msg to the existing receive.