### PR TITLE
version: replace PMIX_CAP_REGEX_PARSER with PMIX_CAP_REGEX2

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -50,7 +50,7 @@
 #define PMIX_CAP_UPCALLS2        3
 #define PMIX_CAP_STOP_PRGTHRD    4
 #define PMIX_CAP_GET_NUMBER_FN   5
-#define PMIX_CAP_REGEX_PARSER    6
+#define PMIX_CAP_REGEX2          6
 
 
 /*****    DEPRECATED    *****/


### PR DESCRIPTION
## Summary

- Remove the stale `PMIX_CAP_REGEX_PARSER` capability flag from `pmix_version.h.in`
- Add `PMIX_CAP_REGEX2` at value 6 to signal availability of the `generate_regex2`/`parse_regex2` API with `pmix_regex2_t`

## Details

`PMIX_CAP_REGEX_PARSER` was superseded by the new regex2 API introduced in the prior commit series. Consumers can now test for `PMIX_CAP_REGEX2` to determine whether `pmix_regex2_t` and the associated generator/parser functions are available without having to check the version number.