### PR TITLE
plog: implement stdfd output formatting, fix XML/smtp bugs, add orientation docs

### DIFF
--- a/docs/how-things-work/pmix_log.rst
+++ b/docs/how-things-work/pmix_log.rst
@@ -181,6 +181,48 @@ Dispatch (pmix_plog_base_log)
      module cannot handle the request; skip to next.
    * Any other error — abort processing.
 
+If, after matching, *no* module was assembled for the request,
+``pmix_plog_base_log()`` returns ``PMIX_OPERATION_SUCCEEDED`` — **not**
+``PMIX_SUCCESS``.  This distinction is load-bearing throughout the log
+path (see `The PMIX_OPERATION_SUCCEEDED convention`_).
+
+
+Module Contract and Cooperation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because ``plog`` is *multi-select*, a single request may be serviced by
+several modules in turn, and the modules must cooperate rather than step
+on each other.  Two mechanisms make this work, and any new or modified
+component must honor both:
+
+**Per-item completion marking.**  The ``data[]`` array is shared, mutable
+state.  A module marks each entry it consumes with
+``PMIX_INFO_OP_COMPLETED(&data[n])`` and skips any entry for which
+``PMIX_INFO_OP_IS_COMPLETE(&data[n])`` is already true.  Both the
+dispatcher (during aggregation suppression) and the sibling modules
+observe these flags, so this is how two modules divide one array without
+double-logging.
+
+**The return-code contract.**  A module's ``log`` must return exactly one
+of:
+
+* ``PMIX_SUCCESS`` / ``PMIX_OPERATION_SUCCEEDED`` — "I handled at least
+  part of this request."
+* ``PMIX_ERR_TAKE_NEXT_OPTION`` or ``PMIX_ERR_NOT_AVAILABLE`` — "none of
+  these keys are mine; let another module try."  Returning this (rather
+  than an error) when a module's keys are simply absent is precisely what
+  lets the multi-select chain — and ``PMIX_LOG_ONCE`` — work.
+* a hard error code — only for genuine failures; it aborts the whole
+  dispatch loop.
+
+The most common ``plog`` defect is an over-eager module that returns
+``PMIX_SUCCESS`` for a request it did not actually handle: doing so
+swallows a ``PMIX_LOG_ONCE`` request and starves the channel the caller
+really wanted.  (Historically the ``syslog`` module has been loose here —
+it falls through to ``PMIX_SUCCESS`` rather than
+``PMIX_ERR_TAKE_NEXT_OPTION`` when its keys are absent; new code should
+follow the explicit convention.)
+
 
 plog Components
 ---------------
@@ -188,16 +230,50 @@ plog Components
 stdfd (src/mca/plog/stdfd/)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Handles ``PMIX_LOG_STDERR`` and ``PMIX_LOG_STDOUT``.
+Claims the ``stdout`` and ``stderr`` channels (set up in the module's
+``init`` from a split of ``"stdout,stderr"``) and handles
+``PMIX_LOG_STDERR`` and ``PMIX_LOG_STDOUT``.  Its ``component_query``
+returns priority ``5`` — deliberately *below* ``syslog`` and ``smtp`` so
+that, absent an explicit ordering, the more notable channels sort ahead
+of plain stdio.
 
-* When called on a *client*: writes directly to ``stderr`` / ``stdout``
-  via ``fprintf``.
-* When called on a *server*: delivers the output to the client's IOF
-  stream via ``PMIx_server_IOF_deliver()`` so it appears on the
-  originating process's stdio.
+* When called on a *client* or *tool*: writes the string directly to
+  ``stderr`` / ``stdout`` via ``fprintf`` — this process *is* the
+  endpoint, so there is nowhere to forward.
+* When called on a *server*: the output belongs to a process whose stdio
+  the server manages, so it is handed to the IOF (I/O forwarding)
+  subsystem via the non-blocking ``PMIx_server_IOF_deliver()`` (targeting
+  ``PMIX_FWD_STDOUT_CHANNEL`` / ``PMIX_FWD_STDERR_CHANNEL``) so it appears
+  on the originating process's stdio.
 
-The component also honours ``PMIX_LOG_TAG_OUTPUT`` (prepend channel name)
-and ``PMIX_LOG_XML_OUTPUT`` (wrap in XML tags).
+The server path allocates a small ``pmix_iof_deliver_t`` scratch object
+that carries a *copy* of the message bytes and the source ``pmix_proc_t``;
+a completion callback (``lkcbfunc``) releases it once IOF delivery
+finishes.  This is a deliberate, local exception to the framework's
+no-copy rule: because ``mylog`` returns before the async delivery
+completes, the caller's ``data`` array cannot be assumed live by then, so
+the payload must be copied.
+
+The component also honors the output-formatting directives
+``PMIX_LOG_TAG_OUTPUT`` (prefix each line with its channel tag),
+``PMIX_LOG_TIMESTAMP_OUTPUT`` (prefix with a timestamp), and
+``PMIX_LOG_XML_OUTPUT`` (wrap the line in an XML element, payload
+escaped).  Rather than duplicate that logic, it maps the directives onto
+a ``pmix_iof_flags_t`` and calls the shared IOF formatter
+``pmix_iof_prep_output()`` so log output is formatted identically to
+forwarded stdio.  The formatter runs only when at least one flag is set;
+otherwise the raw string is written directly, so unformatted logging pays
+no extra cost.
+
+.. note::
+
+   ``pmix_iof_prep_output()`` generates the printed timestamp at emission
+   time (as it does for IOF), so the explicit ``PMIX_LOG_TIMESTAMP``
+   *value* attached to the request is not used for the ``stdfd`` stamp —
+   in contrast to the ``syslog`` and ``smtp`` components, which print the
+   supplied value.  Honoring a caller-supplied timestamp here would be a
+   central enhancement to the shared formatter rather than a
+   ``stdfd``-local change.
 
 syslog (src/mca/plog/syslog/)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,17 +290,39 @@ component falls back to sensible defaults.
 smtp (src/mca/plog/smtp/)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Handles ``PMIX_LOG_EMAIL``.  Requires libesmtp at build time.
+Claims the ``email`` channel and handles ``PMIX_LOG_EMAIL``.  Requires
+libesmtp at build time; the component's ``configure.m4`` disables it when
+libesmtp is absent, so its symbols must never be assumed present
+elsewhere in the library.
 
-Additional directives used only by this component:
+Unlike the other channels, ``PMIX_LOG_EMAIL``'s value is *not* a string —
+it is a ``pmix_data_array_t`` of nested ``pmix_info_t`` entries that
+describe the message.  ``mylog`` picks up that nested array and scans it
+for:
 
-* ``PMIX_LOG_EMAIL_ADDR`` — ``(char*)`` recipient address(es)
+* ``PMIX_LOG_EMAIL_ADDR`` — ``(char*)`` comma-delimited recipient list
 * ``PMIX_LOG_EMAIL_SENDER_ADDR`` — ``(char*)`` sender address
 * ``PMIX_LOG_EMAIL_SUBJECT`` — ``(char*)`` subject line
-* ``PMIX_LOG_EMAIL_SERVER`` — ``(char*)`` SMTP relay hostname
+* ``PMIX_LOG_MSG`` — the body, accepted as either a ``PMIX_STRING`` or a
+  ``PMIX_BYTE_OBJECT``
 
