### PR TITLE
gds/shmem2: make fixed-address segment attach reliable

### DIFF
--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -17,6 +17,9 @@ series, in reverse chronological order.
                   process
 
 Detailed changes since v6.1.0:
+ - gds/shmem2: make fixed-address segment attach reliable, fixing an
+   intermittent spawn-time PMIx_Init failure (PMIX_ERR_PACK_MISMATCH)
+   seen under AddressSanitizer and during MPI_Comm_spawn
  - PR #3868: Multiple commits
     - Update NEWS
     - pmdl/ompi: use the right type to enumerate myenvars

--- a/src/mca/gds/shmem2/gds_shmem2.c
+++ b/src/mca/gds/shmem2/gds_shmem2.c
@@ -1184,19 +1184,6 @@ shmem2_segment_create_and_attach(
     pmix_status_t rc = PMIX_SUCCESS;
     // Pad given size to fill remaining space on the last page.
     const size_t real_segsize = pmix_shmem_utils_pad_to_page(segment_size);
-    // Find a hole in virtual memory that meets our size requirements.
-    size_t base_addr = 0;
-    rc = pmix_vmem_find_hole(
-        VMEM_HOLE_BIGGEST, &base_addr, real_segsize
-    );
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        PMIX_ERROR_LOG(rc);
-        goto out;
-    }
-    PMIX_GDS_SHMEM2_VOUT(
-        "%s: %s found vmhole at address=0x%zx",
-        __func__, segment_name, base_addr
-    );
     // Find a unique path for the shared-memory backing file.
     const char *segment_path = get_shmem2_backing_path(job, segment_name);
     if (PMIX_UNLIKELY(!segment_path)) {
@@ -1223,12 +1210,52 @@ shmem2_segment_create_and_attach(
         PMIX_ERROR_LOG(rc);
         goto out;
     }
-    // Attach to the shared-memory segment.
-    rc = shmem2_attach(job, shmem2_id, (uintptr_t)base_addr);
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        PMIX_ERROR_LOG(rc);
-        goto out;
+    // Find a hole in virtual memory and attach the segment there.
+    //
+    // The hole is located by scanning /proc/self/maps and is then claimed by a
+    // separate mmap(); those two steps are not atomic. PMIx runs its internal
+    // work on a single progress thread, so PMIx never races itself here -- but
+    // the address space is process-wide, so other activity in the process can
+    // take the located hole in between: another thread, the dynamic loader
+    // (dlopen as components/namespaces come up), the C allocator growing an
+    // arena via mmap, or AddressSanitizer's own mappings. This is rare in
+    // general but considerably more likely under ASAN and during
+    // MPI_Comm_spawn. Because the server chooses this address (clients are
+    // later told whichever one we land on), recover from a lost hole by
+    // selecting a new one and retrying rather than failing the spawned job's
+    // PMIx_Init.
+    //
+    // Bypass shmem2_attach() here: on a failed map it reports a client-style
+    // address mismatch and tears the job down, which is wrong for the server,
+    // which chose the address and can simply try another hole.
+    enum { MAX_ATTACH_ATTEMPTS = 16 };
+    for (int attempt = 1; ; ++attempt) {
+        size_t base_addr = 0;
+        rc = pmix_vmem_find_hole(
+            VMEM_HOLE_BIGGEST, &base_addr, real_segsize
+        );
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            PMIX_ERROR_LOG(rc);
+            goto out;
+        }
+        PMIX_GDS_SHMEM2_VOUT(
+            "%s: %s found vmhole at address=0x%zx (attempt %d)",
+            __func__, segment_name, base_addr, attempt
+        );
+        rc = pmix_shmem_segment_attach(
+            shmem2, (uintptr_t)base_addr, PMIX_SHMEM_MUST_MAP_AT_RADDR
+        );
+        if (PMIX_LIKELY(PMIX_SUCCESS == rc)) {
+            break;
+        }
+        // Only the "could not map at the requested address" case is retryable;
+        // pmix_shmem_segment_attach() already detached its failed attempt.
+        if (PMIX_ERR_NOT_AVAILABLE != rc || attempt >= MAX_ATTACH_ATTEMPTS) {
+            PMIX_ERROR_LOG(rc);
+            goto out_release;
+        }
     }
+    pmix_gds_shmem2_set_status(job, shmem2_id, PMIX_GDS_SHMEM2_ATTACHED);
     // Fix-up backing file permission.
     rc = shmem2_segment_fix_perms(job, shmem2);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
@@ -1241,6 +1268,13 @@ out:
             job, shmem2_id, PMIX_GDS_SHMEM2_MINE
         );
     }
