### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 
 major=5
 minor=0
-release=10
+release=11
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -24,7 +24,7 @@ release=10
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=
+greek=rc1
 
 # PMIx required dependency versions.
 # List in x.y.z format.
@@ -118,5 +118,5 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libpmix_so_version=15:10:13
+libpmix_so_version=15:11:13
 

--- a/config/pmix_check_compiler_version.m4
+++ b/config/pmix_check_compiler_version.m4
@@ -5,7 +5,7 @@ dnl Copyright (c) 2021 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -34,7 +34,7 @@ AC_DEFUN([PMIX_CHECK_COMPILER], [
     AC_CACHE_CHECK([for compiler $lower], [pmix_cv_compiler_$1],
     [
             CPPFLAGS_orig=$CPPFLAGS
-            CPPFLAGS="-I${PMIX_TOP_SRCDIR}/pmix/include $CPPFLAGS"
+            CPPFLAGS="-I${PMIX_TOP_SRCDIR} $CPPFLAGS"
             AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>

--- a/docs/man/man1/pmixcc.1.rst
+++ b/docs/man/man1/pmixcc.1.rst
@@ -1,132 +1,160 @@
 .. _man1-pmixcc:
 
-pmixcc
-=========
+PMIx Wrapper Compiler
+=====================
 
 .. include_body
 
-pmixcc |mdash| wrapper compiler for PMIx-based applications or tools
+pmixcc |mdash| PMIx wrapper compiler
 
-SYNOPSIS
---------
+SYNTAX
+------
 
-``pmixcc [options] <file>``
-
-
-DESCRIPTION
------------
-
-``pmixcc`` is a wrapper compiler that can be used to build PMIx-based
-applications or tools.
+``pmixcc [--showme | --showme:compile | --showme:link] ...``
 
 
 OPTIONS
 -------
 
-``pmixcc`` accepts the following options:
+The options include:
 
-* ``-h`` | ``--help``: Show help message
+* ``--showme``: This option comes in several different variants (see
+  below). None of the variants invokes the underlying compiler; they
+  all provide information on how the underlying compiler would have
+  been invoked had ``--showme`` not been used. The basic ``--showme``
+  option outputs the command line that would be executed to compile
+  the program.
 
-* ``--help={common|optimizers|params|target|warnings|[^]{joined|separate|undocumented}}[,...].``: Display specific types of command line options
+  .. note:: If a non-filename argument is passed on the command line,
+            the ``--showme`` option will *not* display any additional
+            flags. For example, both ``"pmixcc --showme`` and
+            ``pmixcc --showme my_source.c`` will show all the
+            wrapper-supplied flags. But ``pmixcc
+            --showme -v`` will only show the underlying compiler name
+            and ``-v``.
 
-* ``-v`` | ``--verbose``: Enable debug output.
+* ``--showme:compile``: Output the compiler flags that would have been
+  supplied to the underlying compiler.
 
-* ``-V`` | ``--version``: Print version and exit.
+* ``--showme:link``: Output the linker flags that would have been
+  supplied to the underlying compiler.
 
-* ``-dumpspecs``: Display all of the built in spec strings.
+* ``--showme:command``: Outputs the underlying compiler
+  command (which may be one or more tokens).
 
-* ``-dumpversion``: Display the version of the compiler.
+* ``--showme:incdirs``: Outputs a space-delimited (but otherwise
+  undecorated) list of directories that the wrapper compiler would
+  have provided to the underlying compiler to indicate
+  where relevant header files are located.
 
-* ``-dumpmachine``: Display the compiler's target processor.
+* ``--showme:libdirs``: Outputs a space-delimited (but otherwise
+  undecorated) list of directories that the wrapper compiler would
+  have provided to the underlying linker to indicate where relevant
+  libraries are located.
 
-* ``-foffload=<targets>``: Specify offloading targets.
+* ``--showme:libs`` Outputs a space-delimited (but otherwise
+  undecorated) list of library names that the wrapper compiler would
+  have used to link an application. For example: ``pmix util``.
 
-* ``-print-search-dirs``: Display the directories in the compiler's search path.
+* ``--showme:version``: Outputs the version number of PMIx.
 
-* ``-print-libgcc-file-name``: Display the name of the compiler's companion library.
+* ``--showme:help``: Output a brief usage help message.
 
-* ``-print-file-name=<lib>``: Display the full path to library <lib>.
-
-* ``-print-prog-name=<prog>``: Display the full path to compiler component <prog>.
-
-* ``-print-multiarch``: Display the target's normalized GNU triplet, used as a component in the library path.
-
-* ``-print-multi-directory``: Display the root directory for versions of libgcc.
-
-* ``-print-multi-lib``: Display the mapping between command line options and multiple library search directories.
-
-* ``-print-multi-os-directory``: Display the relative path to OS libraries.
-
-* ``-print-sysroot``: Display the target libraries directory.
-
-* ``-print-sysroot-headers-suffix``: Display the sysroot suffix used to find headers.
-
-* ``-Wa,<options>``: Pass comma-separated <options> on to the assembler.
-
-* ``-Wp,<options>``: Pass comma-separated <options> on to the preprocessor.
-* ``-Wl,<options>``: Pass comma-separated <options> on to the linker.
-
-* ``-Xassembler <arg>``: Pass <arg> on to the assembler.
-
-* ``-Xpreprocessor <arg>``: Pass <arg> on to the preprocessor.
-
-* ``-Xlinker <arg>``: Pass <arg> on to the linker.
-
-* ``-save-temps``: Do not delete intermediate files.
-
-* ``-save-temps=<arg>``: Do not delete intermediate files.
-
-* ``-no-canonical-prefixes``: Do not canonicalize paths when building relative prefixes to other gcc components.
-
-* ``-pipe``: Use pipes rather than intermediate files.
-
-* ``-time``: Time the execution of each subprocess.
-
-* ``-specs=<file>``: Override built-in specs with the contents of <file>.
-
-* ``-std=<standard>``: Assume that the input sources are for <standard>.
-
-* ``--sysroot=<directory>``: Use <directory> as the root directory for headers and libraries.
-
-* ``-B <directory>``: Add <directory> to the compiler's search paths.
-
-* ``-v``: Display the programs invoked by the compiler.
-
-* ``-###``: Like -v but options quoted and commands not executed.
-
-* ``-E``: Preprocess only; do not compile, assemble or link.
-
-* ``-S``: Compile only; do not assemble or link.
-
-* ``-c``: Compile and assemble, but do not link.
-
-* ``-o <file>``: Place the output into <file>.
-
-* ``-pie``: Create a dynamically linked position independent executable.
-
-* ``-shared``: Create a shared library.
-
-* ``-x <language>``: Specify the language of the following input files.
-  Permissible languages include: c c++ assembler none
-  'none' means revert to the default behavior of
-  guessing the language based on the file's extension.
+See the man page for your underlying compiler for other options that
+can be passed through pmixcc.
 
 
-Options starting with ``-g``, ``-f``, ``-m``, ``-O``, ``-W``, or ``--param`` are automatically
-passed on to the various sub-processes invoked by the compiler.  In order to pass
-other options on to these processes the ``-W<letter>`` options must be used.
-
-
-EXIT STATUS
+DESCRIPTION
 -----------
 
-Returns 0 if build is successful, a non-zero error code if otherwise.
+Conceptually, the role of these commands is quite simple:
+transparently add relevant compiler and linker flags to the user's
+command line that are necessary to compile / link PMIx-based programs,
+and then invoke the underlying compiler to actually perform the
+command.
+
+As such, these commands are frequently referred to as "wrapper"
+compilers because they do not actually compile or link applications
+themselves; they only add in command line flags and invoke the
+back-end compiler.
 
 
-EXAMPLES
+Overview
 --------
 
-Examples of using this command.
+``pmixcc`` is a convenience wrapper for the underlying C compiler.
+Translation of a PMIx-based program requires the linkage of the
+PMIx-specific libraries which may not reside in one of the standard
+search directories of ``ld(1)``. It also often requires the inclusion
+of header files what may also not be found in a standard location.
 
-.. seealso::
-   :ref:`openpmix(5) <man5-openpmix>`
+``pmixcc`` passes its arguments to the underlying C compiler along with
+the ``-I``, ``-L`` and ``-l`` options required by PMIx-based programs.
+
+The PMIx Team *strongly* encourages using the wrapper compiler
+instead of attempting to link to the PMIx library manually. This
+allows the specific implementation of PMIx to change without
+forcing changes to linker directives in users' Makefiles. Indeed, the
+specific set of flags and libraries used by the wrapper compiler
+depends on how PMIx was configured and built; the values can change
+between different installations of the same version of PMIx.
+
+Indeed, since the wrappers are simply thin shells on top of an
+underlying compiler, there are very, very few compelling reasons *not*
+to use PMIx's wrapper compiler. When it is not possible to use
+the wrapper directly, the ``--showme:compile`` and ``--showme:link``
+options should be used to determine what flags the wrapper would have
+used. For example:
+
+.. code:: sh
+
+   shell$ cc -c file1.c `pmixcc --showme:compile`
+
+   shell$ cc -c file2.c `pmixcc --showme:compile`
+
+   shell$ cc file1.o file2.o `pmixcc --showme:link` -o my_program
+
+.. _man1-pmix-wrapper-compiler-files:
+
+FILES
+-----
+
+The strings that the wrapper compiler inserts into the command line
+before invoking the underlying compiler are stored in a text file
+created by PMIx and installed to
+``$pkgdata/pmixcc-wrapper-data.txt``, where:
+
+* ``$pkgdata`` is typically ``$prefix/share/pmix``
+* ``$prefix`` is the top installation directory of PMIx
+
+It is rarely necessary to edit this file, but it can be examined to
+gain insight into what flags the wrapper is placing on the command
+line.
+
+
+ENVIRONMENT VARIABLES
+---------------------
+
+By default, the wrapper uses the compiler that was selected when
+PMIx was configured. This compiler was either found
+automatically by PMIx's "configure" script, or was selected by
+the user via the ``CC`` environment variable
+before ``configure`` was invoked. Additionally, other arguments specific
+to the compiler may have been selected by configure.
+
+These values can be selectively overridden by either editing the text
+files containing this configuration information (see the :ref:`FILES
+<man1-pmix-wrapper-compiler-files>` section), or by setting selected
+environment variables of the form ``pmix_value``.
+
+Valid value names are:
+
+* ``CPPFLAGS``: Flags added when invoking the preprocessor
+
+* ``LDFLAGS``: Flags added when invoking the linker
+
+* ``LIBS``: Libraries added when invoking the linker
+
+* ``CC``: C compiler
+
+* ``CFLAGS``: C compiler flags

--- a/docs/news/news-v5.x.rst
+++ b/docs/news/news-v5.x.rst
@@ -4,6 +4,29 @@ PMIx v5.x series
 This file contains all the NEWS updates for the PMIx v5.x
 series, in reverse chronological order.
 
+5.0.11 -- xx May 2026
+---------------------
+:: important:: This release contains the following important changes:
+
+                * restoration/repair of the OmniPath support component
+                * Repair support of OMPI default MCA params
+
+Detailed changes include:
+ - PR #3869: Multiple commits
+    - Update NEWS and VERSION
+    - pmdl/ompi: use the right type to enumerate myenvars
+    - fix var group lookup in component repository release
+    - Prepend I/O residuals to correct redirected streams
+    - Restore pnet/opa component
+    - Don't pass zero-byte stdin to host
+    - Correct the wrapper compiler man page
+    - Default output to file to nocopy
+    - Properly handle qualified values in client get
+    - Do not double-process IOF formats
+    - Correct cflags used for check_compiler_version.m4
+    - Fully support return of static values
+
+
 5.0.10 -- 23 Jan 2026
 ---------------------
 .. important:: This release includes two critical changes:

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -141,6 +141,7 @@ typedef struct {
 static inline void examples_hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -364,8 +364,12 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
         rc = PMIX_SUCCESS;
     }
     if (PMIX_SUCCESS == rc && NULL != cb->value) {
-        *val = cb->value;
-        cb->value = NULL;
+        if (lg->stval) {
+            PMIx_Value_xfer(*val, cb->value);
+        } else {
+            *val = cb->value;
+            cb->value = NULL;
+        }
     } else {
         *val = NULL;
     }
@@ -424,6 +428,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
         cb->cbfunc.valuefn = cbfunc;
         cb->cbdata = cbdata;
         PMIX_THREADSHIFT(cb, gcbfn);
+        PMIX_RELEASE(lg);
         return PMIX_SUCCESS;
     } else if (PMIX_SUCCESS != rc) {
         /* it's a true error */

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -706,12 +706,18 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     pmix_list_t *kvs = &cb->kvs;
     pmix_kval_t *kv;
     pmix_value_t *val;
-    pmix_info_t *info;
+    pmix_info_t *info, *iptr;
     size_t ninfo, n;
 
     if (NULL != cb->key && 1 == pmix_list_get_size(kvs)) {
         kv = (pmix_kval_t *) pmix_list_get_first(kvs);
-        cb->value = kv->value;
+        if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
+            // extract the actual value
+            iptr = (pmix_info_t*)kv->value->data.darray->array;
+            cb->value = &iptr[0].value;
+        } else {
+            cb->value = kv->value;
+        }
         kv->value = NULL; // protect the value
         return PMIX_SUCCESS;
     }
@@ -739,8 +745,15 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     /* copy the list elements */
     n = 0;
     PMIX_LIST_FOREACH (kv, kvs, pmix_kval_t) {
-        pmix_strncpy(info[n].key, kv->key, PMIX_MAX_KEYLEN);
-        PMIx_Value_xfer(&info[n].value, kv->value);
+        if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
+            // extract the actual value
+            iptr = (pmix_info_t*)kv->value->data.darray->array;
+            pmix_strncpy(info[n].key, iptr[0].key, PMIX_MAX_KEYLEN);
+            PMIx_Value_xfer(&info[n].value, &iptr[0].value);
+        } else {
+            pmix_strncpy(info[n].key, kv->key, PMIX_MAX_KEYLEN);
+            PMIx_Value_xfer(&info[n].value, kv->value);
+        }
         ++n;
     }
     val->data.darray->size = ninfo;

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -973,8 +973,6 @@ pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels, const pmix_proc_
     size_t m;
     pmix_buffer_t *msg;
     pmix_status_t rc;
-    pmix_byte_object_t *wbo;
-    pmix_proc_t proc;
 
     /* if the channel wasn't included, then ignore it */
     if (!(channels & req->channels)) {
@@ -1048,23 +1046,13 @@ pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels, const pmix_proc_
         }
     }
 
-    // process the data based on the request flags
-    PMIX_LOAD_PROCID(&proc, req->requestor->info->pname.nspace, req->requestor->info->pname.rank);
-    wbo = pmix_iof_prep_output(&proc, &req->flags, req->channels, bo);
-    if (NULL == wbo) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
-        PMIX_RELEASE(msg);
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
     /* pack the data */
-    PMIX_BFROPS_PACK(rc, req->requestor, msg, wbo, 1, PMIX_BYTE_OBJECT);
+    PMIX_BFROPS_PACK(rc, req->requestor, msg, bo, 1, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PMIx_Byte_object_free(wbo, 1);
         PMIX_RELEASE(msg);
         return rc;
     }
-    PMIx_Byte_object_free(wbo, 1);
 
     /* send it to the requestor */
     PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -910,6 +910,12 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
     return NULL;
 }
 
