### PR TITLE
preg: add generate_regex2/parse_regex2 API with pmix_regex_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ test/sshot/mytopo.json
 test/sshot/testcoord
 
 test/unit/compress
+test/unit/preg
 
 test/util/numa
 test/util/convert

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -525,10 +525,14 @@ def main():
     definitions.write("\n\n")
     constants.write("\n\n")
     harvest_constants(options, "pmix_tool.h", constants, definitions)
+    # add some space
+    definitions.write("\n\n")
+    constants.write("\n\n")
+    harvest_constants(options, "pmix_deprecated.h", constants, definitions)
     # close the files to ensure all output is written
     constants.close()
     definitions.close()
-    
+
 if __name__ == '__main__':
     main()
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2266,6 +2266,21 @@ typedef struct pmix_byte_object {
 }
 
 
+/****    PMIX REGEX    ****/
+typedef struct pmix_regex {
+    char *type;         // colon-delimited identifier of the encoding method (e.g., "pmix" or "blob")
+    uint8_t *bytes;     // encoded representation (may not be NULL-terminated)
+    size_t len;         // number of bytes in the encoded representation
+} pmix_regex_t;
+
+#define PMIX_REGEX_STATIC_INIT  \
+{                               \
+    .type = NULL,               \
+    .bytes = NULL,              \
+    .len = 0                    \
+}
+
+
 /****    PMIX ENDPOINT    ****/
 typedef struct pmix_endpoint {
     char *uuid;

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -65,6 +65,20 @@
 extern "C" {
 #endif
 
+/***** v5 DEPRECATIONS/REMOVALS *****/
+/* APIs */
+
+/* PMIx_generate_regex is deprecated - use PMIx_generate_regex2 instead.
+ * The new API returns the encoded representation in a pmix_regex_t
+ * rather than a raw char*, properly conveying that the output may
+ * not be a NULL-terminated string. */
+PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regex);
+
+/* PMIx_generate_ppn is deprecated - no replacement is provided as the
+ * per-node process rank mapping is now conveyed through the pmix_regex_t
+ * returned by PMIx_generate_regex2. */
+PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
+
 /***** v4 DECPRECATIONS/REMOVALS *****/
 /* APIs */
 PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -624,57 +624,26 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void);
 
 /* Given a comma-separated list of \refarg{input} values, generate
  * a reduced size representation of the input that can be passed
- * down to PMIx_server_register_nspace for parsing. The order of
- * the individual values in the \refarg{input} string is preserved
- * across the operation. The caller is responsible for releasing
+ * down to PMIx_server_register_nspace for processing, or to
+ * PMIx_parse_regex2 for parsing. The order of the individual
+ * values in the \refarg{input} string is preserved across the
+ * generate/parse operation. The caller is responsible for releasing
  * the returned data.
- *
- * The returned representation may be an arbitrary array of bytes
- * as opposed to a valid NULL-terminated string. However, the
- * method used to generate the representation shall be identified
- * with a colon-delimited string at the beginning of the output.
- * For example, an output starting with "pmix:" indicates that
- * the representation is a PMIx-defined regular expression.
- * In contrast, an output starting with "blob:" is a compressed
- * binary array.
  */
-PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regex);
+PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
+                                               pmix_info_t info[], size_t ninfo,
+                                               pmix_regex_t *regex);
 
-/* Given a reduced size representation of a comma-separated list of
- * input values as typically returned by PMIx_generate_regex, parse
- * the input and return a NULL-terminated argv array of the individual
- * values. The caller is responsible for releasing the returned array.
- */
-PMIX_EXPORT pmix_status_t PMIx_parse_regex(const char *regex,
-                                           char ***output);
 
