### PR TITLE
Rename pmix_regex_t to pmix_regex2_t

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -2039,6 +2039,18 @@ PMIX_EXPORT pmix_node_pid_t* PMIx_Node_pid_create(size_t n);
  * (frees the struct memory itself) */
 PMIX_EXPORT void PMIx_Node_pid_free(pmix_node_pid_t *d, size_t n);
 
+/* initialize a regex2 struct */
+PMIX_EXPORT void PMIx_Regex2_construct(pmix_regex2_t *d);
+
+/* free memory stored inside a regex2 struct */
+PMIX_EXPORT void PMIx_Regex2_destruct(pmix_regex2_t *d);
+
+/* create and initialize an array of regex2 structs */
+PMIX_EXPORT pmix_regex2_t* PMIx_Regex2_create(size_t n);
+
+/* free an array of regex2 structs (frees the struct memory itself) */
+PMIX_EXPORT void PMIx_Regex2_free(pmix_regex2_t *d, size_t n);
+
 /* initialize a resource unit struct */
 PMIX_EXPORT void PMIx_Resource_unit_construct(pmix_resource_unit_t *d);
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1813,7 +1813,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_ENVAR                      46
 #define PMIX_COORD                      47
 #define PMIX_REGATTR                    48
-#define PMIX_REGEX                      49
+// Hole left by deprecation of PMIX_REGEX (use PMIX_REGEX2 instead)
 #define PMIX_JOB_STATE                  50
 #define PMIX_LINK_STATE                 51
 #define PMIX_PROC_CPUSET                52
@@ -1834,6 +1834,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_RESBLOCK_DIRECTIVE         71
 #define PMIX_RESOURCE_UNIT              72
 #define PMIX_NODE_PID                   73
+#define PMIX_REGEX2                     74
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -2267,13 +2268,13 @@ typedef struct pmix_byte_object {
 
 
 /****    PMIX REGEX    ****/
-typedef struct pmix_regex {
+typedef struct pmix_regex2 {
     char *type;         // colon-delimited identifier of the encoding method (e.g., "pmix" or "blob")
     uint8_t *bytes;     // encoded representation (may not be NULL-terminated)
     size_t len;         // number of bytes in the encoded representation
-} pmix_regex_t;
+} pmix_regex2_t;
 
-#define PMIX_REGEX_STATIC_INIT  \
+#define PMIX_REGEX2_STATIC_INIT  \
 {                               \
     .type = NULL,               \
     .bytes = NULL,              \
@@ -2459,6 +2460,7 @@ typedef struct pmix_value {
         pmix_data_buffer_t *dbuf;
         pmix_resource_unit_t *resunit;
         pmix_node_pid_t *nodepid;
+        pmix_regex2_t *regex2;
     } data;
 } pmix_value_t;
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -69,15 +69,21 @@ extern "C" {
 /* APIs */
 
 /* PMIx_generate_regex is deprecated - use PMIx_generate_regex2 instead.
- * The new API returns the encoded representation in a pmix_regex_t
+ * The new API returns the encoded representation in a pmix_regex2_t
  * rather than a raw char*, properly conveying that the output may
  * not be a NULL-terminated string. */
 PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regex);
 
 /* PMIx_generate_ppn is deprecated - no replacement is provided as the
- * per-node process rank mapping is now conveyed through the pmix_regex_t
+ * per-node process rank mapping is now conveyed through the pmix_regex2_t
  * returned by PMIx_generate_regex2. */
 PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
+
+/* DATATYPES */
+/* PMIX_REGEX is deprecated - use PMIX_REGEX2 instead.  The numeric
+ * value is preserved so that wire-format data produced by older
+ * implementations can still be decoded. */
+#define PMIX_REGEX                      49
 
 /***** v4 DECPRECATIONS/REMOVALS *****/
 /* APIs */
@@ -604,6 +610,18 @@ PMIX_EXPORT pmix_node_pid_t* PMIx_Node_pid_create(size_t n);
 /* free memory stored inside an array of node_pid structs
  * (frees the struct memory itself) */
 PMIX_EXPORT void PMIx_Node_pid_free(pmix_node_pid_t *d, size_t n);
+
+/* initialize a regex2 struct */
+PMIX_EXPORT void PMIx_Regex2_construct(pmix_regex2_t *d);
+
+/* free memory stored inside a regex2 struct */
+PMIX_EXPORT void PMIx_Regex2_destruct(pmix_regex2_t *d);
+
+/* create and initialize an array of regex2 structs */
+PMIX_EXPORT pmix_regex2_t* PMIx_Regex2_create(size_t n);
+
+/* free an array of regex2 structs (frees the struct memory itself) */
+PMIX_EXPORT void PMIx_Regex2_free(pmix_regex2_t *d, size_t n);
 
 /* initialize a resource unit struct */
 PMIX_EXPORT void PMIx_Resource_unit_construct(pmix_resource_unit_t *d);

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -632,15 +632,15 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void);
  */
 PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
                                                pmix_info_t info[], size_t ninfo,
-                                               pmix_regex_t *regex);
+                                               pmix_regex2_t *regex);
 
 
-/* Given a pmix_regex_t as returned by PMIx_generate_regex2, expand
+/* Given a pmix_regex2_t as returned by PMIx_generate_regex2, expand
  * the encoded representation and return a NULL-terminated string
  * of the individual values in output. The caller is
  * responsible for releasing the returned string.
  */
-PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex_t *regex,
+PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex2_t *regex,
                                             pmix_info_t info[], size_t ninfo,
                                             char **output);
 

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -560,6 +560,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_satyp(pmix_pointer_array_t *regt
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_nodepid(pmix_pointer_array_t *regtypes,
                                                         pmix_buffer_t *buffer, const void *src,
                                                         int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_regex2(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
+                                                       int32_t num_vals, pmix_data_type_t type);
 
 /*
  * "Standard" unpack functions
@@ -774,6 +777,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_satyp(pmix_pointer_array_t *re
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_nodepid(pmix_pointer_array_t *regtypes,
                                                           pmix_buffer_t *buffer, void *dest,
                                                           int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_regex2(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
+                                                         int32_t *num_vals, pmix_data_type_t type);
 
 /**** DEPRECATED ****/
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_pointer_array_t *regtypes,
@@ -854,6 +860,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_dbuf(pmix_data_buffer_t **dest,
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_nodepid(pmix_node_pid_t **dest,
                                                         pmix_node_pid_t *src,
                                                         pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_regex2(pmix_regex2_t **dest,
+                                                       pmix_regex2_t *src,
+                                                       pmix_data_type_t type);
 
 /*
  * "Standard" print functions
@@ -1023,6 +1032,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *pref
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_nodepid(char **output, char *prefix,
                                                          pmix_node_pid_t *src,
                                                          pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_regex2(char **output, char *prefix,
+                                                        pmix_regex2_t *src,
+                                                        pmix_data_type_t type);
 
 /*
  * Common helper functions

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -1036,6 +1036,30 @@ static pmix_value_cmp_t cmp_darray(pmix_data_array_t *d1,
             }
             return PMIX_EQUAL;
             break;
+        case PMIX_REGEX2: {
+            pmix_regex2_t *rx1 = (pmix_regex2_t *)d1->array;
+            pmix_regex2_t *rx2 = (pmix_regex2_t *)d2->array;
+            for (n = 0; n < d1->size; n++) {
+                int tcmp = (NULL == rx1[n].type && NULL == rx2[n].type) ? 0
+                         : (NULL == rx1[n].type) ? -1
+                         : (NULL == rx2[n].type) ? 1
+                         : strcmp(rx1[n].type, rx2[n].type);
+                if (0 != tcmp) {
+                    return (0 < tcmp) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+                }
+                if (rx1[n].len != rx2[n].len) {
+                    return (rx1[n].len > rx2[n].len) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+                }
+                if (0 < rx1[n].len) {
+                    int bcmp = memcmp(rx1[n].bytes, rx2[n].bytes, rx1[n].len);
+                    if (0 != bcmp) {
+                        return (0 < bcmp) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+                    }
+                }
+            }
+            return PMIX_EQUAL;
+            break;
+        }
 
         default:
             pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %s (%d)",
@@ -1256,6 +1280,28 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p1,
         rc = cmp_nodepid(p1->data.nodepid, p2->data.nodepid);
         return rc;
         break;
+    case PMIX_REGEX2: {
+        pmix_regex2_t *rx1 = p1->data.regex2;
+        pmix_regex2_t *rx2 = p2->data.regex2;
+        int tcmp = (NULL == rx1->type && NULL == rx2->type) ? 0
+                 : (NULL == rx1->type) ? -1
+                 : (NULL == rx2->type) ? 1
+                 : strcmp(rx1->type, rx2->type);
+        if (0 != tcmp) {
+            return (0 < tcmp) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+        }
+        if (rx1->len != rx2->len) {
+            return (rx1->len > rx2->len) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+        }
+        if (0 < rx1->len) {
+            int bcmp = memcmp(rx1->bytes, rx2->bytes, rx1->len);
+            if (0 != bcmp) {
+                return (0 < bcmp) ? PMIX_VALUE1_GREATER : PMIX_VALUE2_GREATER;
+            }
+        }
+        return PMIX_EQUAL;
+        break;
+    }
 
     default:
         pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %s (%d)",

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -520,3 +520,10 @@ pmix_status_t pmix_bfrops_base_copy_nodepid(pmix_node_pid_t **dest,
 {
     return pmix_bfrops_base_tma_copy_nodepid(dest, src, type, NULL);
 }
+
+pmix_status_t pmix_bfrops_base_copy_regex2(pmix_regex2_t **dest,
+                                           pmix_regex2_t *src,
+                                           pmix_data_type_t type)
+{
+    return pmix_bfrops_base_tma_copy_regex2(dest, src, type, NULL);
+}

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -341,6 +341,14 @@ void pmix_bfrops_base_value_load(pmix_value_t *v,
                 PMIX_ERROR_LOG(rc);
             }
             break;
+        case PMIX_REGEX2: {
+            pmix_regex2_t *rx2ptr = (pmix_regex2_t *) data;
+            rc = pmix_bfrops_base_copy_regex2(&v->data.regex2, rx2ptr, PMIX_REGEX2);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+            break;
+        }
 
         default:
             /* silence warnings */
@@ -688,6 +696,13 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
             ndpidptr->pid = ndpd->pid;
             *data = ndpidptr;
             *sz = sizeof(pmix_node_pid_t);
+            break;
+        case PMIX_REGEX2:
+            rc = pmix_bfrops_base_copy_regex2((pmix_regex2_t **) data, kv->data.regex2,
+                                              PMIX_REGEX2);
+            if (PMIX_SUCCESS == rc) {
+                *sz = sizeof(pmix_regex2_t);
+            }
             break;
 
         default:
@@ -1366,6 +1381,17 @@ static pmix_status_t get_darray_size(pmix_data_array_t *array,
                 }
             }
             break;
+        case PMIX_REGEX2: {
+            pmix_regex2_t *rx2 = (pmix_regex2_t *)array->array;
+            *sz = array->size * sizeof(pmix_regex2_t);
+            for (n = 0; n < array->size; n++) {
+                if (NULL != rx2[n].type) {
+                    *sz += strlen(rx2[n].type) + 1;
+                }
+                *sz += rx2[n].len;
+            }
+            break;
+        }
 
         default:
             /* silence warnings */
@@ -1621,6 +1647,13 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
             if (NULL != ndpd->hostname) {
                 *sz += strlen(ndpd->hostname) + 1;  // account for NULL
             }
+            break;
+        case PMIX_REGEX2:
+            *sz = sizeof(pmix_regex2_t);
+            if (NULL != v->data.regex2->type) {
+                *sz += strlen(v->data.regex2->type) + 1;
+            }
+            *sz += v->data.regex2->len;
             break;
 
         default:

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -412,6 +412,26 @@ void PMIx_Node_pid_free(pmix_node_pid_t *d, size_t n)
     pmix_bfrops_base_tma_node_pid_free(d, n, NULL);
 }
 
+void PMIx_Regex2_construct(pmix_regex2_t *d)
+{
+    pmix_bfrops_base_tma_regex2_construct(d, NULL);
+}
+
+void PMIx_Regex2_destruct(pmix_regex2_t *d)
+{
+    pmix_bfrops_base_tma_regex2_destruct(d, NULL);
+}
+
+pmix_regex2_t* PMIx_Regex2_create(size_t n)
+{
+    return pmix_bfrops_base_tma_regex2_create(n, NULL);
+}
+
+void PMIx_Regex2_free(pmix_regex2_t *d, size_t n)
+{
+    pmix_bfrops_base_tma_regex2_free(d, n, NULL);
+}
+
 void PMIx_Resource_unit_construct(pmix_resource_unit_t *d)
 {
     pmix_bfrops_base_tma_resource_unit_construct(d, NULL);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1112,6 +1112,34 @@ pmix_status_t pmix_bfrops_base_pack_regex(pmix_pointer_array_t *regtypes, pmix_b
     return PMIX_SUCCESS;
 }
 
+pmix_status_t pmix_bfrops_base_pack_regex2(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                          const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_regex2_t *ptr = (pmix_regex2_t *) src;
+    int32_t i;
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    for (i = 0; i < num_vals; ++i) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].type, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].len, 1, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+        if (0 < ptr[i].len) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].bytes, ptr[i].len, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
 pmix_status_t pmix_bfrops_base_pack_jobstate(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                              const void *src, int32_t num_vals,
                                              pmix_data_type_t type)

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -800,6 +800,9 @@ static int print_val(char **output, pmix_value_t *src)
         case PMIX_NODE_PID:
             rc = pmix_bfrops_base_print_nodepid(&tp, NULL, src->data.nodepid, PMIX_NODE_PID);
             break;
+        case PMIX_REGEX2:
+            rc = pmix_bfrops_base_print_regex2(&tp, NULL, src->data.regex2, PMIX_REGEX2);
+            break;
         default:
             pmix_asprintf(&tp, " Data type: %s(%d)\tValue: UNPRINTABLE",
                           PMIx_Data_type_string(src->type), (int)(src->type));
@@ -2171,6 +2174,20 @@ pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *prefix,
     } else {
         return PMIX_SUCCESS;
     }
