### PR TITLE
Document proper build system regeneration workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,35 @@ Inspect available MCA parameters for any component with:
 pmix_info --param FRAMEWORK COMPONENT
 ```
 
+## Modifying the configure / build system
+
+Editing the build system means regenerating it — `make` alone can't,
+and trying will wedge the tree. If you change `configure.ac` or any
+`config/*.m4` file (including the embedded oac/Autotools macros), the
+change does not take effect until the build system is regenerated. Do
+not rely on a plain `make`: PMIx builds in maintainer mode, so
+`make` auto-triggers a partial in-tree Autotools regeneration that
+frequently fails (e.g., unexpanded `OAC_*` macros, `config.status`
+errors) and can leave the tree half-regenerated and
+unbuildable. Instead, regenerate and reconfigure explicitly:
+
+```sh
+./autogen.pl
+./configure <same options as the original configure>
+make -j
+```
+
+Recover the original configure invocation options from the existing
+tree with `./config.status --config` (or read the header of
+`config.log`). This process is slow but mandatory after any
+build-system source change — there is no safe shortcut.
+
+Note that editing `Makefile.am` files do *not* require the full
+`autogen.pl` + `./configure` process.  A simple `make` will regenerate
+the relevant `Makefile[.in]` files and then complete the build
+successfully.
+
+
 **"Did I break it?" — layered:**
 
 1. **Build cleanly.** A clean `make` after your change is the baseline.


### PR DESCRIPTION
Port of https://github.com/open-mpi/ompi/pull/13944

Add a new "Modifying the configure / build system" section to AGENTS.md that details the correct process for rebuilding the Autotools-generated build system after changes to configure.ac or config/*.m4 files.

This addresses a critical and frequently misunderstood aspect of PMIx development: the build system cannot be safely regenerated with a plain make command. PMIx builds in maintainer mode, which auto-triggers partial in-tree Autotools regeneration that frequently fails (e.g., unexpanded OAC_* macros, config.status errors) and can leave the tree half-regenerated and unbuildable. This section provides:

    An explicit, step-by-step regeneration workflow (autogen.pl + configure)
    An explanation of why plain make is unsafe and what can go wrong
    Guidance on recovering the original configure invocation options from the existing tree using ./config.status --config
    A clarification that Makefile.am edits do NOT require the full regeneration process — a plain make suffices for those

This guidance is particularly important for AI coding agents, which easily fall into the trap of using make as a shortcut, resulting in broken trees. The section is positioned after the basic build instructions to minimize confusion and provide just-in-time documentation for developers who need to modify the build system.