### PR TITLE
mca: fix deprecated variable source warning

### DIFF
--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -45,7 +45,7 @@ jobs:
          # Tweak PRRTE
          mca_params="$HOME/.prte/mca-params.conf"
          mkdir -p "$(dirname "$mca_params")"
-         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+         echo mapby = :oversubscribe >> "$mca_params"
     - name: Run direct test
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:$RUNNER_TEMP/pmixinstall/bin:${PATH}

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -42,7 +42,7 @@ jobs:
          # Tweak PRRTE
          mca_params="$HOME/.prte/mca-params.conf"
          mkdir -p "$(dirname "$mca_params")"
-         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+         echo mapby = :oversubscribe >> "$mca_params"
     - name: Run simple group
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}

--- a/.github/workflows/pmix_mpi4py.yaml
+++ b/.github/workflows/pmix_mpi4py.yaml
@@ -110,7 +110,7 @@ jobs:
         echo mpi_show_handle_leaks = true >> "$mca_params"
         mca_params="$HOME/.prte/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
-        echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+        echo mapby = :oversubscribe >> "$mca_params"
 
     - name: Show MPI
       run:  ompi_info

--- a/.github/workflows/prrte.yaml
+++ b/.github/workflows/prrte.yaml
@@ -42,7 +42,7 @@ jobs:
          # Tweak PRRTE
          mca_params="$HOME/.prte/mca-params.conf"
          mkdir -p "$(dirname "$mca_params")"
-         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+         echo mapby = :oversubscribe >> "$mca_params"
     - name: Run simple test
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -76,6 +76,7 @@ static char *pmix_mca_base_var_override_file = NULL;
 static char *pmix_mca_base_var_file_prefix = NULL;
 static char *pmix_mca_base_param_file_path = NULL;
 static bool pmix_mca_base_var_suppress_override_warning = false;
+static bool pmix_mca_base_var_suppress_deprecated_warning = true;
 static int pmix_mca_base_var_count = 0;
 static pmix_hash_table_t pmix_mca_base_var_index_hash = PMIX_HASH_TABLE_STATIC_INIT;
 
@@ -358,6 +359,19 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                      &pmix_mca_base_var_override_file);
     free(tmp);
+    if (0 > ret) {
+        return ret;
+    }
+
+    /* Suppress warnings emitted when a deprecated MCA parameter is set.
+     * Defaults to true so that deprecated-but-still-functional parameters
+     * do not spam users; set to false to surface the warnings. */
+    pmix_mca_base_var_suppress_deprecated_warning = true;
+    ret = pmix_mca_base_var_register(
+        "pmix", "mca", "base", "suppress_deprecated_warning",
+        "Suppress warnings when a deprecated MCA parameter is set (default: true)",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_mca_base_var_suppress_deprecated_warning);
     if (0 > ret) {
         return ret;
     }
@@ -1446,7 +1460,7 @@ static int var_set_from_env(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origi
         }
     }
 
-    if (deprecated) {
+    if (deprecated && !pmix_mca_base_var_suppress_deprecated_warning) {
         const char *new_variable = "None (going away)";
 
         if (is_synonym) {
@@ -1510,7 +1524,7 @@ static int var_set_from_file(pmix_mca_base_var_t *var, pmix_mca_base_var_t *orig
             return PMIX_ERR_NOT_FOUND;
         }
 
-        if (deprecated) {
+        if (deprecated && !pmix_mca_base_var_suppress_deprecated_warning) {
             const char *new_variable = "None (going away)";
 
             if (is_synonym) {

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -1435,13 +1435,14 @@ static int var_set_from_env(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origi
     if (NULL != source_env) {
         if (0 == strncasecmp(source_env, "file:", 5)) {
             original->mbv_source_file = append_filename_to_list(source_env + 5);
-            if (0 == strcmp(var->mbv_source_file, pmix_mca_base_var_override_file)) {
+            if (0 == strcmp(original->mbv_source_file, pmix_mca_base_var_override_file)) {
                 original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE;
             } else {
                 original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_FILE;
             }
-        } else if (0 == strcasecmp(source_env, "command")) {
-            var->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE;
+        } else if (0 == strcasecmp(source_env, "command") ||
+                   0 == strcasecmp(source_env, "command_line")) {
+            original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE;
         }
     }
 
@@ -1449,10 +1450,10 @@ static int var_set_from_env(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origi
         const char *new_variable = "None (going away)";
 
         if (is_synonym) {
-            new_variable = var->mbv_full_name;
+            new_variable = original->mbv_full_name;
         }
 
-        switch (var->mbv_source) {
+        switch (original->mbv_source) {
         case PMIX_MCA_BASE_VAR_SOURCE_ENV:
             pmix_show_help("help-pmix-mca-var.txt", "deprecated-mca-env", true, var_full_name,
                            new_variable);
@@ -1464,7 +1465,7 @@ static int var_set_from_env(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origi
         case PMIX_MCA_BASE_VAR_SOURCE_FILE:
         case PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE:
             pmix_show_help("help-pmix-mca-var.txt", "deprecated-mca-file", true, var_full_name,
-                           pmix_mca_base_var_source_file(var), new_variable);
+                           pmix_mca_base_var_source_file(original), new_variable);
             break;
 
         case PMIX_MCA_BASE_VAR_SOURCE_DEFAULT:


### PR DESCRIPTION
This PR is to fix the deprecated MCA variable warning so PMIx reports the right source and the right new variable name.

When the old variable name is set from the environment, PMIx was reporting it as if it came from an MCA params file. It also printed the old variable name as the new variable name.

The case tested was:

- file: `mca_base_component_show_load_errors = 1`
- environment: `PMIX_MCA_mca_component_show_load_errors=0`

Before this change, PMIx reported the source as an MCA variable file and printed:

- `Deprecated variable: mca_component_show_load_errors`
- `New variable:        mca_component_show_load_errors`

After this change, PMIx reports the source as environment/command line and prints:

- `Deprecated variable: mca_component_show_load_errors`
- `New variable:        mca_base_component_show_load_errors`

I also checked the file case. When `mca_component_show_load_errors` is actually in the MCA params file, PMIx still reports the source file and the right new variable name.

Testing:

- `./autogen.pl`
- `../configure --prefix="$PWD/install"`
- `make -j"$(nproc)"`
- `make install`
- checked the environment case with `PMIX_MCA_mca_component_show_load_errors=0`
- checked the file case with `mca_component_show_load_errors = 0` in the MCA params file

Related to open-mpi/ompi#13958.
