### PR TITLE
pstat: orientation docs plus disk/net /proc parsing fixes

### DIFF
--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -19,3 +19,4 @@ find information on that subject here.
    pmix_log.rst
    regex.rst
    ptl.rst
+   pstat.rst

--- a/docs/how-things-work/pstat.rst
+++ b/docs/how-things-work/pstat.rst
@@ -1,0 +1,314 @@
+Process & Resource Statistics (Monitoring)
+==========================================
+
+This document describes how PMIx answers a request for
+resource-utilization statistics — per-process CPU/memory usage, node
+load and memory, disk counters, and network counters — from the
+``PMIx_Process_monitor`` family of APIs down through the MCA ``pstat``
+(Process Statistics) framework and its components. It also covers
+the *periodic* monitoring mode, in which the server keeps sampling on a
+timer and streams each sample back to the requestor as a PMIx event.
+
+For a code-oriented orientation aimed at contributors working *inside*
+the framework, each ``pstat`` directory also carries an ``AGENTS.md``
+(with a ``CLAUDE.md`` symlink): ``src/mca/pstat/AGENTS.md`` for the
+framework as a whole, plus one each in ``plinux/`` and ``test/``. This
+document explains how the pieces fit into the wider library; those explain
+each piece's internals in detail.
+
+
+The Problem
+-----------
+
+A resource manager, a tool such as an activity monitor, or an application
+runtime often needs to know how much CPU, memory, disk, or network a set
+of processes — or a whole node — is consuming. In an HPC system those
+processes are spread across many nodes, and only the PMIx *server* on each
+node can actually read that node's operating system. A client or tool
+cannot read ``/proc`` for a process on some other node.
+
+PMIx therefore exposes a single generic **monitoring** API and routes each
+request to wherever the data lives:
+
+* a **local** portion — processes or a node the receiving server owns — is
+  satisfied by reading the local OS; and
+* a **remote** portion — anything on other nodes — is handed up to the
+  host resource manager, which relays it to the relevant servers.
+
+The ``pstat`` framework owns the *local* half: reading the local operating
+system and packaging the numbers as PMIx attributes. The routing decision
+itself lives just above it, in ``src/common/pmix_monitor.c``.
+
+
+Public API
+----------
+
+Three functions are exported from ``include/pmix.h``::
+
+    pmix_status_t PMIx_Process_monitor(const pmix_info_t *monitor,
+                                       pmix_status_t error,
+                                       const pmix_info_t directives[],
+                                       size_t ndirs,
+                                       pmix_info_t **results,
+                                       size_t *nresults);
+
+    pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor,
+                                          pmix_status_t error,
+                                          const pmix_info_t directives[],
+                                          size_t ndirs,
+                                          pmix_info_cbfunc_t cbfunc,
+                                          void *cbdata);
+
+    void PMIx_Heartbeat(void);
+
+``PMIx_Process_monitor`` is a thin blocking wrapper: it constructs a
+``pmix_cb_t``, calls ``PMIx_Process_monitor_nb``, and sleeps on the
+condition variable inside the callback object until the non-blocking path
+completes. Both are implemented in ``src/common/pmix_monitor.c``.
+
+The single ``monitor`` argument is the request. Its **key** names *what
+kind* of statistics are wanted; its **value** is a ``PMIX_DATA_ARRAY`` of
+``pmix_info_t`` naming the *specific fields*. The ``directives`` array
+qualifies the request — which processes/nodes to target, whether to sample
+once or periodically, an ID handle, and so on. As with every PMIx API, new
+capability is added by defining new attributes rather than new entry
+points.
+
+``PMIx_Heartbeat`` and the ``PMIX_SEND_HEARTBEAT`` monitor key are a
+distinct, lighter-weight use of the same API used for liveness detection;
+they are handled entirely in ``pmix_monitor.c`` and never reach the
+``pstat`` framework, so they are not discussed further here.
+
+
+Request Attributes
+-------------------
+
+The monitor **keys** (the ``monitor->key``) that ``pstat`` understands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Monitor key
+     - Meaning
+   * - ``PMIX_MONITOR_PROC_RESOURCE_USAGE``
+     - per-process statistics
+   * - ``PMIX_MONITOR_NODE_RESOURCE_USAGE``
+     - node load / memory (may nest network + disk)
+   * - ``PMIX_MONITOR_DISK_RESOURCE_USAGE``
+     - disk read/write/io counters
+   * - ``PMIX_MONITOR_NET_RESOURCE_USAGE``
+     - network byte/packet/error counters
+   * - ``PMIX_MONITOR_CANCEL``
+     - cancel a previously-started periodic monitor (value = its ID)
+
+The **directives** that shape a request:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Directive
+     - Effect
+   * - ``PMIX_MONITOR_ID``
+     - caller-supplied string handle; required to later cancel a periodic monitor
+   * - ``PMIX_MONITOR_RESOURCE_RATE``
+     - sample **periodically** every N seconds (uint32) instead of once
+   * - ``PMIX_MONITOR_TARGET_PROCS``
+     - array of ``pmix_proc_t`` restricting which processes to sample
+   * - ``PMIX_MONITOR_TARGET_PIDS``
+     - array of ``pmix_node_pid_t`` (node + pid) restricting the sample
+   * - ``PMIX_MONITOR_TARGET_NODES`` / ``PMIX_MONITOR_TARGET_NODEIDS``
+     - restrict to named nodes / node IDs (used for scope resolution)
+   * - ``PMIX_MONITOR_LOCAL_ONLY``
+     - do not forward any part of the request to the host RM
+
+The **results** come back under one attribute per category, each a
+``PMIX_DATA_ARRAY`` of the individual measurements:
+``PMIX_PROC_RESOURCE_USAGE``, ``PMIX_NODE_RESOURCE_USAGE``,
+``PMIX_DISK_RESOURCE_USAGE``, and ``PMIX_NETWORK_RESOURCE_USAGE``. Each
+inner array is tagged with a sample time (``PMIX_PROC_SAMPLE_TIME``,
+``PMIX_NODE_SAMPLE_TIME``, and so on). Because every component emits the
+same attributes, a caller parses the answer identically regardless of
+which component (or node) produced it.
+
+
+From API to Framework
+---------------------
+
+The path from the public call to the framework is:
+
+#. **Client / tool side.** A non-server process cannot read the OS, so
+   ``PMIx_Process_monitor_nb`` packs the ``monitor``, error code, and
+   directives into a ``PMIX_MONITOR_CMD`` message and sends it to its
+   server. The reply is unpacked and handed to the caller's callback.
+
+#. **Server side, entry.** A server calling the API locally, or receiving
+   the command from a client (``pmix_server_monitor`` in
+   ``src/server/pmix_server_ops.c``), builds a ``pmix_cb_t`` carrying the
+   monitor, directives, and requestor identity, and thread-shifts it onto
+   the progress thread via ``PMIX_THREADSHIFT(cb, pmix_monitor_processing)``.
+
+#. **Scope resolution.** ``pmix_monitor_processing`` walks the target
+   directives to classify the request as *local*, *remote*, or *both*, by
+   comparing the requested procs/nodes/pids against
+   ``pmix_server_globals.clients`` and the local hostname/nodeid:
+
+   * purely local — call ``pmix_pstat.query(...)`` and return its results
+     directly;
+   * purely remote — call ``pmix_host_server.monitor(...)`` (the host RM);
+     if the host provides no monitor entry point, return
+     ``PMIX_ERR_NOT_SUPPORTED``;
+   * both — call ``pmix_pstat.query`` for the local contribution, then
+     pass the request up to the host and *combine* the local results with
+     whatever the host returns (see ``hostcb`` / ``hostprocess``).
+
+#. **Into ``pstat``.** ``pmix_pstat.query`` is the selected component's
+   ``query`` function — the boundary into the framework. It is synchronous
+   and already on the progress thread, so it may read shared server state
+   directly.
+
+The framework itself is opened and a component selected during **server**
+startup, in ``pmix_server_init`` (``src/server/pmix_server.c``), right
+after the ``pgpu`` framework and before the listener starts.
+
+
+Inside the Framework
+--------------------
+
+``pstat`` is a **single-select** framework: exactly one component runs.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Component
+     - Priority
+     - Role
+   * - ``plinux``
+     - 80
+     - Reads real statistics from the Linux ``/proc`` filesystem. Built
+       only on Linux with a readable ``/proc`` and a defined ``HZ``.
+   * - ``test``
+     - 20
+     - Returns fixed, canned values with no OS access. Always built; the
+       fallback on non-Linux hosts and the vehicle for CI.
+
+If no component can run, the base leaves an *unsupported* module in place
+whose ``query`` returns ``PMIX_ERR_NOT_SUPPORTED``, so the monitor API
+degrades cleanly and reports the capability as absent rather than
+crashing.
+
+Selection (``pstat_base_select.c``) is a textbook
+``pmix_mca_base_select``: pick the highest-priority runnable component,
+cache its module in the global ``pmix_pstat``, and call its ``init``.
+
+
+The request object and its two collection modes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each request becomes a ``pmix_pstat_op_t`` (defined in
+``src/mca/pstat/base/base.h``) that records the target peers, the
+selected fields (four all-``bool`` "which fields?" structs —
+``pmix_procstats_t``, ``pmix_ndstats_t``, ``pmix_netstats_t``,
+``pmix_dkstats_t``), the optional device-ID filters, and — for a periodic
+monitor — a libevent timer and interval.
+
+A component's ``query`` fills the op (using the base parse helpers
+``pmix_pstat_parse_procstats`` / ``_ndstats`` / ``_netstats`` /
+``_dkstats`` to translate the requested-field array into the bool
+structs), selects the target peers with
+``PMIX_PSTAT_APPEND_PEER_UNIQUE``, and then drives a single collection
+function, ``update()``, which runs in one of two modes distinguished by
+whether ``op->cb`` is set:
+
+* **Synchronous (``op->cb != NULL``).** ``query`` points ``op->cb`` at a
+  stack callback object holding an info-list builder, calls ``update()``
+  directly, and converts the accumulated list into the ``*results`` array
+  returned to the caller. This produces the immediate answer for a
+  one-shot request — and the *first* sample of a periodic one.
+
+* **Periodic (``op->cb == NULL``).** When a rate was given, ``query``
+  appends the op to ``pmix_pstat_base.ops`` and arms the timer
+  (``PMIX_PSTAT_OP_START``). Each time the timer fires, the *same*
+  ``update()`` runs with ``op->cb == NULL``: it builds a fresh result,
+  and instead of returning it, delivers it asynchronously with
+  ``PMIx_Notify_event(op->eventcode, ...)`` targeted at the requestor,
+  then re-arms the timer.
+
+A one-shot op is released immediately after the synchronous pass; a
+periodic op lives on ``pmix_pstat_base.ops`` until a
+``PMIX_MONITOR_CANCEL`` naming its ``PMIX_MONITOR_ID`` removes and
+releases it (which also deletes the timer).
+
+By default the periodic timer runs on the library's main progress thread.
+Setting the framework MCA parameter ``pstat_base_use_separate_thread``
+moves sampling onto a dedicated ``"PSTAT"`` progress thread so it cannot
+perturb the main thread.
+
+
+Where the numbers come from
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``plinux`` component reads the kernel's ``/proc`` filesystem:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Category
+     - Sources
+   * - per-process
+     - ``/proc/<pid>/stat`` (cmd, state, CPU time via ``HZ``, priority,
+       thread count, processor), ``/proc/<pid>/status``
+       (VmPeak/VmSize/VmRSS), ``/proc/<pid>/smaps`` (summed Pss)
+   * - node
+     - ``/proc/loadavg`` (load averages), ``/proc/meminfo`` (memory/swap)
+   * - disk
+     - ``/proc/diskstats`` (``sd*`` devices)
+   * - network
+     - ``/proc/net/dev`` (per-interface counters)
+
+Only the fields the caller requested are read and emitted. Values that
+``/proc`` reports in kB are normalized to MB. A ``PMIX_MONITOR_NODE_...``
+request can nest network and disk sub-arrays inside the returned node data
+array, so one call can retrieve a full node picture.
+
+The ``test`` component mirrors ``plinux``'s control flow exactly but
+substitutes fixed constants for the OS reads (two fabricated disks, three
+fabricated interfaces, canned per-process and node figures), which makes
+it both a portable fallback and a deterministic test double. To force it
+during development::
+
+    export PMIX_MCA_pstat=test
+
+
+Threading
+---------
+
+Everything in ``pstat`` runs on a PMIx progress thread. ``query`` is
+reached only through the thread-shift performed by the monitor API, so a
+component may touch ``pmix_server_globals.clients`` and other shared
+server state directly. Periodic ``update()`` calls fire from the same
+event base (the main progress thread, or the dedicated ``"PSTAT"`` thread
+if ``pstat_base_use_separate_thread`` is set). Result arrays are assembled
+with the ``PMIx_Info_list_*`` builder helpers, and periodic samples are
+delivered with the standard ``PMIx_Notify_event`` mechanism.
+
+
+Summary
+-------
+
+* ``PMIx_Process_monitor`` / ``_nb`` are the public entry points;
+  ``PMIx_Heartbeat`` is a related liveness call handled outside the
+  framework.
+* ``src/common/pmix_monitor.c`` splits each request into a local part
+  (handled by ``pstat``) and a remote part (handed to the host RM).
+* ``pstat`` is single-select: ``plinux`` reads ``/proc`` on Linux;
+  ``test`` returns canned values everywhere else; an *unsupported* stub
+  covers "no component."
+* A ``pmix_pstat_op_t`` drives both one-shot collection (synchronous,
+  results returned) and periodic monitoring (timer-driven, results pushed
+  as events), distinguished by the ``op->cb`` field.
+* Results are returned as ``PMIX_*_RESOURCE_USAGE`` data arrays, uniform
+  across components and nodes.

