### PR TITLE
Fix status-code value collision for conversion errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,29 @@ and [`docs/contributing.rst`](docs/contributing.rst):
   with `#if FOO`, not `#ifdef FOO`, so a misspelling is a compiler
   error, not a silent false.
 
+**Never reuse a status/event code value.** Every `PMIX_*` status and
+  event constant in [`include/pmix_common.h.in`](include/pmix_common.h.in)
+  must have a numeric value that is unique across the *entire* code base,
+  including the deprecated constants in
+  [`include/pmix_deprecated.h`](include/pmix_deprecated.h). Two active
+  constants sharing a value are indistinguishable to event handlers and
+  status comparisons — a latent, hard-to-trace bug. Before adding or
+  changing a code, sweep both headers for the value you intend to use,
+  e.g.:
+
+  ```sh
+  grep -hoE '^#define[[:space:]]+[A-Z0-9_]+[[:space:]]+-[0-9]+' \
+      include/pmix_common.h.in include/pmix_deprecated.h \
+      | awk '{print $3}' | sort -n | uniq -d
+  ```
+
+  The one legitimate exception is a deprecation *rename*: a deprecated
+  alias in `pmix_deprecated.h` intentionally keeps the same value as the
+  active constant that replaced it (e.g., `PMIX_ERR_EXISTS` and the
+  deprecated `PMIX_EXISTS` are both `-11`). That is a rename, not a new
+  code. Remember too that values in `-230`..`-330` are reserved as system
+  events by the `PMIX_SYSTEM_EVENT()` macro range.
+
 **Constant-on-left comparisons:** Always write `NULL == ptr` rather than `ptr == NULL`.  This turns typos (`=` instead of `==`) into compile errors.
 
 **Always brace blocks:** Use `{ }` around every conditional or loop body, even single-line ones.

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,12 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Resolve a status-code value collision: PMIX_ERR_LOST_PRECISION and
+   PMIX_ERR_CHANGE_SIGN shared the values -400 and -401 with the
+   PMIX_ERR_PROC_KILLED_BY_CMD and PMIX_ERR_PROC_FAILED_TO_START event
+   codes, making the two indistinguishable to event handlers, status
+   comparisons, and PMIx_Error_string. The two conversion-error codes
+   have been renumbered to -202 and -203
  - gds/shmem2: make fixed-address segment attach reliable, fixing an
    intermittent spawn-time PMIx_Init failure (PMIX_ERR_PACK_MISMATCH)
    seen under AddressSanitizer and during MPI_Comm_spawn

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1778,8 +1778,8 @@ typedef int pmix_status_t;
 #define PMIX_EVENT_ACTION_COMPLETE                  -334
 
 /* conversion errors */
-#define PMIX_ERR_LOST_PRECISION                     -400
-#define PMIX_ERR_CHANGE_SIGN                        -401
+#define PMIX_ERR_LOST_PRECISION                     -202
+#define PMIX_ERR_CHANGE_SIGN                        -203
 
 /* define a starting point for user-level defined error
  * constants - negative values larger than this are guaranteed


### PR DESCRIPTION
`PMIX_ERR_LOST_PRECISION` and `PMIX_ERR_CHANGE_SIGN` were defined with the
values `-400` and `-401`, which are **also** used by the
`PMIX_ERR_PROC_KILLED_BY_CMD` and `PMIX_ERR_PROC_FAILED_TO_START` event
codes. Two active constants sharing a numeric value are indistinguishable
to event handlers and status comparisons, and cause the autogenerated
`pmix_event_strings` table (and thus `PMIx_Error_string`) to report
whichever name happens to be harvested first. The duplication was
introduced inadvertently when the conversion-error codes were added.

### Change
- Renumber the two conversion-error codes to the previously unused values
  `-202` and `-203`.
- The process-event codes form a deliberate contiguous block (`-400..-404`)
  derived from the v4 Standard sync and are left in place; the isolated,
  accidentally-duplicated conversion-error pair is the one moved.
- The generated `pmix_event_strings.c` rebuilds from `pmix_common.h.in`, so
  no generated file is hand-edited.
- Adds a golden rule to `AGENTS.md` requiring that every status/event code
  value be unique across `pmix_common.h.in` and `pmix_deprecated.h` (the
  deprecated-alias rename being the sole intentional exception), with a
  one-line sweep command to catch this class of collision before it lands.

### ⚠️ Needs maintainer review
Changing the value of a published constant has ABI/wire-compat
implications. The alternative — renumbering the process-event codes
instead — is also possible; this PR picks the conversion-error pair as the
less-exposed of the two. Please confirm the final code assignments before
merge.