### PR TITLE
Add scheduler allocation timeout warning support

### DIFF
--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -1,23 +1,157 @@
 Overview
 ========
 
-Describe general layout for operation. Tools and apps can potentially
-communicate directly to the scheduler, passing requests and getting
-responses. Or, more commonly, they can communicate such requests to
-their local runtime environment (RTE), which can then act as a relay
-between the requestor and the scheduler.
+PMIx provides a portable, RM-agnostic mechanism by which tools,
+applications, and runtime environments (RTEs) can interact with the
+system scheduler (also referred to as the Workload Manager, or WLM).
+The integration is built from the same primitives used throughout
+PMIx - a small number of generic APIs whose behavior is modulated by
+attributes, plus an event-notification channel for asynchronous
+alerts.
 
-In addition, the RTE itself can use its connection to the scheduler
-for coordinating their interactions. For example, the scheduler may
-use PMIx to inform the RTE of a new session it should instantiate.
-Likewise, the RTE can use PMIx to inform the scheduler that a session
-has terminated and thus all its resources are available for reuse.
+General layout
+--------------
 
-While the PMIx scheduler integration support can be used for the
-more common operations (e.g., submitting allocation requests,
-RTE-scheduler coordination), the primary intent of the support is
-to enable dynamic environments - i.e., the ability for an application
-to request on-the-fly modifications of its session. 
+Two communication paths are supported:
+
+* **Direct.** A tool or application can, where the environment permits,
+  open a connection directly to the scheduler and exchange requests and
+  responses with it.
+
+* **Relayed (more common).** A tool or application communicates its
+  request to its local RTE, which already holds a connection to the
+  scheduler. The RTE then acts as a relay between the requestor and the
+  scheduler, forwarding the request and returning the scheduler's
+  response. This is the typical arrangement because most processes are
+  not granted - and do not want the burden of - a direct scheduler
+  connection.
+
+In addition, the RTE itself uses its connection to the scheduler to
+coordinate their mutual interactions. For example, the scheduler may
+use PMIx to inform the RTE of a new session it should instantiate;
+likewise, the RTE can use PMIx to inform the scheduler that a session
+has terminated and thus all of its resources are available for reuse.
+
+While the scheduler-integration support can be used for the more
+common operations (e.g., submitting allocation requests, RTE-scheduler
+coordination), the primary intent of the support is to enable
+**dynamic environments** - i.e., the ability for an application to
+request on-the-fly modifications of its session.
 
 Support is provided via a few APIs, attributes, and events.
 
