### PR TITLE
ptl: fix potential use-after-free in ptl_base_fns.c

### DIFF
--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -603,7 +603,7 @@ void pmix_ptl_base_complete_connection(pmix_peer_t *peer, char *nspace, pmix_ran
     if (NULL != peer->info->pname.nspace) {
         free(peer->info->pname.nspace);
     }
-    peer->info->pname.nspace = strdup(peer->nptr->nspace);
+    peer->info->pname.nspace = strdup(nspace);
     peer->info->pname.rank = rank;
 
     pmix_ptl_base_set_nonblocking(peer->sd);


### PR DESCRIPTION
At line 606, peer->nptr->nspace was used as the strdup source immediately after being freed (line 599) and reassigned (line 601). Although the reassignment made the use safe in practice, CodeQL flagged the indirect read through the previously-freed pointer as a potential use-after-free.

Replace strdup(peer->nptr->nspace) with strdup(nspace) since nspace is the value that was just assigned to peer->nptr->nspace, making the intent explicit and eliminating the stale-pointer read path.