--- a/src/mca/pstat/AGENTS.md
+++ b/src/mca/pstat/AGENTS.md
@@ -1,0 +1,397 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PSTAT Framework
+
+This document orients AI agents and human contributors working in the
+`pstat` (**P**rocess **Stat**istics) framework. It assumes you have
+already read the top-level [`AGENTS.md`](../../../AGENTS.md) — the golden
+rules, prefix conventions, thread-safety model, and MCA concepts
+described there all apply here and are not repeated. This file covers what
+is specific to `pstat`: what the framework is for, how a monitoring
+request flows through it, the shared data structures and base helpers
+every component leans on, and the contract a component must honor. Each
+component subdirectory (`plinux/`, `test/`) carries its own `AGENTS.md`
+with component-specific detail.
+
+For a wider, API-oriented tour of how this framework implements the
+`PMIx_Process_monitor` family of calls, see
+[`docs/how-things-work/pstat.rst`](../../../docs/how-things-work/pstat.rst).
+
+## What PSTAT does
+
+`pstat` is the back end that samples **resource-utilization statistics**
+from the local operating system and returns them as `pmix_info_t` data.
+It answers four broad questions about the local node:
+
+- **Per-process** usage — CPU time, %CPU, priority, thread count, virtual
+  size, RSS, PSS, process state, etc. (for processes the local PMIx
+  server is hosting).
+- **Node** usage — load averages and the various memory/swap totals.
+- **Disk** usage — read/write counters from the block devices.
+- **Network** usage — per-interface byte/packet/error counters.
+
+It is the engine underneath the `PMIx_Process_monitor` /
+`PMIx_Process_monitor_nb` public APIs (see
+[`src/common/pmix_monitor.c`](../../common/pmix_monitor.c)). It only ever
+runs **inside a PMIx server** — clients and tools relay their monitor
+requests to their server, which is the process that actually reads the
+OS. The framework was originally written to feed the old `ompi-top`
+utility (see the header comment in [`pstat.h`](pstat.h)); today it services
+any caller of the monitor API.
+
+`pstat` is a **single-select** framework: exactly one component is active
+per process. On a Linux node with a readable `/proc`, that is `plinux`
+(priority 80). The `test` component (priority 20) returns deterministic
+canned values and exists so the monitor code path can be exercised on
+platforms without `/proc` and in CI. If no component can run, the base
+installs an "unsupported" module whose every entry point returns
+`PMIX_ERR_NOT_SUPPORTED` — so the monitor API degrades cleanly rather
+than crashing.
+
+## Directory layout
+
+```
+src/mca/pstat/
+├── pstat.h                 Framework public API: module & component types
+├── base/                   Framework infrastructure
+│   ├── base.h              Internal base API: globals, op object, stat-spec
+│   │                       structs, the parse helpers, and the op macros
+│   ├── pstat_base_frame.c  open/close/register, framework decl, op class
+│   ├── pstat_base_select.c single-component selection + init
+│   └── pstat_base_fns.c    the four "parse the request" helpers
+├── plinux/                 Linux /proc reader (the real component)
+└── test/                   canned-data component for CI / unsupported hosts
+```
+
+## Core data structures (`pstat.h`)
+
+`pstat.h` is the framework's public header — the contract every component
+compiles against. It is deliberately tiny:
+
+- **`pmix_pstat_base_module_t`** — the runtime instance. Three function
+  pointers:
+  - `init` (`pmix_pstat_base_module_init_fn_t`) — one-time setup; returns
+    `PMIX_SUCCESS`.
+  - `query` (`pmix_pstat_base_module_query_fn_t`) — **the workhorse**.
+    This is where all the OS reading happens. Signature:
+    ```c
+    pmix_status_t (*query)(pmix_proc_t *requestor,
+                           const pmix_info_t *monitor, pmix_status_t error,
+                           const pmix_info_t directives[], size_t ndirs,
+                           pmix_info_t **results, size_t *nresults);
+    ```
+  - `finalize` (`pmix_pstat_base_module_fini_fn_t`) — teardown.
+
+- **`pmix_pstat_base_component_t`** — just a typedef of the standard
+  `pmix_mca_base_component_t`. `pstat` components carry no extra
+  configuration state, so neither component wraps it in a larger struct;
+  each provides only a `pmix_mca_query_component` that hands back its
+  module and a priority.
+
+- **`PMIX_PSTAT_BASE_VERSION_1_0_0`** — the version macro every
+  component's component struct must open with.
+
+- The global **`pmix_pstat`** — the selected module, the single symbol
+  the rest of the library calls through (`pmix_pstat.query(...)`).
+
+### The `query` contract
+
+`query` is **synchronous and runs on the progress thread** — it does not
+take a callback. It returns a freshly allocated `pmix_info_t` array
+through `*results` / `*nresults`; ownership passes to the caller
+(`pmix_monitor_processing` in `pmix_monitor.c`). The caller has already
+determined that the request involves the local node before calling
+`query`, so a component may assume "this is for us."
+
+The `monitor` argument's **key** names *what kind* of statistics are
+wanted; its **value** (a `PMIX_DATA_ARRAY` of `pmix_info_t`) names the
+specific fields. The recognized monitor keys are:
+
+| Monitor key | Meaning |
+|-------------|---------|
+| `PMIX_MONITOR_PROC_RESOURCE_USAGE` | per-process stats |
+| `PMIX_MONITOR_NODE_RESOURCE_USAGE` | node load/memory (may nest net + disk) |
+| `PMIX_MONITOR_DISK_RESOURCE_USAGE` | disk counters |
+| `PMIX_MONITOR_NET_RESOURCE_USAGE`  | network counters |
+| `PMIX_MONITOR_CANCEL` | stop a previously-started periodic monitor |
+
+The `directives` array qualifies the request. The keys `pstat` components
+act on directly:
+
+| Directive | Effect |
+|-----------|--------|
+| `PMIX_MONITOR_ID` | caller-supplied string handle for this monitor, needed later to cancel it |
+| `PMIX_MONITOR_RESOURCE_RATE` | sample **periodically** every N seconds (uint32) rather than once |
+| `PMIX_MONITOR_TARGET_PROCS` | array of `pmix_proc_t` restricting which processes to sample |
+| `PMIX_MONITOR_TARGET_PIDS` | array of `pmix_node_pid_t` (node+pid) restricting the sample |
+
+(Other monitor directives — `PMIX_MONITOR_LOCAL_ONLY`,
+`PMIX_MONITOR_TARGET_NODES`, `PMIX_MONITOR_PROXY`, `PMIX_SEND_HEARTBEAT`,
+heartbeat handling — are interpreted *above* the framework in
+`pmix_monitor.c` and never reach `query`.)
+
+## How a monitoring request flows
+
+1. **Public API.** A process calls `PMIx_Process_monitor` (blocking) or
+   `PMIx_Process_monitor_nb` (in
+   [`src/common/pmix_monitor.c`](../../common/pmix_monitor.c)). A client
+   or tool packs the request and sends it to its server
+   (`PMIX_MONITOR_CMD`); a server handles it locally. Either way it lands
+   in `pmix_monitor_processing()` on the server's progress thread (the
+   server-side unpack is `pmix_server_monitor()` in
+   `src/server/pmix_server_ops.c`).
+
+2. **Scope resolution.** `pmix_monitor_processing()` inspects the target
+   directives to decide whether the request involves **local** processes,
+   **remote** nodes, or both. Remote participation is handed to the host
+   RM via `pmix_host_server.monitor`; there is nothing `pstat` can do off
+   the local node.
+
+3. **Local sampling.** For any local participation, the monitor code calls
+   `pmix_pstat.query(...)` — i.e. the selected component's `query`. This
+   is the boundary into the framework.
+
+4. **Result delivery.** `query` returns an info array; the monitor code
+   either returns it to the caller (one-shot) or — for a periodic monitor
+   — the component keeps an *op* alive that re-samples on a timer and
+   pushes each update out as a PMIx **event** (`PMIx_Notify_event`)
+   targeted at the requestor.
+
+That last point is the framework's most important structural idea, so it
+gets its own section.
+
+## One-shot vs. periodic monitoring: the `pmix_pstat_op_t` object
+
+A single request can be either a **one-shot** query (return the numbers
+now) or a **periodic** monitor (`PMIX_MONITOR_RESOURCE_RATE` given: keep
+sampling every N seconds and deliver each sample as an event until
+cancelled). Both paths are driven by the same per-request state object,
+`pmix_pstat_op_t`, defined in [`base/base.h`](base/base.h):
+
+| Field | Purpose |
+|-------|---------|
+| `super` | `pmix_list_item_t` — lets a periodic op live on `pmix_pstat_base.ops` |
+| `requestor` | the `pmix_proc_t` to target event notifications at |
+| `id` | the caller's `PMIX_MONITOR_ID` string — the cancel handle |
+| `ev` / `tv` | libevent timer + interval for periodic re-sampling |
+| `active` | true once the periodic timer is armed |
+| `rate` | seconds between samples (0 ⇒ one-shot) |
+| `eventcode` | the status code to raise on each periodic update |
+| `peers` | `pmix_peerlist_t` list of the local processes to sample |
+| `disks` / `nets` | argv of specific disk / network IDs to report (NULL ⇒ all) |
+| `pstats` / `dkstats` / `netstats` / `ndstats` | which individual fields to collect |
+| `cb` | non-NULL during a **synchronous** collection pass (see below) |
+
+The op's constructor/destructor live in `pstat_base_frame.c`
+(`PMIX_CLASS_INSTANCE(pmix_pstat_op_t, ...)`); the destructor deletes an
+armed timer and frees the id/disks/nets/peers, so releasing an op is the
+clean way to tear a monitor down.
+
+### The `op->cb` duality (read this before touching a component)
+
+Each component has an `update()` timer handler that does the actual
+collection. It is invoked in two very different modes, distinguished
+solely by whether `op->cb` is set:
+
+- **`op->cb != NULL` — synchronous collection.** `query` sets `op->cb` to
+  point at a stack `pmix_cb_t` whose `cbdata` holds an *info-list builder
+  handle* (`PMIx_Info_list_start()`), then calls `update()` directly (not
+  via a timer). `update()` appends its results into that existing list and
+  returns; the `noreset` flag is set so it does **not** re-arm a timer.
+  `query` then converts the list to the `*results` array. This is how the
+  immediate/one-shot answer is produced — and also how the *first* sample
+  of a periodic monitor is produced.
+- **`op->cb == NULL` — periodic timer fire.** When the libevent timer
+  later fires, `op->cb` is NULL. `update()` builds its own fresh
+  info-list, converts it, and delivers it asynchronously via
+  `PMIx_Notify_event(op->eventcode, ...)` scoped to `op->requestor`; then
+  it re-arms the timer (`!noreset`).
+
+So `query` always calls `update()` once synchronously to get the initial
+numbers, and *additionally* — if a rate was given — appends the op to
+`pmix_pstat_base.ops` and arms the timer with `PMIX_PSTAT_OP_START` so the
+same `update()` will fire again periodically in event mode. A one-shot op
+is `PMIX_RELEASE`d immediately after the synchronous pass.
+
+### Cancellation
+
+A `PMIX_MONITOR_CANCEL` request carries the `PMIX_MONITOR_ID` string in
+its value. `query` walks `pmix_pstat_base.ops`, matches the id, removes
+the op from the list and `PMIX_RELEASE`s it (which deletes the timer).
+Cancelling an unknown id is deliberately **not** an error.
+
+## The shared stat-spec structs and parse helpers (`base/`)
+
+To keep components from re-parsing the request, the base defines four
+small all-`bool` "which fields do you want" structs and one
+argv-collector per category, plus a helper that fills each from the
+caller's `pmix_info_t` array. These are the reusable heart of the
+framework.
+
+### The four spec structs (`base.h`)
+
+- **`pmix_procstats_t`** — per-process flags: `cmdline`, `pctcpu`,
+  `state`, `time`, `pri`, `nthreads`, `cpu`, `vsize`, `pkvsize`, `rss`,
+  `pss`.
+- **`pmix_dkstats_t`** — disk flags: read/write completed/merged/sectors/
+  millisec, plus `ioprog`, `ioms`, `ioweight`.
+- **`pmix_netstats_t`** — network flags: received/sent bytes/packets/errors.
+- **`pmix_ndstats_t`** — node flags: load averages (`la`, `la5`, `la15`)
+  and memory/swap totals.
+
+Each has `PMIX_*_INIT(a)` (zero it — collect nothing) and `PMIX_*_ALL(a)`
+(set all — collect everything) convenience macros built on `memset`.
+Because these are plain `bool` structs, a component tests "did the caller
+ask for *anything* in this category?" cheaply with a single `memcmp`
+against a zeroed instance — that idiom appears throughout `update()`.
+
+### The four parse helpers (`pstat_base_fns.c`)
+
+These translate the caller's requested-fields info array into the spec
+structs. **Key convention:** if the incoming `info` pointer is `NULL`
+they select *everything* (`PMIX_*_ALL`); otherwise they start from
+"nothing" and flip on exactly the fields whose attribute keys appear.
+
+| Helper | Fills | Also collects |
+|--------|-------|---------------|
+| `pmix_pstat_parse_procstats` | `pmix_procstats_t` | — |
+| `pmix_pstat_parse_dkstats` | `pmix_dkstats_t` | `PMIX_DISK_ID` values into a `disks` argv |
+| `pmix_pstat_parse_netstats` | `pmix_netstats_t` | `PMIX_NETWORK_ID` values into a `nets` argv |
+| `pmix_pstat_parse_ndstats` | `pmix_ndstats_t` | — |
+
+The disk/net helpers do double duty: an ID key (`PMIX_DISK_ID` /
+`PMIX_NETWORK_ID`) names a *specific device to report*, while every other
+key turns on a *field to report for the chosen devices*. An empty
+`disks`/`nets` argv (`NULL`) means "all devices."
+
+Field-key matching uses `PMIx_Check_key`, which does the
+standard/registered-key comparison rather than a raw `strcmp`, so both the
+canonical `PMIX_*` string and any registered alias match.
+
+### The op macros (`base.h`)
+
+- **`PMIX_PSTAT_OP_START(p, s, cb)`** — arm the periodic timer: bind
+  `cb` (the `update` handler) to `p->ev` on the framework event base, set
+  the interval to `s` seconds, mark the op active, and add the timer. Note
+  the `PMIX_POST_OBJECT(p)` memory barrier before the op is handed to the
+  event engine.
+- **`PMIX_PSTAT_APPEND_PEER_UNIQUE(pl, pr)`** — append a `pmix_peer_t` to
+  an op's `peers` list only if it is not already present (dedup), wrapping
+  it in a `pmix_peerlist_t`.
+
+## Base infrastructure in detail
+
+### Globals and lifecycle (`pstat_base_frame.c`)
+
+- **`pmix_pstat_base`** (`pmix_pstat_base_t`): holds the framework event
+  base (`evbase`) and the `ops` list of live periodic monitors.
+- **`pmix_pstat`** — the active module. Initialized to the three
+  `unsupported` stubs; `pmix_pstat_base_select()` overwrites it with the
+  winning component's module (or leaves the stubs in place if none runs).
+- **`pmix_pstat_base_component`** — back-pointer to the selected component.
+
+**Open (`pmix_pstat_base_open`)** decides where periodic timers run.
+The framework-level MCA parameter **`pstat_base_use_separate_thread`**
+(bool, default false) controls this:
+
+- **false (default):** `evbase` is aliased to `pmix_globals.evbase` — the
+  library's main progress thread. Periodic sampling shares that thread.
+- **true:** a dedicated progress thread named `"PSTAT"` is spun up
+  (`pmix_progress_thread_init`) so sampling cannot perturb the main
+  thread. `close` stops and frees it.
+
+Then it constructs `pmix_pstat_base.ops` and opens all components.
+
+**Close (`pmix_pstat_base_close`)** destructs the ops list (tearing down
+any live monitors), calls the selected module's `finalize`, stops the
+separate thread if one was created, and closes the components.
+
+**Register (`pmix_pstat_register`)** registers the single
+`pstat_base_use_separate_thread` MCA parameter.
+
+The framework itself is declared with
+`PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pstat, "process statistics", ...)`.
+It is opened and selected during **server** startup in
+`src/server/pmix_server.c` (search for `pmix_pstat_base_framework`), *after*
+`pgpu` and before the listener starts.
+
+### Selection (`pstat_base_select.c`)
+
+`pmix_pstat_base_select()` is a textbook single-select: call
+`pmix_mca_base_select("pstat", ...)` to pick the highest-priority runnable
+component, cache it in `pmix_pstat`/`pmix_pstat_base_component`, and call
+its `init`. Finding no component is **not** fatal — it simply leaves the
+`unsupported` stubs in place, so `pmix_pstat.query` returns
+`PMIX_ERR_NOT_SUPPORTED` and the monitor API reports the capability as
+absent.
+
+## Threading
+
+Everything in `pstat` runs on a PMIx progress thread — either the main one
+or the dedicated `"PSTAT"` thread, per the MCA parameter above. `query` is
+reached only through the thread-shift already performed by the monitor API
+(`PMIX_THREADSHIFT(cb, pmix_monitor_processing)`), so components may touch
+`pmix_server_globals.clients` and other shared server state directly.
+Periodic `update()` fires from the same event base. Do **not** invent a
+new path that calls `pmix_pstat.query` from an arbitrary user thread
+without thread-shifting first.
+
+Note that the modules build their result arrays with the public
+`PMIx_Info_list_*` builder helpers and raise periodic updates with the
+public `PMIx_Notify_event` — these are the info-list/event utilities the
+rest of the library also uses.
+
+## Building
+
+The framework core (`base/`) is always built into `libpmix`. Each
+component builds as a standard MCA component (DSO
+`pmix_mca_pstat_<name>.la` or static `libpmix_mca_pstat_<name>.la`). Only
+`plinux` ships a `configure.m4`: it enables the component **only** on
+Linux with a readable `/proc/cpuinfo` and a defined `HZ` (from
+`<sys/param.h>`), so on non-Linux hosts only `test` remains and the
+framework falls back to it (or to `unsupported`). Adding a component means
+creating `src/mca/pstat/<name>/` with the usual `Makefile.am`, a component
+struct, and a module; the framework picks it up through the generated
+`base/static-components.h` — no core code changes are needed.
+
+Remember the top-level golden rules that bite here:
+
+- Editing a `Makefile.am` only needs a plain `make`; adding/removing a
+  *component directory* or touching `configure.m4` changes the build
+  wiring resolved by `configure`, so re-run
+  `./autogen.pl && ./configure ... && make`.
+- The framework is only meaningfully exercised inside a server. To test a
+  real change, drive it through `PMIx_Process_monitor` (see the `test`
+  component's `AGENTS.md` for how the canned component makes this possible
+  without `/proc`).
+
+## When adding or modifying a component
+
+- Open the component struct with `PMIX_PSTAT_BASE_VERSION_1_0_0` and set
+  `pmix_mca_component_name` to your component's directory name.
+- Provide a `pmix_mca_query_component` that hands back your
+  `pmix_pstat_base_module_t` and a priority. Return no module / a failure
+  when the component cannot run in this environment.
+- Implement `query` following the established shape: parse the request
+  into a `pmix_pstat_op_t` with the base helpers, select target peers with
+  `PMIX_PSTAT_APPEND_PEER_UNIQUE`, run `update()` synchronously through
+  `op->cb` for the immediate answer, and — if a rate was given — append
+  the op to `pmix_pstat_base.ops` and arm the timer with
+  `PMIX_PSTAT_OP_START`. Honor `PMIX_MONITOR_CANCEL`.
+- Return each result value under the correct published attribute
+  (`PMIX_PROC_RESOURCE_USAGE`, `PMIX_NODE_RESOURCE_USAGE`,
+  `PMIX_DISK_RESOURCE_USAGE`, `PMIX_NETWORK_RESOURCE_USAGE`, each a
+  `PMIX_DATA_ARRAY` of the per-item info), so callers can parse them
+  uniformly regardless of which component produced them.
+- Document any new statistic attribute keys in
+  [`include/pmix_common.h.in`](../../../include/pmix_common.h.in) and the
+  user docs, per the attribute rules in the top-level guide, and teach the
+  matching base parse helper to recognize them.

