### PR TITLE
pstat: add a macOS component and report non-SCSI disks

### DIFF
--- a/docs/how-things-work/pstat.rst
+++ b/docs/how-things-work/pstat.rst
@@ -12,7 +12,8 @@ timer and streams each sample back to the requestor as a PMIx event.
 For a code-oriented orientation aimed at contributors working *inside*
 the framework, each ``pstat`` directory also carries an ``AGENTS.md``
 (with a ``CLAUDE.md`` symlink): ``src/mca/pstat/AGENTS.md`` for the
-framework as a whole, plus one each in ``plinux/`` and ``test/``. This
+framework as a whole, plus one each in ``plinux/``, ``pmacos/``, and
+``test/``. This
 document explains how the pieces fit into the wider library; those explain
 each piece's internals in detail.
 
@@ -189,10 +190,16 @@ Inside the Framework
      - 80
      - Reads real statistics from the Linux ``/proc`` filesystem. Built
        only on Linux with a readable ``/proc`` and a defined ``HZ``.
+   * - ``pmacos``
+     - 80
+     - Reads real statistics on macOS (Darwin) through the native mach,
+       libproc, sysctl, and IOKit interfaces. Built only on Apple hosts;
+       never coexists with ``plinux``, so the shared priority never
+       collides.
    * - ``test``
      - 20
      - Returns fixed, canned values with no OS access. Always built; the
-       fallback on non-Linux hosts and the vehicle for CI.
+       fallback where no native reader is present and the vehicle for CI.
 
 If no component can run, the base leaves an *unsupported* module in place
 whose ``query`` returns ``PMIX_ERR_NOT_SUPPORTED``, so the monitor API

--- a/src/mca/pstat/AGENTS.md
+++ b/src/mca/pstat/AGENTS.md
@@ -18,8 +18,8 @@ described there all apply here and are not repeated. This file covers what
 is specific to `pstat`: what the framework is for, how a monitoring
 request flows through it, the shared data structures and base helpers
 every component leans on, and the contract a component must honor. Each
-component subdirectory (`plinux/`, `test/`) carries its own `AGENTS.md`
-with component-specific detail.
+component subdirectory (`plinux/`, `pmacos/`, `test/`) carries its own
+`AGENTS.md` with component-specific detail.
 
 For a wider, API-oriented tour of how this framework implements the
 `PMIx_Process_monitor` family of calls, see
@@ -49,9 +49,12 @@ any caller of the monitor API.
 
 `pstat` is a **single-select** framework: exactly one component is active
 per process. On a Linux node with a readable `/proc`, that is `plinux`
-(priority 80). The `test` component (priority 20) returns deterministic
+(priority 80); on macOS (Darwin) it is `pmacos` (priority 80), which reads
+the same categories through the mach/libproc/sysctl/IOKit interfaces.
+Only one of these ever builds on a given host, so their equal priorities
+never collide. The `test` component (priority 20) returns deterministic
 canned values and exists so the monitor code path can be exercised on
-platforms without `/proc` and in CI. If no component can run, the base
+platforms without a native reader and in CI. If no component can run, the base
 installs an "unsupported" module whose every entry point returns
 `PMIX_ERR_NOT_SUPPORTED` — so the monitor API degrades cleanly rather
 than crashing.
@@ -68,6 +71,7 @@ src/mca/pstat/
 │   ├── pstat_base_select.c single-component selection + init
 │   └── pstat_base_fns.c    the four "parse the request" helpers
 ├── plinux/                 Linux /proc reader (the real component)
