### PR TITLE
Track collective participation by identity to survive lost connections (fence + group)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ examples/group_lcl_cid
 examples/nodeinfo
 examples/pset
 examples/group_bootstrap
+examples/group_die
 examples/spawn_group
 examples/resolve
 examples/multi_nspace_group

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ examples/nodeinfo
 examples/pset
 examples/group_bootstrap
 examples/group_die
+examples/connect_die
 examples/spawn_group
 examples/resolve
 examples/multi_nspace_group

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,7 @@ test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
 test/unit/gds_fallback
 test/unit/pmix_log
+test/unit/collective_status
 test/unit/run_gds_fallback.pl
 test/unit/util_argv
 test/unit/util_basename

--- a/contrib/dockerswarm/.gitignore
+++ b/contrib/dockerswarm/.gitignore
@@ -1,0 +1,5 @@
+# Out-of-tree (VPATH) build directories created by build.sh macos at the repo
+# root (see README.md).  The Linux build lives in the docker `pmix-build`
+# volume, not on disk, so only the native-macOS trees need ignoring.
+vpath-macos-pmix/
+vpath-macos-prte/

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -1,0 +1,82 @@
+# Base image for the PMIx group-test "swarm" (see README.md).
+#
+# This harness is PMIx-centric: the code under test is *your live openpmix
+# working tree*, which build.sh bind-mounts into a builder container and
+# compiles out-of-tree (VPATH) into a shared volume mounted at /opt/prte.  PMIx
+# is therefore NOT baked into this image.
+#
+# PRRTE is only the launcher we drive the tests through, so its *source* (the
+# master branch) is baked in here and autogen'd, but it is NOT built at image
+# time -- PRRTE must link the PMIx we are testing, so build.sh configures and
+# builds the baked PRRTE source against your freshly-built PMIx at run time.
+#
+# This image therefore provides:
+#
+#   * the build toolchain (so the builder container can compile PMIx + PRRTE),
+#   * PRRTE master source pre-cloned and autogen'd in /src/prrte,
+#   * passwordless SSH between the "nodes", and
+#   * an entrypoint that makes the shared-volume libraries loadable.
+#
+# Build it with ./build.sh (which also drives the PMIx + PRRTE build); a bare
+# `docker build` just produces this base.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential gcc g++ make \
+        autoconf automake libtool m4 flex \
+        perl python3 git \
+        libevent-dev libhwloc-dev zlib1g-dev \
+        openssh-server openssh-client \
+        iproute2 iputils-ping procps less vim ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- baked PRRTE source (the launcher, built at run time) ----
+# Clone PRRTE master with submodules so autogen.pl runs normally, and autogen
+# it now (autogen needs no PMIx).  We deliberately do NOT configure/build here:
+# PRRTE must be built against the PMIx under test, which build.sh bind-mounts
+# and installs at run time.  Override the branch/repo with --build-arg.
+ARG PRRTE_REPO=https://github.com/openpmix/prrte.git
+ARG PRRTE_REF=master
+RUN git clone --recursive -b "$PRRTE_REF" "$PRRTE_REPO" /src/prrte \
+    && cd /src/prrte \
+    && ./autogen.pl
+
+# ---- passwordless SSH between the container "nodes" ----
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519 \
+    && cp /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys \
+    && printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+         > /root/.ssh/config \
+    && chmod 600 /root/.ssh/* \
+    && sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && printf '\nAcceptEnv *\n' >> /etc/ssh/sshd_config
+
+# make the run-time install discoverable for any login shell (build.sh writes
+# /opt/prte/env.sh with PATH/LD_LIBRARY_PATH once it knows the PMIx layout)
+RUN echo '[ -f /opt/prte/env.sh ] && . /opt/prte/env.sh' > /etc/profile.d/prte.sh
+
+# ---- node entrypoint ----
+# The PMIx/PRRTE install lives in the shared /opt/prte volume, which is not on
+# the image's default PATH or ld.so search path.  Before starting sshd:
+#   * register the install's lib dirs with ldconfig so libpmix/libprrte load,
+#     and
+#   * symlink the install's binaries onto the default PATH (/usr/local/bin) so
+#     that `prted` resolves in the non-login shell that plm/ssh uses to launch
+#     daemons on the other nodes -- without this, a multi-node launch fails with
+#     "prted: command not found".
+RUN printf '#!/bin/sh\n\
+for d in /opt/prte/prte/lib /opt/prte/pmix/lib; do\n\
+    [ -d "$d" ] && echo "$d" >> /etc/ld.so.conf.d/prte.conf\n\
+done\n\
+ldconfig\n\
+for b in /opt/prte/prte/bin/*; do\n\
+    [ -e "$b" ] && ln -sf "$b" /usr/local/bin/\n\
+done 2>/dev/null\n\
+exec /usr/sbin/sshd -D -e\n' > /usr/local/bin/node-entrypoint.sh \
+    && chmod +x /usr/local/bin/node-entrypoint.sh
+
+EXPOSE 22
+CMD ["/usr/local/bin/node-entrypoint.sh"]

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1,0 +1,161 @@
+# PMIx group-test "swarm"
+
+A small, self-contained harness for exercising **PMIx group construction**
+across several container "nodes" — real, separate PMIx servers (one `prted` per
+node) so the server-side local-completion and lost-connection accounting
+actually run on more than one daemon. It is the quickest way to run the group
+example programs the way they are meant to be run: distributed across nodes,
+including the case where a participant dies mid-construct.
+
+It is **not** a Docker Swarm in the orchestration sense — just ten plain
+`ubuntu:24.04` containers on one bridge network, each acting as a node. "Swarm"
+is only the nickname.
+
+> This harness is adapted from PRRTE's `contrib/dockerswarm`, inverted to be
+> **PMIx-centric**: the code under test is *your live openpmix working tree*
+> (bind-mounted, built out-of-tree, never stale, no commit required). PRRTE is
+> just the launcher — its master branch is baked into the image as source and
+> built **against your PMIx** at run time, so the launcher's PMIx *server*
+> library is the one you are testing.
+
+---
+
+## 1. What's here
+
+| File | Purpose |
+|------|---------|
+| `build.sh` | Builds PMIx from your **live** tree (VPATH) plus PRRTE master against it: into a shared volume for the Linux swarm, or natively for macOS. Start here. |
+| `run-tests.sh` | Runs the group example programs and reports PASS/FAIL: full multi-node suite on Linux, single-host subset on macOS. |
+| `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
+| `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. |
+
+## 2. How it works
+
+```
+        your live openpmix tree   (bind-mounted read-only)
+                   │
+   ┌───────────────┴───────────────┐
+   │ build.sh linux                │ build.sh macos
+   ▼                               ▼
+ builder container              native on host
+ PMIx  VPATH -> /opt/prte/pmix   PMIx  -> vpath-macos-pmix/install
+ PRRTE VPATH -> /opt/prte/prte   PRRTE -> vpath-macos-prte/install
+ group clients -> /opt/prte/tests   (PRRTE built --with-pmix=<your PMIx>)
+   │                               │
+   ▼                               ▼
+ 10 nodes mount /opt/prte:ro     run-tests.sh macos
+ run-tests.sh linux            (single-host smoke)
+```
+
+- **PMIx is the tree under test.** PRRTE is built `--with-pmix` your PMIx, so
+  `prted` (the PMIx server) links the library you just changed.
+- **Never stale, no commit.** Edit a file, rerun `build.sh`, and the swarm runs
+  your change (the build is incremental).
+- **PRRTE is baked as source.** The image clones PRRTE `master` and runs
+  `autogen.pl`; `build.sh` only configures + builds it (against your PMIx) into
+  the shared volume. Override the branch with `PRRTE_REF=... ./build.sh image`.
+
+## 3. Prerequisites
+
+- Docker (with `docker compose`) and `git` for the Linux swarm.
+- A working autotools toolchain (`autoconf`/`automake`/`libtool`/`perl`) on the
+  host for `autogen.pl` and the macOS build.
+- **Network access during the first image build** (clones PRRTE + submodules,
+  installs apt packages).
+
+## 4. Quick start
+
+```sh
+# from this directory (contrib/dockerswarm/)
+
+# ---- Linux swarm ----
+./build.sh                 # distclean+autogen your PMIx (once), build image,
+                           #   build PMIx + PRRTE + group clients into the volume
+docker compose up -d       # start pmix-node1 .. pmix-node10
+./run-tests.sh linux       # multi-node group construction suite
+
+# ---- native macOS (single host) ----
+./build.sh macos           # native PMIx + PRRTE build under vpath-macos-*
+./run-tests.sh macos       # single-host group smoke
+```
+
+Rebuild after editing PMIx: rerun `./build.sh` (incremental). No image rebuild
+and no `docker compose` restart needed — the nodes read the shared volume.
+
+## 5. Driving it by hand
+
+`run-tests.sh` automates this, but to poke at it yourself:
+
+```sh
+RUN='docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 pmix-node1 bash -lc'
+
+# run a group example across two nodes (a group then spans two PMIx servers)
+$RUN '. /opt/prte/env.sh; prterun --host node1:2,node2:2 -np 4 --map-by node group'
+
+# the other construction methods
+$RUN '. /opt/prte/env.sh; prterun --host node1:2,node2:2 -np 4 --map-by node group_bootstrap'
+```
+
+`. /opt/prte/env.sh` puts the shared-volume install on `PATH`/`LD_LIBRARY_PATH`
+in a non-login `docker exec` shell (login shells get it automatically).
+
+The group example programs (from the PMIx `examples/` directory) are built as
+standalone clients into `/opt/prte/tests`:
+
+| Program | Construction method exercised |
+|---------|-------------------------------|
+| `group` | basic `PMIx_Group_construct` over a proc subset, then destruct |
+| `group_bootstrap` | bootstrap construction (members join a named group) |
+| `group_dmodex` | group + direct modex data exchange |
+| `group_lcl_cid` | local context-id assignment |
+| `asyncgroup` | non-blocking `PMIx_Group_construct_nb` |
+| `multi_nspace_group` | a group spanning more than one namespace |
+
+## 6. What "success" looks like
+
+Each group example prints `Group construct complete` on its constructing ranks
+and exits cleanly, with no `prted` left behind on any node. The multi-node
+launch spreads the ranks across daemons (`--map-by node`), so the group's
+local phase is assembled and completed on more than one PMIx server.
+
+**Participant death.** The `participant death during group construct` check
+launches a variant in which one rank exits before calling the construct; the
+group must still complete on the survivors rather than hang. A hang (the run
+hitting `--timeout`) is the pre-fix failure mode — group collectives received
+no lost-connection accounting at all, so the construct never reached its
+expected count. This check is skipped until the `group_die` client is built
+alongside the group loss-accounting fix.
+
+## 7. Cleanup hygiene
+
+`run-tests.sh` cleans up between tests; if you drive things by hand, clear
+stale state on **every** node between DVM runs:
+
+```sh
+for n in $(seq 1 10); do
+  docker exec pmix-node$n sh -c 'pkill -9 -x prted; pkill -9 -x prte;
+    pkill -9 prterun; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix*; true'
+done
+```
+
+## 8. Rebuilding / resetting
+
+| Want to… | Do |
+|----------|----|
+| pick up a PMIx source edit | `./build.sh` (incremental into the volume) |
+| force a clean rebuild | `docker volume rm pmix-build && ./build.sh` |
+| rebuild the base image (new PRRTE branch) | `PRRTE_REF=v3.0.x ./build.sh image` |
+| tear down the swarm | `docker compose down` (the `pmix-build` volume persists) |
+
+## 9. Topology reference
+
+| Container | hostname | role |
+|-----------|----------|------|
+| `pmix-node1` | node1 | head node — start the DVM here, run all tools here |
+| `pmix-node2`..`pmix-node10` | node2..node10 | additional daemon nodes |
+
+Network: bridge `dvm`. All nodes mount the shared `pmix-build` volume read-only
+at `/opt/prte`, where `build.sh` installs PMIx (`/opt/prte/pmix`), PRRTE
+(`/opt/prte/prte`), the group clients (`/opt/prte/tests`), and writes
+`/opt/prte/env.sh`. To add or remove nodes, copy or delete a service block in
+`docker-compose.yml` (and adjust the `seq 1 10` loops in `run-tests.sh`).

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Build PMIx (your *live* working tree) plus the PRRTE launcher for the group
+# test swarm (README.md) -- no commit required, never stale.
+#
+# This harness is PMIx-centric: the code under test is the openpmix tree this
+# script lives in.  PRRTE master is baked (as source) into the image and built
+# against your PMIx here, so the launcher's PMIx *server* library is the one you
+# are testing -- which is what makes it exercise server-side collective code.
+#
+# The PMIx tree is built OUT OF TREE (VPATH) so the source stays pristine:
+#
+#   ./build.sh          # or 'linux': build (in a container) into the shared
+#                       #   /opt/prte volume that the swarm nodes mount
+#   ./build.sh macos    # build natively on this host (single-host smoke)
+#   ./build.sh image    # (re)build just the base container image
+#
+# Because a VPATH configure refuses to run while the source tree still has an
+# in-tree build, this script runs `make distclean` (once) at the repo root and
+# then `./autogen.pl`.  After that, ALL builds are out-of-tree and your
+# top-level source dir stays clean.
+#
+# Requires: docker (for linux/image), git, and a working autotools toolchain.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(git -C "$here" rev-parse --show-toplevel)"     # the openpmix tree
+
+IMAGE="${IMAGE:-pmix-swarm:latest}"
+VOLUME="${VOLUME:-pmix-build}"
+PRRTE_REF="${PRRTE_REF:-master}"        # baked-image PRRTE branch
+PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
+
+# the group example programs that exercise the construction methods; built as
+# standalone clients against the installed PMIx and launched by prterun/prun.
+# group_die (a member leaves before contributing) drives the lost-connection
+# accounting and is exercised separately by run-tests.sh.
+GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
+BUILD_EXAMPLES="$GROUP_EXAMPLES group_die"
+
+mode="${1:-linux}"
+
+# --- make the source tree VPATH-ready (idempotent) --------------------------
+prep_srcdir() {
+    if [ -f "$root/config.status" ] || [ -f "$root/Makefile" ]; then
+        echo ">>> make distclean (source tree had an in-tree build)"
+        make -C "$root" distclean >/dev/null 2>&1 || true
+    fi
+    if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then
+        echo ">>> autogen.pl"
+        ( cd "$root" && ./autogen.pl )
+    fi
+}
+
+# --- (re)build the base image if needed -------------------------------------
+build_image() {
+    if [ "${1:-}" = force ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        echo ">>> docker build $IMAGE (baked PRRTE $PRRTE_REF)"
+        docker build -t "$IMAGE" \
+            --build-arg PRRTE_REPO="$PRRTE_REPO" \
+            --build-arg PRRTE_REF="$PRRTE_REF" \
+            "$here"
+    else
+        echo ">>> using existing image $IMAGE (./build.sh image to rebuild)"
+    fi
+}
+
+# --- Linux build (in a builder container, into the shared volume) -----------
+build_linux() {
+    prep_srcdir
+    build_image
+    docker volume create "$VOLUME" >/dev/null
+
+    echo ">>> building PMIx (your tree) + PRRTE (baked master) into volume $VOLUME"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e BUILD_EXAMPLES="$BUILD_EXAMPLES" \
+        "$IMAGE" bash -euo pipefail -c '
+            jobs=$(nproc)
+
+            echo ">>>> PMIx from bind-mounted /pmix-src -> /opt/prte/pmix"
+            mkdir -p /opt/prte/vpath-pmix && cd /opt/prte/vpath-pmix
+            [ -f config.status ] || /pmix-src/configure --prefix=/opt/prte/pmix --enable-debug
+            make -j"$jobs" && make install
+
+            echo ">>>> PRRTE (baked master) VPATH build -> /opt/prte/prte"
+            mkdir -p /opt/prte/vpath-prte && cd /opt/prte/vpath-prte
+            [ -f config.status ] || /src/prrte/configure \
+                --prefix=/opt/prte/prte --with-pmix=/opt/prte/pmix --enable-debug
+            make -j"$jobs" && make install
+
+            echo ">>>> group example clients -> /opt/prte/tests"
+            mkdir -p /opt/prte/tests
+            for ex in $BUILD_EXAMPLES; do
+                [ -f "/pmix-src/examples/$ex.c" ] || { echo "   (skip $ex: no source)"; continue; }
+                gcc -O0 -g -o "/opt/prte/tests/$ex" "/pmix-src/examples/$ex.c" \
+                    -I/opt/prte/pmix/include -I/pmix-src/examples \
+                    -L/opt/prte/pmix/lib -lpmix \
+                && echo "   built $ex" || echo "   FAILED to build $ex"
+            done
+
+            # runtime env for login shells (node-entrypoint handles ld.so)
+            printf "export PATH=/opt/prte/prte/bin:/opt/prte/tests:\$PATH\nexport LD_LIBRARY_PATH=/opt/prte/prte/lib:/opt/prte/pmix/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\n" \
+                > /opt/prte/env.sh
+            echo ">>>> done: PMIx in /opt/prte/pmix, PRRTE in /opt/prte/prte, tests in /opt/prte/tests"
+        '
+    echo ">>> Linux build complete."
+    echo ">>> next: docker compose up -d && ./run-tests.sh linux"
+}
+
+# --- macOS build (native, on this host; single-host smoke) ------------------
+build_macos() {
+    prep_srcdir
+    local pfx="$root/vpath-macos-pmix/install"
+    echo ">>> PMIx native VPATH build -> $pfx"
+    mkdir -p "$root/vpath-macos-pmix" && cd "$root/vpath-macos-pmix"
+    [ -f config.status ] || "$root/configure" --prefix="$pfx" --enable-debug ${EXTRA_CONFIGURE_ARGS:-}
+    make -j"$(sysctl -n hw.ncpu)" && make install
+
+    local psrc="$root/vpath-macos-prte/src"
+    if [ ! -d "$psrc" ]; then
+        echo ">>> cloning PRRTE $PRRTE_REF -> $psrc"
+        git clone --recursive -b "$PRRTE_REF" "$PRRTE_REPO" "$psrc"
+        ( cd "$psrc" && ./autogen.pl )
+    fi
+    echo ">>> PRRTE native build -> $root/vpath-macos-prte/install"
+    mkdir -p "$root/vpath-macos-prte/build" && cd "$root/vpath-macos-prte/build"
+    [ -f config.status ] || "$psrc/configure" \
+        --prefix="$root/vpath-macos-prte/install" --with-pmix="$pfx" --enable-debug \
+        ${EXTRA_CONFIGURE_ARGS:-}
+    make -j"$(sysctl -n hw.ncpu)" && make install
+
+    echo ">>> group example clients -> $root/vpath-macos-prte/install/bin"
+    for ex in $BUILD_EXAMPLES; do
+        [ -f "$root/examples/$ex.c" ] || continue
+        gcc -O0 -g -o "$root/vpath-macos-prte/install/bin/$ex" "$root/examples/$ex.c" \
+            -I"$pfx/include" -I"$root/examples" -L"$pfx/lib" -lpmix \
+        && echo "   built $ex" || echo "   FAILED to build $ex"
+    done
+    echo ">>> macOS build complete."
+    echo ">>> next: ./run-tests.sh macos"
+}
+
+case "$mode" in
+    linux) build_linux ;;
+    macos) build_macos ;;
+    image) prep_srcdir; build_image force ;;
+    *) echo "usage: $0 [linux|macos|image]" >&2; exit 2 ;;
+esac

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -41,10 +41,10 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 
 # the group example programs that exercise the construction methods; built as
 # standalone clients against the installed PMIx and launched by prterun/prun.
-# group_die (a member leaves before contributing) drives the lost-connection
-# accounting and is exercised separately by run-tests.sh.
+# group_die and connect_die (a participant leaves before contributing) drive
+# the lost-connection accounting and are exercised separately by run-tests.sh.
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-BUILD_EXAMPLES="$GROUP_EXAMPLES group_die"
+BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die"
 
 mode="${1:-linux}"
 

--- a/contrib/dockerswarm/docker-compose.yml
+++ b/contrib/dockerswarm/docker-compose.yml
@@ -1,0 +1,74 @@
+# A 10-"node" cluster on a private docker network for exercising PMIx group
+# construction across real, separate PMIx servers (one prted per node).  node1
+# is the head node (where you start the DVM and run the tests); node2..node10
+# host the additional daemons a multi-node group spans.
+#
+# Nothing is baked into the image except the toolchain and PRRTE *source*:
+# build.sh compiles your live openpmix working tree (and PRRTE against it)
+# out-of-tree into the shared `pmix-build` volume, which every node mounts
+# read-only at /opt/prte.  So `docker compose up -d` must be preceded by a
+# `./build.sh` (which populates the volume).  See README.md.
+#
+# Ten nodes give a group enough distinct servers that the local-completion and
+# lost-connection accounting run on several daemons at once, and let a group
+# span a multi-level daemon tree.
+
+x-node: &node
+  image: pmix-swarm:latest
+  networks: [dvm]
+  tty: true
+  volumes:
+    - pmix-build:/opt/prte:ro
+
+services:
+  node1:
+    <<: *node
+    hostname: node1
+    container_name: pmix-node1
+  node2:
+    <<: *node
+    hostname: node2
+    container_name: pmix-node2
+  node3:
+    <<: *node
+    hostname: node3
+    container_name: pmix-node3
+  node4:
+    <<: *node
+    hostname: node4
+    container_name: pmix-node4
+  node5:
+    <<: *node
+    hostname: node5
+    container_name: pmix-node5
+  node6:
+    <<: *node
+    hostname: node6
+    container_name: pmix-node6
+  node7:
+    <<: *node
+    hostname: node7
+    container_name: pmix-node7
+  node8:
+    <<: *node
+    hostname: node8
+    container_name: pmix-node8
+  node9:
+    <<: *node
+    hostname: node9
+    container_name: pmix-node9
+  node10:
+    <<: *node
+    hostname: node10
+    container_name: pmix-node10
+
+networks:
+  dvm:
+    driver: bridge
+
+# Populated by build.sh (docker volume create pmix-build) and shared,
+# read-only, by every node.  Declared external so the builder container and
+# these services reference the exact same volume name (no compose prefix).
+volumes:
+  pmix-build:
+    external: true

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise PMIx group construction across the container swarm produced by
+# build.sh, driving the example programs through PRRTE.
+#
+#   ./run-tests.sh linux    # full suite in the 10-container swarm
+#                           #   (requires: ./build.sh && docker compose up -d)
+#   ./run-tests.sh macos    # single-host subset natively on this host
+#                           #   (requires: ./build.sh macos)
+#
+# Prints PASS/FAIL per test and a summary; exits non-zero if anything failed.
+# The point of the multi-node swarm is that a group then spans several distinct
+# PMIx servers (one prted per node), so the server-side local-completion and
+# lost-connection accounting actually run on more than one daemon.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# the group examples build.sh compiles into /opt/prte/tests
+GROUP_EXAMPLES="${GROUP_EXAMPLES:-group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group}"
+
+########################################################################
+# Linux: the full 10-node swarm
+########################################################################
+
+# run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
+RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            pmix-node1 bash -lc ". /opt/prte/env.sh; $*"; }
+ON()  { docker exec "pmix-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+
+cleanup_swarm() {
+    for n in $(seq 1 10); do
+        docker exec "pmix-node$n" sh -c \
+            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
+             pkill -9 prterun 2>/dev/null; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix* 2>/dev/null; true'
+    done
+}
+prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+
+# Per-example launch geometry ($NP ranks spread over $HOSTS) and the marker that
+# signals the group actually formed.  The defaults suit the common case -- four
+# ranks split across two nodes, and a "construct complete" line in the output.
+# A few examples need a different geometry or emit a different success line:
+#   * group_bootstrap exercises the add-members path and rejects jobs smaller
+#     than six ranks; it prints "GROUP CONSTRUCT COMPLETE".
+#   * asyncgroup uses the invite/join model, so rank 0 reports the invite result
+#     rather than a construct.
+#   * multi_nspace_group has rank 0 PMIx_Spawn a two-proc child job and then
+#     builds a group spanning both namespaces, so the allocation must leave slots
+#     free for the spawned child -- launch two parent ranks into an eight-slot
+#     allocation.
+ex_geom() {
+    HOSTS="node1:2,node2:2"; NP=4; WANT='Group construct complete|construct.*succe'
+    case "$1" in
+        group_bootstrap)
+            HOSTS="node1:3,node2:3"; NP=6
+            WANT='GROUP CONSTRUCT COMPLETE|Group construct complete' ;;
+        asyncgroup)
+            WANT='invite complete with status PMIX_SUCCESS' ;;
+        multi_nspace_group)
+            HOSTS="node1:4,node2:4"; NP=2
+            WANT='Group construct complete with status' ;;
+    esac
+}
+
+# launch a program through a transient DVM using the geometry ex_geom picks for
+# it; $1 = test program, rest = extra prterun args.  Captures combined output in
+# $OUT and the expected success marker in $WANT.  The program is named by
+# absolute path: prterun resolves the executable on the head node and ships that
+# path to the other daemons, whose non-login launch environment does not have
+# /opt/prte/tests on PATH.  A --timeout bounds every launch so a genuine hang
+# surfaces as a failure instead of stalling the whole suite.
+OUT=""
+WANT=""
+launch() {
+    local prog="$1"; shift
+    ex_geom "$prog"
+    OUT="$(RUN "prterun --host $HOSTS -np $NP --map-by node --timeout 60 /opt/prte/tests/$prog $* 2>&1")"
+}
+
+test_linux() {
+    if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
+        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
+    fi
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte prun pterm >/dev/null'; then
+        ok "prterun/prte/prun/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    banner "multi-node launch smoke (real cross-daemon RML)"
+    cleanup_swarm
+    out=$(RUN 'prterun --host node1:2,node2:2,node3:2,node4:2 -np 8 --map-by node hostname'); rc=$?
+    n=$(echo "$out" | grep -cE 'node[1-4]')
+    [ "$rc" = 0 ] && [ "$n" = 8 ] \
+        && ok "prterun -np 8 across node1-4, exit 0" \
+        || bad "prterun multi-node (rc=$rc, lines=$n)"
+
+    banner "group construction methods (each across two nodes)"
+    for ex in $GROUP_EXAMPLES; do
+        cleanup_swarm
+        if ! RUN "test -x /opt/prte/tests/$ex"; then
+            skp "$ex (not built)"; continue
+        fi
+        launch "$ex"
+        if echo "$OUT" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+            bad "$ex: HUNG (hit the launch timeout)"
+        elif echo "$OUT" | grep -qiE "$WANT"; then
+            if echo "$OUT" | grep -qiE 'PMIX_ERROR|connection refused'; then
+                bad "$ex: completed but reported an error"
+            else
+                ok "$ex: group constructed across nodes"
+            fi
+        else
+            bad "$ex: no completion (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        fi
+        [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] \
+            || bad "$ex: stray prted left behind"
+    done
+
+    banner "participant death during group construct (loss accounting)"
+    cleanup_swarm
+    # group_die: every rank is a group member; the last rank leaves before
+    # contributing (and without finalizing), so the server must account for the
+    # lost member and complete the construct on the survivors instead of
+    # hanging. Two requirements make this observable through the launcher:
+    #   * --rtos recoverable, so PRRTE does not tear the whole job down when the
+    #     member vanishes without finalizing (which would kill the survivors);
+    #   * whole-job membership + --map-by node, so the victim's node always also
+    #     hosts a surviving member -- the one whose call created the local
+    #     tracker that the loss accounting then completes.
+    # Before groups tracked participation by identity this hung to the timeout.
+    if RUN 'test -x /opt/prte/tests/group_die'; then
+        OUT="$(RUN 'prterun --rtos recoverable --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_die 2>&1')"
+        n=$(echo "$OUT" | grep -c 'complete on survivors')
+        if echo "$OUT" | grep -qiE 'timeout|timed out|DVM timeout'; then
+            bad "group HUNG on participant death (loss accounting missing)"
+        elif [ "$n" -ge 3 ]; then
+            ok "group completed on all 3 survivors after a member died"
+        else
+            bad "group_die: only $n survivors completed: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_die not built"
+    fi
+    cleanup_swarm
+}
+
+########################################################################
+# macOS: native, single host (build + launch smoke)
+########################################################################
+
+test_macos() {
+    local root prefix
+    root="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+    prefix="$root/vpath-macos-prte/install"
+    if [ ! -x "$prefix/bin/prterun" ]; then
+        echo "native build missing -- run: ./build.sh macos" >&2; exit 2
+    fi
+    export PATH="$prefix/bin:$PATH"
+    export DYLD_LIBRARY_PATH="$prefix/lib:$root/vpath-macos-pmix/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    macpk() { pkill -9 prterun 2>/dev/null; pkill -9 -x prte 2>/dev/null; pkill -9 -x prted 2>/dev/null; true; }
+
+    banner "macOS: single-host group construction"
+    for ex in $GROUP_EXAMPLES; do
+        [ -x "$prefix/bin/$ex" ] || { skp "$ex (not built)"; continue; }
+        macpk; sleep 1
+        out="$(prterun -np 4 --timeout 60 "$prefix/bin/$ex" 2>&1)"
+        if echo "$out" | grep -qiE 'Group construct complete|construct.*succe'; then
+            ok "$ex: group constructed (single host)"
+        else
+            skp "$ex: no completion (native Darwin DVM can be flaky): $(echo "$out" | tr '\n' ' ' | tail -c 160)"
+        fi
+    done
+    macpk
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n================  %d passed, %d failed, %d skipped  ================\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -159,6 +159,32 @@ test_linux() {
         skp "group_die not built"
     fi
     cleanup_swarm
+
+    banner "participant death during PMIx_Connect (loss accounting)"
+    cleanup_swarm
+    # connect_die: same shape as group_die, but the collective is PMIx_Connect.
+    # Each rank posts remote-scope data before connecting, which makes the
+    # client send endpoint info to the server -- info the server appends to the
+    # connect tracker AFTER the collective-status slot. The last rank leaves
+    # before calling PMIx_Connect (and without finalizing), so the server must
+    # account for the departed participant and complete the connect on the
+    # survivors instead of hanging, without corrupting the tracker's info array
+    # while recording the loss status. Same two requirements as group_die apply:
+    # --rtos recoverable and whole-job membership + --map-by node.
+    if RUN 'test -x /opt/prte/tests/connect_die'; then
+        OUT="$(RUN 'prterun --rtos recoverable --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/connect_die 2>&1')"
+        n=$(echo "$OUT" | grep -c 'complete on survivors')
+        if echo "$OUT" | grep -qiE 'timeout|timed out|DVM timeout'; then
+            bad "connect HUNG on participant death (loss accounting missing)"
+        elif [ "$n" -ge 3 ]; then
+            ok "connect completed on all 3 survivors after a participant died"
+        else
+            bad "connect_die: only $n survivors completed: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "connect_die not built"
+    fi
+    cleanup_swarm
 }
 
 ########################################################################

--- a/docs/how-things-work/collectives/index.rst
+++ b/docs/how-things-work/collectives/index.rst
@@ -1,0 +1,17 @@
+Server-Side Collective Tracking
+===============================
+
+PMIx collective operations (``PMIx_Fence``, ``PMIx_Connect``,
+``PMIx_Disconnect``, and group construct/destruct) are assembled in two
+phases: the server first gathers the contributions of all *local*
+participants, then hands the assembled operation up to its host
+environment for *global* completion across nodes. This section describes
+how the server tracks local participation, why the historical
+counter-based accounting is unsafe when a participant is lost, and the
+identity-based tracking model that replaces it.
+
+.. toctree::
+   :maxdepth: 2
+
+   tracking_spec
+   tracking_plan

--- a/docs/how-things-work/collectives/tracking_plan.rst
+++ b/docs/how-things-work/collectives/tracking_plan.rst
@@ -87,13 +87,19 @@ operations and add identity accounting. The additive fields:
 
 * ``contributed`` is represented by the existing ``local_cbs`` list — it
   already stores one ``pmix_server_caddy_t`` per contributing peer, and
-  each caddy retains its ``pmix_peer_t *peer``. "Has *this peer*
-  contributed?" is answered by scanning ``local_cbs`` for a caddy whose
-  ``peer`` pointer matches — **by peer, not by name**, which is what
-  makes clones distinguishable.
-* ``departed`` is the new list of expected peers lost before
-  contributing. A peer appears in at most one of ``local_cbs`` /
-  ``departed``.
+  each caddy retains its ``pmix_peer_t *peer``. "Has this rank
+  contributed?" is answered by scanning ``local_cbs`` for a caddy with
+  the departing peer's name. Because ``nlocal`` counts *ranks* (one per
+  local participant, clones not counted separately), the contribution
+  question is correctly asked per rank: a rank is satisfied if any of its
+  peers — the client or a fork/exec'd clone — has an entry. The clone
+  data-loss hazard the spec warns about is avoided not by keying the
+  *check* on the peer pointer but by **never removing a contribution on
+  loss at all** (Case A does nothing), so a sibling clone's data can never
+  be discarded.
+* ``departed`` is the new list (of ``pmix_proclist_t``) of expected ranks
+  lost before contributing, deduplicated by name. A rank appears in at
+  most one of ``local_cbs`` / ``departed``.
 * ``expected`` remains the count ``nlocal`` (established exactly as today,
   including ``PMIX_RANK_WILDCARD`` expansion and the late-registration
   increments). It is **no longer decremented** on loss.
@@ -108,7 +114,7 @@ One function, called from every site that currently hand-rolls the test:
 
 .. code-block:: c
 
-   bool pmix_coll_locally_complete(pmix_server_trkr_t *trk)
+   bool pmix_server_trk_complete(pmix_server_trkr_t *trk)
    {
        if (!trk->def_complete) {
            return false;
@@ -118,127 +124,161 @@ One function, called from every site that currently hand-rolls the test:
                pmix_list_get_size(&trk->departed)) >= trk->nlocal;
    }
 
-Because a peer is counted in exactly one of the two lists and neither is
+Because a rank is counted in exactly one of the two lists and neither is
 ever decremented behind the predicate's back, this cannot complete early:
 a not-yet-heard-from live participant is in neither list, so the sum stays
 below ``nlocal`` until it either contributes or departs. (``>=`` rather
 than ``==`` is deliberate defensive hygiene against any clone
 over-count; see *Clones*.)
 
-Service API
-~~~~~~~~~~~
+As built
+~~~~~~~~
 
-.. code-block:: c
+No new ``pmix_coll_*`` namespace was introduced (see the *[FOLDED]* note
+under the migration sequence). The pieces landed where their data already
+lives:
 
-   /* locate or create the tracker for this operation */
-   pmix_server_trkr_t *pmix_coll_get_tracker(char *id, pmix_proc_t *procs,
-                                             size_t nprocs, pmix_cmd_t type);
+* ``pmix_server_trk_complete`` — the predicate above — in
+  ``pmix_server_ops.c``, declared in ``pmix_server_ops.h``; called from
+  all six fence-family completion sites.
+* Locate/create stays in ``pmix_server_get_tracker`` /
+  ``pmix_server_new_tracker``; contributions are still appended to
+  ``local_cbs`` at each operation's call site.
+* The loss routine is the single Case A / Case B block in
+  ``lost_connection`` (fence family) plus the pending exported
+  ``pmix_server_grp_peer_lost`` (group family).
+* Forwarding to the host stays at each operation's completion site
+  (``fence_nb`` after ``pmix_server_collect_data``; ``connect`` /
+  ``disconnect``; the group host call with context-id / ``grpinfo``
+  aggregation). These handoffs were already per-operation and are left
+  in place.
 