+}
+
+pmix_status_t pmix_bfrops_base_print_regex2(char **output, char *prefix,
+                                            pmix_regex2_t *src,
+                                            pmix_data_type_t type)
+{
+    int ret;
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ret = asprintf(output, "%sData type: PMIX_REGEX2\tType: %s\tLen: %zu",
+                   (NULL == prefix) ? " " : prefix,
+                   (NULL == src->type) ? "NULL" : src->type,
+                   src->len);
+    return (0 > ret) ? PMIX_ERR_OUT_OF_RESOURCE : PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_bfrops_base_print_nodepid(char **output, char *prefix,

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -166,6 +166,8 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_RESBLOCK_DIRECTIVE";
     case PMIX_RESOURCE_UNIT:
         return "PMIX_RESOURCE_UNIT";
+    case PMIX_REGEX2:
+        return "PMIX_REGEX2";
     default:
         return "NOT INITIALIZED";
     }

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -1326,6 +1326,78 @@ pmix_status_t pmix_bfrops_base_tma_copy_nodepid(pmix_node_pid_t **dest,
 }
 
 static inline
+void pmix_bfrops_base_tma_regex2_construct(pmix_regex2_t *d, pmix_tma_t *tma)
+{
+    PMIX_HIDE_UNUSED_PARAMS(tma);
+    d->type = NULL;
+    d->bytes = NULL;
+    d->len = 0;
+}
+
+static inline
+void pmix_bfrops_base_tma_regex2_destruct(pmix_regex2_t *d, pmix_tma_t *tma)
+{
+    if (NULL != d->type) {
+        pmix_tma_free(tma, d->type);
+    }
+    if (NULL != d->bytes) {
+        pmix_tma_free(tma, d->bytes);
+    }
+}
+
+static inline
+pmix_regex2_t* pmix_bfrops_base_tma_regex2_create(size_t n, pmix_tma_t *tma)
+{
+    if (0 == n) {
+        return NULL;
+    }
+    pmix_regex2_t *d = (pmix_regex2_t *)pmix_tma_malloc(tma, n * sizeof(pmix_regex2_t));
+    if (PMIX_LIKELY(NULL != d)) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_regex2_construct(&d[m], tma);
+        }
+    }
+    return d;
+}
+
+static inline
+void pmix_bfrops_base_tma_regex2_free(pmix_regex2_t *d, size_t n, pmix_tma_t *tma)
+{
+    if (NULL != d) {
+        for (size_t m = 0; m < n; m++) {
+            pmix_bfrops_base_tma_regex2_destruct(&d[m], tma);
+        }
+        pmix_tma_free(tma, d);
+    }
+}
+
+static inline
+pmix_status_t pmix_bfrops_base_tma_copy_regex2(pmix_regex2_t **dest,
+                                               pmix_regex2_t *src,
+                                               pmix_data_type_t type,
+                                               pmix_tma_t *tma)
+{
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    pmix_regex2_t *p = pmix_bfrops_base_tma_regex2_create(1, tma);
+    if (PMIX_UNLIKELY(NULL == p)) {
+        return PMIX_ERR_NOMEM;
+    }
+    *dest = p;
+    if (NULL != src->type) {
+        p->type = pmix_tma_strdup(tma, src->type);
+    }
+    if (NULL != src->bytes && 0 < src->len) {
+        p->bytes = (uint8_t *)pmix_tma_malloc(tma, src->len);
+        if (PMIX_LIKELY(NULL != p->bytes)) {
+            memcpy(p->bytes, src->bytes, src->len);
+            p->len = src->len;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static inline
 void pmix_bfrops_base_tma_resource_unit_destruct(pmix_resource_unit_t *d,
                                                  pmix_tma_t *tma)
 {
@@ -3117,6 +3189,26 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         }
         break;
     }
+    case PMIX_REGEX2: {
+        p->array = pmix_bfrops_base_tma_regex2_create(src->size, tma);
+        if (PMIX_UNLIKELY(NULL == p->array)) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+        pmix_regex2_t *const prx = (pmix_regex2_t *)p->array;
+        pmix_regex2_t *const srx = (pmix_regex2_t *)src->array;
+        for (size_t n = 0; n < src->size; n++) {
+            if (NULL != srx[n].type) {
+                prx[n].type = pmix_tma_strdup(tma, srx[n].type);
+            }
+            if (NULL != srx[n].bytes && 0 < srx[n].len) {
+                prx[n].bytes = (uint8_t *)pmix_tma_malloc(tma, srx[n].len);
+                memcpy(prx[n].bytes, srx[n].bytes, srx[n].len);
+                prx[n].len = srx[n].len;
+            }
+        }
+        break;
+    }
     case PMIX_PROC_NSPACE: {
         p->array = pmix_tma_malloc(tma, src->size * sizeof(pmix_nspace_t));
         if (PMIX_UNLIKELY(NULL == p->array)) {
@@ -3333,6 +3425,8 @@ pmix_status_t pmix_bfrops_base_tma_value_xfer(pmix_value_t *p,
         return pmix_bfrops_base_tma_copy_devdist(&p->data.devdist, src->data.devdist, PMIX_DEVICE_DIST, tma);
     case PMIX_ENDPOINT:
         return pmix_bfrops_base_tma_copy_endpoint(&p->data.endpoint, src->data.endpoint, PMIX_ENDPOINT, tma);
+    case PMIX_REGEX2:
+        return pmix_bfrops_base_tma_copy_regex2(&p->data.regex2, src->data.regex2, PMIX_REGEX2, tma);
     case PMIX_REGATTR:
         return pmix_bfrops_base_tma_copy_regattr((pmix_regattr_t **) &p->data.ptr, src->data.ptr,
                                                  PMIX_REGATTR, tma);
@@ -3465,6 +3559,9 @@ void pmix_bfrops_base_tma_data_array_destruct(pmix_data_array_t *d,
             break;
         case PMIX_ENDPOINT:
             pmix_bfrops_base_tma_endpoint_free(d->array, d->size, tma);
+            break;
+        case PMIX_REGEX2:
+            pmix_bfrops_base_tma_regex2_free((pmix_regex2_t *)d->array, d->size, tma);
             break;
         case PMIX_REGEX: {
             pmix_byte_object_t *const bo = (pmix_byte_object_t *)d->array;
@@ -3765,6 +3862,11 @@ void pmix_bfrops_base_tma_value_destruct(pmix_value_t *v,
         case PMIX_REGATTR:
             if (NULL != v->data.ptr) {
                 pmix_bfrops_base_tma_regattr_free(v->data.ptr, 1, tma);
+            }
+            break;
+        case PMIX_REGEX2:
+            if (NULL != v->data.regex2) {
+                pmix_bfrops_base_tma_regex2_free(v->data.regex2, 1, tma);
             }
             break;
         case PMIX_REGEX:

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -626,6 +626,13 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
             }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.nodepid, &m, PMIX_NODE_PID, regtypes);
             return ret;
+        case PMIX_REGEX2:
+            val->data.regex2 = PMIx_Regex2_create(1);
+            if (NULL == val->data.regex2) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.regex2, &m, PMIX_REGEX2, regtypes);
+            return ret;
 
         default:
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data, &m, val->type, regtypes);
@@ -1500,6 +1507,48 @@ pmix_status_t pmix_bfrops_base_unpack_regex(pmix_pointer_array_t *regtypes, pmix
         if (PMIX_SUCCESS != ret) {
             *num_vals = 0;
             return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_bfrops_base_unpack_regex2(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                            void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_regex2_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrop_unpack: %d regex2", *num_vals);
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ptr = (pmix_regex2_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIx_Regex2_construct(&ptr[i]);
+        m = 1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].type, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        m = 1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].len, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        if (0 < ptr[i].len) {
+            ptr[i].bytes = (uint8_t *) malloc(ptr[i].len);
+            m = ptr[i].len;
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].bytes, &m, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                return ret;
+            }
         }
     }
     return PMIX_SUCCESS;

--- a/src/mca/bfrops/v61/bfrop_pmix61.c
+++ b/src/mca/bfrops/v61/bfrop_pmix61.c
@@ -335,6 +335,10 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_nodepid, pmix_bfrops_base_copy_nodepid,
                        pmix_bfrops_base_print_nodepid, &pmix_mca_bfrops_v61_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_REGEX2", PMIX_REGEX2, pmix_bfrops_base_pack_regex2,
+                       pmix_bfrops_base_unpack_regex2, pmix_bfrops_base_copy_regex2,
+                       pmix_bfrops_base_print_regex2, &pmix_mca_bfrops_v61_component.types);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -237,6 +237,19 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                     PMIX_ERROR_LOG(rc);
                     goto release;
                 }
+            } else if (PMIX_REGEX2 == info[n].value.type) {
+                char *decoded = NULL;
+                rc = pmix_preg.parse_regex(info[n].value.data.regex2, NULL, 0, &decoded);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+                rc = pmix_preg.parse_nodes(decoded, &nodes);
+                free(decoded);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
             } else if (PMIX_STRING == info[n].value.type) {
                 rc = pmix_preg.parse_nodes(info[n].value.data.string, &nodes);
                 if (PMIX_SUCCESS != rc) {
@@ -260,6 +273,19 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             if (PMIX_REGEX == info[n].value.type) {
                 if (PMIX_SUCCESS
                     != (rc = pmix_preg.parse_procs(info[n].value.data.bo.bytes, &procs))) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+            } else if (PMIX_REGEX2 == info[n].value.type) {
+                char *decoded = NULL;
+                rc = pmix_preg.parse_regex(info[n].value.data.regex2, NULL, 0, &decoded);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    goto release;
+                }
+                rc = pmix_preg.parse_procs(decoded, &procs);
+                free(decoded);
+                if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto release;
                 }

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -90,9 +90,9 @@ PMIX_EXPORT pmix_status_t pmix_preg_base_release(char *regexp);
 
 PMIX_EXPORT pmix_status_t pmix_preg_base_generate_regex(const char *input,
                                                          pmix_info_t info[], size_t ninfo,
-                                                         pmix_regex_t *regex);
+                                                         pmix_regex2_t *regex);
 