-A failed ``libesmtp`` send emits a ``pmix_show_help`` warning from
-``help-pmix-plog.txt`` topic ``smtp:send_email failed``.
+Recipient and sender fall back to the component's ``to`` / ``from_addr``
+MCA parameters when the request omits them.  The SMTP relay host and port
+come from the ``plog_smtp_server`` / ``plog_smtp_port`` MCA parameters,
+*not* from the request; the component's ``component_query`` resolves the
+server name with ``gethostbyname`` at selection time and disables the
+component (returns no module) if the name will not resolve.  Only one
+email per call and one body per email are permitted; both limits are
+enforced with a hard error return.  ``PMIX_LOG_TIMESTAMP`` (from the
+directives) is added as a ``Timestamp`` header when present.
+
+Delivery is driven through libesmtp in ``send_email``: it temporarily
+ignores ``SIGPIPE`` around the network I/O (restoring the prior handler
+afterward) so a remote hangup cannot kill the process, and it streams the
+body through a small state-machine callback (``message_cb``) that brackets
+the caller's message with the configurable ``plog_smtp_body_prefix`` and
+``plog_smtp_body_suffix`` text.  A failed send emits a ``pmix_show_help``
+warning from ``help-pmix-plog.txt`` topic ``smtp:send_email failed``.
 
 
 pmix_show_help Aggregation
@@ -315,6 +413,33 @@ Set via the standard MCA parameter mechanism, e.g.::
     export PMIX_MCA_pmix_log_host_only=1
 
 
+The PMIX_OPERATION_SUCCEEDED convention
+---------------------------------------
+
+The log path leans heavily on the difference between two success codes,
+and getting it wrong hangs the caller or double-fires a callback:
+
+* ``PMIX_SUCCESS`` means "accepted; a completion callback **will** fire
+  later."  The blocking ``PMIx_Log`` therefore waits on its condition
+  variable, and non-blocking callers expect their ``cbfunc`` to run.
+* ``PMIX_OPERATION_SUCCEEDED`` means "already done synchronously; **no**
+  callback is coming."  ``PMIx_Log`` translates it to ``PMIX_SUCCESS``
+  for its own return but does *not* wait.
+
+This is why:
+
+* ``pmix_plog_base_log()`` returns ``PMIX_OPERATION_SUCCEEDED`` when there
+  was nothing to log (no matching module, or everything suppressed by
+  aggregation) — there is no downstream callback to await.
+* ``pmix_server_log()`` promotes a local ``PMIX_SUCCESS`` from
+  ``pmix_plog.log()`` to ``PMIX_OPERATION_SUCCEEDED`` before replying to
+  the client, signalling that the request was fully handled on the server
+  and the reply carries the final status.
+
+When adding a component or a new entry point, choose the code that
+matches whether a callback will actually be invoked.
+
+
 Thread Safety
 -------------
 
@@ -365,3 +490,10 @@ Key Source Files
      - show-help subsystem & dup tracking
    * - ``src/runtime/pmix_params.c``
      - ``pmix_log_host_only`` MCA parameter
+
+For a code-oriented orientation aimed at contributors working *inside*
+the framework, each ``plog`` directory also carries an ``AGENTS.md``
+(with a ``CLAUDE.md`` symlink): ``src/mca/plog/AGENTS.md`` for the
+framework as a whole, plus one in each of ``stdfd/``, ``syslog/``, and
+``smtp/``.  This document explains how logging is integrated into the
+wider library; those explain each component's internals in detail.

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -22,6 +22,18 @@ Detailed changes since v6.1.0:
    failing PMIx_Init. GDS module selection is now tracked per-client
    rather than per-namespace, so one client falling back does not affect
    its peers
+ - plog/stdfd: implement the output-formatting directives for the
+   stdout/stderr log channels. PMIx_Log requests that carry
+   PMIX_LOG_TAG_OUTPUT, PMIX_LOG_TIMESTAMP_OUTPUT, and/or
+   PMIX_LOG_XML_OUTPUT now have their output tagged, timestamped, and/or
+   wrapped in XML, matching the formatting used for forwarded stdio.
+   These directives were previously accepted but silently ignored
+ - iof: fix XML output escaping. An ampersand was emitted as the invalid
+   entity "&ap;" instead of "&amp;", and each escaped character left a
+   trailing zero byte in the output due to an allocation-size overcount.
+   This affected all XML-formatted stdout/stderr output
+ - plog/smtp: fix the "body_suffix" MCA parameter, which was mistakenly
+   registered under the name "body_prefix" and so could not be set
 
 6.0.0 -- TBD
 ------------

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1435,6 +1435,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                 if ('&' == bo->bytes[n]) {
                     buffer[m++] = '&';
                     buffer[m++] = 'a';
+                    buffer[m++] = 'm';
                     buffer[m++] = 'p';
                     buffer[m++] = ';';
                 } else if ('<' == bo->bytes[n]) {
@@ -1456,6 +1457,11 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                     buffer[m++] = bo->bytes[n];
                 }
             }
