### PR TITLE
Add a little overflow protection

### DIFF
--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +88,7 @@ int pmix_bitmap_init(pmix_bitmap_t *bm, int size)
         if (bm->max_size < bm->array_size)
             bm->max_size = bm->array_size;
     }
-    bm->bitmap = (uint64_t *) malloc(bm->array_size * sizeof(uint64_t));
+    bm->bitmap = (uint64_t *) calloc(bm->array_size, sizeof(uint64_t));
     if (NULL == bm->bitmap) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -544,7 +544,7 @@ static int pretty_print_vpids(pmix_job_t *job) {
     len_ckpt_r      = -3;
     len_ckpt_l      = -3;
 
-    nodename = (char **) malloc(job->num_procs * sizeof(char *));
+    nodename = (char **) calloc(job->num_procs, sizeof(char *));
     for(v=0; v < job->num_procs; v++) {
         char *rankstr;
         vpid = (pmix_proc_t*)job->procs->addr[v];

--- a/src/util/pmix_argv.c
+++ b/src/util/pmix_argv.c
@@ -15,7 +15,7 @@
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -113,7 +113,7 @@ char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
 
     /* Allocate the string. */
 
-    if (NULL == (str = (char *) malloc(str_len))) {
+    if (NULL == (str = (char *) calloc(str_len, sizeof(char)))) {
         return NULL;
     }
 

--- a/src/util/pmix_basename.c
+++ b/src/util/pmix_basename.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,7 +124,7 @@ char *pmix_dirname(const char *filename)
                 }
             }
             if (p != filename) {
-                char *ret = (char *) malloc(p - filename + 1);
+                char *ret = (char *) calloc((p - filename + 1), sizeof(char));
                 pmix_strncpy(ret, filename, p - filename);
                 ret[p - filename] = '\0';
                 return pmix_make_filename_os_friendly(ret);

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,7 +86,7 @@ static pmix_print_args_buffers_t *get_print_name_buffer(void)
     if (NULL == ptr) {
         ptr = (pmix_print_args_buffers_t *) malloc(sizeof(pmix_print_args_buffers_t));
         for (i = 0; i < PMIX_PRINT_NAME_ARG_NUM_BUFS; i++) {
-            ptr->buffers[i] = (char *) malloc((PMIX_PRINT_NAME_ARGS_MAX_SIZE + 1) * sizeof(char));
+            ptr->buffers[i] = (char *) calloc((PMIX_PRINT_NAME_ARGS_MAX_SIZE + 1), sizeof(char));
         }
         ptr->cntr = 0;
         ret = pmix_tsd_setspecific(print_args_tsd_key, (void *) ptr);

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -119,7 +119,7 @@ static char *get_hostname_buffer(void)
         return NULL;
 
     if (NULL == buffer) {
-        buffer = (void *) malloc((NI_MAXHOST + 1) * sizeof(char));
+        buffer = (void *) calloc((NI_MAXHOST + 1), sizeof(char));
         ret = pmix_tsd_setspecific(hostname_tsd_key, buffer);
     }
 
@@ -135,7 +135,7 @@ int pmix_net_init(void)
     args = PMIx_Argv_split(pmix_net_private_ipv4, ';');
     if (NULL != args) {
         count = PMIx_Argv_count(args);
-        private_ipv4 = (private_ipv4_t *) malloc((count + 1) * sizeof(private_ipv4_t));
+        private_ipv4 = (private_ipv4_t *) calloc((count + 1), sizeof(private_ipv4_t));
         if (NULL == private_ipv4) {
             pmix_output(0, "Unable to allocate memory for the private addresses array");
             PMIx_Argv_free(args);

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -98,7 +98,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
     /* Ensure to allocate enough space for tmp: the strlen of the
        incoming path + 1 (for \0) */
 
-    tmp = (char *) malloc(strlen(path) + 1);
+    tmp = (char *) calloc((strlen(path) + 1), sizeof(char));
     tmp[0] = '\0';
 
     /* Iterate through all the subdirectory names in the path,

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -747,7 +747,7 @@ static int make_string(char **out, char **no_newline_string, pmix_output_desc_t 
     if (NULL != ldi->ldi_suffix) {
         total_len += strlen(ldi->ldi_suffix);
     }
-    temp_str = (char *) malloc(total_len * 2);
+    temp_str = (char *) calloc((total_len * 2), sizeof(char));
     if (NULL == temp_str) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -149,7 +149,7 @@ char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
                 if (!delimit) {
                     fullpath = pmix_path_access(fname, env, mode);
                 } else {
-                    pfix = (char *) malloc(strlen(env) + strlen(delimit) + 1);
+                    pfix = (char *) calloc((strlen(env) + strlen(delimit) + 1), sizeof(char));
                     if (NULL == pfix) {
                         return NULL;
                     }

--- a/src/util/pmix_printf.c
+++ b/src/util/pmix_printf.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -240,7 +240,7 @@ int pmix_vasprintf(char **ptr, const char *fmt, va_list ap)
     length = guess_strlen(fmt, ap);
 
     /* allocate a buffer */
-    *ptr = (char *) malloc((size_t) length + 1);
+    *ptr = (char *) calloc(((size_t) length + 1), sizeof(char));
     if (NULL == *ptr) {
         errno = ENOMEM;
         va_end(ap2);

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -401,7 +401,7 @@ static pmix_status_t array2string(char **outstring,
 
     /* Malloc it out */
 
-    (*outstring) = (char *) malloc(len + 1);
+    (*outstring) = (char *) calloc((len + 1), sizeof(char));
     if (NULL == *outstring) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,11 +90,10 @@ pmix_timing_event_t *pmix_timing_event_alloc(pmix_timing_t *t)
         // notch timings overhead
         double alloc_begin = t->get_ts();
 
-        t->buffer = malloc(sizeof(pmix_timing_event_t) * t->buffer_size);
+        t->buffer = calloc(t->buffer_size, sizeof(pmix_timing_event_t));
         if (t->buffer == NULL) {
             return NULL;
         }
-        memset(t->buffer, 0, sizeof(pmix_timing_event_t) * t->buffer_size);
 
         double alloc_end = t->get_ts();
 
@@ -259,9 +258,8 @@ static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__des
         return 0;
     }
 
-    *__descr = malloc(sizeof(struct interval_descr) * t->next_id_cntr);
+    *__descr = calloc(t->next_id_cntr, sizeof(struct interval_descr));
     descr = *__descr;
-    memset(descr, 0, sizeof(struct interval_descr) * t->next_id_cntr);
 
     PMIX_LIST_FOREACH_SAFE (ev, next, t->events, pmix_timing_event_t) {
 
@@ -343,12 +341,11 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
 
     _prepare_descriptions(t, &descr);
 
-    buf = malloc(PMIX_TIMING_OUTBUF_SIZE + 1);
+    buf = calloc((PMIX_TIMING_OUTBUF_SIZE + 1), sizeof(char));
     if (buf == NULL) {
         rc = PMIX_ERR_OUT_OF_RESOURCE;
         goto err_exit;
     }
-    buf[0] = '\0';
 
     double overhead = 0;
     PMIX_LIST_FOREACH (ev, t->events, pmix_timing_event_t) {
@@ -535,12 +532,11 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
         assert(0);
     }
 
-    buf = malloc(PMIX_TIMING_OUTBUF_SIZE + 1);
+    buf = calloc((PMIX_TIMING_OUTBUF_SIZE + 1), sizeof(char));
     if (buf == NULL) {
         rc = PMIX_ERR_OUT_OF_RESOURCE;
         goto err_exit;
     }
-    buf[0] = '\0';
     buf_size = PMIX_TIMING_OUTBUF_SIZE + 1;
     buf_used = 0;
     for (i = 0; i < t->next_id_cntr; i++) {


### PR DESCRIPTION
calloc includes a check for the case where the
number of elements times the size of each element would result in an overflow. Unlikely to happen in normal usage, costs a tiny amount of time - but we don't
use this class in time-sensitive situations.