-PMIX_EXPORT pmix_status_t pmix_preg_base_parse_regex(const pmix_regex_t *regex,
+PMIX_EXPORT pmix_status_t pmix_preg_base_parse_regex(const pmix_regex2_t *regex,
                                                       pmix_info_t info[], size_t ninfo,
                                                       char **output);
 

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -169,7 +169,7 @@ pmix_status_t pmix_preg_base_release(char *regexp)
     return PMIX_ERR_BAD_PARAM;
 }
 
-pmix_status_t pmix_preg_base_parse_regex(const pmix_regex_t *regex,
+pmix_status_t pmix_preg_base_parse_regex(const pmix_regex2_t *regex,
                                           pmix_info_t info[], size_t ninfo,
                                           char **output)
 {
@@ -187,11 +187,11 @@ pmix_status_t pmix_preg_base_parse_regex(const pmix_regex_t *regex,
 
 pmix_status_t pmix_preg_base_generate_regex(const char *input,
                                              pmix_info_t info[], size_t ninfo,
-                                             pmix_regex_t *regex)
+                                             pmix_regex2_t *regex)
 {
     pmix_preg_base_active_module_t *active;
-    pmix_regex_t candidate = PMIX_REGEX_STATIC_INIT;
-    pmix_regex_t best = PMIX_REGEX_STATIC_INIT;
+    pmix_regex2_t candidate = PMIX_REGEX2_STATIC_INIT;
+    pmix_regex2_t best = PMIX_REGEX2_STATIC_INIT;
 
     PMIX_LIST_FOREACH (active, &pmix_preg_globals.actives, pmix_preg_base_active_module_t) {
         if (NULL == active->module->generate_regex) {
@@ -219,7 +219,7 @@ pmix_status_t pmix_preg_base_generate_regex(const char *input,
                 free(candidate.bytes);
             }
         }
-        candidate = (pmix_regex_t) PMIX_REGEX_STATIC_INIT;
+        candidate = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
     }
 
     if (NULL == best.bytes) {

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -52,8 +52,8 @@ static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
 static pmix_status_t release(char *regexp);
 static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
-                                    pmix_regex_t *regex);
-static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex2_t *regex);
+static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[], size_t ninfo,
                                  char **output);
 
 pmix_preg_module_t pmix_preg_compress_module = {
@@ -337,7 +337,7 @@ static pmix_status_t release(char *regexp)
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[], size_t ninfo,
                                  char **output)
 {
     char *tmp = NULL;
@@ -359,7 +359,7 @@ static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], 
 }
 
 static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
