### PR TITLE
docs: fix spelling and grammar errors across documentation

### DIFF
--- a/docs/building-apps/quickstart.rst
+++ b/docs/building-apps/quickstart.rst
@@ -14,7 +14,7 @@ probably work in many environments.
    Please consult the other sections in this chapter for more details,
    if necessary.
 
-PMIx provides a "wrapper" compiler (```pmixcc`` <man1-pmixcc>`)that can be used for
+PMIx provides a "wrapper" compiler (```pmixcc`` <man1-pmixcc>`) that can be used for
 compiling PMIx-based applications. The intent is that users can simply invoke the
 PMIx wrapper compiler instead of their usual language compiler (e.g., ``gcc``).
 For example, instead of invoking your usual C compiler to build your
@@ -29,7 +29,7 @@ All the wrapper compiler does is add a variety of compiler and linker
 flags to the command line and then invoke a back-end compiler.  To be
 specific: the wrapper compilers do not parse source code at all; they
 are solely command-line manipulators, and have nothing to do with the
-actual compilation or linking of programs.  The end result is anI
+actual compilation or linking of programs.  The end result is an
 executable that is properly linked to all the relevant libraries.
 
 .. caution:: It is *absolutely not sufficient* to simply add ``-lpmix``

--- a/docs/developers/git-github.rst
+++ b/docs/developers/git-github.rst
@@ -18,7 +18,7 @@ PMIx's Git repository is `hosted at GitHub
       shell$ git clone --recursive https://github.com/openpmix/openpmix.git
 
 Note that Git is natively capable of using many forms of web
-proxies. If your network setup requires the user of a web proxy,
+proxies. If your network setup requires the use of a web proxy,
 `consult the Git documentation for more details
 <https://git-scm.com/>`_.
 
@@ -100,7 +100,7 @@ commit hash ``123abc``:
 .. code:: sh
 
    # Fetch all upstream git activity, including the merge of the "master" PR.
-   shell$ get fetch --all
+   shell$ git fetch --all
 
    # Check out the target release branch, and advance to the most recent commit.
    shell$ git checkout v5.0.x

--- a/docs/developers/gnu-autotools.rst
+++ b/docs/developers/gnu-autotools.rst
@@ -1,6 +1,6 @@
 .. _developers-installing-autotools-label:
 
-Manually installing the GNU Autootools
+Manually installing the GNU Autotools
 ======================================
 
 There is enough detail in building the GNU Autotools that it warrants
@@ -8,7 +8,7 @@ its own section.
 
 .. note:: As noted above, you only need to read/care about this
           section if you are building PMIx from a Git clone.  End
-          users installing an PMIx distribution tarball do *not*
+          users installing a PMIx distribution tarball do *not*
           need to have the GNU Autotools installed.
 
 Use a package manager
@@ -114,7 +114,7 @@ Installing the GNU Autotools from source
           Autotools manually if you can't use your operating system
           packaging system to install them for you.
 
-The GNU Autotools sources can be can be downloaded from:
+The GNU Autotools sources can be downloaded from:
 
 * https://ftp.gnu.org/gnu/autoconf/
 * https://ftp.gnu.org/gnu/automake/

--- a/docs/developers/rst-for-markdown-expats.rst
+++ b/docs/developers/rst-for-markdown-expats.rst
@@ -152,7 +152,7 @@ Multi-line code/fixed-width font
     case, the example code block will be rendered in the bulleted
     item.
 
-Whereas this parargraph and code block will be outside of the
+Whereas this paragraph and code block will be outside of the
 above bulleted list:
 
 .. code-block:: sh

--- a/docs/developers/source-code.rst
+++ b/docs/developers/source-code.rst
@@ -50,7 +50,7 @@ C / C++
 * PMIx requires a C99-compliant compiler.
 
   * C++-style comments are now allowed (and preferred).
-  * C99-style mixing declarations are allow allowable (and preferred).
+  * C99-style mixing of declarations is allowable (and preferred).
 
 * **ALWAYS** include ``pmix_config.h`` as your first #include file.
   There are very, very few cases where

--- a/docs/developers/sphinx.rst
+++ b/docs/developers/sphinx.rst
@@ -226,7 +226,7 @@ after running ``make install``:
 
       shell$ open $prefix/share/doc/pmix/html/index.html
 