+            /* the initial bufsize was a worst-case over-estimate used to
+             * size the allocation; the actual number of bytes written is
+             * "m". Use that downstream so we don't copy the trailing
+             * zero-fill into the output. */
+            bufsize = m;
         } else {
             buffer = bo->bytes;
             bufsize = bo->size;

--- a/src/mca/plog/AGENTS.md
+++ b/src/mca/plog/AGENTS.md
@@ -1,0 +1,292 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PLOG Framework
+
+This document orients AI agents and human contributors working in the
+`plog` (**P**MIx **Log**ging) framework. It assumes you have already read
+the top-level [`AGENTS.md`](../../../AGENTS.md) — the golden rules,
+prefix conventions, thread-safety model, and MCA concepts described there
+all apply here and are not repeated. This file covers what is specific to
+`plog`: what the framework is for, how a log request flows through it,
+and the contract every component must honor. Each component subdirectory
+carries its own `AGENTS.md` with component-specific detail.
+
+## What PLOG does
+
+`plog` implements the back end of the `PMIx_Log` / `PMIx_Log_nb` public
+APIs. When a client, tool, or server calls `PMIx_Log`, it supplies an
+array of `pmix_info_t` "data" entries — each one a piece of information to
+be recorded — plus an array of "directives" that qualify how the logging
+should happen. The framework's job is to take that request and route
+each data item to whatever *channel* can service it: stdout/stderr,
+the local or global syslog, email, and so on.
+
+The key design idea is that **the channel is selected by the key of the
+data item, not by the caller naming a component**. A caller does not ask
+for "the syslog component"; it hands the framework a
+`pmix.log.syslog` = "some message" info entry, and the framework finds
+whichever active module has claimed the `syslog` channel. This keeps the
+public API stable and lets new logging back ends appear purely as new
+components plus new attribute keys — no API change, consistent with the
+"prefer a new attribute over a new API" rule in the top-level guide.
+
+`plog` is a **multi-select** framework: several components can be active
+at once, each servicing a different (possibly overlapping) set of
+channels. A single `PMIx_Log` call carrying both a `stdout` entry and a
+`syslog` entry will exercise two different modules in one pass.
+
+## Directory layout
+
+```
+src/mca/plog/
+├── plog.h                 Framework public API: module & component types
+├── base/                  Framework infrastructure (see below)
+│   ├── base.h             Internal base API + globals + active-module struct
+│   ├── plog_base_frame.c  open/close/register, framework declaration
+│   ├── plog_base_select.c Component query + priority/ordering logic
+│   ├── plog_base_stubs.c  pmix_plog_base_log() — the routing engine
+│   └── help-pmix-plog.txt show_help text for plog errors
+├── stdfd/                 stdout/stderr channel component
+├── syslog/                local/global syslog channel component
+└── smtp/                  email channel component (optional; needs libesmtp)
+```
+
+## Core data structures (`plog.h`)
+
+`plog.h` is the framework's public header — the contract every component
+compiles against. Read it before anything else. It defines:
+
+- **`pmix_plog_module_t`** — the runtime instance a component hands back.
+  Its fields:
+  - `char *name` — the module's short name (e.g., `"syslog"`). The name
+    `"default"` is special (see selection, below).
+  - `char **channels` — a NULL-terminated argv array of the channel
+    tokens this module services (e.g., `{"stdout","stderr",NULL}`). A
+    `NULL` `channels` pointer is a wildcard meaning "this module handles
+    *every* channel" — used by catch-all/default modules.
+  - `init` / `finalize` — optional lifecycle hooks
+    (`pmix_plog_base_module_init_fn_t` / `_fini_fn_t`).
+  - `log` — the workhorse (`pmix_plog_base_module_log_fn_t`); does the
+    actual delivery.
+
+- **`pmix_plog_base_module_log_fn_t`** — the log entry-point signature,
+  shared verbatim by the framework API and every module:
+  ```c
+  pmix_status_t (*log)(const pmix_proc_t *source,
+                       const pmix_info_t data[], size_t ndata,
+                       const pmix_info_t directives[], size_t ndirs);
+  ```
+
+- **`pmix_plog_API_module_t`** / the global **`pmix_plog`** — a
+  one-field struct exposing `pmix_plog.log`, which points at
+  `pmix_plog_base_log`. This is the single entry point callers outside
+  the framework use (see `src/common/pmix_log.c` and
+  `src/server/pmix_server_ops.c`). Back-end code calls `pmix_plog.log(...)`,
+  never a component's `log` directly.
+
+- **`pmix_plog_base_component_t`** — just a typedef of the standard
+  `pmix_mca_base_component_t`. Simple components (like `stdfd`) use it
+  as-is; components needing configuration state (`syslog`, `smtp`) embed
+  it as a `super` field in a larger struct.
+
+- **`PMIX_PLOG_BASE_VERSION_1_0_0`** — the version macro every component's
+  component struct must open with.
+
+## How a log request flows
+
+1. **Public API.** `PMIx_Log` / `PMIx_Log_nb` (in
+   [`src/common/pmix_log.c`](../../common/pmix_log.c)) validate the call,
+   thread-shift onto the progress thread, and — for the path that runs
+   the request locally — invoke `pmix_plog.log(...)`, i.e.
+   `pmix_plog_base_log()`. (A client typically forwards the request to
+   its server first; the server, or a server/tool logging locally, ends
+   up in `pmix_plog_base_log`. See the note on threading below.)
+
+2. **Routing** — `pmix_plog_base_log()` in `plog_base_stubs.c`. This is
+   the heart of the framework; details in the next section.
+
+3. **Delivery** — each selected module's `log` function receives the
+   *entire* `data`/`directives` arrays (not just the item that matched)
+   and scans them for the keys it knows how to handle, delivering each
+   and marking it complete.
+
+### The routing engine: `pmix_plog_base_log()`
+
+Trace [`base/plog_base_stubs.c`](base/plog_base_stubs.c) carefully — most
+plog bugs live in the interaction between this function and the modules.
+Its algorithm:
+
+1. **Global directives first.** Scan `directives` for:
+   - `PMIX_LOG_ONCE` — stop after the first channel that successfully
+     handles the request (`logonce`).
+   - `PMIX_LOG_AGG`, `PMIX_LOG_KEY`, `PMIX_LOG_VAL` — de-duplication of
+     `show_help`-style messages. When aggregation is on and this
+     key/val pair has been seen before (`pmix_help_check_dups`), every
+     data item is marked complete via `PMIX_INFO_OP_COMPLETED` so nothing
+     is logged twice.
+
+2. **Assemble the channel list in request order.** For each *data* item
+   not already complete, walk the priority-ordered `pmix_plog_globals.actives`
+   array and add any module whose `channels` matches the item's key
+   (matched with `strstr` against each channel token; a `NULL` `channels`
+   is a wildcard that always matches). Modules are appended in the order
+   the *data* is presented, so the caller's first item gets first shot —
+   this is what makes `PMIX_LOG_ONCE` deterministic. The `added` flag on
+   the active-module struct prevents a module being listed twice.
+
+3. **Deliver.** Reset the `added` markers, then call each listed
+   module's `log`. Interpret the return code:
+   - `PMIX_SUCCESS` / `PMIX_OPERATION_SUCCEEDED` — handled; if `logonce`,
+     stop here.
+   - `PMIX_ERR_NOT_AVAILABLE` / `PMIX_ERR_TAKE_NEXT_OPTION` — this module
+     declined; continue to the next.
+   - anything else — a real error; abort the loop and return it.
+
+4. **Nothing to do?** If no module matched, return
+   `PMIX_OPERATION_SUCCEEDED` (**not** `PMIX_SUCCESS`). This distinction
+   matters: `PMIX_SUCCESS` tells the caller a callback will fire later,
+   while `PMIX_OPERATION_SUCCEEDED` means "done synchronously, no callback
+   coming." Returning the wrong one here will hang the caller or double-fire.
+
+**Completion tracking is shared, mutable state on the caller's arrays.**
+Modules mark individual items done with `PMIX_INFO_OP_COMPLETED(&data[n])`,
+and both the router and the other modules honor `PMIX_INFO_OP_IS_COMPLETE`.
+This is how two modules cooperate on one array without double-logging.
+When you write a module, mark each item you consume complete, and skip
+items already marked.
+
+### Return-code contract for modules (important)
+
+A module's `log` must return one of:
+
+- `PMIX_SUCCESS` / `PMIX_OPERATION_SUCCEEDED` — "I handled at least part
+  of this request."
+- `PMIX_ERR_TAKE_NEXT_OPTION` or `PMIX_ERR_NOT_AVAILABLE` — "none of these
+  keys are mine; let another module try." Returning this (rather than an
+  error) when your keys are absent is what lets the multi-select chain and
+  `PMIX_LOG_ONCE` work correctly.
+- a hard error code — only for genuine failures; it aborts the whole
+  routing loop.
+
+Getting this wrong is the most common plog defect: an over-eager module
+that returns `PMIX_SUCCESS` for a request it did not actually handle will
+swallow a `PMIX_LOG_ONCE` request and starve the channel the caller
+actually wanted.
+
+## Base infrastructure in detail
+
+### Globals and lifecycle (`plog_base_frame.c`)
+
+- **`pmix_plog_globals`** (`pmix_plog_globals_t`, declared in `base.h`):
+  - `actives` — a `pmix_pointer_array_t` of
+    `pmix_plog_base_active_module_t`, the selected modules in priority /
+    requested order. This is the array the router walks.
+  - `initialized` / `selected` — guard flags making open and select
+    idempotent.
+  - `channels` — the parsed `plog_base_order` MCA parameter (see below),
+    or `NULL` if the user gave no explicit ordering.
+- **`pmix_plog_open`** constructs `actives` and opens all components.
+- **`pmix_plog_close`** finalizes each active module (calling its
+  `finalize`), releases the active-module wrappers, and closes components.
+- **`pmix_plog_register`** registers the one framework-level MCA
+  parameter, **`pmix_plog_base_order`**: a comma-delimited, prioritized
+  list of channel names controlling both *which* channels are used and in
+  *what* order. It is split into `pmix_plog_globals.channels` here.
+
+### The active-module wrapper (`base.h`)
+
+`pmix_plog_base_active_module_t` wraps each selected module with
+bookkeeping the router and selector need:
+
+| Field | Purpose |
+|-------|---------|
+| `super` | `pmix_list_item_t` — so it can live on a list during selection |
+| `reqd` | this channel was marked "required" via the `:req` modifier |
+| `added` | transient flag: already appended to the current routing list |
+| `pri` | selection priority returned by the component's query |
+| `module` | the `pmix_plog_module_t` the component handed back |
+| `component` | back-pointer to the owning component |
+
+### Selection and ordering (`plog_base_select.c`)
+
+`pmix_plog_base_select()` runs once at init (guarded by
+`pmix_plog_globals.selected`). It:
+
+1. Queries every component's `pmix_mca_query_component`; skips those with
+   no query function or that return no module.
+2. Calls each returned module's `init`; drops the module if `init` fails.
+3. Inserts surviving modules into a temporary list **in descending
+   priority order**, remembering the module named `"default"` if present.
+4. **If the user set `plog_base_order`:** walk the requested channel names
+   in order, moving the matching module from the temp list into the global
+   `actives` array (so user order overrides priority order). A channel
+   name may carry a `:req` (or `:required`) suffix — parsed here — marking
+   it mandatory. If a requested channel has no matching module, the
+   `"default"` module is substituted; if there is no default *and* the
+   channel was required, selection fails with the `reqd-not-found`
+   `show_help` message and `PMIX_ERR_NOT_FOUND`. Unrequested leftover
+   modules are discarded.
+5. **If the user set no order:** all modules go into `actives` in pure
+   priority order.
+
+At high verbosity (>4) it prints the final resolved order — a useful
+debugging hook (`pmix_plog_base_framework.framework_output`).
+
+## Threading
+
+`pmix_plog_base_log()` "takes place in a progress event" — it and the
+modules it invokes run **on the progress thread**, reached via the
+thread-shift performed by the public `PMIx_Log_nb` path. Do not call
+`pmix_plog.log` from an arbitrary user thread without thread-shifting
+first; follow the caddy pattern in the top-level guide. Individual
+modules may themselves thread-shift outward again when they hand work to
+another subsystem — `stdfd`, for example, calls the non-blocking
+`PMIx_server_IOF_deliver` and lets a callback release its scratch object
+rather than blocking the progress thread.
+
+## Building
+
+The framework core (`base/`) is always built into `libpmix`. Each
+component builds as a standard MCA component — either a DSO
+(`pmix_mca_plog_<name>.la`) or a static archive
+(`libpmix_mca_plog_<name>.la`) depending on the build configuration.
+`smtp` and `syslog` ship a `configure.m4` that can disable the component
+when its dependency (libesmtp / `syslog.h`) is absent; `stdfd` has no
+optional dependency and is always available. Adding a component means
+creating `src/mca/plog/<name>/` with the usual `Makefile.am`, a component
+struct, and a module — the framework picks it up through the generated
+`base/static-components.h`; no core code changes are needed.
+
+Remember the top-level golden rules that bite here specifically:
+
+- If you touch any text in `base/help-pmix-plog.txt` (or add a new
+  `show_help` message), you must regenerate the compiled `show_help`
+  content: `rm src/util/pmix_show_help_content.*` then `make`.
+- Editing a `Makefile.am` only needs a plain `make`; adding/removing a
+  *component directory* changes the build wiring resolved by `configure`,
+  so re-run `./autogen.pl && ./configure ... && make`.
+
+## When adding or modifying a component
+
+- Open the component struct with `PMIX_PLOG_BASE_VERSION_1_0_0` and set
+  `pmix_mca_component_name` to your component's directory name.
+- Provide a `query` function returning your `pmix_plog_module_t` and a
+  priority. Return no module (or a failure) when the component cannot run
+  in this environment (missing server, unresolved host, etc.) — see
+  `smtp`'s query, which resolves the SMTP server up front and disables
+  itself if that fails.
+- In your module's `log`, honor the return-code contract above, mark
+  consumed items complete, and skip already-complete items.
+- Claim your channel tokens by populating `module->channels` (usually in
+  `init`), or set it to `NULL` only if you truly are a catch-all.
+- Document any new `PMIX_LOG_*` attribute keys in
+  [`include/pmix_common.h.in`](../../../include/pmix_common.h.in) and the
+  user docs, per the attribute rules in the top-level guide.

