### PR TITLE
Add allocation inheritance datatype and attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ test/sshot/testcoord
 test/unit/compress
 test/unit/preg
 test/unit/bfrops_regex2
+test/unit/bfrops_alloc_inherit
 test/unit/gds_fallback
 test/unit/pmix_log
 test/unit/run_gds_fallback.pl

--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -165,6 +165,8 @@ def harvest_constants(options, path, constants):
                             datatype = "PMIX_UINT16"
                         elif tokens[3] == "(double)":
                             datatype = "PMIX_DOUBLE"
+                        elif tokens[3] == "(pmix_alloc_inheritance_t)":
+                            datatype = "PMIX_ALLOC_INHERIT"
                         else:
                             print("UNKNOWN TOKEN: {tok}".format(tok=tokens[3]))
                             return 1

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1168,6 +1168,7 @@ PMIX_EXPORT void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo
  * - pmix_info_directives_t   (PMIX_INFO_DIRECTIVES)
  * - pmix_data_type_t   (PMIX_DATA_TYPE)
  * - pmix_alloc_directive_t  (PMIX_ALLOC_DIRECTIVE)
+ * - pmix_alloc_inheritance_t  (PMIX_ALLOC_INHERIT)
  * - pmix_iof_channel_t  (PMIX_IOF_CHANNEL)
  * - pmix_job_state_t  (PMIX_JOB_STATE)
  * - pmix_proc_state_t  (PMIX_PROC_STATE)
@@ -1190,6 +1191,7 @@ PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
 PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 PMIX_EXPORT const char* PMIx_Resource_block_directive_string(pmix_resource_block_directive_t directive);
+PMIX_EXPORT const char* PMIx_Alloc_inheritance_string(pmix_alloc_inheritance_t inheritance);
 PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
 PMIX_EXPORT const char* PMIx_Job_state_string(pmix_job_state_t state);
 PMIX_EXPORT const char* PMIx_Get_attribute_string(const char *attribute);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -585,6 +585,12 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SPAWN_PTY                      "pmix.spawn.pty"        // (bool) Spawn a pseudo-terminal
 #define PMIX_PTY_TERMIO                     "pmix.pty.termio"       // (pmix_byte_object_t) Contents of a termio structure
 #define PMIX_PTY_WSIZE                      "pmix.pty.wsize"        // (pmix_byte_object_t) Contents of a window size structure
+#define PMIX_SPAWN_TARGET                   "pmix.spwn.tgt"         // (varies) Specify the allocation(s) to be used when mapping the
+                                                                    //         applications to be spawned.
+                                                                    //         Can be either of two data types:
+                                                                    //           (a) char* - PMIX_ALLOC_ID of the target allocation
+                                                                    //           (b) a pmix_data_array_t of char* allocation IDs
+                                                                    //         Note that an invalid nspace equates to the "default" allocation
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */
@@ -966,7 +972,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_IMAGE                    "pmix.alloc.image"      // (char*) name of the image that the requested nodes are to have on them
 #define PMIX_ALLOC_WAIT_ALL_NODES           "pmix.alloc.waitall"    // (bool) whether or not to wait for all nodes to be scheduled before
                                                                     //        starting to initialize and release nodes for use
-#define PMIX_ALLOC_SHARE                    "pmix.alloc.share"      // (bool) Allow non-exclusive use of specified resources
+#define PMIX_ALLOC_SHARE                    "pmix.alloc.share"      // (bool) Reserve allocated resources - false by default, resources will be reserved
+                                                                    //        for use only by members of the requestor's namespace. If set to true,
+                                                                    //        allocated resources will be made generally available within the
+                                                                    //        requestor's session
 #define PMIX_ALLOC_NOSHELL                  "pmix.alloc.noshell"    // (bool) Immediately exit after allocating resources, without running a command.
 #define PMIX_ALLOC_DEPENDENCY               "pmix.alloc.depend"     // (char*) Defer the start of allocation until the specified dependencies have
                                                                     //         successfully completed.
@@ -1003,14 +1012,11 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_STATUS                   "pmix.alloc.status"     // (pmix_status_t) Result of an allocation request - typically used in event
                                                                     //        notifying processes of the result of an allocation request generated
                                                                     //        by another process
