### PR TITLE
Add preg framework orientation guides and how-it-works doc

### DIFF
--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -17,3 +17,4 @@ find information on that subject here.
    resolve.rst
    adding_datatypes.rst
    pmix_log.rst
+   regex.rst

--- a/docs/how-things-work/regex.rst
+++ b/docs/how-things-work/regex.rst
@@ -1,0 +1,356 @@
+
+Regular Expression (Node/Proc Map) Support
+===========================================
+
+This document describes how PMIx generates and parses the compact
+"regular expressions" it uses to convey a job's **node map** and
+**process map**, from the public server APIs down through the MCA
+``preg`` framework and its components, and how the result is consumed by
+the ``gds/hash`` datastore when a namespace is registered.
+
+For a code-oriented orientation aimed at contributors working *inside*
+the framework, each ``preg`` directory also carries an ``AGENTS.md`` (with
+a ``CLAUDE.md`` symlink): ``src/mca/preg/AGENTS.md`` for the framework as a
+whole, plus one each in ``native/``, ``raw/``, and ``compress/``. This
+document explains how regex support is integrated into the wider library;
+those explain each component's internals in detail.
+
+
+The Problem
+-----------
+
+When a launcher or resource manager starts a job, it must tell the PMIx
+server two things about the layout, and that information must ultimately
+reach every client process:
+
+* the **node map** — the list of node names in the allocation, and
+* the **process map** — the list of process ranks resident on each node.
+
+On a large machine these lists are enormous and highly regular
+(``node000001,node000002,...``). Shipping the raw list to every one of
+hundreds of thousands of processes is wasteful, so PMIx encodes the list
+into a compact, self-describing representation on the producing side and
+expands it again on the consuming side. The ``preg`` framework owns both
+halves of that transform.
+
+Two properties are guaranteed across the encode/decode round trip:
+
+#. **Order preservation** — values come out in the same order they went
+   in.
+#. **Self-identification** — every encoded value is tagged with the name
+   of the scheme that produced it, so a peer can select the correct parser
+   without knowing which components the producer had configured. This is
+   what makes the encoding interoperable across PMIx versions and
+   deployments.
+
+
+Public APIs
+-----------
+
+Two generations of API coexist.
+
+Current API (``pmix_regex2_t``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Declared in ``include/pmix_server.h``::
+
+    pmix_status_t PMIx_generate_regex2(const char *input,
+                                       pmix_info_t info[], size_t ninfo,
+                                       pmix_regex2_t *regex);
+
+    pmix_status_t PMIx_parse_regex2(const pmix_regex2_t *regex,
+                                    pmix_info_t info[], size_t ninfo,
+                                    char **output);
+
+``PMIx_generate_regex2`` takes a comma-separated ``input`` list and fills
+in a ``pmix_regex2_t`` (defined in ``include/pmix_common.h.in``)::
+
+    typedef struct pmix_regex2 {
+        char    *type;    /* encoding tag: "pmix", "raw", "compress"     */
+        uint8_t *bytes;   /* encoded representation (may NOT be a string) */
+        size_t   len;     /* number of bytes in `bytes`                  */
+    } pmix_regex2_t;
+
+``PMIx_parse_regex2`` reverses it, returning a comma-separated string.
+The ``info``/``ninfo`` attribute arrays are required by the PMIx API
+convention but carry no defined attributes yet.
+
+The struct exists because an encoded regex is fundamentally *bytes + a
+length + a type*, not a C string — the ``compress`` encoding contains
+embedded NUL bytes. The matching data type is ``PMIX_REGEX2``; helper
+routines ``PMIx_Regex2_construct`` / ``_destruct`` / ``_create`` /
+``_free`` manage the struct (implemented in
+``src/mca/bfrops/base/bfrop_base_macro_backers.c``).
+
+Deprecated API (``char *``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Declared in ``include/pmix_deprecated.h``::
+
+    pmix_status_t PMIx_generate_regex(const char *input, char **regex);
+    pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
+
+These return the encoded form as a plain ``char *`` and use the
+deprecated ``PMIX_REGEX`` data type (value ``49``). They remain because
+production launchers built against older releases still call them, and
+because the per-node process map is still carried internally in the string
+form. New code should prefer ``PMIx_generate_regex2``.
+
+All four entry points are thin wrappers in ``src/server/pmix_server.c``
+that check ``pmix_globals.initialized`` and forward to the corresponding
+``pmix_preg`` module function::
+
+    PMIx_generate_regex   -> pmix_preg.generate_node_regex
+    PMIx_generate_ppn     -> pmix_preg.generate_ppn
+    PMIx_generate_regex2  -> pmix_preg.generate_regex
+    PMIx_parse_regex2     -> pmix_preg.parse_regex
+
+
+Producer / Consumer Flow
+------------------------
+
+The typical lifecycle of a node map::
+
+  [ Host RM / launcher, e.g. PRRTE ]
+      PMIx_generate_regex2("node01,node02,...", NULL, 0, &regex)
+          └─► pmix_preg.generate_regex()  [smallest encoding wins]
+                                                    │
+      Load regex into a pmix_info_t keyed PMIX_NODE_MAP (type PMIX_REGEX2)
+      (and a PMIX_PROC_MAP for the process layout)
+          │
+          ▼
+      PMIx_server_register_nspace(nspace, ..., info, ninfo, ...)
+          └─► stored via the gds framework
+                    │
+                    ▼
+  [ gds/hash, when unpacking the job-level info ]
+      store_map()  [src/mca/gds/hash/gds_hash.c]
+          PMIX_NODE_MAP:
+              PMIX_REGEX2 -> pmix_preg.parse_regex(regex2, &decoded)
+                             pmix_preg.parse_nodes(decoded, &nodes)
+              PMIX_REGEX  -> pmix_preg.parse_nodes(bo.bytes, &nodes)
+              PMIX_STRING -> pmix_preg.parse_nodes(string, &nodes)
+          PMIX_PROC_MAP: symmetric, using parse_procs
+                    │
+                    ▼
+      The expanded node/rank argv arrays populate the datastore, and the
+      per-process job-level keys (PMIX_NODEID, local peers, etc.) are
+      derived from them and made available to clients via PMIx_Get.
+
+Note the two-step decode for ``PMIX_REGEX2`` in
+``src/mca/gds/hash/gds_hash.c``: ``parse_regex`` turns the
+``pmix_regex2_t`` back into a comma-separated ``char *``, and then the
+*legacy* ``parse_nodes`` expands any ranges in that string into individual
+names. The regex2 struct is the transport; the legacy string parser is
+still the range expander. ``src/mca/gds/hash/process_arrays.c`` performs
+the same ``parse_nodes`` / ``parse_procs`` expansion when node/proc maps
+arrive inside a nested info array.
+
+
+The MCA ``preg`` Framework
+--------------------------
+
+The framework lives under ``src/mca/preg/``. Its module interface
+(``src/mca/preg/preg.h``) is a struct of ten function pointers spanning
+both API generations::
+
+    typedef struct {
+        char *name;
+        /* legacy char* API */
+        pmix_preg_base_module_generate_node_regex_fn_t generate_node_regex;
+        pmix_preg_base_module_generate_ppn_fn_t        generate_ppn;
+        pmix_preg_base_module_parse_nodes_fn_t         parse_nodes;
+        pmix_preg_base_module_parse_procs_fn_t         parse_procs;
+        pmix_preg_base_module_copy_fn_t                copy;
+        pmix_preg_base_module_pack_fn_t                pack;
+        pmix_preg_base_module_unpack_fn_t              unpack;
+        pmix_preg_base_module_release_fn_t             release;
+        /* current pmix_regex2_t API */
+        pmix_preg_base_module_generate_regex_fn_t      generate_regex;
+        pmix_preg_base_module_parse_regex_fn_t         parse_regex;
+    } pmix_preg_module_t;
+
+A component may leave any pointer ``NULL``; the base skips it. ``preg`` is
+a **multi-select** framework — several components are active at once and a
+request is offered to each in priority order.
+
+Component Selection
+~~~~~~~~~~~~~~~~~~~~
+
+``src/mca/preg/base/preg_base_select.c`` queries each component once at
+init, wraps the returned modules, and inserts them into
+``pmix_preg_globals.actives`` in **descending priority order**. If no
+component is selected it emits the ``no-plugins`` ``show_help`` topic and
+returns ``PMIX_ERR_SILENT`` — at least one component is required.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 45
+
+   * - Component
+     - Priority
+     - Active when
+   * - ``compress``
+     - 100
+     - a ``pcompress`` (zlib) module supplies ``compress_string``
+   * - ``raw``
+     - 50
+     - always
+   * - ``native``
+     - 30
+     - always
+
+Dispatch (``preg_base_stubs.c``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every ``pmix_preg`` entry points at a ``pmix_preg_base_*`` stub in
+``src/mca/preg/base/preg_base_stubs.c``. There are three dispatch
+behaviors:
+
+**First-success-wins** — ``generate_node_regex``, ``generate_ppn``,
+``parse_nodes``, ``parse_procs``, ``copy``, ``pack``, ``unpack``. Walk the
+actives in priority order and return on the first ``PMIX_SUCCESS``. If no
+module claims the request, apply a built-in fallback so the call
+essentially never fails:
+
+* ``generate_*`` → ``strdup(input)`` (ship it uncompressed)
+* ``parse_nodes`` → ``PMIx_Argv_split(regex, ',')``
+* ``parse_procs`` → ``PMIx_Argv_split(regex, ';')``
+* ``copy`` → ``strdup`` + ``strlen + 1``
+* ``pack`` / ``unpack`` → serialize as a plain ``PMIX_STRING``
+
+**First-success, no fallback** — ``release`` returns
+``PMIX_ERR_BAD_PARAM`` if no scheme claims the pointer. Always free a
+regex through the framework that produced it.
+
+**Smallest-wins** — ``generate_regex`` is the exception: it calls *every*
+module's ``generate_regex``, keeps the candidate with the smallest
+``len``, frees the losers, and returns the winner (or
+``PMIX_ERR_NOT_SUPPORTED``). This is how the framework automatically
+selects the most compact encoding without the caller choosing a component.
+``parse_regex`` returns to first-success, matching on the ``type`` tag,
+and returns ``PMIX_ERR_NOT_SUPPORTED`` if no active scheme recognizes it.
+
+A practical consequence: because ``raw``'s generators always succeed and
+outrank ``native``, the *legacy* generate path is claimed by ``compress``
+(if present) or ``raw``, and ``native``'s generator is effectively
+shadowed in a default build. ``native`` still serves as the **parser** of
+the ``pmix[...]`` format, which external launchers produce.
+
+
+``preg`` Components
+-------------------
+
+native (src/mca/preg/native/)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Implements PMIx's own range-compressing format, tagged ``pmix``::
+
+    Input:   odin009,odin010,odin011,odin012,odin017,odin018,thor176
+    Output:  pmix[odin[3:9-12,17-18],thor176]
+
+It groups names sharing a prefix, a numeric-field width, and a suffix, and
+coalesces consecutive integers into ``start-end`` ranges. The width
+(``3`` above) preserves leading zeros on expansion. A ``skip`` flag on
+each candidate value enforces order preservation when names of different
+shapes are interleaved. ``native`` implements only the legacy string API
+(``generate_regex`` is ``NULL``); it is the parser of record for
+``pmix[...]`` data whether produced locally or by an external launcher.
+
+raw (src/mca/preg/raw/)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The pass-through, tagged ``raw:``. Its generators simply prepend the tag
+and *always succeed*; its parsers strip the tag and ``PMIx_Argv_split``.
+``raw`` implements the **complete** module — every legacy function and
+both regex2 functions — making it the framework's guaranteed encoder of
+last resort and the baseline candidate in the smallest-wins ``generate_regex``
+contest. For input too small or too random to compress, ``raw`` wins.
+
+compress (src/mca/preg/compress/)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Runs the list through the ``pcompress`` (zlib) framework. It disables
+itself (its ``component_query`` returns an error, so no module is
+selected) when no compression back end is present, so its encoding must
+never be assumed available. Two tags are involved, one per API generation:
+
+* Legacy string form — framed as
+  ``"blob:\0component=zlib:\0size=<N>:\0<N bytes>"``. This contains
+  embedded NUL bytes, which is why ``compress`` implements its own
+  ``copy``/``pack``/``unpack``/``release`` rather than relying on the
+  string fallbacks.
+* regex2 form — ``type = "compress"``, ``bytes`` = raw zlib output,
+  ``len`` = its length (no framing needed, since the struct carries the
+  length explicitly).
+
+At priority 100 it is tried first on every legacy generate and almost
+always wins the smallest-wins regex2 contest — but it is also the
+component most likely to be absent, so both configurations must be tested.
+
+
+Wire Format
+-----------
+
+When a ``pmix_regex2_t`` is transmitted between peers it is serialized by
+``pmix_bfrops_base_pack_regex2`` (``src/mca/bfrops/base/bfrop_base_pack.c``)
+as, in order: the ``type`` string, then ``len`` as a ``PMIX_SIZE``, then
+``len`` ``PMIX_BYTE`` values (only when ``len > 0``). Unpacking mirrors
+this. Per the PMIx interoperability rules this field order is frozen —
+fields may only be appended, never reordered or removed — so that a server
+and client built against different PMIx versions remain compatible.
+
+The legacy string form is serialized either by a component's own
+``pack``/``unpack`` (which ``memcpy`` the exact byte length into the
+buffer, embedded NULs included) or, in the base fallback, as a plain
+``PMIX_STRING``.
+
+
+Thread Safety
+-------------
+
+The ``preg`` functions are pure, synchronous transforms of their
+arguments. They allocate and return; they do not thread-shift, block, or
+mutate shared library state beyond reading the ``actives`` list that was
+built once at init. They are therefore safe to call directly from a
+progress-thread handler — which is exactly where the server APIs and
+``gds/hash`` invoke them — and there is no caddy/thread-shift dance in this
+path. The only ordering constraint is that they must not run concurrently
+with framework open/close, which happens only at startup and shutdown.
+
+
+Key Source Files
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 48 40
+
+   * - File
+     - Purpose
+   * - ``include/pmix_server.h``
+     - ``PMIx_generate_regex2`` / ``PMIx_parse_regex2`` declarations
+   * - ``include/pmix_common.h.in``
+     - ``pmix_regex2_t`` and ``PMIX_REGEX2`` definitions
+   * - ``include/pmix_deprecated.h``
+     - deprecated ``PMIx_generate_regex`` / ``PMIx_generate_ppn`` / ``PMIX_REGEX``
+   * - ``src/server/pmix_server.c``
+     - public API wrappers into ``pmix_preg``
+   * - ``src/mca/preg/preg.h``
+     - ``preg`` MCA module interface
+   * - ``src/mca/preg/preg_types.h``
+     - ``pmix_regex_range_t`` / ``pmix_regex_value_t`` helper classes
+   * - ``src/mca/preg/base/preg_base_select.c``
+     - component selection / priority ordering
+   * - ``src/mca/preg/base/preg_base_stubs.c``
+     - the ``pmix_preg_base_*`` dispatch functions
+   * - ``src/mca/preg/native/preg_native.c``
+     - the ``pmix[...]`` range compressor and parser
+   * - ``src/mca/preg/raw/preg_raw.c``
+     - the ``raw:`` pass-through
+   * - ``src/mca/preg/compress/preg_compress.c``
+     - the ``blob:`` / ``compress`` zlib encoder
+   * - ``src/mca/gds/hash/gds_hash.c``
+     - node/proc map consumer (``store_map``)
+   * - ``src/mca/bfrops/base/bfrop_base_pack.c``
+     - ``pmix_regex2_t`` wire serialization

--- a/src/mca/preg/AGENTS.md
+++ b/src/mca/preg/AGENTS.md
@@ -1,0 +1,320 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PREG Framework
+
+This document orients AI agents and human contributors working in the
+`preg` (**P**MIx **Reg**ular-expression) framework. It assumes you have
+already read the top-level [`AGENTS.md`](../../../AGENTS.md) — the golden
+rules, prefix conventions, thread-safety model, and MCA concepts
+described there all apply here and are not repeated. This file covers
+what is specific to `preg`: what the framework is for, the two
+generations of its API, how a request flows through it, and the contract
+every component must honor. Each component subdirectory carries its own
+`AGENTS.md` with component-specific detail. For an integration-level view
+of how these functions connect to the public server APIs and the
+`gds/hash` datastore, see
+[`docs/how-things-work/regex.rst`](../../../docs/how-things-work/regex.rst).
+
+## What PREG does
+
+`preg` exists to solve one problem: a launcher or resource manager needs
+to hand a PMIx server a **map of the job** — the list of node names in
+the allocation (`PMIX_NODE_MAP`) and the list of process ranks resident
+on each node (`PMIX_PROC_MAP`) — and that list must then be shipped, in a
+compact form, down to every client. On a machine with 100,000 nodes named
+`nodeXXXXXX`, sending the raw comma-separated list to every process is
+wasteful. `preg` "generates" a small encoded representation on the server
+side and "parses" it back into the full argv list on the receiving side.
+
+The canonical example (from `preg.h`):
+
+```
+Input:   odin009,odin010,odin011,odin012,odin017,odin018,thor176
+Output:  pmix[3:9-12,17-18]... , thor176
+```
+
+Two facts about the encoded string are load-bearing for the whole design:
+
+1. **The encoding is self-identifying.** Every encoded value begins with
+   a *tag* naming the scheme that produced it — `pmix[` for the native
+   range compressor, `raw:` for the pass-through, `blob:` for the zlib
+   compressor. A component inspects that tag to decide whether a given
+   blob is "its" to parse, and declines (returns
+   `PMIX_ERR_TAKE_NEXT_OPTION`) if not. This is what lets a server built
+   with one set of components correctly parse data produced by a peer
+   with a different set — the tag, not the local configuration, selects
+   the parser.
+2. **Order is preserved.** The individual values must come back out of
+   the parser in exactly the order they went into the generator. The
+   native component goes to real trouble (the `skip` flag, see its
+   `AGENTS.md`) to guarantee this.
+
+`preg` is a **multi-select** framework: several components are active at
+once, and a request is offered to each in priority order until one claims
+it. It is one of the framework types the top-level guide calls out as
+multi-select (alongside `bfrops` and `psec`).
+
+## Two API generations
+
+This is the single most important thing to understand before editing
+`preg`, because the module struct carries **both** generations at once
+and they behave differently.
+
+### Legacy: the `char *` string API
+
+The original API represents an encoded regex as a plain, NUL-terminated
+`char *`:
+
+| Module fn | Purpose |
+|-----------|---------|
+| `generate_node_regex(input, &regex)` | comma-list of node names → tagged string |
+| `generate_ppn(input, &ppn)` | semicolon-list of per-node rank ranges → tagged string |
+| `parse_nodes(regex, &names)` | tagged string → argv of node names |
+| `parse_procs(regex, &procs)` | tagged string → argv of per-node rank lists |
+| `copy(&dest, &len, input)` | deep-copy an encoded value (it may contain embedded NULs) |
+| `pack(buffer, input)` | serialize an encoded value into a `pmix_buffer_t` |
+| `unpack(buffer, &regex)` | deserialize one back out |
+| `release(regex)` | free a value this scheme produced |
+
+`copy`/`pack`/`unpack`/`release` exist because a `char *` is a leaky
+abstraction for this data: the `compress` scheme's blob **contains
+embedded NUL bytes**, so `strlen`/`strdup` are wrong for it and it needs
+custom copy/pack routines that know its true byte length. This is exactly
+the wart the second generation was created to remove.
+
+The legacy API is still exported to the world through the **deprecated**
+`PMIx_generate_regex()` and `PMIx_generate_ppn()` (see
+[`include/pmix_deprecated.h`](../../../include/pmix_deprecated.h)) and the
+deprecated `PMIX_REGEX` (value `49`) data type. It is still used
+*internally* to carry the per-node process map and as the back-end of the
+regex2 path (see below), so it is far from dead — but no new public
+surface should be built on it.
+
+### Current: the `pmix_regex2_t` API
+
+The second generation makes the "bytes plus length plus type" nature of
+an encoded regex explicit in a struct
+([`include/pmix_common.h.in`](../../../include/pmix_common.h.in)):
+
+```c
+typedef struct pmix_regex2 {
+    char *type;      // encoding tag, e.g. "pmix", "raw", "compress"
+    uint8_t *bytes;  // encoded representation (may NOT be NUL-terminated)
+    size_t len;      // number of bytes in `bytes`
+} pmix_regex2_t;
+```
+
+Two module functions operate on it:
+
+| Module fn | Purpose |
+|-----------|---------|
+| `generate_regex(input, info, ninfo, &regex)` | node-name list → filled-in `pmix_regex2_t` |
+| `parse_regex(&regex, info, ninfo, &output)`  | `pmix_regex2_t` → comma-separated node string |
+
+Note the `pmix_info_t info[], size_t ninfo` parameter pair on both: per
+the top-level rule that *every* PMIx API must carry an attribute array,
+these are present so behavior can be extended by attribute later. No
+attributes are defined for them yet; components currently
+`PMIX_HIDE_UNUSED_PARAMS(info, ninfo)`.
+
+`generate_regex`/`parse_regex` back the current public
+`PMIx_generate_regex2()` / `PMIx_parse_regex2()` server APIs and the
+`PMIX_REGEX2` data type. `type` here is the same tag concept as the
+legacy string prefix, just lifted into its own field instead of being
+smuggled into the front of the byte stream.
+
+**Relationship between the two.** `parse_regex` does not re-implement node
+parsing — it decodes the `pmix_regex2_t` back into a `char *` node list
+and the caller (e.g. `gds/hash`) then runs the *legacy* `parse_nodes` on
+that string. So the two generations interlock: regex2 is the transport,
+the legacy string parser is still the thing that expands ranges. Keep
+that in mind before "simplifying" either half.
+
+## Core data structures
+
+### `preg.h` — the module and version
+
+`preg.h` is the framework's public header, the contract every component
+compiles against. It defines **`pmix_preg_module_t`** (the `.name` field
+plus the ten function pointers above; a component may leave any pointer
+`NULL` and the base will skip it), the exported global
+**`pmix_preg`** module through which all back-end code calls the
+framework, and **`PMIX_PREG_BASE_VERSION_1_0_0`**, the version macro every
+component struct must open with. It also defines `PMIX_MAX_NODE_PREFIX`
+(8192) — the cap on a node-name prefix length used by the native
+generator.
+
+### `preg_types.h` — the range/value helper classes
+
+The native range compressor builds its output from two PMIx classes,
+defined here and instantiated in `preg_base_frame.c`:
+
+- **`pmix_regex_range_t`** `{ int start; int cnt; }` — a contiguous run of
+  integers, e.g. `9-12` is `start=9, cnt=4`.
+- **`pmix_regex_value_t`** `{ char *prefix; char *suffix; int num_digits;
+  pmix_list_t ranges; bool skip; }` — one distinct name shape (prefix +
+  zero-padded number field + optional suffix) together with the list of
+  integer ranges seen for it. `skip` is the ordering-preservation flag
+  described in the native component's `AGENTS.md`.
+
+These are used only by the `native` and (for `generate_ppn`) related code;
+`raw` and `compress` do not touch them.
+
+## Directory layout
+
+```
+src/mca/preg/
+├── preg.h                  Framework public API: module & version macro
+├── preg_types.h            pmix_regex_range_t / pmix_regex_value_t classes
+├── base/                   Framework infrastructure (see below)
+│   ├── base.h              Internal base API + globals + active-module struct
+│   ├── preg_base_frame.c   open/close, framework decl, class instances
+│   ├── preg_base_select.c  component query + priority ordering
+│   └── preg_base_stubs.c   the pmix_preg_base_* routing functions
+├── native/                 the "pmix[...]" range compressor + parser
+├── raw/                    the "raw:" pass-through (no compression)
+└── compress/               the "blob:" zlib compressor (needs pcompress)
+```
+
+## The base routing layer (`preg_base_stubs.c`)
+
+Every entry in the global `pmix_preg` module points at a
+`pmix_preg_base_*` stub here. The stubs are thin dispatchers over the
+priority-ordered `pmix_preg_globals.actives` list, and they come in three
+flavors — know which one you are touching:
+
+1. **First-success-wins** (`generate_node_regex`, `generate_ppn`,
+   `parse_nodes`, `parse_procs`, `copy`, `pack`, `unpack`). Walk the
+   actives in priority order, call the module fn, and **return on the
+   first `PMIX_SUCCESS`**. If no module claims the request, apply a
+   built-in fallback:
+   - `generate_*` → `strdup(input)` (ship the input uncompressed).
+   - `parse_nodes` → `PMIx_Argv_split(regex, ',')`.
+   - `parse_procs` → `PMIx_Argv_split(regex, ';')`.
+   - `copy` → `strdup` + `strlen+1`.
+   - `pack`/`unpack` → treat it as a `PMIX_STRING` via bfrops.
+
+   The fallbacks are why these functions essentially never fail: an
+   unrecognized value is simply treated as a literal string.
+
+2. **`release`** is first-success-wins but has **no fallback** — it
+   returns `PMIX_ERR_BAD_PARAM` if no scheme claims the pointer. Only free
+   a regex through the same framework that produced it.
+
+3. **Smallest-wins** (`generate_regex`, the regex2 generator). This is the
+   exception: it does **not** stop at the first success. It calls *every*
+   module's `generate_regex`, keeps the candidate with the smallest
+   `len`, frees the losers, and returns the winner (or
+   `PMIX_ERR_NOT_SUPPORTED` if none produced anything). This is how the
+   framework automatically picks the most compact encoding — usually
+   `compress`, but `raw` wins for inputs too small or too random to
+   compress. `parse_regex` is back to plain first-success (tag match), and
+   returns `PMIX_ERR_NOT_SUPPORTED` if no active scheme recognizes the
+   `type`.
+
+### A consequence worth internalizing
+
+Because the first-success stubs take priorities in descending order and
+`raw`'s generators **always succeed** (they only prepend `raw:`), the
+legacy `generate_node_regex`/`generate_ppn` path is claimed by `compress`
+(priority 100) when zlib is present, otherwise by `raw` (50) — the
+`native` generator (30) is effectively shadowed on that path in a default
+build. `native` still earns its keep as the **parser** of the `pmix[...]`
+format (which external launchers such as PRRTE emit) and via the
+smallest-wins regex2 path where it is *not* even registered
+(`native.generate_regex == NULL`). Do not "fix" this by reordering
+priorities without understanding that the `pmix[...]` producer and its
+consumer live in different deployments.
+
+## Selection and lifecycle
+
+- **`preg_base_frame.c`** declares the framework
+  (`PMIX_MCA_BASE_FRAMEWORK_DECLARE`), instantiates the global `pmix_preg`
+  module (pointing every slot at the base stubs), and defines the
+  `PMIX_CLASS_INSTANCE`s for `pmix_regex_range_t`, `pmix_regex_value_t`,
+  and the active-module wrapper. `pmix_preg_open` constructs the `actives`
+  list and opens all components; `pmix_preg_close` tears it down.
+- **`preg_base_select.c`** (`pmix_preg_base_select`, called once from
+  library init) queries each component, wraps the returned modules in
+  `pmix_preg_base_active_module_t { pri, module, component }`, and inserts
+  them into `pmix_preg_globals.actives` in **descending priority order**.
+  If zero modules are selected it emits the `no-plugins` `show_help` topic
+  and returns `PMIX_ERR_SILENT` — `preg` requires at least one component.
+  At verbosity >4 it prints the resolved priority list.
+
+Default priorities (from each component's `component_query`):
+
+| Component | Priority | Active when |
+|-----------|----------|-------------|
+| `compress` | 100 | a `pcompress` (zlib) component provides `compress_string` |
+| `raw`      | 50  | always |
+| `native`   | 30  | always |
+
+## Wire format (`pmix_regex2_t` on the buffer)
+
+When a `pmix_regex2_t` travels between peers it is packed by
+`pmix_bfrops_base_pack_regex2` (in `src/mca/bfrops/base/`) as: the `type`
+string, then `len` as a `PMIX_SIZE`, then `len` raw `PMIX_BYTE`s (only if
+`len > 0`). Unpacking mirrors this. Per the top-level interoperability
+rules, this order is frozen — append only, never reorder. The legacy
+string form is packed via each component's own `pack`/`unpack` (which
+`memcpy` the exact byte length into the buffer, embedded NULs and all) or,
+in the fallback, as a plain `PMIX_STRING`.
+
+## Threading
+
+The `preg` functions are pure, synchronous transforms of their arguments —
+they allocate and return, they do not thread-shift, block, or touch shared
+library state beyond the read-only `actives` list built once at init. They
+are therefore safe to call directly from within a progress-thread handler
+(which is where the server APIs and `gds/hash` invoke them). They must
+**not** be called concurrently with framework open/close, but that only
+happens at startup/shutdown. There is no caddy pattern here.
+
+## Building
+
+All three components are statically built into `libpmix` and wired through
+the generated `base/static-components.h`; none ships a `configure.m4`, so
+none is conditionally compiled out — but `compress` disables *itself* at
+runtime (its `component_query` returns an error) if no `pcompress` module
+is available, so its symbols must never be assumed to be in the active
+list. Adding a component means creating `src/mca/preg/<name>/` with the
+usual `Makefile.am`, a component struct opened with
+`PMIX_PREG_BASE_VERSION_1_0_0`, and a module; the framework picks it up
+through `static-components.h`. Editing a `Makefile.am` only needs a plain
+`make`; adding or removing a *component directory* changes the build
+wiring resolved by `configure`, so re-run
+`./autogen.pl && ./configure ... && make`.
+
+`preg` ships no `show_help` text of its own (the only `show_help` it uses,
+`no-plugins`, lives in `help-pmix-runtime.txt`), so the regenerate-the-
+help-content golden rule does not usually bite here.
+
+## When adding or modifying a component
+
+- Open the component struct with `PMIX_PREG_BASE_VERSION_1_0_0` and set
+  `pmix_mca_component_name` to your directory name.
+- Choose a **unique tag** for your encoding and make every generator emit
+  it and every parser gate on it with `strncmp`/`strcmp`, returning
+  `PMIX_ERR_TAKE_NEXT_OPTION` when the tag is not yours. The tag is the
+  interoperability contract — a peer must be able to identify your
+  encoding without knowing your component exists.
+- Preserve value ordering across generate→parse. Test round-trips with
+  interleaved, out-of-order, and mixed-prefix inputs.
+- If your encoding can contain embedded NUL bytes, you **must** implement
+  `copy`/`pack`/`unpack`/`release` (do not rely on the `strdup`/`PMIX_STRING`
+  fallbacks) — see `compress` for the pattern.
+- Prefer implementing the regex2 `generate_regex`/`parse_regex` for any
+  new work; wire the legacy string functions too only if the encoding must
+  also flow through the deprecated `PMIx_generate_regex` path or the
+  internal node/proc map.
+- Never change an existing component's on-the-wire encoding; add a new
+  component (new tag) instead, exactly as with `bfrops` versions.

--- a/src/mca/preg/CLAUDE.md
+++ b/src/mca/preg/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/preg/compress/AGENTS.md
+++ b/src/mca/preg/compress/AGENTS.md
@@ -1,0 +1,129 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PREG `compress` Component
+
+`compress` is the `preg` component that runs the node/proc list through
+the `pcompress` framework (zlib) to produce a binary `blob:` encoding.
+Read the framework [`AGENTS.md`](../AGENTS.md) first; this file covers only
+what is specific to `compress`. It is the highest-priority component and
+usually the one that actually encodes job maps in production.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `preg_compress.h` | Declares the component and module symbols. |
+| `preg_compress_component.c` | Component struct + `component_query`. |
+| `preg_compress.c` | The module: all legacy string functions + both regex2 functions + the `blob:` framing helpers. |
+
+## Availability — this component disables itself
+
+Unlike `raw` and `native`, `compress` is only useful when a compression
+back end exists. Its `component_query`:
+
+```c
+if (NULL == pmix_compress.compress_string) {
+    return PMIX_ERROR;   // no module -> not selected
+}
+*priority = 100;         // highest priority when we ARE available
+```
+
+So `compress` is in `pmix_preg_globals.actives` **only** when a
+`pcompress` component (zlib) is loaded. Never assume its symbols are in
+the active list — everything downstream is written to degrade to `raw`
+when `compress` is absent. It depends on
+[`src/mca/pcompress/pcompress.h`](../../pcompress/pcompress.h) for
+`pmix_compress.compress_string` / `decompress_string`.
+
+## The `blob:` framing
+
+The legacy string form is **not** a printable string — it is a header
+followed by raw compressed bytes, and it contains **embedded NUL bytes**.
+`pack_blob` lays it out as a sequence of NUL-terminated tokens followed by
+the payload:
+
+```
+"blob:\0" "component=zlib:\0" "size=<N>:\0" <N bytes of zlib data>
+```
+
+The parsers walk it by stepping over each token's NUL terminator
+(`idx += strlen(&buf[idx]) + 1`), read `<N>` with `strtoul`, then jump two
+bytes (the `:` and its NUL) to reach the payload. This is why `compress`
+**must** implement its own `copy`/`pack`/`unpack`/`release`: `strlen` and
+`strdup` would stop at the first embedded NUL and truncate the blob. The
+true byte length is reconstructed as
+`N + strlen(PREG_COMPRESS_PREFIX) + strlen("<N>") + 1`.
+
+Every parse/copy/pack/unpack/release first checks the value begins with
+`blob` **and** that the second token is `component=zlib:` — both gates must
+pass, otherwise it returns `PMIX_ERR_TAKE_NEXT_OPTION`. The second check
+ensures `compress` only claims blobs it (a zlib producer) generated, not
+some future `blob:` variant.
+
+## Legacy string operations
+
+- **`generate_node_regex` / `generate_ppn`** — call
+  `pmix_compress.compress_string(input, &tmp, &len)`; if compression fails
+  (or is unavailable) return `PMIX_ERR_TAKE_NEXT_OPTION`, else frame the
+  bytes with `pack_blob`. Note: these compress the **raw input list**, not
+  a `native` regex — the payload is the literal comma/semicolon string.
+- **`parse_nodes` / `parse_procs`** — validate the framing, `strtoul` the
+  size, `decompress_string` back to the original list, then
+  `PMIx_Argv_split` on `,` (nodes) or `;` (procs). Because the compressed
+  payload is just the original delimited list, splitting is all that
+  remains.
+- **`copy` / `pack` / `unpack`** — reconstruct the true byte length as
+  above and `memcpy`/`calloc` the exact bytes; never treat the blob as a
+  C string.
+- **`release`** — validates the framing then `free`s.
+
+## regex2 operations
+
+The regex2 path is cleaner because `pmix_regex2_t` already carries an
+explicit `len`, so no `blob:` framing is needed:
+
+- **`generate_regex`** — `compress_string(input, &compressed, &len)`, then
+  `regex->type = "compress"`, `regex->bytes = compressed`, `regex->len =
+  len`. Returns `PMIX_ERR_TAKE_NEXT_OPTION` if compression is unavailable.
+  Because it produces the smallest encoding for any non-trivial list, it
+  almost always wins the framework's **smallest-wins** `generate_regex`
+  contest.
+- **`parse_regex`** — gates on `regex->type == "compress"`, then
+  `decompress_string(&tmp, regex->bytes, regex->len)` and returns the
+  decompressed node string. The caller (`gds/hash`) then runs the legacy
+  `parse_nodes` on that string to expand it.
+
+Both ignore their `info`/`ninfo` arrays for now
+(`PMIX_HIDE_UNUSED_PARAMS`).
+
+## Note: legacy `blob:` tag vs. regex2 `compress` type
+
+The two API generations use **different tags** for the same component:
+the legacy string form is tagged `blob:` (with a `component=zlib:` marker),
+while the regex2 form sets `type = "compress"` (the module name). They are
+not interchangeable — a `blob:` string will not be recognized by
+`parse_regex`, and a regex2 `compress` blob is raw zlib output with no
+`blob:` header. Keep them straight when tracing data across the two paths.
+
+## Gotchas
+
+- All the framing offset arithmetic in the legacy path is fragile by
+  nature (manual `idx` stepping over embedded NULs). If you change
+  `PREG_COMPRESS_PREFIX` or the token layout in `pack_blob`, every parser's
+  offset math must change with it — they do not share a parsing helper.
+- `decompress_string` failure paths in `parse_nodes`/`parse_procs`/
+  `parse_regex` `free(tmp)` and return `PMIX_ERR_TAKE_NEXT_OPTION`; keep
+  that "decline, don't hard-error" behavior so a corrupt or foreign blob
+  can still be retried by another scheme or the base fallback.
+- Because `compress` sits at priority 100, it is tried first on every
+  legacy generate — but it is also the component most likely to be
+  *absent* (no zlib). Code and tests must exercise both the present and
+  absent configurations.

--- a/src/mca/preg/compress/CLAUDE.md
+++ b/src/mca/preg/compress/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/preg/native/AGENTS.md
+++ b/src/mca/preg/native/AGENTS.md
@@ -1,0 +1,173 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PREG `native` Component
+
+`native` is the `preg` component that implements PMIx's own
+range-compressing regular-expression format — the `pmix[...]` encoding.
+Read the framework [`AGENTS.md`](../AGENTS.md) first; this file covers
+only what is specific to `native`. It is the component that gives the
+`pmix` tag its meaning, and it is the parser of record for the human-
+readable range format that external launchers (e.g. PRRTE) also produce.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `preg_native.h` | Declares the component and module symbols. |
+| `preg_native_component.c` | Component struct + `component_query` (priority **30**, always available). |
+| `preg_native.c` | The module: generate/parse/copy/pack/unpack/release + the range-parsing helpers. |
+
+`native` implements the entire **legacy string API** but leaves the
+regex2 slots `NULL` (`.generate_regex = NULL`, no `parse_regex`). It never
+participates in the smallest-wins regex2 generation path; it works purely
+in the `char *` world.
+
+## The `pmix[...]` format
+
+`native` compresses a comma-separated list of names into ranges, grouping
+names that share a *prefix*, a *number-field width*, and a *suffix*:
+
+```
+Input:   odin009,odin010,odin011,odin012,odin017,odin018,thor176
+Output:  pmix[odin[3:9-12,17-18],thor176]
+```
+
+Reading the encoding:
+
+- The whole thing is wrapped `pmix[ ... ]`; the leading `pmix` is the tag
+  that `parse_nodes`/`parse_procs` gate on.
+- Inside, each element is either a bare name (`thor176`, uncompressible)
+  or `prefix[W:ranges]suffix`, where **`W` is the number of digits** in
+  the zero-padded numeric field. That width is what lets the parser
+  regenerate `009` rather than `9` — leading zeros are preserved.
+- `ranges` is a comma list of `start-end` runs (or bare singletons).
+
+The `generate_ppn` variant emits a semicolon-delimited `pmix[...]` where
+each node's rank ranges are separated by `;` instead of `,`.
+
+## Generation: `generate_node_regex`
+
+This is the algorithmic heart of the component. It builds a list of
+`pmix_regex_value_t` (one per distinct prefix/width/suffix shape), each
+holding a list of `pmix_regex_range_t` runs, then serializes them.
+
+The loop walks the input names left to right and, for each, isolates the
+prefix (leading alphabetic run), the numeric field (its digit count is the
+width `W`), and any trailing suffix. Names that contain non-digit,
+non-alpha characters, or that have no numeric field, are stored verbatim
+and never compressed.
+
+### The `skip` flag — ordering preservation (read this before editing)
+
+The subtle part is that **the parser must reproduce the input order**, and
+ranges only merge with the *last* range on a matching value. Consider:
+
+```
+a28n01, a99n02, a28n02
+```
+
+Naively, `a28n02` would merge with the `a28n01` value, "jumping over"
+`a99n02` and corrupting the order when expanded. To prevent this, when a
+candidate name fails to match an existing `pmix_regex_value_t` on prefix,
+suffix, or width, that value is marked `skip = true` and excluded from all
+*future* matches. So once `a99n02` (a different prefix) is seen, the
+`a28...` value is frozen and `a28n02` starts a fresh value. The comment
+block in `generate_node_regex` documents this with the same example —
+**do not remove the `skip` logic** thinking it's redundant; it is the
+ordering guarantee.
+
+A name is appended to a range only if `vnum == range->start + range->cnt`
+(strictly the next integer); otherwise a new range is started. This is
+what turns `9,10,11,12` into `9-12` but leaves `9,11` as two runs.
+
+### Serialization and the return code
+
+After the list is built, each value is emitted as `prefix[W:ranges]suffix`
+(or just the bare name if it had no ranges), the pieces are joined with
+commas, and the whole is wrapped in `pmix[...]`. If **nothing** was
+compressible (`regexargs` came out empty), it returns
+`PMIX_ERR_TAKE_NEXT_OPTION` so the base moves on. Memory-allocation
+failures return `PMIX_ERR_NOMEM`.
+
+`generate_ppn` is a simpler cousin: it splits the input by `;` (nodes)
+then `,` (ranges per node), coalesces consecutive ranks into ranges, and
+emits `pmix[...]` with `;` node separators. It has a **size guard**: if
+the encoded form is longer than the raw input, it returns
+`PMIX_ERR_TAKE_NEXT_OPTION` rather than bloating the data.
+
+## Parsing: `parse_nodes` / `parse_procs`
+
+Both strip the trailing `]`, split off the leading tag at the first `[`,
+and check it equals `"pmix"`. If it does not, they return
+`PMIX_ERR_TAKE_NEXT_OPTION` — this is *not* an error, it just means the
+blob belongs to another scheme. A malformed `pmix` blob (no `[`) returns
+`PMIX_ERR_BAD_PARAM`.
+
+`parse_nodes` delegates to **`pmix_regex_extract_nodes`**, a hand-written
+scanner that walks the range string, and for each `prefix[W:ranges]suffix`
+group calls `regex_parse_value_ranges` → `regex_parse_value_range`. The
+inner routine reconstructs each name by:
+
+1. copying the prefix,
+2. writing `W` zero characters, then overwriting the low-order digits with
+   the decimal of the current integer (this is the zero-padding logic),
+3. appending the suffix if present,
+
+for every integer from `start` to `end` inclusive. Bare singleton values
+(no `[`) are appended as-is.
+
+`parse_procs` delegates to **`pmix_regex_extract_ppn`**, which splits on
+`;` (nodes), then `,` (ranks), expands each `start-end` run into
+individual rank strings, and rejoins each node's ranks with commas so the
+result is one argv entry per node.
+
+### Editing the parser
+
+These scanners are pointer-arithmetic-heavy and index into a mutable copy
+of the string (they poke `\0` terminators in place). The classic hazards
+are off-by-one on the width padding, mishandling a suffix that itself
+contains no comma, and losing the "more to come" state across a range/
+singleton boundary. Any change here needs round-trip tests against
+`generate_node_regex` output including: leading zeros, suffixes,
+multi-range values, and bare uncompressible names interleaved with ranges.
+
+## copy / pack / unpack / release
+
+Because the `pmix[...]` form is a genuine NUL-terminated string with no
+embedded NULs, these are straightforward:
+
+- `copy` — `strdup` + `strlen+1`, gated on the input starting with `pmix`.
+- `pack` — `pmix_bfrop_buffer_extend` then `memcpy` the string (incl.
+  terminator) directly into the buffer, gated on the `pmix` prefix.
+- `unpack` — read from `buffer->unpack_ptr`, `strdup`, advance the pointer
+  by `strlen+1`, gated on the `pmix` prefix.
+- `release` — `free`, gated on the `pmix` prefix.
+
+Every one returns `PMIX_ERR_TAKE_NEXT_OPTION` when the value is not tagged
+`pmix`, so the base tries the next scheme. The prefix check is only 4
+bytes (`strncmp(input, "pmix", 4)`) — note it does **not** verify the
+`[` follows, so a hypothetical scheme tagged `pmixفoo` would false-match;
+in practice no other tag begins with `pmix`.
+
+## Gotchas
+
+- `native` never sets `.generate_regex`, so it contributes nothing to
+  `PMIx_generate_regex2`. If you want the `pmix[...]` encoding available
+  through the regex2 API, you would add a `generate_regex`/`parse_regex`
+  pair here — but weigh that against `compress`, which almost always wins
+  the smallest-wins contest anyway.
+- Its generators are shadowed by `raw`/`compress` on the legacy path (see
+  the framework `AGENTS.md`), so in a default build `native` is exercised
+  mainly as a **parser** of data produced elsewhere. Test it as a parser,
+  not just as a round-tripper against its own generator.
+- `PMIX_MAX_NODE_PREFIX` (8192) caps the prefix buffer; names with longer
+  prefixes are truncated into the fixed `prefix[]` array. This is a real,
+  if generous, limit.

--- a/src/mca/preg/native/CLAUDE.md
+++ b/src/mca/preg/native/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/preg/raw/AGENTS.md
+++ b/src/mca/preg/raw/AGENTS.md
@@ -1,0 +1,91 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PREG `raw` Component
+
+`raw` is the `preg` component that performs **no compression at all**: it
+wraps the input in a `raw:` tag on the way out and strips it on the way
+back. Read the framework [`AGENTS.md`](../AGENTS.md) first; this file
+covers only what is specific to `raw`. It is the simplest component and
+the framework's guaranteed fallback encoder.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `preg_raw.h` | Declares the component and module symbols. |
+| `preg_raw_component.c` | Component struct + `component_query` (priority **50**, always available). |
+| `preg_raw.c` | The module: all legacy string functions **and** both regex2 functions. |
+
+`raw` is the one component that implements the **complete** module — the
+full legacy string API *and* the regex2 `generate_regex`/`parse_regex`
+pair. That completeness is deliberate: `raw` is the safety net that
+guarantees *some* module can always encode and decode a request.
+
+## What it does
+
+Every operation is a tag manipulation, no real work:
+
+- **`generate_node_regex` / `generate_ppn`** — if the input already starts
+  with `raw:`, `strdup` it; otherwise emit `raw:<input>`. They **always
+  return `PMIX_SUCCESS`** — `raw` never declines to encode.
+- **`parse_nodes`** — require the `raw:` prefix, then
+  `PMIx_Argv_split(&regex[4], ',')`.
+- **`parse_procs`** — require the `raw:` prefix, then
+  `PMIx_Argv_split(&regex[4], ';')`.
+- **`copy` / `pack` / `unpack` / `release`** — the standard tag-gated
+  `strdup` / `memcpy`-into-buffer / pointer-advance / `free`, identical in
+  shape to `native`'s (the `raw:` string has no embedded NULs, so the
+  simple string routines are correct).
+
+Every parse/copy/pack/unpack/release returns `PMIX_ERR_TAKE_NEXT_OPTION`
+when the value is not tagged `raw:`, so the base moves on to another
+scheme.
+
+### regex2 functions
+
+- **`generate_regex`** — sets `regex->type = "raw"`,
+  `regex->bytes = strdup(input)`, `regex->len = strlen(input) + 1`. It
+  always succeeds (barring `PMIX_ERR_NOMEM`), so in the framework's
+  **smallest-wins** regex2 contest `raw` is the baseline every other
+  component must beat. For inputs too small or too random for `compress`
+  to shrink, `raw` legitimately wins.
+- **`parse_regex`** — gates on `regex->type == "raw"` and returns
+  `strdup(regex->bytes)`. Because `raw`'s bytes are just the original NUL-
+  terminated node string, no expansion is needed.
+
+Both currently ignore their `info`/`ninfo` attribute arrays
+(`PMIX_HIDE_UNUSED_PARAMS`); the parameters exist only to satisfy the
+"every API carries attributes" rule.
+
+## Why `raw` matters despite doing nothing
+
+1. **It is the encoder of last resort.** Because its generators always
+   succeed and it sits at priority 50 (above `native`'s 30), the legacy
+   `generate_node_regex` path is claimed by `raw` whenever `compress` is
+   absent — the data still ships, just uncompressed. Removing `raw` would
+   make `native`'s generator reachable again but would also remove the
+   guaranteed-success encoder, so the base's `strdup` fallback would carry
+   more traffic.
+2. **It is the regex2 baseline.** `generate_regex`'s smallest-wins logic
+   needs at least one always-succeeding candidate or it would return
+   `PMIX_ERR_NOT_SUPPORTED` for incompressible input. `raw` is that
+   candidate.
+3. **It round-trips anything.** Since it does not interpret the payload at
+   all, `raw` can carry a list that no range compressor understands.
+
+## Gotchas
+
+- Do not add "cleverness" to `raw`. Its whole value is that it is a
+  transparent, always-available identity transform. If you want smarter
+  encoding, add a new component with a new tag.
+- The `raw:` prefix is exactly 4 bytes and all gates use
+  `strncmp(x, "raw:", 4)`. Keep the tag and the offset (`&regex[4]`) in
+  sync if you ever touch it — but you should not need to.

--- a/src/mca/preg/raw/CLAUDE.md
+++ b/src/mca/preg/raw/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Adds in-depth orientation documentation for the `preg` (regular-expression) framework — the subsystem that generates and parses the compact node/proc map "regexes" PMIx ships to clients. Documentation only; no code or build behavior changes.

### Framework- and component-level guides (`AGENTS.md` + `CLAUDE.md` symlinks)

Following the convention established by the `plog` guides:

- **`src/mca/preg/AGENTS.md`** — the framework as a whole: the two API generations (legacy `char *` vs. current `pmix_regex2_t`) and how they interlock, the three base dispatch behaviors (first-success-wins, release-with-no-fallback, and smallest-wins for `generate_regex`), component selection/priority, the wire format, and the threading model.
- **`native/AGENTS.md`** — the `pmix[...]` range compressor, with emphasis on the `skip` ordering-preservation flag and the parser.
- **`raw/AGENTS.md`** — the always-succeeding `raw:` pass-through and its role as the guaranteed fallback encoder / regex2 baseline.
- **`compress/AGENTS.md`** — the zlib `blob:` framing (embedded NULs), self-disabling behavior, and the two-tag subtlety.

### Developer-facing integration doc

- **`docs/how-things-work/regex.rst`** — ties the framework to the public `PMIx_generate_regex2` / `PMIx_parse_regex2` server APIs (and the deprecated `char *` APIs) and to the `gds/hash` node/proc map consumer, with a call-flow diagram and key-source-files table. Wired into the how-things-work index.

## Notes

One non-obvious behavior is surfaced in both the framework guide and the RST: because `raw`'s generators always succeed and outrank `native`, `native`'s *generator* is effectively shadowed on the legacy path in a default build — `native` earns its keep as the **parser** of `pmix[...]` data that external launchers (e.g. PRRTE) emit.

## Testing

- `sphinx-build` completes with no warnings or errors; `regex.html` generates correctly.
- All RST title underlines validated; all four `CLAUDE.md` symlinks resolve to their `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)