### PR TITLE
Handle case of no log support

### DIFF
--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -173,7 +173,6 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     do {                                                                                           \
         pmix_output_verbose(1, pmix_client_globals.iof_output,                                     \
                              "defining endpt: file %s line %d fd %d", __FILE__, __LINE__, (fid));  \
-        PMIX_CONSTRUCT((snk), pmix_iof_sink_t);                                                    \
         pmix_strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);                            \
         (snk)->name.rank = (nm)->rank;                                                             \
         (snk)->tag = (tg);                                                                         \

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -61,6 +61,10 @@ static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         status = rc;
     }
 
+    if (PMIX_ERR_NOT_AVAILABLE == status) {
+        /* call down to process the request */
+        status = pmix_plog.log(cd->proc, cd->info, cd->ninfo, cd->directives, cd->ndirs);
+    }
     if (NULL != cd->cbfunc.opcbfn) {
         cd->cbfunc.opcbfn(status, cd->cbdata);
     }
@@ -201,12 +205,16 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
             goto local;
         }
-        PMIX_PROC_FREE(source, 1); // don't need this value
 
         // otherwise, we send to our server
         cd = PMIX_NEW(pmix_shift_caddy_t);
+        cd->info = (pmix_info_t*)data;
+        cd->ninfo = ndata;
+        cd->directives = (pmix_info_t*)directives;
+        cd->ndirs = ndirs;
         cd->cbfunc.opcbfn = cbfunc;
         cd->cbdata = cbdata;
+        cd->proc = source;
         msg = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
         if (PMIX_SUCCESS != rc) {

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -137,30 +137,40 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
                                 "%s: plog:stdfd delivering to stderr for source %s",
                                 PMIX_NAME_PRINT(&pmix_globals.myid),
                                 (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            p = PMIX_NEW(pmix_iof_deliver_t);
-            PMIX_XFER_PROCID(&p->source, source);
-            p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-            p->bo.bytes = (char*)malloc(p->bo.size);
-            memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-            rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDERR_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(p);
+            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+                fprintf(stderr, "%s", data[n].value.data.string);
+            } else {
+                p = PMIX_NEW(pmix_iof_deliver_t);
+                PMIX_XFER_PROCID(&p->source, source);
+                p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
+                p->bo.bytes = (char*)malloc(p->bo.size);
+                memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
+                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDERR_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(p);
+                }
             }
         } else if (0 == strncmp(data[n].key, PMIX_LOG_STDOUT, PMIX_MAX_KEYLEN)) {
             pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                                 "%s: plog:stdfd delivering to stdout for source %s",
                                 PMIX_NAME_PRINT(&pmix_globals.myid),
                                 (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            p = PMIX_NEW(pmix_iof_deliver_t);
-            PMIX_XFER_PROCID(&p->source, source);
-            p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-            p->bo.bytes = (char*)malloc(p->bo.size);
-            memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-            rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDOUT_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(p);
+            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+                fprintf(stdout, "%s", data[n].value.data.string);
+            } else {
+                p = PMIX_NEW(pmix_iof_deliver_t);
+                PMIX_XFER_PROCID(&p->source, source);
+                p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
+                p->bo.bytes = (char*)malloc(p->bo.size);
+                memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
+                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDOUT_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(p);
+                }
             }
         }
     }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -62,6 +62,7 @@
 
 #include "src/client/pmix_client_ops.h"
 #include "src/common/pmix_attributes.h"
+#include "src/common/pmix_iof.h"
 #include "src/event/pmix_event.h"
 
 #include "src/runtime/pmix_progress_threads.h"
@@ -316,7 +317,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
         pmix_globals.evauxbase = pmix_globals.evbase;
     }
 
-    /* setup the globals structure */
+    /* setup the globals structures */
     pmix_globals.pid = getpid();
     PMIX_LOAD_PROCID(&pmix_globals.myid, NULL, PMIX_RANK_INVALID);
 
@@ -337,7 +338,11 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                           pmix_globals.event_eviction_time, _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_globals.keyindex, pmix_keyindex_t);
+    // construct client globals structures
     PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_client_globals.iof_stdout, pmix_iof_sink_t);
+    PMIX_CONSTRUCT(&pmix_client_globals.iof_stderr, pmix_iof_sink_t);
+
     /* need to hold off checking the hotel init return code
      * until after we construct all the globals so they can
      * correctly finalize */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -805,14 +805,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* add it to the end of the list of recvs */
     pmix_list_append(&pmix_ptl_base.posted_recvs, &req->super);
 
-    /* if we are a gateway, setup our IOF events */
-    if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
-        /* setup IOF */
-        PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stdout, &pmix_globals.myid, 1,
-                             PMIX_FWD_STDOUT_CHANNEL, pmix_iof_write_handler);
-        PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stderr, &pmix_globals.myid, 2,
-                             PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
-    }
+    /* setup our IOF sinks */
+    PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stdout, &pmix_globals.myid, 1,
+                         PMIX_FWD_STDOUT_CHANNEL, pmix_iof_write_handler);
+    PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stderr, &pmix_globals.myid, 2,
+                         PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* register our attributes */
     if (PMIX_SUCCESS != (rc = pmix_register_server_attrs())) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1548,13 +1548,13 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
                                  cd->directives, cd->ndirs,
                                  localcbfn, (void *) cd);
         } else {
-            // no choice but to process locally
-            goto local;
+            // tell the client that we cannot do this
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_NOT_AVAILABLE;
         }
         return PMIX_SUCCESS;
     }
 
-local:
     /* pass it down */
     pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                         "pmix:server processing locally");


### PR DESCRIPTION
If the PMIx server daemon's host does not offer a
log upcall and is not a gateway, then the server
daemon has no way of processing the request. Notify
the client that the service is not available and have
the client try to perform the request itself.

Always setup the IOF sinks to avoid problems with
hosts that do not expose a log upcall function.
