### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: brew install libevent hwloc autoconf automake libtool
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build OpenPMIx
@@ -71,7 +71,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build OpenPMIx
@@ -107,7 +107,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev python3 python3-pip
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Distcheck

--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -14,7 +14,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build OpenPMIx
@@ -24,7 +24,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/prrte

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install -y --no-install-recommends wget software-properties-common hwloc libhwloc-dev libevent-2.1-7 libevent-dev
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build PMIx
@@ -24,7 +24,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/prrte

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Build

--- a/.github/workflows/pmix_mpi4py.yaml
+++ b/.github/workflows/pmix_mpi4py.yaml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
 
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         clean: false
@@ -48,7 +48,7 @@ jobs:
         make install
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: openpmix/prrte
@@ -67,7 +67,7 @@ jobs:
         make install
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi
@@ -133,7 +133,7 @@ jobs:
               numpy cffi pyyaml
 
     - name: Checkout mpi4py
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository || 'mpi4py/mpi4py' }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -14,7 +14,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
     - name: Build OpenPMIx
@@ -24,7 +24,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/prrte

--- a/.github/workflows/python-bindings.yaml
+++ b/.github/workflows/python-bindings.yaml
@@ -39,7 +39,7 @@ jobs:
             python-version: "3.14"
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-python-bindings
         with:

--- a/.github/workflows/run-xversion.yml
+++ b/.github/workflows/run-xversion.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
 
     - name: Git clone PR
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             path: pr
@@ -35,7 +35,7 @@ jobs:
         make
 
     - name: Git clone branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix

--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,8 @@ test/sshot/server
 test/sshot/mytopo.json
 test/sshot/testcoord
 
