### PR TITLE
bfrops: treat PMIX_RESBLOCK_DIRECTIVE as a simple type when unloading

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -399,6 +399,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         PMIX_PROC_STATE,
         PMIX_POINTER,
         PMIX_ALLOC_DIRECTIVE,
+        PMIX_RESBLOCK_DIRECTIVE,
         PMIX_LINK_STATE,
         PMIX_LOCTYPE,
         PMIX_DEVTYPE,


### PR DESCRIPTION
`pmix_bfrops_base_value_unload()` consults a table of "simple" scalar
data types to reject a NULL output buffer with `PMIX_ERR_BAD_PARAM`
before it copies the value out. `PMIX_RESBLOCK_DIRECTIVE` was missing
from that table even though its unload case performs an unconditional
`memcpy(*data, ...)`. As a result, unloading a resource-block-directive
value into a NULL buffer dereferenced NULL and crashed instead of
returning a clean error.

This adds it to the table so the scalar types are handled consistently.