### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/python-bindings.yaml
+++ b/.github/workflows/python-bindings.yaml
@@ -35,6 +35,8 @@ jobs:
             python-version: "3.12"
           - name: "CPython 3.13"
             python-version: "3.13"
+          - name: "CPython 3.14"
+            python-version: "3.14"
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
@@ -43,3 +45,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set environment variables
+        run: |
+          echo "PYTHONPATH=$(find "$PWD/bindings/python" -type f -name '*.so' -exec dirname {} \; -quit)" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$RUNNER_TEMP/pmixinstall/lib" >> "$GITHUB_ENV"
+
+      - name: Run python bindings test
+        env:
+          PYTHONPATH: ${{ env.PYTHONPATH }}
+          LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
+        working-directory: ./bindings/python/tests/python
+        timeout-minutes: 5
+        run: |
+          python3 server.py

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -935,11 +935,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
     if not isinstance(val['val_type'], pmix_int_types):
         return PMIX_ERR_BAD_PARAM
     value[0].type = val['val_type']
+
     if val['val_type'] == PMIX_BOOL:
         int_bool = pmix_bool_convert(val['value'])
         if int_bool != 0 and int_bool != 1:
             return PMIX_ERR_BAD_PARAM
         value[0].data.flag = int_bool
+
     elif val['val_type'] == PMIX_BYTE:
         # byte val is uint8 type
         if not isinstance(val['value'], pmix_int_types):
@@ -949,6 +951,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.byte = val['value']
+
     elif val['val_type'] == PMIX_STRING:
         if isinstance(val['value'], str):
             pykey = val['value'].encode('ascii')
@@ -959,11 +962,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         except:
             print("String value declared but non-string provided")
             return PMIX_ERR_TYPE_MISMATCH
