### PR TITLE
util/net: fix undefined behavior and edge cases in net helpers

### DIFF
--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -130,7 +130,7 @@ int pmix_net_init(void)
 {
     char **args, *arg;
     uint32_t a, b, c, d, bits, addr;
-    int i, count, found_bad = 0;
+    int i, j, count, found_bad = 0;
 
     args = PMIx_Argv_split(pmix_net_private_ipv4, ';');
     if (NULL != args) {
@@ -141,12 +141,14 @@ int pmix_net_init(void)
             PMIx_Argv_free(args);
             goto do_local_init;
         }
-        for (i = 0; i < count; i++) {
+        /* j tracks the next slot to fill so that malformed entries are
+         * skipped rather than left as zeroed holes - a zero addr is the
+         * array terminator, so a hole would truncate the list. */
+        for (i = 0, j = 0; i < count; i++) {
             arg = args[i];
 
-            (void) sscanf(arg, "%u.%u.%u.%u/%u", &a, &b, &c, &d, &bits);
-
-            if ((a > 255) || (b > 255) || (c > 255) || (d > 255) || (bits > 32)) {
+            if (5 != sscanf(arg, "%u.%u.%u.%u/%u", &a, &b, &c, &d, &bits)
+                || (a > 255) || (b > 255) || (c > 255) || (d > 255) || (bits > 32)) {
                 if (0 == found_bad) {
                     pmix_show_help("help-pmix-util.txt", "malformed net_private_ipv4", true,
                                    args[i]);
@@ -155,11 +157,12 @@ int pmix_net_init(void)
                 continue;
             }
             addr = (a << 24) | (b << 16) | (c << 8) | d;
-            private_ipv4[i].addr = htonl(addr);
-            private_ipv4[i].netmask_bits = bits;
+            private_ipv4[j].addr = htonl(addr);
+            private_ipv4[j].netmask_bits = bits;
+            j++;
         }
-        private_ipv4[i].addr = 0;
-        private_ipv4[i].netmask_bits = 0;
+        private_ipv4[j].addr = 0;
+        private_ipv4[j].netmask_bits = 0;
         PMIx_Argv_free(args);
     }
 
@@ -178,7 +181,18 @@ int pmix_net_finalize(void)
 /* convert a CIDR prefixlen to netmask (in network byte order) */
 uint32_t pmix_net_prefix2netmask(uint32_t prefixlen)
 {
-    return htonl(((1 << prefixlen) - 1) << (32 - prefixlen));
+    /* A prefix of 0 matches everything; anything >= 32 is an exact
+     * match. Handle both ends explicitly: shifting a 32-bit value by
+     * 32 (or by 0 from the other direction) is undefined behavior, and
+     * shifting a signed 1 left by 31 overflows. Compute the mask from
+     * an unsigned all-ones value for the in-between cases. */
+    if (0 == prefixlen) {
+        return 0;
+    }
+    if (32 <= prefixlen) {
+        return htonl(0xFFFFFFFFU);
+    }
+    return htonl(0xFFFFFFFFU << (32 - prefixlen));
 }
 
 bool pmix_net_islocalhost(const struct sockaddr *addr)
@@ -186,9 +200,10 @@ bool pmix_net_islocalhost(const struct sockaddr *addr)
     switch (addr->sa_family) {
     case AF_INET: {
         const struct sockaddr_in *inaddr = (struct sockaddr_in *) addr;
-        /* if it's in the 127. domain, it shouldn't be routed
-           (0x7f == 127) */
-        if (0x7F000000 == (0x7F000000 & ntohl(inaddr->sin_addr.s_addr))) {
+        /* if it's in the 127.0.0.0/8 domain, it shouldn't be routed
+           (0x7f == 127); mask the full top octet so that other
+           addresses such as 255.x are not misclassified */
+        if (0x7F000000 == (0xFF000000 & ntohl(inaddr->sin_addr.s_addr))) {
             return true;
         }
         return false;
@@ -346,7 +361,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
         pmix_output(0, "pmix_net_get_hostname: malloc() failed\n");
         return pmix_hostname_unknown;
     }
-    memset(name, 0, sizeof(*name));
+    memset(name, 0, NI_MAXHOST + 1);
 
     switch (addr->sa_family) {
     case AF_INET:
@@ -372,8 +387,9 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     error = getnameinfo(addr, addrlen, name, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 
     if (error) {
-        int err = errno;
-        pmix_output(0, "pmix_sockaddr2str failed:%s (return code %i)\n", gai_strerror(err), error);
+        /* getnameinfo() returns an EAI_* code directly; decode that,
+         * not errno (which it does not generally set) */
+        pmix_output(0, "pmix_sockaddr2str failed:%s (return code %i)\n", gai_strerror(error), error);
         return pmix_hostname_unknown;
     }
     /* strip any trailing % data as it isn't pertinent */

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -14,3 +14,4 @@ util_environ
 util_alfg
 util_printf
 util_os_dirpath
+util_net

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -11,13 +11,15 @@ check_PROGRAMS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
     util_show_help util_timings util_context_fns \
     util_basename util_string_copy util_argv util_path \
-    util_environ util_alfg util_printf util_os_dirpath
+    util_environ util_alfg util_printf util_os_dirpath \
+    util_net
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
     util_show_help util_timings util_context_fns \
     util_basename util_string_copy util_argv util_path \
-    util_environ util_alfg util_printf util_os_dirpath
+    util_environ util_alfg util_printf util_os_dirpath \
+    util_net
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -99,9 +101,15 @@ util_os_dirpath_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_os_dirpath_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+util_net_SOURCES = util_net.c
+util_net_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_net_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f util_hash util_name_fns \
 	    util_output util_error util_cmd_line \
 	    util_show_help util_timings util_context_fns \
 	    util_basename util_string_copy util_argv util_path \
-	    util_environ util_alfg util_printf util_os_dirpath
+	    util_environ util_alfg util_printf util_os_dirpath \
+	    util_net

--- a/test/unit/util/util_net.c
+++ b/test/unit/util/util_net.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the helpers in src/util/pmix_net.c.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_SYS_SOCKET_H
+#    include <sys/socket.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#    include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+#    include <arpa/inet.h>
+#endif
+
+#include "src/util/pmix_net.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+#if defined(HAVE_STRUCT_SOCKADDR_IN)
+
+/* ------------------------------------------------------------------ */
+/* pmix_net_prefix2netmask                                             */
+/* ------------------------------------------------------------------ */
+
+static void check_netmask(uint32_t prefixlen, uint32_t expected_host)
+{
+    char label[64];
+    uint32_t got = ntohl(pmix_net_prefix2netmask(prefixlen));
+    snprintf(label, sizeof(label), "prefix2netmask(%u) == 0x%08X", prefixlen, expected_host);
+    report(label, got == expected_host);
+}
+
+static void test_prefix2netmask(void)
+{
+    /* A /0 matches everything (mask 0); a /32 is an exact match (all
+     * ones). The boundary values and /31 used to trigger undefined
+     * shift behavior and produced wrong masks. */
+    check_netmask(0, 0x00000000);
+    check_netmask(1, 0x80000000);
+    check_netmask(8, 0xFF000000);
+    check_netmask(16, 0xFFFF0000);
+    check_netmask(24, 0xFFFFFF00);
+    check_netmask(31, 0xFFFFFFFE);
+    check_netmask(32, 0xFFFFFFFF);
+    /* anything beyond /32 is treated as an exact match */
+    check_netmask(33, 0xFFFFFFFF);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_net_islocalhost                                               */
+/* ------------------------------------------------------------------ */
+
+static bool islocalhost_v4(const char *ip)
+{
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    inet_pton(AF_INET, ip, &sa.sin_addr);
+    return pmix_net_islocalhost((struct sockaddr *) &sa);
+}
+
+static void test_islocalhost(void)
+{
+    report("islocalhost(127.0.0.1) == true", islocalhost_v4("127.0.0.1"));
+    report("islocalhost(127.250.1.2) == true", islocalhost_v4("127.250.1.2"));
+    report("islocalhost(10.0.0.1) == false", !islocalhost_v4("10.0.0.1"));
+    /* Regression: 255.x must not be mistaken for the 127/8 range */
+    report("islocalhost(255.1.2.3) == false", !islocalhost_v4("255.1.2.3"));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_net_get_port                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_get_port(void)
+{
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons(8080);
+    report("get_port(8080) == 8080", 8080 == pmix_net_get_port((struct sockaddr *) &sa));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_net_isaddr                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_isaddr(void)
+{
+    report("isaddr(127.0.0.1) == true", pmix_net_isaddr("127.0.0.1"));
+    report("isaddr(::1) == true", pmix_net_isaddr("::1"));
+    report("isaddr(256.1.1.1) == false", !pmix_net_isaddr("256.1.1.1"));
+    report("isaddr(not-an-address) == false", !pmix_net_isaddr("not-an-address"));
+}
+
+#endif /* HAVE_STRUCT_SOCKADDR_IN */
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_net unit tests ===\n\n");
+
+#if defined(HAVE_STRUCT_SOCKADDR_IN)
+    test_prefix2netmask();
+    test_islocalhost();
+    test_get_port();
+    test_isaddr();
+#else
+    fprintf(stdout, "  SKIP: no struct sockaddr_in on this platform\n");
+#endif
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Fixes several boundary/edge-case bugs in `src/util/pmix_net.c`.

## Bugs fixed

1. **`pmix_net_prefix2netmask()` undefined behavior (headline).** The
   mask was computed as `((1 << prefixlen) - 1) << (32 - prefixlen)`.
   `1` is a signed `int`, so `1 << 31` overflows and `1 << 32`
   (prefixlen 32) shifts by the full type width; a prefixlen of 0 makes
   the second shift count 32 — all undefined. Compiled `-O2` this
   yields wrong masks: `/32` → `0xFFFFFFFE` (drops the low bit) and
   `/0` → garbage. Both values are reachable from user
   interface-selection specs (`ptl` `if_include`/`if_exclude`, via
   `atoi` in `ptl_base_fns.c`) and from real interface prefix lengths
   (`pmix_if.c`). Now handles `/0` and `≥/32` explicitly and derives the
   in-between masks from an unsigned all-ones value.

2. **`pmix_net_init()` ignored `sscanf()` return.** A malformed
   private-IPv4 entry left `a/b/c/d/bits` uninitialized and ran the
   range check on indeterminate data. Now requires a full five-field
   parse.

3. **`pmix_net_init()` zero-hole truncation.** Valid entries were
   written at the input index, so a skipped malformed entry left a
   zeroed hole; since a zero `addr` terminates the array, valid entries
   after it were silently dropped. Valid entries are now compacted with
   a separate output index.

4. **`pmix_net_islocalhost()` mask.** Masked the IPv4 address with
   `0x7F000000` instead of `0xFF000000` when testing for `127.0.0.0/8`,
   so `255.x` addresses were also reported as loopback.

5. **`pmix_net_get_hostname()`.** `memset(name, 0, sizeof(*name))`
   cleared a single byte of the `NI_MAXHOST + 1` buffer; and on
   `getnameinfo()` failure it decoded `errno` through `gai_strerror()`
   rather than the `EAI_*` code `getnameinfo()` actually returns. Clears
   the whole buffer and decodes the real return code.

## Test

Adds `test/unit/util/util_net.c` (wired into `make check`) covering
`prefix2netmask` across the boundary values, the `islocalhost` `255.x`
regression, `get_port`, and `isaddr`.

## Verification

- `libpmix` rebuilds clean (no new warnings, `--enable-devel-check`).
- Full `test/unit/util` suite: 17/17 pass, including the new `util_net`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)