-/* The input shall consist of a semicolon-separated list of ranges
- * representing the ranks of processes on each node of the job -
- * e.g.,  "1-4;2-5;8,10,11,12;6,7,9". Each field of the input must
- * correspond to the node name provided at that position in the
- * input to PMIx_generate_regex. Thus, in the example, ranks 1-4
- * would be located on the first node of the comma-separated list
- * of names provided to PMIx_generate_regex, and ranks 2-5 would
- * be on the second name in the list.
- *
- * The returned representation may be an arbitrary array of bytes
- * as opposed to a valid NULL-terminated string. However, the
- * method used to generate the representation shall be identified
- * with a colon-delimited string at the beginning of the output.
- * For example, an output starting with "pmix:" indicates that
- * the representation is a PMIx-defined regular expression.
- * In contrast, an output starting with "blob:" is a compressed
- * binary array.
+/* Given a pmix_regex_t as returned by PMIx_generate_regex2, expand
+ * the encoded representation and return a NULL-terminated string
+ * of the individual values in output. The caller is
+ * responsible for releasing the returned string.
  */
-PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
+PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex_t *regex,
+                                            pmix_info_t info[], size_t ninfo,
+                                            char **output);
 
-/* Given a reduced size representation of a semicolon-separated list
- * of ranges representing the ranks of processes on each node of the
- * job such as is returned by PMIx_generate_ppn, parse the input and
- * return a NULL-terminated array of ranges. The caller is responsible
- * for releasing the returned array.
- */
-PMIX_EXPORT pmix_status_t PMIx_parse_ppn(const char *ppn, char ***output);
 
 /* Setup the data about a particular nspace so it can
  * be passed to any child process upon startup. The PMIx

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -415,7 +415,8 @@ static pmix_attr_init_t server_fns[] = {
                          "PMIX_IOF_FILE_PATTERN",
                         NULL}},
     {.function = "PMIx_server_finalize", .attrs = (char *[]){"NONE", NULL}},
-    {.function = "PMIx_generate_regex", .attrs = (char *[]){"N/A", NULL}},
+    {.function = "PMIx_generate_regex", .attrs = (char *[]){"N/A", NULL}},   // DEPRECATED
+    {.function = "PMIx_generate_regex2", .attrs = (char *[]){"N/A", NULL}},
     {.function = "PMIx_generate_ppn", .attrs = (char *[]){"N/A", NULL}},
     {.function = "PMIx_server_register_nspace", .attrs = (char *[]){"PMIX_REGISTER_NODATA", NULL}},
     {.function = "PMIx_server_deregister_nspace", .attrs = (char *[]){"N/A", NULL}},

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -88,6 +88,14 @@ PMIX_EXPORT pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **re
 
 PMIX_EXPORT pmix_status_t pmix_preg_base_release(char *regexp);
 
+PMIX_EXPORT pmix_status_t pmix_preg_base_generate_regex(const char *input,
+                                                         pmix_info_t info[], size_t ninfo,
+                                                         pmix_regex_t *regex);
+
+PMIX_EXPORT pmix_status_t pmix_preg_base_parse_regex(const pmix_regex_t *regex,
+                                                      pmix_info_t info[], size_t ninfo,
+                                                      char **output);
+
 END_C_DECLS
 
 #endif

--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -60,7 +60,9 @@ pmix_preg_module_t pmix_preg = {
     .copy = pmix_preg_base_copy,
     .pack = pmix_preg_base_pack,
     .unpack = pmix_preg_base_unpack,
-    .release = pmix_preg_base_release
+    .release = pmix_preg_base_release,
+    .generate_regex = pmix_preg_base_generate_regex,
+    .parse_regex  = pmix_preg_base_parse_regex
 };
 
 static pmix_status_t pmix_preg_close(void)

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -168,3 +168,64 @@ pmix_status_t pmix_preg_base_release(char *regexp)
     }
     return PMIX_ERR_BAD_PARAM;
 }
+
+pmix_status_t pmix_preg_base_parse_regex(const pmix_regex_t *regex,
+                                          pmix_info_t info[], size_t ninfo,
+                                          char **output)
+{
+    pmix_preg_base_active_module_t *active;
+
+    PMIX_LIST_FOREACH (active, &pmix_preg_globals.actives, pmix_preg_base_active_module_t) {
+        if (NULL != active->module->parse_regex) {
+            if (PMIX_SUCCESS == active->module->parse_regex(regex, info, ninfo, output)) {
+                return PMIX_SUCCESS;
+            }
+        }
+    }
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix_preg_base_generate_regex(const char *input,
+                                             pmix_info_t info[], size_t ninfo,
+                                             pmix_regex_t *regex)
+{
+    pmix_preg_base_active_module_t *active;
+    pmix_regex_t candidate = PMIX_REGEX_STATIC_INIT;
+    pmix_regex_t best = PMIX_REGEX_STATIC_INIT;
+
+    PMIX_LIST_FOREACH (active, &pmix_preg_globals.actives, pmix_preg_base_active_module_t) {
+        if (NULL == active->module->generate_regex) {
+            continue;
+        }
+        if (PMIX_SUCCESS != active->module->generate_regex(input, info, ninfo, &candidate)) {
+            continue;
+        }
+        /* keep this result if it is the first or smaller than the current best */
+        if (NULL == best.bytes || candidate.len < best.len) {
+            /* release the previous best if there was one */
+            if (NULL != best.type) {
+                free(best.type);
+            }
+            if (NULL != best.bytes) {
+                free(best.bytes);
+            }
+            best = candidate;
+        } else {
+            /* discard this candidate */
+            if (NULL != candidate.type) {
+                free(candidate.type);
+            }
+            if (NULL != candidate.bytes) {
+                free(candidate.bytes);
+            }
+        }
+        candidate = (pmix_regex_t) PMIX_REGEX_STATIC_INIT;
+    }
+
+    if (NULL == best.bytes) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    *regex = best;
+    return PMIX_SUCCESS;
+}

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -51,6 +51,10 @@ static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
 static pmix_status_t release(char *regexp);