--- a/src/mca/pstat/CLAUDE.md
+++ b/src/mca/pstat/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/pstat/plinux/AGENTS.md
+++ b/src/mca/pstat/plinux/AGENTS.md
@@ -166,14 +166,16 @@ These are real observations about the current Linux parsing code; if you
 touch this file, be aware of them (and fixing them is welcome as a
 standalone commit — do not paper over them):
 
-- **`disk_stat` `ioprog`/`ioms`/`ioweight` look buggy.** Those three read
-  from `fields[10]` (the same column used for `wrtms`) and call
-  `strtoul(..., 10/11/12/13)` with a non-decimal *base* argument rather
-  than the intended field index. The `/proc/diskstats` layout puts
-  in-progress/io-ms/weighted-io in fields 11/12/13 and they are all
-  decimal, so this almost certainly should be `strtoul(fields[11..13],
-  NULL, 10)`. Treat the values these fields currently produce as
-  unreliable.
+- **`disk_stat` only handles the classic 14-column `/proc/diskstats`.**
+  The reader indexes fixed columns (device name at `fields[2]`, the 11
+  stat columns at `fields[3]`..`fields[13]`) and, before parsing, *skips*
+  any line with more than 14 fields (`if (14 < PMIx_Argv_count(fields))`).
+  Kernels 4.18+/5.5+ append discard and flush counters, giving 18–20
+  fields per line, so on a modern kernel every `sd*` line is rejected and
+  the disk path returns nothing. Widening the guard (and reading the newer
+  columns) is a genuine, still-open improvement — but be careful to keep
+  the short-line case safe, since partitions on older kernels can present
+  fewer than 14 fields.
 - **`node_stat` matches `/proc/meminfo` keys with exact `strcmp`** (e.g.
   `strcmp(dptr, "MemTotal")`) against the colon-stripped key produced by
   `local_stripper`. This depends on that stripping being exact; changes to