-   /* record a contribution from a connected peer (appends its caddy) */
-   void pmix_coll_add_contribution(pmix_server_trkr_t *trk,
-                                   pmix_server_caddy_t *cd);
+Groups: shared semantics, not a shared struct
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   /* account for a lost peer across ALL trackers it participates in;
-      applies Case A / Case B and drives completion where warranted */
-   void pmix_coll_peer_lost(pmix_peer_t *peer);
+An audit of ``pmix_server_group.c`` (done during implementation) settled
+the open question about the ``grp_block_t`` / ``grp_trk_t`` split: it is
+**not** folded into ``pmix_server_trkr_t``. Each participant call appends
+a fresh ``grp_trk_t`` to the block's ``mbrs`` list, so the group's
+contribution count is ``size(mbrs)`` (not the size of a single
+contribution list); one block can carry several call signatures (leader /
+follower / bootstrap); and the block owns group-only state (context-id,
+``grpinfo`` aggregation). Collapsing that onto the fence tracker would be
+an invasive rewrite of delicate, untested, HPC-critical code for no
+correctness benefit. Instead the group family reuses the *semantics* —
+the completion-predicate shape and the Case A / Case B rules — in its own
+structure. See *Group loss-accounting design* under the migration
+sequence for the concrete plan, and the spec's *What "single" means in
+practice* for the rationale.
 