+    return rc;
+out_release:
+    // Mirror shmem2_attach()'s failure handling: detach and drop the job
+    // tracker entry.
+    (void)pmix_shmem_segment_detach(shmem2);
+    pmix_list_remove_item(&pmix_mca_gds_shmem2_component.jobs, &job->super);
+    PMIX_RELEASE(job);
     return rc;
 }
 

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -22,6 +22,13 @@
 #include <fcntl.h>
 #endif
 #include <sys/mman.h>
+#include <errno.h>
+
+// MAP_FIXED_NOREPLACE (Linux 4.17+) may be unavailable on older systems; fall
+// back to a plain address hint, which the post-mmap address check validates.
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0
+#endif
 
 typedef struct pmix_shmem_header_t {
     /** Reference count. */
@@ -71,22 +78,40 @@ segment_attach(
         goto out;
     }
 
+    // When the caller requires a specific base address (gds/shmem2 stores
+    // absolute pointers, so every process must map the segment at the same
+    // address), use MAP_FIXED_NOREPLACE: the kernel either honors the address
+    // exactly or fails with EEXIST. A bare address is only a hint that the
+    // kernel may silently relocate even when the target range is free.
+    int mmap_flags = MAP_SHARED;
+    const int must_map_at_raddr =
+        (flags & PMIX_SHMEM_MUST_MAP_AT_RADDR) &&
+        (uintptr_t) NULL != desired_base_address;
+    if (must_map_at_raddr) {
+        mmap_flags |= MAP_FIXED_NOREPLACE;
+    }
     mmap_addr = mmap(
         (void *)desired_base_address, shmem->size,
-        PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0
+        PROT_READ | PROT_WRITE, mmap_flags, fd, 0
     );
     if (MAP_FAILED == mmap_addr) {
-        rc = PMIX_ERR_NOMEM;
+        // EEXIST: the requested address is occupied. Report it as "not
+        // available" so the caller can retry at a different address.
+        rc = (must_map_at_raddr && EEXIST == errno)
+                 ? PMIX_ERR_NOT_AVAILABLE : PMIX_ERR_NOMEM;
         goto out;
     }
-    // Check flags.
-    // The caller wants memory mapped at their requested address.
-    if ((flags & PMIX_SHMEM_MUST_MAP_AT_RADDR) &&
-         desired_base_address != (uintptr_t)NULL) {
-        if (desired_base_address != (uintptr_t)mmap_addr) {
-            rc = PMIX_ERR_NOT_AVAILABLE;
-            goto out;
-        }
+    // Fallback for kernels that ignore MAP_FIXED_NOREPLACE and treat the
+    // address as a hint: reject a mapping that did not land where required.
+    if (must_map_at_raddr && desired_base_address != (uintptr_t)mmap_addr) {
+        // The mapping succeeded, just at the wrong address; unmap it here.
+        // The error path below calls pmix_shmem_segment_detach(), which only
+        // unmaps once shmem->attached is set (success only), so the mapping
+        // would otherwise leak -- once per attempt under the gds/shmem2 retry.
+        (void)munmap(mmap_addr, shmem->size);
+        mmap_addr = MAP_FAILED;
+        rc = PMIX_ERR_NOT_AVAILABLE;
+        goto out;
     }
 out:
     if (-1 != fd) {


### PR DESCRIPTION
> **Draft:** depends on #3886 (the master PR) being accepted and merged first.

## Summary

v6.x-series backport of #3886. The `gds/shmem2` segment-attach code on v6.1 is **identical to master**, so the two source files here are byte-for-byte the same as #3886 — no adjustment was needed. The only difference is the news entry: here it is appended to the existing `6.1.1` "Detailed changes" list in `news-v6.x.rst`.

The bug and fix (condensed; see #3886 / the commit message for full detail):

- The server maps each `gds/shmem2` segment at a fixed address chosen via `pmix_vmem_find_hole` + a *hint*-only `mmap()`. The hint is not binding (the kernel may relocate it) and the find-hole→`mmap()` window is not atomic against other process-wide address-space activity, so the claim intermittently lands at the wrong address and `register_job_info` fails — surfacing as a spawned client's `PMIx_Init` failing with `PMIX_ERR_PACK_MISMATCH` (seen under ASAN / `MPI_Comm_spawn`, open-mpi/ompi#13280).
- `segment_attach()` now claims the address with `MAP_FIXED_NOREPLACE` (clean `EEXIST` → `PMIX_ERR_NOT_AVAILABLE`, with a compile-time fallback), and the server's create path retries at a fresh hole instead of failing the job.

## Testing

- Builds warning-free (`./autogen.pl && ./configure && make`) on the `v6.1` branch.
- Same probabilistic ASAN + `MPI_Comm_spawn` reproduction as #3886; the failure no longer occurs.

Related: open-mpi/ompi#13280; master PR #3886
