### PR TITLE
test/unit: add unit tests for src/class modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,7 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[test/sshot/Makefile]
                 pmix_config_prefix[test/unit/Makefile]
                 pmix_config_prefix[test/unit/util/Makefile]
+                pmix_config_prefix[test/unit/class/Makefile]
                 pmix_config_prefix[test/util/Makefile]
                 pmix_config_prefix[docs/Makefile]
                 pmix_config_prefix[maint/pmix.pc])

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -21,7 +21,7 @@
 # $HEADER$
 #
 
-SUBDIRS = util
+SUBDIRS = util class
 
 noinst_SCRIPTS = run_gds_fallback.pl
 

--- a/test/unit/class/.gitignore
+++ b/test/unit/class/.gitignore
@@ -1,0 +1,8 @@
+class_object
+class_list
+class_bitmap
+class_hash_table
+class_pointer_array
+class_ring_buffer
+class_value_array
+class_hotel

--- a/test/unit/class/Makefile.am
+++ b/test/unit/class/Makefile.am
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+check_PROGRAMS = class_object class_list class_bitmap class_hash_table \
+    class_pointer_array class_ring_buffer class_value_array class_hotel
+
+TESTS = class_object class_list class_bitmap class_hash_table \
+    class_pointer_array class_ring_buffer class_value_array class_hotel
+
+class_object_SOURCES = class_object.c
+class_object_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_object_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_list_SOURCES = class_list.c
+class_list_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_list_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_bitmap_SOURCES = class_bitmap.c
+class_bitmap_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_bitmap_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_hash_table_SOURCES = class_hash_table.c
+class_hash_table_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_hash_table_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_pointer_array_SOURCES = class_pointer_array.c
+class_pointer_array_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_pointer_array_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_ring_buffer_SOURCES = class_ring_buffer.c
+class_ring_buffer_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_ring_buffer_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_value_array_SOURCES = class_value_array.c
+class_value_array_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_value_array_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+class_hotel_SOURCES = class_hotel.c
+class_hotel_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_hotel_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+clean-local:
+	rm -f class_object class_list class_bitmap class_hash_table \
+	    class_pointer_array class_ring_buffer class_value_array class_hotel