--- a/src/mca/plog/CLAUDE.md
+++ b/src/mca/plog/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/plog/smtp/AGENTS.md
+++ b/src/mca/plog/smtp/AGENTS.md
@@ -1,0 +1,158 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PLOG `smtp` Component
+
+`smtp` is the `plog` component that delivers a log request as an **email**,
+using the third-party **libesmtp** library. Read the framework
+[`AGENTS.md`](../AGENTS.md) first — this file only covers what is specific
+to `smtp`. It is the most involved of the three components: it has an
+external dependency, a rich configuration struct, a streaming message
+callback, and it handles a *nested* attribute array rather than a flat key.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `plog_smtp.h` | `pmix_plog_smtp_component_t` (server/port, to/from/subject, body prefix+suffix, resolved `hostent`, priority) and the module symbol. Includes `<libesmtp.h>`. |
+| `plog_smtp_component.c` | Component struct, MCA parameter registration, `component_query` (resolves the SMTP server), `smtp_close`. |
+| `plog_smtp.c` | The module: `init`, `finalize`, `mylog`, `send_email`, and the libesmtp callback machinery. |
+| `configure.m4` | Finds libesmtp; the component is built only if it is present. |
+
+## Build gating (`configure.m4`)
+
+`MCA_pmix_plog_smtp_CONFIG` uses `OAC_CHECK_PACKAGE` to locate
+`libesmtp.h` and the `esmtp` library (honoring `--with-smtp[-libdir]`).
+If the user explicitly requested SMTP and it is not found, configure
+**errors out**; otherwise the component silently disables. The resolved
+flags feed `PMIX_EMBEDDED_{LIBS,LDFLAGS,CPPFLAGS}`. Because this is
+configure-time logic, changing it requires the full `./autogen.pl &&
+./configure && make` cycle. libesmtp is the only `plog` component with a
+real third-party link dependency — keep that in mind for portability:
+code here must not be reachable when the component is not built.
+
+## Component (`plog_smtp_component.c`)
+
+### Configuration struct and parameters
+
+`pmix_plog_smtp_component_t` (in `plog_smtp.h`) embeds the base component
+as `super` and holds all the SMTP/email configuration. `smtp_register`
+registers these MCA parameters:
+
+| Param | Field | Default |
+|-------|-------|---------|
+| `plog_smtp_server` | `server` | `"localhost"` |
+| `plog_smtp_port` | `port` | `25` |
+| `plog_smtp_to` | `to` | (none) |
+| `plog_smtp_from_addr` | `from_addr` | (none) |
+| `plog_smtp_from_name` | `from_name` | `"PMIx Plog"` |
+| `plog_smtp_subject` | `subject` | `"PMIx Plog"` |
+| `plog_smtp_body_prefix` | `body_prefix` | boilerplate intro text |
+| `plog_smtp_body_suffix` | `body_suffix` | `"…Sincerely,\nOscar the PMIx Owl"` |
+| `plog_smtp_priority` | `priority` | `10` |
+
+It also stashes the libesmtp version string via `smtp_version()`.
+`smtp_close` frees the heap-allocated strings.
+
+> **Historical note.** Through mid-2026 the body *suffix* parameter was
+> mistakenly registered under the name `"body_prefix"` a second time,
+> making two MCA variables share a name and leaving the suffix unsettable
+> under its own name. This has been fixed to `"body_suffix"` (the name
+> shown above). If you are chasing a report against an older release where
+> `plog_smtp_body_suffix` "does nothing," that is the cause.
+
+### `component_query` resolves the server
+
+Unlike the other components, `smtp`'s query does real work: it calls
+`gethostbyname(component.server)` and, if the name does not resolve,
+**disables the component** (`*priority = 0; *module = NULL; return
+PMIX_ERR_NOT_FOUND`). This front-loads the failure so the module never
+tries to talk to an unresolvable server later. On success it returns
+priority **10** and the module. (The resolved `hostent` is cached in
+`server_hostent`.) This is the canonical example of a `plog` component
+that opts out at query time based on the runtime environment.
+
+## Module (`plog_smtp.c`)
+
+### Channel
+
+`init` claims the single channel `"email"`; `finalize` frees it. The one
+attribute key it handles is `PMIX_LOG_EMAIL` (`pmix.log.email`).
+
+### `mylog` — a nested attribute array
+
+`PMIX_LOG_EMAIL`'s value is **not** a string; it is a
+`pmix_data_array_t` of further `pmix_info_t` entries. `mylog`:
+
+1. Scans the top-level `data` for `PMIX_LOG_EMAIL` (rejecting more than
+   one per call with `PMIX_ERR_BAD_PARAM`), and picks up the nested
+   `input[]` array.
+2. Reads `PMIX_LOG_TIMESTAMP` from the directives.
+3. If no email item is present, returns `PMIX_ERR_TAKE_NEXT_OPTION` —
+   correctly deferring to other modules.
+4. Walks the nested array for:
+   - `PMIX_LOG_EMAIL_ADDR` → recipient list (comma-delimited).
+   - `PMIX_LOG_EMAIL_SENDER_ADDR` → sender ("from").
+   - `PMIX_LOG_EMAIL_SUBJECT` → subject.
+   - `PMIX_LOG_MSG` → the body, accepted as either a `PMIX_STRING` or a
+     `PMIX_BYTE_OBJECT` (more than one message is rejected with
+     `PMIX_ERR_NOT_SUPPORTED`).
+5. If no message body was found, returns `PMIX_ERR_TAKE_NEXT_OPTION`;
+   otherwise calls `send_email(...)` and returns its status.
+
+Recipient/sender fall back to the component defaults (`to`, `from_addr`)
+when the request omits them; `send_email` returns `PMIX_ERR_BAD_PARAM` if
+even the defaults are absent.
+
+### `send_email` and the libesmtp flow
+
+`send_email` drives libesmtp: create session, add message, set server
+(`"server:port"`), reverse path, `To`/`Subject`/`X-Mailer`/`From`/optional
+`Timestamp` headers, register the message-body callback, then
+`smtp_start_session`. Points worth knowing:
+
+- **SIGPIPE is temporarily ignored** around the network I/O (saved and
+  restored via `sigaction`) so a remote server hangup cannot kill the
+  whole process. Preserve this if you refactor.
+- **Error handling is a single `goto error` cleanup path** that destroys
+  the session, restores SIGPIPE, and — on failure — emits the
+  `smtp:send_email failed` `show_help` message (text in
+  [`../base/help-pmix-plog.txt`](../base/help-pmix-plog.txt); regenerate
+  the `show_help` content after editing it).
+- **The message body is streamed via `message_cb`**, a state machine
+  (`SENT_NONE → SENT_HEADER → SENT_BODY_PREFIX → SENT_BODY →
+  SENT_BODY_SUFFIX → SENT_ALL`) that libesmtp pumps for successive chunks.
+  `crnl()` converts lone `\n` to `\r\n` as SMTP requires. The
+  configurable `body_prefix` / `body_suffix` bracket the caller's message.
+
+### Return code
+
+`mylog` returns `PMIX_ERR_TAKE_NEXT_OPTION` when there is no email request
+or no body (proper deference), `PMIX_SUCCESS` on a sent message, or an
+error from `send_email` / a bad request. This follows the framework's
+return-code contract correctly — a good template to copy.
+
+## Gotchas
+
+- **`from_addr` vs. `from_name` vs. request sender.** The SMTP reverse
+  path uses `c->from_addr`; the `From` header uses `from_name` (display)
+  with the resolved `myfrom` address. A request's
+  `PMIX_LOG_EMAIL_SENDER_ADDR` overrides the address but not the display
+  name. If mail shows the wrong sender, this three-way interaction is
+  where to look.
+- **One email per call, one body per email.** Both are hard limits
+  enforced with `PMIX_ERROR_LOG` + error return; don't relax them without
+  reworking `send_email`, which assumes a single message.
+- **`asprintf` vs. `pmix_asprintf`.** `send_email` uses the bare
+  `asprintf` in one spot (the `X-Mailer` header) and `pmix_asprintf`
+  elsewhere. Prefer the `pmix_`-prefixed portable wrappers for any new
+  code here.
+- The component is entirely absent from the build when libesmtp is not
+  installed — never assume its symbols exist elsewhere in `libpmix`.

