### PR TITLE
class/bitmap: zero-initialize the buffer in pmix_bitmap_copy

### DIFF
--- a/src/class/pmix_bitmap.h
+++ b/src/class/pmix_bitmap.h
@@ -172,7 +172,7 @@ static inline void pmix_bitmap_copy(pmix_bitmap_t *dest, pmix_bitmap_t *src)
         if (NULL != dest->bitmap)
             free(dest->bitmap);
         dest->max_size = src->max_size;
-        dest->bitmap = (uint64_t *) malloc(src->array_size * sizeof(uint64_t));
+        dest->bitmap = (uint64_t *) calloc(src->array_size, sizeof(uint64_t));
     }
     memcpy(dest->bitmap, src->bitmap, src->array_size * sizeof(uint64_t));
     dest->array_size = src->array_size;


### PR DESCRIPTION
`pmix_bitmap_copy` allocated the destination buffer with `malloc` while the
rest of the bitmap class consistently zero-initializes its storage (`calloc`
in `pmix_bitmap_init`, `memset` of the grown tail in `set_bit`). This switches
the copy path to `calloc` so the allocation convention is uniform and any
bytes beyond what the immediate `memcpy` overwrites are defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)