-                                    pmix_regex_t *regex)
+                                    pmix_regex2_t *regex)
 {
     uint8_t *compressed = NULL;
     size_t len;

--- a/src/mca/preg/preg.h
+++ b/src/mca/preg/preg.h
@@ -85,7 +85,7 @@ typedef pmix_status_t (*pmix_preg_base_module_unpack_fn_t)(pmix_buffer_t *buffer
 
 typedef pmix_status_t (*pmix_preg_base_module_release_fn_t)(char *regexp);
 
-/* Compress the input node-name list directly into a pmix_regex_t.
+/* Compress the input node-name list directly into a pmix_regex2_t.
  * The module sets regex->type to its name, stores the encoded bytes
  * in regex->bytes, and sets regex->len accordingly.
  * Returns PMIX_ERR_TAKE_NEXT_OPTION if the module cannot handle the input.
@@ -93,14 +93,14 @@ typedef pmix_status_t (*pmix_preg_base_module_release_fn_t)(char *regexp);
 typedef pmix_status_t (*pmix_preg_base_module_generate_regex_fn_t)(const char *input,
                                                                     pmix_info_t info[],
                                                                     size_t ninfo,
-                                                                    pmix_regex_t *regex);
+                                                                    pmix_regex2_t *regex);
 
-/* Expand a pmix_regex_t (as produced by generate_regex) back into a
+/* Expand a pmix_regex2_t (as produced by generate_regex) back into a
  * NULL-terminated argv array of node names in output.
  * Returns PMIX_ERR_TAKE_NEXT_OPTION if the module does not recognize
  * the regex->type value.
  */
-typedef pmix_status_t (*pmix_preg_base_module_parse_regex_fn_t)(const pmix_regex_t *regex,
+typedef pmix_status_t (*pmix_preg_base_module_parse_regex_fn_t)(const pmix_regex2_t *regex,
                                                                  pmix_info_t info[], size_t ninfo,
                                                                  char **output);
 

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -46,8 +46,8 @@ static pmix_status_t pack(pmix_buffer_t *buffer, const char *input);
 static pmix_status_t unpack(pmix_buffer_t *buffer, char **regex);
 static pmix_status_t release(char *regexp);
 static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
-                                    pmix_regex_t *regex);
-static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+                                    pmix_regex2_t *regex);
+static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[], size_t ninfo,
                                  char **output);
 
 pmix_preg_module_t pmix_preg_raw_module = {
@@ -173,7 +173,7 @@ static pmix_status_t release(char *regexp)
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], size_t ninfo,
+static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[], size_t ninfo,
                                  char **output)
 {
     // no attributes are currently defined for this function
@@ -189,7 +189,7 @@ static pmix_status_t parse_regex(const pmix_regex_t *regex, pmix_info_t info[], 
 }
 
 static pmix_status_t generate_regex(const char *input, pmix_info_t info[], size_t ninfo,
-                                    pmix_regex_t *regex)
+                                    pmix_regex2_t *regex)
 {
     // no attributes are currently defined for this function
     PMIX_HIDE_UNUSED_PARAMS(info, ninfo);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2696,7 +2696,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
 
 PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
                                                pmix_info_t info[], size_t ninfo,
-                                               pmix_regex_t *regex)
+                                               pmix_regex2_t *regex)
 {
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -2709,7 +2709,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
 }
 
 
-PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex_t *regex,
+PMIX_EXPORT pmix_status_t PMIx_parse_regex2(const pmix_regex2_t *regex,
                                             pmix_info_t info[], size_t ninfo,
                                             char **output)
 {

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -20,9 +20,9 @@
 # $HEADER$
 #
 
-check_PROGRAMS = compress preg
+check_PROGRAMS = compress preg bfrops_regex2
 
-TESTS = compress preg
+TESTS = compress preg bfrops_regex2
 
 compress_SOURCES =  \
         compress.c
@@ -36,5 +36,11 @@ preg_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 preg_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+bfrops_regex2_SOURCES = \
+        bfrops_regex2.c
+bfrops_regex2_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_regex2_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg
+	rm -f compress preg bfrops_regex2

--- a/test/unit/bfrops_regex2.c
+++ b/test/unit/bfrops_regex2.c
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIX_REGEX2 bfrops support: pack/unpack, copy, print,
+ * and compare operations exercised through the public PMIx API.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_printf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Build a pmix_regex2_t from a comma-separated node list. */
+static int make_regex(const char *nodes, pmix_regex2_t *rx)
+{
+    pmix_status_t rc = PMIx_generate_regex2(nodes, NULL, 0, rx);
+    return (PMIX_SUCCESS == rc && NULL != rx->type &&
+            NULL != rx->bytes && 0 != rx->len);
+}
+
+/* ------------------------------------------------------------------ */
+/* pack / unpack                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_pack_unpack_roundtrip(void)
+{
+    pmix_regex2_t src = PMIX_REGEX2_STATIC_INIT;
+    pmix_regex2_t dst = PMIX_REGEX2_STATIC_INIT;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    if (!make_regex("node001,node002,node003", &src)) {
+        report("pack/unpack round-trip (setup)", 0);
+        return;
+    }
+
+    PMIx_Data_buffer_construct(&buf);
+
+    rc = PMIx_Data_pack(NULL, &buf, &src, 1, PMIX_REGEX2);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_REGEX2);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (src.len == dst.len &&
+        NULL != dst.type  && 0 == strcmp(src.type, dst.type) &&
+        0 == memcmp(src.bytes, dst.bytes, src.len)) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    content mismatch after unpack\n");
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIx_Regex2_destruct(&src);
+    PMIx_Regex2_destruct(&dst);
+    report("pack/unpack round-trip", ok);
+}
+
+/* Pack multiple regex2 values into one buffer and unpack them all. */
+static void test_pack_unpack_multiple(void)
+{
+    const int N = 3;
+    const char *inputs[3] = { "node0001", "gpu001,gpu002", "io001,io002,io003,io004" };
+    pmix_regex2_t src[3];
+    pmix_regex2_t dst[3];
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int i, ok = 1;
+
+    for (i = 0; i < N; i++) {
+        pmix_regex2_t tmp_s = PMIX_REGEX2_STATIC_INIT;
+        pmix_regex2_t tmp_d = PMIX_REGEX2_STATIC_INIT;
+        src[i] = tmp_s;
+        dst[i] = tmp_d;
+    }
+
+    PMIx_Data_buffer_construct(&buf);
+
+    for (i = 0; i < N; i++) {
+        if (!make_regex(inputs[i], &src[i])) {
+            report("pack/unpack multiple (setup)", 0);
+            goto cleanup;
+        }
+        rc = PMIx_Data_pack(NULL, &buf, &src[i], 1, PMIX_REGEX2);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stdout, "    pack[%d] failed: %s\n", i, PMIx_Error_string(rc));
+            report("pack/unpack multiple", 0);
+            goto cleanup;
+        }
+    }
+
+    for (i = 0; i < N; i++) {
+        count = 1;
+        rc = PMIx_Data_unpack(NULL, &buf, &dst[i], &count, PMIX_REGEX2);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stdout, "    unpack[%d] failed: %s\n", i, PMIx_Error_string(rc));
+            ok = 0;
+            break;
+        }
+        if (src[i].len != dst[i].len ||
+            NULL == dst[i].type ||
+            0 != strcmp(src[i].type, dst[i].type) ||
+            0 != memcmp(src[i].bytes, dst[i].bytes, src[i].len)) {
+            fprintf(stdout, "    content mismatch at index %d\n", i);
+            ok = 0;
+            break;
+        }
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    for (i = 0; i < N; i++) {
+        PMIx_Regex2_destruct(&src[i]);
+        PMIx_Regex2_destruct(&dst[i]);
+    }
+    report("pack/unpack multiple values", ok);
+}
+
+/* Unpack into a pmix_value_t to exercise the PMIX_REGEX2 value path. */
+static void test_pack_unpack_via_value(void)
+{
+    pmix_regex2_t src = PMIX_REGEX2_STATIC_INIT;
+    pmix_value_t val;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    if (!make_regex("node100,node101,node102", &src)) {
+        report("pack/unpack via pmix_value_t (setup)", 0);
+        return;
+    }
+
+    PMIx_Data_buffer_construct(&buf);
+
+    /* Load the regex2 into a value and pack the value. */
+    val.type = PMIX_REGEX2;
+    val.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == val.data.regex2) {
+        report("pack/unpack via pmix_value_t (alloc)", 0);
+        goto cleanup;
+    }
+    val.data.regex2->type  = strdup(src.type);
+    val.data.regex2->len   = src.len;
+    val.data.regex2->bytes = malloc(src.len);
+    if (NULL == val.data.regex2->bytes) {
+        report("pack/unpack via pmix_value_t (alloc bytes)", 0);
+        goto cleanup;
+    }
+    memcpy(val.data.regex2->bytes, src.bytes, src.len);
+
+    rc = PMIx_Data_pack(NULL, &buf, &val, 1, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    PMIX_VALUE_DESTRUCT(&val);
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &val, &count, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_REGEX2 == val.type &&
+        NULL != val.data.regex2 &&
+        src.len == val.data.regex2->len &&
+        0 == memcmp(src.bytes, val.data.regex2->bytes, src.len)) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    value mismatch after unpack\n");
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIX_VALUE_DESTRUCT(&val);
+    PMIx_Regex2_destruct(&src);
+    report("pack/unpack via pmix_value_t", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* copy                                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_value_xfer(void)
+{
+    pmix_regex2_t src = PMIX_REGEX2_STATIC_INIT;
+    pmix_value_t vsrc, vdst;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&vsrc);
+    PMIX_VALUE_CONSTRUCT(&vdst);
+
+    if (!make_regex("node200,node201,node202,node203", &src)) {
+        report("PMIx_Value_xfer PMIX_REGEX2 (setup)", 0);
+        return;
+    }
+
+    vsrc.type = PMIX_REGEX2;
+    vsrc.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == vsrc.data.regex2) {
+        report("PMIx_Value_xfer PMIX_REGEX2 (alloc)", 0);
+        PMIx_Regex2_destruct(&src);
+        return;
+    }
+    vsrc.data.regex2->type  = strdup(src.type);
+    vsrc.data.regex2->len   = src.len;
+    vsrc.data.regex2->bytes = malloc(src.len);
+    if (NULL != vsrc.data.regex2->bytes)
+        memcpy(vsrc.data.regex2->bytes, src.bytes, src.len);
+
+    pmix_status_t rc = PMIx_Value_xfer(&vdst, &vsrc);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Value_xfer failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_REGEX2 == vdst.type &&
+        NULL != vdst.data.regex2 &&
+        vsrc.data.regex2->len == vdst.data.regex2->len &&
+        NULL != vdst.data.regex2->type &&
+        0 == strcmp(vsrc.data.regex2->type, vdst.data.regex2->type) &&
+        0 == memcmp(vsrc.data.regex2->bytes, vdst.data.regex2->bytes,
+                    vsrc.data.regex2->len)) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    copied value does not match source\n");
+    }
+
+    /* Verify deep copy - mutating src bytes doesn't affect dst. */
+    if (ok && vsrc.data.regex2->len > 0) {
+        uint8_t *b = (uint8_t *)vsrc.data.regex2->bytes;
+        uint8_t saved = b[0];
+        b[0] ^= 0xFF;
+        if (0 == memcmp(vsrc.data.regex2->bytes, vdst.data.regex2->bytes,
+                        vsrc.data.regex2->len)) {
+            fprintf(stdout, "    copy shares bytes pointer (shallow copy)\n");
+            ok = 0;
+        }
+        b[0] = saved;
+    }
+
+cleanup:
+    PMIX_VALUE_DESTRUCT(&vsrc);
+    PMIX_VALUE_DESTRUCT(&vdst);
+    PMIx_Regex2_destruct(&src);
+    report("PMIx_Value_xfer deep-copies PMIX_REGEX2", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* compare                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_compare_equal(void)
+{
+    pmix_regex2_t r1 = PMIX_REGEX2_STATIC_INIT;
+    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    pmix_value_t v1, v2;
+    pmix_value_cmp_t cmp;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&v1);
+    PMIX_VALUE_CONSTRUCT(&v2);
+
+    if (!make_regex("node300,node301", &r1) ||
+        !make_regex("node300,node301", &r2)) {
+        report("compare equal PMIX_REGEX2 (setup)", 0);
+        goto cleanup;
+    }
+
+    v1.type = PMIX_REGEX2;
+    v1.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == v1.data.regex2) goto cleanup;
+    v1.data.regex2->type  = strdup(r1.type);
+    v1.data.regex2->len   = r1.len;
+    v1.data.regex2->bytes = malloc(r1.len);
+    if (NULL != v1.data.regex2->bytes)
+        memcpy(v1.data.regex2->bytes, r1.bytes, r1.len);
+
+    v2.type = PMIX_REGEX2;
+    v2.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == v2.data.regex2) goto cleanup;
+    v2.data.regex2->type  = strdup(r2.type);
+    v2.data.regex2->len   = r2.len;
+    v2.data.regex2->bytes = malloc(r2.len);
+    if (NULL != v2.data.regex2->bytes)
+        memcpy(v2.data.regex2->bytes, r2.bytes, r2.len);
+
+    cmp = PMIx_Value_compare(&v1, &v2);
+    ok = (PMIX_EQUAL == cmp);
+    if (!ok)
+        fprintf(stdout, "    expected PMIX_EQUAL, got %d\n", (int)cmp);
+
+cleanup:
+    PMIX_VALUE_DESTRUCT(&v1);
+    PMIX_VALUE_DESTRUCT(&v2);
+    PMIx_Regex2_destruct(&r1);
+    PMIx_Regex2_destruct(&r2);
+    report("compare: identical PMIX_REGEX2 values are PMIX_EQUAL", ok);
+}
+
+static void test_compare_different(void)
+{
+    pmix_regex2_t r1 = PMIX_REGEX2_STATIC_INIT;
+    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    pmix_value_t v1, v2;
+    pmix_value_cmp_t cmp;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&v1);
+    PMIX_VALUE_CONSTRUCT(&v2);
+
+    if (!make_regex("node400", &r1) ||
+        !make_regex("node400,node401,node402", &r2)) {
+        report("compare different PMIX_REGEX2 (setup)", 0);
+        goto cleanup;
+    }
+
+    v1.type = PMIX_REGEX2;
+    v1.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == v1.data.regex2) goto cleanup;
+    v1.data.regex2->type  = strdup(r1.type);
+    v1.data.regex2->len   = r1.len;
+    v1.data.regex2->bytes = malloc(r1.len);
+    if (NULL != v1.data.regex2->bytes)
+        memcpy(v1.data.regex2->bytes, r1.bytes, r1.len);
+
+    v2.type = PMIX_REGEX2;
+    v2.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == v2.data.regex2) goto cleanup;
+    v2.data.regex2->type  = strdup(r2.type);
+    v2.data.regex2->len   = r2.len;
+    v2.data.regex2->bytes = malloc(r2.len);
+    if (NULL != v2.data.regex2->bytes)
+        memcpy(v2.data.regex2->bytes, r2.bytes, r2.len);
+
+    cmp = PMIx_Value_compare(&v1, &v2);
+    ok = (PMIX_EQUAL != cmp);
+    if (!ok)
+        fprintf(stdout, "    different values incorrectly reported as PMIX_EQUAL\n");
+
+cleanup:
+    PMIX_VALUE_DESTRUCT(&v1);
+    PMIX_VALUE_DESTRUCT(&v2);
+    PMIx_Regex2_destruct(&r1);
+    PMIx_Regex2_destruct(&r2);
+    report("compare: different PMIX_REGEX2 values are not PMIX_EQUAL", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* print                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_print_value(void)
+{
+    pmix_regex2_t src = PMIX_REGEX2_STATIC_INIT;
+    pmix_value_t val;
+    char *output = NULL;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    if (!make_regex("node500,node501", &src)) {
+        report("print PMIX_REGEX2 value (setup)", 0);
+        return;
+    }
+
+    val.type = PMIX_REGEX2;
+    val.data.regex2 = PMIx_Regex2_create(1);
+    if (NULL == val.data.regex2) {
+        report("print PMIX_REGEX2 value (alloc)", 0);
+        PMIx_Regex2_destruct(&src);
+        return;
+    }
+    val.data.regex2->type  = strdup(src.type);
+    val.data.regex2->len   = src.len;
+    val.data.regex2->bytes = malloc(src.len);
+    if (NULL != val.data.regex2->bytes)
+        memcpy(val.data.regex2->bytes, src.bytes, src.len);
+
+    rc = PMIx_Data_print(&output, NULL, &val, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Data_print failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    /* Output must be non-empty and mention the type name. */
+    if (NULL != output && '\0' != output[0] &&
+        NULL != strstr(output, "PMIX_REGEX2")) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    print output missing expected content: %s\n",
+                output ? output : "(null)");
+    }
+
+cleanup:
+    free(output);
+    PMIX_VALUE_DESTRUCT(&val);
+    PMIx_Regex2_destruct(&src);
+    report("PMIx_Data_print includes 'PMIX_REGEX2' label", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* pack/unpack preserves decodability                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_unpack_then_decode(void)
+{
+    const char *nodes = "node600,node601,node602,node603,node604";
+    pmix_regex2_t src = PMIX_REGEX2_STATIC_INIT;
+    pmix_regex2_t dst = PMIX_REGEX2_STATIC_INIT;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    char *decoded = NULL;
+    int ok = 0;
+
+    if (!make_regex(nodes, &src)) {
+        report("unpack then decode (setup)", 0);
+        return;
+    }
+
+    PMIx_Data_buffer_construct(&buf);
+
+    rc = PMIx_Data_pack(NULL, &buf, &src, 1, PMIX_REGEX2);
+    if (PMIX_SUCCESS != rc) goto cleanup;
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_REGEX2);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    rc = PMIx_parse_regex2(&dst, NULL, 0, &decoded);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    parse_regex2 after unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (NULL != decoded && 0 == strcmp(decoded, nodes)) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    decoded mismatch: expected '%s', got '%s'\n",
+                nodes, decoded ? decoded : "(null)");
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIx_Regex2_destruct(&src);
+    PMIx_Regex2_destruct(&dst);
+    free(decoded);
+    report("unpacked PMIX_REGEX2 still decodable via parse_regex2", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIX_REGEX2 bfrops unit tests ===\n\n");
+
+    /* pack / unpack */
+    test_pack_unpack_roundtrip();
+    test_pack_unpack_multiple();
+    test_pack_unpack_via_value();
+
+    /* copy */
+    test_value_xfer();
+
+    /* compare */
+    test_compare_equal();
+    test_compare_different();
+
+    /* print */
+    test_print_value();
+
+    /* integration: pack → unpack → decode */
+    test_unpack_then_decode();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -9,7 +9,7 @@
  * Unit tests for PMIx_generate_regex2 and PMIx_parse_regex2.
  *
  * Each test calls PMIx_generate_regex2 on a known input, checks that the
- * returned pmix_regex_t is non-empty, then round-trips through
+ * returned pmix_regex2_t is non-empty, then round-trips through
  * PMIx_parse_regex2 and verifies the decoded string matches the original.
  *
  * A simple PASS/FAIL summary is printed for each case.  The program exits
@@ -72,7 +72,7 @@ static void report(const char *name, int passed)
  */
 static int roundtrip(const char *input)
 {
-    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    pmix_regex2_t regex = PMIX_REGEX2_STATIC_INIT;
     char *decoded = NULL;
     pmix_status_t rc;
     int ok = 0;
@@ -83,7 +83,7 @@ static int roundtrip(const char *input)
         goto out;
     }
     if (NULL == regex.type || NULL == regex.bytes || 0 == regex.len) {
-        fprintf(stdout, "    generate_regex2 returned empty pmix_regex_t\n");
+        fprintf(stdout, "    generate_regex2 returned empty pmix_regex2_t\n");
         goto out;
     }
 
@@ -207,7 +207,7 @@ static void test_null_parse_input(void)
 /* Verify parse_regex2 rejects a NULL output pointer */
 static void test_null_parse_output(void)
 {
-    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    pmix_regex2_t regex = PMIX_REGEX2_STATIC_INIT;
     pmix_status_t rc;
 
     rc = PMIx_generate_regex2("node0", NULL, 0, &regex);
@@ -227,7 +227,7 @@ static void test_null_parse_output(void)
 /* Verify that the type field is set to a non-empty string */
 static void test_type_field_set(void)
 {
-    pmix_regex_t regex = PMIX_REGEX_STATIC_INIT;
+    pmix_regex2_t regex = PMIX_REGEX2_STATIC_INIT;
     pmix_status_t rc;
     int ok = 0;
 


### PR DESCRIPTION
Rename the struct type introduced for the generate_regex2/parse_regex2 API from pmix_regex_t to pmix_regex2_t (and its static initializer from PMIX_REGEX_STATIC_INIT to PMIX_REGEX2_STATIC_INIT) to clearly associate the type with the v2 API and avoid confusion with the legacy PMIX_REGEX (49) datatype that stores encoded node lists as a byte object.



Add PMIX_REGEX2 datatype with full bfrops support

Define PMIX_REGEX2 (type 74) as the wire/storage type for pmix_regex2_t values (the struct introduced for the generate_regex2/parse_regex2 API). The existing PMIX_REGEX (49) datatype is left unchanged.

Changes:
- pmix_common.h.in: define PMIX_REGEX2 = 74; add pmix_regex2_t *regex2 member to the pmix_value_t data union
- pmix.h / pmix_deprecated.h: declare PMIx_Regex2_{construct,destruct, create,free} (declarations land in pmix_deprecated.h so they are visible regardless of include order)
- bfrop_base_tma.h: add TMA helper functions (construct/destruct/create/ free/copy) for pmix_regex2_t; add PMIX_REGEX2 cases in the data-array copy, data-array free, value-xfer, and value-free switch statements
- bfrop_base_macro_backers.c: implement PMIx_Regex2_{construct,destruct, create,free} via the TMA helpers
- base.h: declare pack/unpack/copy/print_regex2
- bfrop_base_pack.c: pack type (string) + len (size_t) + raw bytes
- bfrop_base_unpack.c: reverse; add PMIX_REGEX2 case in unpack_value
- bfrop_base_copy.c: thin wrapper over tma_copy_regex2
- bfrop_base_print.c: print type string and byte length; add case in print_value
- bfrop_base_fns.c: PMIX_REGEX2 cases in value_load, value_unload, data_array_get_size, and Value_get_size
- bfrop_base_cmp.c: PMIX_REGEX2 cases in both array and scalar comparators
- bfrop_base_stubs.c: add "PMIX_REGEX2" to type name string
- v61/bfrop_pmix61.c: register PMIX_REGEX2 in the v6.1 bfrops module




test/unit: add bfrops_regex2 unit tests for PMIX_REGEX2

Add bfrops_regex2.c with 8 tests covering all bfrops operations for the PMIX_REGEX2 datatype: pack/unpack (single, multiple, and via pmix_value_t), deep-copy via PMIx_Value_xfer, equal/different compare via PMIx_Value_compare, print output via PMIx_Data_print, and a full pack→unpack→parse_regex2 pipeline test.  Update Makefile.am to build and register the new test binary.




gds/hash: add PMIX_REGEX2 support alongside PMIX_REGEX

For both PMIX_NODE_MAP and PMIX_PROC_MAP, add an else-if branch for PMIX_REGEX2 that mirrors the existing PMIX_REGEX handling. The pmix_regex2_t is first decoded to a plain string via pmix_preg.parse_regex, then the resulting string is passed to parse_nodes or parse_procs respectively.




pmix_common: deprecate PMIX_REGEX datatype in favour of PMIX_REGEX2

Move the PMIX_REGEX (49) #define from pmix_common.h.in to the v5 deprecations section of pmix_deprecated.h, with a comment pointing users to PMIX_REGEX2.  The numeric value is kept unchanged so that older wire-format data can still be decoded.

A hole comment is left in pmix_common.h.in at slot 49.  All existing bfrops pack/unpack/copy/print/compare support for PMIX_REGEX is intentionally retained; pmix_deprecated.h is included at the bottom of pmix_common.h so all in-tree consumers continue to compile.