### PR TITLE
Add unit test for compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,8 @@ test/sshot/server
 test/sshot/mytopo.json
 test/sshot/testcoord
 
+test/unit/compress
+
 test/util/numa
 test/util/convert
 

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,7 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[test/python/Makefile]
                 pmix_config_prefix[test/simple/Makefile]
                 pmix_config_prefix[test/sshot/Makefile]
+                pmix_config_prefix[test/unit/Makefile]
                 pmix_config_prefix[test/util/Makefile]
                 pmix_config_prefix[docs/Makefile]
                 pmix_config_prefix[maint/pmix.pc])

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -8,7 +8,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +80,8 @@ static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbyt
 
     /* get an upper bound on the required output storage */
     len = deflateBound(&strm, inlen);
+    // it's okay if this len > inlen because it includes
+    // working space for the compression library
     if (NULL == (tmp = (uint8_t *) malloc(len))) {
         (void) deflateEnd(&strm);
         return false;

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -8,7 +8,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +80,8 @@ static bool zlibng_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outb
 
     /* get an upper bound on the required output storage */
     len = zng_deflateBound(&strm, inlen);
+    // it's okay if this len > inlen because it includes
+    // working space for the compression library
     if (NULL == (tmp = (uint8_t *) malloc(len))) {
         (void) zng_deflateEnd(&strm);
         return false;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -27,7 +27,7 @@
 if !WANT_HIDDEN
 # these tests use internal symbols
 # use --disable-visibility
-SUBDIRS = simple sshot util
+SUBDIRS = simple sshot util unit
 
 if WANT_PYTHON_BINDINGS
 SUBDIRS += python

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_PROGRAMS = compress
+
+compress_SOURCES =  \
+        compress.c
+compress_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+compress_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+clean-local:
+	rm -f compress

--- a/test/unit/compress.c
+++ b/test/unit/compress.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023-2024 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_types.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/class/pmix_list.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
+
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+
+int main(int argc, char **argv)
+{
+    char **nodes = NULL, **nodesout;
+    char **procs = NULL, **procsout;
+    char *tmp, *regex, *ppn, *t1;
+    int n, rk;
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+
+    /* setup the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+        fprintf(stderr, "Init failed with error %s\n", PMIx_Error_string(rc));
+        return rc;
+    }
+
+    for (n=0; n < 10000; n++) {
+        pmix_asprintf(&tmp, "node%04d", n);
+        PMIx_Argv_append_nosize(&nodes, tmp);
+        free(tmp);
+    }
+    tmp = PMIx_Argv_join(nodes, ',');
+    PMIx_Argv_free(nodes);
+    PMIx_generate_regex(tmp, &regex);
+
+    // reverse it
+    rc = pmix_preg.parse_nodes(regex, &nodesout);
+    fprintf(stderr, "PARSE NODES %s\n", PMIx_Error_string(rc));
+    t1 = PMIx_Argv_join(nodesout, ',');
+    PMIx_Argv_free(nodesout);
+    if (0 == strcmp(t1, tmp)) {
+        fprintf(stderr, "NODES MATCH\n");
+    } else {
+        fprintf(stderr, "NODES ERROR\n");
+    }
+    free(tmp);
+    free(t1);
+
+    rk = 0;
+    for (n = 0; n < 10000; n++) {
+        // just do 2ppn
+        pmix_asprintf(&tmp, "%d,%d", rk, rk+1);
+        PMIx_Argv_append_nosize(&procs, tmp);
+        free(tmp);
+        rk += 2;
+    }
+    tmp = PMIx_Argv_join(procs, ',');
+    PMIx_Argv_free(procs);
+    PMIx_generate_ppn(tmp, &ppn);
+
+    rc = pmix_preg.parse_procs(ppn, &procsout);
+    fprintf(stderr, "PARSE PROCS %s\n", PMIx_Error_string(rc));
+    t1 = PMIx_Argv_join(procsout, ',');
+    PMIx_Argv_free(procsout);
+    if (0 == strcmp(t1, tmp)) {
+        fprintf(stderr, "PROCS MATCH\n");
+    } else {
+        fprintf(stderr, "PROCS ERROR\n");
+    }
+    free(tmp);
+    free(t1);
+
+    /* finalize the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_finalize())) {
+        fprintf(stderr, "Finalize failed with error %d\n", rc);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Add a new unit test directory and start with one to exercise the compression/regex support. Document that zlib and zlibng initial size computations are larger than needed due to including working space.