-#define PMIX_ALLOC_RESERVED                 "pmix.alloc.rsvd"       // (bool) Reserve allocated resources - by default, resources will be reserved
-                                                                    //        for use by members of the requestor's namespace. If set to false,
-                                                                    //        allocated resources will be made generally available within the
-                                                                    //        requestor's session
 #define PMIX_ALLOC_TARGET                   "pmix.alloc.tgt"        // (char*) Namespace to which the allocated resources are to be assigned. If
                                                                     //         a target is given, then the host is to treat the resources as
                                                                     //         reserved to members of that namespace.
-
+#define PMIX_ALLOC_INHERITANCE              "pmix.alloc.inhrt"      // (pmix_alloc_inheritance_t) inheritance rules to be applied to the
+                                                                    //         allocated resources
 
 /* job control attributes */
 #define PMIX_JOB_CTRL_ID                    "pmix.jctrl.id"         // (char*) provide a string identifier for this request
@@ -1855,6 +1861,7 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_RESOURCE_UNIT              72
 #define PMIX_NODE_PID                   73
 #define PMIX_REGEX2                     74
+#define PMIX_ALLOC_INHERIT              75
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -1928,6 +1935,17 @@ typedef uint8_t pmix_alloc_directive_t;
 /* define a value boundary beyond which implementers are free
  * to define their own directive values */
 #define PMIX_ALLOC_EXTERNAL     128
+
+/* define a datatype for specifying inheritance of an allocation */
+typedef uint8_t pmix_alloc_inheritance_t;
+#define PMIX_ALLOC_INHERIT_NONE          1   // no one is to inherit the allocation - it will be released
+                                             // upon termination of the owning namespace
+#define PMIX_ALLOC_INHERIT_CHILD         2   // allocation is to remain alive until all child namespaces have
+                                             // terminated, including derived children
+#define PMIX_ALLOC_INHERIT_DEFAULT       3   // allocation is to become unreserved upon termination of the
+                                             // owning namespace
+#define PMIX_ALLOC_INHERIT_CHILD_DEFAULT 4   // allocation is to become unreserved upon termination of the
+                                             // last derived child namespace
 
 /* define a set of directives for resource block requests */
 typedef uint8_t pmix_resource_block_directive_t;
@@ -2465,6 +2483,7 @@ typedef struct pmix_value {
         void *ptr;
         pmix_alloc_directive_t adir;
         pmix_resource_block_directive_t rbdir;
+        pmix_alloc_inheritance_t inheritance;
         pmix_envar_t envar;
         pmix_coord_t *coord;
         pmix_link_state_t linkstate;

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -221,6 +221,22 @@ PMIX_EXPORT const char *PMIx_Resource_block_directive_string(pmix_resource_block
     }
 }
 
