### PR TITLE
util/argv: fix out-of-bounds and unchecked allocations

### DIFF
--- a/src/util/pmix_argv.c
+++ b/src/util/pmix_argv.c
@@ -150,8 +150,9 @@ size_t pmix_argv_len(char **argv)
     char **p;
     size_t length;
 
-    if (NULL == argv)
+    if (NULL == argv) {
         return (size_t) 0;
+    }
 
     length = sizeof(char *);
 
@@ -181,6 +182,9 @@ char **pmix_argv_copy_strip(char **argv)
     /* create an "empty" list, so that we return something valid if we
      were passed a valid list with no contained elements */
     dupv = (char **) malloc(sizeof(char *));
+    if (NULL == dupv) {
+        return NULL;
+    }
     dupv[0] = NULL;
 
     for (n=0; NULL != argv[n]; n++) {
@@ -190,7 +194,7 @@ char **pmix_argv_copy_strip(char **argv)
             ++start;
         }
         len = strlen(argv[n]);
-        if ('\"' == argv[n][len-1]) {
+        if (0 < len && '\"' == argv[n][len-1]) {
             argv[n][len-1] = '\0';
             mod = true;
         }
@@ -255,8 +259,9 @@ pmix_status_t pmix_argv_delete(int *argc, char ***argv, int start, int num_to_de
 
     /* adjust the argv array */
     tmp = (char **) realloc(*argv, sizeof(char *) * (i + 1));
-    if (NULL != tmp)
+    if (NULL != tmp) {
         *argv = tmp;
+    }
 
     /* adjust the argc: i is start + suffix_count, i.e. the new count */
     (*argc) = i;
@@ -268,6 +273,7 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
 {
     int i, source_count, target_count;
     int suffix_count;
+    char **tmp;
 
     /* Check for the bozo cases */
 
@@ -287,13 +293,17 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
         }
     }
 
-    /* Harder: insertting into the middle */
+    /* Harder: inserting into the middle */
 
     else {
 
-        /* Alloc out new space */
+        /* Allocate new space */
 
-        *target = (char **) realloc(*target, sizeof(char *) * (target_count + source_count + 1));
+        tmp = (char **) realloc(*target, sizeof(char *) * (target_count + source_count + 1));
+        if (NULL == tmp) {
+            return PMIX_ERR_NOMEM;
+        }
+        *target = tmp;
 
         /* Move suffix items down to the end */
 
@@ -319,6 +329,7 @@ pmix_status_t pmix_argv_insert_element(char ***target, int location, char *sourc
 {
     int i, target_count;
     int suffix_count;
+    char **tmp;
 
     /* Check for the bozo cases */
 
@@ -335,8 +346,12 @@ pmix_status_t pmix_argv_insert_element(char ***target, int location, char *sourc
         return PMIX_SUCCESS;
     }
 
-    /* Alloc out new space */
-    *target = (char **) realloc(*target, sizeof(char *) * (target_count + 2));
+    /* Allocate new space */
+    tmp = (char **) realloc(*target, sizeof(char *) * (target_count + 2));
+    if (NULL == tmp) {
+        return PMIX_ERR_NOMEM;
+    }
+    *target = tmp;
 
     /* Move suffix items down to the end */
     suffix_count = target_count - location;

--- a/test/unit/util/util_argv.c
+++ b/test/unit/util/util_argv.c
@@ -261,6 +261,97 @@ static void test_append_unique_idx_duplicate(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* pmix_argv_insert                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_insert_array_middle(void)
+{
+    char **target = NULL;
+    int argc = 0;
+    char **source = NULL;
+
+    pmix_argv_append(&argc, &target, "a");
+    pmix_argv_append(&argc, &target, "d");
+    PMIx_Argv_append_nosize(&source, "b");
+    PMIx_Argv_append_nosize(&source, "c");
+
+    pmix_status_t rc = pmix_argv_insert(&target, 1, source);
+    report("insert array middle: returns PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("insert array middle: argv[0] == \"a\"", target && 0 == strcmp(target[0], "a"));
+    report("insert array middle: argv[1] == \"b\"", target && 0 == strcmp(target[1], "b"));
+    report("insert array middle: argv[2] == \"c\"", target && 0 == strcmp(target[2], "c"));
+    report("insert array middle: argv[3] == \"d\"", target && 0 == strcmp(target[3], "d"));
+    report("insert array middle: argv[4] is NULL", target && NULL == target[4]);
+    /* source must be left unaffected */
+    report("insert array middle: source preserved", source && 0 == strcmp(source[0], "b"));
+    PMIx_Argv_free(target);
+    PMIx_Argv_free(source);
+}
+
+static void test_insert_array_past_end(void)
+{
+    char **target = NULL;
+    int argc = 0;
+    char **source = NULL;
+
+    pmix_argv_append(&argc, &target, "a");
+    PMIx_Argv_append_nosize(&source, "b");
+    PMIx_Argv_append_nosize(&source, "c");
+
+    /* start beyond the end appends */
+    pmix_argv_insert(&target, 10, source);
+    report("insert array past end: argv[0] == \"a\"", target && 0 == strcmp(target[0], "a"));
+    report("insert array past end: argv[1] == \"b\"", target && 0 == strcmp(target[1], "b"));
+    report("insert array past end: argv[2] == \"c\"", target && 0 == strcmp(target[2], "c"));
+    report("insert array past end: argv[3] is NULL", target && NULL == target[3]);
+    PMIx_Argv_free(target);
+    PMIx_Argv_free(source);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_argv_copy_strip                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_copy_strip_quotes(void)
+{
+    char **argv = NULL;
+    PMIx_Argv_append_nosize(&argv, "\"quoted\"");
+    PMIx_Argv_append_nosize(&argv, "plain");
+
+    char **dupv = pmix_argv_copy_strip(argv);
+    report("copy_strip: non-NULL result", NULL != dupv);
+    report("copy_strip: quotes removed", dupv && 0 == strcmp(dupv[0], "quoted"));
+    report("copy_strip: plain unchanged", dupv && 0 == strcmp(dupv[1], "plain"));
+    report("copy_strip: NULL terminated", dupv && NULL == dupv[2]);
+    /* original must be restored to its quoted form */
+    report("copy_strip: original restored", 0 == strcmp(argv[0], "\"quoted\""));
+    PMIx_Argv_free(dupv);
+    PMIx_Argv_free(argv);
+}
+
+static void test_copy_strip_empty_element(void)
+{
+    char **argv = NULL;
+    /* an empty element must not trigger an out-of-bounds access */
+    PMIx_Argv_append_nosize(&argv, "");
+    PMIx_Argv_append_nosize(&argv, "x");
+
+    char **dupv = pmix_argv_copy_strip(argv);
+    report("copy_strip empty: non-NULL result", NULL != dupv);
+    report("copy_strip empty: argv[0] == \"\"", dupv && 0 == strcmp(dupv[0], ""));
+    report("copy_strip empty: argv[1] == \"x\"", dupv && 0 == strcmp(dupv[1], "x"));
+    report("copy_strip empty: NULL terminated", dupv && NULL == dupv[2]);
+    PMIx_Argv_free(dupv);
+    PMIx_Argv_free(argv);
+}
+
+static void test_copy_strip_null(void)
+{
+    char **dupv = pmix_argv_copy_strip(NULL);
+    report("copy_strip NULL returns NULL", NULL == dupv);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -286,6 +377,13 @@ int main(int argc, char **argv)
 
     test_insert_middle();
     test_insert_at_start();
+
+    test_insert_array_middle();
+    test_insert_array_past_end();
+
+    test_copy_strip_quotes();
+    test_copy_strip_empty_element();
+    test_copy_strip_null();
 
     test_append_unique_idx_new();
     test_append_unique_idx_duplicate();


### PR DESCRIPTION
## Summary

Fixes a real out-of-bounds access and two unchecked-allocation crashes in `src/util/pmix_argv.c`, plus minor style cleanups, and adds unit-test coverage.

### Bugs fixed
- **Out-of-bounds in `pmix_argv_copy_strip`**: the trailing-quote check indexed `argv[n][len-1]` without verifying the element was non-empty. For an empty-string element `len == 0`, and since `len` is a `size_t`, `len-1` wraps to `SIZE_MAX` — a wild OOB read (and a potential OOB write if the byte happened to compare equal to `"`). Empty elements are legal in an argv array. Guarded with `0 < len`.
- **Unchecked `realloc` in `pmix_argv_insert` / `pmix_argv_insert_element`**: the result was stored straight back into `*target`, so an allocation failure leaked the original block, overwrote the only pointer to it with NULL, then dereferenced NULL. Now captured in a temporary, returning `PMIX_ERR_NOMEM` on failure — matching the existing pattern in `pmix_argv_delete`.
- **Unchecked `malloc`** of the initial array in `pmix_argv_copy_strip`.

### Style
- Braced single-line conditionals in `pmix_argv_len` and the delete `realloc` per project rules.
- Fixed an `insertting` comment typo.

### Tests
Added cases to `test/unit/util/util_argv.c` (already wired into `make check`) covering `pmix_argv_insert` (middle insert, source-preserved, past-end append), `pmix_argv_copy_strip` (quote stripping, original restored, NULL input), and the empty-element strip case that exercises the OOB fix.

`make check TESTS=util_argv` → 57 assertions pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)