-#. The man pages are installed (by default) to ``$preix/share/man``.
+#. The man pages are installed (by default) to ``$prefix/share/man``.
    If your man page search path includes this location, you can invoke
    commands similar to the following to see the same content that you
    see in these HTML pages:

--- a/docs/how-things-work/adding_datatypes.rst
+++ b/docs/how-things-work/adding_datatypes.rst
@@ -18,7 +18,7 @@ The datatype definition includes four pieces:
 
 Definition of the struct itself
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Almost all datatypes are structures of some kind, though that is not a requirement - a new datatype could simple be an abstraction over a standard C datatype (e.g., declaring something to represent a ``uint32_t``). Structures are required to be formatted as follows:
+Almost all datatypes are structures of some kind, though that is not a requirement - a new datatype could simply be an abstraction over a standard C datatype (e.g., declaring something to represent a ``uint32_t``). Structures are required to be formatted as follows:
 
 .. code-block:: c
 

--- a/docs/how-things-work/distances.rst
+++ b/docs/how-things-work/distances.rst
@@ -2,7 +2,7 @@
 Distance Computation
 ====================
 
-For performance purposes, users would prefer that their application processes utilize devices (e.g., fabric interfaces and GPUs) that are "close" to the location where each process is bound. The term "close" here is defined in terms of communication delay - i.e., the time required for a byte of data to be transferred between the process and the device. As the question relates solely to the selection of one device from several candidates, it is only the relative distance that matters. Thus, the application and/or user simply seeks to know (for example) if a given device is twice as far away as another similar device so that it can choose to user the latter.
+For performance purposes, users would prefer that their application processes utilize devices (e.g., fabric interfaces and GPUs) that are "close" to the location where each process is bound. The term "close" here is defined in terms of communication delay - i.e., the time required for a byte of data to be transferred between the process and the device. As the question relates solely to the selection of one device from several candidates, it is only the relative distance that matters. Thus, the application and/or user simply seeks to know (for example) if a given device is twice as far away as another similar device so that it can choose to use the latter.
 
 
 Here is a pic of one topology:

--- a/docs/how-things-work/sets_groups/group_construct.rst
+++ b/docs/how-things-work/sets_groups/group_construct.rst
@@ -28,7 +28,7 @@ In contrast,
 the *bootstrap* method is a somewhat more dynamic form of the operation
 that assumes each leader only knows the number of group leaders,
 but does not know their process IDs. This is commonly the case when