-   /* the shared completion predicate */
-   bool pmix_coll_locally_complete(pmix_server_trkr_t *trk);
+The two tracker lists therefore remain separate
+(``pmix_server_globals.collectives`` and ``.grp_collectives``);
+``lost_connection`` traverses both — the fence family inline and the
+group family through the exported ``pmix_server_grp_peer_lost``.
 
-   /* forward a locally-complete tracker to the host via the right hook */
-   pmix_status_t pmix_coll_forward(pmix_server_trkr_t *trk);
+Rewriting ``lost_connection`` (fence family — done)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Per-operation hooks
-~~~~~~~~~~~~~~~~~~~
+The collective-adjustment block in
+``src/mca/ptl/base/ptl_base_sendrecv.c`` now, for each tracker the peer
+is an expected participant in:
 
-The only operation-specific behavior is *what to do at handoff*. Model it
-as a tiny dispatch keyed on ``trk->type`` inside ``pmix_coll_forward``
-(fence → ``fence_nb`` after ``pmix_server_collect_data``; connect →
-``connect``; disconnect → ``disconnect``; group → the group host call
-with context-id / grpinfo aggregation). No operation retains its own
-completion or loss logic.
-
-Folding in groups
-~~~~~~~~~~~~~~~~~
-
-The group ``grp_block_t`` / ``grp_trk_t`` split maps onto the unified
-tracker as follows:
-
-* The block's participation bookkeeping (``nlocal``, ``def_complete``,
-  and the counting that drives completion) is exactly what the unified
-  tracker already holds — delete the duplicates.
-* Group-specific state that has no analogue in the other operations
-  (``need_cxtid`` / context-id assignment, ``grpinfo`` aggregation, and
-  the ``block → mbrs`` fan-out where one construct spans multiple
-  sub-collectives) is retained as a thin group-only side structure that
-  *references* the unified tracker rather than re-implementing counting.
-
-**Open decision:** whether one ``grp_block_t`` maps to exactly one
-unified tracker or to several. If a block can legitimately carry more
-than one concurrent sub-collective, the group wrapper keeps its ``mbrs``
-list but each member is (or points at) a unified tracker. Resolve this by
-auditing how ``mbrs`` is populated in ``pmix_server_group.c`` before
-writing code.
-
-Unify the lists
-~~~~~~~~~~~~~~~
-
-Move group trackers onto ``pmix_server_globals.collectives`` (or, if the
-group wrapper is retained, ensure ``pmix_coll_peer_lost`` traverses both
-lists). One list is preferred: it is the change that structurally
-guarantees the lost-connection handler can never again miss an operation
-class.
-
-Rewriting ``lost_connection``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Replace the collective-adjustment block in
-``src/mca/ptl/base/ptl_base_sendrecv.c`` with a single call to
-``pmix_coll_peer_lost(peer)``. That routine, for each tracker the peer is
-an expected participant in:
-
-#. Determine contribution by **peer pointer** (scan ``local_cbs``).
-#. **Case A** (found): do nothing to the accounting — leave the
-   contribution and its data in place, leave ``nlocal`` untouched.
-#. **Case B** (not found): append the peer to ``departed`` (once).
+#. Determine whether the peer's rank has already contributed (scan
+   ``local_cbs`` by name — consistent with the per-rank ``nlocal`` count).
+#. **Case A** (contributed): do nothing — leave the contribution and its
+   data in place, leave ``nlocal`` untouched.
+#. **Case B** (not contributed): append the rank to ``departed`` (once).
 #. Set ``PMIX_LOCAL_COLLECTIVE_STATUS`` (``PMIX_ERR_PARTIAL_SUCCESS`` if
-   live participants remain, else ``PMIX_ERR_LOST_CONNECTION``).
+   any expected participant is still awaited, else
+   ``PMIX_ERR_LOST_CONNECTION``).
 #. If ``host_called`` is already set, stop — the local phase is frozen
    (spec invariant 5).
-#. Otherwise re-evaluate ``pmix_coll_locally_complete`` and, if newly
-   complete, drive it through ``pmix_coll_forward`` exactly as a normal
-   final contribution would.
+#. Otherwise re-evaluate ``pmix_server_trk_complete`` and, if newly
+   complete, drive it through the existing completion block exactly as a
+   normal final contribution would.
 
-All of this continues to run on the progress thread, as it does today;
+All of this continues to run on the progress thread, as it did before;
 no new thread-shifting is introduced.
 
 Migration sequence
 ------------------
 
 Land in small, independently-buildable, independently-reviewable commits
-(the project favors one logical change per commit):
+(the project favors one logical change per commit). Status is recorded
+against each step.
 
-#. **Introduce the predicate.** Add ``pmix_coll_locally_complete`` and the
-   ``departed`` list to ``pmix_server_trkr_t``; replace the six-plus
-   hand-rolled completion tests with calls to it. No behavior change yet
-   (``departed`` is always empty), so this is a pure refactor that must
-   build clean and pass ``make check``.
-#. **Fix loss accounting for fence/connect/disconnect.** Rewrite the
-   ``collectives`` handling in ``lost_connection`` to Case A / Case B via
-   ``departed`` instead of ``--nlocal`` + name-based removal. This is the
-   commit that fixes the reported bug.
-#. **Extract the service.** Move locate/create, add-contribution,
-   forward, and loss accounting into the ``pmix_coll_*`` API; point
-   fence/connect/disconnect at it. Still no group changes.
-#. **Fold in groups.** Port group construct/destruct onto the unified
-   tracker and service; resolve the ``block``/``mbrs`` open decision;
-   unify the tracker lists (or extend the loss traversal). Group
-   collectives now get loss accounting for the first time.
-#. **Remove dead code.** Delete ``local_cnt`` and the now-unused
-   ``grp_block_t`` / ``grp_trk_t`` counting fields.
+#. **[DONE] Introduce the predicate.** Added ``pmix_server_trk_complete``
+   and the ``departed`` list to ``pmix_server_trkr_t``; replaced the six
+   hand-rolled completion tests with calls to it. Behavior-neutral
+   (``departed`` empty), builds clean, ``make check`` green.
+#. **[DONE] Fix loss accounting for fence/connect/disconnect.** Rewrote
+   the ``collectives`` handling in ``lost_connection`` to Case A / Case B
+   via ``departed`` instead of ``--nlocal`` + name-based removal. This is
+   the commit that fixes the reported bug. Verified with ``make check``,
+   ``simptest``, and the ``simpdie`` death-injection scenarios.
+#. **[FOLDED] Extract a ``pmix_coll_*`` service.** After steps 1 and 2
+   there was little left to extract for the fence family: locate/create
+   already live in ``pmix_server_{get,new}_tracker``, the predicate is
+   ``pmix_server_trk_complete`` in ``pmix_server_ops.c``, and the loss
+   routine is the single block in ``lost_connection``. A separate
+   ``pmix_coll_*`` namespace would have been churn without payoff, so this
+   step was folded into steps 1-2 rather than done as a rename. The group
+   entry point (step 4) is exported from ``pmix_server_group.c`` for the
+   same reason — keep the logic with the data it owns.
+#. **[DONE] Remove dead code.** Deleted the vestigial ``local_cnt`` from
+   both ``pmix_server_trkr_t`` and ``grp_block_t``.
+#. **[DONE] Group loss accounting.** Group construct/destruct now get the
+   same Case A / Case B semantics; previously ``lost_connection`` did not
+   touch ``grp_collectives`` at all, so a group whose participant died
+   before contributing hung forever. Implemented as described below and
+   validated with a new death-injection exercise
+   (``examples/group_die.c``): a member leaves before contributing and the
+   survivors' construct completes rather than hangs. ``make check`` and
+   the normal group path (``doubleget``) are unaffected.
 
-Each step keeps the tree building warning-free under
+Each landed step keeps the tree building warning-free under
 ``--enable-devel-check`` and green under ``make check``.
