### PR TITLE
Add DVM grow/shrink completion and failure events

### DIFF
--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -155,3 +155,41 @@ notification range to the requesting process. A recipient handler
 returns ``PMIX_EVENT_ACTION_COMPLETE`` (or the appropriate status) once
 it has reacted, for instance by issuing a ``PMIX_ALLOC_EXTEND`` request
 to lengthen the allocation, or by beginning an orderly shutdown.
+
+Dynamic resource modification
+-----------------------------
+
+A request to grow or shrink a session is satisfied asynchronously: the
+scheduler adjusts the underlying allocation and the RTE then reshapes
+its distributed virtual machine (DVM) to match - starting or stopping
+daemons on the affected nodes. Because this happens in the background,
+the requestor learns the outcome through an event rather than a direct
+return from the request.
+
+Two events report the result, both targeted at the process that
+requested the modification:
+
+* ``PMIX_DVM_IS_READY`` - the DVM has completed the requested
+  grow/shrink operation and is ready for use.
+
+* ``PMIX_ERR_DVM_MOD`` - the requested grow/shrink operation failed
+  (for example, a daemon failed to start on a node added during a grow).
+
+Both events carry a ``pmix_info_t`` payload identifying the affected
+allocation:
+
+============================  ==========================  ==============================================
+Attribute                     Type                        Meaning
+============================  ==========================  ==============================================
+``PMIX_ALLOC_ID``             ``char*``                   Scheduler-assigned ID of the affected
+                                                          allocation.
+``PMIX_ALLOC_REQ_ID``         ``char*``                   User-provided request ID, included whenever
+                                                          one was given on the original request.
+============================  ==========================  ==============================================
+
+As with the timeout warning, ``PMIX_ALLOC_REQ_ID`` is included only when
+the requestor supplied one, allowing the recipient to correlate the
+notification with the request it issued using either identifier. The
+``PMIX_ERR_DVM_MOD`` payload additionally carries whatever information
+is available describing the cause of the failure, so the recipient can
+decide how to recover.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1741,6 +1741,11 @@ typedef int pmix_status_t;
 #define PMIX_ERR_JOB_WDIR_NOT_FOUND                 -233
 #define PMIX_ERR_JOB_INSUFFICIENT_RESOURCES         -234
 #define PMIX_ERR_JOB_SYS_OP_FAILED                  -235
+#define PMIX_ERR_DVM_MOD                            -196     // a requested DVM grow/shrink operation failed (e.g., daemon startup
+                                                             // on grow failed) - payload includes the scheduler allocation ID
+                                                             // (PMIX_ALLOC_ID) and the user-provided allocation ID
+                                                             // (PMIX_ALLOC_REQ_ID), if one was given, plus any available
+                                                             // information describing the cause of the failure
 
 /* job/session-related non-error events */
 #define PMIX_EVENT_JOB_START                        -191
@@ -1749,6 +1754,9 @@ typedef int pmix_status_t;
 #define PMIX_EVENT_SESSION_END                      -193
 #define PMIX_ALLOC_TIMEOUT_WARNING                  -194     // scheduler warning of impending allocation timeout - payload
                                                              // includes the allocation ID(s) and the time remaining
+#define PMIX_DVM_IS_READY                           -195     // the DVM has completed a requested grow/shrink operation - payload
+                                                             // includes the scheduler allocation ID (PMIX_ALLOC_ID) and the
+                                                             // user-provided allocation ID (PMIX_ALLOC_REQ_ID), if one was given
 
 /* process-related events */
 #define PMIX_ERR_PROC_REQUESTED_ABORT               -8


### PR DESCRIPTION
Define two new event codes that the runtime uses to report the outcome
of a requested dynamic resource modification (a session grow or shrink)
back to the process that requested it:

- **`PMIX_DVM_IS_READY`** — the DVM has completed the requested grow/shrink
  operation and is ready for use.
- **`PMIX_ERR_DVM_MOD`** — the requested operation failed (for example, a
  daemon failed to start on a node added during a grow).

Both events carry a payload identifying the affected allocation via
`PMIX_ALLOC_ID` (scheduler-assigned) and, when the requestor supplied one,
`PMIX_ALLOC_REQ_ID` (user-provided). The failure event additionally carries
whatever information is available describing the cause.

Both events are documented in the scheduler integration overview alongside
the existing allocation timeout-warning event.