### PR TITLE
AGENTS.md: add guidance on shared clones, testing, and commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,10 +289,28 @@ successfully.
 	./simptest
 	```
 
+**Test across environments when you can.** Portability across a wide
+variety of environments is a core PMIx goal. The primary development
+environments are common Linux distributions and macOS, but the code is
+expected to run far more widely. When container-based tooling is
+available, it can be a practical way to reproduce, diagnose, and test
+user-space behavior specific to an environment you aren't running
+natively — for example, using Docker on macOS to exercise Linux
+user-space code paths. (Containers don't replace real
+network/hardware/launcher testing, but they're useful for OS and
+user-space differences.)
+
 **Add tests for new code.** Whenever practical, add unit tests under
 [`test/unit`](test/unit) that are wired into `make check` (and therefore run in
 CI). Prefer a `make check`-able test over a manual one-off so the
 coverage sticks and regressions are caught automatically.
+
+**Never bend a test to accommodate a bug.** Do not weaken, skip, or
+rewrite an existing test — and do not craft a new one — merely to make
+buggy behavior pass. Tests encode intended behavior: when one fails, the
+default assumption is that the code is wrong, not the test. If you find a
+genuine bug in the code base, identify it, report it, and where
+appropriate fix it — don't paper over it in the test suite.
 
 
 ## Thread Safety and the Progress Thread
@@ -471,6 +489,21 @@ This requirement is especially critical in **static deployment environments such
 **Adding new data types:**
 New data types may be introduced in new PMIx versions.  The `bfrops` framework is the correct place to add serialization/deserialization support for them.  Each `bfrops` component corresponds to a specific wire-format version; older components remain in the tree to support communication with older peers.  Do not modify the pack/unpack logic of an existing `bfrops` component in a way that changes its wire representation — create a new component (version) instead.
 
+## Working in a shared repository
+
+Don't assume you're the only agent (or person) using this clone. In
+particular, if you're working in a **git worktree**, other worktrees may
+be active against the same underlying repository at the same time. Avoid
+repo-wide git commands that reach outside your own working area and can
+disrupt others — for example, `git worktree prune`, or `git stash`
+(which writes to the repository-wide stash ref shared by all worktrees).
+Keep your git operations scoped to your own branch and worktree.
+
+As a narrow exception, creating a **new branch** when you need to park
+work in progress (for example, instead of `git stash`) is fine. Just be
+careful not to collide with branches that other agents or people may be
+using in the same clone — pick a clearly-scoped, unlikely-to-clash name.
+
 ## Contributing
 
 Authoritative process:
@@ -485,6 +518,11 @@ honor:
   body explaining *why*. PMIx does **not** use Conventional Commits
   (`feat:`/`fix:` prefixes) — write prose. Don't add AI tooling
   attribution. Wrap commit-message lines at around 75 characters.
+- **Keep incidental fixes as their own commits.** Small "drive-by" bug
+  fixes you notice while working on something else are welcome, but it is
+  usually best to land them as standalone commits, separate from your
+  main change, so each can be evaluated and reviewed on its own. One
+  logical change per commit keeps history reviewable and easy to bisect.
 - **Branch flow:** work on a short-lived `topic/<short-description>`
   branch (e.g., `topic/fix-ptl-uaf`, `topic/cap-flags`), then open a
   pull request targeting `master`. After merge, cherry-pick to the


### PR DESCRIPTION
Port of open-mpi/ompi#13975. Adds four new sections/items:

- Test across environments: notes that portability is a core PMIx goal and that container tooling can help exercise OS/user-space differences.

- Never bend a test to accommodate a bug: reminds contributors that tests encode intended behavior and that failing tests point to bugs in the code, not the test suite.

- Working in a shared repository: warns agents not to use repo-wide git commands (e.g., git worktree prune, git stash) that can disrupt other worktrees or contributors sharing the same clone.

- Keep incidental fixes as their own commits: drive-by fixes are welcome but should be standalone commits so each can be reviewed independently.