+
+Group loss-accounting design (as built)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Implemented in ``pmix_server_group.c`` (keeping the two-level structure —
+see the spec's *What "single" means in practice*), reached from
+``lost_connection`` through one exported entry point:
+
+#. Added ``pmix_list_t departed`` and a real ``bool host_called`` to
+   ``grp_block_t`` (the existing ``host_called`` on ``grp_trk_t`` is
+   declared but never set — groups had no host-called gate).
+#. Added ``grp_blk_locally_complete(blk)`` == ``def_complete &&
+   (size(mbrs) + size(departed)) >= nlocal`` (a pure predicate, matching
+   the fence-family shape). Both completion sites gate on it together with
+   ``!blk->host_called``; the normal completion site sets ``host_called``
+   just before calling the host.
+#. Exported ``pmix_server_grp_peer_lost(peer)``, called from
+   ``lost_connection`` alongside the fence-family loop. For each block the
+   peer is an expected member of, that has ``nlocal > 0`` (skipping
+   bootstrap/follower blocks, which pass up per call and never wait) and
+   is not yet ``host_called``: if any member's ``local_cbs`` holds a caddy
+   with the peer's name it already contributed (Case A — do nothing);
+   otherwise record the rank on ``departed`` once (Case B). If that makes
+   the block locally complete, forward it to the host then — no further
+   participant call will arrive to do it.
+#. The loss path repeats the ``aggregate_info`` + ``pmix_host_server
+   .group`` completion (using the first member's ``pcs``, since all
+   non-bootstrap members share the membership) rather than sharing a
+   helper with the normal site: the normal site's error handling is
+   entangled with the triggering caddy's ownership, and duplicating a
+   dozen lines kept that delicate path untouched. This is the one place
+   the group family does not literally share code with itself; the
+   *semantics* (predicate shape, Case A / Case B) are identical.
+
+Keeping this logic inside ``pmix_server_group.c`` confines the delicate
+group lifecycle (context-id, ``grpinfo`` aggregation, ``grpcbfunc``
+reply/removal) to the file that owns it, and gives ``lost_connection`` a
+clean, single call — mirroring how the fence family is handled.
+
+A multi-node harness (``contrib/dockerswarm``) drives the group examples,
+including ``group_die``, across separate PMIx servers under PRRTE.
 
 Testing
 -------

--- a/docs/how-things-work/collectives/tracking_plan.rst
+++ b/docs/how-things-work/collectives/tracking_plan.rst
@@ -1,0 +1,304 @@
+Implementation Plan: A Single Collective-Tracking Service
+=========================================================
+
+.. note::
+
+   This is the implementation plan for the design stated in
+   :doc:`tracking_spec`. It is a working document describing *how* the
+   server code will be reshaped to meet that specification; it will
+   become stale once the work lands and should then be pruned or folded
+   into the narrative docs. Read the specification first — this plan
+   assumes its vocabulary (``expected`` / ``contributed`` / ``departed``,
+   Case A / Case B, the single completion predicate).
+
+Objectives
+----------
+
+#. **Fix the correctness bug.** A local participant that contributes and
+   then dies must not cause early completion, and its already-delivered
+   data must not be discarded (spec invariants 1 and 2).
+#. **Consolidate.** Replace the two parallel tracker families with a
+   single tracking service used by fence, connect, disconnect, and group
+   construct/destruct (spec invariant 7).
+#. **Preserve everything externally observable.** No change to any public
+   type, API signature, ``pmix_server_module_t`` field order, or on-wire
+   message layout. No change to the progress-thread / caddy discipline.
+
+Non-goals
+---------
+
+* Changing the global (inter-node) collective phase — that remains the
+  host environment's responsibility.
+* Changing how modex data is packed or how context IDs are assigned;
+  those become per-operation hooks, unchanged in behavior.
+* Reworking clone semantics beyond what invariant correctness requires
+  (see *Clones* below).
+
+Current state (starting point)
+------------------------------
+
+The code paths this plan touches:
+
+* **Fence/connect/disconnect tracker** — ``pmix_server_trkr_t`` in
+  ``src/include/pmix_globals.h``.
+* **Group tracker (two-level)** — ``grp_block_t`` / ``grp_trk_t`` in
+  ``src/server/pmix_server_group.c``.
+* **Locate/create tracker** — ``pmix_server_get_tracker`` /
+  ``pmix_server_new_tracker`` in ``src/server/pmix_server_fence.c``.
+* **Add contribution and completion test (fence)** —
+  ``src/server/pmix_server_fence.c`` (append to ``local_cbs``, then the
+  ``==`` test).
+* **Completion test (connect/disconnect)** —
+  ``src/server/pmix_server_connect.c``.
+* **Completion test (group)** — ``src/server/pmix_server_group.c``.
+* **Late-registration re-checks** — ``src/server/pmix_server.c``
+  (``register_nspace`` and ``register_client`` paths).
+* **Lost-connection accounting** — ``lost_connection`` in
+  ``src/mca/ptl/base/ptl_base_sendrecv.c``.
+* **Global tracker lists** — ``pmix_server_globals.collectives`` and
+  ``pmix_server_globals.grp_collectives``.
+
+The completion test ``def_complete && pmix_list_get_size(&local_cbs) ==
+nlocal`` is copied at each site above. ``lost_connection`` walks only
+``collectives`` and, per tracker, unconditionally does ``--nlocal`` and
+removes the departed peer's contribution by name.
+
+Design
+------
+
+The service (proposed name ``pmix_coll`` — a set of ``pmix_coll_*``
+functions in a new ``src/server/pmix_server_coll.c`` / ``.h`` pair, or an
+extension of the existing ``pmix_server_ops`` surface) exposes one
+tracker type and a small API.
+
+Unified tracker
+~~~~~~~~~~~~~~~
+
+Extend ``pmix_server_trkr_t`` to be the single tracker for all four
+operations and add identity accounting. The additive fields:
+
+.. code-block:: c
+
+   /* identity accounting (in addition to the existing
+    * nlocal / def_complete / local_cbs / host_called fields) */
+   pmix_list_t departed;   /* peers lost BEFORE contributing:
+                            *   list of pmix_proclist_t (or a caddy that
+                            *   retains the pmix_peer_t) */
+
+* ``contributed`` is represented by the existing ``local_cbs`` list — it
+  already stores one ``pmix_server_caddy_t`` per contributing peer, and
+  each caddy retains its ``pmix_peer_t *peer``. "Has *this peer*
+  contributed?" is answered by scanning ``local_cbs`` for a caddy whose
+  ``peer`` pointer matches — **by peer, not by name**, which is what
+  makes clones distinguishable.
+* ``departed`` is the new list of expected peers lost before
+  contributing. A peer appears in at most one of ``local_cbs`` /
+  ``departed``.
+* ``expected`` remains the count ``nlocal`` (established exactly as today,
+  including ``PMIX_RANK_WILDCARD`` expansion and the late-registration
+  increments). It is **no longer decremented** on loss.
+
+The vestigial ``local_cnt`` field is removed; nothing should compute
+completion from a raw counter after this change.
+
+The single completion predicate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One function, called from every site that currently hand-rolls the test:
+
+.. code-block:: c
+
+   bool pmix_coll_locally_complete(pmix_server_trkr_t *trk)
+   {
+       if (!trk->def_complete) {
+           return false;
+       }
+       /* every expected participant has either contributed or departed */
+       return (pmix_list_get_size(&trk->local_cbs) +
+               pmix_list_get_size(&trk->departed)) >= trk->nlocal;
+   }
+
+Because a peer is counted in exactly one of the two lists and neither is
+ever decremented behind the predicate's back, this cannot complete early:
+a not-yet-heard-from live participant is in neither list, so the sum stays
+below ``nlocal`` until it either contributes or departs. (``>=`` rather
+than ``==`` is deliberate defensive hygiene against any clone
+over-count; see *Clones*.)
+
+Service API
+~~~~~~~~~~~
+
+.. code-block:: c
+
+   /* locate or create the tracker for this operation */
+   pmix_server_trkr_t *pmix_coll_get_tracker(char *id, pmix_proc_t *procs,
+                                             size_t nprocs, pmix_cmd_t type);
+
+   /* record a contribution from a connected peer (appends its caddy) */
+   void pmix_coll_add_contribution(pmix_server_trkr_t *trk,
+                                   pmix_server_caddy_t *cd);
+
+   /* account for a lost peer across ALL trackers it participates in;
+      applies Case A / Case B and drives completion where warranted */
+   void pmix_coll_peer_lost(pmix_peer_t *peer);
+
+   /* the shared completion predicate */
+   bool pmix_coll_locally_complete(pmix_server_trkr_t *trk);
+
+   /* forward a locally-complete tracker to the host via the right hook */
+   pmix_status_t pmix_coll_forward(pmix_server_trkr_t *trk);
+
+Per-operation hooks
+~~~~~~~~~~~~~~~~~~~
+
+The only operation-specific behavior is *what to do at handoff*. Model it
+as a tiny dispatch keyed on ``trk->type`` inside ``pmix_coll_forward``
+(fence → ``fence_nb`` after ``pmix_server_collect_data``; connect →
+``connect``; disconnect → ``disconnect``; group → the group host call
+with context-id / grpinfo aggregation). No operation retains its own
+completion or loss logic.
+
+Folding in groups
+~~~~~~~~~~~~~~~~~
+
+The group ``grp_block_t`` / ``grp_trk_t`` split maps onto the unified
+tracker as follows:
+
+* The block's participation bookkeeping (``nlocal``, ``def_complete``,
+  and the counting that drives completion) is exactly what the unified
+  tracker already holds — delete the duplicates.
+* Group-specific state that has no analogue in the other operations
+  (``need_cxtid`` / context-id assignment, ``grpinfo`` aggregation, and
+  the ``block → mbrs`` fan-out where one construct spans multiple
+  sub-collectives) is retained as a thin group-only side structure that
+  *references* the unified tracker rather than re-implementing counting.
+
+**Open decision:** whether one ``grp_block_t`` maps to exactly one
+unified tracker or to several. If a block can legitimately carry more
+than one concurrent sub-collective, the group wrapper keeps its ``mbrs``
+list but each member is (or points at) a unified tracker. Resolve this by
+auditing how ``mbrs`` is populated in ``pmix_server_group.c`` before
+writing code.
+
+Unify the lists
+~~~~~~~~~~~~~~~
+
+Move group trackers onto ``pmix_server_globals.collectives`` (or, if the
+group wrapper is retained, ensure ``pmix_coll_peer_lost`` traverses both
+lists). One list is preferred: it is the change that structurally
+guarantees the lost-connection handler can never again miss an operation
+class.
+
+Rewriting ``lost_connection``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Replace the collective-adjustment block in
+``src/mca/ptl/base/ptl_base_sendrecv.c`` with a single call to
+``pmix_coll_peer_lost(peer)``. That routine, for each tracker the peer is
+an expected participant in:
+
+#. Determine contribution by **peer pointer** (scan ``local_cbs``).
+#. **Case A** (found): do nothing to the accounting — leave the
+   contribution and its data in place, leave ``nlocal`` untouched.
+#. **Case B** (not found): append the peer to ``departed`` (once).
+#. Set ``PMIX_LOCAL_COLLECTIVE_STATUS`` (``PMIX_ERR_PARTIAL_SUCCESS`` if
+   live participants remain, else ``PMIX_ERR_LOST_CONNECTION``).
+#. If ``host_called`` is already set, stop — the local phase is frozen
+   (spec invariant 5).
+#. Otherwise re-evaluate ``pmix_coll_locally_complete`` and, if newly
+   complete, drive it through ``pmix_coll_forward`` exactly as a normal
+   final contribution would.
+
+All of this continues to run on the progress thread, as it does today;
+no new thread-shifting is introduced.
+
+Migration sequence
+------------------
+
+Land in small, independently-buildable, independently-reviewable commits
+(the project favors one logical change per commit):
+
+#. **Introduce the predicate.** Add ``pmix_coll_locally_complete`` and the
+   ``departed`` list to ``pmix_server_trkr_t``; replace the six-plus
+   hand-rolled completion tests with calls to it. No behavior change yet
+   (``departed`` is always empty), so this is a pure refactor that must
+   build clean and pass ``make check``.
+#. **Fix loss accounting for fence/connect/disconnect.** Rewrite the
+   ``collectives`` handling in ``lost_connection`` to Case A / Case B via
+   ``departed`` instead of ``--nlocal`` + name-based removal. This is the
+   commit that fixes the reported bug.
+#. **Extract the service.** Move locate/create, add-contribution,
+   forward, and loss accounting into the ``pmix_coll_*`` API; point
+   fence/connect/disconnect at it. Still no group changes.
+#. **Fold in groups.** Port group construct/destruct onto the unified
+   tracker and service; resolve the ``block``/``mbrs`` open decision;
+   unify the tracker lists (or extend the loss traversal). Group
+   collectives now get loss accounting for the first time.
+#. **Remove dead code.** Delete ``local_cnt`` and the now-unused
+   ``grp_block_t`` / ``grp_trk_t`` counting fields.
+
+Each step keeps the tree building warning-free under
+``--enable-devel-check`` and green under ``make check``.
+
+Testing
+-------
+
+Add unit tests under ``test/unit`` wired into ``make check`` so the
+coverage sticks in CI. Target scenarios, per operation (fence, connect,
+disconnect, group):
+
+* **Baseline:** all local participants contribute → completes once, with
+  all data, forwarded to host exactly once.
+* **The reported bug (Case A):** participant contributes, then its
+  connection drops before the others call → collective still waits for
+  the remaining participants, completes with the departed participant's
+  data included, and does **not** complete early.
+* **Case B:** participant drops before contributing → collective
+  completes once the remaining live participants contribute; status is
+  ``PMIX_ERR_PARTIAL_SUCCESS`` (or ``PMIX_ERR_LOST_CONNECTION`` if none
+  remain).
+* **Loss after ``host_called``:** dropping a participant after handoff
+  neither re-forwards nor alters completion.
+* **Clones:** two peers sharing one ``{nspace, rank}`` each contribute;
+  losing one after it contributed does not discard the other's
+  contribution.
+* **Late registration vs. concurrent loss:** a rank registering late
+  while another participant is being lost does not complete the
+  collective early.
+
+Then the manual smoke path from the top-level guidance:
+``make check`` in ``test``, and ``./simptest`` in ``test/simple``.
+
+Risks and constraints
+---------------------
+
+* **ABI / wire format:** untouched. All affected structs are internal to
+  ``libpmix``; the fix is behavioral. No ``bfrops`` component changes, no
+  new status/event codes (``PMIX_ERR_PARTIAL_SUCCESS`` and
+  ``PMIX_ERR_LOST_CONNECTION`` already exist).
+* **Thread safety:** all accounting stays on the progress thread; the
+  caddy discipline is unchanged. ``departed`` entries must retain the
+  ``pmix_peer_t`` only if the peer object can outlive the tracker — audit
+  peer refcounting when the peer is being torn down in ``lost_connection``
+  (store the identity, or retain/release, as the lifetime analysis
+  dictates).
+* **Interoperability:** unchanged — this is server-local logic; a peer of
+  any version sees identical behavior on the wire.
+* **Clones** (see design): the peer-keyed contribution check is the
+  correctness-critical part and is handled. Whether ``nlocal`` should
+  count clones distinctly is a pre-existing question this plan does not
+  regress; the ``>=`` predicate tolerates any clone over-count, and the
+  audit in step 4 records whatever semantics ``pmix_server_new_tracker``
+  already implements.
+
+Open decisions to resolve before coding
+----------------------------------------
+
+#. ``grp_block_t`` → one unified tracker, or a retained thin wrapper over
+   many? (Audit ``mbrs`` population.)
+#. One global tracker list, or keep two and traverse both on loss?
+   (Prefer one.)
+#. ``departed`` element type and peer lifetime: store ``pmix_proc_t`` +
+   peer pointer in a small caddy, vs. retain the ``pmix_peer_t``.
+#. Where the service lives: a new ``pmix_server_coll.[ch]`` vs. growing
+   ``pmix_server_ops``.