+├── pmacos/                 macOS reader (mach/libproc/sysctl/IOKit)
 └── test/                   canned-data component for CI / unsupported hosts
 ```
 
@@ -353,10 +357,12 @@ rest of the library also uses.
 
 The framework core (`base/`) is always built into `libpmix`. Each
 component builds as a standard MCA component (DSO
-`pmix_mca_pstat_<name>.la` or static `libpmix_mca_pstat_<name>.la`). Only
-`plinux` ships a `configure.m4`: it enables the component **only** on
-Linux with a readable `/proc/cpuinfo` and a defined `HZ` (from
-`<sys/param.h>`), so on non-Linux hosts only `test` remains and the
+`pmix_mca_pstat_<name>.la` or static `libpmix_mca_pstat_<name>.la`). Both
+real components ship a `configure.m4`: `plinux` enables **only** on Linux
+with a readable `/proc/cpuinfo` and a defined `HZ` (from `<sys/param.h>`),
+and `pmacos` enables **only** on Apple/Darwin (`oac_found_apple`), where
+it also pulls in the IOKit and CoreFoundation frameworks for its per-disk
+statistics. On a host matching neither, only `test` remains and the
 framework falls back to it (or to `unsupported`). Adding a component means
 creating `src/mca/pstat/<name>/` with the usual `Makefile.am`, a component
 struct, and a module; the framework picks it up through the generated

--- a/src/mca/pstat/plinux/AGENTS.md
+++ b/src/mca/pstat/plinux/AGENTS.md
@@ -132,10 +132,11 @@ with the `PMIx_Info_list_*` helpers) to the answer, each tagged with a
 - **`node_stat`** — reads `/proc/loadavg` (the three load averages) and
   `/proc/meminfo` (total/free/buffers/cached/swap-cached/swap-total/
   swap-free/mapped), gated by `op->ndstats`. Emits into the node sub-list.
-- **`disk_stat`** — reads `/proc/diskstats`, keeping lines that look like
-  `sd*` disks (or only those named in `op->disks`), and emits the
-  read/write/io counters selected by `op->dkstats`. Emits
-  `PMIX_DISK_RESOURCE_USAGE`.
+- **`disk_stat`** — reads `/proc/diskstats`, keeping lines whose device
+  name matches a known physical-disk driver prefix — `sd`, `hd`, `vd`,
+  `xvd`, `nvme`, or `mmcblk` (see `is_disk_device`) — or only those named
+  in `op->disks`, and emits the read/write/io counters selected by
+  `op->dkstats`. Emits `PMIX_DISK_RESOURCE_USAGE`.
 - **`net_stat`** — reads `/proc/net/dev` (skipping its two header lines),
   splitting on the `:` after the interface name, and emits the
   received/sent byte/packet/error counters selected by `op->netstats`,
@@ -173,10 +174,12 @@ standalone commit — do not paper over them):
   14 fields, net at least 11. Extra trailing columns are ignored, which is
   what lets the readers accept modern kernels' wider lines (the
   discard/flush counters `/proc/diskstats` gained in 4.18+/5.5+, and the
-  16 columns `/proc/net/dev` supplies per interface). Two real limitations
-  remain: the newer disk discard/flush counters are **not** surfaced as
-  attributes, and disk selection matches only device names containing
-  `"sd"` — so `nvme*` and other non-SCSI devices are skipped entirely.
+  16 columns `/proc/net/dev` supplies per interface). One real limitation
+  remains: the newer disk discard/flush counters are **not** surfaced as
+  attributes. (Disk *selection* is no longer SCSI-only — `is_disk_device`
+  now matches `sd`/`hd`/`vd`/`xvd`/`nvme`/`mmcblk` device-name prefixes,
+  so `nvme*` and other non-SCSI disks are reported. Add a prefix there if
+  a driver you care about is missing.)
 - **`node_stat` matches `/proc/meminfo` keys with exact `strcmp`** (e.g.
   `strcmp(dptr, "MemTotal")`) against the colon-stripped key produced by
   `local_stripper`. This depends on that stripping being exact; changes to

--- a/src/mca/pstat/plinux/pstat_plinux_module.c
+++ b/src/mca/pstat/plinux/pstat_plinux_module.c
@@ -111,6 +111,33 @@ static char *next_field(char *ptr, int barrier)
     return ptr;
 }
 
+/* Decide whether a /proc/diskstats device name refers to a physical
+ * disk we should report. The kernel lists many virtual devices (loop,
+ * ram, dm-*, md*, etc.) that we do not want; restrict to the known
+ * block-device driver name prefixes. Partitions (e.g. "sda1",
+ * "nvme0n1p1") share these prefixes and so are reported as well, which
+ * matches the historical behavior of this reader. */
+static bool is_disk_device(const char *name)
+{
+    static const char *const prefixes[] = {
+        "sd",     /* SCSI / SATA / USB block devices */
+        "hd",     /* legacy IDE */
+        "vd",     /* virtio */
+        "xvd",    /* Xen virtual */
+        "nvme",   /* NVMe */
+        "mmcblk", /* eMMC / SD card */
+        NULL
+    };
+    size_t i;
+
+    for (i = 0; NULL != prefixes[i]; i++) {
+        if (0 == strncmp(name, prefixes[i], strlen(prefixes[i]))) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static float convert_value(char *value)
 {
     char *ptr;
@@ -471,10 +498,6 @@ static pmix_status_t disk_stat(void *answer,
 
     /* read the file one line at a time */
     while (NULL != (dptr = local_getline(fp))) {
-        /* look for the local disks */
-        if (NULL == strstr(dptr, "sd")) {
-            continue;
-        }
         /* parse to extract the fields */
         fields = NULL;
         local_getfields(dptr, &fields);
@@ -490,7 +513,9 @@ static pmix_status_t disk_stat(void *answer,
         }
         // see if this is a disk they want
         if (NULL == disks) {
-            takeit = true;
+            /* no specific disks named - report every device that looks
+             * like a physical disk (sd*, nvme*, vd*, ...) */
+            takeit = is_disk_device(fields[2]);
         } else {
             takeit = false;
             for (n=0; NULL != disks[n]; n++) {

--- a/src/mca/pstat/pmacos/AGENTS.md
+++ b/src/mca/pstat/pmacos/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md: The PSTAT `pmacos` Component
+
+`pmacos` ("**P**MIx **macOS**") is the real, production `pstat` component
+for macOS (Darwin): it samples resource-utilization statistics from a Mac
+using the native mach, libproc, sysctl, and IOKit interfaces — there is no
+`/proc` to read. Read the framework [`AGENTS.md`](../AGENTS.md) first —
+this file only covers what is specific to `pmacos`. The op object, the
+`op->cb` synchronous-vs-timer duality, the four spec structs, and the
+parse helpers are all framework concepts described there. `pmacos` is the
+Darwin analog of [`plinux`](../plinux/AGENTS.md); the two never coexist (a
+given host builds exactly one of them), and its `query`/`update`/cancel
+control flow is deliberately identical to `plinux`'s so only the four
+category readers differ.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `pstat_pmacos.h` | Declares the component and module symbols. |
+| `pstat_pmacos_component.c` | Component struct + `pstat_pmacos_component_query`. |
+| `pstat_pmacos_module.c` | The module: `query`, the periodic `update`, and the four macOS `*_stat` readers. |
+| `configure.m4` | Gates the build to Apple/Darwin and links IOKit + CoreFoundation. |
+
+## Component (`pstat_pmacos_component.c`)
+
+Identical in shape to `plinux`: the bare `pmix_pstat_base_component_t`,
+whose `pstat_pmacos_component_query` is unconditional at run time (all the
+"can I run here?" work was done at **configure** time) and returns the
+module with **priority 80**. 80 beats `test` (20); because `plinux` never
+builds on macOS, the equal 80s never compete.
+
+### Build gating (`configure.m4`)
+
+`MCA_pmix_pstat_pmacos_CONFIG` sets the component "happy" only when
+`oac_found_apple` is `yes` (from `OAC_CHECK_OS_FLAVORS`). When happy it
+sets `pstat_pmacos_LIBS="-framework IOKit -framework CoreFoundation"`,
+`AC_SUBST`s it (the `Makefile.am` feeds it to both the DSO and static
+`LIBADD`), and appends it to `PMIX_EMBEDDED_LIBS` so a **static** build
+links the frameworks into the final consumers. On a non-Apple host the
+whole directory is omitted from the build, so nothing here needs a
+run-time `#ifdef`.
+
+## Module (`pstat_pmacos_module.c`)
+
+`init`/`finalize` are no-ops. `query` and the periodic `update` are copied
+verbatim from `plinux` — they implement the framework contract (request
+dispatch, target-peer resolution, the synchronous `op->cb` pass, the
+periodic timer/event path, and `PMIX_MONITOR_CANCEL`) with no
+platform-specific content. All the macOS specifics live in the four
+readers, each of which appends one or more `PMIX_*_RESOURCE_USAGE` data
+arrays tagged with a `*_SAMPLE_TIME`, exactly like `plinux`.
+
+### The four macOS readers
+
+- **`proc_stat`** — for one peer, `proc_pidinfo(PROC_PIDTASKINFO)` gives
+  CPU time (user+system nanoseconds → `PMIX_TIMEVAL`), thread count,
+  scheduling priority, and virtual/resident sizes;
+  `proc_pidinfo(PROC_PIDTBSDINFO)` gives the process status, mapped to the
+  same single-character state string `plinux` emits (`proc_state_string`);
+  and `proc_name` gives the command name. Only fields whose `op->pstats`
+  flag is set are emitted. Emits `PMIX_PROC_RESOURCE_USAGE`.
+- **`node_stat`** — `getloadavg` for the three load averages,
+  `sysctlbyname("hw.memsize")` for total RAM, `host_statistics64`
+  (`HOST_VM_INFO64`) × page size for free (`free_count`) and cached
+  (`external_page_count`) memory, and `sysctlbyname("vm.swapusage")` for
+  swap total/free. Gated by `op->ndstats`; emits into the node sub-list.
+- **`disk_stat`** — enumerates `IOBlockStorageDriver` services via IOKit,
+  recovers each device's BSD name (`disk0`, `disk1`, …) from its child
+  `IOMedia` (`disk_bsd_name`), and pulls the per-device `Statistics`
+  dictionary. Byte counts are normalized to 512-byte sectors and
+  nanosecond times to milliseconds so the units match `plinux`. Selection
+  honors `op->disks` by exact BSD-name match. Emits
+  `PMIX_DISK_RESOURCE_USAGE`.
+- **`net_stat`** — walks `getifaddrs`, reads the per-interface `if_data`
+  on each `AF_LINK` entry, and emits received/sent byte/packet/error
+  counters selected by `op->netstats`, optionally filtered by `op->nets`.
+  Emits `PMIX_NETWORK_RESOURCE_USAGE`.
+
+Memory/size values reported by the OS in bytes are normalized to MB (float)
+to match the Linux reader; disk/net counters stay as raw `uint64` totals.
+
+## Caveats and known rough edges
+
+If you touch this file, be aware of these (and fixing them is welcome as a
+standalone commit — do not paper over them):
+
+- **Some Linux fields have no macOS analog and are simply not emitted**
+  even when requested: `proc_stat` omits per-process `cpu` (last CPU),
+  `pctcpu`, `pss`, and `pkvsize`; `node_stat` omits `mbuf`,
+  `mswapcached`, and `mmap`; `disk_stat` omits the merged-request counts
+  (`rdmerged`/`wrtmerged`) and the `ioprog`/`ioms`/`ioweight` fields that
+  `/proc/diskstats` exposes but IOKit does not.
+- **`net_stat` uses the 32-bit `if_data` counters** from `getifaddrs`,
+  which can wrap on long-running interfaces. The 64-bit counters would
+  require parsing `sysctl(NET_RT_IFLIST2)` (`if_data64`); switching to
+  that is a reasonable future improvement.
+- **The IOKit main port is passed as `0`** (`PMIX_PSTAT_IOMAIN_PORT`)
+  rather than `kIOMainPortDefault`/`kIOMasterPortDefault`, so the code
+  builds cleanly across macOS SDK versions without version-gating or
+  tripping `-Werror` on the deprecated name.
+- **The registry-plane argument is copied into a full `io_name_t`
+  (`char[128]`) buffer** in `disk_bsd_name` before being passed to the
+  IOKit lookups; passing the short `kIOServicePlane` literal directly
+  trips GCC's `-Wstringop-overread` under `--enable-devel-check`.