+APIs
+----
+
+The principal entry points used to interact with the scheduler are:
+
+* ``PMIx_Allocation_request`` (and its non-blocking form
+  ``PMIx_Allocation_request_nb``) - request a change to an allocation.
+  The accompanying ``pmix_alloc_directive_t`` selects the operation:
+
+  ============================  ==================================================
+  Directive                     Meaning
+  ============================  ==================================================
+  ``PMIX_ALLOC_NEW``            Request a new, disjoint allocation.
+  ``PMIX_ALLOC_EXTEND``         Extend an existing allocation in time and/or
+                                resources.
+  ``PMIX_ALLOC_RELEASE``        Release part or all of an existing allocation,
+                                optionally "lending" the resources back for a
+                                period of time.
+  ``PMIX_ALLOC_REAQUIRE``       Reacquire resources previously lent to the
+                                scheduler.
+  ``PMIX_ALLOC_REQ_CANCEL``     Cancel a pending allocation request.
+  ============================  ==================================================
+
+* ``PMIx_Session_control`` - request a control action against a session
+  (identified by its ``sessionID``; ``UINT32_MAX`` denotes all sessions
+  under the caller's control).
+
+As with every PMIx API, these calls accept an array of ``pmix_info_t``
+attributes so that new behavior can be added over time without altering
+the signatures.
+
+Identifying an allocation
+-------------------------
+
+Two identifiers are associated with an allocation, and either or both
+may appear in requests, queries, and event payloads:
+
+* ``PMIX_ALLOC_REQ_ID`` (``char*``) - a **user-provided** string label
+  for an allocation request, supplied by the requestor so that it can
+  later reference or query the request.
+
+* ``PMIX_ALLOC_ID`` (``char*``) - a **scheduler-provided** string
+  identifier for the resulting allocation, used to reference the
+  allocated resources in subsequent operations (e.g., a later
+  ``PMIx_Spawn``).
+
+Both forms are carried so that a process can correlate a scheduler
+notification with the request it originally issued, regardless of which
+identifier it happens to hold.
+
+Allocation timeout warning
+---------------------------
+
+Allocations are frequently granted for a bounded period of time. When
+the period expires, the scheduler reclaims the resources - typically
+terminating any jobs still running within the allocation. Applications
+that wish to checkpoint, drain work, or request an extension before
+that happens need advance notice.
+
+PMIx supports this through a request attribute and a corresponding
+event.
+
+Requesting a warning
+^^^^^^^^^^^^^^^^^^^^^^
+
+``PMIX_ALLOC_WARN_TIMEOUT`` (``uint32_t``) is passed in the
+``pmix_info_t`` array of an allocation request (for example, alongside
+``PMIX_ALLOC_NEW`` or ``PMIX_ALLOC_EXTEND``). Its value is the number of
+**seconds** prior to expiration at which the requestor wishes to be
+warned - matching the units of the ``PMIX_TIME_REMAINING`` value carried
+in the warning event. By including it, the requestor asks the scheduler
+to deliver an advance warning of the impending timeout of the allocation
+that many seconds ahead of the actual expiration.
+
+Honoring the request is up to the scheduler: like all attributes, it is
+advisory, and a scheduler that does not implement the capability will
+simply ignore it.
+
+Receiving the warning
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When the warning threshold is reached, the scheduler issues the
+``PMIX_ALLOC_TIMEOUT_WARNING`` event. The event is **targeted at the
+process that requested the allocation** - it is not a general
+broadcast - so the requestor registers an event handler for
+``PMIX_ALLOC_TIMEOUT_WARNING`` to receive it.
+
+The accompanying ``pmix_info_t`` payload must include enough
+information for the recipient to identify which allocation is about to
+expire and how long it has left:
+
+============================  ==========================  ==============================================
+Attribute                     Type                        Meaning
+============================  ==========================  ==============================================
+``PMIX_ALLOC_ID``             ``char*``                   Scheduler-assigned ID of the affected
+                                                          allocation.
+``PMIX_ALLOC_REQ_ID``         ``char*``                   User-provided request ID, included whenever
+                                                          one was given on the original request.
+``PMIX_TIME_REMAINING``       ``uint32_t``                Number of seconds remaining before the
+                                                          allocation expires.
+============================  ==========================  ==============================================
+
+The scheduler includes ``PMIX_ALLOC_ID`` in all cases. It also includes
+``PMIX_ALLOC_REQ_ID`` whenever the requestor supplied one, so that the
+recipient can match the warning against the request it issued using
+either identifier. ``PMIX_TIME_REMAINING`` reports the time left at the
+moment the warning is generated, expressed in seconds - the same units
+used for the ``PMIX_ALLOC_WARN_TIMEOUT`` request threshold.
+
+The targeting of the event at the original requestor is expressed in the
+usual way for directed PMIx events - e.g., by restricting the
+notification range to the requesting process. A recipient handler
+returns ``PMIX_EVENT_ACTION_COMPLETE`` (or the appropriate status) once
+it has reacted, for instance by issuing a ``PMIX_ALLOC_EXTEND`` request
+to lengthen the allocation, or by beginning an orderly shutdown.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -956,6 +956,12 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_TIME                     "pmix.alloc.time"       // (char*) time that the allocation shall remain valid. Time is specified in
                                                                     //         usual time format of months:days:hours:minutes:seconds, scanning
                                                                     //         from right to left (i.e., a value of "2" equates to 2 seconds)
+#define PMIX_ALLOC_WARN_TIMEOUT             "pmix.alloc.wtmo"       // (uint32_t) request that the scheduler provide advance warning of the
+                                                                    //         impending timeout (expiration) of the allocation. The value
+                                                                    //         indicates the number of seconds prior to expiration at which the
+                                                                    //         warning is to be delivered. The scheduler issues the warning by
+                                                                    //         generating a PMIX_ALLOC_TIMEOUT_WARNING event targeting the
+                                                                    //         requestor of the allocation.
 #define PMIX_ALLOC_FABRIC_TYPE              "pmix.alloc.nettype"    // (char*) type of desired transport (e.g., tcp, udp)
 #define PMIX_ALLOC_FABRIC_PLANE             "pmix.alloc.netplane"   // (char*) id string for the NIC (aka plane) to be used for this allocation
                                                                     //         (e.g., CIDR for Ethernet)
@@ -1741,6 +1747,8 @@ typedef int pmix_status_t;
 #define PMIX_EVENT_JOB_END                          -145
 #define PMIX_EVENT_SESSION_START                    -192
 #define PMIX_EVENT_SESSION_END                      -193
+#define PMIX_ALLOC_TIMEOUT_WARNING                  -194     // scheduler warning of impending allocation timeout - payload
+                                                             // includes the allocation ID(s) and the time remaining
 
 /* process-related events */
 #define PMIX_ERR_PROC_REQUESTED_ABORT               -8


### PR DESCRIPTION
Populate the scheduler integration overview spec and add the mechanism
by which an allocation requestor can ask the scheduler to warn it
before the allocation expires.

## What changed

- **New attribute `PMIX_ALLOC_WARN_TIMEOUT`** (`uint32_t`, seconds) —
  passed in an allocation request to ask the scheduler to deliver
  advance warning of impending expiration that many seconds ahead of
  time. The units match the existing `PMIX_TIME_REMAINING` attribute.

- **New event code `PMIX_ALLOC_TIMEOUT_WARNING`** — emitted by the
  scheduler to deliver the warning. It targets the allocation
  requestor and carries a payload identifying the affected allocation:
  `PMIX_ALLOC_ID` (scheduler-assigned), `PMIX_ALLOC_REQ_ID`
  (user-provided, when one was given), and `PMIX_TIME_REMAINING`
  (seconds left before expiration).

- **`docs/how-things-work/schedulers/overview.rst`** — expanded from
  stub notes into a full description of the scheduler integration: the
  direct and relayed communication paths, RTE-scheduler coordination,
  the allocation request APIs and directives, the two allocation
  identifiers, and the timeout-warning request attribute and event.

Both the attribute and the event code are added to
`include/pmix_common.h.in`; the autogenerated dictionary and event
string tables pick them up at build time (verified the dictionary
harvests `PMIX_ALLOC_WARN_TIMEOUT` as `PMIX_UINT32`).

## Notes

Defines the attribute, event, and spec only — wiring a scheduler/host
to honor the request and generate the event is follow-on work.