--- a/test/unit/class/class_bitmap.c
+++ b/test/unit/class/class_bitmap.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_bitmap_t:
+ *   init, set_bit, clear_bit, is_set_bit, find_and_set_first_unset_bit,
+ *   clear_all_bits, set_all_bits, is_clear, num_set_bits, num_unset_bits,
+ *   bitwise AND/OR/XOR inplace, copy, are_different, get_string.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/class/pmix_bitmap.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* init                                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    int rc = pmix_bitmap_init(&bm, 64);
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: size >= 64", pmix_bitmap_size(&bm) >= 64);
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* set_bit / is_set_bit / clear_bit                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_set_clear_bit(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 64);
+
+    int rc = pmix_bitmap_set_bit(&bm, 5);
+    report("set_bit: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_bit: bit 5 is set", pmix_bitmap_is_set_bit(&bm, 5));
+    report("set_bit: bit 4 is not set", !pmix_bitmap_is_set_bit(&bm, 4));
+
+    rc = pmix_bitmap_clear_bit(&bm, 5);
+    report("clear_bit: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("clear_bit: bit 5 is now clear", !pmix_bitmap_is_set_bit(&bm, 5));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+static void test_set_beyond_size(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 8);
+
+    int rc = pmix_bitmap_set_bit(&bm, 200);
+    report("set_bit beyond size: auto-expands (returns PMIX_SUCCESS)", PMIX_SUCCESS == rc);
+    report("set_bit beyond size: bit 200 is set", pmix_bitmap_is_set_bit(&bm, 200));
+    report("set_bit beyond size: size grew past 200", pmix_bitmap_size(&bm) > 200);
+
+    PMIX_DESTRUCT(&bm);
+}
+
+static void test_out_of_range_clear(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 8);
+
+    int rc = pmix_bitmap_clear_bit(&bm, 9999);
+    report("clear_bit out of range: returns error", PMIX_SUCCESS != rc);
+    report("is_set_bit out of range: returns false", !pmix_bitmap_is_set_bit(&bm, 9999));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* find_and_set_first_unset_bit                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_find_and_set(void)
+{
+    pmix_bitmap_t bm;
+    int pos;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 64);
+
+    pmix_bitmap_set_bit(&bm, 0);
+    pmix_bitmap_set_bit(&bm, 1);
+    pmix_bitmap_set_bit(&bm, 2);
+
+    int rc = pmix_bitmap_find_and_set_first_unset_bit(&bm, &pos);
+    report("find_and_set: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("find_and_set: first unset bit is 3", 3 == pos);
+    report("find_and_set: bit 3 is now set", pmix_bitmap_is_set_bit(&bm, 3));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* clear_all_bits / set_all_bits / is_clear                             */
+/* ------------------------------------------------------------------ */
+
+static void test_clear_all(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 64);
+
+    pmix_bitmap_set_bit(&bm, 1);
+    pmix_bitmap_set_bit(&bm, 10);
+    pmix_bitmap_set_bit(&bm, 63);
+
+    int rc = pmix_bitmap_clear_all_bits(&bm);
+    report("clear_all: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("clear_all: bit 1 is clear", !pmix_bitmap_is_set_bit(&bm, 1));
+    report("clear_all: bit 63 is clear", !pmix_bitmap_is_set_bit(&bm, 63));
+    report("clear_all: is_clear returns true", pmix_bitmap_is_clear(&bm));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+static void test_set_all(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 64);
+
+    int rc = pmix_bitmap_set_all_bits(&bm);
+    report("set_all: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_all: bit 0 is set", pmix_bitmap_is_set_bit(&bm, 0));
+    report("set_all: bit 63 is set", pmix_bitmap_is_set_bit(&bm, 63));
+    report("set_all: is_clear returns false", !pmix_bitmap_is_clear(&bm));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* num_set_bits / num_unset_bits                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_count_bits(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 64);
+
+    pmix_bitmap_set_bit(&bm, 0);
+    pmix_bitmap_set_bit(&bm, 2);
+    pmix_bitmap_set_bit(&bm, 4);
+
+    report("num_set_bits: 3 set in first 8",   3 == pmix_bitmap_num_set_bits(&bm, 8));
+    report("num_unset_bits: 5 unset in first 8", 5 == pmix_bitmap_num_unset_bits(&bm, 8));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bitwise OR inplace                                                   */
+/* ------------------------------------------------------------------ */
+
+static void test_bitwise_or(void)
+{
+    pmix_bitmap_t a, b;
+    PMIX_CONSTRUCT(&a, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&b, pmix_bitmap_t);
+    pmix_bitmap_init(&a, 64);
+    pmix_bitmap_init(&b, 64);
+
+    pmix_bitmap_set_bit(&a, 0);
+    pmix_bitmap_set_bit(&a, 2);
+    pmix_bitmap_set_bit(&b, 1);
+    pmix_bitmap_set_bit(&b, 2);
+
+    int rc = pmix_bitmap_bitwise_or_inplace(&a, &b);
+    report("bitwise_or: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("bitwise_or: bit 0 set (only in a)",  pmix_bitmap_is_set_bit(&a, 0));
+    report("bitwise_or: bit 1 set (only in b)",  pmix_bitmap_is_set_bit(&a, 1));
+    report("bitwise_or: bit 2 set (in both)",    pmix_bitmap_is_set_bit(&a, 2));
+
+    PMIX_DESTRUCT(&a);
+    PMIX_DESTRUCT(&b);
+}
+
+/* ------------------------------------------------------------------ */
+/* bitwise AND inplace                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_bitwise_and(void)
+{
+    pmix_bitmap_t a, b;
+    PMIX_CONSTRUCT(&a, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&b, pmix_bitmap_t);
+    pmix_bitmap_init(&a, 64);
+    pmix_bitmap_init(&b, 64);
+
+    pmix_bitmap_set_bit(&a, 0);
+    pmix_bitmap_set_bit(&a, 2);
+    pmix_bitmap_set_bit(&b, 1);
+    pmix_bitmap_set_bit(&b, 2);
+
+    int rc = pmix_bitmap_bitwise_and_inplace(&a, &b);
+    report("bitwise_and: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("bitwise_and: bit 0 clear (only in a)", !pmix_bitmap_is_set_bit(&a, 0));
+    report("bitwise_and: bit 1 clear (only in b)", !pmix_bitmap_is_set_bit(&a, 1));
+    report("bitwise_and: bit 2 set (in both)",      pmix_bitmap_is_set_bit(&a, 2));
+
+    PMIX_DESTRUCT(&a);
+    PMIX_DESTRUCT(&b);
+}
+
+/* ------------------------------------------------------------------ */
+/* bitwise XOR inplace                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_bitwise_xor(void)
+{
+    pmix_bitmap_t a, b;
+    PMIX_CONSTRUCT(&a, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&b, pmix_bitmap_t);
+    pmix_bitmap_init(&a, 64);
+    pmix_bitmap_init(&b, 64);
+
+    pmix_bitmap_set_bit(&a, 0);
+    pmix_bitmap_set_bit(&a, 2);
+    pmix_bitmap_set_bit(&b, 1);
+    pmix_bitmap_set_bit(&b, 2);
+
+    int rc = pmix_bitmap_bitwise_xor_inplace(&a, &b);
+    report("bitwise_xor: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("bitwise_xor: bit 0 set (only in a)",    pmix_bitmap_is_set_bit(&a, 0));
+    report("bitwise_xor: bit 1 set (only in b)",    pmix_bitmap_is_set_bit(&a, 1));
+    report("bitwise_xor: bit 2 clear (in both)", !pmix_bitmap_is_set_bit(&a, 2));
+
+    PMIX_DESTRUCT(&a);
+    PMIX_DESTRUCT(&b);
+}
+
+/* ------------------------------------------------------------------ */
+/* copy / are_different                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_copy_and_compare(void)
+{
+    pmix_bitmap_t src, dst;
+    PMIX_CONSTRUCT(&src, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&dst, pmix_bitmap_t);
+    pmix_bitmap_init(&src, 64);
+    pmix_bitmap_init(&dst, 64);
+
+    pmix_bitmap_set_bit(&src, 7);
+    pmix_bitmap_set_bit(&src, 42);
+
+    report("are_different before copy: true", pmix_bitmap_are_different(&src, &dst));
+
+    pmix_bitmap_copy(&dst, &src);
+    report("copy: dst bit 7 is set",  pmix_bitmap_is_set_bit(&dst, 7));
+    report("copy: dst bit 42 is set", pmix_bitmap_is_set_bit(&dst, 42));
+    report("are_different after copy: false", !pmix_bitmap_are_different(&src, &dst));
+
+    PMIX_DESTRUCT(&src);
+    PMIX_DESTRUCT(&dst);
+}
+
+/* ------------------------------------------------------------------ */
+/* get_string                                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_get_string(void)
+{
+    pmix_bitmap_t bm;
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 8);
+
+    char *str = pmix_bitmap_get_string(&bm);
+    report("get_string: returns non-NULL for cleared bitmap", NULL != str);
+    if (NULL != str) {
+        free(str);
+    }
+
+    pmix_bitmap_set_bit(&bm, 0);
+    pmix_bitmap_set_bit(&bm, 3);
+    str = pmix_bitmap_get_string(&bm);
+    report("get_string: non-NULL after setting bits", NULL != str);
+    if (NULL != str) {
+        free(str);
+    }
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_bitmap_t unit tests ===\n\n");
+
+    test_init();
+    test_set_clear_bit();
+    test_set_beyond_size();
+    test_out_of_range_clear();
+    test_find_and_set();
+    test_clear_all();
+    test_set_all();
+    test_count_bits();
+    test_bitwise_or();
+    test_bitwise_and();
+    test_bitwise_xor();
+    test_copy_and_compare();
+    test_get_string();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_hash_table.c
+++ b/test/unit/class/class_hash_table.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_hash_table_t:
+ *   init, get_size, uint32 / uint64 / ptr key ops,
+ *   remove_all, and iteration.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/class/pmix_hash_table.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* init / get_size                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_hash_table_t ht;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    int rc = pmix_hash_table_init(&ht, 16);
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: size is 0", 0 == pmix_hash_table_get_size(&ht));
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* uint32 key: set / get / remove                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_uint32_set_get(void)
+{
+    pmix_hash_table_t ht;
+    void *val;
+    int data1 = 42, data2 = 99;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    int rc = pmix_hash_table_set_value_uint32(&ht, 1, &data1);
+    report("uint32 set key 1: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    rc = pmix_hash_table_set_value_uint32(&ht, 2, &data2);
+    report("uint32 set key 2: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    report("uint32: size is 2", 2 == pmix_hash_table_get_size(&ht));
+
+    rc = pmix_hash_table_get_value_uint32(&ht, 1, &val);
+    report("uint32 get key 1: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("uint32 get key 1: value matches", val == (void *) &data1);
+
+    rc = pmix_hash_table_get_value_uint32(&ht, 2, &val);
+    report("uint32 get key 2: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("uint32 get key 2: value matches", val == (void *) &data2);
+
+    rc = pmix_hash_table_get_value_uint32(&ht, 99, &val);
+    report("uint32 get missing key: returns ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+static void test_uint32_remove(void)
+{
+    pmix_hash_table_t ht;
+    void *val;
+    int data = 7;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    pmix_hash_table_set_value_uint32(&ht, 10, &data);
+
+    int rc = pmix_hash_table_remove_value_uint32(&ht, 10);
+    report("uint32 remove: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    rc = pmix_hash_table_get_value_uint32(&ht, 10, &val);
+    report("uint32 get after remove: ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* uint64 key: set / get / remove                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_uint64_set_get(void)
+{
+    pmix_hash_table_t ht;
+    void *val;
+    int data = 123;
+    uint64_t key = 0xDEADBEEFCAFEBABEULL;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    int rc = pmix_hash_table_set_value_uint64(&ht, key, &data);
+    report("uint64 set: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    rc = pmix_hash_table_get_value_uint64(&ht, key, &val);
+    report("uint64 get: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("uint64 get: value matches", val == (void *) &data);
+
+    rc = pmix_hash_table_remove_value_uint64(&ht, key);
+    report("uint64 remove: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    rc = pmix_hash_table_get_value_uint64(&ht, key, &val);
+    report("uint64 get after remove: ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* ptr (binary) key: set / get / remove                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_ptr_set_get(void)
+{
+    pmix_hash_table_t ht;
+    void *val;
+    int data = 55;
+    const char *key = "mykey";
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    int rc = pmix_hash_table_set_value_ptr(&ht, key, strlen(key), &data);
+    report("ptr set: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    rc = pmix_hash_table_get_value_ptr(&ht, key, strlen(key), &val);
+    report("ptr get: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("ptr get: value matches", val == (void *) &data);
+
+    rc = pmix_hash_table_remove_value_ptr(&ht, key, strlen(key));
+    report("ptr remove: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+
+    rc = pmix_hash_table_get_value_ptr(&ht, key, strlen(key), &val);
+    report("ptr get after remove: ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* remove_all                                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_remove_all(void)
+{
+    pmix_hash_table_t ht;
+    void *val;
+    int d1 = 1, d2 = 2, d3 = 3;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    pmix_hash_table_set_value_uint32(&ht, 1, &d1);
+    pmix_hash_table_set_value_uint32(&ht, 2, &d2);
+    pmix_hash_table_set_value_uint32(&ht, 3, &d3);
+    report("remove_all: size is 3 before", 3 == pmix_hash_table_get_size(&ht));
+
+    int rc = pmix_hash_table_remove_all(&ht);
+    report("remove_all: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("remove_all: size is 0 after", 0 == pmix_hash_table_get_size(&ht));
+
+    rc = pmix_hash_table_get_value_uint32(&ht, 1, &val);
+    report("remove_all: key 1 not found", PMIX_ERR_NOT_FOUND == rc);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* uint32 iteration                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_uint32_iteration(void)
+{
+    pmix_hash_table_t ht;
+    int d1 = 10, d2 = 20, d3 = 30;
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 16);
+
+    pmix_hash_table_set_value_uint32(&ht, 100, &d1);
+    pmix_hash_table_set_value_uint32(&ht, 200, &d2);
+    pmix_hash_table_set_value_uint32(&ht, 300, &d3);
+
+    uint32_t key;
+    void *val;
+    void *node = NULL;
+    int count = 0;
+
+    if (PMIX_SUCCESS == pmix_hash_table_get_first_key_uint32(&ht, &key, &val, &node)) {
+        count++;
+        while (PMIX_SUCCESS
+               == pmix_hash_table_get_next_key_uint32(&ht, &key, &val, node, &node)) {
+            count++;
+        }
+    }
+    report("uint32 iteration: visited all 3 entries", 3 == count);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
+/* sizeof_hash_element                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_sizeof_hash_element(void)
+{
+    size_t sz = pmix_hash_table_sizeof_hash_element();
+    report("sizeof_hash_element: returns positive size", sz > 0);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_hash_table_t unit tests ===\n\n");
+
+    test_init();
+    test_uint32_set_get();
+    test_uint32_remove();
+    test_uint64_set_get();
+    test_ptr_set_get();
+    test_remove_all();
+    test_uint32_iteration();
+    test_sizeof_hash_element();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_hotel.c
+++ b/test/unit/class/class_hotel.c
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_hotel_t:
+ *   init, checkin, checkout, checkout_and_return_occupant,
+ *   knock, is_empty, full-hotel behavior.
+ *
+ * No event base is used; eviction timers are disabled (evbase=NULL).
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/class/pmix_hotel.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Dummy eviction callback -- never fired without an event base */
+static void dummy_evict(pmix_hotel_t *hotel, int room_num, void *occupant)
+{
+    (void) hotel;
+    (void) room_num;
+    (void) occupant;
+}
+
+/* ------------------------------------------------------------------ */
+/* init                                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_hotel_t hotel;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_status_t rc = pmix_hotel_init(&hotel, 5, NULL, 0, dummy_evict);
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: num_rooms is 5", 5 == hotel.num_rooms);
+    report("init: hotel is empty", pmix_hotel_is_empty(&hotel));
+    PMIX_DESTRUCT(&hotel);
+}
+
+static void test_init_bad_params(void)
+{
+    pmix_hotel_t hotel;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+
+    pmix_status_t rc = pmix_hotel_init(&hotel, 0, NULL, 0, dummy_evict);
+    report("init zero rooms: ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = pmix_hotel_init(&hotel, 5, NULL, 0, NULL);
+    report("init NULL callback: ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
+
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* checkin / checkout                                                   */
+/* ------------------------------------------------------------------ */
+
+static void test_checkin_checkout(void)
+{
+    pmix_hotel_t hotel;
+    int room;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 4, NULL, 0, dummy_evict);
+
+    char *guest = "alice";
+    pmix_status_t rc = pmix_hotel_checkin(&hotel, guest, &room);
+    report("checkin: returns PMIX_SUCCESS",       PMIX_SUCCESS == rc);
+    report("checkin: room number valid [0,4)",     room >= 0 && room < 4);
+    report("checkin: hotel not empty",            !pmix_hotel_is_empty(&hotel));
+
+    pmix_hotel_checkout(&hotel, room);
+    report("checkout: hotel is empty again",       pmix_hotel_is_empty(&hotel));
+
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* checkout_and_return_occupant                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_checkout_and_return(void)
+{
+    pmix_hotel_t hotel;
+    int room;
+    void *returned;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 4, NULL, 0, dummy_evict);
+
+    char *guest = "bob";
+    pmix_hotel_checkin(&hotel, guest, &room);
+
+    pmix_hotel_checkout_and_return_occupant(&hotel, room, &returned);
+    report("checkout_and_return: occupant pointer matches",  returned == (void *) guest);
+    report("checkout_and_return: hotel is empty after",      pmix_hotel_is_empty(&hotel));
+
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* knock                                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_knock(void)
+{
+    pmix_hotel_t hotel;
+    int room;
+    void *occupant;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 4, NULL, 0, dummy_evict);
+
+    char *guest = "carol";
+    pmix_hotel_checkin(&hotel, guest, &room);
+
+    pmix_hotel_knock(&hotel, room, &occupant);
+    report("knock: returns correct occupant",   occupant == (void *) guest);
+    report("knock: guest still in hotel",       !pmix_hotel_is_empty(&hotel));
+
+    pmix_hotel_checkout(&hotel, room);
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* hotel full                                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_hotel_full(void)
+{
+    pmix_hotel_t hotel;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 2, NULL, 0, dummy_evict);
+
+    int room1, room2, room3;
+    char *g1 = "d1", *g2 = "d2", *g3 = "d3";
+
+    pmix_status_t rc = pmix_hotel_checkin(&hotel, g1, &room1);
+    report("full test: checkin 1 succeeds", PMIX_SUCCESS == rc);
+    rc = pmix_hotel_checkin(&hotel, g2, &room2);
+    report("full test: checkin 2 succeeds", PMIX_SUCCESS == rc);
+
+    rc = pmix_hotel_checkin(&hotel, g3, &room3);
+    report("full test: checkin 3 fails (hotel full)", PMIX_ERR_OUT_OF_RESOURCE == rc);
+    report("full test: returned room is -1", -1 == room3);
+
+    pmix_hotel_checkout(&hotel, room1);
+    pmix_hotel_checkout(&hotel, room2);
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* multiple guests                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_multiple_guests(void)
+{
+    pmix_hotel_t hotel;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 10, NULL, 0, dummy_evict);
+
+    int rooms[5];
+    char *guests[5] = {"g0", "g1", "g2", "g3", "g4"};
+    bool all_checked_in = true;
+
+    for (int i = 0; i < 5; i++) {
+        pmix_status_t rc = pmix_hotel_checkin(&hotel, guests[i], &rooms[i]);
+        if (PMIX_SUCCESS != rc) {
+            all_checked_in = false;
+        }
+    }
+    report("multi_guests: all 5 checkins succeeded", all_checked_in);
+
+    bool all_correct = true;
+    for (int i = 0; i < 5; i++) {
+        void *occ;
+        pmix_hotel_knock(&hotel, rooms[i], &occ);
+        if (occ != (void *) guests[i]) {
+            all_correct = false;
+        }
+    }
+    report("multi_guests: knock returns correct occupant for each room", all_correct);
+
+    for (int i = 0; i < 5; i++) {
+        pmix_hotel_checkout(&hotel, rooms[i]);
+    }
+    report("multi_guests: all checked out, hotel empty", pmix_hotel_is_empty(&hotel));
+
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+/* re-use a room after checkout                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_room_reuse(void)
+{
+    pmix_hotel_t hotel;
+    int room1, room2;
+    PMIX_CONSTRUCT(&hotel, pmix_hotel_t);
+    pmix_hotel_init(&hotel, 1, NULL, 0, dummy_evict);
+
+    char *g1 = "first";
+    char *g2 = "second";
+
+    pmix_status_t rc = pmix_hotel_checkin(&hotel, g1, &room1);
+    report("room_reuse: first checkin succeeds", PMIX_SUCCESS == rc);
+
+    pmix_hotel_checkout(&hotel, room1);
+
+    rc = pmix_hotel_checkin(&hotel, g2, &room2);
+    report("room_reuse: second checkin succeeds after checkout", PMIX_SUCCESS == rc);
+
+    void *occ;
+    pmix_hotel_knock(&hotel, room2, &occ);
+    report("room_reuse: occupant is 'second'", occ == (void *) g2);
+
+    pmix_hotel_checkout(&hotel, room2);
+    PMIX_DESTRUCT(&hotel);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_hotel_t unit tests ===\n\n");
+
+    test_init();
+    test_init_bad_params();
+    test_checkin_checkout();
+    test_checkout_and_return();
+    test_knock();
+    test_hotel_full();
+    test_multiple_guests();
+    test_room_reuse();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_list.c
+++ b/test/unit/class/class_list.c
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_list_t and pmix_list_item_t:
+ *   append, prepend, remove_first, remove_last, remove_item,
+ *   get_size, is_empty, insert, sort, join, PMIX_LIST_FOREACH.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/class/pmix_list.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* A concrete list item carrying an integer payload */
+struct int_item_t {
+    pmix_list_item_t super;
+    int value;
+};
+typedef struct int_item_t int_item_t;
+PMIX_CLASS_DECLARATION(int_item_t);
+PMIX_CLASS_INSTANCE(int_item_t, pmix_list_item_t, NULL, NULL);
+
+static int_item_t *make_item(int val)
+{
+    int_item_t *it = PMIX_NEW(int_item_t);
+    if (NULL != it) {
+        it->value = val;
+    }
+    return it;
+}
+
+/* ------------------------------------------------------------------ */
+/* Empty list                                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_empty_list(void)
+{
+    pmix_list_t list;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    report("empty list: is_empty returns true", pmix_list_is_empty(&list));
+    report("empty list: get_size returns 0", 0 == pmix_list_get_size(&list));
+    report("empty list: remove_first returns NULL", NULL == pmix_list_remove_first(&list));
+    report("empty list: remove_last returns NULL", NULL == pmix_list_remove_last(&list));
+    PMIX_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* append                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_append(void)
+{
+    pmix_list_t list;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    int_item_t *a = make_item(10);
+    int_item_t *b = make_item(20);
+    int_item_t *c = make_item(30);
+
+    pmix_list_append(&list, (pmix_list_item_t *) a);
+    pmix_list_append(&list, (pmix_list_item_t *) b);
+    pmix_list_append(&list, (pmix_list_item_t *) c);
+
+    report("append: size is 3", 3 == pmix_list_get_size(&list));
+    report("append: not empty", !pmix_list_is_empty(&list));
+
+    int_item_t *first = (int_item_t *) pmix_list_get_first(&list);
+    int_item_t *last  = (int_item_t *) pmix_list_get_last(&list);
+    report("append: first element is 10", 10 == first->value);
+    report("append: last element is 30", 30 == last->value);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* prepend                                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_prepend(void)
+{
+    pmix_list_t list;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(1));
+    pmix_list_prepend(&list, (pmix_list_item_t *) make_item(2));
+    pmix_list_prepend(&list, (pmix_list_item_t *) make_item(3));
+
+    report("prepend: size is 3", 3 == pmix_list_get_size(&list));
+
+    int_item_t *first = (int_item_t *) pmix_list_get_first(&list);
+    int_item_t *last  = (int_item_t *) pmix_list_get_last(&list);
+    report("prepend: first element is 3", 3 == first->value);
+    report("prepend: last element is 1", 1 == last->value);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* remove_first / remove_last                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_remove_first(void)
+{
+    pmix_list_t list;
+    int_item_t *elem;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(10));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(20));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(30));
+
+    elem = (int_item_t *) pmix_list_remove_first(&list);
+    report("remove_first: value is 10", NULL != elem && 10 == elem->value);
+    report("remove_first: size is now 2", 2 == pmix_list_get_size(&list));
+    PMIX_RELEASE(elem);
+
+    elem = (int_item_t *) pmix_list_remove_first(&list);
+    report("remove_first again: value is 20", NULL != elem && 20 == elem->value);
+    PMIX_RELEASE(elem);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+static void test_remove_last(void)
+{
+    pmix_list_t list;
+    int_item_t *elem;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(10));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(20));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(30));
+
+    elem = (int_item_t *) pmix_list_remove_last(&list);
+    report("remove_last: value is 30", NULL != elem && 30 == elem->value);
+    report("remove_last: size is now 2", 2 == pmix_list_get_size(&list));
+    PMIX_RELEASE(elem);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* remove_item                                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_remove_item(void)
+{
+    pmix_list_t list;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    int_item_t *a = make_item(1);
+    int_item_t *b = make_item(2);
+    int_item_t *c = make_item(3);
+
+    pmix_list_append(&list, (pmix_list_item_t *) a);
+    pmix_list_append(&list, (pmix_list_item_t *) b);
+    pmix_list_append(&list, (pmix_list_item_t *) c);
+
+    pmix_list_remove_item(&list, (pmix_list_item_t *) b);
+    report("remove_item: size is 2", 2 == pmix_list_get_size(&list));
+
+    int_item_t *first = (int_item_t *) pmix_list_get_first(&list);
+    int_item_t *last  = (int_item_t *) pmix_list_get_last(&list);
+    report("remove_item: first is 1", 1 == first->value);
+    report("remove_item: last is 3", 3 == last->value);
+
+    PMIX_RELEASE(b);
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_LIST_FOREACH                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_foreach(void)
+{
+    pmix_list_t list;
+    int_item_t *cur;
+    int sum = 0;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(5));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(10));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(15));
+
+    PMIX_LIST_FOREACH(cur, &list, int_item_t) {
+        sum += cur->value;
+    }
+    report("PMIX_LIST_FOREACH: sum of 5+10+15 = 30", 30 == sum);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* insert                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_insert(void)
+{
+    pmix_list_t list;
+    int_item_t *cur;
+    int vals[3];
+    int n = 0;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(1));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(3));
+
+    bool ok = pmix_list_insert(&list, (pmix_list_item_t *) make_item(2), 1);
+    report("insert at index 1: returns true", ok);
+    report("insert at index 1: size is 3", 3 == pmix_list_get_size(&list));
+
+    PMIX_LIST_FOREACH(cur, &list, int_item_t) {
+        if (n < 3) {
+            vals[n++] = cur->value;
+        }
+    }
+    report("insert: order is 1, 2, 3",
+           3 == n && 1 == vals[0] && 2 == vals[1] && 3 == vals[2]);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+static void test_insert_out_of_bounds(void)
+{
+    pmix_list_t list;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(1));
+
+    int_item_t *extra = make_item(99);
+    bool ok = pmix_list_insert(&list, (pmix_list_item_t *) extra, 5);
+    report("insert out of bounds: returns false", !ok);
+    report("insert out of bounds: size unchanged", 1 == pmix_list_get_size(&list));
+    PMIX_RELEASE(extra);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* sort                                                                 */
+/* ------------------------------------------------------------------ */
+
+static int cmp_int_items(pmix_list_item_t **a, pmix_list_item_t **b)
+{
+    int va = ((int_item_t *) *a)->value;
+    int vb = ((int_item_t *) *b)->value;
+    return (va > vb) - (va < vb);
+}
+
+static void test_sort(void)
+{
+    pmix_list_t list;
+    int_item_t *cur;
+    int vals[3];
+    int n = 0;
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(30));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(10));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(20));
+
+    pmix_list_sort(&list, cmp_int_items);
+
+    PMIX_LIST_FOREACH(cur, &list, int_item_t) {
+        if (n < 3) {
+            vals[n++] = cur->value;
+        }
+    }
+    report("sort: order is 10, 20, 30",
+           3 == n && 10 == vals[0] && 20 == vals[1] && 30 == vals[2]);
+
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* join                                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_join(void)
+{
+    pmix_list_t dst;
+    pmix_list_t src;
+    PMIX_CONSTRUCT(&dst, pmix_list_t);
+    PMIX_CONSTRUCT(&src, pmix_list_t);
+
+    pmix_list_append(&dst, (pmix_list_item_t *) make_item(1));
+    pmix_list_append(&dst, (pmix_list_item_t *) make_item(2));
+    pmix_list_append(&src, (pmix_list_item_t *) make_item(3));
+    pmix_list_append(&src, (pmix_list_item_t *) make_item(4));
+
+    pmix_list_join(&dst, pmix_list_get_end(&dst), &src);
+
+    report("join: dst size is 4", 4 == pmix_list_get_size(&dst));
+    report("join: src is empty", pmix_list_is_empty(&src));
+
+    int_item_t *last = (int_item_t *) pmix_list_get_last(&dst);
+    report("join: last element of dst is 4", 4 == last->value);
+
+    PMIX_LIST_DESTRUCT(&dst);
+    PMIX_DESTRUCT(&src);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_LIST_RELEASE                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_list_release(void)
+{
+    pmix_list_t *list = PMIX_NEW(pmix_list_t);
+    report("PMIX_LIST_RELEASE: alloc succeeds", NULL != list);
+    if (NULL == list) {
+        return;
+    }
+
+    pmix_list_append(list, (pmix_list_item_t *) make_item(1));
+    pmix_list_append(list, (pmix_list_item_t *) make_item(2));
+
+    PMIX_LIST_RELEASE(list);
+    report("PMIX_LIST_RELEASE: list pointer is NULL", NULL == list);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_list_t unit tests ===\n\n");
+
+    test_empty_list();
+    test_append();
+    test_prepend();
+    test_remove_first();
+    test_remove_last();
+    test_remove_item();
+    test_foreach();
+    test_insert();
+    test_insert_out_of_bounds();
+    test_sort();
+    test_join();
+    test_list_release();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_object.c
+++ b/test/unit/class/class_object.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pmix_object_t class system:
+ *   PMIX_NEW, PMIX_RETAIN, PMIX_RELEASE, PMIX_CONSTRUCT, PMIX_DESTRUCT,
+ *   reference counting, and class hierarchy.
+ *
+ * pmix_object_t is a pure base class and cannot be instantiated directly
+ * (its cls_construct_array is pre-set to NULL).  All tests use
+ * pmix_list_item_t, the simplest derived class, as a concrete subject.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_object.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_NEW / PMIX_RELEASE                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_new_not_null(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    report("PMIX_NEW returns non-NULL", NULL != obj);
+    if (NULL != obj) {
+        PMIX_RELEASE(obj);
+    }
+}
+
+static void test_new_refcount_one(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("PMIX_NEW refcount: alloc failed", 0);
+        return;
+    }
+    report("PMIX_NEW sets refcount to 1", 1 == ((pmix_object_t *) obj)->obj_reference_count);
+    PMIX_RELEASE(obj);
+}
+
+static void test_release_sets_null(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("PMIX_RELEASE sets NULL: alloc failed", 0);
+        return;
+    }
+    PMIX_RELEASE(obj);
+    report("PMIX_RELEASE sets pointer to NULL", NULL == obj);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_RETAIN                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_retain_increments_refcount(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("PMIX_RETAIN: alloc failed", 0);
+        return;
+    }
+    PMIX_RETAIN(obj);
+    report("PMIX_RETAIN increments refcount to 2", 2 == ((pmix_object_t *) obj)->obj_reference_count);
+    PMIX_RELEASE(obj);
+    report("PMIX_RELEASE after retain: refcount back to 1", 1 == ((pmix_object_t *) obj)->obj_reference_count);
+    PMIX_RELEASE(obj);
+}
+
+static void test_retain_release_multiple(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("multi retain/release: alloc failed", 0);
+        return;
+    }
+    PMIX_RETAIN(obj);
+    PMIX_RETAIN(obj);
+    report("double retain: refcount is 3", 3 == ((pmix_object_t *) obj)->obj_reference_count);
+    PMIX_RELEASE(obj);
+    PMIX_RELEASE(obj);
+    report("double release: refcount is 1", 1 == ((pmix_object_t *) obj)->obj_reference_count);
+    PMIX_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_CONSTRUCT / PMIX_DESTRUCT (stack allocation)                   */
+/* ------------------------------------------------------------------ */
+
+static void test_construct_destruct(void)
+{
+    pmix_list_item_t obj;
+    PMIX_CONSTRUCT(&obj, pmix_list_item_t);
+    report("PMIX_CONSTRUCT: refcount is 1", 1 == ((pmix_object_t *) &obj)->obj_reference_count);
+    report("PMIX_CONSTRUCT: class pointer is non-NULL", NULL != ((pmix_object_t *) &obj)->obj_class);
+    PMIX_DESTRUCT(&obj);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_list_t (deeper subclass)                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_list_object(void)
+{
+    pmix_list_t *lst = PMIX_NEW(pmix_list_t);
+    report("PMIX_NEW(pmix_list_t): non-NULL", NULL != lst);
+    if (NULL != lst) {
+        report("PMIX_NEW(pmix_list_t): refcount is 1",
+               1 == ((pmix_object_t *) lst)->obj_reference_count);
+        PMIX_RELEASE(lst);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Class hierarchy: class name and depth                                */
+/* ------------------------------------------------------------------ */
+
+static void test_class_name(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("class name: alloc failed", 0);
+        return;
+    }
+    report("pmix_list_item_t: class name matches",
+           0 == strcmp(((pmix_object_t *) obj)->obj_class->cls_name, "pmix_list_item_t"));
+    PMIX_RELEASE(obj);
+}
+
+static void test_class_parent(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("class parent: alloc failed", 0);
+        return;
+    }
+    pmix_class_t *cls = ((pmix_object_t *) obj)->obj_class;
+    report("pmix_list_item_t: parent class is non-NULL", NULL != cls->cls_parent);
+    report("pmix_list_item_t: parent class name is pmix_object_t",
+           NULL != cls->cls_parent &&
+           0 == strcmp(cls->cls_parent->cls_name, "pmix_object_t"));
+    PMIX_RELEASE(obj);
+}
+
+static void test_hierarchy_depth(void)
+{
+    pmix_list_item_t *item = PMIX_NEW(pmix_list_item_t);
+    if (NULL == item) {
+        report("hierarchy depth: alloc failed", 0);
+        return;
+    }
+    report("pmix_list_item_t: hierarchy depth >= 2",
+           ((pmix_object_t *) item)->obj_class->cls_depth >= 2);
+    PMIX_RELEASE(item);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_class_t sizeof field                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_class_sizeof(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    if (NULL == obj) {
+        report("class sizeof: alloc failed", 0);
+        return;
+    }
+    report("cls_sizeof matches sizeof(pmix_list_item_t)",
+           ((pmix_object_t *) obj)->obj_class->cls_sizeof == sizeof(pmix_list_item_t));
+    PMIX_RELEASE(obj);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_object_t (class system) unit tests ===\n\n");
+
+    test_new_not_null();
+    test_new_refcount_one();
+    test_release_sets_null();
+    test_retain_increments_refcount();
+    test_retain_release_multiple();
+    test_construct_destruct();
+    test_list_object();
+    test_class_name();
+    test_class_parent();
+    test_hierarchy_depth();
+    test_class_sizeof();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_pointer_array.c
+++ b/test/unit/class/class_pointer_array.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_pointer_array_t:
+ *   init, add, get_item, set_item, test_and_set_item,
+ *   set_size, get_size, remove_all.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/class/pmix_pointer_array.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* init / get_size                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    int rc = pmix_pointer_array_init(&pa, 4, 1024, 4);
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: size == 4", 4 == pmix_pointer_array_get_size(&pa));
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+/* add / get_item                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_add_and_get(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 4, 1024, 4);
+
+    int val1 = 100, val2 = 200, val3 = 300;
+
+    int idx1 = pmix_pointer_array_add(&pa, &val1);
+    int idx2 = pmix_pointer_array_add(&pa, &val2);
+    int idx3 = pmix_pointer_array_add(&pa, &val3);
+
+    report("add: first index >= 0",       idx1 >= 0);
+    report("add: second index >= 0",      idx2 >= 0);
+    report("add: third index >= 0",       idx3 >= 0);
+    report("add: indices are distinct",   idx1 != idx2 && idx2 != idx3);
+
+    report("get_item idx1: value matches", pmix_pointer_array_get_item(&pa, idx1) == &val1);
+    report("get_item idx2: value matches", pmix_pointer_array_get_item(&pa, idx2) == &val2);
+    report("get_item idx3: value matches", pmix_pointer_array_get_item(&pa, idx3) == &val3);
+
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+/* set_item / get_item out of bounds                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_set_item(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 8, 1024, 8);
+
+    int val = 77;
+    int rc = pmix_pointer_array_set_item(&pa, 3, &val);
+    report("set_item: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_item: get_item returns correct pointer",
+           pmix_pointer_array_get_item(&pa, 3) == &val);
+
+    rc = pmix_pointer_array_set_item(&pa, 3, NULL);
+    report("set_item NULL: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_item NULL: get_item returns NULL",
+           NULL == pmix_pointer_array_get_item(&pa, 3));
+
+    report("get_item out of bounds (negative): returns NULL",
+           NULL == pmix_pointer_array_get_item(&pa, -1));
+
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_and_set_item                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_test_and_set(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 8, 1024, 8);
+
+    int val1 = 11, val2 = 22;
+
+    bool ok = pmix_pointer_array_test_and_set_item(&pa, 5, &val1);
+    report("test_and_set: first set at [5] succeeds", ok);
+    report("test_and_set: item is set to val1",
+           pmix_pointer_array_get_item(&pa, 5) == &val1);
+
+    ok = pmix_pointer_array_test_and_set_item(&pa, 5, &val2);
+    report("test_and_set: second set at occupied [5] fails", !ok);
+    report("test_and_set: original value preserved",
+           pmix_pointer_array_get_item(&pa, 5) == &val1);
+
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+/* remove_all                                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_remove_all(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 8, 1024, 8);
+
+    int val = 42;
+    pmix_pointer_array_add(&pa, &val);
+    pmix_pointer_array_add(&pa, &val);
+    pmix_pointer_array_add(&pa, &val);
+
+    pmix_pointer_array_remove_all(&pa);
+
+    int size = pmix_pointer_array_get_size(&pa);
+    bool all_null = true;
+    for (int i = 0; i < size; i++) {
+        if (NULL != pmix_pointer_array_get_item(&pa, i)) {
+            all_null = false;
+            break;
+        }
+    }
+    report("remove_all: all items are NULL", all_null);
+
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+/* set_size / auto-grow                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_set_size(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 4, 1024, 4);
+
+    int rc = pmix_pointer_array_set_size(&pa, 32);
+    report("set_size 32: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_size 32: size >= 32", pmix_pointer_array_get_size(&pa) >= 32);
+
+    PMIX_DESTRUCT(&pa);
+}
+
+static void test_grow_via_set_item(void)
+{
+    pmix_pointer_array_t pa;
+    PMIX_CONSTRUCT(&pa, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pa, 4, 1024, 4);
+
+    int val = 7;
+    int rc = pmix_pointer_array_set_item(&pa, 100, &val);
+    report("set_item beyond current size: returns PMIX_SUCCESS (auto-grow)", PMIX_SUCCESS == rc);
+    report("set_item beyond: value retrievable", pmix_pointer_array_get_item(&pa, 100) == &val);
+    report("set_item beyond: size grew past 100", pmix_pointer_array_get_size(&pa) > 100);
+
+    PMIX_DESTRUCT(&pa);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_pointer_array_t unit tests ===\n\n");
+
+    test_init();
+    test_add_and_get();
+    test_set_item();
+    test_test_and_set();
+    test_remove_all();
+    test_set_size();
+    test_grow_via_set_item();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_ring_buffer.c
+++ b/test/unit/class/class_ring_buffer.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_ring_buffer_t:
+ *   init, push, pop (FIFO order), wraparound displacement, poke.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/class/pmix_ring_buffer.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* init                                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_ring_buffer_t rb;
+    PMIX_CONSTRUCT(&rb, pmix_ring_buffer_t);
+    int rc = pmix_ring_buffer_init(&rb, 4);
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: size is 4", 4 == rb.size);
+    PMIX_DESTRUCT(&rb);
+}
+
+/* ------------------------------------------------------------------ */
+/* push / pop (not full, FIFO order)                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_push_pop_basic(void)
+{
+    pmix_ring_buffer_t rb;
+    PMIX_CONSTRUCT(&rb, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&rb, 4);
+
+    char *a = "alpha";
+    char *b = "beta";
+
+    void *displaced = pmix_ring_buffer_push(&rb, a);
+    report("push first: no displacement (returns NULL)", NULL == displaced);
+    displaced = pmix_ring_buffer_push(&rb, b);
+    report("push second: no displacement (returns NULL)", NULL == displaced);
+
+    void *out = pmix_ring_buffer_pop(&rb);
+    report("pop first: returns 'alpha' (oldest)", out == (void *) a);
+    out = pmix_ring_buffer_pop(&rb);
+    report("pop second: returns 'beta'", out == (void *) b);
+    out = pmix_ring_buffer_pop(&rb);
+    report("pop empty: returns NULL", NULL == out);
+
+    PMIX_DESTRUCT(&rb);
+}
+
+/* ------------------------------------------------------------------ */
+/* wraparound / displacement when ring is full                          */
+/* ------------------------------------------------------------------ */
+
+static void test_wraparound(void)
+{
+    pmix_ring_buffer_t rb;
+    PMIX_CONSTRUCT(&rb, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&rb, 3);
+
+    char *a = "a", *b = "b", *c = "c", *d = "d";
+
+    pmix_ring_buffer_push(&rb, a);
+    pmix_ring_buffer_push(&rb, b);
+    pmix_ring_buffer_push(&rb, c);
+
+    /* Ring is full; pushing 'd' displaces the oldest ('a') */
+    void *displaced = pmix_ring_buffer_push(&rb, d);
+    report("wraparound: displaced element is 'a' (oldest)", displaced == (void *) a);
+
+    /* Remaining elements dequeue in FIFO order: b, c, d */
+    void *out = pmix_ring_buffer_pop(&rb);
+    report("wraparound pop 1: 'b'", out == (void *) b);
+    out = pmix_ring_buffer_pop(&rb);
+    report("wraparound pop 2: 'c'", out == (void *) c);
+    out = pmix_ring_buffer_pop(&rb);
+    report("wraparound pop 3: 'd'", out == (void *) d);
+    out = pmix_ring_buffer_pop(&rb);
+    report("wraparound pop 4: empty -> NULL", NULL == out);
+
+    PMIX_DESTRUCT(&rb);
+}
+
+/* ------------------------------------------------------------------ */
+/* Multiple wraparounds                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_multiple_wraps(void)
+{
+    pmix_ring_buffer_t rb;
+    PMIX_CONSTRUCT(&rb, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&rb, 2);
+
+    char *a = "a", *b = "b", *c = "c", *d = "d";
+
+    pmix_ring_buffer_push(&rb, a);
+    pmix_ring_buffer_push(&rb, b);
+
+    void *dis1 = pmix_ring_buffer_push(&rb, c);
+    report("multi_wrap: push c displaces a", dis1 == (void *) a);
+
+    void *dis2 = pmix_ring_buffer_push(&rb, d);
+    report("multi_wrap: push d displaces b", dis2 == (void *) b);
+
+    void *out = pmix_ring_buffer_pop(&rb);
+    report("multi_wrap: pop returns c", out == (void *) c);
+    out = pmix_ring_buffer_pop(&rb);
+    report("multi_wrap: pop returns d", out == (void *) d);
+
+    PMIX_DESTRUCT(&rb);
+}
+
+/* ------------------------------------------------------------------ */
+/* poke                                                                 */
+/*                                                                      */
+/* poke(i >= 0): element at offset i from tail (oldest).               */
+/*   poke(0) returns the oldest item (= what pop would return next).   */
+/* poke(i < 0): the most recently pushed element (at head - 1).        */
+/* ------------------------------------------------------------------ */
+
+static void test_poke(void)
+{
+    pmix_ring_buffer_t rb;
+    PMIX_CONSTRUCT(&rb, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&rb, 4);
+
+    char *a = "a", *b = "b", *c = "c";
+    pmix_ring_buffer_push(&rb, a);
+    pmix_ring_buffer_push(&rb, b);
+    pmix_ring_buffer_push(&rb, c);
+
+    /* poke(0) -> oldest (what pop would return first) = 'a' */
+    void *p = pmix_ring_buffer_poke(&rb, 0);
+    report("poke(0): returns oldest 'a'", p == (void *) a);
+
+    /* poke(1) -> second oldest = 'b' */
+    p = pmix_ring_buffer_poke(&rb, 1);
+    report("poke(1): returns second 'b'", p == (void *) b);
+
+    /* poke(-1) -> most recently pushed = 'c' */
+    p = pmix_ring_buffer_poke(&rb, -1);
+    report("poke(-1): returns most recent 'c'", p == (void *) c);
+
+    /* poke() does not remove items */
+    void *out = pmix_ring_buffer_pop(&rb);
+    report("poke does not remove: pop still returns 'a'", out == (void *) a);
+
+    PMIX_DESTRUCT(&rb);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_ring_buffer_t unit tests ===\n\n");
+
+    test_init();
+    test_push_pop_basic();
+    test_wraparound();
+    test_multiple_wraps();
+    test_poke();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_value_array.c
+++ b/test/unit/class/class_value_array.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_value_array_t:
+ *   init, get_size, set_size, reserve, get/set item (macros and functions),
+ *   append_item, remove_item, PMIX_VALUE_ARRAY_GET_BASE.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/class/pmix_value_array.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* init / get_size                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_init(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    int rc = pmix_value_array_init(&va, sizeof(int));
+    report("init: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("init: get_size is 0", 0 == pmix_value_array_get_size(&va));
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* set_size                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_set_size(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    int rc = pmix_value_array_set_size(&va, 10);
+    report("set_size 10: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_size 10: get_size is 10", 10 == (int) pmix_value_array_get_size(&va));
+
+    rc = pmix_value_array_set_size(&va, 5);
+    report("set_size shrink to 5: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("set_size shrink: get_size is 5", 5 == (int) pmix_value_array_get_size(&va));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* reserve                                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_reserve(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    int rc = pmix_value_array_reserve(&va, 100);
+    report("reserve 100: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("reserve: get_size still 0 (no items added)", 0 == (int) pmix_value_array_get_size(&va));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* GET_ITEM / SET_ITEM macros                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_get_set_item_macros(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+    pmix_value_array_set_size(&va, 5);
+
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 0, 100);
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 1, 200);
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 4, 500);
+
+    report("GET_ITEM macro [0]: 100", 100 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0));
+    report("GET_ITEM macro [1]: 200", 200 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 1));
+    report("GET_ITEM macro [4]: 500", 500 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 4));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_value_array_set_item / get_item (functions, auto-grow)         */
+/* ------------------------------------------------------------------ */
+
+static void test_set_item_fn(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(double));
+
+    double v = 3.14;
+    int rc = pmix_value_array_set_item(&va, 2, &v);
+    report("set_item fn at [2]: PMIX_SUCCESS (auto-grows)", PMIX_SUCCESS == rc);
+    report("set_item fn: size is now 3", 3 == (int) pmix_value_array_get_size(&va));
+
+    double *p = (double *) pmix_value_array_get_item(&va, 2);
+    report("get_item fn [2]: non-NULL", NULL != p);
+    report("get_item fn [2]: value is 3.14", NULL != p && 3.14 == *p);
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* append_item                                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_append_item(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    for (int i = 0; i < 5; i++) {
+        int rc = pmix_value_array_append_item(&va, &i);
+        report("append_item: PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    }
+    report("append 5 items: size is 5", 5 == (int) pmix_value_array_get_size(&va));
+
+    bool ok = true;
+    for (int i = 0; i < 5; i++) {
+        if (i != PMIX_VALUE_ARRAY_GET_ITEM(&va, int, i)) {
+            ok = false;
+        }
+    }
+    report("append_item: values correct in order", ok);
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* remove_item                                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_remove_item(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    for (int v = 10; v <= 50; v += 10) {
+        pmix_value_array_append_item(&va, &v);
+    }
+    /* Array: [10, 20, 30, 40, 50] */
+
+    int rc = pmix_value_array_remove_item(&va, 1); /* remove index 1 (value 20) */
+    report("remove_item [1]: PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("remove_item: size is 4", 4 == (int) pmix_value_array_get_size(&va));
+    report("remove_item: new [0] is 10", 10 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0));
+    report("remove_item: new [1] is 30", 30 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 1));
+    report("remove_item: new [3] is 50", 50 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 3));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_VALUE_ARRAY_GET_BASE macro                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_get_base(void)
+{
+    pmix_value_array_t va;
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+    pmix_value_array_set_size(&va, 3);
+
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 0, 7);
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 1, 8);
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 2, 9);
+
+    int *base = PMIX_VALUE_ARRAY_GET_BASE(&va, int);
+    report("GET_BASE: pointer non-NULL", NULL != base);
+    report("GET_BASE: base[0] is 7", 7 == base[0]);
+    report("GET_BASE: base[1] is 8", 8 == base[1]);
+    report("GET_BASE: base[2] is 9", 9 == base[2]);
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_value_array_t unit tests ===\n\n");
+
+    test_init();
+    test_set_size();
+    test_reserve();
+    test_get_set_item_macros();
+    test_set_item_fn();
+    test_append_item();
+    test_remove_item();
+    test_get_base();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Adds `test/unit/class/` with one test executable per `src/class` module, covering all eight class types: `pmix_object_t`, `pmix_list_t`/`pmix_list_item_t`, `pmix_bitmap_t`, `pmix_hash_table_t`, `pmix_pointer_array_t`, `pmix_ring_buffer_t`, `pmix_value_array_t`, and `pmix_hotel_t`.
- Wires all eight executables into `make check` via `test/unit/class/Makefile.am`; adds the subdir to `test/unit/Makefile.am` (`SUBDIRS`) and the corresponding `AC_CONFIG_FILES` entry in `configure.ac`.
- Lists all eight executables in `test/unit/class/.gitignore`.

## Test executables

| Executable | What it tests |
|---|---|
| `class_object` | PMIX_NEW/RETAIN/RELEASE, reference counting, PMIX_CONSTRUCT/DESTRUCT, class hierarchy (name, parent, depth, sizeof). Uses `pmix_list_item_t` as concrete subject — `pmix_object_t` is a pure base class and cannot be instantiated directly. |
| `class_list` | append, prepend, remove_first/last/item, get_first/last, get_size, is_empty, insert (including out-of-bounds), sort, join, PMIX_LIST_FOREACH, PMIX_LIST_DESTRUCT/RELEASE |
| `class_bitmap` | set/clear/is_set_bit, find_and_set_first_unset_bit, clear_all/set_all, num_set/unset_bits, bitwise OR/AND/XOR inplace, copy, are_different, get_string |
| `class_hash_table` | uint32/uint64/ptr set/get/remove, remove_all, forward iteration, sizeof_hash_element |
| `class_pointer_array` | init, add, get/set_item, test_and_set_item (occupied-slot rejection), set_size, auto-grow via set_item beyond current size, remove_all |
| `class_ring_buffer` | push/pop (FIFO), wraparound displacement of oldest element, multiple wraps, poke semantics (poke(0)=oldest, poke(-1)=most recent) |
| `class_value_array` | set_size (grow/shrink), reserve (capacity without changing size), GET/SET_ITEM macros, set_item fn with auto-grow, append_item, remove_item (compaction), GET_BASE |
| `class_hotel` | init, bad-param rejection (0 rooms or NULL evict callback), checkin/checkout, checkout_and_return_occupant, knock (non-removing peek), hotel-full (PMIX_ERR_OUT_OF_RESOURCE), multiple guests, room reuse |

## Test plan

- [ ] `make check` in `test/unit/class/` — all 8 pass
- [ ] `make check` from top level includes the new subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)