--- a/src/mca/pstat/plinux/AGENTS.md
+++ b/src/mca/pstat/plinux/AGENTS.md
@@ -166,16 +166,17 @@ These are real observations about the current Linux parsing code; if you
 touch this file, be aware of them (and fixing them is welcome as a
 standalone commit — do not paper over them):
 
-- **`disk_stat` only handles the classic 14-column `/proc/diskstats`.**
-  The reader indexes fixed columns (device name at `fields[2]`, the 11
-  stat columns at `fields[3]`..`fields[13]`) and, before parsing, *skips*
-  any line with more than 14 fields (`if (14 < PMIx_Argv_count(fields))`).
-  Kernels 4.18+/5.5+ append discard and flush counters, giving 18–20
-  fields per line, so on a modern kernel every `sd*` line is rejected and
-  the disk path returns nothing. Widening the guard (and reading the newer
-  columns) is a genuine, still-open improvement — but be careful to keep
-  the short-line case safe, since partitions on older kernels can present
-  fewer than 14 fields.
+- **The `disk_stat` / `net_stat` readers index fixed columns.** Both use
+  positional columns (disk: device name at `fields[2]`, stats at
+  `fields[3]`..`fields[13]`; net: stats at `fields[0]`..`fields[10]`), so
+  each guards against a short line before parsing — disk requires at least
+  14 fields, net at least 11. Extra trailing columns are ignored, which is
+  what lets the readers accept modern kernels' wider lines (the
+  discard/flush counters `/proc/diskstats` gained in 4.18+/5.5+, and the
+  16 columns `/proc/net/dev` supplies per interface). Two real limitations
+  remain: the newer disk discard/flush counters are **not** surfaced as
+  attributes, and disk selection matches only device names containing
+  `"sd"` — so `nvme*` and other non-SCSI devices are skipped entirely.
 - **`node_stat` matches `/proc/meminfo` keys with exact `strcmp`** (e.g.
   `strcmp(dptr, "MemTotal")`) against the colon-stripped key produced by
   `local_stripper`. This depends on that stripping being exact; changes to