--- a/docs/how-things-work/collectives/tracking_spec.rst
+++ b/docs/how-things-work/collectives/tracking_spec.rst
@@ -1,0 +1,351 @@
+Specification: Tracking Local Collective Participation
+======================================================
+
+.. note::
+
+   This is a *design specification*. It states how the PMIx server is
+   required to track local participation in collective operations, and
+   in particular how it must account for participants whose connections
+   are lost. It documents the intended behavior and the invariants that
+   any implementation must preserve. The companion implementation plan
+   lives alongside this document in the same directory.
+
+Scope
+-----
+
+This specification covers the server-side tracking of *local*
+participation in the collective operations that PMIx assembles on a node
+before forwarding to the host environment:
+
+* ``PMIx_Fence`` / ``PMIx_Fence_nb`` (``PMIX_FENCENB_CMD``)
+* ``PMIx_Connect`` / ``PMIx_Connect_nb`` (``PMIX_CONNECTNB_CMD``)
+* ``PMIx_Disconnect`` / ``PMIx_Disconnect_nb`` (``PMIX_DISCONNECTNB_CMD``)
+* ``PMIx_Group_construct`` / ``_destruct`` (``PMIX_GROUP_CONSTRUCT_CMD``,
+  ``PMIX_GROUP_DESTRUCT_CMD``)
+
+It does **not** cover the global (inter-node) phase, which is the
+responsibility of the host environment, nor the wire encoding of the
+collected data, which belongs to ``bfrops``.
+
+Background: how a collective is assembled
+-----------------------------------------
+
+A collective names a set of participating processes. Some of those
+processes are *local* — clients (and their clones) connected to this
+server — and some may be remote. The server's job in the local phase is
+to wait until **every local participant has contributed** its call, then
+pass the assembled operation up to the host for global completion.
+
+The server represents each in-flight collective with a *tracker*. For
+fence/connect/disconnect this is ``pmix_server_trkr_t`` (defined in
+``src/include/pmix_globals.h``); group operations use the parallel
+``grp_block_t`` / ``grp_trk_t`` structures in
+``src/server/pmix_server_group.c``. Trackers live on the server-global
+lists ``pmix_server_globals.collectives`` and
+``pmix_server_globals.grp_collectives`` respectively.
+
+A tracker records, among other things:
+
+* the participant list (``pcs`` / ``npcs``) as originally supplied;
+* the *expected* number of local participants (``nlocal``);
+* a list of the contributions received so far (``local_cbs``, a list of
+  ``pmix_server_caddy_t``, one entry per contributing peer — including a
+  separate entry for each fork/exec'd clone of a participating rank);
+* whether the tracker *definition* is complete (``def_complete``: every
+  participating namespace has been registered so ``nlocal`` is known to
+  be final);
+* whether the operation has already been handed to the host
+  (``host_called``).
+
+When a local client calls the collective, the server locates or creates
+the matching tracker and appends the caller's caddy to ``local_cbs``.
+
+The counter-based completion test and its vulnerability
+-------------------------------------------------------
+
+Historically, local completion has been decided by comparing a count of
+contributions against the expected local count. In the current code the
+test appears (in several places) as:
+
+.. code-block:: c
+
+   if (trk->def_complete &&
+       pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+       /* local phase complete -- forward to host */
+   }
+
+That is: *the number of contributions received equals the number of
+local participants expected.* This is a **cardinality** test — it counts
+contributions and expected participants, but it does not record *which*
+specific participants have contributed.
+
+Separately, when a client's connection is lost, the server must account
+for its departure so that a collective it was expected to join does not
+hang forever. The lost-connection handler
+(``lost_connection`` in ``src/mca/ptl/base/ptl_base_sendrecv.c``)
+currently, for each tracker the departing peer belongs to:
+
+#. decrements the expected count (``--trk->nlocal``); and
+#. removes any contribution the peer had already made from
+   ``local_cbs`` (matched by process name).
+
+Because participation is tracked only as a count, these two adjustments
+race against the ordinary participation path. The failure has two
+distinct symptoms.
+
+**1. Early completion.** A cardinality test cannot tell the difference
+between "this participant has not called yet" and "this participant
+called and then died." If the expected count is reduced for a
+participant whose contribution was already counted, the remaining live
+participants can drive the count to the (now lowered) threshold before
+they have all actually called in. The collective completes early and is
+forwarded to the host with a subset of the intended local contributions.
+
+   *Illustration.* A fence expects three local participants: ranks 0, 1,
+   and 2. Rank 0 calls the fence; its contribution is counted. Rank 0
+   then dies before ranks 1 and 2 call. In a pure counter model, rank
+   0's contribution remains counted while the expected total is
+   decremented to two; when ranks 1 and 2 call, the count reaches the
+   lowered threshold of two and the fence completes — even though it was
+   supposed to also include the (still-live-at-call-time) semantics of
+   all three, and rank 2 may not yet have called at all.
+
+**2. Loss of already-delivered data.** For a data-collecting fence, a
+participant's contribution *is* its modex data. Discarding a departed
+participant's contribution after it was delivered removes that data from
+the assembled collective, so the surviving participants receive an
+incomplete result — a silent correctness error, not merely a timing one.
+
+The root cause in both cases is the same: **participation is tracked as a
+count rather than by participant identity.** A count cannot answer the
+one question the lost-connection handler must ask — *"has this specific
+participant already contributed?"*
+
+Required model: track participation by identity
+-----------------------------------------------
+
+The server must track local collective participation **by participant
+identity**, not by a bare counter. Conceptually, each tracker maintains
+three sets of local participants:
+
+``expected``
+    The local participants the collective is waiting on. Established as
+    namespaces register and as the participant list is resolved against
+    the set of local processes (including ``PMIX_RANK_WILDCARD``
+    expansion). A participant enters ``expected`` when it is known to be
+    a local member of the operation.
+
+``contributed``
+    The local participants that have delivered their call for this
+    collective, together with whatever data or info that call carried.
+    A participant enters ``contributed`` exactly once per required
+    contribution.
+
+``departed``
+    Local participants that were lost (connection dropped, abnormal
+    termination) **before** contributing. A participant enters
+    ``departed`` only if it was expected and had not already
+    contributed.
+
+Completion rule
+~~~~~~~~~~~~~~~
+
+The local phase is complete when the tracker definition is complete
+(``def_complete``) **and every expected participant has been accounted
+for** — that is, each expected participant is either in ``contributed``
+or in ``departed``:
+
+.. code-block:: text
+
+   local_complete  ==  def_complete
+                       AND  (contributed ∪ departed)  ⊇  expected
+
+Equivalently, the collective is still pending as long as at least one
+expected participant has neither contributed nor departed.
+
+This must be the **single** completion predicate used everywhere the
+question "is this collective locally complete?" is asked. Today that
+question is asked, with a hand-rolled cardinality test, in at least six
+places (the fence, connect, and disconnect contribution paths; the two
+late-registration re-checks in ``pmix_server.c``; and the lost-connection
+handler). All of them must consult one shared predicate so the accounting
+can never diverge between call sites.
+
+Lost-connection accounting rules
+---------------------------------
+
+When a connection is lost, for every tracker (on **both** the
+``collectives`` and ``grp_collectives`` lists) in which the departing
+peer is an expected participant, the server must apply exactly one of the
+following, based on whether that specific participant has already
+contributed:
+
+**Case A — the participant had already contributed.**
+   *Ignore the loss for purposes of this collective.* The contribution
+   stands: it remains in ``contributed`` and its delivered data remains
+   part of the assembled collective. The expected count is **not**
+   reduced and the contribution is **not** removed. The participant has
+   already discharged its obligation to this collective; its subsequent
+   death is irrelevant to local completion.
+
+**Case B — the participant had not yet contributed.**
+   The participant can never contribute now, so move it from
+   ``expected`` accounting into ``departed`` (in the counter view: it is
+   removed from the set of contributions still being waited on). This
+   allows the collective to complete once the remaining live participants
+   contribute, rather than hanging forever on a participant that will
+   never call.
+
+In both cases the completion predicate is then re-evaluated. If the
+collective has become locally complete as a result, it is processed
+exactly as it would be on a normal final contribution (see *Interaction
+with the host handoff* below).
+
+Note the asymmetry with the current implementation, which in every case
+both decrements the expected count *and* removes any prior contribution.
+Case A above forbids both of those adjustments; that is the specific
+change that fixes the vulnerability.
+
+Status reporting on loss
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a loss affects a collective, the server continues to report the
+outcome to the surviving participants via the
+``PMIX_LOCAL_COLLECTIVE_STATUS`` info field on the tracker:
+
+* If at least one expected participant still remains after the loss is
+  accounted for, the status is ``PMIX_ERR_PARTIAL_SUCCESS``.
+* If the loss leaves no remaining live participants, the status is
+  ``PMIX_ERR_LOST_CONNECTION``.
+
+A loss falling under Case A (the participant already contributed) does
+not by itself change the set of remaining participants and therefore does
+not, on its own, downgrade the status.
+
+Required architecture: a single tracking service
+-------------------------------------------------
+
+The behaviors above must be provided by **one collective-tracking service
+with a single code path**, shared by all four operations, rather than by
+per-operation copies of the accounting logic.
+
+Today the logic is duplicated. Fence, connect, and disconnect use
+``pmix_server_trkr_t`` on ``pmix_server_globals.collectives``; group
+operations use the parallel ``grp_block_t`` / ``grp_trk_t`` pair on
+``pmix_server_globals.grp_collectives``. The two carry essentially the
+same state — participant list, expected count, definition-complete flag,
+contribution list, host-handoff flag, lock, event — split across slightly
+different layouts, and the completion test is hand-rolled at each of the
+six-plus call sites that ask "is this collective locally complete?" This
+duplication is precisely what let the group path drift out of sync: the
+lost-connection handler was never taught about ``grp_collectives``, so
+group collectives receive no loss accounting at all.
+
+Consolidating removes that class of defect by construction. The service
+must own:
+
+* tracker lifecycle (locate-or-create, release);
+* the identity accounting — the ``expected`` / ``contributed`` /
+  ``departed`` sets;
+* the single completion predicate defined above, evaluated in exactly one
+  function;
+* lost-connection accounting (Case A / Case B), applied uniformly to
+  every tracker on a single tracker list;
+* the host-handoff gate (``host_called``); and
+* delivery of results to the surviving local participants.
+
+Behavior that genuinely differs between operations must be confined to a
+small set of per-operation hooks the service invokes — which host
+callback to forward to, and how to assemble the operation's payload
+(modex-data collection for fence; context-id assignment and group-info
+aggregation for group construct). Everything else is shared. A single
+service is the only tractable way to keep the invariants below true: a
+predicate or a rule that exists in exactly one place cannot drift out of
+agreement with a copy of itself.
+
+Additional required behaviors
+-----------------------------
+
+**Clones share a rank but are distinct contributors.** A process may
+fork/exec one or more clones that connect to the same server with the
+same ``{namespace, rank}`` and independently join a collective. Identity
+tracking must therefore key on the *connected peer*, not solely on the
+``{namespace, rank}`` name: losing one peer must not silently discard a
+clone's contribution that happens to share the same name, and the
+expected/contributed accounting must remain consistent when clones
+participate. Name-based matching (``PMIX_CHECK_NAMES``) alone is
+insufficient to distinguish a peer from its clone and must not be the
+basis for deciding whether "this participant" contributed.
+
+**Contribution is idempotent and terminal.** A given required
+contribution is recorded once. Once recorded, it is never removed by
+loss accounting (Case A). A duplicate call for the same required
+contribution must not double-count toward completion.
+
+**Late registration must not race the accounting.** Namespaces and
+clients may register after a collective has already begun (the host may
+spawn a client that calls in before the local ``register_client`` event
+fires). The paths that raise ``nlocal`` / grow ``expected`` on late
+registration and then re-test completion must use the same identity-based
+predicate, so that a late registration and a concurrent loss cannot
+combine to complete a collective early.
+
+**Interaction with the host handoff.** Once a tracker has been forwarded
+to the host (``host_called`` is set), local completion has already
+occurred and the local accounting is frozen: a subsequent loss must not
+attempt to re-complete or re-forward the collective. The server waits for
+the host to return, then delivers the result to whichever local
+participants are still connected. Losing a participant after handoff only
+affects whether a reply can be delivered to that participant — never the
+completion or contents of the collective.
+
+**Group operations have the same requirement.** The group
+construct/destruct trackers (``grp_block_t`` / ``grp_trk_t`` on
+``grp_collectives``) use the same counter-based accounting and are
+subject to the same vulnerability. They must adopt the identity-based
+model and must be traversed by the lost-connection handler, which today
+walks only the ``collectives`` list.
+
+Invariants
+----------
+
+An implementation of this specification must preserve the following at
+all times:
+
+#. **A contribution, once recorded, is only ever removed by delivering
+   the collective's result to that participant — never by loss
+   accounting.**
+#. **The expected participation set is reduced for a lost participant
+   only if that participant had not yet contributed.**
+#. **Local completion is decided by one shared predicate**, evaluated
+   identically at every call site, expressed in terms of the
+   ``expected``, ``contributed``, and ``departed`` sets.
+#. **A collective completes locally if and only if its definition is
+   complete and every expected participant has either contributed or
+   departed-before-contributing.**
+#. **After ``host_called`` is set, local loss accounting never re-drives
+   completion** for that tracker.
+#. **The rules apply uniformly** to fence, connect, disconnect, and group
+   operations, and to both directly-connected clients and their clones.
+#. **All four operations are tracked by one service through one code
+   path.** There is a single tracker representation, a single completion
+   predicate, and a single lost-connection accounting routine; no
+   operation carries a private copy of the participation logic.
+
+Relationship to the current implementation
+-------------------------------------------
+
+The behaviors above are partially and fragilely approximated today: the
+fence/connect/disconnect path attempts to remove a departed peer's
+contribution from ``local_cbs`` while also decrementing ``nlocal``, but
+it does so by process name (so it cannot distinguish clones), it discards
+already-delivered data (violating invariant 1), it duplicates the
+completion test across many call sites, and it does not cover group
+operations at all. The implementation plan describes how to collapse the
+two tracker families into the single identity-based tracking service
+required here — one tracker representation, one completion predicate, one
+lost-connection routine — while preserving the established tracker
+lifecycle, the thread-safety (progress-thread / caddy) rules, and full
+ABI and wire-format compatibility (the tracker structures are internal to
+``libpmix``; no public type, API signature, or on-wire message layout
+changes).

--- a/docs/how-things-work/collectives/tracking_spec.rst
+++ b/docs/how-things-work/collectives/tracking_spec.rst
@@ -258,24 +258,48 @@ Behavior that genuinely differs between operations must be confined to a
 small set of per-operation hooks the service invokes — which host
 callback to forward to, and how to assemble the operation's payload
 (modex-data collection for fence; context-id assignment and group-info
-aggregation for group construct). Everything else is shared. A single
-service is the only tractable way to keep the invariants below true: a
-predicate or a rule that exists in exactly one place cannot drift out of
-agreement with a copy of itself.
+aggregation for group construct). Everything else is shared. Sharing the
+logic in exactly one place is the only tractable way to keep the
+invariants below true: a predicate or a rule that exists once cannot
+drift out of agreement with a copy of itself.
+
+**What "single" means in practice.** The fence, connect, and disconnect
+operations do share one tracker type (``pmix_server_trkr_t``), and for
+them the requirement is literal: one struct, one predicate, one loss
+routine. The group operations are the exception. Their tracker is a
+two-level structure — a ``grp_block_t`` owning a list of ``grp_trk_t``
+members, one per call signature — because a single group construct can
+be assembled from several distinct signatures (leader, followers,
+bootstrap), the contribution count is the number of member trackers
+rather than the size of a single contribution list, and the block carries
+group-only state (context-id assignment, group-info aggregation). Forcing
+that onto ``pmix_server_trkr_t`` would be an invasive rewrite of delicate,
+HPC-critical code that currently has no automated test coverage. The
+consolidation requirement for the group family is therefore satisfied by
+sharing the *semantics* — the same completion-predicate shape
+(contributed + departed ≥ expected) and the same Case A / Case B
+lost-connection rules — expressed in the group's own structure and
+reached through a single exported entry point, rather than by collapsing
+the two structs into one. Invariant 7 below is stated in these terms.
 
 Additional required behaviors
 -----------------------------
 