+void pmix_iof_init_flags(pmix_iof_flags_t *flags)
+{
+    memset(flags, 0, sizeof(pmix_iof_flags_t));
+    flags->nocopy = true;
+}
+
 void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
 {
     if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT) ||

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -2058,6 +2058,11 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
             /* nothing we can do with this info - no point in reactivating it */
             return;
         }
+        if (0 == bo.size) {
+            // our stdin fd has closed - nothing to do, and
+            // we don't reactivate the event
+            return;
+        }
         PMIX_BYTE_OBJECT_CREATE(boptr, 1);
         if (0 < bo.size) {
             boptr->bytes = (char*)malloc(bo.size);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1650,22 +1650,30 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         return rc;
     }
 
-    /* see if we have some residual for this name/stream */
-    inputdata = bo->bytes;
-    inputsize = bo->size;
-    copied = false;
-    PMIX_LIST_FOREACH(res, &pmix_server_globals.iof_residuals, pmix_iof_residual_t) {
-        if (PMIX_CHECK_PROCID(name, &res->name) || (stream & res->stream)) {
-            /* we need to pre-pend the residual data to the new
-             * data so any lines can be completed */
-            inputdata = (char*)malloc(inputsize + res->bo.size);
-            memcpy(inputdata, res->bo.bytes, res->bo.size);
-            memcpy(&inputdata[res->bo.size], bo->bytes, bo->size);
-            inputsize += res->bo.size;
-            copied = true;
-            pmix_list_remove_item(&pmix_server_globals.iof_residuals, &res->super);
-            PMIX_RELEASE(res);
-            break;
+    if (myflags.raw) {
+        rc = write_output_line(name, channel, &myflags, stream,
+                               copystdout, copystderr, bo);
+        return rc;
+
+    } else {
+
+        /* see if we have some residual for this name/stream */
+        inputdata = bo->bytes;
+        inputsize = bo->size;
+        copied = false;
+        PMIX_LIST_FOREACH(res, &pmix_server_globals.iof_residuals, pmix_iof_residual_t) {
+            if (PMIX_CHECK_PROCID(name, &res->name) && (stream & res->stream)) {
+                /* we need to pre-pend the residual data to the new
+                 * data so any lines can be completed */
+                inputdata = (char*)malloc(inputsize + res->bo.size);
+                memcpy(inputdata, res->bo.bytes, res->bo.size);
+                memcpy(&inputdata[res->bo.size], bo->bytes, bo->size);
+                inputsize += res->bo.size;
+                copied = true;
+                pmix_list_remove_item(&pmix_server_globals.iof_residuals, &res->super);
+                PMIX_RELEASE(res);
+                break;
+            }
         }
     }
 

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -275,6 +275,7 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                const pmix_byte_object_t *bo,
                                                const pmix_info_t *info, size_t ninfo,
                                                pmix_iof_req_t *req);
+PMIX_EXPORT void pmix_iof_init_flags(pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
 PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -781,6 +781,7 @@ pmix_event_t *pmix_event_new(pmix_event_base_t *b, int fd, short fg, event_callb
 void pmix_hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -52,6 +52,7 @@
 
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"
+#include "src/common/pmix_iof.h"
 #include "src/mca/bfrops/bfrops_types.h"
 #include "src/mca/bfrops/base/bfrop_base_tma.h"
 #include "src/threads/pmix_threads.h"
@@ -149,7 +150,7 @@ static void nscon(pmix_namespace_t *p)
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
     PMIX_CONSTRUCT(&p->setup_data, pmix_list_t);
-    memset(&p->iof_flags, 0, sizeof(p->iof_flags));
+    pmix_iof_init_flags(&p->iof_flags);
     PMIX_CONSTRUCT(&p->sinks, pmix_list_t);
 
 }
@@ -324,7 +325,7 @@ static void iofreqcon(pmix_iof_req_t *p)
     p->remote_id = 0;
     p->procs = NULL;
     p->nprocs = 0;
-    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&p->flags);
     p->channels = PMIX_FWD_NO_CHANNELS;
     p->cbfunc = NULL;
     p->regcbfunc = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -327,7 +327,7 @@ typedef struct {
     .rank = false,                  \
     .file = NULL,                   \
     .directory = NULL,              \
-    .nocopy = false,                \
+    .nocopy = true,                 \
     .merge = false,                 \
     .local_output = false,          \
     .local_output_given = false,    \

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -335,7 +335,7 @@ pmix_mca_base_component_repository_release_internal(pmix_mca_base_component_repo
 {
     int group_id;
 
-    group_id = pmix_mca_base_var_group_find(NULL, ri->ri_type, ri->ri_name);
+    group_id = pmix_mca_base_var_group_find("*", ri->ri_type, ri->ri_name);
     if (0 <= group_id) {
         /* ensure all variables are deregistered before we dlclose the component */
         pmix_mca_base_var_group_deregister(group_id);

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -823,6 +825,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     pmix_info_t info[2];
     uint32_t n;
     pmix_cb_t cb;
+    pmix_mca_base_var_file_value_t *fv;
 
     pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
                         "pmdl:ompi: setup fork for %s", PMIX_NAME_PRINT(proc));
@@ -1159,8 +1162,8 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     PMIX_DESTRUCT(&cb);
 
     /* add any envars we collected from param files */
-    PMIX_LIST_FOREACH(kv, &myenvars, pmix_kval_t) {
-        PMIx_Setenv(kv->value->data.envar.envar, kv->value->data.envar.value, true, env);
+    PMIX_LIST_FOREACH(fv, &myenvars, pmix_mca_base_var_file_value_t) {
+        PMIx_Setenv(fv->mbvfv_var, fv->mbvfv_value, true, env);
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -1,0 +1,56 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = pnet_opa.h
+sources = \
+        pnet_opa_component.c \
+        pnet_opa.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pnet_opa_DSO
+lib =
+lib_sources =
+component = pmix_mca_pnet_opa.la
+component_sources = $(headers) $(sources)
+else
+lib = libpmix_mca_pnet_opa.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+pmix_mca_pnet_opa_la_SOURCES = $(component_sources)
+pmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+pmix_mca_pnet_opa_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libpmix_mca_pnet_opa_la_SOURCES = $(lib_sources)
+libpmix_mca_pnet_opa_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -1,0 +1,27 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pnet_opa_CONFIG([action-if-can-compile],
+#                          [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_opa_CONFIG], [
+    AC_CONFIG_FILES([src/mca/pnet/opa/Makefile])
+
+    AS_IF([test "yes" = "yes"],
+          [$1
+           pmix_pnet_opa=yes],
+          [$2
+           pmix_pnet_opa=no])
+
+    PMIX_SUMMARY_ADD([Transports], [OmniPath], [], [$pmix_pnet_opa])
+
+])dnl

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#    include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#endif
+#include <time.h>
+
+#include "pmix_common.h"
+
+#include "src/class/pmix_list.h"
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/pcompress/pcompress.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/pmix_alfg.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
+#include "src/util/pmix_environ.h"
+
+#include "pnet_opa.h"
+#include "src/mca/pnet/base/base.h"
+#include "src/mca/pnet/pnet.h"
+
+static pmix_status_t allocate(pmix_namespace_t *nptr,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist);
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr,
+                                         pmix_info_t info[], size_t ninfo);
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_list_t *inventory);
+static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t directives[], size_t ndirs);
+pmix_pnet_module_t pmix_opa_module = {
+    .name = "opa",
+    .allocate = allocate,
+    .setup_local_network = setup_local_network,
+    .collect_inventory = collect_inventory,
+    .deliver_inventory = deliver_inventory
+};
+
+/* some network transports require a little bit of information to
+ * "pre-condition" them - i.e., to setup their individual transport
+ * connections so they can generate their endpoint addresses. This
+ * function provides a means for doing so. The resulting info is placed
+ * into the app_context's env array so it will automatically be pushed
+ * into the environment of every MPI process when launched.
+ */
+
+static inline void transports_use_rand(uint64_t *unique_key)
+{
+    pmix_rng_buff_t rng;
+    pmix_srand(&rng, (unsigned int) time(NULL));
+    unique_key[0] = pmix_rand(&rng);
+    unique_key[1] = pmix_rand(&rng);
+}
+
+static char *transports_print(uint64_t *unique_key)
+{
+    unsigned int *int_ptr;
+    size_t i, j, string_key_len, written_len;
+    char *string_key = NULL, *format = NULL;
+
+    /* string is two 64 bit numbers printed in hex with a dash between
+     * and zero padding.
+     */
+    string_key_len = (sizeof(uint64_t) * 2) * 2 + strlen("-") + 1;
+    string_key = (char *) malloc(string_key_len);
+    if (NULL == string_key) {
+        return NULL;
+    }
+
+    string_key[0] = '\0';
+    written_len = 0;
+
+    /* get a format string based on the length of an unsigned int.  We
+     * want to have zero padding for sizeof(unsigned int) * 2
+     * characters -- when printing as a hex number, each byte is
+     * represented by 2 hex characters.  Format will contain something
+     * that looks like %08lx, where the number 8 might be a different
+     * number if the system has a different sized long (8 would be for
+     * sizeof(int) == 4)).
+     */
+    if (0 > asprintf(&format, "%%0%dx", (int) (sizeof(unsigned int)) * 2)) {
+        free(string_key);
+        return NULL;
+    }
+
+    /* print the first number */
+    int_ptr = (unsigned int *) &unique_key[0];
+    for (i = 0; i < sizeof(uint64_t) / sizeof(unsigned int); ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j = 0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        pmix_snprintf(string_key + written_len, string_key_len - written_len, format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+
+    /* print the middle dash */
+    pmix_snprintf(string_key + written_len, string_key_len - written_len, "-");
+    written_len = strlen(string_key);
+
+    /* print the second number */
+    int_ptr = (unsigned int *) &unique_key[1];
+    for (i = 0; i < sizeof(uint64_t) / sizeof(unsigned int); ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j = 0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        pmix_snprintf(string_key + written_len, string_key_len - written_len, format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+    free(format);
+
+    return string_key;
+}
+
+/* NOTE: if there is any binary data to be transferred, then
+ * this function MUST pack it for transport as the host will
+ * not know how to do so */
+static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist)
+{
+    uint64_t unique_key[2];
+    char *string_key;
+    int fd_rand;
+    size_t bytes_read, n, m, p;
+    pmix_buffer_t mydata; // Buffer used to store information to be transmitted (scratch storage)
+    pmix_kval_t *kv;
+    pmix_envar_t envar;
+    pmix_byte_object_t bo;
+    bool envars = false, seckeys = false;
+    pmix_status_t rc;
+    pmix_info_t *iptr;
+    pmix_list_t cache;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:opa:allocate for nspace %s", nptr->nspace);
+
+    if (NULL == info) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    PMIX_ENVAR_CONSTRUCT(&envar);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ENVARS)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ALL)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+            seckeys = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_NONENVARS)) {
+            seckeys = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NETWORK)) {
+            iptr = (pmix_info_t *) info[n].value.data.darray->array;
+            m = info[n].value.data.darray->size;
+            for (p = 0; p < m; p++) {
+                if (PMIX_CHECK_KEY(&iptr[p], PMIX_ALLOC_NETWORK_SEC_KEY)) {
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_ALLOC_NETWORK_ID)) {
+                    /* need to track the request by this ID */
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_ENVARS)) {
+                    envars = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_ALL)) {
+                    envars = PMIX_INFO_TRUE(&iptr[p]);
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                } else if (PMIX_CHECK_KEY(&iptr[p], PMIX_SETUP_APP_NONENVARS)) {
+                    seckeys = PMIX_INFO_TRUE(&iptr[p]);
+                }
+            }
+        }
+    }
+    /* setup a buffer - we will pack the info into it for transmission to
+     * the backend compute node daemons */
+    PMIX_CONSTRUCT(&mydata, pmix_buffer_t);
+
+    if (seckeys) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet: opa providing seckeys");
+        /* put the number here - or else create an appropriate string. this just needs to
+         * eventually be a string variable
+         */
+        if (-1 == (fd_rand = open("/dev/urandom", O_RDONLY))) {
+            transports_use_rand(unique_key);
+        } else {
+            bytes_read = read(fd_rand, (char *) unique_key, 16);
+            if (bytes_read != 16) {
+                transports_use_rand(unique_key);
+            }
+            close(fd_rand);
+        }
+
+        if (NULL == (string_key = transports_print(unique_key))) {
+            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            PMIX_DESTRUCT(&mydata);
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+
+        PMIX_ENVAR_LOAD(&envar, "OMPI_MCA_orte_precondition_transports", string_key, ':');
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata, &envar, 1, PMIX_ENVAR);
+        free(string_key);
+        PMIX_ENVAR_DESTRUCT(&envar);
+    }
+
+    if (envars) {
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "pnet: opa harvesting envars %s excluding %s",
+                            (NULL == pmix_mca_pnet_opa_component.incparms)
+                                ? "NONE"
+                                : pmix_mca_pnet_opa_component.incparms,
+                            (NULL == pmix_mca_pnet_opa_component.excparms)
+                                ? "NONE"
+                                : pmix_mca_pnet_opa_component.excparms);
+        /* harvest envars to pass along */
+        PMIX_CONSTRUCT(&cache, pmix_list_t);
+        if (NULL != pmix_mca_pnet_opa_component.include) {
+            rc = pmix_util_harvest_envars(pmix_mca_pnet_opa_component.include,
+                                          pmix_mca_pnet_opa_component.exclude, &cache);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_LIST_DESTRUCT(&cache);
+                PMIX_DESTRUCT(&mydata);
+                return rc;
+            }
+            /* pack anything that was found */
+            PMIX_LIST_FOREACH (kv, &cache, pmix_kval_t) {
+                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata,
+                                 &kv->value->data.envar, 1, PMIX_ENVAR);
+            }
+            PMIX_LIST_DESTRUCT(&cache);
+        }
+    }
+
+    // unload the buffer
+    PMIX_UNLOAD_BUFFER(&mydata, bo.bytes, bo.size);
+    // if nothing was packed, then we have nothing to send
+    if (0 == bo.size) {
+        PMIX_DESTRUCT(&mydata);
+        return PMIX_SUCCESS;
+    }
+
+    /* load all our results into a buffer for xmission to the backend */
+    PMIX_KVAL_NEW(kv, PMIX_PNET_OPA_BLOB);
+    if (NULL == kv || NULL == kv->value) {
+        PMIX_DESTRUCT(&mydata);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_BYTE_OBJECT;
+    /* to help scalability, compress this blob */
+    if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
+                               (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
+        kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+    } else {
+        kv->value->data.bo.bytes = bo.bytes;
+        kv->value->data.bo.size = bo.size;
+    }
+    PMIX_DESTRUCT(&mydata);
+    pmix_list_append(ilist, &kv->super);
+    return PMIX_SUCCESS;
+}
+
+/* PMIx_server_setup_local_support calls the "setup_local_network" function.
+ * The Standard requires that this come _after_ the host calls the
+ * PMIx_server_register_nspace function to ensure that any required information
+ * is available to the components. Thus, we have the PMIX_NODE_MAP and
+ * PMIX_PROC_MAP available to us and can use them here.
+ *
+ * When the host calls "setup_local_support", it passes down an array
+ * containing the information the "lead" server (e.g., "mpirun") collected
+ * from PMIx_server_setup_application. In this case, we search for a blob
+ * that our "allocate" function may have included in that info.
+ */
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *ns,
+                                         pmix_info_t info[], size_t ninfo)
+{
+    size_t n;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_status_t rc = PMIX_SUCCESS;
+    uint8_t *data;
+    size_t size;
+    bool release = false;
+    pmix_envar_list_item_t *ev;
+    pmix_proc_t proc;
+    pmix_kval_t *kv;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:opa:setup_local with %lu info", (unsigned long) ninfo);
+
+    /* prep the unpack buffer */
+    PMIX_CONSTRUCT(&bkt, pmix_buffer_t);
+
+    for (n = 0; n < ninfo; n++) {
+        /* look for my key */
+        if (PMIX_CHECK_KEY(&info[n], PMIX_PNET_OPA_BLOB)) {
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:opa:setup_local found my blob");
+
+            /* if this is a compressed byte object, decompress it */
+            if (PMIX_COMPRESSED_BYTE_OBJECT == info[n].value.type) {
+                pmix_compress.decompress(&data, &size, (uint8_t *) info[n].value.data.bo.bytes,
+                                         info[n].value.data.bo.size);
+                release = true;
+            } else {
+                data = (uint8_t *) info[n].value.data.bo.bytes;
+                size = info[n].value.data.bo.size;
+            }
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
+
+            /* all we packed was envars, so just cycle thru */
+            ev = PMIX_NEW(pmix_envar_list_item_t);
+            cnt = 1;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            while (PMIX_SUCCESS == rc) {
+                pmix_list_append(&ns->envars, &ev->super);
+                /* if this is the transport key, save it */
+                if (0 == strncmp(ev->envar.envar, "OMPI_MCA_orte_precondition_transports", PMIX_MAX_KEYLEN)) {
+                    /* add it to the job-level info */
+                    PMIX_LOAD_PROCID(&proc, ns->ns->nspace, PMIX_RANK_WILDCARD);
+                    PMIX_KVAL_NEW(kv, PMIX_CREDENTIAL);
+                    kv->value->type = PMIX_STRING;
+                    kv->value->data.string = strdup(ev->envar.value);
+                    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, PMIX_INTERNAL, kv);
+                    PMIX_RELEASE(kv); // maintain refcount
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                    }
+                }
+                /* get the next envar */
+                ev = PMIX_NEW(pmix_envar_list_item_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            }
+            if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+                rc = PMIX_SUCCESS;
+            }
+            // we will have created one more envar than we want
+            PMIX_RELEASE(ev);
+
+            /* we are done */
+            break;
+        }
+    }
+
+    if (release) {
+        free(data);
+    }
+
+    return rc;
+}
+
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_list_t *inventory)
+{
+    /* search the topology for OPA NICs */
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs, inventory);
+
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t directives[], size_t ndirs)
+{
+    /* look for our inventory blob */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, directives, ndirs);
+
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/opa/pnet_opa.h
+++ b/src/mca/pnet/opa/pnet_opa.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PNET_OPA_H
+#define PMIX_PNET_OPA_H
+
+#include "src/include/pmix_config.h"
+
+#include "src/mca/pnet/pnet.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pnet_base_component_t super;
+    char *incparms;
+    char *excparms;
+    char **include;
+    char **exclude;
+} pmix_pnet_opa_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pnet_opa_component_t pmix_mca_pnet_opa_component;
+extern pmix_pnet_module_t pmix_opa_module;
+
+/* define a key for any blob we need to send in a launch msg */
+#define PMIX_PNET_OPA_BLOB "pmix.pnet.opa.blob"
+
+/* define an inventory key */
+#define PMIX_PNET_OPA_INVENTORY_KEY "pmix.pnet.opa.inventory"
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -1,0 +1,115 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "pmix_common.h"
+
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/mca/pnet/base/base.h"
+#include "src/util/pmix_argv.h"
+
+#include "pnet_opa.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_status_t component_register(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pnet_opa_component_t pmix_mca_pnet_opa_component = {
+    .super = {
+        PMIX_PNET_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "opa",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_register_component_params = component_register,
+        .pmix_mca_query_component = component_query,
+    },
+    .include = NULL,
+    .exclude = NULL
+};
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pnet, opa)
+
+static pmix_status_t component_register(void)
+{
+    pmix_mca_base_component_t *component = &pmix_mca_pnet_opa_component.super;
+
+    pmix_mca_pnet_opa_component.incparms = "HFI_*,PSM2_*";
+    (void) pmix_mca_base_component_var_register(
+        component, "include_envars",
+        "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING,
+        &pmix_mca_pnet_opa_component.incparms);
+    if (NULL != pmix_mca_pnet_opa_component.incparms) {
+        pmix_mca_pnet_opa_component.include = PMIx_Argv_split(pmix_mca_pnet_opa_component.incparms, ',');
+    }
+
+    pmix_mca_pnet_opa_component.excparms = NULL;
+    (void) pmix_mca_base_component_var_register(
+        component, "exclude_envars",
+        "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING,
+        &pmix_mca_pnet_opa_component.excparms);
+    if (NULL != pmix_mca_pnet_opa_component.excparms) {
+        pmix_mca_pnet_opa_component.exclude = PMIx_Argv_split(pmix_mca_pnet_opa_component.excparms, ',');
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_open(void)
+{
+    pmix_status_t rc;
+
+    rc = pmix_hwloc_check_vendor(&pmix_globals.topology, 0x8086, 0x208);
+    return rc;
+}
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 10;
+    *module = (pmix_mca_base_module_t *) &pmix_opa_module;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,7 +65,6 @@ pmix_pnet_opa_component_t pmix_mca_pnet_opa_component = {
     .include = NULL,
     .exclude = NULL
 };
-PMIX_MCA_BASE_COMPONENT_INIT(pmix, pnet, opa)
 
 static pmix_status_t component_register(void)
 {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -244,7 +244,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
 #endif
 
     pmix_init_called = true;
-    memset(&flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&flags);
 
     if (PMIX_SUCCESS != pmix_init_util(info, ninfo, NULL)) {
         return PMIX_ERROR;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -5388,7 +5388,7 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->copied = false;
     p->keys = NULL;
     p->channels = PMIX_FWD_NO_CHANNELS;
-    memset(&p->flags, 0, sizeof(pmix_iof_flags_t));
+    pmix_iof_init_flags(&p->flags);
     p->bo = NULL;
     p->nbo = 0;
     p->cbfunc = NULL;

--- a/test/simple/get_put_example.c
+++ b/test/simple/get_put_example.c
@@ -11,6 +11,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/test/simple/hybrid.c
+++ b/test/simple/hybrid.c
@@ -6,6 +6,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,6 +40,7 @@ static pmix_proc_t myproc;
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/test/simple/simpvni.c
+++ b/test/simple/simpvni.c
@@ -10,6 +10,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -12,6 +12,7 @@
 static void hide_unused_params(int x, ...)
 {
     va_list ap;
+    (void)x;
 
     va_start(ap, x);
     va_end(ap);


### PR DESCRIPTION
[Fully support return of static values](https://github.com/openpmix/openpmix/commit/cace7bbd17fd5654a6a0be2f3ccf79babbc9f545)

If someone provides backing storage and request we return a static
value, then return the value in their location. Note this is only
available via the blocking form of PMIx_Get as there is no way
to pass the address of the backing storage to the non-blocking
function.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/679f6956050c23d8193e5a8cdb2a6a2af3d696e7)

[Correct cflags used for check_compiler_version.m4](https://github.com/openpmix/openpmix/commit/ef4677988676db1b05de80724e31cfd9c5e8c3a9)

Patch provided by George Bosilca

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/f29cfc71074806695add4b1691026e5eb4ac835c)

[Do not double-process IOF formats](https://github.com/openpmix/openpmix/commit/8ae614fe2a69c181254c65611d20ac4821b7495b)

Let the endpoint tool process the output to tag it.

Thanks to @jlakisTT for the report!

Signed-off-by: Ralph Castain <rhc@pmix.org>
    (cherry picked from commit https://github.com/openpmix/openpmix/commit/c682ed79fdb80784e29c93dd8270cd104da4ddad)

[Properly handle qualified values in client get](https://github.com/openpmix/openpmix/commit/c4a0130fb9b32d69363662eae677a307583df034)

When the internal fetch returns a qualified value, we need
to extract only the "actual" value and return that to the
caller. We specifically do not want to include the qualifiers
in the returned value.

NOTE: we cannot just have the internal fetch perform that
operation for us as the server needs to retrieve the full
qualified value (value plus qualifiers) when responding to
a request from a client. Otherwise, the client would store
the value without the qualifiers, thereby converting it to
an "unqualified" value for any subsequent "get" requests.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/7e6488dbb376bfde0ce3f32d6a1586b92a45788c)

[Default output to file to nocopy](https://github.com/openpmix/openpmix/commit/009c42b1afc8ae6925e7d2026bf1426d7a02357f)

Don't copy output going to files to stdout/err
streams by default.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/f8ab5467ef15087fd2959372525edb6208a7e116)

[Correct the wrapper compiler man page](https://github.com/openpmix/openpmix/commit/0aaa347a96c6801882b14cc3238df9ced56f047b)

It was garbage copy from some unclear source, so let's
make it actually be relevant to PMIx.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/d40c0f038af72625c1f6306978b5c3a5251b1517)

[Don't pass zero-byte stdin to host](https://github.com/openpmix/openpmix/commit/e27b6623a5a043ce92af4bdf558b96f2fcc862c9)

If we read zero bytes, then our stdin has closed - no
need to pass that to the host.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/e75b5cc1d52da665d9aeda004907948f4da59681)

[Restore pnet/opa component](https://github.com/openpmix/openpmix/commit/2dc2ea16b62367c17e3b9675d53005a431b02363)

pnet/opa was removed because of a report that OPA-PSM2 was being
selected with non-OPA devices. Reportedly,
(vendor=0x8086,class=0x0208) had been recycled for a non-OPA100 device.

However this report seems to have been in error; the user did in-fact
have an OPA100 device in their system.

So restore pnet/opa by reverting commit https://github.com/openpmix/openpmix/commit/d52ebb7968e60525fd3c082dc632109f342a1f9f
("Eliminate stale pnet/opa component").

Signed-off-by: Brendan Cunningham <bcunningham@cornelisnetworks.com>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/16c45527aa3566c15ccdf6d82267ec41a21fa895)

[Prepend I/O residuals to correct redirected streams](https://github.com/openpmix/openpmix/commit/6bac5727f41b1f25c18fb00eb8e0ea305152a059)

A stored I/O residual is included in the redirected stream of a given
process only when *both* the name of the process *and* the stream kind
match the residual metadata. This prevents cross-contamination of
redirected outputs between distinct processes.

Signed-off-by: Jakub Benda <albandil@atlas.cz>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/9a5c62d07bf3de9190440a87c3005afb6106a3d9)

[fix var group lookup in component repository release](https://github.com/openpmix/openpmix/commit/27d609e4fb301c977ffdfd03bfaa15bb066d8aa6)

Port of https://github.com/open-mpi/ompi/pull/13897

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/3aeefe9d5a2460e6d864e1f770bef3fb345c5f47)

[pmdl/ompi: use the right type to enumerate myenvars](https://github.com/openpmix/openpmix/commit/2f9e2a3a5254458cab94732360f65200b68d19c5)

myenvars is pmix_list_t populated with pmix_mca_base_var_file_value_t
objects, so use the right type when enumerating is it setup_fork()

Refs https://github.com/open-mpi/ompi/issues/13303

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2053724c0a251fc084e20382f550a34dbf5342af)

[Cleanups and update VERSION and NEWS](https://github.com/openpmix/openpmix/commit/f0af12d40c01294917dbc5e3dd701153cc550c1b)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick