### PR TITLE
ptl/base: don't prune a gracefully-finalized proc from collectives

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -8,6 +8,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -102,6 +103,45 @@ static void lost_connection(pmix_peer_t *peer)
                 }
                 if (!flag) {
                     continue;
+                }
+                /* If this peer disconnected as the result of an orderly
+                 * PMIx_Finalize (rather than a fault), do not prune it from a
+                 * *fence* it has not yet joined. Under the repeated
+                 * PMIx_Init/PMIx_Finalize usage model (e.g., the MPI Sessions
+                 * model), the peer will reconnect via a subsequent PMIx_Init
+                 * and is still required to participate in the namespace's
+                 * fences. Because a wildcard fence tracker lists every proc in
+                 * the namespace, a proc that is momentarily disconnected
+                 * between the PMIx_Finalize of one cycle and the PMIx_Init of
+                 * the next matches, by name, a fence tracker that a faster
+                 * peer already opened for the next cycle; pruning it there
+                 * decrements nlocal and lets that fence complete short
+                 * (PMIX_ERR_PARTIAL_SUCCESS), desynchronizing the fence
+                 * sequence and hanging the peers still expecting it. This is
+                 * consistent with the nlocalprocs and event-notification
+                 * handling below, which already special-case peer->finalized.
+                 *
+                 * Scope this strictly to fence (PMIX_FENCENB_CMD). The other
+                 * collective types handled here - connect, disconnect, and
+                 * group construct - establish persistent relationships and are
+                 * not part of the per-cycle init/finalize pattern, so their
+                 * existing fault-tolerance pruning is left unchanged. A
+                 * blocking PMIx_Fence cannot have been joined by a peer that
+                 * subsequently called PMIx_Finalize (the fence must have
+                 * returned first), but a non-blocking PMIx_Fence_nb can be
+                 * abandoned that way, so we still prune when the peer had
+                 * actually joined the tracker. */
+                if (peer->finalized && PMIX_FENCENB_CMD == trk->type) {
+                    bool joined = false;
+                    PMIX_LIST_FOREACH (rinfo, &trk->local_cbs, pmix_server_caddy_t) {
+                        if (PMIX_CHECK_NAMES(&rinfo->peer->info->pname, &peer->info->pname)) {
+                            joined = true;
+                            break;
+                        }
+                    }
+                    if (!joined) {
+                        continue;
+                    }
                 }
                 /* it should - adjust the count */
                 --trk->nlocal;


### PR DESCRIPTION
Fixes #3931: a `PMIx_Fence` over a namespace deadlocks under repeated
`PMIx_Init`/`PMIx_Finalize` (the MPI Sessions usage model) because
`lost_connection()` prunes a gracefully-finalized -- and immediately
reconnecting -- proc from an in-progress collective, completing it short
(`PMIX_ERR_PARTIAL_SUCCESS`) and desynchronizing the namespace's fence
sequence. See #3931 for the full analysis and a pure-PMIx reproducer (no
MPI; `test/simple/simptest` + a small client).

### The fix

`lost_connection()` already special-cases `peer->finalized` for the
`nptr->nlocalprocs` decrement and the `PMIX_ERR_LOST_CONNECTION` event,
but the collective-pruning loop between them did not. This teaches that
loop to leave a gracefully-finalized proc that has not yet joined a
tracker in place, so its reconnected incarnation can still complete the
collective. A faulted (non-finalized) proc -- or a finalized proc that had
actually joined the tracker (a non-blocking fence abandoned via Finalize)
-- is still pruned, so fault tolerance for a genuinely dead client is
preserved.

### Validation

- Pure-PMIx reproducer (`simptest` + client, 4 procs, heavy CPU load):
  - before: hangs within a run or two;
  - after: 50/50 runs × 200 cycles complete cleanly, 0 hangs.
- Fault-tolerance regression check: a client that `_exit()`s mid-fence
  (no finalize) still lets the survivors' fence complete
  (`PMIX_ERR_PARTIAL_SUCCESS`) rather than hang.
- End-to-end in Open MPI (this patch applied to the embedded PMIx): the
  MPI Sessions reproducer from open-mpi/ompi#14125 (repeated
  `MPI_Session_init`/`MPI_Session_finalize` under load) goes from hanging
  on ~run 1 to **30/30 runs × 300 cycles (9,000 cycles/rank) clean**.

### Cherry-pick

If this is the right approach, it should also be cherry-picked to **`v6.1`**
-- the OpenPMIx branch that Open MPI's `main` and `v6.0.x` branches embed
(submodule pinned at `v6.1.1rc2` / `cb89026`). Those are the Open MPI
release lines that ship MPI Sessions, so that is where the fix is needed
downstream. (Open MPI `v5.0.x` embeds `v5.0` and predates the Sessions
model, so it is not affected via this path.)

### Note / open question

The server cannot distinguish "gracefully finalized and will reconnect"
from "gracefully finalized for good"; this patch optimizes for the former
(the Sessions model). The theoretical trade-off: a proc that finalizes
*permanently* while still named in peers' ongoing wildcard fence would now
cause that fence to wait rather than complete short. That is not reachable
in well-formed symmetric usage (a proc shouldn't finalize while still
expected in a collective), and completing a whole-namespace fence after a
member has permanently departed was already returning incomplete data --
but flagging it in case a different mechanism is preferred (e.g., a short
grace period before pruning, or fence-generation tracking).

@rhc54 -- would appreciate your review, particularly on that edge case.
