### PR TITLE
Add CodeQL advanced workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# CodeQL configuration for PMIx.  Push / PR scans load this file
+# locally from the checked-out branch.  The scheduled cross-branch scan
+# loads this same file from the default branch via CodeQL's remote
+# config-file syntax, so the release-branch scans do not require a local
+# copy of this file to already exist.
+
+name: "PMIx CodeQL config"
+
+paths-ignore:
+  - '**/test'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,103 +1,222 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
 #
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
+# Additional copyrights may follow
 #
+# $HEADER$
+#
+# CodeQL (GitHub code scanning / static analysis) configuration for
+# OpenPMIx.
+#
+# What this workflow does:
+#
+#   1. Runs CodeQL analysis on every pull request and on every push
+#      (i.e., merge) to master and the supported release branches.  This
+#      catches newly-introduced problems at the moment code changes.
+#
+#   2. Runs a periodic (weekly, Monday morning UTC) CodeQL scan of master
+#      *and* the active release branches.
+#
+# Why run periodic scans in addition to the per-PR / per-merge scans?
+#
+#   The PR/merge scans only ever examine code at the moment it changes.
+#   But CodeQL's query packs and analysis engine are continually
+#   updated as new classes of vulnerabilities (and new CVEs) are
+#   discovered.  The weekly scan re-analyzes the *existing* code base
+#   with the latest queries, so a vulnerability pattern that was
+#   unknown when a piece of code was merged can still be found later --
+#   even though that code has not changed and therefore would never be
+#   re-examined by a push/PR scan.  Release branches in particular tend
+#   to go quiet between point releases, so the periodic scan is often
+#   the only thing that keeps their results current.
+#
+# A note on branches and where this file must live:
+#
+#   - push and pull_request workflows always run from the copy of this
+#     file on the branch receiving the push / targeted by the PR (not
+#     from master).  So to get PR and merge analysis on a release branch
+#     (e.g., v5.0.x), this file must also be committed on that branch.
+#
+#   - The schedule (cron) event is special: it only ever fires from the
+#     default branch (master).  To periodically scan the release branches
+#     as well, the scheduled job below explicitly checks out each branch
+#     and tells the analyze action which ref/sha to attribute the results
+#     to.  The scheduled job is therefore inert on the release branches
+#     (it never fires there); only the copy on master drives the weekly
+#     scans.
+
 name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "master", "*" ]
+    # Defined once here (&scan_branches) and reused by pull_request
+    # below via a YAML alias, so the two trigger lists cannot drift.
+    branches: &scan_branches
+      - master
+      - 'v[5-9].*.x'       # Matches v5.0.x through v9.9.x
+      - 'v[1-9][0-9]+.*.x' # Matches v10.0.x and higher (double digits+)
   pull_request:
-    branches: [ "master", "*" ]
+    branches: *scan_branches
   schedule:
-    - cron: '27 15 * * 0'
+    # Monday morning (UTC).  The off-the-hour minute avoids GitHub's
+    # top-of-the-hour scheduling congestion.
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
+# Cancel a superseded in-progress run when a newer commit is pushed to
+# the same pull request, to avoid stacking up expensive C/C++ builds.
+# The group includes the event name so push/schedule runs live in
+# separate groups, and cancellation is enabled only for pull_request
+# runs -- never the weekly scheduled scan or pushes to a branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # -------------------------------------------------------------------
+  # Event-driven analysis: scans the ref that triggered the push / PR.
+  # -------------------------------------------------------------------
   analyze:
-    name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-
+    if: >-
+      github.event_name != 'schedule' &&
+      github.event_name != 'workflow_dispatch'
+    name: Analyze ${{ matrix.language }} (${{ github.ref_name }})
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: c-cpp
-          build-mode: autobuild
-        - language: python
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          libevent_cppflags=$(pkg-config libevent --cflags)
+          libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
+          ./autogen.pl
+          ./configure CPPFLAGS="$libevent_cppflags" LDFLAGS="$libevent_ldflags"
+          make -j $(nproc)
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+  # -------------------------------------------------------------------
+  # Scheduled/manual analysis: explicitly scans master and each release
+  # branch. The schedule only fires from the default branch (master);
+  # see the header comment. workflow_dispatch intentionally runs this
+  # same matrix so the scheduled path can be tested without waiting for
+  # the next cron event.
+  # -------------------------------------------------------------------
+  analyze-scheduled:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    name: Scheduled analysis - ${{ matrix.language }} (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Concrete branch names only: this matrix drives
+        # 'actions/checkout', so (unlike the on.push.branches globs)
+        # these cannot be globs or regexes. New release branches must be
+        # added here, too.
+        branch:
+          - master
+        language:
+          - actions
+          - c-cpp
+          - python
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Resolve commit SHA
+        id: commit
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: >-
+            ${{ github.repository }}/.github/codeql/codeql-config.yml@${{ github.event.repository.default_branch }}
+
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
+
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          libevent_cppflags=$(pkg-config libevent --cflags)
+          libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
+          ./autogen.pl
+          ./configure CPPFLAGS="$libevent_cppflags" LDFLAGS="$libevent_ldflags"
+          make -j $(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+          # Attribute results to the checked-out branch rather than to
+          # master (which is what a schedule event would otherwise report
+          # against).
+          ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
[ci: add CodeQL advanced workflow](https://github.com/openpmix/openpmix/commit/be6f6cee9a4a027b777af85443d38ff8056b07c6)

Add a GitHub CodeQL workflow that performs static analysis on the
C/C++ and Python sources, as well as GitHub Actions files.

- Event-driven job runs on every push/PR to master and release branches
- Scheduled job runs weekly (Monday 05:17 UTC) from master, scanning
  master and each named release branch with the latest query packs
- Installs libhwloc-dev and libevent-dev before building; passes
  libevent pkg-config flags to configure, matching the existing CI
- Uses the existing .github/codeql/codeql-config.yml sidecar
  (which excludes test directories)

Signed-off-by: Ralph <rhc@pmix.org>

[Add CodeQL sidecar](https://github.com/openpmix/openpmix/commit/9edede99d244ba550cafd03a45656d85d4ffe8c0)

Signed-off-by: Ralph <rhc@pmix.org>