--- a/src/mca/pstat/pmacos/CLAUDE.md
+++ b/src/mca/pstat/pmacos/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/pstat/pmacos/Makefile.am
+++ b/src/mca/pstat/pmacos/Makefile.am
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        pstat_pmacos.h \
+        pstat_pmacos_component.c \
+        pstat_pmacos_module.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pstat_pmacos_DSO
+component_noinst =
+component_install = pmix_mca_pstat_pmacos.la
+else
+component_noinst = libpmix_mca_pstat_pmacos.la
+component_install =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+pmix_mca_pstat_pmacos_la_SOURCES = $(sources)
+pmix_mca_pstat_pmacos_la_LDFLAGS = -module -avoid-version
+pmix_mca_pstat_pmacos_la_LIBADD = $(pstat_pmacos_LIBS) $(top_builddir)/src/libpmix.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libpmix_mca_pstat_pmacos_la_SOURCES = $(sources)
+libpmix_mca_pstat_pmacos_la_LDFLAGS = -module -avoid-version
+libpmix_mca_pstat_pmacos_la_LIBADD = $(pstat_pmacos_LIBS)

--- a/src/mca/pstat/pmacos/configure.m4
+++ b/src/mca/pstat/pmacos/configure.m4
@@ -1,0 +1,44 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# MCA_pmix_pstat_pmacos_CONFIG(action-if-can-compile,
+#                              [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pstat_pmacos_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pstat/pmacos/Makefile])
+
+    AC_REQUIRE([OAC_CHECK_OS_FLAVORS])
+
+    # The macOS reader is built only on Apple (Darwin), where the mach,
+    # libproc, sysctl, and IOKit interfaces it uses are guaranteed to be
+    # present. It links the IOKit and CoreFoundation frameworks for the
+    # per-disk statistics.
+    AS_IF([test "$oac_found_apple" = "yes"],
+          [pstat_pmacos_happy="yes"],
+          [pstat_pmacos_happy="no"])
+
+    AS_IF([test "$pstat_pmacos_happy" = "yes"],
+          [pstat_pmacos_LIBS="-framework IOKit -framework CoreFoundation"
+           AC_SUBST([pstat_pmacos_LIBS])
+           PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS $pstat_pmacos_LIBS"
+           $1],
+          [$2])
+])

--- a/src/mca/pstat/pmacos/owner.txt
+++ b/src/mca/pstat/pmacos/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: Nanook Consulting
+status: maintenance

--- a/src/mca/pstat/pmacos/pstat_pmacos.h
+++ b/src/mca/pstat/pmacos/pstat_pmacos.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2025      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Process/node/disk/network statistics for macOS (Darwin) systems.
+ *
+ */
+
+#ifndef pmix_pstat_PMACOS_EXPORT_H
+#define pmix_pstat_PMACOS_EXPORT_H
+
+#include "pmix_config.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/pstat/pstat.h"
+
+BEGIN_C_DECLS
+
+/**
+ * Globally exported variable
+ */
+PMIX_EXPORT extern const pmix_pstat_base_component_t pmix_mca_pstat_pmacos_component;
+
+PMIX_EXPORT extern const pmix_pstat_base_module_t pmix_pstat_pmacos_module;
+
+END_C_DECLS
+#endif /* pmix_pstat_PMACOS_EXPORT_H */

