### PR TITLE
client: verify calling process is a fence participant

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1632,6 +1632,7 @@ typedef int pmix_status_t;
 #define PMIX_ERR_EMPTY                              -60
 #define PMIX_ERR_LOST_CONNECTION                    -61
 #define PMIX_ERR_EXISTS_OUTSIDE_SCOPE               -62
+#define PMIX_ERR_NOT_A_MEMBER                       -66
 #define PMIX_ERR_NOT_AVAILABLE                      -64
 
 /* Process set */

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -61,6 +61,7 @@ static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd, const pmix_p
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
                         void *cbdata);
 static void op_cbfunc(pmix_status_t status, void *cbdata);
+static bool fence_client_is_included(const pmix_proc_t *procs, size_t nprocs);
 
 PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
                                      const pmix_info_t info[], size_t ninfo)
@@ -116,6 +117,28 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     return rc;
 }
 
+/* Return true if pmix_globals.myid is covered by the resolved procs array.
+ * Called after group expansion, so every entry carries a real nspace.
+ * PMIX_RANK_WILDCARD, PMIX_RANK_LOCAL_NODE, and PMIX_RANK_LOCAL_PEERS all
+ * cover the calling process when the nspace matches. */
+static bool fence_client_is_included(const pmix_proc_t *procs, size_t nprocs)
+{
+    size_t n;
+
+    for (n = 0; n < nprocs; n++) {
+        if (!PMIX_CHECK_NSPACE(procs[n].nspace, pmix_globals.myid.nspace)) {
+            continue;
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank ||
+            PMIX_RANK_LOCAL_NODE == procs[n].rank ||
+            PMIX_RANK_LOCAL_PEERS == procs[n].rank ||
+            procs[n].rank == pmix_globals.myid.rank) {
+            return true;
+        }
+    }
+    return false;
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
                                         const pmix_info_t info[], size_t ninfo,
                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
@@ -168,6 +191,14 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
             return rc;
         }
         created = true;
+    }
+
+    /* verify that the calling process is among the fence participants */
+    if (!fence_client_is_included(rgs, nrg)) {
+        if (created) {
+            PMIX_PROC_FREE(rgs, nrg);
+        }
+        return PMIX_ERR_NOT_A_MEMBER;
     }
 
     msg = PMIX_NEW(pmix_buffer_t);


### PR DESCRIPTION
Add a check in PMIx_Fence_nb that rejects the call with PMIX_ERR_NOT_A_MEMBER when the calling process is not covered by the supplied procs array.  The check runs after pmix_client_convert_group_procs() has expanded any group nspaces to real pmix_proc_t entries, so group membership is handled transparently.  PMIX_RANK_WILDCARD, PMIX_RANK_LOCAL_NODE, and PMIX_RANK_LOCAL_PEERS all satisfy the check when the nspace matches the caller.

Define PMIX_ERR_NOT_A_MEMBER (-66) as the specific error code for this condition.  The build system regenerates src/include/pmix_event_strings.[ch] from pmix_common.h.in, so PMIx_Error_string() will return "PMIX_ERR_NOT_A_MEMBER" for the new code automatically.

Refs https://github.com/openpmix/openpmix/issues/3850