### PR TITLE
Add ptl framework orientation guides and how-it-works doc

### DIFF
--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -18,3 +18,4 @@ find information on that subject here.
    adding_datatypes.rst
    pmix_log.rst
    regex.rst
+   ptl.rst

--- a/docs/how-things-work/ptl.rst
+++ b/docs/how-things-work/ptl.rst
@@ -1,0 +1,350 @@
+
+Transport Layer (Client/Server/Tool Connections)
+=================================================
+
+This document describes how PMIx connects a process to the PMIx server it
+talks to, and how messages then flow between them: how a server publishes
+where it can be reached, how a client or tool discovers and connects to
+it, the identity/security handshake both sides run, and how framed
+messages are sent and received over the socket in steady state. All of
+this is the job of the MCA ``ptl`` (PMIx Transport Layer) framework.
+
+For a code-oriented orientation aimed at contributors working *inside*
+the framework, each ``ptl`` directory also carries an ``AGENTS.md`` (with
+a ``CLAUDE.md`` symlink): ``src/mca/ptl/AGENTS.md`` for the framework as a
+whole, plus one each in ``client/``, ``server/``, and ``tool/``. This
+document explains how the transport layer fits into the wider library;
+those explain each piece's internals in detail.
+
+
+The Problem
+-----------
+
+Every PMIx message — a ``PMIx_Get``, a fence, an event notification,
+forwarded I/O — ultimately travels over a socket between a process and
+its server. Before any of that can happen, three things must be arranged:
+
+* the server must make itself **findable** — a client that was launched
+  under it, and a tool that shows up later, both need a way to learn the
+  server's address;
+* the two ends must complete a **handshake** that establishes identity,
+  negotiates the serialization (``bfrops``) and datastore (``gds``)
+  modules they will use, and validates a security credential; and
+* once connected, messages must be **framed, matched, and delivered**
+  reliably on PMIx's single progress thread without blocking it.
+
+The ``ptl`` framework owns all three. Everything above the socket —
+serializing the payload (``bfrops``), the security credential itself
+(``psec``), where the data is stored (``gds``) — belongs to other
+frameworks; ``ptl`` is the pipe and the rules for setting it up.
+
+
+An Unusual Framework Shape
+--------------------------
+
+``ptl`` is a **single-select** framework — exactly one component is active
+in a given process — but it is structured differently from most PMIx
+frameworks, and understanding that difference is the key to reading the
+code.
+
+In a typical framework the component contains the implementation and
+``base/`` is just plumbing. In ``ptl`` it is inverted: **the base contains
+essentially all of the code** — TCP sockets, message framing, the
+handshake, the listener, interface discovery, rendezvous files,
+send/receive, and teardown — while the three components (``client``,
+``server``, ``tool``) are thin *role selectors*. Each component's
+``component_query`` inspects the local process type and claims the process
+only if it matches:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 15 70
+
+   * - Component
+     - Priority
+     - Selected when the local peer is…
+   * - ``client``
+     - 50
+     - a client **and not** a tool (a "pure" client)
+   * - ``tool``
+     - 40
+     - any tool — debugger, launcher, or client-tool
+   * - ``server``
+     - 30
+     - a server **and not** a tool (a "pure" server)
+
+These conditions are mutually exclusive, so at most one component ever
+returns a module and the priorities never actually break a tie. A
+**launcher** is ``tool+server`` and therefore uses the ``tool`` component
+— which is why a tool, not just a server, is able to set up a listener.
+
+There is only one transport today: TCP, identified on the wire as
+``PMIX_PROTOCOL_V2``. The older Unix-domain-socket transport
+(``PMIX_PROTOCOL_V1``, "usock") has been removed. Handshake version
+differences are handled *inside* the base by inspecting the peer's version
+string, not by swapping components.
+
+
+Publishing a Server: the Listener
+---------------------------------
+
+A server (or launcher, or any tool that will spawn children) makes itself
+reachable in ``pmix_ptl_base_setup_listener``
+(``src/mca/ptl/base/ptl_base_listener.c``):
+
+#. **Choose an interface.** Enumerate the node's interfaces, filter them
+   through any ``if_include`` / ``if_exclude`` directives, and default to
+   a **loopback** device. Only if remote or tool connections were
+   requested does it fall back to a public interface.
+#. **Bind a listen socket.** Try each configured port (default ``0`` —
+   let the kernel assign one), set ``SO_REUSEADDR`` and close-on-exec,
+   ``listen`` with ``SOMAXCONN``, and make the socket non-blocking.
+#. **Publish the URI.** Build a URI of the form
+   ``nspace.rank;tcp4://host:port`` and store it in ``gds`` under both
+   ``PMIX_MYSERVER_URI`` and (for older tools) ``PMIX_SERVER_URI``. If
+   ``report_uri`` is set, also emit it to stdout (``-``), stderr (``+``),
+   an integer pipe fd, or a named file.
+#. **Drop rendezvous files.** Depending on the server's role and flags,
+   write well-known contact files that a client or tool can later
+   discover in the tmpdir tree:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 45 55
+
+      * - File
+        - Written by
+      * - ``pmix.sched.<host>``
+        - a scheduler
+      * - ``pmix.sysctrlr.<host>``
+        - a system controller
+      * - ``pmix.sys.<host>``
+        - a server offering *system*-level tool support
+      * - ``pmix.<host>.tool``
+        - a server offering *session*-level tool support
+      * - ``pmix.<host>.tool.<pid>``
+        - any tool-supporting server (keyed by PID)
+      * - ``pmix.<host>.tool.<nspace>``
+        - any tool-supporting server (keyed by nspace)
+
+   Each file contains the URI, the server's version, its PID, its
+   ``uid:gid``, and a timestamp. The ``pmix_ptl_base`` state struct
+   records (via its ``created_*`` flags) exactly which files and
+   directories this process created, so ``pmix_ptl_close`` can remove
+   precisely those at shutdown and nothing that belongs to a peer.
+
+``pmix_ptl_base_start_listening`` then registers the listen socket's
+accept event on the progress thread.
+
+
+Finding and Connecting to a Server
+----------------------------------
+
+The outbound side is driven by ``pmix_ptl.connect_to_peer``, called
+(blocking) during ``PMIx_Init`` or ``PMIx_tool_init``. There are two
+implementations, chosen by the selected component.
+
+Clients: the short path
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A pure client uses the ``client`` component's own ``connect_to_peer``
+(``src/mca/ptl/client/ptl_client.c``). A client already knows its server,
+so the logic is short:
+
+#. use an explicit ``PMIX_SERVER_URI`` from the info array if present;
+#. otherwise consult the environment via ``pmix_ptl_base_set_peer``, which
+   walks the active ``bfrops`` modules and looks for the corresponding
+   ``PMIX_SERVER_URIvNN`` variable — finding one yields both the URI and
+   the server's version;
+#. if neither exists, the process was not launched under a server: mark it
+   a **singleton**, probe for a system server via ``pmix.sys.<host>``, and
+   fall back to standalone operation if none is found.
+
+Tools and servers: the discovery matrix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tools (and servers connecting upward) use
+``pmix_ptl_base_connect_to_peer`` (``src/mca/ptl/base/ptl_base_connect.c``),
+which searches for the right server among many possibilities, roughly from
+most specific to least:
+
+* an explicit ``PMIX_SERVER_URI`` / ``PMIX_TCP_URI``;
+* a rendezvous / ``PMIX_TOOL_ATTACHMENT_FILE``;
+* a caller-specified **connection order** — ``PMIX_CONNECT_SYSTEM_FIRST``,
+  ``PMIX_CONNECT_TO_SYSTEM``, ``PMIX_CONNECT_TO_SCHEDULER``,
+  ``PMIX_CONNECT_TO_SYS_CONTROLLER`` — each mapping to a well-known
+  rendezvous filename;
+* a specific server PID or nspace; or
+* a directory search of the session tmpdir, taking the first
+  ``pmix.<host>.tool*`` server that answers.
+
+``PMIX_TOOL_CONNECT_OPTIONAL`` decides whether failing to find a server is
+an error or simply leaves the tool unconnected.
+
+Both paths converge on ``pmix_ptl_base_make_connection``, which parses the
+URI into a socket address, opens the connection (with retries), sends the
+connect-ack, runs the handshake, and — on success —
+``pmix_ptl_base_complete_connection`` records the server and arms the
+steady-state send/receive events.
+
+
+The Handshake
+-------------
+
+Once the socket is open, the connecting side sends a **connect-ack**: a
+message header followed by a payload the two ends have agreed to lay out
+field by field. The payload carries the security module name, a
+credential, a one-byte **flag** identifying the kind of connector, the
+process's identity (nspace/rank and/or uid/gid), its version, its
+``bfrops`` module and buffer type, its ``gds`` module, and an optional
+info blob.
+
+The flag (``pmix_rnd_flag_t``, values 0–10, defined in
+``src/mca/ptl/base/ptl_base_handshake.h``) distinguishes a simple client
+from a legacy tool, a launcher, a self-started tool that *needs* an
+identifier versus one that was *given* one, a server-started tool, a
+singleton, or a scheduler. The server switches on this flag to decide how
+much of the message to read and how to treat the connector.
+
+The payload is built with the ``PMIX_PTL_PUT_*`` macros on the sending
+side (``construct_message`` in ``ptl_base_fns.c``) and parsed with the
+symmetric ``PMIX_PTL_GET_*`` macros on the receiving side
+(``pmix_ptl_base_connection_handler`` in ``ptl_base_connection_hdlr.c``).
+The two macro families are deliberately mirror images so the two ends can
+be read side by side.
+
+**The field order of the handshake is a frozen wire-format contract.** A
+server and a client built from different PMIx releases must interoperate,
+so per PMIx's interoperability rules the layout is append-only: new fields
+may be added at the end, but nothing may be inserted, removed, or
+reordered. (There is one explicit legacy branch: a 2.0 peer's handshake
+ends at the version string, and the server assumes ``v20`` ``bfrops`` and
+``ds12,hash`` ``gds`` for it.)
+
+On the server side the connection handler:
+
+#. reads and parses the handshake (with the socket temporarily in blocking
+   mode), guarding sizes against ``PMIX_MAX_CRED_SIZE`` and taint limits;
+#. for a **simple client or singleton**, verifies the nspace and rank were
+   pre-registered, creates the peer, and assigns its ``psec`` / ``bfrops``
+   / ``gds`` compatibility modules;
+#. for a **tool or launcher**, runs the two-step ``process_tool_request``,
+   which may call the host's ``tool_connected`` upcall to assign a fresh
+   nspace, then returns it to the tool via ``process_cbfunc``;
+#. validates the credential with ``PMIX_PSEC_VALIDATE_CONNECTION``, informs
+   the host through ``client_connected2``, sends back the status and the
+   peer's array index, runs the security handshake if the ``psec`` module
+   requested one, arms the peer's events, and flushes any cached event
+   notifications to the newly connected peer.
+
+
+Messages in Steady State
+------------------------
+
+Once connected, all traffic is framed and runs on the progress thread
+(``src/mca/ptl/base/ptl_base_sendrecv.c``).
+
+Framing
+~~~~~~~
+
+Every message is a fixed header followed by its payload::
+
+    struct pmix_ptl_hdr_t {
+        int32_t  pindex;   /* sender's peer-array index          */
+        uint32_t tag;      /* matches a send to its posted recv  */
+        uint32_t nbytes;   /* payload length after the header    */
+    };
+
+Header integers travel in network byte order — this is the one place
+``ptl`` must be endian-correct on the wire; the payload itself is handled
+by ``bfrops``.
+
+Tags route a message to the right handler. Low reserved values name
+persistent channels (``PMIX_PTL_TAG_NOTIFY`` = 0,
+``PMIX_PTL_TAG_HEARTBEAT`` = 1, ``PMIX_PTL_TAG_IOF`` = 2); dynamic tags
+start at ``PMIX_PTL_TAG_DYNAMIC`` (100) and are handed out one per
+request/response exchange. To keep the two ends of a bidirectional socket
+from ever choosing the same dynamic tag, the dynamic-tag space is **split
+in half**: the side that accepted the connection uses the upper half, the
+side that initiated it uses the lower half. ``UINT_MAX`` is a
+wildcard/"any tag" recv.
+
+Sending and receiving
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Back-end code never calls ``send()``/``recv()`` directly. It uses macros
+from ``ptl_types.h`` that each allocate a small caddy, retain the peer,
+and thread-shift onto the progress thread:
+
+* ``PMIX_PTL_SEND_RECV`` — a two-way exchange: posts a one-shot recv on the
+  next dynamic tag, sends the request, and delivers the reply to a
+  callback;
+* ``PMIX_PTL_SEND_ONEWAY`` — fire-and-forget on a fixed tag;
+* ``PMIX_SERVER_QUEUE_REPLY`` — the server's reply path, queued directly
+  from within the progress thread.
+
+On the wire side, ``pmix_ptl_base_send_handler`` ``writev``\ s the header
+and payload together when the socket is writable, resuming across partial
+writes and ``EAGAIN``; ``pmix_ptl_base_recv_handler`` reads the header,
+bounds-checks ``nbytes`` against the ``max_msg_size`` MCA parameter,
+allocates and reads the payload, then posts the completed message to
+``pmix_ptl_base_process_msg``. That function walks the posted-recv list,
+matches on ``(peer, tag)``, and fires the recv's callback; a dynamic-tag
+recv is one-shot and is removed after it fires. A message that matches no
+posted recv is, by design, an error — this subsystem never receives
+anything it did not previously ask for.
+
+A send to oneself (``peer == pmix_globals.mypeer``) skips the socket
+entirely and is matched locally — this is how a server delivers messages
+to itself.
+
+Losing a connection
+~~~~~~~~~~~~~~~~~~~~~
+
+When a socket error or peer close is detected, ``lost_connection`` unwinds
+the state that depended on the peer: it stops the peer's events and closes
+the socket, and then either (as a server) accounts for the departed client
+in every collective it was participating in, purges its cached
+notifications, and reports ``PMIX_ERR_LOST_CONNECTION``; or (as a client
+whose server died) completes any in-flight ``SEND_RECV`` with an empty
+buffer so blocked callers do not hang, before reporting the event.
+
+
+Threading Model
+---------------
+
+Two regimes coexist:
+
+* **Init-time connection is synchronous.** ``connect_to_peer`` runs in the
+  caller's thread during ``PMIx_Init`` / ``PMIx_tool_init``, performs
+  *blocking* socket I/O, and returns only when the handshake is complete.
+  The server's per-connection handshake likewise flips the socket to
+  blocking mode for its duration. This is acceptable because it happens at
+  startup, before the peer joins steady-state traffic.
+* **Steady-state I/O is entirely on the progress thread.** Every
+  ``PMIX_PTL_SEND_*`` macro thread-shifts; the send/receive handlers,
+  message matching, the accept handler, and the connection handler all run
+  on ``pmix_globals.evbase``. Shared state — the posted-recv list, a
+  peer's send/receive queues — is touched only there.
+
+The various caddies (``pmix_ptl_sr_t``, ``pmix_ptl_queue_t``,
+``pmix_pending_connection_t``, and the connection handler's own object)
+each carry the mandatory ``pmix_event_t`` and retain the peer so it
+outlives the asynchronous hop, exactly as PMIx's thread-safety rules
+require.
+
+
+Configuration
+-------------
+
+The framework's behavior is tunable through MCA parameters registered in
+``ptl_base_frame.c`` (all under the ``pmix_ptl_base_`` prefix, most with
+deprecated ``pmix_ptl_tcp_`` synonyms): ``max_msg_size``,
+``if_include`` / ``if_exclude``, ``ipv4_ports`` / ``ipv6_ports``,
+``disable_ipv4_family`` / ``disable_ipv6_family``,
+``connection_wait_time`` / ``max_retries`` (how long and how often to wait
+for a server's rendezvous file to appear), ``handshake_wait_time`` /
+``handshake_max_retries``, and ``report_uri``. Inspect the current values
+for a build with::
+
+    pmix_info --param ptl base

--- a/src/mca/ptl/AGENTS.md
+++ b/src/mca/ptl/AGENTS.md
@@ -1,0 +1,460 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PTL Framework
+
+This document orients AI agents and human contributors working in the
+`ptl` (**P**MIx **T**ransport **L**ayer) framework. It assumes you have
+already read the top-level [`AGENTS.md`](../../../AGENTS.md) — the golden
+rules, prefix conventions, thread-safety/caddy model, and MCA concepts
+described there all apply here and are not repeated. This file covers
+what is specific to `ptl`: what the framework is for, the (unusual) way
+its components are selected, the wire protocol, how a connection is
+established from both ends, and how steady-state messages flow. Each
+component subdirectory (`client/`, `server/`, `tool/`) carries its own
+`AGENTS.md` with role-specific detail. For an integration-level view of
+how this framework connects a PMIx process to its server, see
+[`docs/how-things-work/ptl.rst`](../../../docs/how-things-work/ptl.rst).
+
+## What PTL does
+
+`ptl` is the socket layer that carries every PMIx message between a
+process and the PMIx server it talks to. It owns four things:
+
+1. **Connection establishment** — discovering *where* the server is (an
+   env var, an explicit URI, or a rendezvous file dropped in a tmpdir),
+   opening the TCP socket, and running the identity/security **handshake**
+   that both sides must agree on before any real traffic flows.
+2. **The listener** — on the server/tool side, selecting a network
+   interface, binding a listen socket, publishing its URI, and dropping
+   the rendezvous files that let clients and tools find it.
+3. **Message framing and transport** — a fixed header plus payload, sent
+   and received on the libevent progress thread, with a posted-recv/tag
+   matching scheme for delivering replies.
+4. **Connection teardown** — detecting a dropped peer and unwinding all
+   the state (events, collectives, notifications) that depended on it.
+
+Everything above the socket — packing/unpacking, security credentials,
+datastore selection — belongs to other frameworks (`bfrops`, `psec`,
+`gds`). `ptl` is purely the pipe and the rules for setting it up.
+
+## The single most important structural fact
+
+`ptl` is a **single-select** framework (only one component is active at a
+time), but it does **not** work the way most single-select frameworks do.
+
+In a typical framework the component *is* the implementation and the
+`base/` directory is just plumbing. In `ptl` it is the reverse: **the
+base owns essentially all of the code** — TCP sockets, framing, the
+handshake, the listener, interface discovery, rendezvous files,
+send/recv, teardown — and the three components (`client`, `server`,
+`tool`) are extremely thin *role selectors*. A component is little more
+than a `pmix_ptl_module_t` whose function pointers mostly point straight
+back at `pmix_ptl_base_*` functions in `base/`.
+
+Consequently:
+
+- **Components partition by process role, not by transport.** Only one
+  wins because `component_query` gates on `pmix_globals.mypeer`'s type
+  (see the selection table below), and the gates are mutually exclusive.
+  The `client` component takes a *pure client*; the `tool` component
+  takes *any tool* (including a launcher, which is tool+server); the
+  `server` component takes a *pure server*.
+- **The component priorities are effectively vestigial.** Because the
+  gates never overlap, at most one component ever returns a module, so
+  the "highest priority wins" logic in `pmix_ptl_base_select` never
+  actually arbitrates between two candidates.
+- **The header comment in `ptl.h` describes an aspiration, not today's
+  reality.** It says components exist to support new handshake versions
+  and new transports. In practice there is one transport (TCP, protocol
+  `PMIX_PROTOCOL_V2`); the old Unix-domain-socket transport (`usock`,
+  `PMIX_PROTOCOL_V1`) is gone except for the vestigial `base/usock.h`.
+  Handshake versioning is handled *inside* the base by inspecting the
+  peer's version string, not by swapping components.
+
+If you are looking for "the TCP code," it is in `base/`, not in a
+component. Read `base/` first.
+
+## Module interface (`pmix_ptl_module_t`)
+
+Defined in [`ptl.h`](ptl.h). A component fills in the subset of these it
+needs; the rest stay `NULL`.
+
+| Field | Signature | Who sets it | Purpose |
+|-------|-----------|-------------|---------|
+| `name` | `char *` | all | component name string |
+| `init` / `finalize` | `(void)` | none today | per-module lifecycle hooks (unused) |
+| `recv` | register a persistent recv | none today | vestigial — posted recvs are managed directly by the base |
+| `cancel` | cancel a persistent recv | none today | vestigial |
+| `connect_to_peer` | `(peer, info, ninfo, &suri)` | **all three** | open + handshake a connection *up* to a server |
+| `query_servers` | `(dirname, list)` | none today | vestigial — server discovery runs through `pmix_ptl_base_query_servers` |
+| `setup_listener` | `(info, ninfo)` | server, tool | bind a listen socket and publish rendezvous |
+| `setup_fork` | `(proc, &env)` | server, tool | inject `PMIX_*_TMPDIR` env into forked children |
+
+Note how much is `NULL`: `init`, `finalize`, `recv`, `cancel`, and
+`query_servers` are never wired by any current component. Do not assume a
+non-`NULL` value; the base guards these paths in other ways. The only
+functionally distinct component implementation is the `client`
+component's *own* `connect_to_peer` (a simpler client-only path) versus
+the shared `pmix_ptl_base_connect_to_peer` used by `server` and `tool`.
+
+The selected module is copied into the exported global
+**`pmix_ptl`** (in `base/ptl_base_frame.c`) during selection; all
+back-end code reaches the framework through that global and through the
+`PMIX_PTL_*` macros in [`ptl_types.h`](ptl_types.h).
+
+## Selection and lifecycle
+
+- **`base/ptl_base_frame.c`** declares the framework
+  (`PMIX_MCA_BASE_FRAMEWORK_DECLARE`), instantiates the global
+  `pmix_ptl_base` state struct and the `pmix_ptl` module, registers all
+  the MCA parameters (`pmix_ptl_register`), opens components
+  (`pmix_ptl_open`), and defines the `PMIX_CLASS_INSTANCE`s for the many
+  transport objects (`pmix_ptl_send_t`, `pmix_ptl_recv_t`,
+  `pmix_ptl_posted_recv_t`, `pmix_ptl_sr_t`, `pmix_ptl_queue_t`,
+  `pmix_pending_connection_t`, `pmix_listener_t`, `pmix_connection_t`).
+  `pmix_ptl_close` is where all the rendezvous files and tmpdirs created
+  by the listener are removed.
+- **`base/ptl_base_select.c`** (`pmix_ptl_base_select`) queries each
+  component, keeps the highest-priority module whose `init` (if any)
+  succeeds, and copies it into `pmix_ptl`. If none is selected it emits
+  the `no-plugins` `show_help` topic and returns `PMIX_ERR_SILENT` —
+  `ptl` requires exactly one component.
+
+Selection table (from each component's `component_query`):
+
+| Component | Priority | Selected when the local peer is… |
+|-----------|----------|----------------------------------|
+| `client`  | 50 | a client **and not** a tool (a "pure" client) |
+| `tool`    | 40 | any tool (debugger, launcher, or client-tool) |
+| `server`  | 30 | a server **and not** a tool (a "pure" server) |
+
+Remember these conditions are exclusive, so priority order never breaks a
+tie in practice. A **launcher** (`PMIX_PROC_LAUNCHER` = tool+server) is a
+tool for selection purposes and therefore uses the `tool` component —
+which is why the `tool` module carries `setup_listener` (a launcher must
+*listen* for its own children while also *connecting up* to its server).
+
+## Core data structures ([`ptl_types.h`](ptl_types.h))
+
+### Message header and tags
+
+```c
+typedef struct {
+    int32_t  pindex;   // sender's process index (peer array slot)
+    pmix_ptl_tag_t tag;  // matches a send to its posted recv
+    uint32_t nbytes;   // payload length following the header
+#if SIZEOF_SIZE_T == 8
+    uint32_t padding;  // keeps the header 8-byte aligned
+#endif
+} pmix_ptl_hdr_t;
+```
+
+Every message is `hdr` followed by `hdr.nbytes` of payload. Header
+integer fields travel in **network byte order** (`htonl`/`ntohl`) — this
+is the one place `ptl` must be endian-correct on the wire.
+
+Tags (`pmix_ptl_tag_t`, a `uint32_t`) route a message to the right
+handler:
+
+- **Reserved/persistent** tags: `PMIX_PTL_TAG_NOTIFY` (0),
+  `PMIX_PTL_TAG_HEARTBEAT` (1), `PMIX_PTL_TAG_IOF` (2). A persistent recv
+  posted on one of these fires for every matching message and is never
+  removed.
+- **Dynamic** tags start at `PMIX_PTL_TAG_DYNAMIC` (100) and are handed
+  out one per `SEND_RECV`. A dynamic-tag recv is **one-shot** — it is
+  removed after the reply fires.
+
+A subtle but load-bearing detail: the dynamic-tag space for a peer is
+**split in half** so the two ends of a bidirectional socket never collide
+on a tag. The side that *accepted* the connection uses the upper half
+(`base/ptl_base_connection_hdlr.c` sets `dyn_tags_start` to the midpoint);
+the side that *initiated* it uses the lower half
+(`pmix_ptl_base_make_connection` sets it to `PMIX_PTL_TAG_DYNAMIC`).
+`UINT_MAX` is reserved as a wildcard/"any tag" recv.
+
+### Transport objects
+
+- **`pmix_ptl_send_t`** — a queued outbound message (its own `hdr` +
+  `pmix_buffer_t *data`, plus `sdptr`/`sdbytes` cursor for partial
+  writes). Lives on a peer's `send_queue`; the head is the peer's
+  `send_msg` "on-deck" slot.
+- **`pmix_ptl_recv_t`** — an inbound message under assembly (`hdr` first,
+  then a malloc'd `data` region), carried by the peer's `recv_msg`.
+- **`pmix_ptl_posted_recv_t`** — a registered interest in `(peer, tag)`
+  with a `cbfunc`. Held on the framework-global
+  `pmix_ptl_base.posted_recvs` list; matched in `process_msg`.
+- **`pmix_ptl_sr_t`** / **`pmix_ptl_queue_t`** — the thread-shift caddies
+  behind the `PMIX_PTL_SEND_RECV` and `PMIX_PTL_SEND_ONEWAY` macros. Each
+  carries its own `pmix_event_t ev` (required by `PMIX_THREADSHIFT`) and
+  a retained `peer`.
+- **`pmix_pending_connection_t`** — a freshly `accept`ed but not-yet-
+  processed inbound connection (raw socket + everything parsed out of the
+  handshake). Built by the listener, consumed by the connection handler.
+- **`pmix_listener_t`** — the bound listen socket, its URI, its protocol,
+  and the accept `cbfunc`.
+- **`pmix_connection_t`** (declared in `base/base.h`) — one parsed
+  rendezvous entry (`nspace`, `rank`, `uri`, `version`) produced when
+  reading a connection file.
+
+### Process type and version
+
+`pmix_proc_type_t` packs a process's role bit-mask (`PMIX_PROC_CLIENT`,
+`PMIX_PROC_SERVER`, `PMIX_PROC_TOOL`, `PMIX_PROC_LAUNCHER`,
+`PMIX_PROC_SCHEDULER`, …) with its `major.minor.release` version. The
+`PMIX_PEER_IS_*` / `PMIX_PROC_IS_*` macros test the role bits; the
+`PMIX_PEER_IS_Vxx` / `PMIX_PEER_TRIPLET` macros test versions
+(255 = wildcard). These roles are what the component `component_query`
+functions and the connection handler switch on.
+
+## The public transport macros
+
+Back-end code never calls `send()`/`recv()`. It uses these macros from
+`ptl_types.h`, each of which allocates a caddy, retains the peer, and
+`PMIX_THREADSHIFT`s onto the progress thread:
+
+- **`PMIX_PTL_SEND_RECV(rc, peer, buf, cbfunc, cbdata)`** — two-way. Posts
+  a one-shot recv on the next dynamic tag, then sends `buf`. The reply is
+  delivered to `cbfunc`. Runs `pmix_ptl_base_send_recv`.
+- **`PMIX_PTL_SEND_ONEWAY(rc, peer, buf, tag)`** — fire-and-forget on a
+  fixed `tag`. Runs `pmix_ptl_base_send`.
+- **`PMIX_SERVER_QUEUE_REPLY(rc, peer, tag, buf)`** — the server's reply
+  path; queues a `pmix_ptl_send_t` directly onto the peer's send queue and
+  arms the send event. (This one runs inline in the progress thread — it
+  is only ever called from there.)
+
+All three short-circuit to `PMIX_ERR_UNREACH` if the peer is already
+`finalized`. The buffer is consumed (freed) by the transport.
+
+## How a message flows (steady state — `base/ptl_base_sendrecv.c`)
+
+**Sending.** `pmix_ptl_base_send` / `_send_recv` build a
+`pmix_ptl_send_t`, place it in the peer's `send_msg` on-deck slot (or
+append to `send_queue`), and activate the peer's persistent `send_event`.
+When the socket is writable, `pmix_ptl_base_send_handler` calls
+`send_msg`, which `writev`s the header and payload as one iovec. Partial
+writes / `EAGAIN` return `PMIX_ERR_RESOURCE_BUSY` and the event refires
+later; a hard error triggers `lost_connection`.
+
+**Receiving.** When the socket is readable,
+`pmix_ptl_base_recv_handler` reads the fixed-size header first, bounds-
+checks `nbytes` against `pmix_ptl_base.max_msg_size`, allocates the data
+region, reads the payload (resuming across `EAGAIN`), then
+`PMIX_ACTIVATE_POST_MSG` posts the completed `pmix_ptl_recv_t` to
+`pmix_ptl_base_process_msg`.
+
+**Matching.** `process_msg` walks `pmix_ptl_base.posted_recvs` looking for
+a recv whose `(peer, tag)` matches (with `UINT_MAX` as wildcard), loads
+the payload into a `pmix_buffer_t`, and fires the recv's `cbfunc`. A
+dynamic-tag recv is then removed and released. An unmatched message is an
+error (`unexpected-message` `show_help`) — by design this subsystem never
+receives anything it did not previously ask for.
+
+**Loopback.** A send whose peer is `pmix_globals.mypeer` skips the socket
+entirely: the buffer is handed straight to `PMIX_ACTIVATE_POST_MSG` and
+matched locally. This is how a server delivers to itself.
+
+**Teardown.** `lost_connection` stops the peer's events, closes the
+socket, and — if we are a server — accounts for the departed client in
+every collective tracker it was part of (adjusting counts, possibly
+completing or forwarding the collective), purges its cached
+notifications, and reports `PMIX_ERR_LOST_CONNECTION`. If instead our
+*server* died, it completes any in-flight `SEND_RECV`s with an empty
+buffer so blocked callers do not hang, then reports the event.
+
+## How a connection is established
+
+### Outbound (a process connecting up to its server)
+
+Entry point is `pmix_ptl.connect_to_peer`, invoked (blocking) during
+init. Two implementations:
+
+- **Client** (`client/ptl_client.c`): the simple path. Reads
+  `PMIX_SERVER_URI` from the info array or environment (via
+  `pmix_ptl_base_set_peer`, which also detects the server's version by
+  which `PMIX_SERVER_URIvNN` env var is set); if none is found, tries the
+  system rendezvous file and otherwise declares itself a **singleton**.
+- **Tool/server** (`base/ptl_base_connect_to_peer`): the full discovery
+  matrix. Honors a caller-specified connection **order**
+  (`PMIX_CONNECT_SYSTEM_FIRST`, `PMIX_CONNECT_TO_SYSTEM`,
+  `PMIX_CONNECT_TO_SCHEDULER`, `PMIX_CONNECT_TO_SYS_CONTROLLER`), an
+  explicit URI, a rendezvous/attachment file, a server PID, a server
+  nspace, or a directory search of the session tmpdir — collecting our
+  pid/uid/gid/cmd-line into an info array to hand the server along the way.
+
+Both converge on **`pmix_ptl_base_make_connection`**:
+`setup_connection` (parse the `tcp4://host:port` URI into a
+`sockaddr_storage`) → `pmix_ptl_base_connect` (open the socket, retrying)
+→ `send_connect_ack` (`construct_message` builds the handshake blob) →
+`recv_connect_ack` (run the client or tool handshake) → assign the lower
+half of the dynamic-tag space. Then `pmix_ptl_base_complete_connection`
+sets the `connected` flag, records the server's nspace/rank, and arms the
+recv/send events for steady-state traffic.
+
+### Inbound (a server accepting a client or tool)
+
+The listener's accept handler
+(`base/ptl_base_listener.c::connection_event_handler`) does the minimum —
+`accept`, wrap the fd in a `pmix_pending_connection_t`, and post it — then
+`base/ptl_base_connection_hdlr.c::pmix_ptl_base_connection_handler` does
+the real work on the progress thread:
+
+1. Read the handshake header + payload (socket temporarily in **blocking**
+   mode), guarded by `PMIX_MAX_CRED_SIZE` / taint limits.
+2. Parse it with the `PMIX_PTL_GET_*` macros
+   ([`base/ptl_base_handshake.h`](base/ptl_base_handshake.h)): psec name,
+   credential, a **flag** (`pmix_rnd_flag_t`, 0–10) identifying the kind
+   of connector, the peer's procid/uid/gid, version, bfrops module, buffer
+   type, gds module, and an optional info blob. There is a special case
+   for a 2.0 peer, whose handshake ends at the version string.
+3. Branch on the flag: a **simple client / singleton** must already be a
+   registered nspace+rank; a **tool/launcher** goes through the two-step
+   `process_tool_request` (which may call the host's `tool_connected` to
+   get an nspace assigned, then `process_cbfunc` sends it back).
+4. Assign the peer's compat modules (`psec`, `bfrops`, `gds`), validate
+   the credential (`PMIX_PSEC_VALIDATE_CONNECTION`), tell the host via
+   `client_connected2`, then `_cnct_complete` sends back the status +
+   the peer's array index, runs the security handshake if the psec module
+   asked for one, arms events, and flushes any cached notifications.
+
+The `PMIX_PTL_PUT_*` (build) and `PMIX_PTL_GET_*` (parse) macro pairs are
+deliberately symmetric so the two ends can be read side by side. **The
+field order in the handshake is a wire-format contract** — per the
+top-level interoperability rules it is append-only; never insert or
+reorder.
+
+## The listener (`base/ptl_base_listener.c`)
+
+`pmix_ptl_base_setup_listener` is where a server/tool chooses how it can
+be reached:
+
+- **Interface selection.** Enumerate interfaces, filter through
+  `if_include`/`if_exclude`, and default to a **loopback** device. Only
+  if remote or tool connections were requested does it fall back to a
+  public interface; the various "no interfaces" `show_help` topics fire
+  when the request cannot be satisfied.
+- **Bind.** Try each port from `ipv4_ports` / `ipv6_ports` (default `0` =
+  let the kernel choose), set `SO_REUSEADDR` and close-on-exec, `listen`
+  with `SOMAXCONN`, and make the socket non-blocking.
+- **Publish.** Build the URI `nspace.rank;tcp4://host:port`, store it in
+  `gds` under both `PMIX_MYSERVER_URI` and (for older tools)
+  `PMIX_SERVER_URI`, optionally emit it via `report_uri`
+  (`-`=stdout, `+`=stderr, an integer pipe fd, or a file).
+- **Rendezvous files.** Depending on role/flags, drop contact files a
+  peer can discover: `pmix.sched.<host>` (scheduler),
+  `pmix.sysctrlr.<host>` (system controller), `pmix.sys.<host>` (system
+  tool), `pmix.<host>.tool` (session tool), `pmix.<host>.tool.<pid>`, and
+  `pmix.<host>.tool.<nspace>`. Each holds `uri / version / pid / uid:gid /
+  timestamp`. The `created_*` bookkeeping in `pmix_ptl_base` records which
+  of these we made so `pmix_ptl_close` can remove exactly those.
+
+`pmix_ptl_base_start_listening` then registers the listen socket's accept
+event on the progress thread.
+
+## MCA parameters (registered in `ptl_base_frame.c`)
+
+All under the `pmix_ptl_base_` prefix, most with deprecated
+`pmix_ptl_tcp_` synonyms retained for compatibility:
+
+| Parameter | Meaning |
+|-----------|---------|
+| `max_msg_size` | cap (MB) on an inbound message; 0 → taint limit |
+| `if_include` / `if_exclude` | interface selection (mutually exclusive) |
+| `ipv4_ports` / `ipv6_ports` | ports to try when binding the listener |
+| `disable_ipv4_family` / `disable_ipv6_family` | skip a whole address family (IPv6 disabled by default) |
+| `connection_wait_time` / `max_retries` | how long/often to wait for a server's connection file to appear |
+| `handshake_wait_time` / `handshake_max_retries` | timeout/retries on the connect-ack exchange |
+| `report_uri` | where to print the listener URI |
+
+Per the top-level guidance, prefer adding an MCA parameter (or, better, an
+attribute honored by `connect_to_peer`/`setup_listener`) over hard-coding
+a new constant.
+
+## Threading model
+
+Two distinct regimes coexist, and confusing them is the most common way
+to break this framework:
+
+1. **Init-time connection is synchronous and blocking.** `connect_to_peer`
+   runs in the caller's thread during `PMIx_Init`/`PMIx_tool_init`, does
+   *blocking* socket I/O, and returns only once the handshake completes.
+   The listener's per-connection handshake likewise flips the socket to
+   blocking mode for the duration. This is acceptable precisely because it
+   is startup, before the peer is participating in steady-state traffic.
+2. **Steady-state I/O is entirely on the progress thread.** Every
+   `PMIX_PTL_SEND_*` macro thread-shifts; the send/recv handlers,
+   `process_msg`, the accept handler, and the connection handler all run
+   on `pmix_globals.evbase`. Shared state
+   (`pmix_ptl_base.posted_recvs`, a peer's send/recv queues) is touched
+   only there.
+
+The caddies (`pmix_ptl_sr_t`, `pmix_ptl_queue_t`, `pmix_pending_connection_t`,
+`cnct_hdlr_t`) all carry the mandatory `pmix_event_t ev` and retain the
+peer so it outlives the async hop, exactly as the top-level thread-safety
+rules require. The blocking file-wait paths (`pmix_ptl_base_parse_uri_file`,
+`check_server`) use a local `pmix_lock_t` + evtimer to sleep on the
+progress thread without spinning.
+
+## Directory layout
+
+```
+src/mca/ptl/
+├── ptl.h                       Framework API: module struct, macros, component struct, version
+├── ptl_types.h                 Header, tags, transport objects, proc-type & version macros
+├── base/
+│   ├── base.h                  Internal base API + the pmix_ptl_base global-state struct
+│   ├── ptl_base_handshake.h    PUT_*/GET_* handshake (de)serialization macros + rnd flags
+│   ├── ptl_base_frame.c        open/close, MCA params, framework decl, class instances
+│   ├── ptl_base_select.c       role-based component selection
+│   ├── ptl_base_connect.c      outbound connection: discovery matrix + socket connect
+│   ├── ptl_base_connection_hdlr.c  inbound connection: accept → parse handshake → validate
+│   ├── ptl_base_listener.c     interface selection, bind, publish URI, rendezvous files
+│   ├── ptl_base_sendrecv.c     send/recv handlers, tag matching, lost-connection teardown
+│   ├── ptl_base_fns.c          handshake build/parse, URI parsing, file discovery, helpers
+│   ├── ptl_base_stubs.c        version comparison + notification-recv registration
+│   └── usock.h                 vestige of the removed Unix-socket transport
+├── client/                     pure-client role (its own simpler connect_to_peer)
+├── server/                     pure-server role (base connect + listener + fork)
+└── tool/                       any-tool role (base connect + listener w/ cleanup + fork)
+```
+
+## Building
+
+All three components are statically built into `libpmix` and wired
+through the generated `base/static-components.h`; none ships a
+`configure.m4`, so none is conditionally compiled out. Editing a
+`Makefile.am` only needs a plain `make`; adding or removing a *component
+directory* changes the build wiring resolved by `configure`, so re-run
+`./autogen.pl && ./configure … && make`. `ptl` **does** ship its own
+`show_help` file, `base/help-ptl-base.txt` — per the top-level golden
+rule, after any add/delete/modify of that text you must
+`rm src/util/pmix_show_help_content.* && make` to regenerate the compiled
+help content.
+
+## When working in this framework
+
+- **Do not add a component to implement a new transport or handshake
+  without team consensus.** The current design puts everything in the
+  base and selects components by role; a genuine second transport would be
+  a significant departure. Discuss it on a GitHub issue first.
+- **Treat the handshake and header layouts as frozen wire formats.**
+  Append only, never reorder — a server and client built from different
+  PMIx releases must interoperate (see the top-level interoperability
+  rules). The `PMIX_PTL_PUT_*`/`GET_*` pairs must stay symmetric.
+- **Never touch a peer's queues or the posted-recv list outside the
+  progress thread.** Use the `PMIX_PTL_*` macros; they thread-shift for
+  you. Only `connect_to_peer`/`setup_listener` run synchronously, and only
+  at init.
+- **Keep the `created_*` bookkeeping honest.** Every rendezvous file or
+  tmpdir the listener creates must be recorded so `pmix_ptl_close` removes
+  exactly what we made and nothing a peer owns.
+- **Watch byte order.** Header integers and the handshake's `PUT_U32`/
+  `GET_U32` fields are network-order on the wire; the payload buffer is
+  handled by `bfrops`, not here.

--- a/src/mca/ptl/CLAUDE.md
+++ b/src/mca/ptl/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/ptl/client/AGENTS.md
+++ b/src/mca/ptl/client/AGENTS.md
@@ -1,0 +1,106 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PTL `client` Component
+
+`client` is the `ptl` component selected by a **pure client** process — a
+process that was registered with a PMIx server before it started and
+connects via `PMIx_Init`. Read the framework [`AGENTS.md`](../AGENTS.md)
+first; this file covers only what is specific to `client`. It is the
+simplest of the three components and the only one that supplies its *own*
+`connect_to_peer` rather than reusing the base's discovery matrix.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `ptl_client.h` | Declares the component and module symbols. |
+| `ptl_client_component.c` | Component struct + `component_query` (priority **50**). |
+| `ptl_client.c` | The module: a single `connect_to_peer` implementation. |
+
+## When it is selected
+
+`component_query` returns the module only when the local peer
+
+```c
+PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)
+```
+
+i.e. a client that is *not also* a tool. A client-tool or launcher is a
+tool for selection purposes and takes the [`tool`](../tool/AGENTS.md)
+component instead. Because this gate is mutually exclusive with the tool
+and server gates, the priority value (50) never actually arbitrates a tie
+— see the framework doc.
+
+## The module
+
+```c
+pmix_ptl_module_t pmix_ptl_client_module = {
+    .name = "client",
+    .connect_to_peer = connect_to_peer
+};
+```
+
+Everything else is `NULL`. A client never listens for connections, never
+forks PMIx children of its own, and needs no `init`/`finalize` — it only
+ever connects *up* to the one server that started it.
+
+## What `connect_to_peer` does
+
+This is the **short** connection path, in contrast to the full discovery
+matrix in `pmix_ptl_base_connect_to_peer` used by tools and servers. A
+client already knows (or can trivially find) its server, so the logic is:
+
+1. **Look for an explicit `PMIX_SERVER_URI`** in the passed info array. If
+   present, split the version prefix from the URI, and call
+   `pmix_ptl_base_set_peer` on each `:`-separated candidate to select the
+   matching `bfrops` module and record the server's version.
+2. **Collect our identity** (`PMIX_PROC_PID`, `PMIX_CMD_LINE`) into an
+   info array to hand the server during the handshake.
+3. **If no URI was given, check the environment** via
+   `pmix_ptl_base_set_peer(peer, &evar)` — which walks the active
+   `bfrops` modules in priority order and, for each, looks for the
+   corresponding `PMIX_SERVER_URIvNN` env var. Finding one both yields the
+   URI *and* tells us the server's version.
+4. **Singleton fallback.** If neither a URI nor an env var is found, this
+   process was not launched under a PMIx server. Mark ourselves a
+   `PMIX_PROC_SINGLETON`, assign default `bfrops` modules, and look for a
+   *system* server via the `pmix.sys.<host>` rendezvous file in the system
+   tmpdir. If that connects, great; otherwise return `PMIX_ERR_UNREACH`
+   and the library proceeds as a standalone singleton.
+5. **Connect.** With a URI in hand, `pmix_ptl_base_parse_uri` splits it
+   into `nspace` / `rank` / `suri`, and `pmix_ptl_base_make_connection`
+   opens the socket and runs the handshake. `pmix_ptl_base_complete_connection`
+   then records the server and arms the steady-state events.
+
+## Why the client path is separate
+
+The base `connect_to_peer` exists to serve *tools*, which may connect to
+any of several servers (system, scheduler, controller, a specific PID or
+nspace, an arbitrary URI) and must search for them. A client has exactly
+one server — the one that registered and launched it — so folding it into
+the tool matrix would add branches that can never fire for a client and
+would blur the singleton-detection logic. Keeping the client path small
+and separate is deliberate; resist the urge to "unify" the two.
+
+## Gotchas
+
+- **The singleton decision lives here.** A client that finds no server is
+  how PMIx recognizes a singleton. Do not change the fallback to return an
+  error before the system-server probe, or singletons that *do* have a
+  system server will fail to connect.
+- **Version detection is a side effect of URI discovery.**
+  `pmix_ptl_base_set_peer` couples "which env var is set" to "which
+  `bfrops`/version the server speaks." If you refactor URI lookup, keep
+  that coupling — the client otherwise has no other signal for the
+  server's version at connect time.
+- The heavy lifting (socket, handshake, framing) is all in the base; this
+  file only decides *where* to connect. Bug reports about the wire
+  protocol belong in `base/`, not here.

--- a/src/mca/ptl/client/CLAUDE.md
+++ b/src/mca/ptl/client/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/ptl/server/AGENTS.md
+++ b/src/mca/ptl/server/AGENTS.md
@@ -1,0 +1,94 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PTL `server` Component
+
+`server` is the `ptl` component selected by a **pure server** process —
+one that hosts the PMIx server library for a resource manager or launcher
+and is *not* itself a tool. Read the framework [`AGENTS.md`](../AGENTS.md)
+first; this file covers only what is specific to `server`. It is a pure
+pass-through to the base: it adds no code of its own, only wiring.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `ptl_server.h` | Declares the component and module symbols. |
+| `ptl_server_component.c` | Component struct + `component_query` (priority **30**). |
+| `ptl_server.c` | The module — three base function pointers, nothing else. |
+
+Note `ptl_server.c` has no functions of its own at all:
+
+```c
+pmix_ptl_module_t pmix_ptl_server_module = {
+    .name = "server",
+    .connect_to_peer = pmix_ptl_base_connect_to_peer,
+    .setup_fork      = pmix_ptl_base_setup_fork,
+    .setup_listener  = pmix_ptl_base_setup_listener
+};
+```
+
+## When it is selected
+
+`component_query` returns the module only when the local peer
+
+```c
+PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)
+```
+
+The `!PMIX_PEER_IS_TOOL` clause is what makes this the *pure*-server
+component: a **launcher** is `tool+server` and therefore matches the
+[`tool`](../tool/AGENTS.md) gate, not this one. So the `server` component
+runs in exactly the classic case — an RM daemon (e.g. PRRTE's `prted`,
+Slurm's plugin host) that accepts client and tool connections but never
+connects *as a tool* to anything above it.
+
+## What each wired function does
+
+All three point straight at the base; see the framework doc and the base
+sources for detail.
+
+- **`setup_listener` → `pmix_ptl_base_setup_listener`**: the server's main
+  job. Selects an interface (loopback unless remote/tool connections were
+  requested), binds a listen socket, publishes its URI into `gds`, and
+  drops the rendezvous files (`pmix.sys.<host>`, `pmix.<host>.tool*`, and
+  — if this server is a scheduler or system controller — the
+  correspondingly named files) that let clients and tools find it. The
+  accept event is then armed by `pmix_ptl_base_start_listening`, and every
+  inbound connection is handled by
+  `base/ptl_base_connection_hdlr.c::pmix_ptl_base_connection_handler`.
+- **`setup_fork` → `pmix_ptl_base_setup_fork`**: injects
+  `PMIX_SERVER_TMPDIR` and `PMIX_SYSTEM_TMPDIR` into the environment of
+  child processes the server launches, so those children's `ptl` layer can
+  find the same rendezvous directories.
+- **`connect_to_peer` → `pmix_ptl_base_connect_to_peer`**: present so a
+  server can, when needed, connect *up* to another server (e.g. a system
+  server or scheduler) using the full discovery matrix. In the common case
+  a pure server only *accepts* connections and never uses this.
+
+## Why there is nothing else here
+
+The entire server-side protocol — accepting sockets, parsing the
+handshake, validating credentials, assigning compat modules, calling the
+host's `client_connected2` / `tool_connected` upcalls — lives in
+`base/ptl_base_connection_hdlr.c`, not in this component. The `server`
+component is just the role marker that says "this process should listen."
+If you are debugging how the server treats an incoming connection, that
+file is where to look; changes here would only ever be to the three
+pointers above.
+
+## Contrast with the `tool` component
+
+The [`tool`](../tool/AGENTS.md) module wires the *same* three base
+functions but wraps `setup_listener` in an extra step that registers the
+tool's own rendezvous files for cleanup via `PMIx_Job_control_nb`. A pure
+server does not need that wrapper (its files are removed directly in
+`pmix_ptl_close`), which is the only functional difference between the two
+modules' listener setup.

--- a/src/mca/ptl/server/CLAUDE.md
+++ b/src/mca/ptl/server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/ptl/tool/AGENTS.md
+++ b/src/mca/ptl/tool/AGENTS.md
@@ -1,0 +1,126 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PTL `tool` Component
+
+`tool` is the `ptl` component selected by **any tool** process — a
+debugger, profiler, launcher, or client-tool that initializes via
+`PMIx_tool_init`. Read the framework [`AGENTS.md`](../AGENTS.md) first;
+this file covers only what is specific to `tool`. It is the broadest of
+the three components (it claims launchers and client-tools as well as
+plain tools) and the only one that adds a small wrapper of its own around
+the base.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `ptl_tool.h` | Declares the component and module symbols. |
+| `ptl_tool_component.c` | Component struct + `component_query` (priority **40**). |
+| `ptl_tool.c` | The module + a local `setup_listener` wrapper. |
+
+```c
+pmix_ptl_module_t pmix_ptl_tool_module = {
+    .name = "tool",
+    .connect_to_peer = pmix_ptl_base_connect_to_peer,
+    .setup_fork      = pmix_ptl_base_setup_fork,
+    .setup_listener  = setup_listener   // local wrapper, see below
+};
+```
+
+## When it is selected
+
+`component_query` returns the module whenever
+
+```c
+PMIX_PEER_IS_TOOL(pmix_globals.mypeer)
+```
+
+That single condition is deliberately broad. Because `PMIX_PROC_LAUNCHER`
+and `PMIX_PROC_CLIENT_TOOL` both include the `PMIX_PROC_TOOL` bit, this
+component also serves:
+
+- **Launchers** (`tool+server`) — which is why the module carries
+  `setup_listener`: a launcher must *listen* for the children it spawns
+  while also *connecting up* to its own server.
+- **Client-tools** (`tool+client`) — a process that is both a registered
+  client and a tool.
+
+The pure-[`client`](../client/AGENTS.md) and pure-[`server`](../server/AGENTS.md)
+gates explicitly exclude tools, so there is never a selection conflict.
+
+## The `connect_to_peer` path
+
+`tool` uses the base's full **discovery matrix**
+(`pmix_ptl_base_connect_to_peer`), not the client's short path. A tool may
+be trying to reach any of several servers and must search for the right
+one. The base honors, roughly in this order of specificity:
+
+- an explicit `PMIX_SERVER_URI` / `PMIX_TCP_URI`;
+- a rendezvous / `PMIX_TOOL_ATTACHMENT_FILE`;
+- a caller-supplied **connection order**
+  (`PMIX_CONNECT_SYSTEM_FIRST`, `PMIX_CONNECT_TO_SYSTEM`,
+  `PMIX_CONNECT_TO_SCHEDULER`, `PMIX_CONNECT_TO_SYS_CONTROLLER`), each of
+  which maps to a well-known rendezvous filename in the system tmpdir;
+- a specific server **PID** (`pmix.<host>.tool.<pid>`) or **nspace**
+  (`pmix.<host>.tool.<nspace>`);
+- otherwise a directory search of the session tmpdir for any
+  `pmix.<host>.tool*` server, taking the first that connects.
+
+`PMIX_TOOL_CONNECT_OPTIONAL` controls whether failure to find a server is
+fatal or simply leaves the tool unconnected. All of this lives in
+`base/ptl_base_connect.c`; the component only selects it.
+
+## The local `setup_listener` wrapper
+
+This is the one piece of genuinely component-specific code in `ptl`. It
+calls `pmix_ptl_base_setup_listener` (identical to what the `server`
+component uses) and then adds a cleanup step:
+
+```c
+rc = pmix_ptl_base_setup_listener(info, ninfo);
+...
+if (connected) {
+    // register our nspace/session rendezvous files with the server
+    // for cleanup via PMIx_Job_control_nb(PMIX_REGISTER_CLEANUP, ...)
+}
+```
+
+If the tool is connected to a server, it hands that server the paths of
+the rendezvous files it just created (`nspace_filename`,
+`session_filename`) via `PMIx_Job_control_nb` with `PMIX_REGISTER_CLEANUP`.
+That way, if the tool dies abruptly, the **server** removes the tool's
+stale rendezvous files — a pure server has no equivalent need because it
+removes its own files directly in `pmix_ptl_close`.
+
+## Why a tool both listens and connects
+
+A plain debugger only connects up to a server and would not strictly need
+`setup_listener`. But a **launcher** — the dominant tool case — is
+simultaneously a server to the processes it starts. Rather than split
+tools into "listening" and "non-listening" variants, the single `tool`
+component always wires `setup_listener`; a tool that never spawns children
+simply never has anyone connect to its listener. Keep this in mind before
+"optimizing away" the listener for tools.
+
+## Gotchas
+
+- **The cleanup registration is guarded by `pmix_globals.connected`.** A
+  tool that set up its listener *before* connecting to a server will not
+  register its files for remote cleanup. That ordering is intentional
+  (you cannot ask a server to clean up for you before you have a server),
+  but it means an unconnected tool relies on its own `pmix_ptl_close` to
+  remove its files.
+- Like the other components, `tool` contains no transport code. The
+  handshake it performs when connecting (as a `PMIX_TOOL_*` flag value)
+  and the server-side handling of a tool connection both live in the
+  base — `ptl_base_fns.c` (`pmix_ptl_base_tool_handshake`,
+  `pmix_ptl_base_set_flag`) and `ptl_base_connection_hdlr.c`
+  (`process_tool_request` / `process_cbfunc`).

--- a/src/mca/ptl/tool/CLAUDE.md
+++ b/src/mca/ptl/tool/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Document the PMIx Transport Layer (`ptl`) framework for AI agents and human contributors.

The `ptl` framework has an unusual shape for a single-select framework: nearly all of the logic — TCP sockets, message framing, the connection handshake, the listener, rendezvous-file discovery, send/recv, and teardown — lives in the base, while the three components (`client`, `server`, `tool`) are thin role selectors chosen by process type. These guides capture that structure and the load-bearing details a contributor needs before working in the area.

### What's added

- **`src/mca/ptl/AGENTS.md`** — framework guide: the role-based selection model, the module interface, the message header/tag scheme (including the split dynamic-tag space that keeps the two ends of a socket from colliding), the public `PMIX_PTL_*` transport macros, steady-state send/recv/match/teardown, both directions of connection establishment, the handshake wire-format contract, the listener and its rendezvous files, MCA parameters, and the two-regime (blocking-at-init / progress-thread-in-steady-state) threading model.
- **`src/mca/ptl/{client,server,tool}/AGENTS.md`** — per-component internals, focusing on how each role is selected and what little code (if any) each adds beyond the base.
- A **`CLAUDE.md` symlink** alongside each `AGENTS.md`, matching the convention already used under `src/mca/preg` and `src/mca/plog`.
- **`docs/how-things-work/ptl.rst`** — a developer-facing prose explanation of how the transport layer integrates into the wider library, wired into the how-things-work index and cross-referencing the `AGENTS.md` files (same pattern as `regex.rst` ↔ `preg`).

### Testing

Documentation only; no functional change. Built the docs with `sphinx-build` — `ptl.rst` renders with no warnings, errors, or toctree issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)