--- a/src/mca/plog/smtp/CLAUDE.md
+++ b/src/mca/plog/smtp/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/plog/smtp/plog_smtp_component.c
+++ b/src/mca/plog/smtp/plog_smtp_component.c
@@ -135,7 +135,7 @@ static pmix_status_t smtp_register(void)
         "The PMIx SMTP plog wishes to inform you of the following message:\n\n");
      }
 
-    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super, "body_prefix",
+    (void) pmix_mca_base_component_var_register(&pmix_mca_plog_smtp_component.super, "body_suffix",
                                                 "Text to put at the end of the mail message",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING,
                                                 &suffix);

--- a/src/mca/plog/stdfd/AGENTS.md
+++ b/src/mca/plog/stdfd/AGENTS.md
@@ -1,0 +1,148 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PLOG `stdfd` Component
+
+`stdfd` ("standard **f**ile **d**escriptors") is the `plog` component that
+delivers log data to **stdout** and **stderr**. Read the framework
+[`AGENTS.md`](../AGENTS.md) first — this file only covers what is specific
+to `stdfd`. It is the simplest of the three components and the best
+starting point for understanding the module contract.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `plog_stdfd.h` | Declares the component (`pmix_mca_plog_stdfd_component`) and module (`pmix_plog_stdfd_module`) symbols. |
+| `plog_stdfd_component.c` | Component struct + `component_query`. |
+| `plog_stdfd.c` | The module: `init`, `finalize`, and `mylog`. |
+
+There is no `configure.m4` and no optional dependency — `stdfd` is always
+built and always available.
+
+## Component (`plog_stdfd_component.c`)
+
+The component uses the bare `pmix_plog_base_component_t` (no extra
+configuration state, so no wrapping struct and no
+`register_component_params`). `component_query` is unconditional:
+
+```c
+*priority = 5;
+*module = (pmix_mca_base_module_t *) &pmix_plog_stdfd_module;
+return PMIX_SUCCESS;
+```
+
+Priority **5** is deliberately low — below `syslog` (10) and `smtp` (10) —
+so that in unordered selection the more "notable" channels sort ahead of
+plain stdout/stderr. `stdfd` never disables itself.
+
+## Module (`plog_stdfd.c`)
+
+### Channels
+
+`init` claims two channels by splitting `"stdout,stderr"` into
+`module->channels`; `finalize` frees that argv. So the router will list
+this module for any data item whose key contains `stdout` or `stderr`.
+The keys it actually handles are the attributes `PMIX_LOG_STDOUT`
+(`pmix.log.stdout`) and `PMIX_LOG_STDERR` (`pmix.log.stderr`), each
+carrying a `char*` string payload.
+
+### `mylog` behavior
+
+For each not-yet-complete data item, `mylog` matches `PMIX_LOG_STDERR` or
+`PMIX_LOG_STDOUT` and then splits on the caller's role:
+
+- **Client or tool** (`PMIX_PEER_IS_CLIENT` / `PMIX_PEER_IS_TOOL`): write
+  the string straight to the local `stderr` / `stdout` with `fprintf`.
+  There is nowhere to forward to — this process *is* the endpoint.
+- **Server / daemon** (everything else): the output belongs to a process
+  whose stdio the server is managing, so it is handed to the IOF
+  (I/O forwarding) subsystem via
+  `PMIx_server_IOF_deliver(&source, PMIX_FWD_STDOUT_CHANNEL |
+  PMIX_FWD_STDERR_CHANNEL, ...)` so it reaches the correct output stream.
+
+### The IOF hand-off and its scratch object
+
+For the server path, `mylog` allocates a small
+`pmix_iof_deliver_t` object (defined locally) that carries a copy of the
+source `pmix_proc_t` and a `pmix_byte_object_t` holding the message bytes
+(NUL terminator included). This is passed to the **non-blocking**
+`PMIx_server_IOF_deliver`; the completion callback `lkcbfunc` simply
+`PMIX_RELEASE`s the object. This is deliberate:
+
+- The module must not block the progress thread waiting on IOF, so it
+  uses the async form and lets the callback clean up.
+- This one *does* copy the payload into the scratch object rather than
+  aliasing the caller's `data`. That is a legitimate exception to the
+  framework's no-copy rule: `mylog` returns immediately while IOF
+  delivery completes later, so the caller's `data` array cannot be
+  assumed live by then. (Contrast the caddy no-copy rule in the top-level
+  guide, which relies on the caller keeping inputs valid until *their*
+  callback fires — a guarantee that does not extend across this internal
+  async boundary.)
+
+### Return code
+
+`mylog` starts `rc = PMIX_ERR_TAKE_NEXT_OPTION` and only sets success via
+the IOF path. If none of the data keys are stdout/stderr it returns
+`PMIX_ERR_TAKE_NEXT_OPTION`, correctly telling the router "not mine, try
+the next module." If there is no data at all it returns
+`PMIX_ERR_NOT_AVAILABLE`. Note it does **not** call
+`PMIX_INFO_OP_COMPLETED` on the client/tool `fprintf` path — worth keeping
+in mind if you extend it to cooperate with other modules on the same
+array.
+
+### Output-formatting directives
+
+`mylog` honors three directives that decorate the emitted text:
+
+- `PMIX_LOG_TAG_OUTPUT` — prefix each line with its channel tag
+  (`[nspace,rank]<stdout>: `).
+- `PMIX_LOG_TIMESTAMP_OUTPUT` — prefix with a timestamp.
+- `PMIX_LOG_XML_OUTPUT` — wrap the line in an XML element
+  (`<stdout .../>`), with the payload XML-escaped.
+
+Rather than reimplement this formatting, `stdfd` maps those directives
+onto a `pmix_iof_flags_t` and calls the shared IOF formatter
+`pmix_iof_prep_output()` (in `src/common/pmix_iof.c`), so log output looks
+identical to forwarded stdio. The formatter is only invoked when at least
+one flag is set (`flags.set`); with no formatting directives the fast path
+writes the raw string with a single `fprintf`, so the common case pays
+nothing. Because `pmix_iof_prep_output` tags each line with the source
+identity, `mylog` falls back to `pmix_globals.myid` when the caller
+passes a `NULL` source.
+
+Note a deliberate limitation: `pmix_iof_prep_output` generates the
+timestamp at emission time (matching IOF), so the explicit
+`PMIX_LOG_TIMESTAMP` *value* on the request is not used for the printed
+stamp — unlike the `syslog`/`smtp` components, which do print the supplied
+value. Reconciling that would mean teaching the shared formatter to accept
+a caller-supplied timestamp; it is intentionally left as a central,
+IOF-wide change rather than a `stdfd`-local divergence.
+
+The formatted bytes are written directly on the client/tool path
+(`fwrite`) and handed to IOF on the server path (the `pmix_iof_deliver_t`
+takes ownership of the formatter's buffer). `pmix_iof_prep_output`
+returns a plain `malloc`'d `pmix_byte_object_t`, so `stdfd` frees it with
+`free()` (or steals its `bytes` pointer) rather than a public
+byte-object API.
+
+## Gotchas
+
+- Because its priority is low and it claims only two specific channels,
+  `stdfd` is easy to reason about — but it is often the *last* channel a
+  `PMIX_LOG_ONCE` request reaches. If you are debugging "my stdout log
+  never appears," check whether a higher-priority module claimed the
+  request first.
+- The role split (client/tool vs. server) is the subtle part. A change
+  that makes a server `fprintf` directly, or a client call
+  `PMIx_server_IOF_deliver` (which it has no server to service), will
+  misbehave. Preserve the `PMIX_PEER_IS_CLIENT || PMIX_PEER_IS_TOOL`
+  branch.

--- a/src/mca/plog/stdfd/CLAUDE.md
+++ b/src/mca/plog/stdfd/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -103,7 +103,12 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
     size_t n;
     pmix_status_t rc;
     pmix_iof_deliver_t *p;
-    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs);
+    pmix_iof_flags_t flags = PMIX_IOF_FLAGS_STATIC_INIT;
+    pmix_iof_channel_t channel;
+    pmix_byte_object_t raw;
+    pmix_byte_object_t *formatted;
+    const pmix_proc_t *name;
+    FILE *stream;
 
     /* if there is no data, then we don't handle it */
     if (NULL == data || 0 == ndata) {
@@ -114,18 +119,31 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
                         "%s: plog:stdfd called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-#if 0
-    /* check to see if there are any relevant directives */
-    for (n = 0; n < ndirs; n++) {
-        if (0 == strncmp(directives[n].key, PMIX_LOG_TIMESTAMP, PMIX_MAX_KEYLEN)) {
-            flags.timestamp = directives[n].value.data.time;
-        } else if (0 == strncmp(directives[n].key, PMIX_LOG_XML_OUTPUT, PMIX_MAX_KEYLEN)) {
-            flags.xml = PMIX_INFO_TRUE(&directives[n]);
-        } else if (0 == strncmp(directives[n].key, PMIX_LOG_TAG_OUTPUT, PMIX_MAX_KEYLEN)) {
-            flags.tag = PMIX_INFO_TRUE(&directives[n]);
+    /* check for any output-formatting directives that apply to the
+     * stdout/stderr channels - these tell us to label the output with
+     * the channel name, prefix it with a timestamp, and/or wrap it in
+     * xml. We reuse the common IOF output formatter so that log output
+     * is formatted identically to forwarded stdio. */
+    if (NULL != directives) {
+        for (n = 0; n < ndirs; n++) {
+            if (0 == strncmp(directives[n].key, PMIX_LOG_TAG_OUTPUT, PMIX_MAX_KEYLEN)) {
+                flags.tag = PMIX_INFO_TRUE(&directives[n]);
+            } else if (0 == strncmp(directives[n].key, PMIX_LOG_TIMESTAMP_OUTPUT, PMIX_MAX_KEYLEN)) {
+                flags.timestamp = PMIX_INFO_TRUE(&directives[n]);
+            } else if (0 == strncmp(directives[n].key, PMIX_LOG_XML_OUTPUT, PMIX_MAX_KEYLEN)) {
+                flags.xml = PMIX_INFO_TRUE(&directives[n]);
+            }
         }
     }
-#endif
+    /* the formatter only decorates the output if at least one flag is set */
+    if (flags.tag || flags.timestamp || flags.xml) {
+        flags.set = true;
+    }
+
+    /* the formatter tags each line with the identity of the source, so
+     * fall back to our own ID if the caller did not provide one */
+    name = (NULL == source) ? &pmix_globals.myid : source;
+
     /* check to see if there are any stdfd entries */
     rc = PMIX_ERR_TAKE_NEXT_OPTION;
     for (n = 0; n < ndata; n++) {
@@ -133,44 +151,57 @@ static pmix_status_t mylog(const pmix_proc_t *source, const pmix_info_t data[], 
             continue;
         }
         if (0 == strncmp(data[n].key, PMIX_LOG_STDERR, PMIX_MAX_KEYLEN)) {
-            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
-                                "%s: plog:stdfd delivering to stderr for source %s",
-                                PMIX_NAME_PRINT(&pmix_globals.myid),
-                                (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
-                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-                fprintf(stderr, "%s", data[n].value.data.string);
-            } else {
-                p = PMIX_NEW(pmix_iof_deliver_t);
-                PMIX_XFER_PROCID(&p->source, source);
-                p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-                p->bo.bytes = (char*)malloc(p->bo.size);
-                memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDERR_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(p);
-                }
-            }
+            channel = PMIX_FWD_STDERR_CHANNEL;
+            stream = stderr;
         } else if (0 == strncmp(data[n].key, PMIX_LOG_STDOUT, PMIX_MAX_KEYLEN)) {
-            pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
-                                "%s: plog:stdfd delivering to stdout for source %s",
-                                PMIX_NAME_PRINT(&pmix_globals.myid),
-                                (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
-            if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
-                PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-                fprintf(stdout, "%s", data[n].value.data.string);
+            channel = PMIX_FWD_STDOUT_CHANNEL;
+            stream = stdout;
+        } else {
+            continue;
+        }
+
+        pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
+                            "%s: plog:stdfd delivering to %s for source %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            (PMIX_FWD_STDERR_CHANNEL == channel) ? "stderr" : "stdout",
+                            (NULL == source) ? "NULL" : PMIX_NAME_PRINT(source));
+
+        /* apply the requested tag/timestamp/xml formatting, if any */
+        formatted = NULL;
+        if (flags.set) {
+            raw.bytes = data[n].value.data.string;
+            raw.size = strlen(data[n].value.data.string);
+            formatted = pmix_iof_prep_output(name, &flags, channel, &raw);
+        }
+
+        if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) ||
+            PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
+            /* we are the endpoint - write directly to our own stream */
+            if (NULL != formatted) {
+                fwrite(formatted->bytes, 1, formatted->size, stream);
+                free(formatted->bytes);
+                free(formatted);
             } else {
-                p = PMIX_NEW(pmix_iof_deliver_t);
-                PMIX_XFER_PROCID(&p->source, source);
+                fprintf(stream, "%s", data[n].value.data.string);
+            }
+        } else {
+            /* hand off to IOF for delivery to the source proc's stream */
+            p = PMIX_NEW(pmix_iof_deliver_t);
+            PMIX_XFER_PROCID(&p->source, name);
+            if (NULL != formatted) {
+                /* take ownership of the formatted bytes */
+                p->bo.bytes = formatted->bytes;
+                p->bo.size = formatted->size;
+                free(formatted);
+            } else {
                 p->bo.size = strlen(data[n].value.data.string) + 1; // include NULL terminator
-                p->bo.bytes = (char*)malloc(p->bo.size);
+                p->bo.bytes = (char *) malloc(p->bo.size);
                 memcpy(p->bo.bytes, data[n].value.data.string, p->bo.size);
-                rc = PMIx_server_IOF_deliver(&p->source, PMIX_FWD_STDOUT_CHANNEL, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(p);
-                }
+            }
+            rc = PMIx_server_IOF_deliver(&p->source, channel, &p->bo, NULL, 0, lkcbfunc, (void *) p);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(p);
             }
         }
     }