--- a/src/mca/pstat/plinux/AGENTS.md
+++ b/src/mca/pstat/plinux/AGENTS.md
@@ -1,0 +1,187 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PSTAT `plinux` Component
+
+`plinux` ("**P**MIx **Linux**") is the real, production `pstat` component:
+it samples resource-utilization statistics from a Linux node by reading
+the kernel's `/proc` filesystem. Read the framework
+[`AGENTS.md`](../AGENTS.md) first — this file only covers what is specific
+to `plinux`. The op object, the `op->cb` synchronous-vs-timer duality, the
+four spec structs, and the parse helpers are all framework concepts
+described there.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `pstat_plinux.h` | Declares the component and module symbols. |
+| `pstat_plinux_component.c` | Component struct + `pstat_plinux_component_query`. |
+| `pstat_plinux_module.c` | The module: `query`, the periodic `update`, the four `*_stat` readers, and the `/proc` text-parsing helpers. |
+| `configure.m4` | Gates the build to Linux-with-`/proc`. |
+
+## Component (`pstat_plinux_component.c`)
+
+The component uses the bare `pmix_pstat_base_component_t`. Its
+`pstat_plinux_component_query` is unconditional at run time — all the
+"can I run here?" work was done at **configure** time — and simply
+returns the module with **priority 80**:
+
+```c
+*priority = 80;
+*module = (pmix_mca_base_module_t *) &pmix_pstat_plinux_module;
+return PMIX_SUCCESS;
+```
+
+80 easily beats `test` (20), so on any node where `plinux` was built it
+wins selection.
+
+### Build gating (`configure.m4`)
+
+`MCA_pmix_pstat_plinux_CONFIG` sets the component "happy" only when
+`oac_found_linux` is `yes` **and** `/proc/cpuinfo` is readable, then
+additionally requires that `HZ` is declared (via `<sys/param.h>`). `HZ`
+is essential: the module converts the kernel's jiffies-based CPU time
+fields into seconds by dividing by `HZ`. On a non-Linux host the whole
+component directory is omitted from the build, so nothing here needs a
+run-time `#ifdef`.
+
+## Module (`pstat_plinux_module.c`)
+
+`init`/`finalize` are no-ops. All the substance is in `query`, its four
+category readers, and the shared line-parsers.
+
+### `query` — request dispatch
+
+`query` implements exactly the framework contract described in the
+framework guide. Its shape:
+
+1. **Cancel fast-path.** If the monitor key is `PMIX_MONITOR_CANCEL`,
+   find the op by its `PMIX_MONITOR_ID` string in `pmix_pstat_base.ops`,
+   remove and release it, and return (unknown id ⇒ success).
+2. **Build an op.** `PMIX_NEW(pmix_pstat_op_t)`, copy in the `requestor`
+   and `eventcode`, and scan `directives` for `PMIX_MONITOR_ID` and
+   `PMIX_MONITOR_RESOURCE_RATE`.
+3. **Branch on the monitor key** — one block each for
+   `PMIX_MONITOR_PROC_RESOURCE_USAGE`, `..._NODE_...`, `..._DISK_...`,
+   `..._NET_...`. Each block:
+   - parses its requested fields out of `monitor->value` (a data array)
+     with the corresponding base helper;
+   - for the proc block, resolves the **target peers** — from
+     `PMIX_MONITOR_TARGET_PROCS` / `PMIX_MONITOR_TARGET_PIDS`, or, if
+     neither was given, *all* local clients — using
+     `PMIX_PSTAT_APPEND_PEER_UNIQUE` against
+     `pmix_server_globals.clients`;
+   - runs `update()` synchronously via a stack `op->cb` to produce the
+     immediate `*results`;
+   - if a rate was given, appends the op to `pmix_pstat_base.ops` and arms
+     the timer with `PMIX_PSTAT_OP_START(op, op->rate, update)`; otherwise
+     `PMIX_RELEASE`s the one-shot op.
+
+The **node** block is the interesting one: `PMIX_MONITOR_NODE_RESOURCE_USAGE`
+parses node, net, *and* disk specs from the same array, so a single node
+request can nest network and disk sub-arrays inside the returned
+`PMIX_NODE_RESOURCE_USAGE` data array. It also filters "empty" answers:
+if the collected array holds only the two items the block itself seeded
+(hostname + nodeID), it treats that as "no data found" and returns success
+with no results.
+
+`PMIX_ERR_EMPTY` from the info-list conversion is mapped to
+`PMIX_SUCCESS` in the proc/disk/net blocks — an empty sample is not an
+error.
+
+### `update` — the collection engine
+
+`update()` is both the synchronous collector (called directly by `query`
+with `op->cb` set) and the periodic timer handler (fired by libevent with
+`op->cb == NULL`). See the framework guide for the full duality; the
+Linux specifics:
+
+- It uses a zeroed spec struct + `memcmp` to decide whether each category
+  was requested before doing any file I/O.
+- The node path collects node stats into a sub-list and, when net/disk
+  were *also* requested as part of a node request, folds them into that
+  same sub-list (tracked by `nettaken` / `dktaken` so the standalone
+  net/disk blocks below don't double-collect).
+- On the timer path it wraps the result as an event: it adds
+  `PMIX_EVENT_NON_DEFAULT` and a `PMIX_EVENT_CUSTOM_RANGE` targeting
+  `op->requestor`, converts the list, and calls `PMIx_Notify_event` with
+  `PMIX_RANGE_CUSTOM`; a `pmix_cb_t` carries the info and is released by
+  the `evrelease` completion callback.
+
+### The four `/proc` readers
+
+Each reader appends one or more `PMIX_*_RESOURCE_USAGE` data arrays (built
+with the `PMIx_Info_list_*` helpers) to the answer, each tagged with a
+`*_SAMPLE_TIME`.
+
+- **`proc_stat`** — for one peer, opens `/proc/<pid>/stat` and parses it
+  field-by-field per `proc(5)`: command name, state, the utime+stime CPU
+  time (converted via `HZ` into a `PMIX_TIMEVAL`), priority, thread count,
+  and the processor number. It then reads `/proc/<pid>/status` for
+  `VmPeak`/`VmSize`/`VmRSS`, and `/proc/<pid>/smaps` (summing every `Pss:`
+  line) for proportional set size. Only fields whose `op->pstats` flag is
+  set are emitted. Emits `PMIX_PROC_RESOURCE_USAGE`.
+- **`node_stat`** — reads `/proc/loadavg` (the three load averages) and
+  `/proc/meminfo` (total/free/buffers/cached/swap-cached/swap-total/
+  swap-free/mapped), gated by `op->ndstats`. Emits into the node sub-list.
+- **`disk_stat`** — reads `/proc/diskstats`, keeping lines that look like
+  `sd*` disks (or only those named in `op->disks`), and emits the
+  read/write/io counters selected by `op->dkstats`. Emits
+  `PMIX_DISK_RESOURCE_USAGE`.
+- **`net_stat`** — reads `/proc/net/dev` (skipping its two header lines),
+  splitting on the `:` after the interface name, and emits the
+  received/sent byte/packet/error counters selected by `op->netstats`,
+  optionally filtered by `op->nets`. Emits `PMIX_NETWORK_RESOURCE_USAGE`.
+
+Values that `/proc` reports in kB are normalized to MB by
+`convert_value()` (divides by 1024 when the field is suffixed `kB`).
+
+### The text-parsing helpers
+
+`/proc` files are whitespace-formatted text, so the module carries three
+small parsers, all operating on a single static line buffer `input`:
+
+- **`local_getline`** — `fgets` one line into `input`, strip the trailing
+  newline, skip leading non-alphanumerics.
+- **`local_stripper`** — split a `key: value` line at the colon, trimming
+  whitespace, returning the value (and NUL-terminating the key in place).
+- **`local_getfields`** — tokenize a line into a `PMIx_Argv` of
+  alphanumeric fields. Used for the positional `diskstats` / `net/dev`
+  columns.
+- **`next_field`** (in `proc_stat`) — advance a pointer past the current
+  whitespace-delimited field, used to walk the fixed `/proc/<pid>/stat`
+  layout.
+
+## Caveats and known rough edges
+
+These are real observations about the current Linux parsing code; if you
+touch this file, be aware of them (and fixing them is welcome as a
+standalone commit — do not paper over them):
+
+- **`disk_stat` `ioprog`/`ioms`/`ioweight` look buggy.** Those three read
+  from `fields[10]` (the same column used for `wrtms`) and call
+  `strtoul(..., 10/11/12/13)` with a non-decimal *base* argument rather
+  than the intended field index. The `/proc/diskstats` layout puts
+  in-progress/io-ms/weighted-io in fields 11/12/13 and they are all
+  decimal, so this almost certainly should be `strtoul(fields[11..13],
+  NULL, 10)`. Treat the values these fields currently produce as
+  unreliable.
+- **`node_stat` matches `/proc/meminfo` keys with exact `strcmp`** (e.g.
+  `strcmp(dptr, "MemTotal")`) against the colon-stripped key produced by
+  `local_stripper`. This depends on that stripping being exact; changes to
+  the helpers can silently drop fields.
+- **Static line buffer.** `input` (and thus `local_getline` /
+  `local_stripper`) is a single shared static buffer, so the readers are
+  **not** reentrant. That is fine today because everything runs on one
+  progress thread, but do not call these from a second thread.
+- The `PMIX_PROC_PERCENT_CPU` (`pctcpu`) flag is parsed by the base helper
+  but `proc_stat` does not currently compute a %CPU value — computing it
+  would require two samples over an interval.

--- a/src/mca/pstat/plinux/CLAUDE.md
+++ b/src/mca/pstat/plinux/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/pstat/plinux/pstat_plinux_module.c
+++ b/src/mca/pstat/plinux/pstat_plinux_module.c
@@ -481,7 +481,10 @@ static pmix_status_t disk_stat(void *answer,
         if (NULL == fields) {
             continue;
         }
-        if (14 < PMIx_Argv_count(fields)) {
+        /* we index fixed columns up through fields[13], so require at
+         * least 14 fields; modern kernels append discard/flush columns
+         * that we simply ignore */
+        if (14 > PMIx_Argv_count(fields)) {
             PMIx_Argv_free(fields);
             continue;
         }
@@ -693,7 +696,10 @@ static pmix_status_t net_stat(void *answer, char**nets,
         if (NULL == fields) {
             continue;
         }
-        if (11 < PMIx_Argv_count(fields)) {
+        /* we index fixed columns up through fields[10], so require at
+         * least 11 fields; /proc/net/dev supplies 16 per interface and we
+         * simply ignore the extras */
+        if (11 > PMIx_Argv_count(fields)) {
             PMIx_Argv_free(fields);
             continue;
         }

--- a/src/mca/pstat/plinux/pstat_plinux_module.c
+++ b/src/mca/pstat/plinux/pstat_plinux_module.c
@@ -596,7 +596,7 @@ static pmix_status_t disk_stat(void *answer,
         }
 
         if (dkst->ioprog) {
-            u64 = strtoul(fields[10], NULL, 11);
+            u64 = strtoul(fields[11], NULL, 10);
             rc = PMIx_Info_list_add(cache, PMIX_DISK_IO_IN_PROGRESS, &u64, PMIX_UINT64);
             if (PMIX_SUCCESS != rc) {
                 PMIx_Info_list_release(cache);
@@ -606,7 +606,7 @@ static pmix_status_t disk_stat(void *answer,
             }
         }
         if (dkst->ioms) {
-            u64 = strtoul(fields[10], NULL, 12);
+            u64 = strtoul(fields[12], NULL, 10);
             rc = PMIx_Info_list_add(cache, PMIX_DISK_IO_MILLISEC, &u64, PMIX_UINT64);
             if (PMIX_SUCCESS != rc) {
                 PMIx_Info_list_release(cache);
@@ -616,7 +616,7 @@ static pmix_status_t disk_stat(void *answer,
             }
         }
         if (dkst->ioweight) {
-            u64 = strtoul(fields[10], NULL, 13);
+            u64 = strtoul(fields[13], NULL, 10);
             rc = PMIx_Info_list_add(cache, PMIX_DISK_IO_WEIGHTED, &u64, PMIX_UINT64);
             if (PMIX_SUCCESS != rc) {
                 PMIx_Info_list_release(cache);

--- a/src/mca/pstat/test/AGENTS.md
+++ b/src/mca/pstat/test/AGENTS.md
@@ -1,0 +1,113 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PSTAT `test` Component
+
+`test` is the canned-data `pstat` component. It answers monitor requests
+with fixed, deterministic values instead of reading the operating system,
+so the whole `PMIx_Process_monitor` code path can be exercised on
+platforms that have no `/proc` (macOS, other Unixes) and in CI where a
+stable, reproducible answer is wanted. Read the framework
+[`AGENTS.md`](../AGENTS.md) first — this file only covers what is specific
+to `test`.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `pstat_test.h` | Declares the component and module symbols. |
+| `pstat_test_component.c` | Component struct + `pstat_test_component_query`. |
+| `pstat_test.c` | The module: `query`, `update`, and the four canned `*_stat` readers. |
+
+There is **no `configure.m4`**: `test` has no OS dependency and is always
+built, so it is available as a fallback on every platform.
+
+## Component (`pstat_test_component.c`)
+
+Bare `pmix_pstat_base_component_t`; `pstat_test_component_query` returns
+the module at **priority 20**:
+
+```c
+*priority = 20;
+*module = (pmix_mca_base_module_t *) &pmix_pstat_test_module;
+return PMIX_SUCCESS;
+```
+
+20 is below `plinux` (80), so on a Linux node with `/proc` the real
+component wins and `test` stays dormant. On any host where `plinux` was
+not built, `test` is the highest-priority runnable component and is
+selected — which is exactly why the monitor API still works (with fake
+numbers) on non-Linux systems.
+
+## Module (`pstat_test.c`)
+
+The module is a near-exact structural clone of `plinux`'s module, and
+this is deliberate: keeping the two in lock-step means the `test`
+component genuinely exercises the same request-dispatch, op-lifecycle,
+and `update()` duality that `plinux` uses — only the leaf `*_stat`
+readers differ. Concretely:
+
+- **`query`** is line-for-line the same dispatch as `plinux`'s: same
+  cancel fast-path, same op construction, same `PMIX_MONITOR_ID` /
+  `PMIX_MONITOR_RESOURCE_RATE` parsing, same four monitor-key branches,
+  same peer selection against `pmix_server_globals.clients`, same
+  synchronous-`op->cb` collection plus optional periodic timer arming.
+  (One small divergence: `test`'s `query` does not `memcpy` the requestor
+  into the op, since it targets its periodic events at
+  `PMIX_RANGE_LOCAL`.)
+- **`update`** is the same synchronous-vs-timer engine, with the same
+  `nettaken`/`dktaken` node-nesting logic. The only behavioral difference
+  from `plinux` is the notification **range**: on the timer path `test`
+  calls `PMIx_Notify_event(..., PMIX_RANGE_LOCAL, ...)` rather than a
+  custom range to the requestor.
+
+### The canned readers
+
+The four readers have the same signatures and emit the same attributes as
+`plinux`'s, but with hard-coded values and no file I/O:
+
+- **`proc_stat`** — for the given peer, emits the real proc ID / pid /
+  hostname (those *are* known), then fixed values for each requested
+  field: state `"R"`, cmdline `"test-stats"`, a `1234.5678` timeval,
+  priority 5, 10 threads, CPU 2, and fixed floats for peak-vsize / vsize /
+  RSS / PSS. Tagged with a real `PMIX_PROC_SAMPLE_TIME`.
+- **`node_stat`** — fixed load averages and memory/swap figures.
+- **`disk_stat`** — fabricates **two** disks (`sd00`, `sd01`) with fixed
+  counters; ignores the `disks` filter.
+- **`net_stat`** — fabricates **three** interfaces (`net000`..`net002`)
+  with fixed counters; ignores the `nets` filter.
+
+Because the values are constants, a test can assert on them exactly.
+
+## Using `test` to exercise the framework
+
+When you change anything in the base or the monitor plumbing and want to
+verify it without a Linux node, force selection of this component so the
+answer is deterministic:
+
+```sh
+# make the server use the test pstat component
+export PMIX_MCA_pstat=test
+```
+
+Then drive a request through `PMIx_Process_monitor` from a client against
+that server. This is the practical way to smoke-test framework-level
+changes (op lifecycle, cancel, periodic-rate timers, result marshalling)
+on a developer laptop.
+
+## When modifying `test`
+
+- **Keep it in structural sync with `plinux`.** Its value as a test
+  double comes from executing the *same* control flow. If you add a
+  monitor key, a directive, or change the op lifecycle in `plinux`, mirror
+  it here so CI keeps covering the new path.
+- Keep the emitted values fixed and documented — downstream tests may
+  assert on them. If you must change a canned value, grep the test suite
+  for callers first.

--- a/src/mca/pstat/test/CLAUDE.md
+++ b/src/mca/pstat/test/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Adds contributor-facing orientation documentation for the `pstat`
(process statistics) framework, and — as separate standalone commits —
fixes two real bugs in the `plinux` component's `/proc` parsing that the
documentation work surfaced.

## Commits

1. **Add pstat framework orientation guides and how-it-works doc.**
   Framework-level and per-component `AGENTS.md` files (each with a
   `CLAUDE.md` symlink) for `src/mca/pstat/`, plus a developer-facing
   `docs/how-things-work/pstat.rst` explaining how the
   `PMIx_Process_monitor` API path descends through the framework and its
   components (query contract, the `pmix_pstat_op_t` request object and
   its synchronous-vs-timer collection duality, the shared stat-spec
   structs and parse helpers, selection, lifecycle, and the local/remote
   scope resolution in `pmix_monitor.c`).

2. **`pstat/plinux`: fix `disk_stat` I/O field parsing.** The `ioprog`,
   `ioms`, and `ioweight` disk statistics all read from `fields[10]` (the
   write-milliseconds column) and passed a bogus `strtoul()` *base*
   argument (11/12/13) in place of a field index. Per the
   `/proc/diskstats` layout these are fields 11/12/13, read with base 10.

3. **`pstat/plinux`: fix inverted field-count guards in disk/net
   readers.** Both `disk_stat` and `net_stat` guarded their fixed-column
   indexing with the comparison inverted — rejecting lines with *more*
   than the needed field count instead of *fewer*. As a result modern
   `/proc/diskstats` lines (18–20 columns on 4.18+/5.5+ kernels) were all
   dropped, and `/proc/net/dev` (always 16 columns per interface) was
   dropped on every system, so the network reader returned nothing at
   all. The guards now require a *minimum* field count and ignore extra
   trailing columns.

## Testing

`plinux` is a Linux-only component (gated on `oac_found_linux` + `HZ`),
so it is not built on the macOS development host. The two parsing fixes
were verified on Linux via Docker (`gcc -Wall -Wextra -Werror -std=c11`):
the corrected column reads pull the intended values, wide modern-kernel
lines are now accepted, and genuinely short lines are still rejected to
keep the fixed-index reads safe. The new RST builds cleanly under the
configured Sphinx with no warnings.

## Notes

- Both parsing fixes are kept as standalone commits, separate from the
  docs, so each can be reviewed and bisected independently.
- Remaining known limitations (documented in the updated `plinux`
  `AGENTS.md` caveats, not addressed here): the newer disk discard/flush
  counters are not surfaced as attributes, and disk selection still
  matches only device names containing `"sd"` (so `nvme*` devices are
  skipped).