### PR TITLE
Update log support by adding MCA parameter

### DIFF
--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -33,6 +33,7 @@
 
 #include "src/client/pmix_client_ops.h"
 #include "src/include/pmix_globals.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
@@ -279,9 +280,9 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         return rc;
     }
 
-    /* get here if we are a server - if we are not a gateway, then
-     * we don't handle this ourselves if the host support is available */
-    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
+    /* get here if we are a server - if we are not a gateway, or the
+     * host-only log param is set, pass this to the host if available */
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer) || pmix_log_host_only) {
         cb = PMIX_NEW(pmix_cb_t);
         cb->cbfunc.opfn = cbfunc;
         cb->cbdata = cbdata;
@@ -299,6 +300,12 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         } else if (NULL != pmix_host_server.log) {
             pmix_host_server.log(cb->proc, data, ndata, directives, ndirs,
                                  localcbfn, (void *) cb);
+        } else if (pmix_log_host_only) {
+            // caller explicitly requested host-only handling; never fall local
+            PMIX_PROC_FREE(source, 1);
+            cb->proc = NULL;
+            PMIX_RELEASE(cb);
+            return PMIX_ERR_NOT_SUPPORTED;
         } else {
             // no choice but to process locally
             goto local;

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -56,6 +56,7 @@ bool pmix_bind_progress_thread_reqd = false;
 int pmix_maxfd = 1024;
 int pmix_server_client_fintime;
 bool pmix_keep_fqdn_hostnames = false;
+bool pmix_log_host_only = false;
 
 char *pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_KEY_COUNT] = {NULL};
 static char *pmix_var_dump_color_string = NULL;
@@ -308,6 +309,13 @@ pmix_status_t pmix_register_params(void)
                                       "Whether or not to keep FQDN hostnames [default: no]",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &pmix_keep_fqdn_hostnames);
+
+    pmix_log_host_only = false;
+    (void) pmix_mca_base_var_register("pmix", "pmix", NULL, "log_host_only",
+                                      "Direct all PMIx_Log handling to the host environment;"
+                                      " the library's plog framework will not be invoked [default: no]",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &pmix_log_host_only);
 
     /* Var-dump color */
 

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -52,6 +52,7 @@ PMIX_EXPORT extern bool pmix_bind_progress_thread_reqd;
 PMIX_EXPORT extern int pmix_maxfd;
 PMIX_EXPORT extern int pmix_server_client_fintime;
 PMIX_EXPORT extern bool pmix_keep_fqdn_hostnames;
+PMIX_EXPORT extern bool pmix_log_host_only;
 
 /** version string of pmix */
 extern const char pmix_version_string[];

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -25,6 +25,7 @@
 #include "include/pmix_server.h"
 #include "src/mca/pcompress/pcompress.h"
 #include "src/include/pmix_globals.h"
+#include "src/runtime/pmix_rte.h"
 
 #ifdef HAVE_STRING_H
 #    include <string.h>
@@ -1523,9 +1524,10 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
         }
     }
 