+test/unit/compress
+
 test/util/numa
 test/util/convert
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md: Guidance for AI Contributors to PMIx
+
+This document is an orientation guide for AI coding agents and their human operators working in the PMIx (OpenPMIx) source tree.
+
+## Overview
+
+PMIx (Process Management Interface - Exascale) is an open-source reference implementation of the PMIx Standard, a low-level API used by resource managers and launchers to communicate with processes in high-performance computing environments.  It provides a framework through which programming models, tools, and runtime systems can exchange information without depending on a specific resource manager or job launcher.
+
+## Single-Layer Architecture
+
+Unlike multi-layer projects, PMIx has a single abstraction layer that generates one top-level shared library: **`libpmix`**.  All source lives under `src/` and is organized into functional subsystems:
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/class/` | C++-like "classes" built on the PMIx class system |
+| `src/client/` | Client-side PMIx API implementation |
+| `src/common/` | Code shared between client, server, and tool roles |
+| `src/event/` | Event-loop integration (libevent wrapper) |
+| `src/hwloc/` | Hardware locality (hwloc) integration |
+| `src/include/` | Top-level internal headers (e.g., `pmix_config.h`) |
+| `src/mca/` | MCA frameworks and components |
+| `src/runtime/` | Library startup and shutdown |
+| `src/server/` | Server-side PMIx API implementation |
+| `src/threads/` | Threading utilities and locks |
+| `src/tool/` | Tool-role support |
+| `src/tools/` | User-facing executables (`pmix_info`, etc.) |
+| `src/util/` | Miscellaneous utility code |
+
+The public C headers live under `include/` at the top level of the repository.
+
+## MCA: Modular Component Architecture
+
+PMIx uses plugins organized as **Framework → Component → Module**.  The MCA tree layout is strictly:
+
+```
+src/mca/FRAMEWORK/COMPONENT/
+```
+
+No directory under `src/mca/` may break this pattern (except `base/` subdirectories, which hold framework infrastructure, not components).
+
+### Frameworks
+
+| Framework | Description |
+|-----------|-------------|
+| `bfrops` | Buffer Operations — pack/unpack, copy, print, compare data types; multi-select (one component per wire format version) |
+| `gds` | Generalized DataStore — stores job-level and peer data; assign-on-demand per peer |
+| `pcompress` | Compression of large data objects |
+| `pdl` | Dynamic library (dlopen) abstraction |
+| `pgpu` | GPU resource discovery and support |
+| `pif` | Network interface discovery |
+| `pinstalldirs` | Installation directory resolution |
+| `plog` | Logging of user-provided alerts |
+| `pmdl` | Programming Model support — collects env-vars and parameters for MPI, OpenMP, etc. |
+| `pnet` | Network support and endpoint computation for "instant on" launch |
+| `preg` | Regular expression generator and parser; multi-select |
+| `prm` | Resource Manager translation of generic PMIx directives |
+| `psec` | Security operations (connection handshakes); multi-select |
+| `psensor` | Process monitoring, resource utilization, and health checks |
+| `psquash` | Internal integer squashing during transmission |
+| `pstat` | System statistics at process, node, and disk levels |
+| `ptl` | Transport Layer for client-server and tool-server communication; single-select |
+
+**Single-select vs. multi-select:** A single-select framework activates exactly one component at a time (`ptl` is an example).  A multi-select framework can have several components active simultaneously (`bfrops`, `preg`, `psec`).  Check the framework header comment before assuming which kind you are modifying.
+
+### Adding or Modifying Components
+
+1. Place new component code in `src/mca/FRAMEWORK/COMPONENT/`.
+2. Follow the existing naming convention: filenames use `framework_component_*` prefixes; public symbols use `pmix_framework_component_` prefixes.
+3. Register an `open`, `close`, and `query` function in the component struct.
+4. Wire the component into the build system via `Makefile.am` changes in the component directory.
+
+## Key Coding Rules
+
+**Include order:** `pmix_config.h` must be the very first `#include` in every C source file, before any system headers.
+
+**Prefix rule:** All internal symbols and filenames must carry the appropriate prefix to avoid namespace collisions:
+- Public API symbols: `PMIx_` (functions) / `PMIX_` (macros/types)
+- Internal library symbols: `pmix_`
+- Framework-scoped symbols: `pmix_FRAMEWORK_` (e.g., `pmix_ptl_`)
+- Component-scoped symbols: `pmix_FRAMEWORK_COMPONENT_` (e.g., `pmix_ptl_client_`)
+
+**Symbol visibility:** Use `PMIX_EXPORT` on any symbol that must be visible outside `libpmix.so`.  Do not mark internal symbols with `PMIX_EXPORT`.
+
+**Constant-on-left comparisons:** Always write `NULL == ptr` rather than `ptr == NULL`.  This turns typos (`=` instead of `==`) into compile errors.
+
+**Always brace blocks:** Use `{ }` around every conditional or loop body, even single-line ones.
+
+**Indentation:** 4 spaces, never tab characters.
+
+**Language standard:** C99 is required.  C++-style `//` comments are allowed and preferred.
+
+**No hand-editing of generated files:** Do not modify files produced by autotools (`configure`, `Makefile.in`, etc.), pre-rendered documentation, or third-party vendored code.
+
+## Building and Testing
+
+PMIx uses GNU Autotools.  From a clean clone:
+
+```sh
+./autogen.pl
+./configure --prefix=/path/to/install
+make -j$(nproc)
+make install
+```
+
+Run the test suite with:
+
+```sh
+make check
+```
+
+Inspect available MCA parameters for any component with:
+
+```sh
+pmix_info --param FRAMEWORK COMPONENT
+```
+
+## Performance Considerations
+
+PMIx is used in latency-critical paths during job launch and process management at scale.  Avoid adding heap allocations, lock acquisitions, or branches to hot paths without first measuring the impact.  Microseconds matter at the scale PMIx targets.
+
+## Contributing Requirements
+
+- Every commit **must** include a `Signed-off-by:` line (`git commit -s`).  Pull requests without it will not be accepted.
+- Write descriptive commit messages explaining *why* the change is made, not just what changed.
+- Update documentation under `docs/` for any user-visible behavior change.
+- Target the `master` branch for new development; use appropriate cherry-pick procedures for backports to release branches.
+- Open a pull request against [https://github.com/openpmix/openpmix](https://github.com/openpmix/openpmix).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,43 @@
-# AGENTS.md: Guidance for AI Contributors to PMIx
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: Guidance for AI and Human Contributors to PMIx
 
 This document is an orientation guide for AI coding agents and their human operators working in the PMIx (OpenPMIx) source tree.
+This file is an *orientation map*, not the
+full rulebook: the authoritative, human-maintained documentation lives
+under [`docs/developers/`](docs/developers/) and
+[`docs/contributing.rst`](docs/contributing.rst) (rendered at
+<https://docs.openpmix.org/>). When this file and those docs disagree,
+**the docs win** — and please fix this file.
+
+AI-assisted contributions are welcome. But PMIx runs on the largest
+supercomputers in the world and across a huge range of operating
+systems and hardware. We want careful, portable code — not
+plausible-looking code that solves one problem in one environment at the
+expense of others. Hold yourself to the same bar as a thoughtful human
+contributor.
 
 ## Overview
 
-PMIx (Process Management Interface - Exascale) is an open-source reference implementation of the PMIx Standard, a low-level API used by resource managers and launchers to communicate with processes in high-performance computing environments.  It provides a framework through which programming models, tools, and runtime systems can exchange information without depending on a specific resource manager or job launcher.
+PMIx (Process Management Interface - Exascale) is an open-source reference implementation of the PMIx Standard (see <https://pmix.org/standard>), a low-level API used by resource managers and launchers to communicate with processes in high-performance computing environments.  It provides a framework through which programming models, tools, and runtime systems can exchange information without depending on a specific resource manager or job launcher.
+
+Note that you will see **OpenPMIx** frequently referred to
+as just **PMIx**. While there is a separate PMIx Standard, there
+are (as of this writing) no alternative implementations of that
+Standard. In fact, the Standard post-dates the library by several
+years, and often lags behind the library in terms of new definitions.
+Thus, it is customary to refer to the library as just **PMIx** and
+drop the longer name - at least, until some other implementation
+arises (which many consider unlikely).
+
 
 ## Single-Layer Architecture
 
@@ -29,6 +62,19 @@ Unlike multi-layer projects, PMIx has a single abstraction layer that generates 
 The public C headers live under `include/` at the top level of the repository.
 
 ## MCA: Modular Component Architecture
+
+PMIx is built almost entirely out of MCA plugins.
+Read [`docs/developers/terminology.rst`](docs/developers/terminology.rst)
+and the MCA section it points to before doing real work. The hierarchy:
+
+- **Project** → **Framework** → **Component** → **Module** (runtime
+  instance, like a C++ object). Each level is isolated from its
+  siblings; a framework exposes a top-level header for its public API.
+- Example: `src/mca/preg/` is the PREG framework;
+  `src/mca/preg/raw/` is one component within it.
+- **MCA parameters** let users change behavior at run time (env var,
+  file, CLI). **Prefer adding an MCA parameter over hard-coding a
+  constant** — this is idiomatic and expected here.
 
 PMIx uses plugins organized as **Framework → Component → Module**.  The MCA tree layout is strictly:
 
@@ -69,7 +115,10 @@ No directory under `src/mca/` may break this pattern (except `base/` subdirector
 3. Register an `open`, `close`, and `query` function in the component struct.
 4. Wire the component into the build system via `Makefile.am` changes in the component directory.
 
-## Key Coding Rules
+## Golden rules (the things agents most often get wrong)
+
+From [`docs/developers/source-code.rst`](docs/developers/source-code.rst)
+and [`docs/contributing.rst`](docs/contributing.rst):
 
 **Include order:** `pmix_config.h` must be the very first `#include` in every C source file, before any system headers.
 
@@ -81,15 +130,36 @@ No directory under `src/mca/` may break this pattern (except `base/` subdirector
 
 **Symbol visibility:** Use `PMIX_EXPORT` on any symbol that must be visible outside `libpmix.so`.  Do not mark internal symbols with `PMIX_EXPORT`.
 
+**PMIx back-end code must never call public `PMIx_*()` APIs.** The
+  bindings are thin wrappers; call the internal `pmix_*` routines, not
+  the user-facing entry points.
+
+**New files need the standard copyright/license header.** Copy the
+  multi-institution BSD header block — including the `Copyright (c) 2026      Nanook Consulting  All rights reserved.
+  multi-institution BSD header block — including the `$COPYRIGHT$` and
+  `$HEADER$` tokens — from a neighboring file. If you substantially
+  change an existing file, add your copyright line to its block.
+
+**`#define` logical macros to `0` or `1`; never `#undef` them.** Test
+  with `#if FOO`, not `#ifdef FOO`, so a misspelling is a compiler
+  error, not a silent false.
+
 **Constant-on-left comparisons:** Always write `NULL == ptr` rather than `ptr == NULL`.  This turns typos (`=` instead of `==`) into compile errors.
 
 **Always brace blocks:** Use `{ }` around every conditional or loop body, even single-line ones.
 
 **Indentation:** 4 spaces, never tab characters.
 
-**Language standard:** C99 is required.  C++-style `//` comments are allowed and preferred.
+**Language standard:** C11 is required.  C++-style `//` comments are allowed and preferred.
 
-**No hand-editing of generated files:** Do not modify files produced by autotools (`configure`, `Makefile.in`, etc.), pre-rendered documentation, or third-party vendored code.
+**Stay compiler-warning-free.** PMIx strives to build with zero
+  compiler warnings. Do not attempt to introduce code that adds new warnings. Git checkouts
+  default to configure with `--enable-devel-check` - this instructs the compiler
+  to error out on all warnings, and to warn on everything (e.g., unused variables).
+  The CI checkers all operate with this option, so you won't pass CI if your
+  code is generating warnings.
+
+**No hand-editing of generated files:** Do not modify files produced by autotools (`configure`, `Makefile.in`, etc.), pre-rendered documentation, or third-party vendored code. Edit the source code instead.
 
 ## Building and Testing
 
@@ -114,9 +184,53 @@ Inspect available MCA parameters for any component with:
 pmix_info --param FRAMEWORK COMPONENT
 ```
 
+**"Did I break it?" — layered:**
+
+1. **Build cleanly.** A clean `make` after your change is the baseline.
+   PMIx is highly configurable at build time: many components,
+   source files, directories, and generated artifacts are selected or
+   omitted by `configure` and Automake based on the local environment.
+   For any change to code or documentation that might be conditionally
+   built, verify that your configured build is actually compiling or
+   generating the thing you changed; do not assume this can be checked
+   only by looking for `#if` blocks.
+2. **Documentation-only changes can be narrower.** If the change is
+   wholly under [`docs/`](docs/), it is often enough to configure with
+   Sphinx support and run `make` in the `docs/` build directory instead
+   of doing a full build, install, smoke test, or `make check`. Make
+   sure Sphinx was really enabled by `configure`; one practical check is
+   that `SPHINX_BUILD` in `config.status` names a valid executable, and
+   that the summary at the end of configure includes the line
+   "HTML docs and man pages: building and installing"
+3. **Quick smoke test.** After `make install`, change to the `test` directory
+   and run the test suite with:
+
+	```sh
+	make check
+	```
+
+	Then change to the `simple` directory below `test` and run:
+
+	```sh
+	./simptest
+	```
+
+**Add tests for new code.** Whenever practical, add unit tests under
+[`test/unit`](test/unit) that are wired into `make check` (and therefore run in
+CI). Prefer a `make check`-able test over a manual one-off so the
+coverage sticks and regressions are caught automatically.
+
+
 ## Performance Considerations
 
-PMIx is not generally used in latency-critical paths, but it is important that the code remain time-sensitive: PMIx can be used as a dependency by time-sensitive libraries, so unnecessary overhead is never acceptable.  Avoid adding heap allocations, lock acquisitions, or branches to hot paths without first measuring the impact.
+PMIx is not generally used in latency-critical paths, but it is important that the code remain time-sensitive: PMIx can be used as a dependency by time-sensitive libraries, so unnecessary overhead is never acceptable. Concrete rules for hot paths include:
+
+- **Don't add allocations, locks, or branches to the critical
+  hot paths** without a clear, measured justification.
+- **Guard debug output and expensive assertions behind
+  `PMIX_ENABLE_DEBUG`** so release builds pay nothing for them.
+- **Prefer an MCA parameter** to a hard-coded constant when a value
+  might need tuning per environment.
 
 ## Version Interoperability
 
@@ -130,10 +244,37 @@ PMIx is required to be interoperable across released versions.  A server built a
 **Adding new data types:**
 New data types may be introduced in new PMIx versions.  The `bfrops` framework is the correct place to add serialization/deserialization support for them.  Each `bfrops` component corresponds to a specific wire-format version; older components remain in the tree to support communication with older peers.  Do not modify the pack/unpack logic of an existing `bfrops` component in a way that changes its wire representation — create a new component (version) instead.
 
-## Contributing Requirements
+## Contributing
 
-- Every commit **must** include a `Signed-off-by:` line (`git commit -s`).  Pull requests without it will not be accepted.
-- Write descriptive commit messages explaining *why* the change is made, not just what changed.
-- Update documentation under `docs/` for any user-visible behavior change.
-- Target the `master` branch for new development; use appropriate cherry-pick procedures for backports to release branches.
-- Open a pull request against [https://github.com/openpmix/openpmix](https://github.com/openpmix/openpmix).
+Authoritative process:
+[`docs/contributing.rst`](docs/contributing.rst). Highlights agents must
+honor:
+
+- **Sign off every commit.** Each commit needs a `Signed-off-by:` line
+  per the Contributor's Declaration — use `git commit -s`. Commits
+  without it are not accepted. This applies to AI-assisted work too: the
+  human submitter certifies the contribution.
+- **Commit messages:** a short first line saying *what* changed, then a
+  body explaining *why*. PMIx does **not** use Conventional Commits
+  (`feat:`/`fix:` prefixes) — write prose. Don't add AI tooling
+  attribution. Wrap commit-message lines at around 75 characters.
+- **Branch flow:** land on `master` first via a GitHub pull request, then
+  cherry-pick to the relevant release branch(es) `vMAJOR.MINOR.x` with a
+  `(cherry picked from commit ...)` line at the end of the commit
+  message; use `git cherry-pick -x` to add it. Never commit features
+  directly to a release branch. See
+  [`docs/developers/git-github.rst`](docs/developers/git-github.rst).
+- **Update the docs and the news** when user-visible behavior
+  changes: RST under [`docs/`](docs/), and a release-notes entry under
+  [`docs/news/`](docs/news/)
+  (`news-vMAJOR.x.rst`).
+
+
+## When in doubt
+
+- Match the surrounding code's style and conventions — this is an old,
+  multi-author code base with established patterns.
+- Read any relevant [`docs/developers/`](docs/developers/) or
+  [`docs/how-things-work/`](docs/how-things-work/) page before
+  inventing a new pattern.
+- Ask on a GitHub issue for anything large before writing it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,19 @@ pmix_info --param FRAMEWORK COMPONENT
 
 ## Performance Considerations
 
-PMIx is used in latency-critical paths during job launch and process management at scale.  Avoid adding heap allocations, lock acquisitions, or branches to hot paths without first measuring the impact.  Microseconds matter at the scale PMIx targets.
+PMIx is not generally used in latency-critical paths, but it is important that the code remain time-sensitive: PMIx can be used as a dependency by time-sensitive libraries, so unnecessary overhead is never acceptable.  Avoid adding heap allocations, lock acquisitions, or branches to hot paths without first measuring the impact.
+
+## Version Interoperability
+
+PMIx is required to be interoperable across released versions.  A server built against one PMIx version must be able to communicate with a client built against a different version, whether older or newer.
+
+**Wire-format stability rules:**
+- The order and content of fields in any message must not change between versions.
+- New information may only be appended to the end of an existing message; nothing may be inserted, removed, or reordered.
+- Readers must tolerate trailing data they do not recognize (forward compatibility) and must not require fields that did not exist in older versions (backward compatibility).
+
+**Adding new data types:**
+New data types may be introduced in new PMIx versions.  The `bfrops` framework is the correct place to add serialization/deserialization support for them.  Each `bfrops` component corresponds to a specific wire-format version; older components remain in the tree to support communication with older peers.  Do not modify the pack/unpack logic of an existing `bfrops` component in a way that changes its wire representation — create a new component (version) instead.
 
 ## Contributing Requirements
 

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,7 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[test/python/Makefile]
                 pmix_config_prefix[test/simple/Makefile]
                 pmix_config_prefix[test/sshot/Makefile]
+                pmix_config_prefix[test/unit/Makefile]
                 pmix_config_prefix[test/util/Makefile]
                 pmix_config_prefix[docs/Makefile]
                 pmix_config_prefix[maint/pmix.pc])

--- a/docs/building-apps/quickstart.rst
+++ b/docs/building-apps/quickstart.rst
@@ -14,7 +14,7 @@ probably work in many environments.
    Please consult the other sections in this chapter for more details,
    if necessary.
 
-PMIx provides a "wrapper" compiler (```pmixcc`` <man1-pmixcc>`)that can be used for
+PMIx provides a "wrapper" compiler (```pmixcc`` <man1-pmixcc>`) that can be used for
 compiling PMIx-based applications. The intent is that users can simply invoke the
 PMIx wrapper compiler instead of their usual language compiler (e.g., ``gcc``).
 For example, instead of invoking your usual C compiler to build your
@@ -29,7 +29,7 @@ All the wrapper compiler does is add a variety of compiler and linker
 flags to the command line and then invoke a back-end compiler.  To be
 specific: the wrapper compilers do not parse source code at all; they
 are solely command-line manipulators, and have nothing to do with the
-actual compilation or linking of programs.  The end result is anI
+actual compilation or linking of programs.  The end result is an
 executable that is properly linked to all the relevant libraries.
 
 .. caution:: It is *absolutely not sufficient* to simply add ``-lpmix``

--- a/docs/developers/git-github.rst
+++ b/docs/developers/git-github.rst
@@ -18,7 +18,7 @@ PMIx's Git repository is `hosted at GitHub
       shell$ git clone --recursive https://github.com/openpmix/openpmix.git
 
 Note that Git is natively capable of using many forms of web
-proxies. If your network setup requires the user of a web proxy,
+proxies. If your network setup requires the use of a web proxy,
 `consult the Git documentation for more details
 <https://git-scm.com/>`_.
 
@@ -100,7 +100,7 @@ commit hash ``123abc``:
 .. code:: sh
 
    # Fetch all upstream git activity, including the merge of the "master" PR.
-   shell$ get fetch --all
+   shell$ git fetch --all
 
    # Check out the target release branch, and advance to the most recent commit.
    shell$ git checkout v5.0.x

--- a/docs/developers/gnu-autotools.rst
+++ b/docs/developers/gnu-autotools.rst
@@ -1,6 +1,6 @@
 .. _developers-installing-autotools-label:
 
-Manually installing the GNU Autootools
+Manually installing the GNU Autotools
 ======================================
 
 There is enough detail in building the GNU Autotools that it warrants
@@ -8,7 +8,7 @@ its own section.
 
 .. note:: As noted above, you only need to read/care about this
           section if you are building PMIx from a Git clone.  End
-          users installing an PMIx distribution tarball do *not*
+          users installing a PMIx distribution tarball do *not*
           need to have the GNU Autotools installed.
 
 Use a package manager
@@ -114,7 +114,7 @@ Installing the GNU Autotools from source
           Autotools manually if you can't use your operating system
           packaging system to install them for you.
 
-The GNU Autotools sources can be can be downloaded from:
+The GNU Autotools sources can be downloaded from:
 
 * https://ftp.gnu.org/gnu/autoconf/
 * https://ftp.gnu.org/gnu/automake/

--- a/docs/developers/rst-for-markdown-expats.rst
+++ b/docs/developers/rst-for-markdown-expats.rst
@@ -152,7 +152,7 @@ Multi-line code/fixed-width font
     case, the example code block will be rendered in the bulleted
     item.
 
-Whereas this parargraph and code block will be outside of the
+Whereas this paragraph and code block will be outside of the
 above bulleted list:
 
 .. code-block:: sh

--- a/docs/developers/source-code.rst
+++ b/docs/developers/source-code.rst
@@ -50,7 +50,7 @@ C / C++
 * PMIx requires a C99-compliant compiler.
 
   * C++-style comments are now allowed (and preferred).
-  * C99-style mixing declarations are allow allowable (and preferred).
+  * C99-style mixing of declarations is allowable (and preferred).
 
 * **ALWAYS** include ``pmix_config.h`` as your first #include file.
   There are very, very few cases where

--- a/docs/developers/sphinx.rst
+++ b/docs/developers/sphinx.rst
@@ -226,7 +226,7 @@ after running ``make install``:
 
       shell$ open $prefix/share/doc/pmix/html/index.html
 
-#. The man pages are installed (by default) to ``$preix/share/man``.
+#. The man pages are installed (by default) to ``$prefix/share/man``.
    If your man page search path includes this location, you can invoke
    commands similar to the following to see the same content that you
    see in these HTML pages:

--- a/docs/how-things-work/adding_datatypes.rst
+++ b/docs/how-things-work/adding_datatypes.rst
@@ -18,7 +18,7 @@ The datatype definition includes four pieces:
 
 Definition of the struct itself
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Almost all datatypes are structures of some kind, though that is not a requirement - a new datatype could simple be an abstraction over a standard C datatype (e.g., declaring something to represent a ``uint32_t``). Structures are required to be formatted as follows:
+Almost all datatypes are structures of some kind, though that is not a requirement - a new datatype could simply be an abstraction over a standard C datatype (e.g., declaring something to represent a ``uint32_t``). Structures are required to be formatted as follows:
 
 .. code-block:: c
 

--- a/docs/how-things-work/distances.rst
+++ b/docs/how-things-work/distances.rst
@@ -2,7 +2,7 @@
 Distance Computation
 ====================
 
-For performance purposes, users would prefer that their application processes utilize devices (e.g., fabric interfaces and GPUs) that are "close" to the location where each process is bound. The term "close" here is defined in terms of communication delay - i.e., the time required for a byte of data to be transferred between the process and the device. As the question relates solely to the selection of one device from several candidates, it is only the relative distance that matters. Thus, the application and/or user simply seeks to know (for example) if a given device is twice as far away as another similar device so that it can choose to user the latter.
+For performance purposes, users would prefer that their application processes utilize devices (e.g., fabric interfaces and GPUs) that are "close" to the location where each process is bound. The term "close" here is defined in terms of communication delay - i.e., the time required for a byte of data to be transferred between the process and the device. As the question relates solely to the selection of one device from several candidates, it is only the relative distance that matters. Thus, the application and/or user simply seeks to know (for example) if a given device is twice as far away as another similar device so that it can choose to use the latter.
 
 
 Here is a pic of one topology:

--- a/docs/how-things-work/sets_groups/group_construct.rst
+++ b/docs/how-things-work/sets_groups/group_construct.rst
@@ -28,7 +28,7 @@ In contrast,
 the *bootstrap* method is a somewhat more dynamic form of the operation
 that assumes each leader only knows the number of group leaders,
 but does not know their process IDs. This is commonly the case when
-two or mote collections of processes wish to join together (e.g., in an
+two or more collections of processes wish to join together (e.g., in an
 MPI connect/accept operation), but only the "root" processes
 know of each other. In such cases, each root process typically knows the
 process ID of all processes in its collection, but only the root

--- a/docs/how-things-work/sets_groups/overview.rst
+++ b/docs/how-things-work/sets_groups/overview.rst
@@ -42,11 +42,11 @@ Process *sets* differ from process *groups* in several key ways:
 * Process *sets* have no implied relationship between their members - i.e., a process in a process set has no concept of a ``pset rank`` as it would in a process *group*.
 
     * Process *set* identifiers are set by the host environment or by the user at time of application submission for execution -
-      there are no PMIx client API's provided by which an application can define a process set or change a process set membership.
+      there are no PMIx client APIs provided by which an application can define a process set or change a process set membership.
       In contrast, PMIx process *groups* can only be defined dynamically by the application.
 
     * Process *sets* are immutable - members cannot be added or removed once the set has been defined. In contrast, PMIx process *groups* can dynamically
-      change their membership using the appropriate API's.
+      change their membership using the appropriate APIs.
 
     * Process *groups* can be used in calls to PMIx operations. Members of process *groups* that are involved in an operation are translated by their
       PMIx library into their *native* identifier prior to the operation being passed to the host environment. For example, an application can define a

--- a/docs/installing-pmix/configure-cli-options/conventions.rst
+++ b/docs/installing-pmix/configure-cli-options/conventions.rst
@@ -6,7 +6,7 @@
 ``configure`` will, by default, search for header files and/or
 libraries for various optional features (e.g., various network
 support libraries).  If the relevant files are found, PMIx
-will built support for that feature.  If they are not found, PMIx
+will build support for that feature.  If they are not found, PMIx
 will skip building support for that feature.
 
 However, if you specify ``--with-FOO`` (where ``FOO`` is the
@@ -17,7 +17,7 @@ feature that was specifically requested, and will therefore abort so
 that a human can resolve out the issue.
 
 .. note:: Using ``--with-FOO`` to force PMIx's ``configure``
-          script to abort it if can't find support for a given feature
+          script to abort if it can't find support for a given feature
           may be preferable to unexpectedly discovering at run-time
           that PMIx is missing support for a critical feature.
 

--- a/docs/installing-pmix/configure-cli-options/installation.rst
+++ b/docs/installing-pmix/configure-cli-options/installation.rst
@@ -297,7 +297,7 @@ be used with ``configure``:
   the FOO components failing to load because ``libFOO.so`` is not
   available on their systems.
 
-  Conversely, system administrators tend to build an PMIx that is
+  Conversely, system administrators tend to build a PMIx that is
   targeted at their specific environment, and contains few (if any)
   components that are not needed.  In such cases, they might want
   their users to be warned that the FOO network components failed to

--- a/docs/installing-pmix/configure-cli-options/runtime.rst
+++ b/docs/installing-pmix/configure-cli-options/runtime.rst
@@ -7,7 +7,7 @@ The following are command line options for various runtime systems that
 can be used with ``configure``:
 
 * ``--with-alps``:
-  Force the building of for the Cray Alps run-time environment.  If
+  Force the building of support for the Cray Alps run-time environment.  If
   Alps support cannot be found, configure will abort.
 
 * ``--with-lsf=DIR``:

--- a/docs/installing-pmix/definitions.rst
+++ b/docs/installing-pmix/definitions.rst
@@ -2,7 +2,7 @@ Definitions
 ===========
 
 * **Source tree:** The tree where the PMIx source code is located.
-  It is typically the result of expanding an PMIx distribution
+  It is typically the result of expanding a PMIx distribution
   source code bundle, such as a tarball.
 * **Build tree:** The tree where PMIx was built.  It is always
   related to a specific source tree, but may actually be a different

--- a/docs/installing-pmix/filesystem-requirements.rst
+++ b/docs/installing-pmix/filesystem-requirements.rst
@@ -4,12 +4,12 @@ Filesystem requirements
 .. _install-filesystem-timestamp-warning-label:
 
 .. warning:: If you are building PMIx on a network filesystem, the
-   machine you on which you are building *must* be time-synchronized
+   machine on which you are building *must* be time-synchronized
    with the file server.
 
 Specifically: PMIx's build system *requires* accurate filesystem
 timestamps.  If your ``make`` output shows that it ran GNU Automake,
-Autoconf, and/or Libtool, or includes warning about timestamps in the
+Autoconf, and/or Libtool, or includes warnings about timestamps in the
 future, perhaps looking something like this::
 
    Warning: File `Makefile.am' has modification time 3.6e+04 s in the future

--- a/docs/installing-pmix/installation-location.rst
+++ b/docs/installing-pmix/installation-location.rst
@@ -109,7 +109,7 @@ Installing over a prior PMIx installation
 .. warning:: The PMIx team does not recommend installing a new
    version of PMIx over an existing / older installation of PMIx.
 
-In its default configuration, an PMIx installation consists of
+In its default configuration, a PMIx installation consists of
 several shared libraries, header files, executables, and plugins
 (dynamic shared objects |mdash| DSOs).  These installation files act
 together as a single entity.  The specific filenames and
@@ -152,7 +152,7 @@ upgrading your PMIx installation:
   the same installation prefix, and then run ``make uninstall``.  Or
   use one of the other methods, above.
 
-Relocating an PMIx installation
+Relocating a PMIx installation
 -------------------------------
 
 It can be desirable to initially install PMIx to one location
@@ -182,7 +182,7 @@ PMIx-based application.  For example, if PMIx had initially been installed to
 ``/home/pmix``, setting ``PMIX_PREFIX`` to ``/home/pmix`` will
 enable PMIx to function properly.
 
-"Stage" an PMIx installation in a temporary location
+"Stage" a PMIx installation in a temporary location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When *creating* self-contained installation packages, systems such as

--- a/docs/installing-pmix/packagers.rst
+++ b/docs/installing-pmix/packagers.rst
@@ -36,7 +36,7 @@ treatment of components that may be of interest to packagers:
    .. note:: See the descriptions of ``--enable-mca-dso`` and
              ``--enable-mca-static`` :ref:`in this section
              <label-building-installation-cli-options>` for more
-             details about how to change this defaults.
+             details about how to change these defaults.
 
 A side effect of these two defaults is that all the components
 included in the PMIx libraries will bring their dependencies with

--- a/docs/installing-pmix/quickstart.rst
+++ b/docs/installing-pmix/quickstart.rst
@@ -101,7 +101,7 @@ Note that VPATH builds are fully supported.  For example:
 
 Parallel builds are also supported (although some versions of ``make``,
 such as GNU make, will only use the first target listed on the command
-line when executable parallel builds).  For example (assume GNU make):
+line when executing parallel builds).  For example (assume GNU make):
 
 .. code-block:: sh
 
@@ -202,7 +202,7 @@ functionality.  Some of these libraries, such as `HWLOC
 a varying number of additional libraries (such as libpci or libudev).
 While PMIx's wrapper compiler will add the correct direct dependencies
 for third party packages, it will frequently not pull in the right
-sub-libraries.  When linking against dyanamic library versions of
+sub-libraries.  When linking against dynamic library versions of
 these dependencies, this is not a problem (and is preferred behavior
 to avoid adding unnecessary indirect linking dependencies).  However,
 this does cause problems for building entirely static versions of

--- a/docs/installing-pmix/vpath-builds.rst
+++ b/docs/installing-pmix/vpath-builds.rst
@@ -3,7 +3,7 @@
 VPATH builds
 ============
 
-VPATH build are fully supported. For example:
+VPATH builds are fully supported. For example:
 
 .. code-block:: sh
 

--- a/docs/man/man1/pmixcc.1.rst
+++ b/docs/man/man1/pmixcc.1.rst
@@ -86,7 +86,7 @@ Overview
 Translation of a PMIx-based program requires the linkage of the
 PMIx-specific libraries which may not reside in one of the standard
 search directories of ``ld(1)``. It also often requires the inclusion
-of header files what may also not be found in a standard location.
+of header files that may also not be found in a standard location.
 
 ``pmixcc`` passes its arguments to the underlying C compiler along with
 the ``-I``, ``-L`` and ``-l`` options required by PMIx-based programs.

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -38,7 +38,7 @@ If successful, the function will return ``PMIX_SUCCESS`` and will fill
 the provided structure with the server-assigned namespace and rank of
 the process within the application.
 
-Note that the PMIx client library is referenced counted, and so
+Note that the PMIx client library is reference counted, and so
 multiple calls to ``PMIx_Init`` are allowed. Thus, one way to obtain
 the namespace and rank of the process is to simply call ``PMIx_Init``
 with a non-NULL parameter.

--- a/docs/mca.rst
+++ b/docs/mca.rst
@@ -42,7 +42,7 @@ customize include the following:
 
 * ``ptl``: PMIx Transport Layer; users may need to assist the
   messaging layer with selection of network interfaces and
-  controls parameters
+  control parameters
 * ``pmdl``: Programming Model and Library; identify environmental
   variables to be forwarded to application processes
 

--- a/docs/news/news-v1.x.rst
+++ b/docs/news/news-v1.x.rst
@@ -29,7 +29,7 @@ series, in reverse chronological order.
 - Replace stale PMIX_DECLSPEC with PMIX_EXPORT (PR #448)
 - Memory barrier fixes for thread shifting (PR #387)
 - Fix race condition in dmodex (PR #346)
-- Allow disable backward compatability for PMI-1/2 (PR #350)
+- Allow disable backward compatibility for PMI-1/2 (PR #350)
 - Fix segv in PMIx_server_deregister_nspace (PR #343)
 - Fix possible hang in PMIx_Abort (PR #339)
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -32,7 +32,7 @@ Compiler Notes
 
 * The Portland Group compilers prior to version 7.0 require the
   ``-Msignextend`` compiler flag to extend the sign bit when converting
-  from a shorter to longer integer.  This is is different than other
+  from a shorter to longer integer.  This is different than other
   compilers (such as GNU).  When compiling PMIx with the Portland
   compiler suite, the following flags should be passed to PMIx's
   configure script:

--- a/docs/release-notes/compilers.rst
+++ b/docs/release-notes/compilers.rst
@@ -32,11 +32,11 @@ Compiler Notes
   very little (if any) testing performed on IA64 platforms (with any
   compiler).  Support is "best effort" for these platforms, but it is
   doubtful that any effort will be expended to fix the Intel 9.1 /
-  10.0 compiler issuers on this platform.
+  10.0 compiler issues on this platform.
 
 * Early versions of the Intel 12.1 Linux compiler suite on x86_64 seem
   to have a bug that prevents PMIx from working.  Symptoms
-  including immediate segv of the wrapper compiler (``pmixcc``) and
+  include immediate segv of the wrapper compiler (``pmixcc``) and
   PMIx-based applications.  If you upgrade to the latest
   version of the Intel 12.1 Linux compiler suite, the problem will go
   away.

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -26,7 +26,7 @@ major, minor, release, and an optional quantifier.
 
 * Minor: The minor number is the second integer in the version
   string (e.g., v1.2.3). Changes in the minor number typically
-  indicate a incremental change in the code base and/or end-user
+  indicate an incremental change in the code base and/or end-user
   functionality. The minor number is always included in the version
   number:
 

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -173,7 +173,6 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     do {                                                                                           \
         pmix_output_verbose(1, pmix_client_globals.iof_output,                                     \
                              "defining endpt: file %s line %d fd %d", __FILE__, __LINE__, (fid));  \
-        PMIX_CONSTRUCT((snk), pmix_iof_sink_t);                                                    \
         pmix_strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);                            \
         (snk)->name.rank = (nm)->rank;                                                             \
         (snk)->tag = (tg);                                                                         \

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -61,6 +61,10 @@ static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         status = rc;
     }
 
+    if (PMIX_ERR_NOT_AVAILABLE == status) {
+        /* call down to process the request */
+        status = pmix_plog.log(cd->proc, cd->info, cd->ninfo, cd->directives, cd->ndirs);
+    }
     if (NULL != cd->cbfunc.opcbfn) {
         cd->cbfunc.opcbfn(status, cd->cbdata);
     }
@@ -201,12 +205,16 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
             goto local;
         }
-        PMIX_PROC_FREE(source, 1); // don't need this value
 
         // otherwise, we send to our server
         cd = PMIX_NEW(pmix_shift_caddy_t);
+        cd->info = (pmix_info_t*)data;
+        cd->ninfo = ndata;
+        cd->directives = (pmix_info_t*)directives;
+        cd->ndirs = ndirs;
         cd->cbfunc.opcbfn = cbfunc;
         cd->cbdata = cbdata;
+        cd->proc = source;
         msg = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
         if (PMIX_SUCCESS != rc) {

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -8,7 +8,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +80,8 @@ static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbyt
 
     /* get an upper bound on the required output storage */
     len = deflateBound(&strm, inlen);
+    // it's okay if this len > inlen because it includes
+    // working space for the compression library
     if (NULL == (tmp = (uint8_t *) malloc(len))) {
         (void) deflateEnd(&strm);
         return false;

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -8,7 +8,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +80,8 @@ static bool zlibng_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outb
 
     /* get an upper bound on the required output storage */
     len = zng_deflateBound(&strm, inlen);
+    // it's okay if this len > inlen because it includes
+    // working space for the compression library
     if (NULL == (tmp = (uint8_t *) malloc(len))) {
         (void) zng_deflateEnd(&strm);
         return false;

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -137,30 +137,40 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
                                 "%s: plog:stdfd delivering to stderr for source %s",
                                 PMIX_NAME_PRINT(&pmix_globals.myid),
                                 (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            p = PMIX_NEW(pmix_iof_deliver_t);
-            PMIX_XFER_PROCID(&p->source, source);
-            p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-            p->bo.bytes = (char*)malloc(p->bo.size);
-            memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-            rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDERR_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(p);
+            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+                fprintf(stderr, "%s", data[n].value.data.string);
+            } else {
+                p = PMIX_NEW(pmix_iof_deliver_t);
+                PMIX_XFER_PROCID(&p->source, source);
+                p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
+                p->bo.bytes = (char*)malloc(p->bo.size);
+                memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
+                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDERR_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(p);
+                }
             }
         } else if (0 == strncmp(data[n].key, PMIX_LOG_STDOUT, PMIX_MAX_KEYLEN)) {
             pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                                 "%s: plog:stdfd delivering to stdout for source %s",
                                 PMIX_NAME_PRINT(&pmix_globals.myid),
                                 (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            p = PMIX_NEW(pmix_iof_deliver_t);
-            PMIX_XFER_PROCID(&p->source, source);
-            p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-            p->bo.bytes = (char*)malloc(p->bo.size);
-            memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-            rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDOUT_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(p);
+            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+                fprintf(stdout, "%s", data[n].value.data.string);
+            } else {
+                p = PMIX_NEW(pmix_iof_deliver_t);
+                PMIX_XFER_PROCID(&p->source, source);
+                p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
+                p->bo.bytes = (char*)malloc(p->bo.size);
+                memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
+                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDOUT_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(p);
+                }
             }
         }
     }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -62,6 +62,7 @@
 
 #include "src/client/pmix_client_ops.h"
 #include "src/common/pmix_attributes.h"
+#include "src/common/pmix_iof.h"
 #include "src/event/pmix_event.h"
 
 #include "src/runtime/pmix_progress_threads.h"
@@ -316,7 +317,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
         pmix_globals.evauxbase = pmix_globals.evbase;
     }
 
-    /* setup the globals structure */
+    /* setup the globals structures */
     pmix_globals.pid = getpid();
     PMIX_LOAD_PROCID(&pmix_globals.myid, NULL, PMIX_RANK_INVALID);
 
@@ -337,7 +338,11 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                           pmix_globals.event_eviction_time, _notification_eviction_cbfunc);
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_globals.keyindex, pmix_keyindex_t);
+    // construct client globals structures
     PMIX_CONSTRUCT(&pmix_client_globals.groups, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_client_globals.iof_stdout, pmix_iof_sink_t);
+    PMIX_CONSTRUCT(&pmix_client_globals.iof_stderr, pmix_iof_sink_t);
+
     /* need to hold off checking the hotel init return code
      * until after we construct all the globals so they can
      * correctly finalize */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -788,14 +788,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* add it to the end of the list of recvs */
     pmix_list_append(&pmix_ptl_base.posted_recvs, &req->super);
 
-    /* if we are a gateway, setup our IOF events */
-    if (PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
-        /* setup IOF */
-        PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stdout, &pmix_globals.myid, 1,
-                             PMIX_FWD_STDOUT_CHANNEL, pmix_iof_write_handler);
-        PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stderr, &pmix_globals.myid, 2,
-                             PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
-    }
+    /* setup our IOF sinks */
+    PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stdout, &pmix_globals.myid, 1,
+                         PMIX_FWD_STDOUT_CHANNEL, pmix_iof_write_handler);
+    PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stderr, &pmix_globals.myid, 2,
+                         PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* register our attributes */
     if (PMIX_SUCCESS != (rc = pmix_register_server_attrs())) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1548,13 +1548,13 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
                                  cd->directives, cd->ndirs,
                                  localcbfn, (void *) cd);
         } else {
-            // no choice but to process locally
-            goto local;
+            // tell the client that we cannot do this
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_NOT_AVAILABLE;
         }
         return PMIX_SUCCESS;
     }
 
-local:
     /* pass it down */
     pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                         "pmix:server processing locally");

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -27,7 +27,7 @@
 if !WANT_HIDDEN
 # these tests use internal symbols
 # use --disable-visibility
-SUBDIRS = simple sshot util
+SUBDIRS = simple sshot util unit
 
 if WANT_PYTHON_BINDINGS
 SUBDIRS += python

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_PROGRAMS = compress
+
+compress_SOURCES =  \
+        compress.c
+compress_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+compress_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+clean-local:
+	rm -f compress

--- a/test/unit/compress.c
+++ b/test/unit/compress.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2023-2024 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_types.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/class/pmix_list.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
+
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+
+int main(int argc, char **argv)
+{
+    char **nodes = NULL, **nodesout;
+    char **procs = NULL, **procsout;
+    char *tmp, *regex, *ppn, *t1;
+    int n, rk;
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+
+    /* setup the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+        fprintf(stderr, "Init failed with error %s\n", PMIx_Error_string(rc));
+        return rc;
+    }
+
+    for (n=0; n < 10000; n++) {
+        pmix_asprintf(&tmp, "node%04d", n);
+        PMIx_Argv_append_nosize(&nodes, tmp);
+        free(tmp);
+    }
+    tmp = PMIx_Argv_join(nodes, ',');
+    PMIx_Argv_free(nodes);
+    PMIx_generate_regex(tmp, &regex);
+
+    // reverse it
+    rc = pmix_preg.parse_nodes(regex, &nodesout);
+    fprintf(stderr, "PARSE NODES %s\n", PMIx_Error_string(rc));
+    t1 = PMIx_Argv_join(nodesout, ',');
+    PMIx_Argv_free(nodesout);
+    if (0 == strcmp(t1, tmp)) {
+        fprintf(stderr, "NODES MATCH\n");
+    } else {
+        fprintf(stderr, "NODES ERROR\n");
+    }
+    free(tmp);
+    free(t1);
+
+    rk = 0;
+    for (n = 0; n < 10000; n++) {
+        // just do 2ppn
+        pmix_asprintf(&tmp, "%d,%d", rk, rk+1);
+        PMIx_Argv_append_nosize(&procs, tmp);
+        free(tmp);
+        rk += 2;
+    }
+    tmp = PMIx_Argv_join(procs, ',');
+    PMIx_Argv_free(procs);
+    PMIx_generate_ppn(tmp, &ppn);
+
+    rc = pmix_preg.parse_procs(ppn, &procsout);
+    fprintf(stderr, "PARSE PROCS %s\n", PMIx_Error_string(rc));
+    t1 = PMIx_Argv_join(procsout, ',');
+    PMIx_Argv_free(procsout);
+    if (0 == strcmp(t1, tmp)) {
+        fprintf(stderr, "PROCS MATCH\n");
+    } else {
+        fprintf(stderr, "PROCS ERROR\n");
+    }
+    free(tmp);
+    free(t1);
+
+    /* finalize the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_finalize())) {
+        fprintf(stderr, "Finalize failed with error %d\n", rc);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
[Bump actions/checkout to v6](https://github.com/openpmix/openpmix/commit/79fd438c6f7cad7499c9ca50cf1c330dfff3c0f6)

Node 20 will be deprecated in June, actions/checkout@6 uses Node 24.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2ddbf91567b63a222ef929769f514a1d35cd16ae)

[Handle case of no log support](https://github.com/openpmix/openpmix/commit/92f6a85c82ee7d0e3e20e6aeb3fa34f0a62e216a)

If the PMIx server daemon's host does not offer a
log upcall and is not a gateway, then the server
daemon has no way of processing the request. Notify
the client that the service is not available and have
the client try to perform the request itself.

Always setup the IOF sinks to avoid problems with
hosts that do not expose a log upcall function.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/2978c48b0f7d714691f83703d4e516dd9943e10c)

[docs: fix spelling and grammar errors across documentation](https://github.com/openpmix/openpmix/commit/7436d5d86d647bb90904b657b24760c39c97f55c)

Fix 34 spelling and grammar errors found across 26 documentation files.

Signed-off-by: Ralph <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/fd4226aa577e911aece8bd793e4c7ed4c2fbf494)

[Add unit test for compression](https://github.com/openpmix/openpmix/commit/5625a60b49d9dc612908e25dff92b5de420054a9)

Add a new unit test directory and start with one to exercise
the compression/regex support. Document that zlib and zlibng
initial size computations are larger than needed due to
including working space.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/45b1f2859ff79f2c175cbcdd16bfdbd532da9d6e)

[Add AGENTS.md to guide AI contributors](https://github.com/openpmix/openpmix/commit/dae0529e0ba285d873a864aeb9848261899ec2e9)

Provides orientation for AI coding agents working in the PMIx source
tree: project overview, single-layer architecture layout, MCA framework
table with all 16 frameworks, coding rules, build instructions, and
contributing requirements.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Ralph <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/8126b061682d9933fa5d07e38316f1084d141160)

[AGENTS.md: correct performance note and add version interoperability …](https://github.com/openpmix/openpmix/commit/becaecd014210cf7e11dbb0ecae163612f0185b9)

…section

The previous "Performance Considerations" section incorrectly stated that
PMIx is used in latency-critical paths. PMIx is not generally
latency-critical itself, but must remain time-sensitive because it can be
a dependency of time-sensitive libraries.

The new "Version Interoperability" section documents the wire-format
compatibility rules that AI contributors must follow:
- Message field order and content must not change between versions.
- New data may only be appended to the end of a message.
- Readers must handle both forward and backward compatibility.
- New data types belong in new bfrops components; existing components
  must not have their wire representation changed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Ralph <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/84cbc96d530e56bd0be6d52e6166e5cc8951d133)

[Add more language to AGENTS.md](https://github.com/openpmix/openpmix/commit/7d4ad2c26d2a00325eb41eaef188349a4d20ebd3)

Provide more specifics on the golden rules - e.g., copyright notices,
logical macro usage, warning-free code. Update C99 required to C11.
Add "did I break it" section.

Signed-off-by: Ralph <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/openpmix/commit/bbc2c5232a5f9365cfeb1b26ea9db759349df4e3)
