### PR TITLE
util/string_copy: fix size_t underflow OOB writes

### DIFF
--- a/src/util/pmix_string_copy.c
+++ b/src/util/pmix_string_copy.c
@@ -12,6 +12,10 @@
 #include "pmix_config.h"
 
 #include <assert.h>
+#include <stdio.h>
+#ifdef HAVE_STRING_H
+#    include <string.h>
+#endif
 
 #include "src/util/pmix_string_copy.h"
 
@@ -30,6 +34,12 @@ void pmix_string_copy(char *dest, const char *src, size_t dest_len)
     // obvious.
     assert(dest_len <= PMIX_MAX_SIZE_ALLOWED_BY_PMIX_STRING_COPY);
 
+    // A zero-length destination buffer has no room for even the
+    // terminating '\0'.  Do nothing rather than write to dest[-1].
+    if (0 == dest_len) {
+        return;
+    }
+
     for (i = 0; i < dest_len; ++i, ++src, ++new_dest) {
         *new_dest = *src;
         if ('\0' == *src) {
@@ -44,10 +54,19 @@ char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;
     char input[1024];
+    size_t len;
 
     ret = fgets(input, 1024, fp);
     if (NULL != ret) {
-        input[strlen(input) - 1] = '\0'; /* remove newline */
+        /* strip a trailing newline, if present.  fgets does not
+         * guarantee one: a line longer than the buffer or a final
+         * line at EOF will have none, so we must not blindly delete
+         * the last character.  Guard against an empty string as well
+         * to avoid a size_t underflow on input[len - 1]. */
+        len = strlen(input);
+        if (0 < len && '\n' == input[len - 1]) {
+            input[len - 1] = '\0';
+        }
         buff = strdup(input);
         return buff;
     }

--- a/test/unit/util/util_string_copy.c
+++ b/test/unit/util/util_string_copy.c
@@ -6,7 +6,7 @@
  *
  * $HEADER$
  *
- * Unit tests for pmix_string_copy().
+ * Unit tests for pmix_string_copy() and pmix_getline().
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -77,6 +77,21 @@ static void test_copy_single_byte_dest(void)
     report("copy 1-byte dest: null terminated", '\0' == dest[0]);
 }
 
+/* dest_len == 0: nothing may be written (no dest[-1] underflow) */
+static void test_copy_zero_len_dest(void)
+{
+    /* surround the target byte with sentinels; a buggy implementation
+     * writes to target[-1], i.e. guard[0] */
+    char guard[3];
+    char *target = &guard[1];
+    guard[0] = (char) 0xAB;
+    guard[1] = (char) 0xCD;
+    guard[2] = (char) 0xEF;
+    pmix_string_copy(target, "hello", 0);
+    report("copy 0-len dest: no underflow write", (unsigned char) 0xAB == (unsigned char) guard[0]);
+    report("copy 0-len dest: target untouched", (unsigned char) 0xCD == (unsigned char) guard[1]);
+}
+
 /* empty source string */
 static void test_copy_empty_src(void)
 {
@@ -96,6 +111,94 @@ static void test_copy_no_overwrite_beyond_null(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* pmix_getline                                                        */
+/* ------------------------------------------------------------------ */
+
+/* write the given contents to a fresh temp file, rewound for reading */
+static FILE *make_tmpfile(const char *contents)
+{
+    FILE *fp = tmpfile();
+    if (NULL == fp) {
+        return NULL;
+    }
+    if (0 < strlen(contents)) {
+        fwrite(contents, 1, strlen(contents), fp);
+    }
+    rewind(fp);
+    return fp;
+}
+
+/* a normal newline-terminated line has its newline stripped */
+static void test_getline_strip_newline(void)
+{
+    FILE *fp = make_tmpfile("hello\nworld\n");
+    char *line;
+
+    line = pmix_getline(fp);
+    report("getline: first line stripped", line && 0 == strcmp(line, "hello"));
+    free(line);
+    line = pmix_getline(fp);
+    report("getline: second line stripped", line && 0 == strcmp(line, "world"));
+    free(line);
+    line = pmix_getline(fp);
+    report("getline: EOF returns NULL", NULL == line);
+    free(line);
+    fclose(fp);
+}
+
+/* a final line with no trailing newline must keep all its characters */
+static void test_getline_no_trailing_newline(void)
+{
+    FILE *fp = make_tmpfile("nonewline");
+    char *line = pmix_getline(fp);
+    report("getline: unterminated last line preserved", line && 0 == strcmp(line, "nonewline"));
+    free(line);
+    fclose(fp);
+}
+
+/* an empty line ("\n") must return an empty string, not underflow */
+static void test_getline_empty_line(void)
+{
+    FILE *fp = make_tmpfile("\nafter\n");
+    char *line;
+
+    line = pmix_getline(fp);
+    report("getline: empty line returns \"\"", line && 0 == strcmp(line, ""));
+    free(line);
+    line = pmix_getline(fp);
+    report("getline: line after empty preserved", line && 0 == strcmp(line, "after"));
+    free(line);
+    fclose(fp);
+}
+
+/* a line longer than the internal buffer must not lose a character to
+ * the newline-stripping logic (the first fgets read has no newline) */
+static void test_getline_long_line(void)
+{
+    char big[2000];
+    memset(big, 'a', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+
+    FILE *fp = make_tmpfile(big);
+    char *line = pmix_getline(fp);
+    /* the internal buffer is 1024, so the first read returns 1023
+     * 'a' chars with no newline; none of them may be dropped */
+    report("getline: long line not truncated by strip",
+           line && 1023 == strlen(line) && (size_t) (strspn(line, "a")) == strlen(line));
+    free(line);
+    fclose(fp);
+}
+
+static void test_getline_empty_file(void)
+{
+    FILE *fp = make_tmpfile("");
+    char *line = pmix_getline(fp);
+    report("getline: empty file returns NULL", NULL == line);
+    free(line);
+    fclose(fp);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -107,8 +210,15 @@ int main(int argc, char **argv)
     test_copy_exact_fit();
     test_copy_truncate();
     test_copy_single_byte_dest();
+    test_copy_zero_len_dest();
     test_copy_empty_src();
     test_copy_no_overwrite_beyond_null();
+
+    test_getline_strip_newline();
+    test_getline_no_trailing_newline();
+    test_getline_empty_line();
+    test_getline_long_line();
+    test_getline_empty_file();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;


### PR DESCRIPTION
## Summary

Fixes two `size_t`-underflow out-of-bounds writes in `src/util/pmix_string_copy.c`, plus a silent data-corruption bug in `pmix_getline`, and adds unit-test coverage.

### Bugs fixed
- **`pmix_string_copy` OOB write on `dest_len == 0`**: the function writes `dest[dest_len - 1]` after its copy loop. When `dest_len` is 0 the loop body never runs and, since `dest_len` is a `size_t`, `dest_len - 1` wraps to `SIZE_MAX` — an out-of-bounds write at `dest[SIZE_MAX]`. Now returns early for a zero-size buffer (which has no room for even the terminating `'\0'`).
- **`pmix_getline` drops a real character / underflows**: it unconditionally deleted the last character of each line, assuming it was always a newline. `fgets` does *not* append a newline when a line exceeds the 1024-byte buffer or when the final line ends at EOF without one, so a legitimate data byte was silently lost. And when `fgets` returns a zero-length string (e.g. an embedded NUL byte), `strlen(input) - 1` underflows and writes to `input[-1]`. Now strips the trailing character only when it is actually `'\n'`, guarding the empty-string case.

### Hygiene
- Added the previously-transitive `<stdio.h>`/`<string.h>` includes directly.

### Tests
Extended `test/unit/util/util_string_copy.c` (already wired into `make check`):
- `pmix_string_copy`: zero-length-buffer case with sentinel guards.
- `pmix_getline` (previously had no coverage): newline stripping across lines + EOF, unterminated final line preserved, empty line returns `""`, over-long (>1023 byte) line not truncated by the strip logic, and empty file returns NULL.

`make check TESTS=util_string_copy` → 19 assertions pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)