-    /* if we are not the gateway, then pass this up to the host
-     * for transfer to the gateway, if available */
-    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer)) {
+    /* if we are not the gateway, or the host-only log param is set,
+     * then pass this up to the host for transfer to the gateway, if
+     * available */
+    if (!PMIX_PEER_IS_GATEWAY(pmix_globals.mypeer) || pmix_log_host_only) {
         pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                             "pmix:server not gateway");
         cd->cbfunc.opcbfn = cbfunc;

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -21,9 +21,9 @@
 # $HEADER$
 #
 
-check_PROGRAMS = compress preg bfrops_regex2 gds_fallback
+check_PROGRAMS = compress preg bfrops_regex2 gds_fallback pmix_log
 
-TESTS = compress preg bfrops_regex2 gds_fallback
+TESTS = compress preg bfrops_regex2 gds_fallback pmix_log
 
 compress_SOURCES =  \
         compress.c
@@ -49,5 +49,11 @@ gds_fallback_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 gds_fallback_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+pmix_log_SOURCES = \
+        pmix_log.c
+pmix_log_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+pmix_log_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 gds_fallback
+	rm -f compress preg bfrops_regex2 gds_fallback pmix_log

--- a/test/unit/pmix_log.c
+++ b/test/unit/pmix_log.c
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIx_Log and PMIx_Log_nb.
+ *
+ * The process is initialized as a non-gateway PMIx server.  Gateway
+ * behavior is exercised by temporarily setting the PMIX_PROC_GATEWAY_ACT
+ * flag on pmix_globals.mypeer, which is safe in a single-process unit
+ * test.  The pmix_log_host_only global is manipulated directly between
+ * test cases; it is reset to false after every test that sets it.
+ *
+ * Test cases:
+ *
+ *  bad-param: PMIx_Log rejects NULL/zero-length data.
+ *  bad-param: PMIx_Log_nb rejects NULL/zero-length data.
+ *
+ *  non-gateway + log2 registered + host_only=false → log2 invoked
+ *  non-gateway + log2 registered + host_only=true  → log2 invoked
+ *  non-gateway + no host log    + host_only=false  → falls local (plog)
+ *  non-gateway + no host log    + host_only=true   → PMIX_ERR_NOT_SUPPORTED
+ *
+ *  gateway + log2 registered + host_only=false → local plog (unchanged)
+ *  gateway + log2 registered + host_only=true  → log2 invoked
+ *  gateway + no host log     + host_only=false → local plog (unchanged)
+ *  gateway + no host log     + host_only=true  → PMIX_ERR_NOT_SUPPORTED
+ *
+ *  PMIx_Log_nb: cbfunc is invoked on completion.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/ptl_types.h"
+#include "src/runtime/pmix_rte.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/threads/pmix_threads.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Stub host log2 callback                                             */
+/* ------------------------------------------------------------------ */
+
+static int log2_call_count = 0;
+
+static pmix_status_t stub_log2(const pmix_proc_t *client,
+                                const pmix_info_t data[], size_t ndata,
+                                const pmix_info_t directives[], size_t ndirs,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(client, data, ndata, directives, ndirs);
+    ++log2_call_count;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test helpers                                                        */
+/* ------------------------------------------------------------------ */
+
+static void install_log2(void)
+{
+    log2_call_count = 0;
+    pmix_host_server.log2 = stub_log2;
+    pmix_host_server.log = NULL;
+}
+
+static void clear_host_log(void)
+{
+    pmix_host_server.log2 = NULL;
+    pmix_host_server.log = NULL;
+}
+
+static void set_gateway(bool gw)
+{
+    if (gw) {
+        pmix_globals.mypeer->proc_type.type |= PMIX_PROC_GATEWAY_ACT;
+    } else {
+        pmix_globals.mypeer->proc_type.type &= ~((uint32_t) PMIX_PROC_GATEWAY_ACT);
+    }
+}
+
+static void make_data(pmix_info_t *info)
+{
+    PMIX_INFO_LOAD(info, PMIX_LOG_STDERR, "pmix_log unit test", PMIX_STRING);
+}
+
+/* ------------------------------------------------------------------ */
+/* Parameter-validation tests                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_log_null_data(void)
+{
+    pmix_status_t rc = PMIx_Log(NULL, 0, NULL, 0);
+    report("PMIx_Log: NULL data returns PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+}
+
+static void test_lognb_null_data(void)
+{
+    pmix_status_t rc = PMIx_Log_nb(NULL, 0, NULL, 0, NULL, NULL);
+    report("PMIx_Log_nb: NULL data returns PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* Non-gateway dispatch tests                                          */
+/* ------------------------------------------------------------------ */
+
+/* Non-gateway server always enters the host-dispatch branch regardless
+ * of host_only; when log2 is registered it must be called. */
+static void test_nongateway_log2_hostonly_false(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(false);
+    install_log2();
+    pmix_log_host_only = false;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("non-gateway + log2 registered + host_only=false: log2 invoked",
+           PMIX_SUCCESS == rc && 1 == log2_call_count);
+    PMIX_INFO_DESTRUCT(data);
+}
+
+static void test_nongateway_log2_hostonly_true(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(false);
+    install_log2();
+    pmix_log_host_only = true;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("non-gateway + log2 registered + host_only=true: log2 invoked",
+           PMIX_SUCCESS == rc && 1 == log2_call_count);
+    PMIX_INFO_DESTRUCT(data);
+    pmix_log_host_only = false;
+}
+
+/* No host log functions and host_only=false: falls through to the local
+ * plog framework.  We cannot predict what plog returns in a minimal test
+ * environment, so only assert that the stricter host_only error was NOT
+ * returned. */
+static void test_nongateway_nohost_hostonly_false(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(false);
+    clear_host_log();
+    pmix_log_host_only = false;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("non-gateway + no host log + host_only=false: falls local (not ERR_NOT_SUPPORTED)",
+           PMIX_ERR_NOT_SUPPORTED != rc);
+    PMIX_INFO_DESTRUCT(data);
+}
+
+/* No host log functions and host_only=true: must return NOT_SUPPORTED. */
+static void test_nongateway_nohost_hostonly_true(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(false);
+    clear_host_log();
+    pmix_log_host_only = true;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("non-gateway + no host log + host_only=true: PMIX_ERR_NOT_SUPPORTED",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_INFO_DESTRUCT(data);
+    pmix_log_host_only = false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Gateway dispatch tests                                              */
+/* ------------------------------------------------------------------ */
+
+/* Gateway + host_only=false: plog framework is used regardless of
+ * whether a host log function is registered (original behavior). */
+static void test_gateway_log2_hostonly_false(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(true);
+    install_log2();
+    pmix_log_host_only = false;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("gateway + log2 registered + host_only=false: falls local (log2 not called)",
+           PMIX_ERR_NOT_SUPPORTED != rc && 0 == log2_call_count);
+    PMIX_INFO_DESTRUCT(data);
+    set_gateway(false);
+}
+
+/* Gateway + log2 registered + host_only=true: log2 must be called. */
+static void test_gateway_log2_hostonly_true(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(true);
+    install_log2();
+    pmix_log_host_only = true;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("gateway + log2 registered + host_only=true: log2 invoked",
+           PMIX_SUCCESS == rc && 1 == log2_call_count);
+    PMIX_INFO_DESTRUCT(data);
+    set_gateway(false);
+    pmix_log_host_only = false;
+}
+
+/* Gateway + no host log + host_only=false: falls local (original behavior). */
+static void test_gateway_nohost_hostonly_false(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(true);
+    clear_host_log();
+    pmix_log_host_only = false;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("gateway + no host log + host_only=false: falls local (not ERR_NOT_SUPPORTED)",
+           PMIX_ERR_NOT_SUPPORTED != rc);
+    PMIX_INFO_DESTRUCT(data);
+    set_gateway(false);
+}
+
+/* Gateway + no host log + host_only=true: must return NOT_SUPPORTED. */
+static void test_gateway_nohost_hostonly_true(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+
+    set_gateway(true);
+    clear_host_log();
+    pmix_log_host_only = true;
+    make_data(data);
+
+    rc = PMIx_Log(data, 1, NULL, 0);
+    report("gateway + no host log + host_only=true: PMIX_ERR_NOT_SUPPORTED",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_INFO_DESTRUCT(data);
+    set_gateway(false);
+    pmix_log_host_only = false;
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Log_nb: cbfunc is invoked on completion                       */
+/* ------------------------------------------------------------------ */
+
+static void nb_cbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_WAKEUP_THREAD(lock);
+}
+
+static void test_lognb_cbfunc_invoked(void)
+{
+    pmix_info_t data[1];
+    pmix_status_t rc;
+    pmix_lock_t lock;
+
+    set_gateway(false);
+    install_log2();
+    pmix_log_host_only = false;
+    make_data(data);
+    PMIX_CONSTRUCT_LOCK(&lock);
+
+    rc = PMIx_Log_nb(data, 1, NULL, 0, nb_cbfunc, &lock);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&lock);
+    }
+    PMIX_DESTRUCT_LOCK(&lock);
+
+    report("PMIx_Log_nb: cbfunc invoked on completion",
+           PMIX_SUCCESS == rc && 1 == log2_call_count);
+    PMIX_INFO_DESTRUCT(data);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIx_Log / PMIx_Log_nb unit tests ===\n\n");
+
+    /* Parameter validation */
+    test_log_null_data();
+    test_lognb_null_data();
+
+    /* Non-gateway dispatch */
+    test_nongateway_log2_hostonly_false();
+    test_nongateway_log2_hostonly_true();
+    test_nongateway_nohost_hostonly_false();
+    test_nongateway_nohost_hostonly_true();
+
+    /* Gateway dispatch */
+    test_gateway_log2_hostonly_false();
+    test_gateway_log2_hostonly_true();
+    test_gateway_nohost_hostonly_false();
+    test_gateway_nohost_hostonly_true();
+
+    /* Non-blocking completion */
+    test_lognb_cbfunc_invoked();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
[server/log: add pmix_log_host_only MCA parameter](https://github.com/openpmix/openpmix/commit/ff6f919bb319eb4888f23f726ed3d314e7d21db3)

Add a new boolean MCA parameter, pmix_log_host_only (env var
PMIX_MCA_pmix_log_host_only), defaulting to false.  When set to
true, all PMIx_Log handling is directed to the host environment;
the library's plog framework is never invoked.

Declare the variable in src/runtime/pmix_params.c and export it
via src/runtime/pmix_rte.h.

pmix_server_log() in src/server/pmix_server_ops.c handles
client-originated log messages arriving over the wire.  Extend
its non-gateway branch condition so that it also delegates to the
host when pmix_log_host_only is set.

PMIx_Log_nb() in src/common/pmix_log.c handles the case where the
host itself calls PMIx_Log directly as a gateway server, which
bypasses pmix_server_log() entirely.  Apply the same extension
there.  Add a stricter fallback: when pmix_log_host_only is true
and the host registers neither log2 nor log, return
PMIX_ERR_NOT_SUPPORTED rather than silently falling through to
local plog processing — the caller explicitly requested host-only
handling and should never get library-side processing as a surprise.

Resulting dispatch behaviour for PMIx_Log_nb on a server:

  Non-gateway, host_only false:  delegate to host if available,
                                 else fall local (unchanged)
  Non-gateway, host_only true:   delegate to host; return
                                 PMIX_ERR_NOT_SUPPORTED if no
                                 host log function is registered
  Gateway, host_only false:      process locally via plog (unchanged)
  Gateway, host_only true:       delegate to host; return
                                 PMIX_ERR_NOT_SUPPORTED if no
                                 host log function is registered

Signed-off-by: Ralph <rhc@pmix.org>

[test/unit: add PMIx_Log / PMIx_Log_nb unit tests](https://github.com/openpmix/openpmix/commit/91d1f421ca58939eb0cdeabcdad53ca72c95ce5a)

Add test/unit/pmix_log.c and wire it into make check via
test/unit/Makefile.am.

The test binary initializes as a non-gateway PMIx server and covers
eleven cases:

Parameter validation
  - PMIx_Log with NULL/zero-length data → PMIX_ERR_BAD_PARAM
  - PMIx_Log_nb with NULL/zero-length data → PMIX_ERR_BAD_PARAM

Non-gateway dispatch (host-dispatch branch is always entered)
  - log2 registered, host_only=false → log2 invoked
  - log2 registered, host_only=true  → log2 invoked
  - no host log,     host_only=false → falls local via plog
  - no host log,     host_only=true  → PMIX_ERR_NOT_SUPPORTED

Gateway dispatch
  - log2 registered, host_only=false → falls local via plog (log2 not called)
  - log2 registered, host_only=true  → log2 invoked
  - no host log,     host_only=false → falls local via plog
  - no host log,     host_only=true  → PMIX_ERR_NOT_SUPPORTED

Non-blocking
  - PMIx_Log_nb cbfunc is invoked on completion

Gateway mode is exercised by temporarily setting PMIX_PROC_GATEWAY_ACT
on pmix_globals.mypeer; pmix_log_host_only is reset to false after
every test case that sets it.

Signed-off-by: Ralph <rhc@pmix.org>