+PMIX_EXPORT const char *PMIx_Alloc_inheritance_string(pmix_alloc_inheritance_t inheritance)
+{
+    switch (inheritance) {
+    case PMIX_ALLOC_INHERIT_NONE:
+        return "NONE";
+    case PMIX_ALLOC_INHERIT_CHILD:
+        return "CHILD";
+    case PMIX_ALLOC_INHERIT_DEFAULT:
+        return "DEFAULT";
+    case PMIX_ALLOC_INHERIT_CHILD_DEFAULT:
+        return "CHILD_DEFAULT";
+    default:
+        return "UNSPECIFIED";
+    }
+}
+
 PMIX_EXPORT const char *pmix_command_string(pmix_cmd_t cmd)
 {
     switch (cmd) {

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -478,6 +478,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_resblock_directive(pmix_pointer_
                                                                    pmix_buffer_t *buffer,
                                                                    const void *src, int32_t num_vals,
                                                                    pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_alloc_inheritance(pmix_pointer_array_t *regtypes,
+                                                                  pmix_buffer_t *buffer,
+                                                                  const void *src, int32_t num_vals,
+                                                                  pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
                                                             pmix_buffer_t *buffer, const void *src,
                                                             int32_t num_vals,
@@ -688,6 +692,10 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_resblock_directive(pmix_pointe
                                                                      pmix_buffer_t *buffer, void *dest,
                                                                      int32_t *num_vals,
                                                                      pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_alloc_inheritance(pmix_pointer_array_t *regtypes,
+                                                                    pmix_buffer_t *buffer, void *dest,
+                                                                    int32_t *num_vals,
+                                                                    pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
                                                               pmix_buffer_t *buffer, void *dest,
                                                               int32_t *num_vals,
@@ -968,6 +976,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_resblock_directive(char **output, char *prefix,
                                                                     pmix_resource_block_directive_t *src,
                                                                     pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_alloc_inheritance(char **output, char *prefix,
+                                                                   pmix_alloc_inheritance_t *src,
+                                                                   pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
                                                              pmix_iof_channel_t *src,
                                                              pmix_data_type_t type);

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -890,6 +890,10 @@ static pmix_value_cmp_t cmp_darray(pmix_data_array_t *d1,
             ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_resource_block_directive_t));
             PMIX_CHECK_SIMPLE(ret);
             break;
+        case PMIX_ALLOC_INHERIT:
+            ret = memcmp(d1->array, d2->array, d1->size * sizeof(pmix_alloc_inheritance_t));
+            PMIX_CHECK_SIMPLE(ret);
+            break;
         case PMIX_ENVAR:
             e1 = (pmix_envar_t*)d1->array;
             e2 = (pmix_envar_t*)d2->array;
@@ -1210,6 +1214,10 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p1,
         break;
     case PMIX_RESBLOCK_DIRECTIVE:
         ret = memcmp(&p1->data.rbdir, &p2->data.rbdir, sizeof(pmix_resource_block_directive_t));
+        PMIX_CHECK_SIMPLE(ret);
+        break;
+    case PMIX_ALLOC_INHERIT:
+        ret = memcmp(&p1->data.inheritance, &p2->data.inheritance, sizeof(pmix_alloc_inheritance_t));
         PMIX_CHECK_SIMPLE(ret);
         break;
     case PMIX_ENVAR:

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -174,6 +174,10 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src, pmix_data_type_t
         datasize = sizeof(pmix_resource_block_directive_t);
         break;
 
+    case PMIX_ALLOC_INHERIT:
+        datasize = sizeof(pmix_alloc_inheritance_t);
+        break;
+
     case PMIX_JOB_STATE:
         datasize = sizeof(pmix_job_state_t);
         break;

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -229,6 +229,9 @@ void pmix_bfrops_base_value_load(pmix_value_t *v,
         case PMIX_RESBLOCK_DIRECTIVE:
             memcpy(&(v->data.rbdir), data, sizeof(pmix_resource_block_directive_t));
             break;
+        case PMIX_ALLOC_INHERIT:
+            memcpy(&(v->data.inheritance), data, sizeof(pmix_alloc_inheritance_t));
+            break;
         case PMIX_ENVAR:
             envar = (pmix_envar_t *) data;
             if (NULL != envar->envar) {
@@ -400,6 +403,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         PMIX_POINTER,
         PMIX_ALLOC_DIRECTIVE,
         PMIX_RESBLOCK_DIRECTIVE,
+        PMIX_ALLOC_INHERIT,
         PMIX_LINK_STATE,
         PMIX_LOCTYPE,
         PMIX_DEVTYPE,
@@ -565,6 +569,10 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         case PMIX_RESBLOCK_DIRECTIVE:
             memcpy(*data, &(kv->data.rbdir), sizeof(pmix_resource_block_directive_t));
             *sz = sizeof(pmix_resource_block_directive_t);
+            break;
+        case PMIX_ALLOC_INHERIT:
+            memcpy(*data, &(kv->data.inheritance), sizeof(pmix_alloc_inheritance_t));
+            *sz = sizeof(pmix_alloc_inheritance_t);
             break;
         case PMIX_ENVAR:
             PMIX_ENVAR_CREATE(envar, 1);
@@ -1218,6 +1226,9 @@ static pmix_status_t get_darray_size(pmix_data_array_t *array,
         case PMIX_RESBLOCK_DIRECTIVE:
             *sz = array->size * sizeof(pmix_resource_block_directive_t);
             break;
+        case PMIX_ALLOC_INHERIT:
+            *sz = array->size * sizeof(pmix_alloc_inheritance_t);
+            break;
         case PMIX_ENVAR:
             *sz = array->size * sizeof(pmix_envar_t);
             en = (pmix_envar_t*)array->array;
@@ -1524,6 +1535,9 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
             break;
         case PMIX_RESBLOCK_DIRECTIVE:
             *sz = sizeof(pmix_resource_block_directive_t);
+            break;
+        case PMIX_ALLOC_INHERIT:
+            *sz = sizeof(pmix_alloc_inheritance_t);
             break;
         case PMIX_ENVAR:
             *sz = sizeof(pmix_envar_t);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -981,6 +981,18 @@ pmix_status_t pmix_bfrops_base_pack_resblock_directive(pmix_pointer_array_t *reg
     return ret;
 }
 
+pmix_status_t pmix_bfrops_base_pack_alloc_inheritance(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
+                                                      int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
+}
+
 pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
                                                 pmix_buffer_t *buffer, const void *src,
                                                 int32_t num_vals, pmix_data_type_t type)

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -749,6 +749,9 @@ static int print_val(char **output, pmix_value_t *src)
         case PMIX_RESBLOCK_DIRECTIVE:
             rc = pmix_bfrops_base_print_resblock_directive(&tp, NULL, &src->data.adir, PMIX_RESBLOCK_DIRECTIVE);
             break;
+        case PMIX_ALLOC_INHERIT:
+            rc = pmix_bfrops_base_print_alloc_inheritance(&tp, NULL, &src->data.inheritance, PMIX_ALLOC_INHERIT);
+            break;
         case PMIX_ENVAR:
             rc = pmix_bfrops_base_print_envar(&tp, NULL, &src->data.envar, PMIX_ENVAR);
             break;
@@ -1214,6 +1217,7 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
     pmix_regattr_t *rgptr;
     pmix_alloc_directive_t *adptr;
     pmix_resource_block_directive_t *rbptr;
+    pmix_alloc_inheritance_t *inhptr;
     pmix_envar_t *evptr;
     pmix_coord_t *coptr;
     pmix_link_state_t *lkptr;
@@ -1373,6 +1377,10 @@ pmix_status_t pmix_bfrops_base_print_darray(char **output, char *prefix,
             case PMIX_RESBLOCK_DIRECTIVE:
                 rbptr = (pmix_resource_block_directive_t*)src->array;
                 rc = pmix_bfrops_base_print_resblock_directive(&tp, prefix, &rbptr[n], PMIX_RESBLOCK_DIRECTIVE);
+                break;
+            case PMIX_ALLOC_INHERIT:
+                inhptr = (pmix_alloc_inheritance_t*)src->array;
+                rc = pmix_bfrops_base_print_alloc_inheritance(&tp, prefix, &inhptr[n], PMIX_ALLOC_INHERIT);
                 break;
             case PMIX_ENVAR:
                 evptr = (pmix_envar_t*)src->array;
@@ -1599,6 +1607,25 @@ pmix_status_t pmix_bfrops_base_print_resblock_directive(char **output, char *pre
     ret = asprintf(output, "%sData type: PMIX_RESBLOCK_DIRECTIVE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Resource_block_directive_string(*src));
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
+pmix_status_t pmix_bfrops_base_print_alloc_inheritance(char **output, char *prefix,
+                                                       pmix_alloc_inheritance_t *src,
+                                                       pmix_data_type_t type)
+{
+    int ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    ret = asprintf(output, "%sData type: PMIX_ALLOC_INHERIT\tValue: %s",
+                   (NULL == prefix) ? " " : prefix,
+                   PMIx_Alloc_inheritance_string(*src));
 
     if (0 > ret) {
         return PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -168,6 +168,8 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_RESOURCE_UNIT";
     case PMIX_REGEX2:
         return "PMIX_REGEX2";
+    case PMIX_ALLOC_INHERIT:
+        return "PMIX_ALLOC_INHERIT";
     default:
         return "NOT INITIALIZED";
     }

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -3374,6 +3374,9 @@ pmix_status_t pmix_bfrops_base_tma_value_xfer(pmix_value_t *p,
     case PMIX_RESBLOCK_DIRECTIVE:
         memcpy(&p->data.rbdir, &src->data.rbdir, sizeof(pmix_resource_block_directive_t));
         break;
+    case PMIX_ALLOC_INHERIT:
+        memcpy(&p->data.inheritance, &src->data.inheritance, sizeof(pmix_alloc_inheritance_t));
+        break;
     case PMIX_ENVAR:
         pmix_bfrops_base_tma_envar_construct(&p->data.envar, tma);
 

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1327,6 +1327,18 @@ pmix_status_t pmix_bfrops_base_unpack_resblock_directive(pmix_pointer_array_t *r
     return ret;
 }
 
+pmix_status_t pmix_bfrops_base_unpack_alloc_inheritance(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
+                                                        int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    PMIX_HIDE_UNUSED_PARAMS(type);
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
+}
+
 pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
                                                   pmix_buffer_t *buffer, void *dest,
                                                   int32_t *num_vals, pmix_data_type_t type)

--- a/src/mca/bfrops/v61/bfrop_pmix61.c
+++ b/src/mca/bfrops/v61/bfrop_pmix61.c
@@ -238,6 +238,11 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_resblock_directive, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_resblock_directive, &pmix_mca_bfrops_v61_component.types);
 
+    PMIX_REGISTER_TYPE("PMIX_ALLOC_INHERIT", PMIX_ALLOC_INHERIT,
+                       pmix_bfrops_base_pack_alloc_inheritance,
+                       pmix_bfrops_base_unpack_alloc_inheritance, pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_alloc_inheritance, &pmix_mca_bfrops_v61_component.types);
+
     PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL", PMIX_IOF_CHANNEL, pmix_bfrops_base_pack_iof_channel,
                        pmix_bfrops_base_unpack_iof_channel, pmix_bfrops_base_std_copy,
                        pmix_bfrops_base_print_iof_channel, &pmix_mca_bfrops_v61_component.types);

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl
 
 EXTRA_DIST = run_gds_fallback.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 gds_fallback pmix_log
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log
 
-TESTS = compress preg bfrops_regex2 gds_fallback run_gds_fallback.pl pmix_log
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log
 
 compress_SOURCES =  \
         compress.c
@@ -49,6 +49,12 @@ bfrops_regex2_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_regex2_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+bfrops_alloc_inherit_SOURCES = \
+        bfrops_alloc_inherit.c
+bfrops_alloc_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_alloc_inherit_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 gds_fallback_SOURCES = \
         gds_fallback.c
 gds_fallback_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -62,4 +68,4 @@ pmix_log_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress preg bfrops_regex2 gds_fallback pmix_log
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log

--- a/test/unit/bfrops_alloc_inherit.c
+++ b/test/unit/bfrops_alloc_inherit.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIX_ALLOC_INHERIT bfrops support: pack/unpack, copy,
+ * print, and compare operations exercised through the public PMIx API.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* pack / unpack                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_pack_unpack_roundtrip(void)
+{
+    pmix_alloc_inheritance_t src = PMIX_ALLOC_INHERIT_CHILD;
+    pmix_alloc_inheritance_t dst = PMIX_ALLOC_INHERIT_NONE;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    PMIx_Data_buffer_construct(&buf);
+
+    rc = PMIx_Data_pack(NULL, &buf, &src, 1, PMIX_ALLOC_INHERIT);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_ALLOC_INHERIT);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (src == dst) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    value mismatch: packed %u, unpacked %u\n",
+                (unsigned) src, (unsigned) dst);
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    report("pack/unpack round-trip", ok);
+}
+
+/* Pack multiple values into one buffer and unpack them all. */
+static void test_pack_unpack_multiple(void)
+{
+    const int N = 3;
+    pmix_alloc_inheritance_t src[3] = {
+        PMIX_ALLOC_INHERIT_NONE,
+        PMIX_ALLOC_INHERIT_CHILD,
+        PMIX_ALLOC_INHERIT_DEFAULT
+    };
+    pmix_alloc_inheritance_t dst[3] = { 0, 0, 0 };
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int i, ok = 1;
+
+    PMIx_Data_buffer_construct(&buf);
+
+    /* Pack all three in a single packing operation. */
+    rc = PMIx_Data_pack(NULL, &buf, src, N, PMIX_ALLOC_INHERIT);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        ok = 0;
+        goto cleanup;
+    }
+
+    count = N;
+    rc = PMIx_Data_unpack(NULL, &buf, dst, &count, PMIX_ALLOC_INHERIT);
+    if (PMIX_SUCCESS != rc || count != N) {
+        fprintf(stdout, "    unpack failed: %s (count=%d)\n",
+                PMIx_Error_string(rc), (int) count);
+        ok = 0;
+        goto cleanup;
+    }
+
+    for (i = 0; i < N; i++) {
+        if (src[i] != dst[i]) {
+            fprintf(stdout, "    mismatch at index %d: %u != %u\n",
+                    i, (unsigned) src[i], (unsigned) dst[i]);
+            ok = 0;
+            break;
+        }
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    report("pack/unpack multiple values", ok);
+}
+
+/* Pack/unpack through a pmix_value_t to exercise the value path. */
+static void test_pack_unpack_via_value(void)
+{
+    pmix_value_t val;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+    PMIx_Data_buffer_construct(&buf);
+
+    val.type = PMIX_ALLOC_INHERIT;
+    val.data.inheritance = PMIX_ALLOC_INHERIT_DEFAULT;
+
+    rc = PMIx_Data_pack(NULL, &buf, &val, 1, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    PMIX_VALUE_DESTRUCT(&val);
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &val, &count, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_ALLOC_INHERIT == val.type &&
+        PMIX_ALLOC_INHERIT_DEFAULT == val.data.inheritance) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    value mismatch after unpack (type=%d, val=%u)\n",
+                (int) val.type, (unsigned) val.data.inheritance);
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIX_VALUE_DESTRUCT(&val);
+    report("pack/unpack via pmix_value_t", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* copy                                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_value_xfer(void)
+{
+    pmix_value_t vsrc, vdst;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&vsrc);
+    PMIX_VALUE_CONSTRUCT(&vdst);
+
+    vsrc.type = PMIX_ALLOC_INHERIT;
+    vsrc.data.inheritance = PMIX_ALLOC_INHERIT_CHILD;
+
+    rc = PMIx_Value_xfer(&vdst, &vsrc);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Value_xfer failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_ALLOC_INHERIT == vdst.type &&
+        vsrc.data.inheritance == vdst.data.inheritance) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    copied value does not match source\n");
+    }
+
+cleanup:
+    PMIX_VALUE_DESTRUCT(&vsrc);
+    PMIX_VALUE_DESTRUCT(&vdst);
+    report("PMIx_Value_xfer copies PMIX_ALLOC_INHERIT", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* compare                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_compare_equal(void)
+{
+    pmix_value_t v1, v2;
+    pmix_value_cmp_t cmp;
+    int ok;
+
+    PMIX_VALUE_CONSTRUCT(&v1);
+    PMIX_VALUE_CONSTRUCT(&v2);
+
+    v1.type = PMIX_ALLOC_INHERIT;
+    v1.data.inheritance = PMIX_ALLOC_INHERIT_DEFAULT;
+    v2.type = PMIX_ALLOC_INHERIT;
+    v2.data.inheritance = PMIX_ALLOC_INHERIT_DEFAULT;
+
+    cmp = PMIx_Value_compare(&v1, &v2);
+    ok = (PMIX_EQUAL == cmp);
+    if (!ok) {
+        fprintf(stdout, "    expected PMIX_EQUAL, got %d\n", (int) cmp);
+    }
+
+    PMIX_VALUE_DESTRUCT(&v1);
+    PMIX_VALUE_DESTRUCT(&v2);
+    report("compare: identical PMIX_ALLOC_INHERIT values are PMIX_EQUAL", ok);
+}
+
+static void test_compare_different(void)
+{
+    pmix_value_t v1, v2;
+    pmix_value_cmp_t cmp;
+    int ok;
+
+    PMIX_VALUE_CONSTRUCT(&v1);
+    PMIX_VALUE_CONSTRUCT(&v2);
+
+    v1.type = PMIX_ALLOC_INHERIT;
+    v1.data.inheritance = PMIX_ALLOC_INHERIT_NONE;
+    v2.type = PMIX_ALLOC_INHERIT;
+    v2.data.inheritance = PMIX_ALLOC_INHERIT_CHILD;
+
+    cmp = PMIx_Value_compare(&v1, &v2);
+    ok = (PMIX_EQUAL != cmp);
+    if (!ok) {
+        fprintf(stdout, "    different values incorrectly reported as PMIX_EQUAL\n");
+    }
+
+    PMIX_VALUE_DESTRUCT(&v1);
+    PMIX_VALUE_DESTRUCT(&v2);
+    report("compare: different PMIX_ALLOC_INHERIT values are not PMIX_EQUAL", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* print                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_print_value(void)
+{
+    pmix_value_t val;
+    char *output = NULL;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    val.type = PMIX_ALLOC_INHERIT;
+    val.data.inheritance = PMIX_ALLOC_INHERIT_CHILD;
+
+    rc = PMIx_Data_print(&output, NULL, &val, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Data_print failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    /* Output must mention the type name and the converted string value. */
+    if (NULL != output && '\0' != output[0] &&
+        NULL != strstr(output, "PMIX_ALLOC_INHERIT") &&
+        NULL != strstr(output, "CHILD")) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    print output missing expected content: %s\n",
+                output ? output : "(null)");
+    }
+
+cleanup:
+    free(output);
+    PMIX_VALUE_DESTRUCT(&val);
+    report("PMIx_Data_print includes 'PMIX_ALLOC_INHERIT' label and value", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* string converter                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_string_converter(void)
+{
+    int ok = 1;
+
+    if (0 != strcmp(PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_NONE), "NONE")) {
+        fprintf(stdout, "    NONE mismatch: got '%s'\n",
+                PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_NONE));
+        ok = 0;
+    }
+    if (0 != strcmp(PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_CHILD), "CHILD")) {
+        fprintf(stdout, "    CHILD mismatch: got '%s'\n",
+                PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_CHILD));
+        ok = 0;
+    }
+    if (0 != strcmp(PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_DEFAULT), "DEFAULT")) {
+        fprintf(stdout, "    DEFAULT mismatch: got '%s'\n",
+                PMIx_Alloc_inheritance_string(PMIX_ALLOC_INHERIT_DEFAULT));
+        ok = 0;
+    }
+
+    report("PMIx_Alloc_inheritance_string returns expected names", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIX_ALLOC_INHERIT bfrops unit tests ===\n\n");
+
+    /* pack / unpack */
+    test_pack_unpack_roundtrip();
+    test_pack_unpack_multiple();
+    test_pack_unpack_via_value();
+
+    /* copy */
+    test_value_xfer();
+
+    /* compare */
+    test_compare_equal();
+    test_compare_different();
+
+    /* print */
+    test_print_value();
+
+    /* string converter */
+    test_string_converter();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Introduce a new `pmix_alloc_inheritance_t` (`PMIX_ALLOC_INHERIT`) data
type for expressing what becomes of an allocation when its owning
namespace terminates. Three values are defined:

- `PMIX_ALLOC_INHERIT_NONE` — release the allocation upon termination of
  the owning namespace
- `PMIX_ALLOC_INHERIT_CHILD` — retain until all child namespaces
  (including derived children) terminate
- `PMIX_ALLOC_INHERIT_DEFAULT` — the allocation becomes unreserved  upon
termination of the owning namespace
- `PMIX_ALLOC_INHERIT_CHILD_DEFAULT` —  the allocation becomes unreserved
upon termination of the last derived child namespace

The value is carried in the `pmix_value_t` union as `inheritance` and is
selected via the new `PMIX_ALLOC_INHERITANCE` attribute.

Full bfrops support is added in the base functions (pack, unpack,
std-copy sizing, compare, TMA copy, value load/unload, and print), and
the type is registered in the v61 component — matching how other newly
introduced types are wired into only the most recent wire-format
version. A `PMIx_Alloc_inheritance_string()` converter returns the
trailing word of each value name (`NONE`, `CHILD`, `DEFAULT`) and is used
by the print routine. The dictionary generator learns to map the
`(pmix_alloc_inheritance_t)` annotation to `PMIX_ALLOC_INHERIT` so the
attribute harvests cleanly.

A new `make check` unit test, `bfrops_alloc_inherit`, exercises
pack/unpack (single, multiple, and via `pmix_value_t`), value transfer,
compare, print, and the string converter.

Also includes related allocation attribute updates carried on this
branch: a new `PMIX_SPAWN_TARGET` attribute for mapping spawned
applications onto specific allocations, and a reworked `PMIX_ALLOC_SHARE`
definition that replaces the former `PMIX_ALLOC_RESERVED`.