-**Clones share a rank but are distinct contributors.** A process may
-fork/exec one or more clones that connect to the same server with the
-same ``{namespace, rank}`` and independently join a collective. Identity
-tracking must therefore key on the *connected peer*, not solely on the
-``{namespace, rank}`` name: losing one peer must not silently discard a
-clone's contribution that happens to share the same name, and the
-expected/contributed accounting must remain consistent when clones
-participate. Name-based matching (``PMIX_CHECK_NAMES``) alone is
-insufficient to distinguish a peer from its clone and must not be the
-basis for deciding whether "this participant" contributed.
+**Clones share a rank but must not corrupt the accounting.** A process
+may fork/exec one or more clones that connect to the same server with the
+same ``{namespace, rank}`` and independently join a collective. The
+overriding requirement is that losing one peer must never discard a
+clone's contribution that shares the same name. The current expected
+count (``nlocal``) is maintained per *rank* — a clone is not counted as a
+separate expected participant — so the contribution question is asked per
+rank too: a rank is satisfied once any of its peers has contributed. The
+clone data-loss hazard is closed not by keying the contribution *check*
+on the peer pointer but by the stronger guarantee that **a loss never
+removes a contribution at all** (Case A does nothing): whatever a rank's
+peers delivered stays in the collective regardless of which peer's
+connection drops. (A future change that made ``nlocal`` count clones
+individually would move the contribution check to the peer granularity;
+until then, per-rank name matching is the consistent choice.)
 
 **Contribution is idempotent and terminal.** A given required
 contribution is recorded once. Once recorded, it is never removed by
@@ -327,10 +351,13 @@ all times:
    completion** for that tracker.
 #. **The rules apply uniformly** to fence, connect, disconnect, and group
    operations, and to both directly-connected clients and their clones.
-#. **All four operations are tracked by one service through one code
-   path.** There is a single tracker representation, a single completion
-   predicate, and a single lost-connection accounting routine; no
-   operation carries a private copy of the participation logic.
+#. **Participation logic is shared, not copied.** Fence, connect, and
+   disconnect are tracked by one tracker representation with one
+   completion predicate and one lost-connection routine. Group operations,
+   whose two-level tracker differs materially, reuse the same completion-
+   predicate shape and the same Case A / Case B loss semantics through a
+   single exported entry point rather than a private copy. No operation
+   carries its own divergent copy of the participation rules.
 
 Relationship to the current implementation
 -------------------------------------------

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -13,6 +13,7 @@ find information on that subject here.
    distances.rst
    schedulers/index.rst
    sets_groups/index.rst
+   collectives/index.rst
    inheritance/index.rst
    resolve.rst
    adding_datatypes.rst

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
-                  simple simple_server abort
+                  simple simple_server abort group_die
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -96,6 +96,10 @@ tool_LDADD = $(top_builddir)/src/libpmix.la
 group_SOURCES = group.c examples.h
 group_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_LDADD = $(top_builddir)/src/libpmix.la
+
+group_die_SOURCES = group_die.c examples.h
+group_die_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_die_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
-                  simple simple_server abort group_die
+                  simple simple_server abort group_die connect_die
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -100,6 +100,10 @@ group_LDADD = $(top_builddir)/src/libpmix.la
 group_die_SOURCES = group_die.c examples.h
 group_die_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_die_LDADD = $(top_builddir)/src/libpmix.la
+
+connect_die_SOURCES = connect_die.c examples.h
+connect_die_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+connect_die_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)

--- a/examples/connect_die.c
+++ b/examples/connect_die.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise PMIx_Connect when a participant is lost before it contributes.
+ *
+ * Every rank in the job is part of the connect set.  Each rank first posts a
+ * bit of remote-scope data and commits it, then all ranks sync with a fence.
+ * The remote-scope put matters: the client only sends endpoint info to the
+ * server on connect when it has such data posted, and that endpoint info is
+ * appended to the connect tracker's info array AFTER the collective-status
+ * slot.  This is exactly the layout that used to make the server's
+ * lost-connection accounting write the status over the appended endpoint info
+ * (see docs/how-things-work/collectives and the ptl fix that locates the
+ * status slot by key).
+ *
+ * After the fence, every rank EXCEPT the last calls PMIx_Connect; the last
+ * rank leaves WITHOUT calling it (after a short delay, so the others have
+ * already entered the connect and their servers have built the local
+ * trackers) and WITHOUT calling PMIx_Finalize, so the server sees a dropped
+ * connection.  The server must account for the departed participant and
+ * complete the connect on the survivors rather than hang.
+ *
+ * The whole job is the connect set (rather than a subset) so that, when
+ * launched across nodes, the victim's node always also hosts a surviving
+ * participant -- the one that creates the local tracker the loss accounting
+ * then completes.  Launch with a launcher that does not kill the job when the
+ * victim exits; under PRRTE that is `prterun --rtos recoverable ...`.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_value_t value;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    char key[64];
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* post some remote-scope data and commit it.  This is what causes the
+     * client to send endpoint info to the server on connect, appended to the
+     * tracker's info array after the collective-status slot. */
+    snprintf(key, sizeof(key), "connect-die-remote-%u", myproc.rank);
+    value.type = PMIX_UINT64;
+    value.data.uint64 = 1000UL + (unsigned long) myproc.rank;
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, key, &value))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the connect set; the last rank is the victim */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        /* the "victim": a participant that leaves before contributing.  Delay
+         * briefly so the other participants have entered the connect and their
+         * servers have built the local trackers, then leave without calling it
+         * - and without calling PMIx_Finalize, so the server sees a dropped
+         * connection and must run its lost-connection accounting.  We exit with
+         * status 0 so the launcher does not abort the whole job; the dropped
+         * socket, not the exit code, is what exercises the server. */
+        fprintf(stderr, "%d leaving BEFORE PMIx_Connect (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    fprintf(stderr, "%d executing PMIx_Connect\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    rc = PMIx_Connect(procs, nprocs, NULL, 0);
+    PMIX_PROC_FREE(procs, nprocs);
+
+    /* The connect must COMPLETE rather than hang.  It may return success or a
+     * partial-success/lost-connection status depending on how the host treats
+     * the departed participant; either way, reaching here is the point of the
+     * test - the collective did not hang on the lost participant, and the
+     * server did not corrupt the tracker's info array while accounting for the
+     * loss. */
+    fprintf(stderr, "%d Connect complete on survivors: status %s\n",
+            myproc.rank, PMIx_Error_string(rc));
+
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "Client ns %s rank %d: FINALIZED\n", myproc.nspace, myproc.rank);
+    return 0;
+}