-two or mote collections of processes wish to join together (e.g., in an
+two or more collections of processes wish to join together (e.g., in an
 MPI connect/accept operation), but only the "root" processes
 know of each other. In such cases, each root process typically knows the
 process ID of all processes in its collection, but only the root

--- a/docs/how-things-work/sets_groups/overview.rst
+++ b/docs/how-things-work/sets_groups/overview.rst
@@ -42,11 +42,11 @@ Process *sets* differ from process *groups* in several key ways:
 * Process *sets* have no implied relationship between their members - i.e., a process in a process set has no concept of a ``pset rank`` as it would in a process *group*.
 
     * Process *set* identifiers are set by the host environment or by the user at time of application submission for execution -
-      there are no PMIx client API's provided by which an application can define a process set or change a process set membership.
+      there are no PMIx client APIs provided by which an application can define a process set or change a process set membership.
       In contrast, PMIx process *groups* can only be defined dynamically by the application.
 
     * Process *sets* are immutable - members cannot be added or removed once the set has been defined. In contrast, PMIx process *groups* can dynamically
-      change their membership using the appropriate API's.
+      change their membership using the appropriate APIs.
 
     * Process *groups* can be used in calls to PMIx operations. Members of process *groups* that are involved in an operation are translated by their
       PMIx library into their *native* identifier prior to the operation being passed to the host environment. For example, an application can define a

--- a/docs/installing-pmix/configure-cli-options/conventions.rst
+++ b/docs/installing-pmix/configure-cli-options/conventions.rst
@@ -6,7 +6,7 @@
 ``configure`` will, by default, search for header files and/or
 libraries for various optional features (e.g., various network
 support libraries).  If the relevant files are found, PMIx
-will built support for that feature.  If they are not found, PMIx
+will build support for that feature.  If they are not found, PMIx
 will skip building support for that feature.
 
 However, if you specify ``--with-FOO`` (where ``FOO`` is the
@@ -17,7 +17,7 @@ feature that was specifically requested, and will therefore abort so
 that a human can resolve out the issue.
 
 .. note:: Using ``--with-FOO`` to force PMIx's ``configure``
-          script to abort it if can't find support for a given feature
+          script to abort if it can't find support for a given feature
           may be preferable to unexpectedly discovering at run-time
           that PMIx is missing support for a critical feature.
 

--- a/docs/installing-pmix/configure-cli-options/installation.rst
+++ b/docs/installing-pmix/configure-cli-options/installation.rst
@@ -297,7 +297,7 @@ be used with ``configure``:
   the FOO components failing to load because ``libFOO.so`` is not
   available on their systems.
 
-  Conversely, system administrators tend to build an PMIx that is
+  Conversely, system administrators tend to build a PMIx that is
   targeted at their specific environment, and contains few (if any)
   components that are not needed.  In such cases, they might want
   their users to be warned that the FOO network components failed to

--- a/docs/installing-pmix/configure-cli-options/runtime.rst
+++ b/docs/installing-pmix/configure-cli-options/runtime.rst
@@ -7,7 +7,7 @@ The following are command line options for various runtime systems that
 can be used with ``configure``:
 
 * ``--with-alps``:
-  Force the building of for the Cray Alps run-time environment.  If
+  Force the building of support for the Cray Alps run-time environment.  If
   Alps support cannot be found, configure will abort.
 
 * ``--with-lsf=DIR``:

--- a/docs/installing-pmix/definitions.rst
+++ b/docs/installing-pmix/definitions.rst
@@ -2,7 +2,7 @@ Definitions
 ===========
 
 * **Source tree:** The tree where the PMIx source code is located.
-  It is typically the result of expanding an PMIx distribution
+  It is typically the result of expanding a PMIx distribution
   source code bundle, such as a tarball.
 * **Build tree:** The tree where PMIx was built.  It is always
   related to a specific source tree, but may actually be a different

--- a/docs/installing-pmix/filesystem-requirements.rst
+++ b/docs/installing-pmix/filesystem-requirements.rst
@@ -4,12 +4,12 @@ Filesystem requirements
 .. _install-filesystem-timestamp-warning-label:
 
 .. warning:: If you are building PMIx on a network filesystem, the
-   machine you on which you are building *must* be time-synchronized
+   machine on which you are building *must* be time-synchronized
    with the file server.
 
 Specifically: PMIx's build system *requires* accurate filesystem
 timestamps.  If your ``make`` output shows that it ran GNU Automake,
-Autoconf, and/or Libtool, or includes warning about timestamps in the
+Autoconf, and/or Libtool, or includes warnings about timestamps in the
 future, perhaps looking something like this::
 
    Warning: File `Makefile.am' has modification time 3.6e+04 s in the future

--- a/docs/installing-pmix/installation-location.rst
+++ b/docs/installing-pmix/installation-location.rst
@@ -109,7 +109,7 @@ Installing over a prior PMIx installation
 .. warning:: The PMIx team does not recommend installing a new
    version of PMIx over an existing / older installation of PMIx.
 
-In its default configuration, an PMIx installation consists of
+In its default configuration, a PMIx installation consists of
 several shared libraries, header files, executables, and plugins
 (dynamic shared objects |mdash| DSOs).  These installation files act
 together as a single entity.  The specific filenames and
@@ -152,7 +152,7 @@ upgrading your PMIx installation:
   the same installation prefix, and then run ``make uninstall``.  Or
   use one of the other methods, above.
 
-Relocating an PMIx installation
+Relocating a PMIx installation
 -------------------------------
 
 It can be desirable to initially install PMIx to one location
@@ -182,7 +182,7 @@ PMIx-based application.  For example, if PMIx had initially been installed to
 ``/home/pmix``, setting ``PMIX_PREFIX`` to ``/home/pmix`` will
 enable PMIx to function properly.
 
-"Stage" an PMIx installation in a temporary location
+"Stage" a PMIx installation in a temporary location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When *creating* self-contained installation packages, systems such as

--- a/docs/installing-pmix/packagers.rst
+++ b/docs/installing-pmix/packagers.rst
@@ -36,7 +36,7 @@ treatment of components that may be of interest to packagers:
    .. note:: See the descriptions of ``--enable-mca-dso`` and
              ``--enable-mca-static`` :ref:`in this section
              <label-building-installation-cli-options>` for more
-             details about how to change this defaults.
+             details about how to change these defaults.
 
 A side effect of these two defaults is that all the components
 included in the PMIx libraries will bring their dependencies with

--- a/docs/installing-pmix/quickstart.rst
+++ b/docs/installing-pmix/quickstart.rst
@@ -101,7 +101,7 @@ Note that VPATH builds are fully supported.  For example:
 
 Parallel builds are also supported (although some versions of ``make``,
 such as GNU make, will only use the first target listed on the command
-line when executable parallel builds).  For example (assume GNU make):
+line when executing parallel builds).  For example (assume GNU make):
 
 .. code-block:: sh
 
@@ -202,7 +202,7 @@ functionality.  Some of these libraries, such as `HWLOC
 a varying number of additional libraries (such as libpci or libudev).
 While PMIx's wrapper compiler will add the correct direct dependencies
 for third party packages, it will frequently not pull in the right
-sub-libraries.  When linking against dyanamic library versions of
+sub-libraries.  When linking against dynamic library versions of
 these dependencies, this is not a problem (and is preferred behavior
 to avoid adding unnecessary indirect linking dependencies).  However,
 this does cause problems for building entirely static versions of

--- a/docs/installing-pmix/vpath-builds.rst
+++ b/docs/installing-pmix/vpath-builds.rst
@@ -3,7 +3,7 @@
 VPATH builds
 ============
 
-VPATH build are fully supported. For example:
+VPATH builds are fully supported. For example:
 
 .. code-block:: sh
 

--- a/docs/man/man1/pmixcc.1.rst
+++ b/docs/man/man1/pmixcc.1.rst
@@ -86,7 +86,7 @@ Overview
 Translation of a PMIx-based program requires the linkage of the
 PMIx-specific libraries which may not reside in one of the standard
 search directories of ``ld(1)``. It also often requires the inclusion
-of header files what may also not be found in a standard location.
+of header files that may also not be found in a standard location.
 
 ``pmixcc`` passes its arguments to the underlying C compiler along with
 the ``-I``, ``-L`` and ``-l`` options required by PMIx-based programs.

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -38,7 +38,7 @@ If successful, the function will return ``PMIX_SUCCESS`` and will fill
 the provided structure with the server-assigned namespace and rank of
 the process within the application.
 
-Note that the PMIx client library is referenced counted, and so
+Note that the PMIx client library is reference counted, and so
 multiple calls to ``PMIx_Init`` are allowed. Thus, one way to obtain
 the namespace and rank of the process is to simply call ``PMIx_Init``
 with a non-NULL parameter.

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -42,7 +42,7 @@ customize include the following:
 
 * ``ptl``: PMIx Transport Layer; users may need to assist the
   messaging layer with selection of network interfaces and
-  controls parameters
+  control parameters
 * ``pmdl``: Programming Model and Library; identify environmental
   variables to be forwarded to application processes
 

--- a/docs/news/news-v1.x.rst
+++ b/docs/news/news-v1.x.rst
@@ -29,7 +29,7 @@ series, in reverse chronological order.
 - Replace stale PMIX_DECLSPEC with PMIX_EXPORT (PR #448)
 - Memory barrier fixes for thread shifting (PR #387)
 - Fix race condition in dmodex (PR #346)
-- Allow disable backward compatability for PMI-1/2 (PR #350)
+- Allow disable backward compatibility for PMI-1/2 (PR #350)
 - Fix segv in PMIx_server_deregister_nspace (PR #343)
 - Fix possible hang in PMIx_Abort (PR #339)
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -32,7 +32,7 @@ Compiler Notes
 
 * The Portland Group compilers prior to version 7.0 require the
   ``-Msignextend`` compiler flag to extend the sign bit when converting
-  from a shorter to longer integer.  This is is different than other
+  from a shorter to longer integer.  This is different than other
   compilers (such as GNU).  When compiling PMIx with the Portland
   compiler suite, the following flags should be passed to PMIx's
   configure script:

--- a/docs/release-notes/compilers.rst
+++ b/docs/release-notes/compilers.rst
@@ -32,11 +32,11 @@ Compiler Notes
   very little (if any) testing performed on IA64 platforms (with any
   compiler).  Support is "best effort" for these platforms, but it is
   doubtful that any effort will be expended to fix the Intel 9.1 /
-  10.0 compiler issuers on this platform.
+  10.0 compiler issues on this platform.
 
 * Early versions of the Intel 12.1 Linux compiler suite on x86_64 seem
   to have a bug that prevents PMIx from working.  Symptoms
-  including immediate segv of the wrapper compiler (``pmixcc``) and
+  include immediate segv of the wrapper compiler (``pmixcc``) and
   PMIx-based applications.  If you upgrade to the latest
   version of the Intel 12.1 Linux compiler suite, the problem will go
   away.

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -26,7 +26,7 @@ major, minor, release, and an optional quantifier.
 
 * Minor: The minor number is the second integer in the version
   string (e.g., v1.2.3). Changes in the minor number typically
-  indicate a incremental change in the code base and/or end-user
+  indicate an incremental change in the code base and/or end-user
   functionality. The minor number is always included in the version
   number:
 


### PR DESCRIPTION
Fix 34 spelling and grammar errors found across 26 documentation files.

Typo fixes:
- gnu-autotools.rst: 'Autootools' -> 'Autotools' in section heading
- quickstart.rst (installing-pmix): 'dyanamic' -> 'dynamic'
- sphinx.rst: '\$preix/share/man' -> '\$prefix/share/man'
- rst-for-markdown-expats.rst: 'parargraph' -> 'paragraph'
- compilers.rst (release-notes): 'issuers' -> 'issues'
- distances.rst: 'choose to user the latter' -> 'choose to use the latter'
- git-github.rst: 'shell\$ get fetch --all' -> 'shell\$ git fetch --all' (critical: this was a broken shell command example)
- git-github.rst: 'requires the user of a web proxy' -> 'requires the use of a web proxy'
- news-v1.x.rst: 'compatability' -> 'compatibility'
- group_construct.rst: 'two or mote collections' -> 'two or more collections'

Grammar fixes:
- release-notes.rst: 'This is is different' -> 'This is different' (duplicate word)
- gnu-autotools.rst: 'can be can be downloaded' -> 'can be downloaded' (duplicate phrase)
- compilers.rst (release-notes): 'Symptoms including' -> 'Symptoms include'
- quickstart.rst (installing-pmix): 'when executable parallel builds' ->
  'when executing parallel builds'
- vpath-builds.rst: 'VPATH build are' -> 'VPATH builds are'
- filesystem-requirements.rst: 'machine you on which you are building' ->
  'machine on which you are building'
- filesystem-requirements.rst: 'includes warning about' -> 'includes warnings about'
- source-code.rst: 'mixing declarations are allow allowable' ->
  'mixing of declarations is allowable' (duplicate word, restructured)
- PMIx_Init.3.rst: 'referenced counted' -> 'reference counted'
- pmixcc.1.rst: 'header files what may also' -> 'header files that may also'
- adding_datatypes.rst: 'could simple be' -> 'could simply be'
- mca.rst: 'controls parameters' -> 'control parameters'
- packagers.rst: 'how to change this defaults' -> 'how to change these defaults'
- runtime.rst: 'Force the building of for the Cray' ->
  'Force the building of support for the Cray'
- overview.rst (sets_groups): 'API\\'s' -> 'APIs' (apostrophe misused for plural, 2 instances)
- quickstart.rst (building-apps): spurious 'I' appended to 'an' at line end
- quickstart.rst (building-apps): missing space before 'that' after closing parenthesis

Article (a/an) errors:
- definitions.rst: 'expanding an PMIx' -> 'expanding a PMIx'
- gnu-autotools.rst: 'installing an PMIx distribution tarball' ->
  'installing a PMIx distribution tarball'
- installation-location.rst: 'an PMIx installation' -> 'a PMIx installation' (3 instances)
- installation.rst (configure-cli-options): 'build an PMIx' -> 'build a PMIx'
- versions.rst: 'indicate a incremental change' -> 'indicate an incremental change'

configure CLI option fixes:
- conventions.rst: word order: 'abort it if can't find' -> 'abort if it can't find'
- conventions.rst: 'PMIx will built support' -> 'PMIx will build support'"