--- a/src/mca/pstat/pmacos/pstat_pmacos_component.c
+++ b/src/mca/pstat/pmacos/pstat_pmacos_component.c
@@ -1,0 +1,72 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2025      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "pmix_config.h"
+
+#include "pmix_common.h"
+#include "pstat_pmacos.h"
+#include "src/mca/pstat/pstat.h"
+
+/*
+ * Public string showing the pstat pmacos component version number
+ */
+const char *pmix_pstat_pmacos_component_version_string
+    = "PMIX pmacos pstat MCA component version " PMIX_VERSION;
+
+/*
+ * Local function
+ */
+static int pstat_pmacos_component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+
+const pmix_pstat_base_component_t pmix_mca_pstat_pmacos_component = {
+
+    PMIX_PSTAT_BASE_VERSION_1_0_0,
+
+    /* Component name and version */
+    .pmix_mca_component_name = "pmacos",
+    PMIX_MCA_BASE_MAKE_VERSION(component,
+                               PMIX_MAJOR_VERSION,
+                               PMIX_MINOR_VERSION,
+                               PMIX_RELEASE_VERSION),
+
+    .pmix_mca_query_component = pstat_pmacos_component_query,
+};
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pstat, pmacos)
+
+static int pstat_pmacos_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 80;
+    *module = (pmix_mca_base_module_t *) &pmix_pstat_pmacos_module;
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pstat/pmacos/pstat_pmacos_module.c
+++ b/src/mca/pstat/pmacos/pstat_pmacos_module.c
@@ -1,0 +1,1208 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2025      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+/* This component is only compiled on macOS (Darwin), where the
+ * mach, libproc, sysctl, IOKit, and BSD networking interfaces below
+ * are all guaranteed to be present. */
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_TIME_H
+#    include <sys/time.h>
+#endif
+#include <sys/proc.h> /* for the SIDL/SRUN/... process-state codes */
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <libproc.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <mach/vm_statistics.h>
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOBSD.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/storage/IOBlockStorageDriver.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_printf.h"
+
+#include "src/mca/pstat/base/base.h"
+#include "pstat_pmacos.h"
+
+/*
+ * API functions
+ */
+static pmix_status_t pmacos_module_init(void);
+static pmix_status_t query(pmix_proc_t *requestor,
+                           const pmix_info_t *monitor, pmix_status_t error,
+                           const pmix_info_t directives[], size_t ndirs,
+                           pmix_info_t **results, size_t *nresults);
+static pmix_status_t pmacos_module_fini(void);
+
+/*
+ * macOS pstat module
+ */
+const pmix_pstat_base_module_t pmix_pstat_pmacos_module = {
+    /* Initialization function */
+    .init = pmacos_module_init,
+    .query = query,
+    .finalize = pmacos_module_fini
+};
+
+/* Passing 0 (MACH_PORT_NULL) as the IOKit main port requests the
+ * default port. Doing so works across all macOS releases without
+ * depending on either kIOMainPortDefault (only defined on macOS 12+)
+ * or the deprecated kIOMasterPortDefault (which trips -Werror on newer
+ * SDKs). */
+#define PMIX_PSTAT_IOMAIN_PORT ((mach_port_t) 0)
+
+static pmix_status_t pmacos_module_init(void)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t pmacos_module_fini(void)
+{
+    return PMIX_SUCCESS;
+}
+
+/* Translate a macOS proc_bsdinfo status code into the single-character
+ * process-state string used by the Linux reader, so callers see a
+ * consistent representation regardless of platform. */
+static const char *proc_state_string(uint32_t status)
+{
+    switch (status) {
+    case SIDL:
+        return "I"; /* being created */
+    case SRUN:
+        return "R"; /* runnable */
+    case SSLEEP:
+        return "S"; /* sleeping */
+    case SSTOP:
+        return "T"; /* stopped */
+    case SZOMB:
+        return "Z"; /* zombie */
+    default:
+        return "?";
+    }
+}
+
+static pmix_status_t proc_stat(void *answer, pmix_peer_t *peer,
+                               pmix_procstats_t *pst)
+{
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    struct proc_taskinfo pti;
+    struct proc_bsdinfo bsd;
+    char comm[256];
+    int nb;
+    float fval;
+    uint16_t u16;
+    int32_t i32;
+    struct timeval evtime;
+    double dtime;
+    void *cache;
+    time_t sample_time;
+    pmix_data_array_t darray;
+
+    time(&sample_time);
+    cache = PMIx_Info_list_start();
+
+    // start with the proc ID
+    PMIx_Load_procid(&proc, peer->info->pname.nspace, peer->info->pname.rank);
+    rc = PMIx_Info_list_add(cache, PMIX_PROCID, &proc, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIx_Info_list_release(cache);
+        return rc;
+    }
+    // add the pid
+    rc = PMIx_Info_list_add(cache, PMIX_PROC_PID, &peer->info->pid, PMIX_PID);
+    if (PMIX_SUCCESS != rc) {
+        PMIx_Info_list_release(cache);
+        return rc;
+    }
+    // add the hostname
+    rc = PMIx_Info_list_add(cache, PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIx_Info_list_release(cache);
+        return rc;
+    }
+
+    /* pull the task-level info: CPU time, thread count, priority, and
+     * virtual/resident sizes */
+    nb = proc_pidinfo(peer->info->pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti));
+    if (nb == (int) sizeof(pti)) {
+        if (pst->time) {
+            /* pti reports CPU time in nanoseconds */
+            dtime = (double) (pti.pti_total_user + pti.pti_total_system) / 1.0e9;
+            evtime.tv_sec = (int) dtime;
+            evtime.tv_usec = (int) (1000000.0 * (dtime - evtime.tv_sec));
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_TIME, (void *) &evtime, PMIX_TIMEVAL);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+        if (pst->pri) {
+            i32 = (int32_t) pti.pti_priority;
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_PRIORITY, &i32, PMIX_INT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+        if (pst->nthreads) {
+            u16 = (uint16_t) pti.pti_threadnum;
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_NUM_THREADS, &u16, PMIX_UINT16);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+        if (pst->vsize) {
+            /* normalize bytes to MB to match the Linux reader */
+            fval = (float) pti.pti_virtual_size / (1024.0 * 1024.0);
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_VSIZE, &fval, PMIX_FLOAT);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+        if (pst->rss) {
+            fval = (float) pti.pti_resident_size / (1024.0 * 1024.0);
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_RSS, &fval, PMIX_FLOAT);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+    }
+
+    /* pull the BSD-level info for the process state */
+    if (pst->state) {
+        nb = proc_pidinfo(peer->info->pid, PROC_PIDTBSDINFO, 0, &bsd, sizeof(bsd));
+        if (nb == (int) sizeof(bsd)) {
+            rc = PMIx_Info_list_add(cache, PMIX_PROC_OS_STATE,
+                                    (char *) proc_state_string(bsd.pbi_status), PMIX_STRING);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+    }
+
+    /* the command name */
+    if (pst->cmdline) {
+        memset(comm, 0, sizeof(comm));
+        if (0 < proc_name(peer->info->pid, comm, sizeof(comm))) {
+            rc = PMIx_Info_list_add(cache, PMIX_CMD_LINE, comm, PMIX_STRING);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(cache);
+                return rc;
+            }
+        }
+    }
+
+    /* NOTE: macOS does not expose an inexpensive per-process last-CPU
+     * (pctcpu/cpu) or proportional/peak virtual size (pss/pkvsize), so
+     * those fields are simply not reported here. */
+
+    // record the sample time
+    rc = PMIx_Info_list_add(cache, PMIX_PROC_SAMPLE_TIME, &sample_time, PMIX_TIME);
+    if (PMIX_SUCCESS != rc) {
+        PMIx_Info_list_release(cache);
+        return rc;
+    }
+    // add this to the final answer
+    rc = PMIx_Info_list_convert(cache, &darray);
+    PMIx_Info_list_release(cache);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    rc = PMIx_Info_list_add(answer, PMIX_PROC_RESOURCE_USAGE, &darray, PMIX_DATA_ARRAY);
+
+    return rc;
+}
+
+/* Pull a signed 64-bit integer property out of an IOKit statistics
+ * dictionary; returns 0 if the key is absent or not a number. */
+static uint64_t cf_dict_u64(CFDictionaryRef dict, CFStringRef key)
+{
+    CFNumberRef num;
+    int64_t val = 0;
+
+    num = (CFNumberRef) CFDictionaryGetValue(dict, key);
+    if (NULL != num && CFGetTypeID(num) == CFNumberGetTypeID()) {
+        CFNumberGetValue(num, kCFNumberSInt64Type, &val);
+    }
+    return (uint64_t) val;
+}
+
+/* Recover the BSD device name (e.g. "disk0") for an IOBlockStorageDriver
+ * by searching its child IOMedia objects for the kIOBSDNameKey property.
+ * Returns true and fills name/namelen on success. */
+static bool disk_bsd_name(io_registry_entry_t drive, char *name, size_t namelen)
+{
+    io_iterator_t children;
+    io_registry_entry_t child;
+    CFStringRef cfname;
+    bool found = false;
+    /* The IOKit registry-plane argument is typed io_name_t (char[128]);
+     * copy the plane name into a full-sized buffer so the compiler's
+     * buffer-size analysis doesn't flag the short string literal. */
+    io_name_t plane;
+
+    memset(plane, 0, sizeof(plane));
+    strlcpy(plane, kIOServicePlane, sizeof(plane));
+
+    if (KERN_SUCCESS != IORegistryEntryGetChildIterator(drive, plane, &children)) {
+        return false;
+    }
+    while (!found && 0 != (child = IOIteratorNext(children))) {
+        cfname = (CFStringRef) IORegistryEntrySearchCFProperty(child, plane,
+                                                               CFSTR(kIOBSDNameKey),
+                                                               kCFAllocatorDefault,
+                                                               kIORegistryIterateRecursively);
+        if (NULL != cfname) {
+            if (CFStringGetCString(cfname, name, namelen, kCFStringEncodingUTF8)) {
+                found = true;
+            }
+            CFRelease(cfname);
+        }
+        IOObjectRelease(child);
+    }
+    IOObjectRelease(children);
+    return found;
+}
+
+static pmix_status_t disk_stat(void *answer,
+                               char **disks,
+                               pmix_dkstats_t *dkst)
+{
+    io_iterator_t drives;
+    io_registry_entry_t drive;
+    CFMutableDictionaryRef match;
+    CFDictionaryRef stats;
+    char bsdname[128];
+    void *cache;
+    size_t n;
+    bool takeit;
+    uint64_t u64;
+    pmix_data_array_t darray;
+    time_t sample_time;
+    pmix_status_t rc;
+
+    /* enumerate the block-storage drivers - each carries a per-device
+     * statistics dictionary */
+    match = IOServiceMatching(kIOBlockStorageDriverClass);
+    if (NULL == match) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    if (KERN_SUCCESS != IOServiceGetMatchingServices(PMIX_PSTAT_IOMAIN_PORT, match, &drives)) {
+        /* IOServiceGetMatchingServices consumes the match dictionary */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    while (0 != (drive = IOIteratorNext(drives))) {
+        /* determine the device's BSD name (disk0, disk1, ...) */
+        if (!disk_bsd_name(drive, bsdname, sizeof(bsdname))) {
+            IOObjectRelease(drive);
+            continue;
+        }
+        // see if this is a disk they want
+        if (NULL == disks) {
+            takeit = true;
+        } else {
+            takeit = false;
+            for (n = 0; NULL != disks[n]; n++) {
+                if (0 == strcmp(bsdname, disks[n])) {
+                    takeit = true;
+                    break;
+                }
+            }
+        }
+        if (!takeit) {
+            IOObjectRelease(drive);
+            continue;
+        }
+
+        stats = (CFDictionaryRef) IORegistryEntryCreateCFProperty(drive,
+                                        CFSTR(kIOBlockStorageDriverStatisticsKey),
+                                        kCFAllocatorDefault, 0);
+        if (NULL == stats) {
+            IOObjectRelease(drive);
+            continue;
+        }
+        time(&sample_time);
+
+        /* take the fields of interest */
+        cache = PMIx_Info_list_start();
+        // start with the diskID
+        rc = PMIx_Info_list_add(cache, PMIX_DISK_ID, bsdname, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            goto diskerr;
+        }
+        if (dkst->rdcompleted) {
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsReadsKey));
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_READ_COMPLETED, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        if (dkst->rdsectors) {
+            /* macOS reports bytes; normalize to 512-byte sectors to
+             * match the Linux reader's units */
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsBytesReadKey)) / 512;
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_READ_SECTORS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        if (dkst->rdms) {
+            /* total read time is reported in nanoseconds */
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsTotalReadTimeKey))
+                  / 1000000;
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_READ_MILLISEC, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        if (dkst->wrtcompleted) {
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsWritesKey));
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_WRITE_COMPLETED, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        if (dkst->wrtsectors) {
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsBytesWrittenKey)) / 512;
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_WRITE_SECTORS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        if (dkst->wrtms) {
+            u64 = cf_dict_u64(stats, CFSTR(kIOBlockStorageDriverStatisticsTotalWriteTimeKey))
+                  / 1000000;
+            rc = PMIx_Info_list_add(cache, PMIX_DISK_WRITE_MILLISEC, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto diskerr;
+            }
+        }
+        /* NOTE: macOS does not expose merged-request counts (rdmerged/
+         * wrtmerged) nor the in-progress/weighted-io fields (ioprog/ioms/
+         * ioweight), so those requested fields are not reported. */
+
+        // record the sample time
+        rc = PMIx_Info_list_add(cache, PMIX_DISK_SAMPLE_TIME, &sample_time, PMIX_TIME);
+        if (PMIX_SUCCESS != rc) {
+            goto diskerr;
+        }
+
+        // add this to the final answer
+        rc = PMIx_Info_list_convert(cache, &darray);
+        PMIx_Info_list_release(cache);
+        CFRelease(stats);
+        IOObjectRelease(drive);
+        if (PMIX_SUCCESS != rc) {
+            IOObjectRelease(drives);
+            return rc;
+        }
+        rc = PMIx_Info_list_add(answer, PMIX_DISK_RESOURCE_USAGE, &darray, PMIX_DATA_ARRAY);
+        if (PMIX_SUCCESS != rc) {
+            IOObjectRelease(drives);
+            return rc;
+        }
+        continue;
+
+    diskerr:
+        PMIx_Info_list_release(cache);
+        CFRelease(stats);
+        IOObjectRelease(drive);
+        IOObjectRelease(drives);
+        return rc;
+    }
+    IOObjectRelease(drives);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t net_stat(void *answer, char **nets,
+                              pmix_netstats_t *netst)
+{
+    struct ifaddrs *ifap, *ifa;
+    struct if_data *ifd;
+    void *cache;
+    size_t n;
+    bool takeit;
+    uint64_t u64;
+    pmix_data_array_t darray;
+    time_t sample_time;
+    pmix_status_t rc;
+
+    if (0 != getifaddrs(&ifap)) {
+        /* not an error if we cannot read this as it isn't critical */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    for (ifa = ifap; NULL != ifa; ifa = ifa->ifa_next) {
+        /* the per-interface counters live on the AF_LINK entry */
+        if (NULL == ifa->ifa_addr || AF_LINK != ifa->ifa_addr->sa_family ||
+            NULL == ifa->ifa_data) {
+            continue;
+        }
+        // see if this is a network they want
+        if (NULL == nets) {
+            takeit = true;
+        } else {
+            takeit = false;
+            for (n = 0; NULL != nets[n]; n++) {
+                if (0 == strcmp(ifa->ifa_name, nets[n])) {
+                    takeit = true;
+                    break;
+                }
+            }
+        }
+        if (!takeit) {
+            continue;
+        }
+        ifd = (struct if_data *) ifa->ifa_data;
+        time(&sample_time);
+
+        /* take the fields of interest */
+        cache = PMIx_Info_list_start();
+        // start with the network ID
+        rc = PMIx_Info_list_add(cache, PMIX_NETWORK_ID, ifa->ifa_name, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            goto neterr;
+        }
+
+        if (netst->rcvdb) {
+            u64 = ifd->ifi_ibytes;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_RECVD_BYTES, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+        if (netst->rcvdp) {
+            u64 = ifd->ifi_ipackets;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_RECVD_PCKTS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+        if (netst->rcvde) {
+            u64 = ifd->ifi_ierrors;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_RECVD_ERRS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+
+        if (netst->sntb) {
+            u64 = ifd->ifi_obytes;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_SENT_BYTES, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+        if (netst->sntp) {
+            u64 = ifd->ifi_opackets;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_SENT_PCKTS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+        if (netst->snte) {
+            u64 = ifd->ifi_oerrors;
+            rc = PMIx_Info_list_add(cache, PMIX_NET_SENT_ERRS, &u64, PMIX_UINT64);
+            if (PMIX_SUCCESS != rc) {
+                goto neterr;
+            }
+        }
+
+        // record the sample time
+        rc = PMIx_Info_list_add(cache, PMIX_NET_SAMPLE_TIME, &sample_time, PMIX_TIME);
+        if (PMIX_SUCCESS != rc) {
+            goto neterr;
+        }
+        // add this to the final answer
+        rc = PMIx_Info_list_convert(cache, &darray);
+        PMIx_Info_list_release(cache);
+        if (PMIX_SUCCESS != rc) {
+            freeifaddrs(ifap);
+            return rc;
+        }
+        rc = PMIx_Info_list_add(answer, PMIX_NETWORK_RESOURCE_USAGE, &darray, PMIX_DATA_ARRAY);
+        if (PMIX_SUCCESS != rc) {
+            freeifaddrs(ifap);
+            return rc;
+        }
+        continue;
+
+    neterr:
+        PMIx_Info_list_release(cache);
+        freeifaddrs(ifap);
+        return rc;
+    }
+    freeifaddrs(ifap);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t node_stat(void *ilist, pmix_ndstats_t *ndst)
+{
+    double loadavg[3];
+    int nla;
+    int64_t memsize;
+    struct xsw_usage swap;
+    vm_statistics64_data_t vm;
+    vm_size_t pagesize = 0;
+    mach_msg_type_number_t cnt;
+    size_t len;
+    float fval;
+    pmix_status_t rc;
+    time_t sample_time;
+
+    time(&sample_time);
+
+    /* load averages */
+    nla = getloadavg(loadavg, 3);
+    if (0 < nla && ndst->la) {
+        fval = (float) loadavg[0];
+        rc = PMIx_Info_list_add(ilist, PMIX_NODE_LOAD_AVG, &fval, PMIX_FLOAT);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+    if (1 < nla && ndst->la5) {
+        fval = (float) loadavg[1];
+        rc = PMIx_Info_list_add(ilist, PMIX_NODE_LOAD_AVG5, &fval, PMIX_FLOAT);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+    if (2 < nla && ndst->la15) {
+        fval = (float) loadavg[2];
+        rc = PMIx_Info_list_add(ilist, PMIX_NODE_LOAD_AVG15, &fval, PMIX_FLOAT);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    /* total physical memory (bytes) - normalize to MB */
+    if (ndst->mtot) {
+        len = sizeof(memsize);
+        if (0 == sysctlbyname("hw.memsize", &memsize, &len, NULL, 0)) {
+            fval = (float) memsize / (1024.0 * 1024.0);
+            rc = PMIx_Info_list_add(ilist, PMIX_NODE_MEM_TOTAL, &fval, PMIX_FLOAT);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+        }
+    }
+
+    /* free and cached memory from the mach VM statistics */
+    if (ndst->mfree || ndst->mcached) {
+        if (KERN_SUCCESS == host_page_size(mach_host_self(), &pagesize)) {
+            cnt = HOST_VM_INFO64_COUNT;
+            if (KERN_SUCCESS == host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                                                  (host_info64_t) &vm, &cnt)) {
+                if (ndst->mfree) {
+                    fval = (float) ((uint64_t) vm.free_count * (uint64_t) pagesize)
+                           / (1024.0 * 1024.0);
+                    rc = PMIx_Info_list_add(ilist, PMIX_NODE_MEM_FREE, &fval, PMIX_FLOAT);
+                    if (PMIX_SUCCESS != rc) {
+                        return rc;
+                    }
+                }
+                if (ndst->mcached) {
+                    /* externally-backed (file-cache) pages are the closest
+                     * analog to Linux "cached" memory */
+                    fval = (float) ((uint64_t) vm.external_page_count * (uint64_t) pagesize)
+                           / (1024.0 * 1024.0);
+                    rc = PMIx_Info_list_add(ilist, PMIX_NODE_MEM_CACHED, &fval, PMIX_FLOAT);
+                    if (PMIX_SUCCESS != rc) {
+                        return rc;
+                    }
+                }
+            }
+        }
+    }
+
+    /* swap usage (bytes) - normalize to MB */
+    if (ndst->mswaptot || ndst->mswapfree) {
+        len = sizeof(swap);
+        if (0 == sysctlbyname("vm.swapusage", &swap, &len, NULL, 0)) {
+            if (ndst->mswaptot) {
+                fval = (float) swap.xsu_total / (1024.0 * 1024.0);
+                rc = PMIx_Info_list_add(ilist, PMIX_NODE_SWAP_TOTAL, &fval, PMIX_FLOAT);
+                if (PMIX_SUCCESS != rc) {
+                    return rc;
+                }
+            }
+            if (ndst->mswapfree) {
+                fval = (float) swap.xsu_avail / (1024.0 * 1024.0);
+                rc = PMIx_Info_list_add(ilist, PMIX_NODE_MEM_SWAP_FREE, &fval, PMIX_FLOAT);
+                if (PMIX_SUCCESS != rc) {
+                    return rc;
+                }
+            }
+        }
+    }
+
+    /* NOTE: macOS has no direct analog for the buffers, swap-cached, or
+     * mapped totals, so those requested fields are not reported. */
+
+    rc = PMIx_Info_list_add(ilist, PMIX_NODE_SAMPLE_TIME, &sample_time, PMIX_TIME);
+    return rc;
+}
+
+static void evrelease(pmix_status_t status, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_RELEASE(cb);
+}
+
+static void update(int sd, short args, void *cbdata)
+{
+    pmix_pstat_op_t *op = (pmix_pstat_op_t *) cbdata;
+    void *answer, *ilist;
+    pmix_peerlist_t *plist;
+    pmix_status_t rc;
+    pmix_data_array_t darray;
+    pmix_cb_t *cb;
+    pmix_procstats_t zproc;
+    pmix_ndstats_t znd;
+    pmix_netstats_t znet;
+    pmix_dkstats_t zdk;
+    bool nettaken, dktaken, noreset;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    cb = op->cb;
+    if (NULL == cb) {
+        answer = PMIx_Info_list_start();
+        noreset = false;
+    } else {
+        answer = cb->cbdata;
+        noreset = true;
+    }
+    PMIX_PROCSTATS_INIT(&zproc);
+    PMIX_NDSTATS_INIT(&znd);
+    PMIX_NETSTATS_INIT(&znet);
+    PMIX_DKSTATS_INIT(&zdk);
+    nettaken = false;
+    dktaken = false;
+
+    // start with general directives
+
+    if (op->active) {
+        // avoid the default event
+        PMIX_INFO_LIST_ADD(rc, answer, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+
+        /* target this notification solely to the requestor */
+        PMIX_INFO_LIST_ADD(rc, answer, PMIX_EVENT_CUSTOM_RANGE, &op->requestor, PMIX_PROC);
+    }
+
+    // check for pstat request
+    if (0 != memcmp(&op->pstats, &zproc, sizeof(pmix_procstats_t))) {
+        PMIX_LIST_FOREACH(plist, &op->peers, pmix_peerlist_t) {
+            rc = proc_stat(answer, plist->peer, &op->pstats);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIx_Info_list_release(answer);
+                goto reset;
+            }
+        }
+    }
+
+    // check for node stats
+    if (0 != memcmp(&op->ndstats, &znd, sizeof(pmix_ndstats_t))) {
+        ilist = PMIx_Info_list_start();
+        // start with hostname
+        rc = PMIx_Info_list_add(ilist, PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(ilist);
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+        // add our nodeID
+        rc = PMIx_Info_list_add(ilist, PMIX_NODEID, &pmix_globals.nodeid, PMIX_UINT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(ilist);
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+        // collect the stats
+        rc = node_stat(ilist, &op->ndstats);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(ilist);
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+        if (0 != memcmp(&op->netstats, &znet, sizeof(pmix_netstats_t))) {
+            nettaken = true;
+            rc = net_stat(ilist, op->nets, &op->netstats);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(ilist);
+                PMIx_Info_list_release(answer);
+                goto reset;
+            }
+        }
+        if (0 != memcmp(&op->dkstats, &zdk, sizeof(pmix_dkstats_t))) {
+            dktaken = true;
+            rc = disk_stat(ilist, op->disks, &op->dkstats);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Info_list_release(ilist);
+                PMIx_Info_list_release(answer);
+                goto reset;
+            }
+        }
+        // add this to the final answer
+        rc = PMIx_Info_list_convert(ilist, &darray);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(ilist);
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+        PMIx_Info_list_release(ilist);
+        rc = PMIx_Info_list_add(answer, PMIX_NODE_RESOURCE_USAGE, &darray, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+    }
+
+    // check for net stats
+    if (!nettaken && 0 != memcmp(&op->netstats, &znet, sizeof(pmix_netstats_t))) {
+        rc = net_stat(answer, op->nets, &op->netstats);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+    }
+
+    // check for disk stats
+    if (!dktaken && 0 != memcmp(&op->dkstats, &zdk, sizeof(pmix_dkstats_t))) {
+        rc = disk_stat(answer, op->disks, &op->dkstats);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(answer);
+            goto reset;
+        }
+    }
+
+    if (NULL == cb) {
+        // convert to info array
+        rc = PMIx_Info_list_convert(answer, &darray);
+        PMIx_Info_list_release(answer);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto reset;
+        }
+        // setup the event
+        cb = PMIX_NEW(pmix_cb_t);
+        cb->info = (pmix_info_t *) darray.array;
+        cb->ninfo = darray.size;
+        cb->infocopy = true;
+        rc = PMIx_Notify_event(op->eventcode, &pmix_globals.myid,
+                               PMIX_RANGE_CUSTOM, cb->info, cb->ninfo,
+                               evrelease, (void *) cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+
+reset:
+    if (!noreset) {
+        // reset the timer
+        pmix_event_evtimer_add(&op->ev, &op->tv);
+    }
+}
+
+static pmix_status_t query(pmix_proc_t *requestor,
+                           const pmix_info_t *monitor, pmix_status_t eventcode,
+                           const pmix_info_t directives[], size_t ndirs,
+                           pmix_info_t **results, size_t *nresults)
+{
+    pmix_info_t *iptr;
+    size_t sz;
+    size_t n, m;
+    int k;
+    pmix_peer_t *ptr;
+    pmix_proc_t proc, *procs;
+    pmix_node_pid_t *ppid;
+    pmix_status_t rc;
+    bool tgtprocsgiven;
+    pmix_data_array_t darray;
+    pmix_pstat_op_t *op;
+    pmix_netstats_t znet;
+    pmix_dkstats_t zdk;
+    pmix_info_t *xfer;
+    pmix_cb_t cb;
+
+    *results = NULL;
+    *nresults = 0;
+    PMIX_NETSTATS_INIT(&znet);
+    PMIX_DKSTATS_INIT(&zdk);
+
+    if (PMIx_Check_key(monitor->key, PMIX_MONITOR_CANCEL)) {
+        // cancel an existing monitor operation - ID must be the provided value
+        if (monitor->value.type != PMIX_STRING) {
+            return PMIX_ERR_BAD_PARAM;
+        }
+        // cycle through our list of ops operations
+        if (0 == pmix_list_get_size(&pmix_pstat_base.ops)) {
+            // we don't have any operations - this is okay
+            return PMIX_SUCCESS;
+        }
+        PMIX_LIST_FOREACH(op, &pmix_pstat_base.ops, pmix_pstat_op_t) {
+            if (0 == strcmp(monitor->value.data.string, op->id)) {
+                // terminate this operation
+                pmix_list_remove_item(&pmix_pstat_base.ops, &op->super);
+                PMIX_RELEASE(op);
+                return PMIX_SUCCESS;
+            }
+        }
+        // didn't find the operation - this is okay
+        return PMIX_SUCCESS;
+    }
+
+    op = PMIX_NEW(pmix_pstat_op_t);
+    memcpy(&op->requestor, requestor, sizeof(pmix_proc_t));
+    op->eventcode = eventcode;
+
+    for (n = 0; n < ndirs; n++) {
+        // did they give us an ID for this request?
+        if (PMIx_Check_key(directives[n].key, PMIX_MONITOR_ID)) {
+            op->id = strdup(directives[n].value.data.string);
+
+        } else if (PMIx_Check_key(directives[n].key, PMIX_MONITOR_RESOURCE_RATE)) {
+            // they are asking us to update it at regular intervals
+            rc = PMIx_Value_get_number(&directives[n].value, (void *) &op->rate, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(op);
+                return rc;
+            }
+        }
+        if (NULL != op->id && 0 < op->rate) {
+            // don't keep searching if unnecessary
+            break;
+        }
+    }
+
+    // see what data we are being asked to collect
+    if (PMIx_Check_key(monitor->key, PMIX_MONITOR_PROC_RESOURCE_USAGE)) {
+        tgtprocsgiven = false;
+        // see which values are to be returned
+        iptr = (pmix_info_t *) monitor->value.data.darray->array;
+        sz = monitor->value.data.darray->size;
+        pmix_pstat_parse_procstats(&op->pstats, iptr, sz);
+
+        // we already know this request involves us since it was checked
+        // before calling us, so see which of our processes are included
+        if (NULL == directives) {
+            // all of our processes are included - no ID or rate can be included
+            for (k = 0; k < pmix_server_globals.clients.size; k++) {
+                ptr = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
+                if (NULL == ptr) {
+                    continue;
+                }
+                PMIX_PSTAT_APPEND_PEER_UNIQUE(&op->peers, ptr);
+            }
+            goto processprocs;
+        }
+
+        // check for specific procs and directives
+        for (n = 0; n < ndirs; n++) {
+            if (PMIx_Check_key(directives[n].key, PMIX_MONITOR_TARGET_PROCS)) {
+                if (PMIX_DATA_ARRAY != directives[n].value.type ||
+                    NULL == directives[n].value.data.darray ||
+                    NULL == directives[n].value.data.darray->array) {
+                    PMIX_RELEASE(op);
+                    return PMIX_ERR_BAD_PARAM;
+                }
+                tgtprocsgiven = true;
+                // they specified the procs
+                procs = (pmix_proc_t *) directives[n].value.data.darray->array;
+                sz = directives[n].value.data.darray->size;
+                for (m = 0; m < sz; m++) {
+                    for (k = 0; k < pmix_server_globals.clients.size; k++) {
+                        ptr = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
+                        if (NULL == ptr) {
+                            continue;
+                        }
+                        PMIx_Load_procid(&proc, ptr->info->pname.nspace, ptr->info->pname.rank);
+                        if (PMIx_Check_procid(&procs[m], &proc)) {
+                            PMIX_PSTAT_APPEND_PEER_UNIQUE(&op->peers, ptr);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (PMIx_Check_key(directives[n].key, PMIX_MONITOR_TARGET_PIDS)) {
+                if (PMIX_DATA_ARRAY != directives[n].value.type ||
+                    NULL == directives[n].value.data.darray ||
+                    NULL == directives[n].value.data.darray->array) {
+                    PMIX_RELEASE(op);
+                    return PMIX_ERR_BAD_PARAM;
+                }
+                tgtprocsgiven = true;
+                // is our node included?
+                ppid = (pmix_node_pid_t *) directives[n].value.data.darray->array;
+                sz = directives[n].value.data.darray->size;
+                for (m = 0; m < sz; m++) {
+                    // see if this node is us
+                    if (ppid[m].nodeid == pmix_globals.nodeid ||
+                        pmix_check_local(ppid[m].hostname)) {
+                        // is this one of our procs?
+                        for (k = 0; k < pmix_server_globals.clients.size; k++) {
+                            ptr = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
+                            if (NULL == ptr) {
+                                continue;
+                            }
+                            if (ppid[m].pid == ptr->info->pid) {
+                                PMIX_PSTAT_APPEND_PEER_UNIQUE(&op->peers, ptr);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // when we come out of the loop, it is possible that we were not
+        // given any target procs via any of the attributes. In this case,
+        // we assume that we are to take all local procs
+        if (!tgtprocsgiven) {
+            for (k = 0; k < pmix_server_globals.clients.size; k++) {
+                ptr = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
+                if (NULL == ptr) {
+                    continue;
+                }
+                PMIX_PSTAT_APPEND_PEER_UNIQUE(&op->peers, ptr);
+            }
+        }
+
+processprocs:
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.cbdata = PMIx_Info_list_start();
+        op->cb = &cb;
+        update(0, 0, (void *) op);
+        // convert to info array
+        rc = PMIx_Info_list_convert(cb.cbdata, &darray);
+        PMIx_Info_list_release(cb.cbdata);
+        PMIX_DESTRUCT(&cb);
+        op->cb = NULL;
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            PMIX_RELEASE(op);
+            if (PMIX_ERR_EMPTY == rc) {
+                // this is not an error
+                rc = PMIX_SUCCESS;
+            }
+            return rc;
+        }
+        *results = (pmix_info_t *) darray.array;
+        *nresults = darray.size;
+
+        // if we were given a rate, then setup the event to generate
+        // the requested updates
+        if (0 < op->rate) {
+            pmix_list_append(&pmix_pstat_base.ops, &op->super);
+            PMIX_PSTAT_OP_START(op, op->rate, update);
+        } else {
+            // otherwise, this was a one-time request, so we are done with the op
+            PMIX_RELEASE(op);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (PMIx_Check_key(monitor->key, PMIX_MONITOR_NODE_RESOURCE_USAGE)) {
+        // we already know we are a target node since we are
+        // being called
+        iptr = (pmix_info_t *) monitor->value.data.darray->array;
+        sz = monitor->value.data.darray->size;
+        // determine what stats to return - might include net and disk values
+        pmix_pstat_parse_ndstats(&op->ndstats, iptr, sz);
+        pmix_pstat_parse_netstats(&op->nets, &op->netstats, iptr, sz);
+        pmix_pstat_parse_dkstats(&op->disks, &op->dkstats, iptr, sz);
+        // start collecting response
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.cbdata = PMIx_Info_list_start();
+        op->cb = &cb;
+        // start with hostname
+        rc = PMIx_Info_list_add(cb.cbdata, PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(cb.cbdata);
+            op->cb = NULL;
+            PMIX_DESTRUCT(&cb);
+            PMIX_RELEASE(op);
+            return rc;
+        }
+        // add our nodeID
+        rc = PMIx_Info_list_add(cb.cbdata, PMIX_NODEID, &pmix_globals.nodeid, PMIX_UINT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(cb.cbdata);
+            op->cb = NULL;
+            PMIX_DESTRUCT(&cb);
+            PMIX_RELEASE(op);
+            return rc;
+        }
+        // collect the stats
+        update(0, 0, (void *) op);
+        // add this to the final answer
+        rc = PMIx_Info_list_convert(cb.cbdata, &darray);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Info_list_release(cb.cbdata);
+            op->cb = NULL;
+            PMIX_DESTRUCT(&cb);
+            PMIX_RELEASE(op);
+            return rc;
+        }
+        PMIx_Info_list_release(cb.cbdata);
+        PMIX_DESTRUCT(&cb);
+        op->cb = NULL;
+        // if the array has only two items in it, then those are the hostname
+        // and nodeID we provided and not any data - this is equivalent to
+        // "empty" as no data was found
+        if (3 > darray.size) {
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            PMIX_RELEASE(op);
+            return PMIX_SUCCESS;
+        }
+        PMIX_INFO_CREATE(xfer, 1);
+        PMIX_INFO_LOAD(xfer, PMIX_NODE_RESOURCE_USAGE, &darray, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        *results = xfer;
+        *nresults = 1;
+
+        // if we were given a rate, then setup the event to generate
+        // the requested updates
+        if (0 < op->rate) {
+            pmix_list_append(&pmix_pstat_base.ops, &op->super);
+            PMIX_PSTAT_OP_START(op, op->rate, update);
+        } else {
+            // otherwise, this was a one-time request, so we are done with the op
+            PMIX_RELEASE(op);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (PMIx_Check_key(monitor->key, PMIX_MONITOR_DISK_RESOURCE_USAGE)) {
+        // we already know we are a target node since we are
+        // being called
+        iptr = (pmix_info_t *) monitor->value.data.darray->array;
+        sz = monitor->value.data.darray->size;
+        // assemble any provided disk IDs and/or stat specifications
+        pmix_pstat_parse_dkstats(&op->disks, &op->dkstats, iptr, sz);
+        // collect the stats
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.cbdata = PMIx_Info_list_start();
+        op->cb = &cb;
+        update(0, 0, (void *) op);
+        // convert to info array
+        rc = PMIx_Info_list_convert(cb.cbdata, &darray);
+        PMIx_Info_list_release(cb.cbdata);
+        PMIX_DESTRUCT(&cb);
+        op->cb = NULL;
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            PMIX_RELEASE(op);
+            if (PMIX_ERR_EMPTY == rc) {
+                // empty = nothing found, not an error
+                rc = PMIX_SUCCESS;
+            }
+            return rc;
+        }
+        *results = (pmix_info_t *) darray.array;
+        *nresults = darray.size;
+
+        // if we were given a rate, then setup the event to generate
+        // the requested updates
+        if (0 < op->rate) {
+            pmix_list_append(&pmix_pstat_base.ops, &op->super);
+            PMIX_PSTAT_OP_START(op, op->rate, update);
+        } else {
+            // otherwise, this was a one-time request, so we are done with the op
+            PMIX_RELEASE(op);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (PMIx_Check_key(monitor->key, PMIX_MONITOR_NET_RESOURCE_USAGE)) {
+        // we already know we are a target node since we are
+        // being called
+        iptr = (pmix_info_t *) monitor->value.data.darray->array;
+        sz = monitor->value.data.darray->size;
+        // assemble any provided network IDs and/or stat specifications
+        pmix_pstat_parse_netstats(&op->nets, &op->netstats, iptr, sz);
+        // collect the stats
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.cbdata = PMIx_Info_list_start();
+        op->cb = &cb;
+        update(0, 0, (void *) op);
+        // convert to info array
+        rc = PMIx_Info_list_convert(cb.cbdata, &darray);
+        PMIx_Info_list_release(cb.cbdata);
+        PMIX_DESTRUCT(&cb);
+        op->cb = NULL;
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(op);
+            if (PMIX_ERR_EMPTY == rc) {
+                // empty = nothing found, not an error
+                rc = PMIX_SUCCESS;
+            }
+            return rc;
+        }
+        *results = (pmix_info_t *) darray.array;
+        *nresults = darray.size;
+
+        // if we were given a rate, then setup the event to generate
+        // the requested updates
+        if (0 < op->rate) {
+            pmix_list_append(&pmix_pstat_base.ops, &op->super);
+            PMIX_PSTAT_OP_START(op, op->rate, update);
+        } else {
+            // otherwise, this was a one-time request, so we are done with the op
+            PMIX_RELEASE(op);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    return PMIX_SUCCESS;
+}


### PR DESCRIPTION
Two related improvements to the `pstat` (process statistics) framework.

## 1. Report non-SCSI disks in the Linux reader

`disk_stat` in `plinux` filtered `/proc/diskstats` with `strstr(line, "sd")`
— a whole-line substring match that only recognized SCSI/SATA devices and
skipped NVMe, virtio, Xen, and MMC/SD-card disks entirely. It is replaced
with an `is_disk_device()` helper that tests the device-name column against
the known physical-disk driver prefixes (`sd`, `hd`, `vd`, `xvd`, `nvme`,
`mmcblk`). Disks named explicitly in `op->disks` are still honored by exact
match.

## 2. New `pmacos` component

Adds a macOS (Darwin) `pstat` component — previously the monitor API on a
Mac fell back to the canned `test` component or the unsupported stubs and
returned no real data. `pmacos` is the Darwin analog of `plinux` at priority
80; the two never coexist (each `configure.m4` gates to its own OS). The
request-dispatch / periodic-update / cancel logic mirrors `plinux`; only the
four category readers are platform-specific:

- **proc** — `proc_pidinfo` (task + BSD info) and `proc_name`
- **node** — `getloadavg`, `sysctl` (`hw.memsize`, `vm.swapusage`), `host_statistics64`
- **disk** — IOKit `IOBlockStorageDriver` statistics, keyed by BSD name, with units normalized to match Linux (512-byte sectors, milliseconds)
- **net** — `getifaddrs` `if_data` per-interface counters

`configure.m4` enables the component only on Apple hosts and links IOKit +
CoreFoundation (added to `PMIX_EMBEDDED_LIBS` so static builds link them).

## Testing

- Full `make` / `make install` clean under `--enable-devel-check` (`-Werror`, GCC).
- Driven end-to-end through `examples/monitor` (proc, node, disk, net, periodic
  updates, and cancellation): "Test finished OK!" with real data, including
  multiple disks (`disk0`, `disk4`, `disk6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)