--- a/examples/group_die.c
+++ b/examples/group_die.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise group construction when a member is lost before it contributes.
+ *
+ * Every rank in the job is a group member.  All ranks first sync with a fence,
+ * then every rank EXCEPT the last calls PMIx_Group_construct; the last rank
+ * leaves WITHOUT calling it (after a short delay, so the others have already
+ * entered the construct and their servers have created the local trackers) and
+ * WITHOUT calling PMIx_Finalize, so the server sees a dropped connection. The
+ * server must account for the departed member and complete the construct on the
+ * survivors rather than hang. Before the server tracked group participation by
+ * identity this would hang, because the group's local phase never reached its
+ * expected count. See docs/how-things-work/collectives.
+ *
+ * The whole job is the membership (rather than a subset) so that, when launched
+ * across nodes, the victim's node always also hosts a surviving member -- the
+ * one that creates the local tracker the loss accounting then completes. Launch
+ * with a launcher that does not kill the job when the victim exits; under PRRTE
+ * that is `prterun --rtos recoverable ...`.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t info, *results;
+    size_t nresults;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        /* the "victim": a member that leaves before contributing.  Delay
+         * briefly so the other members have entered the construct and their
+         * servers have built the local trackers, then leave without calling it
+         * - and without calling PMIx_Finalize, so the server sees a dropped
+         * connection and must run its lost-connection accounting.  We exit with
+         * status 0 so the launcher does not abort the whole job; the dropped
+         * socket, not the exit code, is what exercises the server. */
+        fprintf(stderr, "%d leaving BEFORE group construct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    PMIX_INFO_LOAD(&info, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+
+    results = NULL;
+    nresults = 0;
+    rc = PMIx_Group_construct("diegroup", procs, nprocs, &info, 1, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+
+    /* The construct must COMPLETE rather than hang.  It may return success or a
+     * partial-success/lost-connection status depending on how the host treats
+     * the departed member; either way, reaching here is the point of the
+     * test - the collective did not hang on the lost participant. */
+    fprintf(stderr, "%d Group construct complete on survivors: status %s\n",
+            myproc.rank, PMIx_Error_string(rc));
+
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "Client ns %s rank %d: FINALIZED\n", myproc.nspace, myproc.rank);
+    return 0;
+}

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -593,6 +593,11 @@ typedef struct {
     pmix_list_t local_cbs;  // list of pmix_server_caddy_t for sending result to the local participants
                             //    Note: there may be multiple entries for a given proc if that proc
                             //    has fork/exec'd clones that are also participating
+    pmix_list_t departed;   // local participants lost (connection dropped) BEFORE contributing.
+                            //    Participation is tracked by identity: a peer that already
+                            //    contributed (appears on local_cbs) is never moved here, so its
+                            //    loss cannot complete the collective early nor discard its data.
+                            //    See docs/how-things-work/collectives for the specification.
     uint32_t nlocal;        // number of local participants
     uint32_t local_cnt;     // number of local participants who have contributed
     pmix_info_t *info;      // array of info structs

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -599,7 +599,6 @@ typedef struct {
                             //    loss cannot complete the collective early nor discard its data.
                             //    See docs/how-things-work/collectives for the specification.
     uint32_t nlocal;        // number of local participants
-    uint32_t local_cnt;     // number of local participants who have contributed
     pmix_info_t *info;      // array of info structs
     size_t ninfo;           // number of info structs in array
     pmix_list_t grpinfo;    // list of group info to be distributed

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -127,7 +127,7 @@ static void lost_connection(pmix_peer_t *peer)
                     continue;
                 }
                 /* are we now locally complete? */
-                if (trk->def_complete && trk->nlocal == pmix_list_get_size(&trk->local_cbs)) {
+                if (pmix_server_trk_complete(trk)) {
                     /* if this is a local-only collective, then resolve it now */
                     if (trk->local) {
                         /* everyone else has called in - we need to let them know

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -221,6 +221,11 @@ static void lost_connection(pmix_peer_t *peer)
                 }
             }
 
+            /* account for the loss in any in-flight group construct/destruct
+             * collectives as well - these are tracked separately from the
+             * fence/connect/disconnect collectives above */
+            pmix_server_grp_peer_lost(peer);
+
             /* if the peer simply died without finalizing,
              * then reduce the number of local procs */
             if (!peer->finalized && 0 < peer->nptr->nlocalprocs) {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -154,7 +154,19 @@ static void lost_connection(pmix_peer_t *peer)
                 } else {
                     rc = PMIX_ERR_LOST_CONNECTION;
                 }
-                PMIX_INFO_LOAD(&trk->info[trk->ninfo-1], PMIX_LOCAL_COLLECTIVE_STATUS, &rc, PMIX_STATUS);
+                /* record the collective's health in the
+                 * PMIX_LOCAL_COLLECTIVE_STATUS slot the participant handlers
+                 * seeded. Locate it by key rather than by position: connect
+                 * appends endpoint and job-level info AFTER that slot (see
+                 * pmix_server_connect), so it is not reliably the last element
+                 * of trk->info - writing trk->info[trk->ninfo-1] would clobber
+                 * the appended info and leave the real status slot stale. */
+                for (n = 0; n < trk->ninfo; n++) {
+                    if (PMIX_CHECK_KEY(&trk->info[n], PMIX_LOCAL_COLLECTIVE_STATUS)) {
+                        trk->info[n].value.data.status = rc;
+                        break;
+                    }
+                }
                 /* if the host has already been called for this tracker,
                  * then the local phase is frozen - just wait for the host
                  * to return from the operation */

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -154,19 +154,10 @@ static void lost_connection(pmix_peer_t *peer)
                 } else {
                     rc = PMIX_ERR_LOST_CONNECTION;
                 }
-                /* record the collective's health in the
-                 * PMIX_LOCAL_COLLECTIVE_STATUS slot the participant handlers
-                 * seeded. Locate it by key rather than by position: connect
-                 * appends endpoint and job-level info AFTER that slot (see
-                 * pmix_server_connect), so it is not reliably the last element
-                 * of trk->info - writing trk->info[trk->ninfo-1] would clobber
-                 * the appended info and leave the real status slot stale. */
-                for (n = 0; n < trk->ninfo; n++) {
-                    if (PMIX_CHECK_KEY(&trk->info[n], PMIX_LOCAL_COLLECTIVE_STATUS)) {
-                        trk->info[n].value.data.status = rc;
-                        break;
-                    }
-                }
+                /* record the collective's health in the status slot the
+                 * participant handlers seeded (located by key, since connect
+                 * appends info after it - see pmix_server_set_collective_status) */
+                pmix_server_set_collective_status(trk->info, trk->ninfo, rc);
                 /* if the host has already been called for this tracker,
                  * then the local phase is frozen - just wait for the host
                  * to return from the operation */

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -60,7 +60,8 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
 static void lost_connection(pmix_peer_t *peer)
 {
     pmix_server_trkr_t *trk, *tnxt;
-    pmix_server_caddy_t *rinfo, *rnext;
+    pmix_server_caddy_t *rinfo;
+    pmix_proclist_t *dp;
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
@@ -92,7 +93,7 @@ static void lost_connection(pmix_peer_t *peer)
              * have been added to any collective tracker until
              * after it successfully connected */
             PMIX_LIST_FOREACH_SAFE (trk, tnxt, &pmix_server_globals.collectives, pmix_server_trkr_t) {
-                /* check if the process should be participating in this collective */
+                /* check if this peer should be participating in this collective */
                 flag = false;
                 for (n=0; n < trk->npcs; n++) {
                     if (PMIX_CHECK_NAMES(&trk->pcs[n], &peer->info->pname)) {
@@ -103,26 +104,60 @@ static void lost_connection(pmix_peer_t *peer)
                 if (!flag) {
                     continue;
                 }
-                /* it should - adjust the count */
-                --trk->nlocal;
-                if (0 < trk->nlocal) {
+                /* Determine whether this participant has already contributed.
+                 * Its rank counts as contributed if any of its local peers -
+                 * the client or a fork/exec'd clone sharing the same name -
+                 * has an entry on local_cbs. If so, the contribution and the
+                 * data it already delivered stand: we ignore the loss for
+                 * this collective. We do NOT reduce the expected count and do
+                 * NOT remove the contribution, so the collective neither
+                 * completes early nor drops the departed peer's data. The
+                 * dead peer's reply caddy is harmless - its socket has been
+                 * closed, so the eventual QUEUE_REPLY is dropped rather than
+                 * sent. */
+                flag = false;
+                PMIX_LIST_FOREACH (rinfo, &trk->local_cbs, pmix_server_caddy_t) {
+                    if (PMIX_CHECK_NAMES(&rinfo->peer->info->pname, &peer->info->pname)) {
+                        flag = true;
+                        break;
+                    }
+                }
+                if (flag) {
+                    /* already contributed - nothing to account for */
+                    continue;
+                }
+                /* This participant had not yet contributed and now never will.
+                 * Record its rank as departed (once) so the collective can
+                 * complete on the remaining live participants instead of
+                 * hanging forever. Participation is tracked per rank, matching
+                 * the way nlocal is counted, so a clone sharing the name does
+                 * not add a second departed entry. */
+                flag = false;
+                PMIX_LIST_FOREACH (dp, &trk->departed, pmix_proclist_t) {
+                    if (PMIX_CHECK_NAMES(&dp->proc, &peer->info->pname)) {
+                        flag = true;
+                        break;
+                    }
+                }
+                if (!flag) {
+                    dp = PMIX_NEW(pmix_proclist_t);
+                    PMIX_LOAD_PROCID(&dp->proc, peer->info->pname.nspace,
+                                     peer->info->pname.rank);
+                    pmix_list_append(&trk->departed, &dp->super);
+                }
+                /* report the collective's health to the surviving participants:
+                 * partial success if any expected participant is still awaited,
+                 * else lost-connection */
+                if ((pmix_list_get_size(&trk->local_cbs) +
+                     pmix_list_get_size(&trk->departed)) < trk->nlocal) {
                     rc = PMIX_ERR_PARTIAL_SUCCESS;
                 } else {
                     rc = PMIX_ERR_LOST_CONNECTION;
                 }
                 PMIX_INFO_LOAD(&trk->info[trk->ninfo-1], PMIX_LOCAL_COLLECTIVE_STATUS, &rc, PMIX_STATUS);
-                /* see if it already participated in this tracker */
-                PMIX_LIST_FOREACH_SAFE (rinfo, rnext, &trk->local_cbs, pmix_server_caddy_t) {
-                    if (!PMIX_CHECK_NAMES(&rinfo->peer->info->pname, &peer->info->pname)) {
-                        continue;
-                    }
-                    /* remove it from the list */
-                    pmix_list_remove_item(&trk->local_cbs, &rinfo->super);
-                    PMIX_RELEASE(rinfo);
-                }
                 /* if the host has already been called for this tracker,
-                 * then do nothing here - just wait for the host to return
-                 * from the operation */
+                 * then the local phase is frozen - just wait for the host
+                 * to return from the operation */
                 if (trk->host_called) {
                     continue;
                 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1309,7 +1309,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
         /* update this tracker's status */
         trk->def_complete = all_def;
         /* is this now locally completed? */
-        if (trk->def_complete && pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        if (pmix_server_trk_complete(trk)) {
             /* it did, so now we need to process it
              * we don't want to block someone
              * here, so kick any completed trackers into a
@@ -2202,7 +2202,7 @@ static void _register_client(int sd, short args, void *cbdata)
             /* update this tracker's status */
             trk->def_complete = all_def;
             /* is this now locally completed? */
-            if (trk->def_complete && pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+            if (pmix_server_trk_complete(trk)) {
                 /* it did, so now we need to process it
                  * we don't want to block someone
                  * here, so kick any completed trackers into a

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -172,7 +172,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
      * let the local host's server know that we are at the
      * "fence" point - they will callback once the [dis]connect
      * across all participants has been completed */
-    if (trk->def_complete && pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+    if (pmix_server_trk_complete(trk)) {
         if (trk->local) {
             /* the operation is being atomically completed and the host will
              * not be calling us back - ensure we notify all participants.
@@ -400,7 +400,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * let the local host's server know that we are at the
      * "fence" point - they will callback once the [dis]connect
      * across all participants has been completed */
-    if (trk->def_complete && pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+    if (pmix_server_trk_complete(trk)) {
         /* if all the participants are local, then we don't need the host */
         if (trk->local) {
             /* the operation is being atomically completed and the host will

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -1026,7 +1026,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
      * let the local host's server know that we are at the
      * "fence" point - they will callback once the barrier
      * across all participants has been completed */
-    if (trk->def_complete && pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+    if (pmix_server_trk_complete(trk)) {
         pmix_output_verbose(2, pmix_server_globals.fence_output,
                             "fence LOCALLY complete");
         /* if a timeout was set, then we delete it here as we can

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -89,7 +89,16 @@ typedef struct {
     size_t npcs;
     pmix_info_t *info;
     size_t ninfo;
-    pmix_list_t mbrs;  // list of grp_trk_t
+    pmix_list_t mbrs;  // list of grp_trk_t - one per participant call; its
+                       //    size is the number of local participants that have
+                       //    contributed
+    pmix_list_t departed;   // ranks lost (connection dropped) BEFORE contributing;
+                            //    list of pmix_proclist_t, deduplicated by name.
+                            //    Counted alongside mbrs so the construct can
+                            //    complete on the survivors rather than hang.
+                            //    See docs/how-things-work/collectives.
+    bool host_called;       // the block has been forwarded to the host - the
+                            //    local phase is frozen
     bool def_complete;      // all local procs have been registered and the trk definition is complete
     uint32_t nlocal;        // number of local participants
 } grp_block_t;
@@ -104,6 +113,8 @@ static void gbcon(grp_block_t *p)
     p->info = NULL;
     p->ninfo = 0;
     PMIX_CONSTRUCT(&p->mbrs, pmix_list_t);
+    PMIX_CONSTRUCT(&p->departed, pmix_list_t);
+    p->host_called = false;
     p->def_complete = false;
     p->nlocal = 0;
 }
@@ -119,6 +130,7 @@ static void gbdes(grp_block_t *p)
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
     PMIX_LIST_DESTRUCT(&p->mbrs);
+    PMIX_LIST_DESTRUCT(&p->departed);
 }
 static PMIX_CLASS_INSTANCE(grp_block_t,
                            pmix_list_item_t,
@@ -282,6 +294,20 @@ static void check_definition_complete(grp_block_t *blk)
     // if we get here, then we have completed definition of the block
     blk->def_complete = true;
     blk->nlocal = nlocal;
+}
+
+/* The group analog of pmix_server_trk_complete: the block's definition must be
+ * complete and every expected local participant must be accounted for - either
+ * by having contributed (a member tracker on mbrs) or by having departed before
+ * contributing (an entry on departed). Kept in the same shape as the
+ * fence-family predicate. See docs/how-things-work/collectives. */
+static bool grp_blk_locally_complete(grp_block_t *blk)
+{
+    if (!blk->def_complete) {
+        return false;
+    }
+    return (pmix_list_get_size(&blk->mbrs) +
+            pmix_list_get_size(&blk->departed)) >= blk->nlocal;
 }
 
 static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
@@ -942,7 +968,7 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     }
 
     /* are we locally complete? */
-    if (!blk->def_complete || pmix_list_get_size(&blk->mbrs) != blk->nlocal) {
+    if (blk->host_called || !grp_blk_locally_complete(blk)) {
         /* if we are not locally complete, then we are done */
         return PMIX_SUCCESS;
     }
@@ -959,6 +985,8 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_RELEASE(blk);
         return rc;
     }
+    // the local phase is complete - freeze it and pass up to the host
+    blk->host_called = true;
     rc = pmix_host_server.group(op, blk->id, trk->pcs, trk->npcs,
                                 blk->info, blk->ninfo, grpcbfunc, blk);
     if (PMIX_SUCCESS != rc) {
@@ -980,4 +1008,96 @@ error:
         PMIX_INFO_FREE(info, ninfo);
     }
     return rc;
+}
+
+/* Account for a lost peer across all in-flight group construct/destruct blocks.
+ * This is the group-family analog of the fence/connect/disconnect accounting in
+ * lost_connection(), expressed in the group's two-level structure, and is
+ * called from that same handler. Participation is tracked by identity: if the
+ * departing peer's rank has already contributed (a member tracker holds a caddy
+ * with its name) its contribution stands and the loss is ignored (Case A);
+ * otherwise the rank is recorded as departed so the construct can complete on
+ * the surviving participants instead of hanging (Case B). See
+ * docs/how-things-work/collectives. */
+void pmix_server_grp_peer_lost(pmix_peer_t *peer)
+{
+    grp_block_t *blk, *bnext;
+    grp_trk_t *trk;
+    pmix_server_caddy_t *scd;
+    pmix_proclist_t *dp;
+    pmix_status_t rc;
+    bool ismbr, contributed, known;
+    size_t n;
+
+    PMIX_LIST_FOREACH_SAFE (blk, bnext, &pmix_server_globals.grp_collectives, grp_block_t) {
+        /* bootstrap/follower blocks are passed up per-call and never wait on a
+         * local count (nlocal == 0), so nothing here can hang; and a block that
+         * has already been forwarded to the host has a frozen local phase.
+         * Skip both. */
+        if (0 == blk->nlocal || blk->host_called) {
+            continue;
+        }
+        /* is this peer an expected member of this group, and has its rank
+         * already contributed? */
+        ismbr = false;
+        contributed = false;
+        PMIX_LIST_FOREACH (trk, &blk->mbrs, grp_trk_t) {
+            for (n = 0; n < trk->npcs; n++) {
+                if (PMIX_CHECK_NAMES(&trk->pcs[n], &peer->info->pname)) {
+                    ismbr = true;
+                    break;
+                }
+            }
+            PMIX_LIST_FOREACH (scd, &trk->local_cbs, pmix_server_caddy_t) {
+                if (PMIX_CHECK_NAMES(&scd->peer->info->pname, &peer->info->pname)) {
+                    contributed = true;
+                    break;
+                }
+            }
+            if (contributed) {
+                break;
+            }
+        }
+        if (!ismbr || contributed) {
+            /* not a participant, or Case A (already contributed - its
+             * contribution and data stand, so ignore the loss) */
+            continue;
+        }
+        /* Case B: the rank had not yet contributed and never will. Record it as
+         * departed (once) so the construct can complete on the survivors. */
+        known = false;
+        PMIX_LIST_FOREACH (dp, &blk->departed, pmix_proclist_t) {
+            if (PMIX_CHECK_NAMES(&dp->proc, &peer->info->pname)) {
+                known = true;
+                break;
+            }
+        }
+        if (!known) {
+            dp = PMIX_NEW(pmix_proclist_t);
+            PMIX_LOAD_PROCID(&dp->proc, peer->info->pname.nspace, peer->info->pname.rank);
+            pmix_list_append(&blk->departed, &dp->super);
+        }
+        /* did that complete the local phase? if so we must forward to the host
+         * now - no further participant call will arrive to do it for us. All
+         * non-bootstrap members carry the same membership, so use the first. */
+        if (grp_blk_locally_complete(blk)) {
+            trk = (grp_trk_t *) pmix_list_get_first(&blk->mbrs);
+            rc = aggregate_info(blk);
+            if (PMIX_SUCCESS != rc) {
+                pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
+                PMIX_RELEASE(blk);
+                continue;
+            }
+            blk->host_called = true;
+            rc = pmix_host_server.group(blk->grpop, blk->id, trk->pcs, trk->npcs,
+                                        blk->info, blk->ninfo, grpcbfunc, blk);
+            if (PMIX_OPERATION_SUCCEEDED == rc) {
+                /* the host will not call back - drive completion ourselves */
+                grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
+            } else if (PMIX_SUCCESS != rc) {
+                pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
+                PMIX_RELEASE(blk);
+            }
+        }
+    }
 }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -92,7 +92,6 @@ typedef struct {
     pmix_list_t mbrs;  // list of grp_trk_t
     bool def_complete;      // all local procs have been registered and the trk definition is complete
     uint32_t nlocal;        // number of local participants
-    uint32_t local_cnt;     // number of local participants who have contributed
 } grp_block_t;
 static void gbcon(grp_block_t *p)
 {
@@ -107,7 +106,6 @@ static void gbcon(grp_block_t *p)
     PMIX_CONSTRUCT(&p->mbrs, pmix_list_t);
     p->def_complete = false;
     p->nlocal = 0;
-    p->local_cnt = 0;
 }
 static void gbdes(grp_block_t *p)
 {

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -985,6 +985,15 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_RELEASE(blk);
         return rc;
     }
+    /* if an expected member was lost before contributing, the block still
+     * completes on the survivors - but record the degraded status in the
+     * block's info so the host sees it, matching the fence/connect/disconnect
+     * families. The status slot is located by key (see
+     * pmix_server_set_collective_status). */
+    if (0 < pmix_list_get_size(&blk->departed)) {
+        pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                          PMIX_ERR_LOST_CONNECTION);
+    }
     // the local phase is complete - freeze it and pass up to the host
     blk->host_called = true;
     rc = pmix_host_server.group(op, blk->id, trk->pcs, trk->npcs,
@@ -1088,6 +1097,11 @@ void pmix_server_grp_peer_lost(pmix_peer_t *peer)
                 PMIX_RELEASE(blk);
                 continue;
             }
+            /* a member was lost before contributing (that is why we are here):
+             * record the degraded status in the block's info so the host sees
+             * it, matching the fence/connect/disconnect families */
+            pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                              PMIX_ERR_LOST_CONNECTION);
             blk->host_called = true;
             rc = pmix_host_server.group(blk->grpop, blk->id, trk->pcs, trk->npcs,
                                         blk->info, blk->ninfo, grpcbfunc, blk);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2995,6 +2995,7 @@ static void tcon(pmix_server_trkr_t *t)
     PMIX_CONSTRUCT_LOCK(&t->lock);
     t->def_complete = false;
     PMIX_CONSTRUCT(&t->local_cbs, pmix_list_t);
+    PMIX_CONSTRUCT(&t->departed, pmix_list_t);
     t->nlocal = 0;
     t->local_cnt = 0;
     t->info = NULL;
@@ -3019,6 +3020,7 @@ static void tdes(pmix_server_trkr_t *t)
         free(t->pcs);
     }
     PMIX_LIST_DESTRUCT(&t->local_cbs);
+    PMIX_LIST_DESTRUCT(&t->departed);
     if (NULL != t->info) {
         PMIX_INFO_FREE(t->info, t->ninfo);
     }
@@ -3028,6 +3030,25 @@ static void tdes(pmix_server_trkr_t *t)
 PMIX_CLASS_INSTANCE(pmix_server_trkr_t,
                     pmix_list_item_t,
                     tcon, tdes);
+
+/* The single predicate for deciding whether a collective's local phase
+ * is complete. The tracker definition must be complete (all participating
+ * nspaces registered, so nlocal is final) AND every expected local
+ * participant must be accounted for - either by having contributed (an
+ * entry on local_cbs) or by having departed before contributing (an entry
+ * on departed). A live participant that has not yet been heard from is on
+ * neither list, so the sum stays below nlocal until it either contributes
+ * or departs. The '>=' comparison is deliberate: it tolerates any
+ * over-count from fork/exec'd clones without falsely reporting the
+ * collective as incomplete. See docs/how-things-work/collectives. */
+bool pmix_server_trk_complete(pmix_server_trkr_t *trk)
+{
+    if (!trk->def_complete) {
+        return false;
+    }
+    return (pmix_list_get_size(&trk->local_cbs) +
+            pmix_list_get_size(&trk->departed)) >= trk->nlocal;
+}
 
 static void cdcon(pmix_server_caddy_t *cd)
 {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2997,7 +2997,6 @@ static void tcon(pmix_server_trkr_t *t)
     PMIX_CONSTRUCT(&t->local_cbs, pmix_list_t);
     PMIX_CONSTRUCT(&t->departed, pmix_list_t);
     t->nlocal = 0;
-    t->local_cnt = 0;
     t->info = NULL;
     t->ninfo = 0;
     PMIX_CONSTRUCT(&t->grpinfo, pmix_list_t);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3049,6 +3049,32 @@ bool pmix_server_trk_complete(pmix_server_trkr_t *trk)
             pmix_list_get_size(&trk->departed)) >= trk->nlocal;
 }
 
+/* Record a collective's completion status in the tracker's info array. The
+ * participant handlers seed a PMIX_LOCAL_COLLECTIVE_STATUS slot; locate it by
+ * key rather than by position. It is the last element for the fence and
+ * disconnect families, but connect appends per-participant endpoint info and
+ * (for cross-namespace connects) job-level info AFTER that slot (see
+ * pmix_server_connect), so a positional write to info[ninfo-1] would clobber
+ * the appended info and leave the real status slot stale. Locating by key is
+ * correct for every family and cannot underflow when info is unset. If the
+ * slot is absent this is a no-op. Shared with the collective-status unit test
+ * (test/unit/collective_status.c). */
+void pmix_server_set_collective_status(pmix_info_t *info, size_t ninfo,
+                                       pmix_status_t status)
+{
+    size_t n;
+
+    if (NULL == info) {
+        return;
+    }
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_LOCAL_COLLECTIVE_STATUS)) {
+            info[n].value.data.status = status;
+            return;
+        }
+    }
+}
+
 static void cdcon(pmix_server_caddy_t *cd)
 {
     memset(&cd->ev, 0, sizeof(pmix_event_t));

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -426,6 +426,9 @@ PMIX_EXPORT pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
 
 PMIX_EXPORT bool pmix_server_trk_complete(pmix_server_trkr_t *trk);
 
+PMIX_EXPORT void pmix_server_set_collective_status(pmix_info_t *info, size_t ninfo,
+                                                   pmix_status_t status);
+
 PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);
 
 #endif // PMIX_SERVER_OPS_H

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -426,4 +426,6 @@ PMIX_EXPORT pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
 
 PMIX_EXPORT bool pmix_server_trk_complete(pmix_server_trkr_t *trk);
 
+PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);
+
 #endif // PMIX_SERVER_OPS_H

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -424,4 +424,6 @@ PMIX_EXPORT pmix_server_trkr_t *pmix_server_new_tracker(char *id, pmix_proc_t *p
 PMIX_EXPORT pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                                                    pmix_buffer_t *buf);
 
+PMIX_EXPORT bool pmix_server_trk_complete(pmix_server_trkr_t *trk);
+
 #endif // PMIX_SERVER_OPS_H

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl
 
 EXTRA_DIST = run_gds_fallback.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status
 
 compress_SOURCES =  \
         compress.c
@@ -67,5 +67,11 @@ pmix_log_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_log_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+collective_status_SOURCES = \
+        collective_status.c
+collective_status_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+collective_status_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status

--- a/test/unit/collective_status.c
+++ b/test/unit/collective_status.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for pmix_server_set_collective_status().
+ *
+ * This is the routine the server's lost-connection accounting uses to record a
+ * collective's completion status in the tracker's info array. The status slot
+ * (PMIX_LOCAL_COLLECTIVE_STATUS) is seeded by the participant handlers. For the
+ * fence and disconnect families it is the last element of the array; but the
+ * connect handler appends per-participant endpoint info, and for a
+ * cross-namespace connect job-level info, AFTER that slot. A positional write
+ * to info[ninfo-1] would therefore clobber the appended info on connect and
+ * leave the real status slot stale. The routine locates the slot by key to
+ * avoid that.
+ *
+ * These tests assert the slot's contents directly:
+ *
+ *  connect layout   : status slot in the middle, endpoint + job-level info
+ *                     after it -> the status slot is updated and the appended
+ *                     info is left untouched.
+ *  fence layout     : status slot last -> updated correctly.
+ *  status absent    : no PMIX_LOCAL_COLLECTIVE_STATUS slot -> no-op, no change.
+ *  degenerate input : NULL array / zero length -> no crash, no write.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* keys used for the synthetic appended info */
+#define ENDPT_KEY "test.endpt.data"
+#define JOB_KEY   "test.job.data"
+#define USER_KEY  "test.user.dir"
+
+#define ENDPT_VAL 0xE11E11ULL
+#define JOB_VAL   0x70B70BULL
+#define USER_VAL  0xABCDEFULL
+
+/* Build a connect-style tracker info array:
+ *   [0] a user directive
+ *   [1] PMIX_SORTED_PROC_ARRAY
+ *   [2] PMIX_LOCAL_COLLECTIVE_STATUS (seeded to PMIX_SUCCESS)  <-- NOT last
+ *   [3] appended endpoint info
+ *   [4] appended job-level info
+ */
+static pmix_info_t *make_connect_layout(size_t *ninfo)
+{
+    pmix_info_t *info;
+    pmix_status_t seed = PMIX_SUCCESS;
+    uint64_t u;
+
+    *ninfo = 5;
+    PMIX_INFO_CREATE(info, 5);
+    u = USER_VAL;
+    PMIX_INFO_LOAD(&info[0], USER_KEY, &u, PMIX_UINT64);
+    PMIX_INFO_LOAD(&info[1], PMIX_SORTED_PROC_ARRAY, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[2], PMIX_LOCAL_COLLECTIVE_STATUS, &seed, PMIX_STATUS);
+    u = ENDPT_VAL;
+    PMIX_INFO_LOAD(&info[3], ENDPT_KEY, &u, PMIX_UINT64);
+    u = JOB_VAL;
+    PMIX_INFO_LOAD(&info[4], JOB_KEY, &u, PMIX_UINT64);
+    return info;
+}
+
+static void test_connect_layout(void)
+{
+    pmix_info_t *info;
+    size_t ninfo;
+    int ok;
+
+    info = make_connect_layout(&ninfo);
+    pmix_server_set_collective_status(info, ninfo, PMIX_ERR_LOST_CONNECTION);
+
+    /* the status slot (index 2, by key) must now carry the loss status */
+    ok = (PMIX_CHECK_KEY(&info[2], PMIX_LOCAL_COLLECTIVE_STATUS)
+          && PMIX_ERR_LOST_CONNECTION == info[2].value.data.status);
+    report("connect layout: status slot updated by key", ok);
+
+    /* the appended endpoint and job-level info must be untouched */
+    ok = (PMIX_CHECK_KEY(&info[3], ENDPT_KEY)
+          && PMIX_UINT64 == info[3].value.type
+          && ENDPT_VAL == info[3].value.data.uint64);
+    report("connect layout: appended endpoint info intact", ok);
+
+    ok = (PMIX_CHECK_KEY(&info[4], JOB_KEY)
+          && PMIX_UINT64 == info[4].value.type
+          && JOB_VAL == info[4].value.data.uint64);
+    report("connect layout: appended job-level info intact", ok);
+
+    /* the untouched leading slots must remain what they were */
+    ok = (PMIX_CHECK_KEY(&info[0], USER_KEY)
+          && USER_VAL == info[0].value.data.uint64
+          && PMIX_CHECK_KEY(&info[1], PMIX_SORTED_PROC_ARRAY));
+    report("connect layout: leading slots intact", ok);
+
+    PMIX_INFO_FREE(info, ninfo);
+}
+
+static void test_fence_layout(void)
+{
+    pmix_info_t *info;
+    size_t ninfo = 3;
+    pmix_status_t seed = PMIX_SUCCESS;
+    uint64_t u = USER_VAL;
+    int ok;
+
+    /* fence/disconnect layout: status slot is the last element */
+    PMIX_INFO_CREATE(info, 3);
+    PMIX_INFO_LOAD(&info[0], USER_KEY, &u, PMIX_UINT64);
+    PMIX_INFO_LOAD(&info[1], PMIX_SORTED_PROC_ARRAY, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[2], PMIX_LOCAL_COLLECTIVE_STATUS, &seed, PMIX_STATUS);
+
+    pmix_server_set_collective_status(info, ninfo, PMIX_ERR_PARTIAL_SUCCESS);
+
+    ok = (PMIX_CHECK_KEY(&info[2], PMIX_LOCAL_COLLECTIVE_STATUS)
+          && PMIX_ERR_PARTIAL_SUCCESS == info[2].value.data.status);
+    report("fence layout: trailing status slot updated", ok);
+
+    PMIX_INFO_FREE(info, ninfo);
+}
+
+static void test_status_absent(void)
+{
+    pmix_info_t *info;
+    size_t ninfo = 2;
+    uint64_t u = USER_VAL;
+    int ok;
+
+    /* no PMIX_LOCAL_COLLECTIVE_STATUS slot present */
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], USER_KEY, &u, PMIX_UINT64);
+    u = ENDPT_VAL;
+    PMIX_INFO_LOAD(&info[1], ENDPT_KEY, &u, PMIX_UINT64);
+
+    /* must not write anywhere and must not crash */
+    pmix_server_set_collective_status(info, ninfo, PMIX_ERR_LOST_CONNECTION);
+
+    ok = (PMIX_CHECK_KEY(&info[0], USER_KEY)
+          && USER_VAL == info[0].value.data.uint64
+          && PMIX_CHECK_KEY(&info[1], ENDPT_KEY)
+          && ENDPT_VAL == info[1].value.data.uint64);
+    report("status absent: no slot touched", ok);
+
+    PMIX_INFO_FREE(info, ninfo);
+}
+
+static void test_degenerate(void)
+{
+    pmix_info_t *info;
+    size_t ninfo = 1;
+    pmix_status_t seed = PMIX_SUCCESS;
+
+    /* NULL array and zero length must be safe no-ops */
+    pmix_server_set_collective_status(NULL, 0, PMIX_ERR_LOST_CONNECTION);
+    pmix_server_set_collective_status(NULL, 5, PMIX_ERR_LOST_CONNECTION);
+    report("degenerate: NULL array is a safe no-op", 1);
+
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_LOCAL_COLLECTIVE_STATUS, &seed, PMIX_STATUS);
+    /* ninfo of zero over a valid array must not scan or write */
+    pmix_server_set_collective_status(info, 0, PMIX_ERR_LOST_CONNECTION);
+    report("degenerate: zero length does not scan",
+           PMIX_SUCCESS == info[0].value.data.status);
+    PMIX_INFO_FREE(info, ninfo);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== pmix_server_set_collective_status unit tests ===\n\n");
+
+    test_connect_layout();
+    test_fence_layout();
+    test_status_absent();
+    test_degenerate();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

The PMIx server tracked local participation in collective operations
(fence, connect, disconnect, group construct/destruct) with a simple
count of contributions compared against an expected local count. This
cardinality accounting cannot distinguish a participant that has *not
yet* called from one that called and *then died*. When a client
contributes and its connection is later lost, the lost-connection
handler both decrements the expected count and removes the
contribution, which can drive the remaining live participants to the
lowered threshold before they have all called in. The collective then
completes early, and for a data-collecting fence the departed client's
already-delivered data is discarded. The group family had no
lost-connection accounting at all, so a group whose participant died
before contributing hung forever.

## Fix

Track participation by **identity**, not by counter:

- **Case A** — the departing peer already contributed (its rank has an
  entry on `local_cbs`, whether from the client itself or a fork/exec
  clone sharing its name): the loss is ignored for that collective, so
  its contribution and data stand and the collective completes on the
  full set.
- **Case B** — the peer had not yet contributed: its rank is recorded on
  the tracker's new `departed` list so the collective can complete on
  the remaining live participants instead of hanging.

Completion for the fence/connect/disconnect family is decided by a
single predicate, `pmix_server_trk_complete()` (contributions + departures
vs `nlocal`), replacing six hand-rolled copies of the test. The group
construct/destruct family keeps its two-level `grp_block_t`/`grp_trk_t`
structure but gains the same predicate shape and Case A / Case B
semantics through one exported entry point,
`pmix_server_grp_peer_lost()`.

### Scope of the group family

Only `PMIx_Group_construct`/`_destruct` are server-side collectives with
local trackers (`grpop` is only ever `PMIX_GROUP_CONSTRUCT`/`_DESTRUCT`),
so they are what the lost-connection accounting covers.
`PMIx_Group_invite`/`_join`/`_leave` are an event-driven negotiation
layer (`PMIx_Notify_event` with `PMIX_GROUP_INVITED` /
`INVITE_ACCEPTED` / `INVITE_DECLINED` / `INVITE_FAILED` /
`GROUP_CONSTRUCT_COMPLETE`) — they create no collective trackers and have
no `nlocal`-gated local phase, so the early-completion / hang class does
not apply to them; a lost invitee is handled through the event/timeout
path. A successful invite/join sequence funnels into a construct
collective, which is covered.

## Status-slot handling

While auditing `PMIx_Connect` for the same class of bug, found a distinct
pre-existing defect: `lost_connection` recorded the collective status by
writing `PMIX_LOCAL_COLLECTIVE_STATUS` to the *last* element of
`trk->info`. That slot is last for fence and disconnect, but connect
appends per-participant endpoint info (whenever the client posted
remote-scope data) and job-level info (for cross-namespace connects)
*after* it. On a connect participant's death the write clobbered the
appended info handed to `pmix_host_server.connect` and left the real
status slot stale at `SUCCESS`. The status slot is now located by key,
via a small shared helper (`pmix_server_set_collective_status()`).

For consistency, the group construct/destruct path now sets the same
status slot on a lost participant too (it previously left it at
`SUCCESS`, telling the host the local phase completed cleanly even when a
member had departed). Clients continue to receive their group status
through `grpcbfunc`; this only corrects what the host is told.

## Documentation

A design spec and implementation plan under
`docs/how-things-work/collectives/` describe the identity-based model,
the single-tracking-service architecture (and why the group family
shares *semantics* rather than the struct), and the migration steps.

## Testing

- `make check` is green under CI's `--disable-visibility` config
  (util 17/17, class 8/8, unit 8/8) and the build is clean under
  `--enable-devel-check`.
- New white-box unit test `test/unit/collective_status.c` (wired into
  `make check`) asserts `pmix_server_set_collective_status()` updates the
  status slot by key and leaves connect's appended endpoint/job-level
  info intact across the connect layout, the fence/disconnect layout, an
  absent slot, and degenerate input — 8/8.
- New death-injection exercisers: `examples/group_die.c` (a group member
  leaves mid-construct) and `examples/connect_die.c` (a `PMIx_Connect`
  participant leaves before contributing, after each rank posted
  remote-scope data so the server appends endpoint info — driving both
  the identity completion and the by-key status-slot handling). The
  survivors complete rather than hang.
- New `contrib/dockerswarm` harness (PMIx bind-mounted as
  code-under-test, PRRTE master baked in, 10-node swarm) drives all
  exercisers across separate PMIx servers. Full suite is green — **10
  passed / 0 failed**: cross-daemon launch smoke, all six group
  construction methods across two nodes (including `multi_nspace_group`,
  which builds a group spanning a parent + spawned-child namespace, and
  `asyncgroup`, which exercises the invite/join negotiation), and the
  participant-death loss-accounting scenarios for both group construct
  and `PMIx_Connect` (`prterun --rtos recoverable`), where all three
  survivors complete after a participant dies.