+static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex_t *regex);
+static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                 char **output);
 
 pmix_preg_module_t pmix_preg_compress_module = {
     .name = "compress",
@@ -61,7 +65,9 @@ pmix_preg_module_t pmix_preg_compress_module = {
     .copy = copy,
     .pack = pack,
     .unpack = unpack,
-    .release = release
+    .release = release,
+    .generate_regex = generate_regex,
+    .parse_regex = parse_regex
 };
 
 #define PREG_COMPRESS_PREFIX "blob: component=zlib: size="
@@ -328,6 +334,53 @@ static pmix_status_t release(char *regexp)
 
     // just free it
     free(regexp);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                 char **output)
+{
+    char *tmp = NULL;
+
+    // no attributes are currently defined for this function
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    if (NULL == regex || NULL == regex->type ||
+        0 != strcmp(regex->type, pmix_preg_compress_module.name)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    if (!pmix_compress.decompress_string(&tmp, regex->bytes, regex->len)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *output = tmp;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex_t *regex)
+{
+    uint8_t *compressed = NULL;
+    size_t len;
+
+    // no attributes are currently defined for this function
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    if (!pmix_compress.compress_string((char *) input, &compressed, &len)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    if (NULL == compressed) {
+        return PMIX_ERR_NOMEM;
+    }
+
+    regex->type = strdup(pmix_preg_compress_module.name);
+    if (NULL == regex->type) {
+        free(compressed);
+        return PMIX_ERR_NOMEM;
+    }
+    regex->bytes = compressed;
+    regex->len = len;
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -61,7 +61,8 @@ pmix_preg_module_t pmix_preg_native_module = {
     .copy = copy,
     .pack = pack,
     .unpack = unpack,
-    .release = release
+    .release = release,
+    .generate_regex = NULL
 };
 
 static pmix_status_t regex_parse_value_ranges(char *base, char *ranges, int num_digits,
@@ -934,3 +935,4 @@ static pmix_status_t release(char *regexp)
     free(regexp);
     return PMIX_SUCCESS;
 }
+

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -85,6 +85,25 @@ typedef pmix_status_t (*pmix_preg_base_module_unpack_fn_t)(pmix_buffer_t *buffer
 
 typedef pmix_status_t (*pmix_preg_base_module_release_fn_t)(char *regexp);
 
+/* Compress the input node-name list directly into a pmix_regex_t.
+ * The module sets regex->type to its name, stores the encoded bytes
+ * in regex->bytes, and sets regex->len accordingly.
+ * Returns PMIX_ERR_TAKE_NEXT_OPTION if the module cannot handle the input.
+ */
+typedef pmix_status_t (*pmix_preg_base_module_generate_regex_fn_t)(const char *input,
+                                                                    pmix_info_t info[],
+                                                                    size_t ninfo,
+                                                                    pmix_regex_t *regex);
+
+/* Expand a pmix_regex_t (as produced by generate_regex) back into a
+ * NULL-terminated argv array of node names in output.
+ * Returns PMIX_ERR_TAKE_NEXT_OPTION if the module does not recognize
+ * the regex->type value.
+ */
+typedef pmix_status_t (*pmix_preg_base_module_parse_regex_fn_t)(const pmix_regex_t *regex,
+                                                                 pmix_info_t info[], size_t ninfo,
+                                                                 char **output);
+
 /**
  * Base structure for a PREG module
  */
@@ -98,6 +117,8 @@ typedef struct {
     pmix_preg_base_module_pack_fn_t pack;
     pmix_preg_base_module_unpack_fn_t unpack;
     pmix_preg_base_module_release_fn_t release;
+    pmix_preg_base_module_generate_regex_fn_t generate_regex;
+    pmix_preg_base_module_parse_regex_fn_t parse_regex;
 } pmix_preg_module_t;
 
 /* we just use the standard component definition */

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -45,6 +45,10 @@ static pmix_status_t copy(char **dest, size_t *len, const char *input);
 static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
 static pmix_status_t release(char *regexp);
+static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex_t *regex);
+static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                 char **output);
 
 pmix_preg_module_t pmix_preg_raw_module = {
     .name = "raw",
@@ -55,7 +59,9 @@ pmix_preg_module_t pmix_preg_raw_module = {
     .copy = copy,
     .pack = pack,
     .unpack = unpack,
-    .release = release
+    .release = release,
+    .generate_regex = generate_regex,
+    .parse_regex = parse_regex
 };
 
 static pmix_status_t generate_node_regex(const char *input, char **regexp)
@@ -164,5 +170,40 @@ static pmix_status_t release(char *regexp)
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
     free(regexp);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                 char **output)
+{
+    // no attributes are currently defined for this function
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    if (NULL == regex || NULL == regex->type ||
+        0 != strcmp(regex->type, pmix_preg_raw_module.name)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    *output = strdup((const char *) regex->bytes);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex_t *regex)
+{
+    // no attributes are currently defined for this function
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    regex->type = strdup(pmix_preg_raw_module.name);
+    if (NULL == regex->type) {
+        return PMIX_ERR_NOMEM;
+    }
+    regex->bytes = (uint8_t *) strdup(input);
+    if (NULL == regex->bytes) {
+        free(regex->type);
+        regex->type = NULL;
+        return PMIX_ERR_NOMEM;
+    }
+    regex->len = strlen(input) + 1;
     return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2694,14 +2694,33 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
     return pmix_preg.generate_node_regex(input, regexp);
 }
 
-pmix_status_t PMIx_parse_regex(const char *regex,
-                               char ***output)
+PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
+                                               pmix_info_t info[], size_t ninfo,
+                                               pmix_regex_t *regex)
 {
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
+    if (NULL == regex) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
-    return pmix_preg.parse_nodes(regex, output);
+    return pmix_preg.generate_regex(input, info, ninfo, regex);
+}
+
+
+PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex_t *regex,
+                                            pmix_info_t info[], size_t ninfo,
+                                            char **output)
+{
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+    if (NULL == regex || NULL == output) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    return pmix_preg.parse_regex(regex, info, ninfo, output);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
@@ -2713,15 +2732,6 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
     return pmix_preg.generate_ppn(input, regexp);
 }
 
-pmix_status_t PMIx_parse_ppn(const char *ppn,
-                             char ***output)
-{
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
-        return PMIX_ERR_INIT;
-    }
-
-    return pmix_preg.parse_procs(ppn, output);
-}
 
 
 static void _setup_op(pmix_status_t rc, void *cbdata)

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -20,7 +20,9 @@
 # $HEADER$
 #
 
-noinst_PROGRAMS = compress
+check_PROGRAMS = compress preg
+
+TESTS = compress preg
 
 compress_SOURCES =  \
         compress.c
@@ -28,5 +30,11 @@ compress_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 compress_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+preg_SOURCES = \
+        preg.c
+preg_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+preg_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress
+	rm -f compress preg

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIx_generate_regex2 and PMIx_parse_regex2.
+ *
+ * Each test calls PMIx_generate_regex2 on a known input, checks that the
+ * returned pmix_regex_t is non-empty, then round-trips through
+ * PMIx_parse_regex2 and verifies the decoded string matches the original.
+ *
+ * A simple PASS/FAIL summary is printed for each case.  The program exits
+ * with 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_printf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Minimal server module - only init/finalize are exercised */
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+/* Report a single test result and update counters */
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/*
+ * Round-trip helper: generate a regex from input, then parse it back and
+ * compare the decoded string to input.  Returns 1 on success, 0 on failure.
+ */
+static int roundtrip(const char *input)
+{
+    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    char *decoded = NULL;
+    pmix_status_t rc;
+    int ok = 0;
+
+    rc = PMIx_generate_regex2(input, NULL, 0, &regex);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    generate_regex2 failed: %s\n", PMIx_Error_string(rc));
+        goto out;
+    }
+    if (NULL == regex.type || NULL == regex.bytes || 0 == regex.len) {
+        fprintf(stdout, "    generate_regex2 returned empty pmix_regex_t\n");
+        goto out;
+    }
+
+    rc = PMIx_parse_regex2(&regex, NULL, 0, &decoded);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    parse_regex2 failed: %s\n", PMIx_Error_string(rc));
+        goto out;
+    }
+    if (NULL == decoded) {
+        fprintf(stdout, "    parse_regex2 returned NULL output\n");
+        goto out;
+    }
+
+    if (0 == strcmp(decoded, input)) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    mismatch:\n      expected: %s\n      got:      %s\n",
+                input, decoded);
+    }
+
+out:
+    if (NULL != regex.type)  free(regex.type);
+    if (NULL != regex.bytes) free(regex.bytes);
+    if (NULL != decoded)     free(decoded);
+    return ok;
+}
+
+/* ------------------------------------------------------------------ */
+/* Individual test cases                                               */
+/* ------------------------------------------------------------------ */
+
+/* Single node, no numeric suffix */
+static void test_single_node(void)
+{
+    report("single node", roundtrip("node0"));
+}
+
+/* Small homogeneous cluster - nodes share a prefix and contiguous range */
+static void test_contiguous_range(void)
+{
+    char *input = NULL;
+    char **nodes = NULL;
+    int n;
+
+    for (n = 0; n < 8; n++) {
+        char tmp[32];
+        snprintf(tmp, sizeof(tmp), "node%04d", n);
+        PMIx_Argv_append_nosize(&nodes, tmp);
+    }
+    input = PMIx_Argv_join(nodes, ',');
+    PMIx_Argv_free(nodes);
+
+    report("contiguous range (node0000-node0007)", roundtrip(input));
+    free(input);
+}
+
+/* Non-contiguous node numbers */
+static void test_non_contiguous(void)
+{
+    report("non-contiguous (node001,node003,node007)",
+           roundtrip("node001,node003,node007"));
+}
+
+/* Mixed prefixes in a single list */
+static void test_mixed_prefixes(void)
+{
+    report("mixed prefixes (odin,thor)",
+           roundtrip("odin001,odin002,odin003,thor010,thor011"));
+}
+
+/* Nodes with no numeric component at all */
+static void test_no_digits(void)
+{
+    report("no-digit names (login,head,storage)",
+           roundtrip("login,head,storage"));
+}
+
+/* Large list - exercises compression path when zlib is available */
+static void test_large_list(void)
+{
+    char **nodes = NULL;
+    char *input = NULL;
+    int n;
+
+    for (n = 0; n < 10000; n++) {
+        char tmp[32];
+        snprintf(tmp, sizeof(tmp), "node%05d", n);
+        PMIx_Argv_append_nosize(&nodes, tmp);
+    }
+    input = PMIx_Argv_join(nodes, ',');
+    PMIx_Argv_free(nodes);
+
+    report("large list (10000 nodes)", roundtrip(input));
+    free(input);
+}
+
+/* Nodes with a numeric suffix after the digits (e.g. HPC blade naming) */
+static void test_suffix(void)
+{
+    report("nodes with suffix (node01n,node02n,node03n)",
+           roundtrip("node01n,node02n,node03n"));
+}
+
+/* Verify generate_regex2 rejects a NULL regex pointer */
+static void test_null_regex_param(void)
+{
+    pmix_status_t rc = PMIx_generate_regex2("node0", NULL, 0, NULL);
+    report("NULL regex param returns PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* Verify parse_regex2 rejects a NULL regex pointer */
+static void test_null_parse_input(void)
+{
+    char *out = NULL;
+    pmix_status_t rc = PMIx_parse_regex2(NULL, NULL, 0, &out);
+    report("NULL regex input returns PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* Verify parse_regex2 rejects a NULL output pointer */
+static void test_null_parse_output(void)
+{
+    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    pmix_status_t rc;
+
+    rc = PMIx_generate_regex2("node0", NULL, 0, &regex);
+    if (PMIX_SUCCESS != rc) {
+        report("NULL parse output (setup failed)", 0);
+        return;
+    }
+
+    rc = PMIx_parse_regex2(&regex, NULL, 0, NULL);
+    report("NULL parse output param returns PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+
+    if (NULL != regex.type)  free(regex.type);
+    if (NULL != regex.bytes) free(regex.bytes);
+}
+
+/* Verify that the type field is set to a non-empty string */
+static void test_type_field_set(void)
+{
+    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    pmix_status_t rc;
+    int ok = 0;
+
+    rc = PMIx_generate_regex2("node0001,node0002,node0003", NULL, 0, &regex);
+    if (PMIX_SUCCESS == rc && NULL != regex.type && '\0' != regex.type[0]) {
+        ok = 1;
+    }
+    report("type field is non-empty after generate_regex2", ok);
+
+    if (NULL != regex.type)  free(regex.type);
+    if (NULL != regex.bytes) free(regex.bytes);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIx_generate_regex2 / PMIx_parse_regex2 unit tests ===\n\n");
+
+    /* Parameter validation */
+    test_null_regex_param();
+    test_null_parse_input();
+    test_null_parse_output();
+
+    /* Functional round-trip */
+    test_single_node();
+    test_contiguous_range();
+    test_non_contiguous();
+    test_mixed_prefixes();
+    test_no_digits();
+    test_suffix();
+    test_large_list();
+
+    /* Structural checks */
+    test_type_field_set();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Introduce pmix_regex_t (type, bytes, len) in pmix_common.h and add two new server APIs that operate on it:

  PMIx_generate_regex2(input, info[], ninfo, pmix_regex_t*)
    Replaces the deprecated PMIx_generate_regex (char** output). The
    preg framework's new generate_regex entry point collects results
    from all active modules that implement it and returns the smallest
    encoding. The compress component zlib-compresses the input; the raw
    component stores it verbatim. The native component does not implement
    this entry point. PMIx_generate_ppn is deprecated into
    pmix_deprecated.h alongside PMIx_generate_regex.

  PMIx_parse_regex2(pmix_regex_t*, info[], ninfo, char**output)
    Counterpart to generate_regex2. The preg framework's new parse_regex
    entry point iterates active modules; each checks regex->type against
    its own name and decodes accordingly (decompress for "compress",
    strdup for "raw").

Remove PMIx_parse_regex and PMIx_parse_ppn (string-based, superseded).

Add test/unit/preg.c with 11 unit tests (parameter validation, functional round-trips, structural checks) wired into make check via check_PROGRAMS and TESTS in test/unit/Makefile.am. Add test/unit/preg to .gitignore.