--- a/src/mca/plog/syslog/AGENTS.md
+++ b/src/mca/plog/syslog/AGENTS.md
@@ -1,0 +1,149 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PLOG `syslog` Component
+
+`syslog` is the `plog` component that delivers log messages to the system
+logger via the POSIX `syslog(3)` facility. Read the framework
+[`AGENTS.md`](../AGENTS.md) first — this file only covers what is specific
+to `syslog`. Compared to `stdfd`, this component adds configuration state
+(a wrapping component struct with MCA parameters) and a
+local-vs-global distinction.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `plog_syslog.h` | Declares `pmix_plog_syslog_component_t` (extends the base component with `console`, `level`, `facility`) and the module symbol. |
+| `plog_syslog_component.c` | Component struct, MCA parameter registration, `component_query`. |
+| `plog_syslog.c` | The module: `init`, `finalize`, `mylog`, and `write_local`. |
+| `configure.m4` | Disables the component if `<syslog.h>` is not available. |
+
+## Build gating (`configure.m4`)
+
+`MCA_pmix_plog_syslog_CONFIG` probes for `<syslog.h>` with
+`AC_CHECK_HEADER`; the component is built only if the header compiles.
+On platforms lacking syslog it silently drops out. Because this is a
+`configure`-time decision, **adding or changing this gating requires the
+full `./autogen.pl && ./configure && make` cycle**, not a plain `make`.
+
+## Component (`plog_syslog_component.c`)
+
+### Extended component struct
+
+`pmix_plog_syslog_component_t` embeds the base component as `super` and
+adds three configured fields:
+
+| Field | MCA param | Meaning |
+|-------|-----------|---------|
+| `console` | `plog_syslog_console` (bool) | Add `LOG_CONS` behavior — fall back to the console if the logger is unreachable. |
+| `level` | `plog_syslog_level` (string) | Default syslog **severity** (`LOG_ERR`, `LOG_INFO`, …). |
+| `facility` | `plog_syslog_facility` (string) | Syslog **facility** (`LOG_USER`, `LOG_DAEMON`, `LOG_AUTH`, `LOG_AUTHPRIV`). |
+
+### Parameter parsing
+
+`syslog_register` registers the three parameters and maps the
+human-friendly strings onto the `LOG_*` constants from `<syslog.h>`:
+
+- **level**: `err` → `LOG_ERR`, `alert`, `crit`, `emerg`, `warn` →
+  `LOG_WARNING`, `not` → `LOG_NOTICE`, `info` (the registered default),
+  `debug`/`dbg` → `LOG_DEBUG`. An unrecognized value emits the
+  `syslog:unrec-level` `show_help` message and makes the registration
+  return `PMIX_ERR_NOT_SUPPORTED`.
+- **facility**: `auth` → `LOG_AUTH`, `priv` → `LOG_AUTHPRIV`, `daemon` →
+  `LOG_DAEMON`, `user` → `LOG_USER` (default). Unrecognized values emit
+  `syslog:unrec-facility` and return `PMIX_ERR_NOT_SUPPORTED`.
+
+Note the struct's static initializer sets `level = LOG_ERR`, but the
+registered string default is `"info"`, so after registration the
+effective default level is `LOG_INFO`. Both `syslog:unrec-*` help texts
+live in [`../base/help-pmix-plog.txt`](../base/help-pmix-plog.txt) — edits
+there require regenerating the `show_help` content (`rm
+src/util/pmix_show_help_content.*` then `make`).
+
+### `component_query`
+
+Unconditional: priority **10**, returns `pmix_plog_syslog_module`.
+(The header-availability check already happened at configure time, so if
+the component exists it can run.)
+
+## Module (`plog_syslog.c`)
+
+### Channels and lifecycle
+
+`init` claims the channel set
+`"lsys,gsys,syslog,local_syslog,global_syslog"` and opens the logger with
+`openlog("PMIx Log Report:", LOG_CONS | LOG_PID, LOG_USER)`. `finalize`
+calls `closelog()` and frees the channels argv. Those channel tokens map
+to three attribute keys:
+
+- `PMIX_LOG_SYSLOG` (`pmix.log.syslog`) — log to the local syslog
+  (default behavior).
+- `PMIX_LOG_LOCAL_SYSLOG` (`pmix.log.lsys`) — explicitly local syslog.
+- `PMIX_LOG_GLOBAL_SYSLOG` (`pmix.log.gsys`) — the "global" / master
+  syslog.
+
+### `mylog` behavior
+
+`mylog` reads two directives up front: `PMIX_LOG_SYSLOG_PRI` overrides the
+severity for this call (default is the component's configured `level`),
+and `PMIX_LOG_TIMESTAMP` supplies a `time_t` stamp. It then scans the
+data items:
+
+- `PMIX_LOG_SYSLOG` and `PMIX_LOG_LOCAL_SYSLOG` → `write_local(...)`.
+- `PMIX_LOG_GLOBAL_SYSLOG` → **only** written if this process is a gateway
+  server (`PMIX_PEER_IS_GATEWAY`); otherwise it is skipped (logged at
+  verbosity, not delivered). The intent is that a "global" message is
+  forwarded up to the gateway node and recorded in *that* node's syslog,
+  so only the gateway actually emits it. Non-gateway peers silently
+  decline. There is currently no separate forwarding transport here — the
+  gateway simply writes locally.
+
+### `write_local`
+
+Formats and emits one record:
+
+```c
+syslog(severity, "%s %s:%s PROC %s REPORTS: %s",
+       tod, my-id, sev2str(severity), source-id, msg);
+```
+
+`tod` is the human-readable timestamp (`ctime_r`, trailing newline
+trimmed) when a timestamp was supplied, or `"N/A"`. `sev2str` maps the
+numeric severity to a label for the message text. It always returns
+`PMIX_SUCCESS`.
+
+### Return code
+
+On success `mylog` returns `PMIX_SUCCESS`. If a `write_local` fails it
+returns that error immediately (aborting the router loop, per the
+framework contract). If there is no data it returns
+`PMIX_ERR_NOT_AVAILABLE`. Note that, unlike `stdfd`/`smtp`, this module
+does *not* return `PMIX_ERR_TAKE_NEXT_OPTION` when its keys are simply
+absent — it just falls through the scan and returns `PMIX_SUCCESS`
+because `rc` from the last matched entry (or the initial state) is
+returned. If you extend this module, prefer the explicit
+"none-of-my-keys → `PMIX_ERR_TAKE_NEXT_OPTION`" convention so
+`PMIX_LOG_ONCE` chaining stays correct.
+
+## Gotchas
+
+- **Severity vs. facility are different axes.** `level` is per-message
+  severity (`LOG_ERR`…`LOG_DEBUG`); `facility` categorizes the source
+  program (`LOG_USER`…). The current `openlog` hard-codes `LOG_USER`
+  regardless of the configured `facility` field — the facility parameter
+  is parsed and stored but not yet applied at `openlog` time. Keep that in
+  mind before assuming the facility parameter changes routing.
+- The global-syslog path depends entirely on the gateway check; on a
+  non-gateway peer a `pmix.log.gsys` request produces no output by
+  design. Don't "fix" that into an unconditional local write.
+- `console` maps conceptually to `LOG_CONS`, which `init` already passes
+  to `openlog`; the parameter exists mainly for callers/consumers that
+  inspect it.

--- a/src/mca/plog/syslog/CLAUDE.md
+++ b/src/mca/plog/syslog/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This branch grew out of a documentation pass on the `plog` framework and
picked up several fixes along the way. Each is a separate commit.

## Bug fixes

- **plog/smtp: misregistered `body_suffix` parameter.** The email body
  *suffix* MCA parameter was registered a second time under the name
  `body_prefix`, so the two collided and the suffix could not be set. Now
  registered correctly as `body_suffix`.

- **iof: XML escaping in `pmix_iof_prep_output`.** Two defects corrupted
  XML-formatted stdout/stderr output: an ampersand was emitted as the
  invalid entity `&ap;` instead of `&amp;`, and an allocation-size
  overcount caused one trailing NUL byte to be appended per escaped
  character. Both are fixed; XML output is now well-formed.

## Feature

- **plog/stdfd: honor the output-formatting log directives.** The
  stdout/stderr log channels accepted `PMIX_LOG_TAG_OUTPUT`,
  `PMIX_LOG_TIMESTAMP_OUTPUT`, and `PMIX_LOG_XML_OUTPUT` but silently
  ignored them (the handling was stubbed out behind `#if 0`). They are
  now implemented by mapping onto a `pmix_iof_flags_t` and reusing the
  shared IOF formatter, so log output is tagged/timestamped/XML-wrapped
  identically to forwarded stdio. The unformatted case keeps the direct
  `fprintf` fast path.

## Documentation

- Framework- and component-level `AGENTS.md` orientation guides (with
  `CLAUDE.md` symlinks) for `plog` and its `stdfd`, `syslog`, and `smtp`
  components.
- Corrections and developer-level additions to the "How Things Work"
  `PMIx_Log` document, plus news entries.

## Testing

- Clean build under `--enable-devel-check` (warnings-as-errors).
- `test/simple/simptest` passes with no regression.
- The stdfd formatting was exercised end-to-end with a disconnected tool
  driving `PMIx_Log_nb` with each directive; verified tag, timestamp, and
  XML output (including correct `&amp;`/`&lt;`/`&gt;` escaping and no
  trailing NUL padding).