+
     elif val['val_type'] == PMIX_SIZE:
         if not isinstance(val['value'], pmix_int_types):
             print("size_t value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.size = val['value']
+
     elif val['val_type'] == PMIX_PID:
         if not isinstance(val['value'], pmix_int_types):
             print("pid value declared but non-integer provided")
@@ -972,11 +977,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("pid value is negative")
             return PMIX_ERR_BAD_PARAM
         value[0].data.pid = val['value']
+
     elif val['val_type'] == PMIX_INT:
         if not isinstance(val['value'], pmix_int_types):
             print("integer value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.integer = val['value']
+
     elif val['val_type'] == PMIX_INT8:
         if not isinstance(val['value'], pmix_int_types):
             print("int8 value declared but non-integer provided")
@@ -985,6 +992,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("int8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.int8 = val['value']
+
     elif val['val_type'] == PMIX_INT16:
         if not isinstance(val['value'], pmix_int_types):
             print("int16 value declared but non-integer provided")
@@ -993,6 +1001,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("int16 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.int16 = val['value']
+
     elif val['val_type'] == PMIX_INT32:
         if not isinstance(val['value'], pmix_int_types):
             print("int32 value declared but non-integer provided")
@@ -1001,6 +1010,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("int32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.int32 = val['value']
+
     elif val['val_type'] == PMIX_INT64:
         if not isinstance(val['value'], pmix_int_types):
             print("int64 value declared but non-integer provided")
@@ -1009,6 +1019,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("int64 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.int64 = val['value']
+
     elif val['val_type'] == PMIX_UINT:
         if not isinstance(val['value'], pmix_int_types):
             print("integer value declared but non-integer provided")
@@ -1017,6 +1028,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint value out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint = val['value']
+
     elif val['val_type'] == PMIX_UINT8:
         if not isinstance(val['value'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
@@ -1025,6 +1037,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint8 = val['value']
+
     elif val['val_type'] == PMIX_UINT16:
         if not isinstance(val['value'], pmix_int_types):
             print("uint16 value declared but non-integer provided")
@@ -1033,6 +1046,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint16 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint16 = val['value']
+
     elif val['val_type'] == PMIX_UINT32:
         if not isinstance(val['value'], pmix_int_types):
             print("uint32 value declared but non-integer provided")
@@ -1041,6 +1055,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint32 = val['value']
+
     elif val['val_type'] == PMIX_UINT64:
         if not isinstance(val['value'], pmix_int_types):
             print("int64 value declared but non-integer provided")
@@ -1049,26 +1064,32 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint64 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint64 = val['value']
+
     elif val['val_type'] == PMIX_FLOAT:
         float_val = float(val['value'])
         if not isinstance(float_val, float):
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.fval = float_val
+
     elif val['val_type'] == PMIX_DOUBLE:
         double_val = float(val['value'])
         if not isinstance(double_val, float):
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.dval = double_val
+
     # TODO: need a way to verify usable timevals passed in?
     elif val['val_type'] == PMIX_TIMEVAL:
         value[0].data.tv.tv_sec  = val['value']['sec']
         value[0].data.tv.tv_usec = val['value']['usec']
+
     elif val['val_type'] == PMIX_TIME:
         value[0].data.time = val['val_type']
+
     elif val['val_type'] == PMIX_STATUS:
         if not isinstance(val['value'], int):
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.status = val['value']
+
     elif val['val_type'] == PMIX_PROC_RANK:
         if not isinstance(val['value'], int):
             return PMIX_ERR_TYPE_MISMATCH
@@ -1076,6 +1097,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.rank = val['value']
+
+    elif val['val_type'] == PMIX_PROC_NSPACE:
+        value[0].data.nspace = <pmix_nspace_t*> PyMem_Malloc(sizeof(pmix_nspace_t))
+        if not value[0].data.nspace:
+            return PMIX_ERR_NOMEM
+        pmix_copy_nspace(value[0].data.nspace[0], val['value'])
+
     elif val['val_type'] == PMIX_PROC:
         value[0].data.proc = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
         if not value[0].data.proc:
@@ -1090,6 +1118,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.proc[0].rank = val['value']['rank']
+
     # TODO: pmix byte object conversion isn't working
     elif val['val_type'] == PMIX_BYTE_OBJECT:
         value[0].data.bo.size = val['value']['size']
@@ -1098,6 +1127,20 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             return PMIX_ERR_NOMEM
         pyptr = <char*>val['value']['bytes']
         memcpy(value[0].data.bo.bytes, pyptr, value[0].data.bo.size)
+
+    # regex is can be a string or a byte object
+    elif val['val_type'] == PMIX_REGEX:
+        regex = val['value']
+        ba = pmix_convert_regex(regex)
+        if not isinstance(ba, bytearray):
+            return PMIX_ERR_TYPE_MISMATCH
+        value[0].data.bo.size  = len(val['value'])
+        value[0].data.bo.bytes = <char*> PyMem_Malloc(value[0].data.bo.size)
+        if not value[0].data.bo.bytes:
+            return PMIX_ERR_NOMEM
+        pyptr = <char*>ba
+        memcpy(value[0].data.bo.bytes, pyptr, value[0].data.bo.size)
+
     elif val['val_type'] == PMIX_PERSISTENCE:
         # pmix_persistence_t is defined as uint8
         if not isinstance(val['value'], pmix_int_types):
@@ -1107,6 +1150,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.persist = val['value']
+
     elif val['val_type'] == PMIX_SCOPE:
         # pmix_scope_t is defined as uint8
         if not isinstance(val['value'], pmix_int_types):
@@ -1116,6 +1160,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.scope = val['value']
+
     elif val['val_type'] == PMIX_RANGE:
         # pmix_data_range_t is defined as uint8
         if not isinstance(val['value'], pmix_int_types):
@@ -1125,6 +1170,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.range = val['value']
+
     elif val['val_type'] == PMIX_PROC_STATE:
         # pmix_proc_state_t is defined as uint8
         if not isinstance(val['value'], pmix_int_types):
@@ -1134,6 +1180,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.state = val['value']
+
     elif val['val_type'] == PMIX_PROC_INFO:
         value[0].data.pinfo = <pmix_proc_info_t*> PyMem_Malloc(sizeof(pmix_proc_info_t))
         if not value[0].data.pinfo:
@@ -1174,6 +1221,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.pinfo[0].state = val['value']['state']
+
     elif val['val_type'] == PMIX_DATA_ARRAY:
         value[0].data.darray = <pmix_data_array_t*> PyMem_Malloc(sizeof(pmix_data_array_t))
         if not value[0].data.darray:
@@ -1187,6 +1235,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             pmix_load_darray(value[0].data.darray, value[0].data.darray[0].type, val['value']['array'])
         except:
             return PMIX_ERR_NOT_SUPPORTED
+
     elif val['val_type'] == PMIX_ALLOC_DIRECTIVE:
         if not isinstance(val['value'], pmix_int_types):
             print("allocdirective value declared but non-integer provided")
@@ -1195,6 +1244,16 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             print("allocdirective value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.adir = val['value']
+
+    elif val['val_type'] == PMIX_RESBLOCK_DIRECTIVE:
+        if not isinstance(val['value'], pmix_int_types):
+            print("resblockdirective value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 255:
+            print("allocdirective value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.rbdir = val['value']
+
     elif val['val_type'] == PMIX_ENVAR:
         enval = val['value']['envar']
         if isinstance(enval, str):
@@ -1216,30 +1275,244 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             value[0].data.envar.separator = enval
         else:
             value[0].data.envar.separator = ord(enval)
-    elif val['val_type'] == PMIX_REGEX:
-        regex = val['value']
-        ba = pmix_convert_regex(regex)
-        if not isinstance(ba, bytearray):
-            return PMIX_ERR_TYPE_MISMATCH
-        value[0].data.bo.size  = len(val['value'])
-        value[0].data.bo.bytes = <char*> PyMem_Malloc(value[0].data.bo.size)
-        if not value[0].data.bo.bytes:
+
+    elif val['val_type'] == PMIX_COORD:
+        value[0].data.coord = <pmix_coord_t*> PyMem_Malloc(sizeof(pmix_coord_t))
+        if not value[0].data.coord:
             return PMIX_ERR_NOMEM
-        pyptr = <char*>ba
-        memcpy(value[0].data.bo.bytes, pyptr, value[0].data.bo.size)
+        value[0].data.coord[0].view = val['value']['view']
+        dims = val['value']['dims']
+        value[0].data.coord[0].coord = <uint32_t*> PyMem_Malloc(dims * sizeof(uint32_t))
+        if not value[0].data.coord[0].coord:
+            return PMIX_ERR_NOMEM
+        pyptr = <char*> val['value']['coord']
+        memcpy(value[0].data.coord[0].coord, pyptr, dims * sizeof(uint32_t))
+        value[0].data.coord[0].dims = dims
+
+    elif val['val_type'] == PMIX_LINK_STATE:
+        if not isinstance(val['value'], pmix_int_types):
+            print("linkstate value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 255:
+            print("linkstate value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.linkstate = val['value']
+
+    elif val['val_type'] == PMIX_JOB_STATE:
+        if not isinstance(val['value'], pmix_int_types):
+            print("jobstate value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 255:
+            print("linkstate value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.jstate = val['value']
+
+    elif val['val_type'] == PMIX_TOPO:
+        return PMIX_ERR_NOT_SUPPORTED
+
+    elif val['val_type'] == PMIX_PROC_CPUSET:
+        return PMIX_ERR_NOT_SUPPORTED
+
+    elif val['val_type'] == PMIX_LOCTYPE:
+        if not isinstance(val['value'], pmix_int_types):
+            print("locality value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 65535:
+            print("locality value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.locality = val['value']
+
+    elif val['val_type'] == PMIX_GEOMETRY:
+        value[0].data.geometry = <pmix_geometry_t*> PyMem_Malloc(sizeof(pmix_geometry_t))
+        if not value[0].data.geometry:
+            return PMIX_ERR_NOMEM
+        value[0].data.geometry[0].fabric = val['value']['fabric']
+        uuid = val['value']['uuid']
+        if isinstance(uuid, str):
+            pyuuid = uuid.encode('ascii')
+        else:
+            pyuuid = uuid
+        pyuuidptr = <const char *>(pyuuid)
+        value[0].data.geometry[0].uuid = strdup(pyuuidptr)
+        osname = val['value']['osname']
+        if isinstance(osname, str):
+            pyosname = osname.encode('ascii')
+        else:
+            pyosname = osname
+        pyosnameptr = <const char *>(pyosname)
+        value[0].data.geometry[0].osname = strdup(pyosnameptr)
+        ncoords = val['value']['ncoords']
+        value[0].data.geometry[0].coordinates = <pmix_coord_t*> PyMem_Malloc(ncoords * sizeof(pmix_coord_t))
+        if not value[0].data.geometry[0].coordinates:
+            return PMIX_ERR_NOMEM
+        n = 0
+        for k in val['value']['coords']:
+            value[0].data.geometry[0].coordinates[n].view = k['view']
+            dims = k['dims']
+            value[0].data.geometry[0].coordinates[n].coord = <uint32_t*> PyMem_Malloc(dims * sizeof(uint32_t))
+            if not value[0].data.geometry[0].coordinates[n].coord:
+                return PMIX_ERR_NOMEM
+            pyptr = <char*> k['coord']
+            memcpy(value[0].data.geometry[0].coordinates[n].coord, pyptr, dims * sizeof(uint32_t))
+            value[0].data.geometry[0].coordinates[n].dims = dims
+            n = n + 1
+        return PMIX_ERR_NOT_SUPPORTED
+
+    elif val['val_type'] == PMIX_DEVTYPE:
+        if not isinstance(val['value'], pmix_int_types):
+            print("devtype value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 18446744073709551615:
+            print("devtype value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.devtype = val['value']
+
+    elif val['val_type'] == PMIX_DEVICE:
+        value[0].data.device = <pmix_device_t*> PyMem_Malloc(sizeof(pmix_device_t))
+        if not value[0].data.device:
+            return PMIX_ERR_NOMEM
+        uuid = val['value']['uuid']
+        if isinstance(uuid, str):
+            pyuuid = uuid.encode('ascii')
+        else:
+            pyuuid = uuid
+        pyuuidptr = <const char *>(pyuuid)
+        value[0].data.device[0].uuid = strdup(pyuuidptr)
+        osname = val['value']['osname']
+        if isinstance(osname, str):
+            pyosname = osname.encode('ascii')
+        else:
+            pyosname = osname
+        pyosnameptr = <const char *>(pyosname)
+        value[0].data.device[0].osname = strdup(pyosnameptr)
+        if not isinstance(val['value']['type'], pmix_int_types):
+            print("devtype value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['type'] > 18446744073709551615:
+            print("devtype value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.device[0].type = val['value']['type']
+
+    elif val['val_type'] == PMIX_DEVICE_DIST:
+        value[0].data.devdist = <pmix_device_distance_t*> PyMem_Malloc(sizeof(pmix_device_distance_t))
+        if not value[0].data.devdist:
+            return PMIX_ERR_NOMEM
+        uuid = val['value']['uuid']
+        if isinstance(uuid, str):
+            pyuuid = uuid.encode('ascii')
+        else:
+            pyuuid = uuid
+        pyuuidptr = <const char *>(pyuuid)
+        value[0].data.devdist[0].uuid = strdup(pyuuidptr)
+        osname = val['value']['osname']
+        if isinstance(osname, str):
+            pyosname = osname.encode('ascii')
+            pyosname = osname
+        pyosnameptr = <const char *>(pyosname)
+        value[0].data.devdist[0].osname = strdup(pyosnameptr)
+        if not isinstance(val['value']['mindist'], pmix_int_types):
+            print("mindist value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['mindist'] > 65535:
+            print("mindist value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.devdist[0].mindist = val['value']['mindist']
+        if not isinstance(val['value']['maxdist'], pmix_int_types):
+            print("maxdist value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['maxdist'] > 65535:
+            print("maxdist value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.devdist[0].maxdist = val['value']['maxdist']
+
+    elif val['val_type'] == PMIX_ENDPOINT:
+        value[0].data.endpoint = <pmix_endpoint_t*> PyMem_Malloc(sizeof(pmix_endpoint_t))
+        if not value[0].data.endpoint:
+            return PMIX_ERR_NOMEM
+        uuid = val['value']['uuid']
+        if isinstance(uuid, str):
+            pyuuid = uuid.encode('ascii')
+        else:
+            pyuuid = uuid
+        pyuuidptr = <const char *>(pyuuid)
+        value[0].data.endpoint[0].uuid = strdup(pyuuidptr)
+        osname = val['value']['osname']
+        if isinstance(osname, str):
+            pyosname = osname.encode('ascii')
+            pyosname = osname
+        pyosnameptr = <const char *>(pyosname)
+        value[0].data.endpoint[0].osname = strdup(pyosnameptr)
+        value[0].data.endpoint[0].endpt.size = val['value']['endpt']['size']
+        value[0].data.endpoint[0].endpt.bytes = <char*> PyMem_Malloc(value[0].data.endpoint[0].endpt.size)
+        if not value[0].data.endpoint[0].endpt.bytes:
+            return PMIX_ERR_NOMEM
+        pyptr = <char*>val['value']['endpt']['bytes']
+        memcpy(value[0].data.endpoint[0].endpt.bytes, pyptr, value[0].data.endpoint[0].endpt.size)
+
+    elif val['val_type'] == PMIX_DATA_BUFFER:
+        return PMIX_ERR_NOT_SUPPORTED
+
+    elif val['val_type'] == PMIX_RESOURCE_UNIT:
+        value[0].data.resunit = <pmix_resource_unit_t*> PyMem_Malloc(sizeof(pmix_resource_unit_t))
+        if not value[0].data.resunit:
+            return PMIX_ERR_NOMEM
+        if not isinstance(val['value']['type'], pmix_int_types):
+            print("devtype value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['type'] > 18446744073709551615:
+            print("devtype value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.resunit[0].type = val['value']['type']
+        if not isinstance(val['value']['count'], pmix_int_types):
+            print("count value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['count'] > 18446744073709551615:
+            print("count value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.resunit[0].count = val['value']['count']
+
+    elif val['val_type'] == PMIX_NODE_PID:
+        value[0].data.nodepid = <pmix_node_pid_t*> PyMem_Malloc(sizeof(pmix_node_pid_t))
+        if not value[0].data.nodepid:
+            return PMIX_ERR_NOMEM
+        hostname = val['value']['hostname']
+        if isinstance(hostname, str):
+            pyhostname = hostname.encode('ascii')
+        else:
+            pyhostname = hostname
+        pyhostnameptr = <const char *>(pyhostname)
+        value[0].data.nodepid[0].hostname = strdup(pyhostnameptr)
+        if not isinstance(val['value']['nodeid'], pmix_int_types):
+            print("nodeid value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['nodeid'] > 4294967295:
+            print("nodeid value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.nodepid[0].nodeid = val['value']['nodeid']
+        if not isinstance(val['value']['pid'], pmix_int_types):
+            print("pid value declared but non-integer provided")
+            return PMIX_ERR_TYPE_MISMATCH
+        if val['value']['pid'] > 4294967295:
+            print("pid value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
+        value[0].data.nodepid[0].pid = val['value']['pid']
+
     else:
         print("UNRECOGNIZED VALUE TYPE: "+str(val['val_type']))
         return PMIX_ERR_NOT_SUPPORTED
     return PMIX_SUCCESS
 
 cdef dict pmix_unload_value(const pmix_value_t *value):
+
     if PMIX_BOOL == value[0].type:
         if value[0].data.flag:
             return {'value':True, 'val_type':PMIX_BOOL}
         else:
             return {'value':False, 'val_type':PMIX_BOOL}
+
     elif PMIX_BYTE == value[0].type:
         return {'value':value[0].data.byte, 'val_type':PMIX_BYTE}
+
     elif PMIX_STRING == value[0].type:
         pyb = value[0].data.string
         try:
@@ -1247,57 +1520,89 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         except:
             pystr = pyb
         return {'value':pystr, 'val_type':PMIX_STRING}
+
     elif PMIX_SIZE == value[0].type:
         return {'value':value[0].data.size, 'val_type':PMIX_SIZE}
+
     elif PMIX_PID == value[0].type:
         return {'value':value[0].data.pid, 'val_type':PMIX_PID}
+
     elif PMIX_INT == value[0].type:
         return {'value':value[0].data.integer, 'val_type':PMIX_INT}
+
     elif PMIX_INT8 == value[0].type:
         return {'value':value[0].data.int8, 'val_type':PMIX_INT8}
+
     elif PMIX_INT16 == value[0].type:
         return {'value':value[0].data.int16, 'val_type':PMIX_INT16}
+
     elif PMIX_INT32 == value[0].type:
         return {'value':value[0].data.int32, 'val_type':PMIX_INT32}
+
     elif PMIX_INT64 == value[0].type:
         return {'value':value[0].data.int64, 'val_type':PMIX_INT64}
+
     elif PMIX_UINT == value[0].type:
         return {'value':value[0].data.uint, 'val_type':PMIX_UINT}
+
     elif PMIX_UINT8 == value[0].type:
         return {'value':value[0].data.uint8, 'val_type':PMIX_UINT8}
+
     elif PMIX_UINT16 == value[0].type:
         return {'value':value[0].data.uint16, 'val_type':PMIX_UINT16}
+
     elif PMIX_UINT32 == value[0].type:
         return {'value':value[0].data.uint32, 'val_type':PMIX_UINT32}
+
     elif PMIX_UINT64 == value[0].type:
         return {'value':value[0].data.uint64, 'val_type':PMIX_UINT64}
+
     elif PMIX_FLOAT == value[0].type:
         return {'value':value[0].data.fval, 'val_type':PMIX_FLOAT}
+
     elif PMIX_DOUBLE == value[0].type:
         return {'value':value[0].data.dval, 'val_type':PMIX_DOUBLE}
+
     elif PMIX_TIMEVAL == value[0].type:
         return {'value':{'sec':value[0].data.tv.tv_sec, 'usec':value[0].data.tv.tv_usec},
         'val_type':PMIX_TIMEVAL}
+
     elif PMIX_TIME == value[0].type:
         return {'value':value[0].data.time, 'val_type':PMIX_TIME}
+
     elif PMIX_STATUS == value[0].type:
         return {'value':value[0].data.status, 'val_type':PMIX_STATUS}
+
     elif PMIX_PROC_RANK == value[0].type:
         return {'value':value[0].data.rank, 'val_type':PMIX_PROC_RANK}
+
+    elif PMIX_PROC_NSPACE == value[0].type:
+        pyns = (<bytes>value[0].data.nspace[0]).decode('UTF-8')
+        return {'value':pyns, 'val_type':PMIX_PROC_NSPACE}
+
     elif PMIX_PROC == value[0].type:
         pyns = (<bytes>value[0].data.proc[0].nspace).decode('UTF-8')
         return {'value':{'nspace':pyns, 'rank':value[0].data.proc[0].rank}, 'val_type':PMIX_PROC}
+
     elif PMIX_BYTE_OBJECT == value[0].type:
-        mybytes = <bytes>value[0].data.bo.bytes[:value[0].data.bo.size]
+        mybytes = <bytes>value[0].data.bo.bytes[value[0].data.bo.size]
         return {'value':{'bytes':mybytes, 'size':value[0].data.bo.size}, 'val_type':PMIX_BYTE_OBJECT}
+
+    elif PMIX_REGEX == value[0].type:
+        return {'value': value[0].data.bo.bytes, 'val_type': PMIX_REGEX}
+
     elif PMIX_PERSISTENCE == value[0].type:
         return {'value':value[0].data.persist, 'val_type':PMIX_PERSISTENCE}
+
     elif PMIX_SCOPE == value[0].type:
         return {'value':value[0].data.scope, 'val_type':PMIX_SCOPE}
+
     elif PMIX_RANGE == value[0].type:
         return {'value':value[0].data.range, 'val_type':PMIX_RANGE}
+
     elif PMIX_PROC_STATE == value[0].type:
         return {'value':value[0].data.state, 'val_type':PMIX_PROC_STATE}
+
     elif PMIX_PROC_INFO == value[0].type:
         pins = (<bytes>value[0].data.pinfo[0].proc.nspace).decode('UTF-8')
         pirk = value[0].data.pinfo[0].proc.rank
@@ -1308,6 +1613,7 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         pist = value[0].data.pinfo[0].state
         pians = {'proc': {'nspace':pins, 'rank':pirk}, 'hostname': pihost, 'executable': pexec, 'pid': pipid, 'exitcode': piex, 'state': pist}
         return {'value':pians, 'val_type':PMIX_PROC_INFO}
+
     elif PMIX_DATA_ARRAY == value[0].type:
         try:
             # assume pmix_unload_darray does own type checks
@@ -1317,16 +1623,85 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
             return {'value':darray, 'val_type':PMIX_DATA_ARRAY}
         except:
             return PMIX_ERR_NOT_SUPPORTED
+
     elif PMIX_ALLOC_DIRECTIVE == value[0].type:
         return {'value':value[0].data.adir, 'val_type':PMIX_ALLOC_DIRECTIVE}
+
+    elif PMIX_RESBLOCK_DIRECTIVE == value[0].type:
+        return {'value':value[0].data.rbdir, 'val_type':PMIX_RESBLOCK_DIRECTIVE}
+
     elif PMIX_ENVAR == value[0].type:
         pyenv = (<bytes>value[0].data.envar.envar).decode('UTF-8')
         pyval = (<bytes>value[0].data.envar.value).decode('UTF-8')
         pysep = value[0].data.envar.separator
         pyenvans = {'envar': pyenv, 'value': pyval, 'separator': pysep}
         return {'value':pyenvans, 'val_type':PMIX_ENVAR}
-    elif PMIX_REGEX == value[0].type:
-        return {'value': value[0].data.bo.bytes, 'val_type': PMIX_REGEX}
+
+    elif PMIX_COORD == value[0].type:
+        pyview = value[0].data.coord[0].view
+        pydims = value[0].data.coord[0].dims
+        mybytes = <bytes>value[0].data.coord[0].coord[pydims]
+        return {'value': {'view': pyview, 'coord': mybytes, 'dims': pydims}, 'val_type': PMIX_COORD}
+
+    elif PMIX_LINK_STATE == value[0].type:
+        return {'value': value[0].data.linkstate, 'val_type': PMIX_LINK_STATE}
+
+    elif PMIX_JOB_STATE == value[0].type:
+        return {'value': value[0].data.jstate, 'val_type': PMIX_JOB_STATE}
+
+    elif PMIX_TOPO == value[0].type:
+        return {'value': None, 'val_type': PMIX_TOPO}
+
+    elif PMIX_PROC_CPUSET == value[0].type:
+        return {'value': None, 'val_type': PMIX_PROC_CPUSET}
+
+    elif PMIX_LOCTYPE == value[0].type:
+        return {'value': value[0].data.locality, 'val_type': PMIX_LOCTYPE}
+
+    elif PMIX_GEOMETRY == value[0].type:
+        pyfabric = value[0].data.geometry[0].fabric
+        pyuuid = (<bytes>value[0].data.geometry[0].uuid).decode('UTF-8')
+        pyosname = (<bytes>value[0].data.geometry[0].osname).decode('UTF-8')
+        pyncoord = value[0].data.geometry[0].ncoords
+        pylist = []
+        for n in range(pyncoord):
+            pyview = value[0].data.geometry.coordinates[n].view
+            pydims = value[0].data.geometry.coordinates[n].dims
+            mybytes = <bytes>value[0].data.geometry.coordinates[n].coord[pydims]
+            pyc = {'view': pyview, 'coord': mybytes, 'dims': pydims}
+            pylist.append(pyc)
+        return {'value': {'fabric': pyfabric, 'uuid': pyuuid, 'osname': pyosname, 'coords': pylist}, 'val_type': PMIX_GEOMETRY}
+
+    elif PMIX_DEVTYPE == value[0].type:
+        return {'value': value[0].data.devtype, 'val_type': PMIX_DEVTYPE}
+
+    elif PMIX_DEVICE == value[0].type:
+        pyuuid = (<bytes>value[0].data.device[0].uuid).decode('UTF-8')
+        pyosname = (<bytes>value[0].data.device[0].osname).decode('UTF-8')
+        pyval = {'uuid': pyuuid, 'osname': pyosname, 'type': value[0].data.device[0].type}
+        return {'value': pyval, 'val_type': PMIX_DEVICE}
+
+    elif PMIX_DEVICE_DIST == value[0].type:
+        pyuuid = (<bytes>value[0].data.devdist[0].uuid).decode('UTF-8')
+        pyosname = (<bytes>value[0].data.devdist[0].osname).decode('UTF-8')
+        pyval = {'uuid': pyuuid, 'osname': pyosname, 'mindist': value[0].data.devdist[0].mindist, 'maxdist': value[0].data.devdist[0].maxdist}
+        return {'value': pyval, 'val_type': PMIX_DEVICE_DIST}
+
+    elif PMIX_ENDPOINT == value[0].type:
+        pyuuid = (<bytes>value[0].data.endpoint[0].uuid).decode('UTF-8')
+        pyosname = (<bytes>value[0].data.endpoint[0].osname).decode('UTF-8')
+        pysize = value[0].data.endpoint[0].size
+        mybytes = <bytes>value[0].data.endpoint[0].bytes[pysize]
+        pyval = {'uuid': pyuuid, 'osname': pyosname, 'endpt': {'bytes': mybytes, 'size': pysize}}
+        return {'value': pyval, 'val_type': PMIX_ENDPOINT}
+
+    elif PMIX_RESOURCE_UNIT == value[0].type:
+        return {'value': {'type': value[0].data.resunit[0].type, 'count': value[0].data.resunit[0].count}, 'val_type': PMIX_RESOURCE_UNIT}
+
+    elif PMIX_NODE_PID == value[0].type:
+        pyhostname = (<bytes>value[0].data.nodepid[0].hostname).decode('UTF-8')
+        return {'value': {'hostname': pyhostname, 'nodeid': value[0].data.nodepid[0].nodeid, 'pid': value[0].data.nodepid[0].pid}, 'val_type': PMIX_NODE_PID}
+
     else:
         print("Unload_value: provided type is unknown", value[0].type)
         return {'value': None, 'val_type': PMIX_UNDEF}
@@ -1449,7 +1824,6 @@ cdef int pmix_unload_units(const pmix_resource_unit_t *units, size_t nunits, ili
     while n < nunits:
         d     = {}
         d['type']      = units[n].type
-        # TODO: don't know how to decide if flags was defined or not??
         d['count']    = units[n].count
         ilist.append(d)
         n += 1

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1440,6 +1440,22 @@ cdef void pmix_free_info(pmix_info_t *array, size_t sz):
         n += 1
     free(array)
 
+
+# Convert array of resource units into a python list of
+# dictionaries
+cdef int pmix_unload_units(const pmix_resource_unit_t *units, size_t nunits, ilist:list):
+    cdef size_t n
+    n = 0
+    while n < nunits:
+        d     = {}
+        d['type']      = units[n].type
+        # TODO: don't know how to decide if flags was defined or not??
+        d['count']    = units[n].count
+        ilist.append(d)
+        n += 1
+    return PMIX_SUCCESS
+
+
 # Convert list of python pmix_pdata_t dicts into an
 # array of pmix_pdata_t structs
 #

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -27,12 +27,12 @@ myhdlrs = []
 myname = {}
 
 
-cdef struct icbd: 
+cdef struct icbd:
     pmix_info_t *info
     size_t ninfo
 ctypedef icbd pypmix_info_cbdata_t
 
-cdef struct mcbd: 
+cdef struct mcbd:
     char *data
     size_t size
 ctypedef mcbd pypmix_modex_cbdata_t
@@ -84,7 +84,7 @@ def pypmix_op_cbfunc(int rc, dict cbdata_dict):
     cdef void* cbdata
     cbfunc = <pmix_op_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
     cbdata = <void*> <uintptr_t> cbdata_dict['cbdata']
-    
+
     if NULL == cbfunc:
         return
 
@@ -117,9 +117,9 @@ def pypmix_info_cbfunc(int rc, list refarginfo, dict cbdata_dict):
     icbd.ninfo = ninfo
 
     with nogil:
-        cbfunc(rc, info, ninfo, cbdata, info_release, <void*> icbd) 
+        cbfunc(rc, info, ninfo, cbdata, info_release, <void*> icbd)
 
-def pypmix_modex_cbfunc(int status, bytearray ret_data, dict cbdata_dict):    
+def pypmix_modex_cbfunc(int status, bytearray ret_data, dict cbdata_dict):
     cdef char *data
     cdef size_t size = len(ret_data)
     cdef pmix_modex_cbfunc_t cbfunc = <pmix_modex_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
@@ -137,7 +137,7 @@ def pypmix_modex_cbfunc(int status, bytearray ret_data, dict cbdata_dict):
     mcbd.size = size
 
     with nogil:
-        cbfunc(status, data, size, cbdata, modex_release, mcbd)   
+        cbfunc(status, data, size, cbdata, modex_release, mcbd)
 
 def pypmix_lookup_cbfunc(int rc, list pdata, dict cbdata_dict):
     cdef pmix_lookup_cbfunc_t cbfunc = <pmix_lookup_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
@@ -163,7 +163,7 @@ def pypmix_lookup_cbfunc(int rc, list pdata, dict cbdata_dict):
             pd = NULL
     else:
         pd = NULL
-    
+
     with nogil:
         cbfunc(rc, pd, ndata, cbdata)
 
@@ -179,7 +179,7 @@ def pypmix_spawn_cbfunc(int rc, str nspace, dict cbdata_dict):
 
     if PMIX_SUCCESS == rc:
         strcpy(c_nspace, nspace)
-    
+
     with nogil:
         cbfunc(rc, c_nspace, cbdata)
 
@@ -195,7 +195,7 @@ def pypmix_tool_connection_cbfunc(int rc, dict proc, dict cbdata_dict):
     if PMIX_SUCCESS == rc:
         pmix_copy_nspace(c_proc.nspace, proc['nspace'])
         c_proc.rank = proc['rank']
-    
+
     with nogil:
         cbfunc(rc, &c_proc, cbdata)
 
@@ -219,7 +219,7 @@ def pypmix_credential_cbfunc(int rc, dict byteobject, list info, dict cbdata_dic
         if PMIX_SUCCESS != prc:
             print("Error transferring info to C:", prc)
             return prc
-    
+
     with nogil:
         cbfunc(rc, &c_byteobject, c_info, ninfo, cbdata)
 
@@ -244,7 +244,7 @@ def pypmix_validation_cbfunc(int rc, dict byteobject, list info, dict cbdata_dic
         if PMIX_SUCCESS != prc:
             print("Error transferring info to C:", prc)
             return prc
-    
+
     with nogil:
         cbfunc(rc, c_info, ninfo, cbdata)
 
@@ -817,8 +817,13 @@ cdef class PMIxClient:
         ninfo   = 0
 
         # allocate and load pmix info structs from python list of dictionaries
-        info_ptr = &info
-        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if dicts is not None:
+            info_ptr = &info
+            rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+            if PMIX_SUCCESS != rc:
+                return rc
+        else:
+            info = NULL
 
         # convert the list of dictionaries to array of
         # pmix_pdata_t structs
@@ -832,11 +837,7 @@ cdef class PMIxClient:
                 for d in data:
                     pykey = d['key']
                     pmix_copy_key(pdata[n].key, pykey)
-                    rc = 0
                     n += 1
-                if PMIX_SUCCESS != rc:
-                    pmix_free_pdata(pdata, npdata)
-                    return rc
             else:
                 pdata = NULL
         else:
@@ -1784,7 +1785,8 @@ def setmodulefn(k, f):
                  'deregisterevents', 'listener', 'notify_event', 'query',
                  'toolconnected', 'log', 'allocate', 'jobcontrol',
                  'monitor', 'getcredential', 'validatecredential',
-                 'iofpull', 'pushstdin', 'group', 'fabric', 'sessioncontrol']
+                 'iofpull', 'pushstdin', 'group', 'fabric', 'clientconnected2',
+                 'toolconnected2', 'log2', 'sessioncontrol', 'resourceblock']
     if k not in permitted:
         return PMIX_ERR_BAD_PARAM
     if not k in pmixservermodule:
@@ -1816,7 +1818,6 @@ cdef class PMIxServer(PMIxClient):
         cdef size_t sz
 
         # setup server module
-        self.server_module_init()
         if map is None or 0 == len(map):
             print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
             return PMIX_ERR_INIT
@@ -1827,6 +1828,9 @@ cdef class PMIxServer(PMIxClient):
             except KeyError:
                 print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
                 return PMIX_ERR_INIT
+
+        # setup server module functions
+        self.server_module_init(kvkeys)
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -1837,58 +1841,78 @@ cdef class PMIxServer(PMIxClient):
             rc = PMIx_server_init(&self.myserver, NULL, 0)
         return rc
 
-    def server_module_init(self):
+    def server_module_init(self, kvkeys:list):
         # v1.x interfaces
-        self.myserver.client_connected2 = <pmix_server_client_connected2_fn_t>clientconnected
-        self.myserver.client_finalized = <pmix_server_client_finalized_fn_t>clientfinalized
-        self.myserver.abort = <pmix_server_abort_fn_t>clientaborted
-        self.myserver.fence_nb = <pmix_server_fencenb_fn_t>fencenb
-        self.myserver.direct_modex = <pmix_server_dmodex_req_fn_t>directmodex
-        self.myserver.publish = <pmix_server_publish_fn_t>publish
-        self.myserver.lookup = <pmix_server_lookup_fn_t>lookup
-        self.myserver.unpublish = <pmix_server_unpublish_fn_t>unpublish
-        self.myserver.spawn = <pmix_server_spawn_fn_t>spawn
-        self.myserver.connect = <pmix_server_connect_fn_t>connect
-        self.myserver.disconnect = <pmix_server_disconnect_fn_t>disconnect
-        self.myserver.register_events = <pmix_server_register_events_fn_t>registerevents
-        self.myserver.deregister_events = <pmix_server_deregister_events_fn_t>deregisterevents
+        if 'clientconnected' in kvkeys:
+            self.myserver.client_connected = <pmix_server_client_connected_fn_t>clientconnected
+        if 'clientfinalized' in kvkeys:
+            self.myserver.client_finalized = <pmix_server_client_finalized_fn_t>clientfinalized
+        if 'abort' in kvkeys:
+            self.myserver.abort = <pmix_server_abort_fn_t>clientaborted
+        if 'fencenb' in kvkeys:
+            self.myserver.fence_nb = <pmix_server_fencenb_fn_t>fencenb
+        if 'directmodex' in kvkeys:
+            self.myserver.direct_modex = <pmix_server_dmodex_req_fn_t>directmodex
+        if 'publish' in kvkeys:
+            self.myserver.publish = <pmix_server_publish_fn_t>publish
+        if 'lookup' in kvkeys:
+            self.myserver.lookup = <pmix_server_lookup_fn_t>lookup
+        if 'unpublish' in kvkeys:
+            self.myserver.unpublish = <pmix_server_unpublish_fn_t>unpublish
+        if 'spawn' in kvkeys:
+            self.myserver.spawn = <pmix_server_spawn_fn_t>spawn
+        if 'connect' in kvkeys:
+            self.myserver.connect = <pmix_server_connect_fn_t>connect
+        if 'disconnect' in kvkeys:
+            self.myserver.disconnect = <pmix_server_disconnect_fn_t>disconnect
+        if 'registerevents' in kvkeys:
+            self.myserver.register_events = <pmix_server_register_events_fn_t>registerevents
+        if 'deregisterevents' in kvkeys:
+            self.myserver.deregister_events = <pmix_server_deregister_events_fn_t>deregisterevents
         # skip the listener entry as Python servers will never
         # provide their own socket listener thread
         #
         # v2.x interfaces
-        self.myserver.notify_event = <pmix_server_notify_event_fn_t>notifyevent
-        self.myserver.query = <pmix_server_query_fn_t>query
-        self.myserver.tool_connected = <pmix_server_tool_connection_fn_t>toolconnected
-        self.myserver.log = <pmix_server_log_fn_t>log
-        self.myserver.allocate = <pmix_server_alloc_fn_t>allocate
-        self.myserver.job_control = <pmix_server_job_control_fn_t>jobcontrol
-        self.myserver.monitor = <pmix_server_monitor_fn_t>monitor
+        if 'notifyevent' in kvkeys:
+            self.myserver.notify_event = <pmix_server_notify_event_fn_t>notifyevent
+        if 'query' in kvkeys:
+            self.myserver.query = <pmix_server_query_fn_t>query
+        if 'toolconnected' in kvkeys:
+            self.myserver.tool_connected = <pmix_server_tool_connection_fn_t>toolconnected
+        if 'log' in kvkeys:
+            self.myserver.log = <pmix_server_log_fn_t>log
+        if 'allocate' in kvkeys:
+            self.myserver.allocate = <pmix_server_alloc_fn_t>allocate
+        if 'jobcontrol' in kvkeys:
+            self.myserver.job_control = <pmix_server_job_control_fn_t>jobcontrol
+        if 'monitor' in kvkeys:
+            self.myserver.monitor = <pmix_server_monitor_fn_t>monitor
         # v3.x interfaces
-        self.myserver.get_credential = <pmix_server_get_cred_fn_t>getcredential
-        self.myserver.validate_credential = <pmix_server_validate_cred_fn_t>validatecredential
-        self.myserver.iof_pull = <pmix_server_iof_fn_t>iofpull
-        self.myserver.push_stdin = <pmix_server_stdin_fn_t>pushstdin
+        if 'getcredential' in kvkeys:
+            self.myserver.get_credential = <pmix_server_get_cred_fn_t>getcredential
+        if 'validatecredential' in kvkeys:
+            self.myserver.validate_credential = <pmix_server_validate_cred_fn_t>validatecredential
+        if 'iofpull' in kvkeys:
+            self.myserver.iof_pull = <pmix_server_iof_fn_t>iofpull
+        if 'pushstdin' in kvkeys:
+            self.myserver.push_stdin = <pmix_server_stdin_fn_t>pushstdin
         # v4.x interfaces
-        self.myserver.group = <pmix_server_grp_fn_t>group
-        self.myserver.fabric = <pmix_server_fabric_fn_t>fabric
-        # v5.x interfaces
-        self.myserver.session_control = <pmix_server_session_control_fn_t>sessioncontrol
-
-    # Allow a tool to set server module callback functions
-    # when it needs to also act as a server
-    def set_server_module(self, map:dict):
-        # setup server module
-        if map is None or 0 == len(map):
-            print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
-            return PMIX_ERR_INIT
-        kvkeys = list(map.keys())
-        for key in kvkeys:
-            try:
-                setmodulefn(key, map[key])
-            except KeyError:
-                print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
-                return PMIX_ERR_INIT
-        return PMIX_SUCCESS
+        if 'group' in kvkeys:
+            self.myserver.group = <pmix_server_grp_fn_t>group
+        if 'fabric' in kvkeys:
+            self.myserver.fabric = <pmix_server_fabric_fn_t>fabric
+        # v6.x interfaces
+        if 'clientconnected2' in kvkeys:
+            self.myserver.client_connected2 = <pmix_server_client_connected2_fn_t>clientconnected2
+        if 'toolconnected2' in kvkeys:
+            self.myserver.tool_connected2 = <pmix_server_tool_connection2_fn_t>toolconnected2
+        if 'log2' in kvkeys:
+            self.myserver.log2 = <pmix_server_log2_fn_t>log2
+        # pending interfaces
+        if 'sessioncontrol' in kvkeys:
+            self.myserver.session_control = <pmix_server_session_control_fn_t>sessioncontrol
+        if 'resourceblock' in kvkeys:
+            self.myserver.resource_block = <pmix_server_resource_block_fn_t>resourceblock
 
     def finalize(self):
         # finalize
@@ -2304,7 +2328,29 @@ cdef int clientconnected(pmix_proc_t *proc, void *server_object,
         pmix_unload_procs(proc, 1, myproc)
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['clientconnected'](myproc[0], pypmix_op_cbfunc, cbdata_dict)
-    
+
+    return PMIX_ERR_NOT_FOUND
+
+cdef int clientconnected2(pmix_proc_t *proc, void *server_object,
+                          pmix_info_t info[], size_t ninfo,
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'clientconnected2' in keys:
+        if not proc:
+            return PMIX_ERR_BAD_PARAM
+        args = {}
+        myproc = []
+        pmix_unload_procs(proc, 1, myproc)
+        args['proc'] = myproc[0]
+        ilist = []
+        if NULL != info:
+            rc = pmix_unload_info(info, ninfo, ilist)
+            if PMIX_SUCCESS != rc:
+                return rc
+            args['directives'] = ilist
+        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+        return pmixservermodule['clientconnected2'](args, pypmix_op_cbfunc, cbdata_dict)
+
     return PMIX_ERR_NOT_FOUND
 
 cdef int clientfinalized(pmix_proc_t *proc, void *server_object,
@@ -2344,7 +2390,7 @@ cdef int clientaborted(const pmix_proc_t *proc, void *server_object,
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         # upcall it
         return pmixservermodule['abort'](args, pypmix_op_cbfunc, cbdata_dict)
-    
+
     return PMIX_ERR_NOT_SUPPORTED
 
 cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
@@ -2375,7 +2421,7 @@ cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
             args['data'] = barray
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['fencenb'](args, pypmix_modex_cbfunc, cbdata_dict)
-    
+
     return PMIX_ERR_NOT_SUPPORTED
 
 
@@ -2438,7 +2484,7 @@ cdef int lookup(const pmix_proc_t *proc, char **keys,
             args['directives'] = ilist
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['lookup'](args, pypmix_lookup_cbfunc, cbdata_dict)
-        
+
     return PMIX_ERR_NOT_SUPPORTED
 
 cdef int unpublish(const pmix_proc_t *proc, char **keys,
@@ -2460,7 +2506,7 @@ cdef int unpublish(const pmix_proc_t *proc, char **keys,
             args['directives'] = ilist
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['unpublish'](args, pypmix_op_cbfunc, cbdata_dict)
-    
+
     return PMIX_ERR_NOT_SUPPORTED
 
 cdef int spawn(const pmix_proc_t *proc,
@@ -2583,7 +2629,7 @@ cdef int notifyevent(pmix_status_t code,
             args['directives'] = ilist
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['notifyevent'](args, pypmix_op_cbfunc, cbdata_dict)
-    
+
     return PMIX_ERR_NOT_SUPPORTED
 
 
@@ -2664,7 +2710,7 @@ cdef int allocate(const pmix_proc_t *client,
             args['directives'] = keyvals
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['allocate'](args, pypmix_info_cbfunc, cbdata_dict)
-    
+
     return PMIX_ERR_NOT_SUPPORTED
 
 
@@ -2737,7 +2783,7 @@ cdef int getcredential(const pmix_proc_t *proc,
         return pmixservermodule['getcredential'](args, pypmix_credential_cbfunc, cbdata_dict)
 
     return PMIX_ERR_NOT_SUPPORTED
-   
+
 cdef int validatecredential(const pmix_proc_t *proc,
                             const pmix_byte_object_t *cred,
                             const pmix_info_t directives[], size_t ndirs,
@@ -2765,7 +2811,7 @@ cdef int validatecredential(const pmix_proc_t *proc,
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['validatecredential'](args, pypmix_validation_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED       
+    return PMIX_ERR_NOT_SUPPORTED
 
 cdef int iofpull(const pmix_proc_t procs[], size_t nprocs,
                  const pmix_info_t directives[], size_t ndirs,
@@ -2823,7 +2869,7 @@ cdef int pushstdin(const pmix_proc_t *source,
         return pmixservermodule['pushstdin'](args, pypmix_op_cbfunc, cbdata_dict)
 
     return PMIX_ERR_NOT_SUPPORTED
-    
+
 
 # TODO: This function requires that the server execute the
 # provided callback function to return the group info, and
@@ -2874,6 +2920,47 @@ cdef int fabric(const pmix_proc_t *requestor,
 
     return PMIX_ERR_NOT_SUPPORTED
 
+cdef int toolconnected2(pmix_info_t *info, size_t ninfo,
+                        pmix_tool_connection_cbfunc_t cbfunc,
+                        void *cbdata) noexcept with gil:
+    keys = pmixservermodule.keys()
+    ret_proc = {'nspace': "UNDEF", 'rank': PMIX_RANK_UNDEF}
+    if 'toolconnected2' in keys:
+        args = {}
+        ilist = []
+        if NULL != info:
+            pmix_unload_info(info, ninfo, ilist)
+            args['directives'] = ilist
+        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+        return pmixservermodule['toolconnected2'](args, pypmix_tool_connection_cbfunc, cbdata_dict)
+
+    return PMIX_ERR_NOT_SUPPORTED
+
+cdef int log2(const pmix_proc_t *client,
+              const pmix_info_t data[], size_t ndata,
+              const pmix_info_t directives[], size_t ndirs,
+              pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    keys = pmixservermodule.keys()
+    if 'log2' in keys:
+        args = {}
+        ilist = []
+        myproc = []
+        mydirs = []
+        if NULL == client:
+            return PMIX_ERR_BAD_PARAM
+        pmix_unload_procs(client, 1, myproc)
+        args['source'] = myproc[0]
+        if NULL != data:
+            pmix_unload_info(data, ndata, ilist)
+            args['data'] = ilist
+        if NULL != directives:
+            pmix_unload_info(directives, ndirs, mydirs)
+            args['directives'] = mydirs
+        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+        return pmixservermodule['log2'](args, pypmix_op_cbfunc, cbdata_dict)
+
+    return PMIX_ERR_NOT_SUPPORTED
+
 cdef int sessioncontrol(const pmix_proc_t *requestor,
                         uint32_t sessionID,
                         const pmix_info_t directives[], size_t ndirs,
@@ -2901,6 +2988,41 @@ cdef int sessioncontrol(const pmix_proc_t *requestor,
 
     return PMIX_ERR_NOT_SUPPORTED
 
+cdef int resourceblock(const pmix_proc_t *requestor,
+                       pmix_resource_block_directive_t directive,
+                       const char *block,
+                       const pmix_resource_unit_t *units, size_t nunits,
+                       const pmix_info_t *info, size_t ninfo,
+                       pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'resourceblock' in keys:
+        args = {}
+        myproc = []
+        blist = []
+        ulist = []
+        ilist = []
+        barray = None
+
+        if NULL == requestor:
+            return PMIX_ERR_BAD_PARAM
+        if NULL == units:
+            return PMIX_ERR_BAD_PARAM
+        pmix_unload_procs(requestor, 1, myproc)
+        args['requestor'] = myproc[0]
+        args['directive'] = directive
+        args['block'] = block
+        rc = pmix_unload_units(units, nunits, ulist)
+        if PMIX_SUCCESS != rc:
+            return rc
+        args['units'] = ulist
+        if NULL != info:
+            rc = pmix_unload_info(info, ninfo, ilist)
+            if PMIX_SUCCESS != rc:
+                return rc
+            args['info'] = ilist
+        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+        return pmixservermodule['resourceblock'](args, pypmix_info_cbfunc, cbdata_dict)
+
 
 cdef class PMIxTool(PMIxServer):
     def __cinit__(self):
@@ -2923,9 +3045,6 @@ cdef class PMIxTool(PMIxServer):
         # init myname
         myname = {'nspace':'UNASSIGNED', 'rank':PMIX_RANK_UNDEF}
 
-        # init server module in case the tool uses it
-        self.server_module_init()
-
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
@@ -2940,7 +3059,6 @@ cdef class PMIxTool(PMIxServer):
         if PMIX_SUCCESS == rc:
             # convert the returned name
             myname = {'nspace': (<bytes>self.myproc.nspace).decode('UTF-8'), 'rank': self.myproc.rank}
-            rc = PMIx_tool_set_server_module(&self.myserver);
         return rc, myname
 
     # Finalize the tool library
@@ -3030,6 +3148,24 @@ cdef class PMIxTool(PMIxServer):
         if 0 < ninfo:
             pmix_free_info(info, ninfo)
         return rc
+
+    # Allow a tool to set server module callback functions
+    # when it needs to also act as a server
+    def set_server_module(self, map:dict):
+        # setup server module
+        if map is None or 0 == len(map):
+            print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
+            return PMIX_ERR_INIT
+        kvkeys = list(map.keys())
+        for key in kvkeys:
+            try:
+                setmodulefn(key, map[key])
+            except KeyError:
+                print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
+                return PMIX_ERR_INIT
+        self.server_module_init(kvkeys)
+        return PMIX_SUCCESS
+
 
     def iof_pull(self, pyprocs:list, iof_channel:int, pydirs:list, hdlr):
         cdef pmix_proc_t *procs
@@ -3208,7 +3344,6 @@ cdef class PMIxScheduler(PMIxTool):
         if PMIX_SUCCESS == rc:
             # convert the returned name
             myname = {'nspace': (<bytes>self.myproc.nspace).decode('UTF-8'), 'rank': self.myproc.rank}
-            rc = PMIx_tool_set_server_module(&self.myserver);
         return rc, myname
 
     # Finalize the tool library

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -706,18 +706,21 @@ cdef class PMIxClient:
             pmix_copy_nspace(p.nspace, proc['nspace'])
             p.rank = proc['rank']
 
-        # convert key,val to pmix_value_t and pmix_key_t
-        pmix_copy_key(key, ky)
-
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
 
         val = None
 
-        # pass it into the get API
-        with nogil:
-            rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
+        # None key - pass NULL to return all data
+        if ky is None:
+            with nogil:
+                rc = PMIx_Get(&p, NULL, info, ninfo, &val_ptr)
+        else:
+            # convert key,val to pmix_value_t and pmix_key_t
+            pmix_copy_key(key, ky)
+            with nogil:
+                rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
         if PMIX_SUCCESS == rc:
             val = pmix_unload_value(val_ptr)
             pmix_free_value(self, val_ptr)

--- a/bindings/python/tests/python/client.py
+++ b/bindings/python/tests/python/client.py
@@ -141,7 +141,8 @@ def main():
     test_fence(foo, procs, info)
 
     pdata_key = [{'key':'ARBITRARY'}]
-    test_lookup(foo, pdata_key, None)
+    info = []
+    test_lookup(foo, pdata_key, info)
 
     pykeys = ['ARBITRARY']
     info = []

--- a/bindings/python/tests/python/client.py
+++ b/bindings/python/tests/python/client.py
@@ -117,6 +117,7 @@ def main():
 
     # put value into keystore
     test_put(foo, PMIX_GLOBAL, "mykey", {'value':1, 'val_type':PMIX_INT32})
+    test_put(foo, PMIX_GLOBAL, "secondkey", {'value':2, 'val_type':PMIX_INT32})
 
     # commit it
     test_commit(foo)
@@ -128,6 +129,9 @@ def main():
 
     info = []
     test_get(foo, {'nspace':"testnspace", 'rank': 0}, "mykey", info)
+
+    # Get all keys for this proc
+    test_get(foo, {'nspace':"testnspace", 'rank': 0}, None, info)
 
     # test a fence that should return not_supported because
     # we pass a required attribute that doesn't exist

--- a/bindings/python/tests/python/server.py
+++ b/bindings/python/tests/python/server.py
@@ -25,7 +25,10 @@ def main():
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")
     rc = foo.initialized()
-    print("Initialized: ", rc)
+    if rc == True:
+        print("Initialized: True")
+    else:
+        print("Initialized: False")
     vers = foo.get_version()
     print("Version: ", vers)
 
@@ -46,16 +49,16 @@ def main():
              {'key':PMIX_JOB_SIZE, 'value':1, 'val_type':PMIX_UINT32}]
     print("REGISTERING NSPACE")
     rc = foo.register_nspace("testnspace", 1, kvals)
-    print("RegNspace ", rc)
+    print("RegNspace ", foo.error_string(rc))
 
     # register a client
     uid = os.getuid()
     gid = os.getgid()
     rc = foo.register_client({'nspace':"testnspace", 'rank':0}, uid, gid)
-    print("RegClient ", rc)
+    print("RegClient ", foo.error_string(rc))
     # setup the fork
     rc = foo.setup_fork({'nspace':"testnspace", 'rank':0}, env)
-    print("SetupFrk", rc)
+    print("SetupFrk", foo.error_string(rc))
 
     # setup the client argv
     args = ["./client.py"]

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -4,6 +4,33 @@ PMIx v6.x series
 This file contains all the NEWS updates for the PMIx v6.x
 series, in reverse chronological order.
 
+6.1.1 -- xx May 2026
+--------------------
+:: important:: This release contains the following important changes:
+
+                * restoration/repair of the OmniPath support component
+                * update of the Python bindings and fix to allow Python
+                  to retrieve all nspace-level info via PMIx_Get
+                * fix messaging problem in the PMIx communication logic
+                  that could cause a message from one process to be
+                  incorrectly delivered to a pending receive for another
+                  process
+
+Detailed changes since v6.1.0:
+ - PR #3855: Multiple commits
+    - Cleanup error paths in net_get_hostname
+    - Update Python bindings
+    - Update Python-related workflow to actually test bindings
+    - Add missing data types to value load/unload
+    - Don't pass zero-byte stdin to host
+    - test: add get() test without keys specified
+    - bindings: capture None as NULL key in get()
+    - Remove unnecessary hwloc version protection
+    - Restore pnet/opa component
+    - Add fn to print peer type
+    - Fix messaging problem in ptl recv
+
+
 6.1.0 -- 27 Feb 2025
 --------------------
 .. important:: This is the second release in the v6 family. The release

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -2110,6 +2110,11 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
             /* nothing we can do with this info - no point in reactivating it */
             return;
         }
+        if (0 == bo.size) {
+            // our stdin fd has closed - nothing to do, and
+            // we don't reactivate the event
+            return;
+        }
         PMIX_BYTE_OBJECT_CREATE(boptr, 1);
         if (0 < bo.size) {
             boptr->bytes = (char*)malloc(bo.size);

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -17,9 +17,7 @@
 #include "src/include/pmix_config.h"
 
 #include <hwloc.h>
-#if HWLOC_API_VERSION >= 0x20000
 #include <hwloc/shmem.h>
-#endif
 
 #include "pmix_common.h"
 #include "src/mca/bfrops/base/base.h"
@@ -196,15 +194,9 @@ pmix_status_t pmix_hwloc_pack_topology(pmix_buffer_t *buf, pmix_topology_t *src,
     }
 
     /* extract an xml-buffer representation of the tree */
-#if HWLOC_API_VERSION < 0x20000
-    if (0 != hwloc_topology_export_xmlbuffer(src->topology, &xmlbuffer, &len)) {
-        return PMIX_ERROR;
-    }
-#else
     if (0 != hwloc_topology_export_xmlbuffer(src->topology, &xmlbuffer, &len, 0)) {
         return PMIX_ERROR;
     }
-#endif
 
     /* add to buffer */
     PMIX_BFROPS_PACK_TYPE(rc, buf, &xmlbuffer, 1, PMIX_STRING, regtypes);
@@ -282,20 +274,11 @@ pmix_status_t pmix_hwloc_unpack_topology(pmix_buffer_t *buf, pmix_topology_t *de
      * explicitly set a flag so hwloc sets things up correctly
      */
     flags = HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM;
-#if HWLOC_API_VERSION < 0x00020000
-    flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
-    flags |= HWLOC_TOPOLOGY_FLAG_IO_DEVICES;
-#else
     if (0 != hwloc_topology_set_io_types_filter(t, HWLOC_TYPE_FILTER_KEEP_IMPORTANT)) {
         hwloc_topology_destroy(t);
         return PMIX_ERROR;
     }
-#    if HWLOC_API_VERSION < 0x00020100
-    flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
-#    else
     flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
-#    endif
-#endif
     if (0 != hwloc_topology_set_flags(t, flags)) {
         hwloc_topology_destroy(t);
         return PMIX_ERROR;
@@ -471,11 +454,6 @@ void pmix_ploc_base_release_topology(pmix_topology_t *topo, size_t n)
 
 pmix_status_t pmix_hwloc_get_topology_size(pmix_topology_t *ptr, size_t *sz)
 {
-#if HWLOC_API_VERSION < 0x20000
-    PMIX_HIDE_UNUSED_PARAMS(ptr);
-    *sz = 0;
-    return PMIX_ERR_NOT_SUPPORTED;
-#else
     int err;
 
     err = hwloc_shmem_topology_get_length(ptr->topology, sz, 0);
@@ -484,5 +462,4 @@ pmix_status_t pmix_hwloc_get_topology_size(pmix_topology_t *ptr, size_t *sz)
         return PMIX_ERROR;
     }
     return PMIX_SUCCESS;
-#endif
 }

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -1,0 +1,56 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = pnet_opa.h
+sources = \
+        pnet_opa_component.c \
+        pnet_opa.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pnet_opa_DSO
+lib =
+lib_sources =
+component = pmix_mca_pnet_opa.la
+component_sources = $(headers) $(sources)
+else
+lib = libpmix_mca_pnet_opa.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+pmix_mca_pnet_opa_la_SOURCES = $(component_sources)
+pmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+pmix_mca_pnet_opa_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libpmix_mca_pnet_opa_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -1,0 +1,27 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_opa_CONFIG([action-if-can-compile],
+#                          [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_opa_CONFIG], [
+    AC_CONFIG_FILES([src/mca/pnet/opa/Makefile])
+
+    AS_IF([test "yes" = "yes"],
+          [$1
+           pmix_pnet_opa=yes],
+          [$2
+           pmix_pnet_opa=no])
+
+    PMIX_SUMMARY_ADD([Transports], [OmniPath], [], [$pmix_pnet_opa])
+
+])dnl

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#    include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "pmix_common.h"
+
+#include "src/class/pmix_list.h"
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/pcompress/pcompress.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/pmix_alfg.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
+#include "src/util/pmix_environ.h"
+
+#include "pnet_opa.h"
+#include "src/mca/pnet/base/base.h"
+#include "src/mca/pnet/pnet.h"
+
+static pmix_status_t allocate(pmix_namespace_t *nptr,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist);
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr,
+                                         pmix_info_t info[], size_t ninfo);
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_list_t *inventory);
+static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t directives[], size_t ndirs);
+pmix_pnet_module_t pmix_opa_module = {
+    .name = "opa",
+    .allocate = allocate,
+    .setup_local_network = setup_local_network,
+    .collect_inventory = collect_inventory,
+    .deliver_inventory = deliver_inventory
+};
+
+/* some network transports require a little bit of information to
+ * "pre-condition" them - i.e., to setup their individual transport
+ * connections so they can generate their endpoint addresses. This
+ * function provides a means for doing so. The resulting info is placed
+ * into the app_context's env array so it will automatically be pushed
+ * into the environment of every MPI process when launched.
+ */
+
+static inline void transports_use_rand(uint64_t *unique_key)
+{
+    pmix_rng_buff_t rng;
+    pmix_srand(&rng, (unsigned int) time(NULL));
+    unique_key[0] = pmix_rand(&rng);
+    unique_key[1] = pmix_rand(&rng);
+}
+
+static char *transports_print(uint64_t *unique_key)
+{
+    unsigned int *int_ptr;
+    size_t i, j, string_key_len, written_len;
+    char *string_key = NULL, *format = NULL;
+
+    /* string is two 64 bit numbers printed in hex with a dash between
+     * and zero padding.
+     */
+    string_key_len = (sizeof(uint64_t) * 2) * 2 + strlen("-") + 1;
+    string_key = (char *) malloc(string_key_len);
+    if (NULL == string_key) {
+        return NULL;
+    }
+
+    string_key[0] = '\0';
+    written_len = 0;
+
+    /* get a format string based on the length of an unsigned int.  We
+     * want to have zero padding for sizeof(unsigned int) * 2
+     * characters -- when printing as a hex number, each byte is
+     * represented by 2 hex characters.  Format will contain something
+     * that looks like %08lx, where the number 8 might be a different
+     * number if the system has a different sized long (8 would be for
+     * sizeof(int) == 4)).
+     */
+    if (0 > asprintf(&format, "%%0%dx", (int) (sizeof(unsigned int)) * 2)) {
+        free(string_key);
+        return NULL;
+    }
+
+    /* print the first number */
+    int_ptr = (unsigned int *) &unique_key[0];
+    for (i = 0; i < sizeof(uint64_t) / sizeof(unsigned int); ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j = 0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        pmix_snprintf(string_key + written_len, string_key_len - written_len, format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+
+    /* print the middle dash */
+    pmix_snprintf(string_key + written_len, string_key_len - written_len, "-");
+    written_len = strlen(string_key);
+
+    /* print the second number */
+    int_ptr = (unsigned int *) &unique_key[1];
+    for (i = 0; i < sizeof(uint64_t) / sizeof(unsigned int); ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j = 0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        pmix_snprintf(string_key + written_len, string_key_len - written_len, format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+    free(format);
+
+    return string_key;
+}
+
+/* NOTE: if there is any binary data to be transferred, then
+ * this function MUST pack it for transport as the host will
+ * not know how to do so */
+static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist)
+{
+    uint64_t unique_key[2];
+    char *string_key;
+    int fd_rand;
+    size_t bytes_read, n, m, p;
+    pmix_buffer_t mydata; // Buffer used to store information to be transmitted (scratch storage)
+    pmix_kval_t *kv;
+    pmix_envar_t envar;
+    pmix_byte_object_t bo;
+    bool envars = false, seckeys = false;
+    pmix_status_t rc;
+    pmix_info_t *iptr;
+    pmix_list_t cache;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:opa:allocate for nspace %s", nptr->nspace);
+
+    if (NULL == info) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    PMIX_ENVAR_CONSTRUCT(&envar);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ENVARS)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ALL)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+            seckeys = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_NONENVARS)) {
+            seckeys = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NETWORK)) {
+            iptr = (pmix_info_t *) info[n].value.data.darray->array;
+            m = info[n].value.data.darray->size;
+            for (p = 0; p < m; p++) {
+                if (PMIX_CHECK_KEY(&iptr[p], PMIX_ALLOC_NETWORK_SEC_KEY)) {
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_ALLOC_NETWORK_ID)) {
+                    /* need to track the request by this ID */
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_ENVARS)) {
+                    envars = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_ALL)) {
+                    envars = PMIX_INFO_TRUE(&iptr[p]);
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_NONENVARS)) {
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                }
+            }
+        }
+    }
+    /* setup a buffer - we will pack the info into it for transmission to
+     * the backend compute node daemons */
+    PMIX_CONSTRUCT(&mydata, pmix_buffer_t);
+
+    if (seckeys) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet: opa providing seckeys");
+        /* put the number here - or else create an appropriate string. this just needs to
+         * eventually be a string variable
+         */
+        if (-1 == (fd_rand = open("/dev/urandom", O_RDONLY))) {
+            transports_use_rand(unique_key);
+        } else {
+            bytes_read = read(fd_rand, (char *) unique_key, 16);
+            if (bytes_read != 16) {
+                transports_use_rand(unique_key);
+            }
+            close(fd_rand);
+        }
+
+        if (NULL == (string_key = transports_print(unique_key))) {
+            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            PMIX_DESTRUCT(&mydata);
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+
+        PMIX_ENVAR_LOAD(&envar, "OMPI_MCA_orte_precondition_transports", string_key, ':');
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata, &envar, 1, PMIX_ENVAR);
+        free(string_key);
+        PMIX_ENVAR_DESTRUCT(&envar);
+    }
+
+    if (envars) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet: opa harvesting envars %s excluding %s",
+                            (NULL == pmix_mca_pnet_opa_component.incparms)
+                                ? "NONE"
+                                : pmix_mca_pnet_opa_component.incparms,
+                            (NULL == pmix_mca_pnet_opa_component.excparms)
+                                ? "NONE"
+                                : pmix_mca_pnet_opa_component.excparms);
+        /* harvest envars to pass along */
+        PMIX_CONSTRUCT(&cache, pmix_list_t);
+        if (NULL != pmix_mca_pnet_opa_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_opa_component.include,
+                                          pmix_mca_pnet_opa_component.exclude, &cache);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_DESTRUCT(&mydata);
+                return rc;
+            }
+            /* pack anything that was found */
+            PMIX_LIST_FOREACH (kv, &cache, pmix_kval_t) {
+                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata,
+                                 &kv->value->data.envar, 1, PMIX_ENVAR);
+            }
+            PMIX_LIST_DESTRUCT(&cache);
+        }
+    }
+
+    // unload the buffer
+    PMIX_UNLOAD_BUFFER(&mydata, bo.bytes, bo.size);
+    // if nothing was packed, then we have nothing to send
+    if (0 == bo.size) {
+        PMIX_DESTRUCT(&mydata);
+        return PMIX_SUCCESS;
+    }
+
+    /* load all our results into a buffer for xmission to the backend */
+    PMIX_KVAL_NEW(kv, PMIX_PNET_OPA_BLOB);
+    if (NULL == kv || NULL == kv->value) {
+        PMIX_DESTRUCT(&mydata);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_BYTE_OBJECT;
+    /* to help scalability, compress this blob */
+    if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
+                               (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
+        kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+    } else {
+        kv->value->data.bo.bytes = bo.bytes;
+        kv->value->data.bo.size = bo.size;
+    }
+    PMIX_DESTRUCT(&mydata);
+    pmix_list_append(ilist, &kv->super);
+    return PMIX_SUCCESS;
+}
+
+/* PMIx_server_setup_local_support calls the "setup_local_network" function.
+ * The Standard requires that this come _after_ the host calls the
+ * PMIx_server_register_nspace function to ensure that any required information
+ * is available to the components. Thus, we have the PMIX_NODE_MAP and
+ * PMIX_PROC_MAP available to us and can use them here.
+ *
+ * When the host calls "setup_local_support", it passes down an array
+ * containing the information the "lead" server (e.g., "mpirun") collected
+ * from PMIx_server_setup_application. In this case, we search for a blob
+ * that our "allocate" function may have included in that info.
+ */
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
+                                         pmix_info_t info[], size_t ninfo)
+{
+    size_t n;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_status_t rc = PMIX_SUCCESS;
+    uint8_t *data;
+    size_t size;
+    bool release = false;
+    pmix_envar_list_item_t *ev;
+    pmix_proc_t proc;
+    pmix_kval_t *kv;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:opa:setup_local with %lu info", (unsigned long) ninfo);
+
+    /* prep the unpack buffer */
+    PMIX_CONSTRUCT(&bkt, pmix_buffer_t);
+
+    for (n = 0; n < ninfo; n++) {
+        /* look for my key */
+        if (PMIX_CHECK_KEY(&info[n], PMIX_PNET_OPA_BLOB)) {
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:opa:setup_local found my blob");
+
+            /* if this is a compressed byte object, decompress it */
+            if (PMIX_COMPRESSED_BYTE_OBJECT == info[n].value.type) {
+                pmix_compress.decompress(&data, &size, (uint8_t *) info[n].value.data.bo.bytes,
+                                         info[n].value.data.bo.size);
+                release = true;
+            } else {
+                data = (uint8_t *) info[n].value.data.bo.bytes;
+                size = info[n].value.data.bo.size;
+            }
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
+
+            /* all we packed was envars, so just cycle thru */
+            ev = PMIX_NEW(pmix_envar_list_item_t);
+            cnt = 1;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            while (PMIX_SUCCESS == rc) {
+                pmix_list_append(&ns->envars, &ev->super);
+                /* if this is the transport key, save it */
+                if (0 == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports", PMIX_MAX_KEYLEN)) {
+                    /* add it to the job-level info */
+                    PMIX_LOAD_PROCID(&proc, ns->ns->nspace, PMIX_RANK_WILDCARD);
+                    PMIX_KVAL_NEW(kv, PMIX_CREDENTIAL);
+                    kv->value->type = PMIX_STRING;
+                    kv->value->data.string = strdup(ev->envar.value);
+                    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, PMIX_INTERNAL, kv);
+                    PMIX_RELEASE(kv); // maintain refcount
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                    }
+                }
+                /* get the next envar */
+                ev = PMIX_NEW(pmix_envar_list_item_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            }
+            if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+                rc = PMIX_SUCCESS;
+            }
+            // we will have created one more envar than we want
+            PMIX_RELEASE(ev);
+
+            /* we are done */
+            break;
+        }
+    }
+
+    if (release) {
+        free(data);
+    }
+
+    return rc;
+}
+
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_list_t *inventory)
+{
+    /* search the topology for OPA NICs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
+
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t directives[], size_t ndirs)
+{
+    /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
+
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/opa/pnet_opa.h
+++ b/src/mca/pnet/opa/pnet_opa.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PNET_OPA_H
+#define PMIX_PNET_OPA_H
+
+#include "src/include/pmix_config.h"
+
+#include "src/mca/pnet/pnet.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pnet_base_component_t super;
+    char *incparms;
+    char *excparms;
+    char **include;
+    char **exclude;
+} pmix_pnet_opa_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pnet_opa_component_t pmix_mca_pnet_opa_component;
+extern pmix_pnet_module_t pmix_opa_module;
+
+/* define a key for any blob we need to send in a launch msg */
+#define PMIX_PNET_OPA_BLOB "pmix.pnet.opa.blob"
+
+/* define an inventory key */
+#define PMIX_PNET_OPA_INVENTORY_KEY "pmix.pnet.opa.inventory"
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -1,0 +1,115 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "pmix_common.h"
+
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/mca/pnet/base/base.h"
+#include "src/util/pmix_argv.h"
+
+#include "pnet_opa.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_status_t component_register(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pnet_opa_component_t pmix_mca_pnet_opa_component = {
+    .super = {
+        PMIX_PNET_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "opa",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_register_component_params = component_register,
+        .pmix_mca_query_component = component_query,
+    },
+    .include = NULL,
+    .exclude = NULL
+};
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pnet, opa)
+
+static pmix_status_t component_register(void)
+{
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_opa_component.super;
+
+    pmix_mca_pnet_opa_component.incparms = "HFI_*,PSM2_*";
+    (void) pmix_mca_base_component_var_register(
+        component, "include_envars",
+        "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING,
+        &pmix_mca_pnet_opa_component.incparms);
+    if (NULL != pmix_mca_pnet_opa_component.incparms) {
+        pmix_mca_pnet_opa_component.include = PMIx_Argv_split(pmix_mca_pnet_opa_component.incparms, ',');
+    }
+
+    pmix_mca_pnet_opa_component.excparms = NULL;
+    (void) pmix_mca_base_component_var_register(
+        component, "exclude_envars",
+        "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING,
+        &pmix_mca_pnet_opa_component.excparms);
+    if (NULL != pmix_mca_pnet_opa_component.excparms) {
+        pmix_mca_pnet_opa_component.exclude = PMIx_Argv_split(pmix_mca_pnet_opa_component.excparms, ',');
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_open(void)
+{
+    pmix_status_t rc;
+
+    rc = pmix_hwloc_check_vendor(&pmix_globals.topology, 0x8086, 0x208);
+    return rc;
+}
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 10;
+    *module = (pmix_mca_base_module_t *) &pmix_opa_module;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -177,6 +177,8 @@ PMIX_EXPORT char **pmix_ptl_base_split_and_resolve(const char *orig_str,
                                                    const char *name);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_peer(pmix_peer_t *peer, char **evar);
 PMIX_EXPORT char *pmix_ptl_base_get_cmd_line(void);
+
+PMIX_EXPORT char *pmix_ptl_base_peer_type(pmix_peer_t *peer);
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -134,9 +134,6 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_connection(char *uri,
                                                          struct sockaddr_storage *connection,
                                                          size_t *len);
 
-PMIX_EXPORT void pmix_ptl_base_post_recv(int fd, short args, void *cbdata);
-PMIX_EXPORT void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
-
 PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
 

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -121,3 +121,12 @@ interfaces were found after applying any include or exclude directives:
 
 Please adjust your include or exclude to allow selection of an
 available interface.
+#
+[unexpected-message]
+The PMIx messaging system has received an unexpected message:
+
+  Peer: %s
+  Tag:  %u
+
+The message cannot be processed and will be ignored. Please
+report this error to the PMIx developers.

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -643,6 +643,22 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         kv = PMIX_NEW(pmix_info_caddy_t);
         PMIX_INFO_LOAD(&launcher, PMIX_LAUNCHER, NULL, PMIX_BOOL);
+        kv->info = &launcher;
+        pmix_list_append(&ilist, &kv->super);
+    }
+
+    /* if I am a system controller, tell them so */
+    if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
+        kv = PMIX_NEW(pmix_info_caddy_t);
+        PMIX_INFO_LOAD(&launcher, PMIX_SERVER_SYS_CONTROLLER, NULL, PMIX_BOOL);
+        kv->info = &launcher;
+        pmix_list_append(&ilist, &kv->super);
+    }
+
+    /* if I am a scheduler, tell them so */
+    if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
+        kv = PMIX_NEW(pmix_info_caddy_t);
+        PMIX_INFO_LOAD(&launcher, PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
         kv->info = &launcher;
         pmix_list_append(&ilist, &kv->super);
     }

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -1405,3 +1405,37 @@ char **pmix_ptl_base_split_and_resolve(const char *orig_str,
     PMIx_Argv_free(argv);
     return interfaces;
 }
+
+char *pmix_ptl_base_peer_type(pmix_peer_t *peer)
+{
+    char **types = NULL;
+    char *ans;
+
+    if (PMIX_PEER_IS_CLIENT(peer)) {
+        PMIx_Argv_append_nosize(&types, "CLIENT");
+    }
+    if (PMIX_PEER_IS_SINGLETON(peer)) {
+        PMIx_Argv_append_nosize(&types, "SINGLETON");
+    }
+    if (PMIX_PEER_IS_SERVER(peer)) {
+        PMIx_Argv_append_nosize(&types, "SERVER");
+    }
+    if (PMIX_PEER_IS_TOOL(peer)) {
+        PMIx_Argv_append_nosize(&types, "TOOL");
+    }
+    if (PMIX_PEER_IS_LAUNCHER(peer)) {
+        PMIx_Argv_append_nosize(&types, "LAUNCHER");
+    }
+    if (PMIX_PEER_IS_GATEWAY(peer)) {
+        PMIx_Argv_append_nosize(&types, "GATEWAY");
+    }
+    if (PMIX_PEER_IS_SCHEDULER(peer)) {
+        PMIx_Argv_append_nosize(&types, "SCHEDULER");
+    }
+    if (PMIX_PEER_IS_SYS_CTRLR(peer)) {
+        PMIx_Argv_append_nosize(&types, "SYSCTRLR");
+    }
+    ans = PMIx_Argv_join(types, ',');
+    PMIx_Argv_free(types);
+    return ans;
+}

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -325,7 +325,6 @@ static pmix_status_t pmix_ptl_close(void)
     }
     /* the component will cleanup when closed */
     PMIX_LIST_DESTRUCT(&pmix_ptl_base.posted_recvs);
-    PMIX_LIST_DESTRUCT(&pmix_ptl_base.unexpected_msgs);
     PMIX_DESTRUCT(&pmix_ptl_base.listener);
 
     if (NULL != pmix_ptl_base.scheduler_filename) {
@@ -462,7 +461,6 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     /* initialize globals */
     pmix_ptl_base.initialized = true;
     PMIX_CONSTRUCT(&pmix_ptl_base.posted_recvs, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_ptl_base.unexpected_msgs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_ptl_base.listener, pmix_listener_t);
     pmix_ptl_base.connection = (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
     if (NULL == pmix_ptl_base.connection) {
@@ -557,6 +555,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_recv_t,
 
 static void prcon(pmix_ptl_posted_recv_t *p)
 {
+    p->peer = NULL;
     p->tag = UINT32_MAX;
     p->cbfunc = NULL;
     p->cbdata = NULL;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -712,7 +712,8 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(ms);
 
-    if (NULL == ms->peer || ms->peer->sd < 0 || NULL == ms->peer->info || NULL == ms->peer->nptr) {
+    if (NULL == ms->peer || ms->peer->sd < 0 ||
+        NULL == ms->peer->info || NULL == ms->peer->nptr) {
         /* this peer has lost connection */
         if (NULL != ms->bfr) {
             PMIX_RELEASE(ms->bfr);
@@ -737,11 +738,13 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     if (NULL != ms->cbfunc) {
         /* if a callback msg is expected, setup a recv for it */
         req = PMIX_NEW(pmix_ptl_posted_recv_t);
+        req->peer = ms->peer;
         req->tag = tag;
         req->cbfunc = ms->cbfunc;
         req->cbdata = ms->cbdata;
 
-        pmix_output_verbose(5, pmix_ptl_base_framework.framework_output, "posting recv on tag %d",
+        pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
+                            "posting recv on tag %d",
                             req->tag);
         /* add it to the list of recvs - we cannot have unexpected messages
          * in this subsystem as the server never sends us something that
@@ -810,15 +813,21 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
     PMIX_ACQUIRE_OBJECT(msg);
 
     pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                        "%s:%d message received %d bytes for tag %u on socket %d",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank, (int) msg->hdr.nbytes,
-                        msg->hdr.tag, msg->sd);
+                        "%s message received from %s with %d bytes for tag %u on socket %d",
+                        PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_PEER_PRINT(msg->peer),
+                        (int) msg->hdr.nbytes, msg->hdr.tag, msg->sd);
 
     /* see if we have a waiting recv for this message */
     PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
         pmix_output_verbose(5, pmix_ptl_base_framework.framework_output,
-                            "checking msg on tag %u for tag %u", msg->hdr.tag, rcv->tag);
+                            "checking msg from %s on tag %u for peer %s tag %u",
+                            (NULL == msg->peer) ? "NULL" : PMIX_PEER_PRINT(msg->peer), msg->hdr.tag,
+                            (NULL == rcv->peer) ? "NULL" : PMIX_PEER_PRINT(rcv->peer), rcv->tag);
 
+        // if the msg and rcv peers don't match, then skip this rcv
+        if (NULL != rcv->peer && msg->peer != rcv->peer && UINT_MAX != rcv->tag) {
+            continue;
+        }
         if (msg->hdr.tag == rcv->tag || UINT_MAX == rcv->tag) {
             if (NULL != rcv->cbfunc) {
                 /* construct and load the buffer */
@@ -851,20 +860,9 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
         }
     }
 
-    /* if the tag in this message is above the dynamic marker, then
-     * that is an error */
-    if (PMIX_PTL_TAG_DYNAMIC <= msg->hdr.tag) {
-        pmix_output(0, "UNEXPECTED MESSAGE tag = %d from source %s:%d", msg->hdr.tag,
-                    msg->peer->info->pname.nspace, msg->peer->info->pname.rank);
-        PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
-        PMIX_RELEASE(msg);
-        return;
-    }
-
-    /* it is possible that someone may post a recv for this message
-     * at some point, so we have to hold onto it */
-    pmix_list_append(&pmix_ptl_base.unexpected_msgs, &msg->super);
-    /* ensure we post the modified object before another thread
-     * picks it back up */
-    PMIX_POST_OBJECT(msg);
+    /* we should never see an unexpected msg */
+    pmix_show_help("help-ptl-base.txt", "unexpected-message", true,
+                   PMIX_PEER_PRINT(msg->peer), msg->hdr.tag);
+    PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
+    PMIX_RELEASE(msg);
 }

--- a/src/mca/ptl/base/ptl_base_stubs.c
+++ b/src/mca/ptl/base/ptl_base_stubs.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,59 +106,4 @@ pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc)
      * we didn't previously request */
     pmix_list_prepend(&pmix_ptl_base.posted_recvs, &req->super);
     return PMIX_SUCCESS;
-}
-
-void pmix_ptl_base_post_recv(int fd, short args, void *cbdata)
-{
-    (void) fd;
-    (void) args;
-    pmix_ptl_posted_recv_t *req = (pmix_ptl_posted_recv_t *) cbdata;
-    pmix_ptl_recv_t *msg, *nmsg;
-    pmix_buffer_t buf;
-
-    pmix_output_verbose(5, pmix_ptl_base_framework.framework_output, "posting recv on tag %d",
-                        req->tag);
-
-    /* add it to the list of recvs */
-    pmix_list_append(&pmix_ptl_base.posted_recvs, &req->super);
-
-    /* now check the unexpected msg queue to see if we already
-     * recvd something for it */
-    PMIX_LIST_FOREACH_SAFE (msg, nmsg, &pmix_ptl_base.unexpected_msgs, pmix_ptl_recv_t) {
-        if (msg->hdr.tag == req->tag || UINT_MAX == req->tag) {
-            if (NULL != req->cbfunc) {
-                /* construct and load the buffer */
-                PMIX_CONSTRUCT(&buf, pmix_buffer_t);
-                if (NULL != msg->data) {
-                    buf.base_ptr = (char *) msg->data;
-                    buf.bytes_allocated = buf.bytes_used = msg->hdr.nbytes;
-                    buf.unpack_ptr = buf.base_ptr;
-                    buf.pack_ptr = ((char *) buf.base_ptr) + buf.bytes_used;
-                }
-                msg->data = NULL; // protect the data region
-                req->cbfunc(msg->peer, &msg->hdr, &buf, req->cbdata);
-                PMIX_DESTRUCT(&buf); // free's the msg data
-            }
-            pmix_list_remove_item(&pmix_ptl_base.unexpected_msgs, &msg->super);
-            PMIX_RELEASE(msg);
-        }
-    }
-}
-
-void pmix_ptl_base_cancel_recv(int fd, short args, void *cbdata)
-{
-    (void) fd;
-    (void) args;
-    pmix_ptl_posted_recv_t *req = (pmix_ptl_posted_recv_t *) cbdata;
-    pmix_ptl_posted_recv_t *rcv;
-
-    PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
-        if (rcv->tag == req->tag) {
-            pmix_list_remove_item(&pmix_ptl_base.posted_recvs, &rcv->super);
-            PMIX_RELEASE(rcv);
-            PMIX_RELEASE(req);
-            return;
-        }
-    }
-    PMIX_RELEASE(req);
 }

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,42 +160,10 @@ typedef struct pmix_ptl_module_t pmix_ptl_module_t;
         }                                            \
     } while (0)
 
-#define PMIX_PTL_RECV(r, c, t)                                               \
-    do {                                                                     \
-        pmix_ptl_posted_recv_t *req;                                         \
-        req = PMIX_NEW(pmix_ptl_posted_recv_t);                              \
-        if (NULL == req) {                                                   \
-            (r) = PMIX_ERR_NOMEM;                                            \
-        } else {                                                             \
-            req->tag = (t);                                                  \
-            req->cbfunc = (c);                                               \
-            pmix_event_assign(&(req->ev), pmix_globals.evbase, -1, EV_WRITE, \
-                              pmix_ptl_base_post_recv, req);                 \
-            pmix_event_active(&(req->ev), EV_WRITE, 1);                      \
-            (r) = PMIX_SUCCESS;                                              \
-        }                                                                    \
-    } while (0)
-
-#define PMIX_PTL_CANCEL(r, t)                                                \
-    do {                                                                     \
-        pmix_ptl_posted_recv_t *req;                                         \
-        req = PMIX_NEW(pmix_ptl_posted_recv_t);                              \
-        if (NULL == req) {                                                   \
-            (r) = PMIX_ERR_NOMEM;                                            \
-        } else {                                                             \
-            req->tag = (t);                                                  \
-            pmix_event_assign(&(req->ev), pmix_globals.evbase, -1, EV_WRITE, \
-                              pmix_ptl_base_cancel_recv, req);               \
-            pmix_event_active(&(req->ev), EV_WRITE, 1);                      \
-            (r) = PMIX_SUCCESS;                                              \
-        }                                                                    \
-    } while (0)
-
 /* expose functions used by the macros */
 PMIX_EXPORT extern void pmix_ptl_base_send(int sd, short args, void *cbdata);
 PMIX_EXPORT extern void pmix_ptl_base_send_recv(int sd, short args, void *cbdata);
 PMIX_EXPORT extern void pmix_ptl_base_register_recv(int sd, short args, void *cbdata);
-PMIX_EXPORT extern void pmix_ptl_base_cancel_recv(int sd, short args, void *cbdata);
 
 /****    COMPONENT STRUCTURE DEFINITION    ****/
 

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -264,6 +264,7 @@ PMIX_CLASS_DECLARATION(pmix_ptl_recv_t);
 typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
+    struct pmix_peer_t *peer;
     uint32_t tag;
     pmix_ptl_cbfunc_t cbfunc;
     void *cbdata;

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,6 +66,8 @@
 #include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
+
+char *pmix_hostname_unknown = "UNKNOWN";
 
 /* this function doesn't depend on sockaddr_h */
 bool pmix_net_isaddr(const char *name)
@@ -341,8 +343,8 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     char *p;
 
     if (NULL == name) {
-        pmix_output(0, "pmix_sockaddr2str: malloc() failed\n");
-        return NULL;
+        pmix_output(0, "pmix_net_get_hostname: malloc() failed\n");
+        return pmix_hostname_unknown;
     }
     memset(name, 0, sizeof(*name));
 
@@ -354,11 +356,9 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
 #    if defined(__NetBSD__)
         /* hotfix for netbsd: on my netbsd machine, getnameinfo
            returns an unknown error code. */
-        if (NULL
-            == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
+        if (NULL == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
             pmix_output(0, "pmix_sockaddr2str failed with error code %d", errno);
-            free(name);
-            return NULL;
+            return pmix_hostname_unknown;
         }
         return name;
 #    else
@@ -366,8 +366,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
 #    endif
         break;
     default:
-        free(name);
-        return NULL;
+        return pmix_hostname_unknown;
     }
 
     error = getnameinfo(addr, addrlen, name, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
@@ -375,8 +374,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     if (error) {
         int err = errno;
         pmix_output(0, "pmix_sockaddr2str failed:%s (return code %i)\n", gai_strerror(err), error);
-        free(name);
-        return NULL;
+        return pmix_hostname_unknown;
     }
     /* strip any trailing % data as it isn't pertinent */
     if (NULL != (p = strrchr(name, '%'))) {

--- a/test/simple/simpdist.c
+++ b/test/simple/simpdist.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,7 +106,6 @@ static hwloc_obj_type_t convert_type(const char *name, char **strname)
             *strname = "PACKAGE";
         }
         return HWLOC_OBJ_PACKAGE;
-#if HWLOC_API_VERSION >= 0x20000
     } else if (0 == strncasecmp(name, "L3", 2)) {
         if (NULL != strname) {
             *strname = "L3CACHE";
@@ -122,15 +121,6 @@ static hwloc_obj_type_t convert_type(const char *name, char **strname)
             *strname = "L1CACHE";
         }
         return HWLOC_OBJ_L1CACHE;
-#else
-    } else if (0 == strncasecmp(name, "L3", 2) ||
-               0 == strncasecmp(name, "L2", 2) ||
-               0 == strncasecmp(name, "L1", 2)) {
-        if (NULL != strname) {
-            *strname = "CACHE";
-        }
-        return HWLOC_OBJ_CACHE;
-#endif
     } else {
         fprintf(stderr, "UNRECOGNIZED HWLOC TYPE: %s\n", name);
         return HWLOC_OBJ_TYPE_MAX;

--- a/test/util/numa.c
+++ b/test/util/numa.c
@@ -9,9 +9,7 @@
 int main(int argc, char **argv)
 {
     hwloc_topology_t topo;
-#if HWLOC_API_VERSION >= 0x20000
     int ret;
-#endif
     int num, weight, N;
     hwloc_obj_t obj;
     unsigned width, w;
@@ -35,14 +33,12 @@ int main(int argc, char **argv)
     /* since we are loading this from an external source, we have to
      * explicitly set a flag so hwloc sets things up correctly
      */
-#if HWLOC_API_VERSION >= 0x20000
     ret = hwloc_topology_set_io_types_filter(topo, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
     if (0 != ret) {
         fprintf(stderr, "IOTYPES FAILED\n");
         hwloc_topology_destroy(topo);
         return ret;
     }
-#endif
     if (0 != hwloc_topology_set_flags(topo, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)) {
         fprintf(stderr, "SETFLAGS FAILED\n");
         hwloc_topology_destroy(topo);


### PR DESCRIPTION
[Cleanup error paths in net_get_hostname](https://github.com/openpmix/openpmix/commit/7cd9ddb1da5893d77b31b9891b7c4614cf9eb750)

Cannot free the tsd buffer, and returning NULL can cause
the calling print function to fail. So create a default
static error response and use it instead.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/61bd925224ee512041dea591eacc0d675cfea22e)

[Update Python bindings](https://github.com/openpmix/openpmix/commit/154863412475a6808ddcf012ddaee9f99c5ec296)

Cover new server upcalls. Only define upcalls that the host
server actually supports. Fix a couple of minor bugs in the
test codes.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/afc860c627821e3c3704ad69f0b4b6cf07d82fad)

[Update Python-related workflow to actually test bindings](https://github.com/openpmix/openpmix/commit/d1bdf1d8636400db4bce975e2392e6c708a52164)

Not a comprehensive test by any means, but better than nothing

Thanks to @jjlakis for the contribution.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9cf88ad3f5a58fd4ffee72185365e80c00083c44)

[Add missing data types to value load/unload](https://github.com/openpmix/openpmix/commit/18510bd96f349b08c5dae1272481120073bb89d9)

Update Python bindings to support missing data types.
Still need to update the data array sections.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2a2be0efe5ba6805b3ebcdf29dde58fedb48fc8e)

[Don't pass zero-byte stdin to host](https://github.com/openpmix/openpmix/commit/d13e60f5fb81b1e1ea1f7e978ab8c12ff555f44a)

If we read zero bytes, then our stdin has closed - no
need to pass that to the host.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/e75b5cc1d52da665d9aeda004907948f4da59681)

[test: add get() test without keys specified](https://github.com/openpmix/openpmix/commit/c4c221b5b23ebdde94efbec389160c04cf4f32bc)

Signed-off-by: Jacek J. Lakis <mlody3k@gmail.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/236a08d489eb55abb79939376a910393c02824d9)

[bindings: capture None as NULL key in get()](https://github.com/openpmix/openpmix/commit/19b4f624947d78d82ec20c14d6b988fdf2e1af33)

Signed-off-by: Jacek J. Lakis <mlody3k@gmail.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/bac21db6a1f77a62366b8746649e8805ebcef920)

[Remove unnecessary hwloc version protection](https://github.com/openpmix/openpmix/commit/8cab6e9fbe2568f5db22189f985674f9d30bb01d)

We now require hwloc >= 2.x, so no need to check for
earlier versions

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/effd1438b32f7d862d5e895ac7e93e5b14ad2363)

[Restore pnet/opa component](https://github.com/openpmix/openpmix/commit/cf9d7812f264db56b0faa12743ee2203d30fcb37)

pnet/opa was removed because of a report that OPA-PSM2 was being
selected with non-OPA devices. Reportedly,
(vendor=0x8086,class=0x0208) had been recycled for a non-OPA100 device.

However this report seems to have been in error; the user did in-fact
have an OPA100 device in their system.

So restore pnet/opa by reverting commit https://github.com/openpmix/openpmix/commit/d52ebb7968e60525fd3c082dc632109f342a1f9f
("Eliminate stale pnet/opa component").

Signed-off-by: Brendan Cunningham <bcunningham@cornelisnetworks.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/16c45527aa3566c15ccdf6d82267ec41a21fa895)

[Add fn to print peer type](https://github.com/openpmix/openpmix/commit/3dd9aecacf42354e31c5b530dde5d2e54fe8b4fd)

Add a helper function to print the peer type. Include info
indicating the proc is a scheduler or sys controller to
the connection handshake.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7f57e40f739ac36a5d9df5dc2cf08918c08817c6)

[Fix messaging problem in ptl recv](https://github.com/openpmix/openpmix/commit/bff670797ac27d7e54838430fd4f1330a0e6a500)

Posted receives need to be separated out by expected
peer. As things stand, a proc could send a message to
a server and post a recv on the corresponding tag. If
another proc (say a tool) then sends a message on that
same tag (since all dynamic tags start at the same value),
the recv processor would incorrectly match the msg to the
existing receive.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/8e405607ca5686c27668584ccbd80ed6e19bad06)

[Update NEWS](https://github.com/openpmix/openpmix/pull/3855/commits/4f5003fb2288b56efbde69ec7e90ba82232f17a1)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick