### PR TITLE
Client init/finalize cycling: state-lifecycle spec, teardown fixes, and regression test

### DIFF
--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -10,6 +10,7 @@ find information on that subject here.
    :maxdepth: 2
 
    session_dirs.rst
+   init-finalize.rst
    distances.rst
    schedulers/index.rst
    sets_groups/index.rst

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -1,0 +1,300 @@
+Client Init/Finalize Lifecycle and Server-Side State
+====================================================
+
+This document specifies how the PMIx server manages the per-client and
+per-namespace state associated with a client across the ``PMIx_Init`` /
+``PMIx_Finalize`` boundary. Its purpose is to define the intended
+behavior precisely enough to implement and test it, and in particular to
+guarantee one property:
+
+.. admonition:: The cycling guarantee
+   :class: note
+
+   A client may cycle ``PMIx_Init`` → *(work: fences, gets, puts,
+   events, …)* → ``PMIx_Finalize`` and then ``PMIx_Init`` again, any
+   number of times, reusing the **same namespace and rank**, and each
+   new ``PMIx_Init`` must present a **fresh interaction state** on the
+   server. No state produced in one cycle may leak into the next. The
+   host environment is **not** required to deregister and re-register the
+   client between cycles for this to hold.
+
+For a code-oriented view of the socket connection that underlies each
+init, see :doc:`ptl`. This document is concerned with the *state
+lifecycle*, not the transport.
+
+
+The Problem
+-----------
+
+When a client calls ``PMIx_Init``, the server accumulates state on its
+behalf: a peer object holding the connection, event-loop registrations,
+tag counters, and a datastore (``gds``) module assignment; entries in
+collective trackers as the client fences; event and I/O-forwarding
+registrations; cached notifications; and committed key/value data. The
+server also carries longer-lived, job-scoped state in the namespace
+object: the roster of ranks, the count of local processes, the GDS job
+data, and network/programming-model resources reserved for the job.
+
+A single ``PMIx_Init``/``PMIx_Finalize`` pass, followed by the host
+tearing the job down, is the common case and works. The difficulty is
+the *cycling* case. ``PMIx_Finalize`` on the client side tears the client
+library all the way down (including the class system), so a subsequent
+``PMIx_Init`` is a brand-new library instance that opens a **new** socket
+and reconnects. On the server, the namespace and the rank are still
+registered — the host did not tear them down — so the second init must
+reconnect onto existing job-scoped state while starting from a clean
+per-client slate. If per-client state from the first cycle survives into
+the second, the client sees stale data, duplicated accounting, or leaked
+objects.
+
+The design below draws a sharp line between **job-scoped** state, which
+belongs to the namespace and persists until the host deregisters it, and
+**client-scoped** state, which belongs to a single init/finalize cycle
+and must not survive one.
+
+
+The Actors
+----------
+
+``pmix_namespace_t`` (``nptr``)
+    The job. Holds the ``ranks`` list, ``nlocalprocs`` (the number of
+    local clients registered for this namespace), ``nfinalized`` (how
+    many of those have finalized), the compatibility modules negotiated
+    for the job, the namespace-level epilog, and the association to the
+    GDS job data. Persists until the host calls
+    ``PMIx_server_deregister_nspace``.
+
+``pmix_rank_info_t`` (``info``)
+    One entry per rank on ``nptr->ranks``. Records the rank's identity
+    (``pname``), ``uid``/``gid``, the host's ``server_object``, the index
+    (``peerid``) of the peer object serving this rank in the server's
+    ``clients`` array, and ``proc_cnt`` — the number of live *clones* of
+    this rank (see below). This is **registration** state: it is created
+    by ``PMIx_server_register_client`` (or lazily on first connect) and
+    lives until the client or the namespace is deregistered. It is
+    **not** torn down by finalize.
+
+``pmix_peer_t`` (``peer``)
+    The per-connection object: socket, send/receive queues, event
+    registrations, dynamic-tag counters, the ``finalized`` flag, the
+    peer's assigned ``gds`` module, and the peer-level epilog. Held in
+    ``pmix_server_globals.clients`` and pointed to by ``info->peerid``.
+    This is the primary carrier of **client-scoped** state.
+
+Clones
+    A client may ``fork``/``exec`` a child that also calls ``PMIx_Init``
+    using the *same* namespace and rank as its parent — in PMIx
+    terminology, a *clone* of that client. Each clone opens its own
+    socket and is tracked by ``info->proc_cnt``. A rank is only fully
+    finalized when the original
+    client **and all of its clones** have finalized — i.e. when
+    ``proc_cnt`` returns to zero.
+
+
+The Three Teardown Triggers
+---------------------------
+
+Server-side cleanup is driven by exactly three events. Each has a
+distinct, non-overlapping responsibility. The remainder of this document
+is normative: "must" denotes a required behavior.
+
+1. Client finalize (all clones included)
+    A client, together with all of its clones, has finalized — the rank's
+    ``proc_cnt`` has dropped to zero. The peer object serving that rank
+    is **recycled in place**: the server performs an object
+    destruct/construct on it and repoints it at the namespace it belongs
+    to. The object is **not** released and is **not** removed from the
+    namespace's client list. See `Recycling the peer on finalize`_.
+
+2. Host deregisters a client (``PMIx_server_deregister_client``)
+    The server removes the peer object from the namespace and releases
+    it. See `Deregistering a client`_.
+
+3. Host deregisters the namespace (``PMIx_server_deregister_nspace``)
+    The server removes all GDS-registered job data for the namespace,
+    removes and releases all peer objects belonging to the namespace, and
+    cleans up all remaining references to the namespace. See
+    `Deregistering the namespace`_.
+
+The essential distinction is that **finalize is reversible and
+deregistration is terminal**. Finalize leaves the registration intact so
+the client can init again; only the host, by deregistering, declares that
+the client or the whole job is gone for good and its objects may be
+freed.
+
+
+Recycling the Peer on Finalize
+------------------------------
+
+When the last live process for a rank finalizes (``proc_cnt`` reaches
+zero), the server **must** reset the peer object rather than release it:
+
+* Run the peer's destructor (``PMIX_DESTRUCT``) so that every allocation
+  and reference the object accumulated during the cycle is torn down:
+  pending send/receive messages and queues, event registrations, the
+  peer-level epilog, the reference to its namespace, its ``gds``
+  assignment, dynamic-tag state, and the ``finalized`` flag.
+
+* Immediately reconstruct it (``PMIX_CONSTRUCT``) so it returns to the
+  pristine state a freshly allocated peer would have — in particular
+  ``finalized`` is once again ``false`` and all lists and counters are
+  empty.
+
+* Repoint the reconstructed object at the namespace it serves
+  (re-establish ``peer->nptr`` with a retained reference), so the peer
+  remains associated with its job.
+
+* Leave the object in ``pmix_server_globals.clients`` at its existing
+  slot, and leave ``info->peerid`` pointing at it. The **registration**
+  (the ``pmix_rank_info_t`` on ``nptr->ranks`` and the client-array slot)
+  is deliberately preserved.
+
+The result is a registered rank whose peer object is a clean, empty
+container ready to be repopulated. When the client calls ``PMIx_Init``
+again and reconnects, the server reuses this existing, reset peer for the
+rank instead of allocating a new one — so no peer object is orphaned and
+the second cycle starts from a guaranteed-fresh per-client state.
+
+Why destruct/construct rather than release? Releasing the peer would
+either strand ``info->peerid`` (a dangling index) or force the host to
+re-register the client before it could init again — defeating the cycling
+guarantee. Recycling in place keeps the registration valid and the
+client-array slot stable while still discarding every byte of
+client-scoped state from the previous cycle.
+
+Job-scoped accounting must be reconciled at the same time so that it does
+not drift across cycles. In particular, the namespace's finalized
+accounting (``nfinalized`` relative to ``nlocalprocs``) and the rank's
+``proc_cnt`` must reflect the true, current number of connected processes
+after a recycle, so that a client which finalizes and re-inits is not
+double-counted and the "all local processes finalized" condition remains
+accurate for the job as a whole.
+
+What finalize does **not** do
+    Finalize does not remove the rank from ``nptr->ranks``, does not
+    release the peer, does not drop the namespace's GDS job data, and
+    does not touch network or programming-model resources reserved for
+    the job. Those are job-scoped and survive until the host deregisters.
+    Transient, client-scoped registrations that are keyed to the peer —
+    event registrations, I/O-forwarding requests, in-flight direct-modex
+    requests, and cached notifications targeting the client — are pruned
+    as part of the teardown so they do not linger on the reset object.
+
+
+Deregistering a Client
+----------------------
+
+``PMIx_server_deregister_client`` is the host's declaration that a
+specific rank is gone and will not init again. Here the peer is **removed
+and released**, not recycled:
+
+* Remove the peer object from the namespace: release the reference the
+  namespace/registration holds, null out the client-array slot
+  identified by ``info->peerid``, and remove the ``pmix_rank_info_t``
+  from ``nptr->ranks``.
+
+* Release the peer object.
+
+* Restore any job resources that were charged to the rank (network
+  allocations, monitoring/sensors) and honor the peer's epilog, exactly
+  as when a client terminates.
+
+After a client is deregistered, the rank no longer exists on the server;
+a subsequent connection for that rank would be rejected unless the host
+re-registers it.
+
+
+Deregistering the Namespace
+---------------------------
+
+``PMIx_server_deregister_nspace`` is the host's declaration that the
+entire job is gone. This is the terminal, whole-namespace teardown and
+**must** reclaim everything the namespace owned:
+
+* Remove all GDS-registered job data for the namespace (``gds`` del of
+  the namespace), so no key/value or job-info data survives.
+
+* Remove and release **all** peer objects belonging to the namespace —
+  both those still recycled/idle from a finalize and any that never
+  finalized — nulling their client-array slots and freeing every
+  ``pmix_rank_info_t`` on ``nptr->ranks``.
+
+* Release the network and programming-model resources reserved for the
+  job, run the namespace epilog, and prune every remaining reference to
+  the namespace: event and I/O-forwarding registrations, cached
+  notifications targeting any of its procs, and finally the namespace
+  object itself.
+
+Nothing that names the namespace may remain after this call returns.
+
+
+State Ownership Summary
+-----------------------
+
+The following table classifies the state and states which trigger frees
+it. "Recycled" means reset in place by finalize (not freed); "Released"
+means freed.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 22 22
+
+   * - State
+     - Client finalize (all clones)
+     - Deregister client
+     - Deregister nspace
+   * - Peer object (``pmix_peer_t``)
+     - Recycled (destruct/construct, repointed, kept)
+     - Released, slot nulled
+     - Released, slot nulled
+   * - Event / IOF / direct-modex regs, cached notifications for the peer
+     - Pruned
+     - Pruned
+     - Pruned
+   * - Peer epilog
+     - Executed
+     - Executed
+     - Executed (peer) + namespace epilog
+   * - Rank info (``pmix_rank_info_t`` on ``nptr->ranks``)
+     - Kept (registration preserved)
+     - Removed, released
+     - Removed, released
+   * - GDS job data for the namespace
+     - Kept
+     - Kept
+     - Removed
+   * - Network / programming-model job resources
+     - Kept
+     - Rank's share restored
+     - Released (whole job)
+   * - Namespace object (``pmix_namespace_t``)
+     - Kept
+     - Kept
+     - Released; all references purged
+
+
+Invariants
+----------
+
+An implementation of the above must uphold these invariants:
+
+* **No cross-cycle carryover.** After a recycle, the peer object must be
+  indistinguishable from a freshly allocated one except that it is
+  already associated with its namespace. ``finalized`` is ``false``; all
+  queues, event registrations, tag counters, and datastore assignments
+  are empty/default.
+
+* **No orphaned peers.** Cycling init/finalize must not leave unreferenced
+  peer objects in the ``clients`` array. Recycling in place, rather than
+  allocating a new peer on reconnect, is what guarantees this.
+
+* **No counter drift.** Per-namespace finalized accounting and per-rank
+  ``proc_cnt`` must return to values consistent with the actual number of
+  connected processes after each cycle, so that the job-level "all local
+  processes finalized" condition and any resource-release keyed on it
+  remain correct no matter how many times clients cycle.
+
+* **Registration outlives finalize; only deregistration is terminal.**
+  The ``pmix_rank_info_t`` and the client-array slot persist across
+  finalize and are removed only by an explicit host deregister. GDS job
+  data and job resources persist until ``PMIx_server_deregister_nspace``.

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -1,11 +1,13 @@
-Client Init/Finalize Lifecycle and Server-Side State
-====================================================
+Client Init/Finalize Lifecycle and State Management
+===================================================
 
-This document specifies how the PMIx server manages the per-client and
-per-namespace state associated with a client across the ``PMIx_Init`` /
-``PMIx_Finalize`` boundary. Its purpose is to define the intended
-behavior precisely enough to implement and test it, and in particular to
-guarantee one property:
+This document specifies how PMIx manages the state associated with a
+client across the ``PMIx_Init`` / ``PMIx_Finalize`` boundary. It has two
+halves: the **server-side** management of the per-client and
+per-namespace state the server holds on a client's behalf, and the
+**client-side** teardown of the client library itself. Its purpose is to
+define the intended behavior precisely enough to implement and test it,
+and in particular to guarantee one property:
 
 .. admonition:: The cycling guarantee
    :class: note
@@ -273,6 +275,84 @@ means freed.
      - Released; all references purged
 
 
+Client-Side Teardown
+--------------------
+
+Everything above concerns the state a *server* holds for a client. The
+cycling guarantee has a second half: the client's own library must tear
+itself down on ``PMIx_Finalize`` so that a subsequent ``PMIx_Init`` in
+the same process starts from a clean slate. Unlike the server side —
+where finalize deliberately *preserves* registration state — the client
+side has no such asymmetry to manage: a client ``PMIx_Finalize`` (once
+the init reference count reaches zero) is a full teardown of the library,
+and a later ``PMIx_Init`` is a brand-new library instance that opens a
+fresh socket and reconnects.
+
+The teardown runs ``PMIx_Finalize`` → ``pmix_rte_finalize`` → framework
+closes plus ``pmix_finalize_util`` and the release of the progress
+thread; it is the mirror image of ``PMIx_Init`` → ``pmix_rte_init`` →
+``pmix_init_util`` plus the framework opens. The governing principle is
+**symmetry**: finalize must undo exactly what init did, leaving no
+residue that the next init would either trip over or skip.
+
+The reference-count guard
+    ``PMIx_Init`` is reference-counted: nested init/init/…/finalize
+    sequences only tear down on the *last* finalize, when the counter
+    returns to zero. The full teardown described here applies to that
+    final finalize. A nested (non-final) finalize must leave the library
+    running and untouched.
+
+Three requirements make the symmetry real, and an implementation **must**
+uphold all three:
+
+1. **Every one-time-init latch must be reset.** Any ``static`` boolean or
+   counter that guards a "do this once" step in init (module
+   registration, key creation, subsystem setup) must be cleared by the
+   corresponding finalize, so the step runs again on the next init.
+   Leaving a latch set silently *skips* re-initialization on the second
+   cycle — the failure is not a crash at finalize but wrong or missing
+   state later. The multi-select framework ``initialized`` flags, the MCA
+   parameter-registration latch, and the attribute/output/show-help
+   subsystems all follow this rule and are the model to copy.
+
+2. **Every freed global must be nulled, and every per-cycle flag reset.**
+   A global pointer whose target is freed during finalize must be set to
+   ``NULL`` in the same step. Two hazards follow from not doing so:
+
+   * **Dangling reuse.** A non-``NULL`` pointer to freed memory defeats
+     the ``if (NULL == p)`` guards that would otherwise make a
+     between-cycles access safe; it reads as "still valid" and yields a
+     use-after-free. The event base, the shared progress-thread tracker,
+     and the cached server peer are pointers of this kind.
+
+   * **Stale mode flags.** A flag that records *how* this cycle was set
+     up — most importantly the singleton indicator, which records that
+     the process came up with no server and therefore constructed the
+     server-side I/O-forwarding lists — must be reset on every fresh
+     init, not only when it happens to be toggled. A stale singleton flag
+     carried from a no-server cycle into a with-server cycle drives
+     finalize to tear down lists the with-server path never built.
+
+3. **Init and finalize of the utility layer must stay in lockstep.**
+   ``pmix_init_util`` opens a fixed set of low-level subsystems (output,
+   install-dirs, show-help, the keyval parser, the MCA base and its
+   variable system, the network and interface helpers). Each must be
+   closed on finalize. Whether the close lives in ``pmix_finalize_util``
+   or inline in ``pmix_rte_finalize`` is an implementation choice, but the
+   two lists must be kept in correspondence: a subsystem added to init
+   without a matching teardown persists across a cycle and breaks the
+   clean-slate guarantee for the next init.
+
+Platform caveat: destructor support
+    On platforms that provide neither a compiler ``destructor``
+    attribute nor linker ``-fini`` support, the library cannot guarantee
+    cleanup at unload, and re-initialization after finalize is
+    **explicitly unsupported** — a second ``PMIx_Init`` returns
+    ``PMIX_ERR_NOT_SUPPORTED`` rather than risk an inconsistent restart.
+    The cycling guarantee therefore applies only where destructor or
+    ``-fini`` support is present (the mainstream case).
+
+
 Invariants
 ----------
 
@@ -298,3 +378,9 @@ An implementation of the above must uphold these invariants:
   The ``pmix_rank_info_t`` and the client-array slot persist across
   finalize and are removed only by an explicit host deregister. GDS job
   data and job resources persist until ``PMIx_server_deregister_nspace``.
+
+* **The client library reinitializes from a clean slate.** After the
+  final ``PMIx_Finalize``, no ``static`` init-once latch remains set, no
+  global pointer references freed memory, and no per-cycle mode flag
+  retains a value from the previous cycle. The next ``PMIx_Init`` behaves
+  exactly as the first.

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -688,6 +688,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                          PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* setup the globals */
+    /* reset the singleton indicator on every fresh init: it is a static
+     * that records how *this* cycle came up, and is only set true below
+     * if we fail to find a server. Leaving a stale "true" from a prior
+     * singleton cycle would cause finalize to tear down the server-side
+     * IOF lists that a subsequent with-server cycle never constructed. */
+    pmix_client_globals.singleton = false;
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -46,6 +46,7 @@
 #include "src/mca/ptl/base/base.h"
 #include "src/threads/pmix_tsd.h"
 #include "src/util/pmix_keyval_parse.h"
+#include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_net.h"
@@ -161,8 +162,18 @@ void pmix_rte_finalize(void)
         pmix_var_dump_color[i] = NULL;
     }
     pmix_tsd_keys_destruct();
+    /* clear the print-buffer TSD latch now that its key has been deleted,
+     * so a subsequent PMIx_Init recreates it */
+    pmix_name_fns_finalize();
 
     pmix_finalize_util();
     // release the event base
     pmix_progress_thread_stop(NULL);
+    /* the event base has now been freed - clear our cached pointers so a
+     * subsequent PMIx_Init starts from a clean slate and nothing in the
+     * gap dereferences freed memory. evauxbase either aliased evbase or
+     * was supplied externally by the caller (who owns it); in both cases
+     * we only drop our reference, we do not free it here */
+    pmix_globals.evbase = NULL;
+    pmix_globals.evauxbase = NULL;
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -68,6 +68,7 @@
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/runtime/pmix_init_util.h"
+#include "src/threads/pmix_threads.h"
 
 const char pmix_version_string[] = PMIX_IDENT_STRING;
 const char* pmix_tool_basename = NULL;
@@ -158,6 +159,14 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
     if (pmix_atomic_check_bool(&pmix_globals.util_initialized)) {
         return PMIX_SUCCESS;
     }
+
+    /* record the initializing thread as "main" so that thread-specific
+     * data keys it creates (e.g., in pmix_net_init) are registered for
+     * cleanup. Without this the registry stays empty and every key -
+     * and its pthread slot - leaks across an init/finalize cycle,
+     * eventually exhausting PTHREAD_KEYS_MAX. init and finalize run on
+     * this same thread, so it is also where pmix_tsd_keys_destruct runs. */
+    pmix_thread_set_main();
 
     /* initialize the output system */
     if (!pmix_output_init()) {

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -380,6 +380,12 @@ pmix_status_t pmix_progress_thread_stop(const char *name)
                 stop_progress_engine(trk);
             }
             pmix_list_remove_item(&tracking, &trk->super);
+            /* if this is the shared tracker, clear the cached pointer so a
+             * PMIx_Progress call between finalize and the next init does
+             * not dereference freed memory */
+            if (trk == shared_thread_tracker) {
+                shared_thread_tracker = NULL;
+            }
             PMIX_RELEASE(trk);
             return PMIX_SUCCESS;
         }
@@ -415,6 +421,9 @@ pmix_status_t pmix_progress_thread_finalize(const char *name)
             }
 
             pmix_list_remove_item(&tracking, &trk->super);
+            if (trk == shared_thread_tracker) {
+                shared_thread_tracker = NULL;
+            }
             PMIX_RELEASE(trk);
             return PMIX_SUCCESS;
         }

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -117,9 +117,16 @@ int pmix_tsd_keys_destruct(void)
                 pmix_tsd_setspecific(pmix_tsd_key_values[i].key, NULL);
             }
         }
+        /* delete the key itself so its slot is not leaked across an
+         * init/finalize cycle - callers that created it will recreate
+         * it on the next PMIx_Init */
+        pmix_tsd_key_delete(pmix_tsd_key_values[i].key);
     }
     if (0 < pmix_tsd_key_values_count) {
         free(pmix_tsd_key_values);
+        /* null the registry so the next pmix_tsd_key_create reallocs from
+         * a clean base rather than a freed pointer */
+        pmix_tsd_key_values = NULL;
         pmix_tsd_key_values_count = 0;
     }
     return PMIX_SUCCESS;

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -65,6 +65,15 @@ static void buffer_cleanup(void *value)
     }
 }
 
+void pmix_name_fns_finalize(void)
+{
+    /* the TSD key (and the per-thread buffers hung off it) are torn down
+     * by pmix_tsd_keys_destruct during finalize; clear our latch here so
+     * that a subsequent PMIx_Init recreates and re-registers the key
+     * rather than reusing one that no longer exists. */
+    fns_init = false;
+}
+
 static pmix_print_args_buffers_t *get_print_name_buffer(void)
 {
     pmix_print_args_buffers_t *ptr;

--- a/src/util/pmix_name_fns.h
+++ b/src/util/pmix_name_fns.h
@@ -58,5 +58,10 @@ PMIX_EXPORT char *pmix_util_print_rank(const pmix_rank_t vpid);
 
 PMIX_EXPORT int pmix_util_compare_proc(const void *a, const void *b);
 
+/* reset the one-time initialization of the print-buffer TSD key so that
+ * a subsequent PMIx_Init recreates it. The key itself is deleted by
+ * pmix_tsd_keys_destruct; this only clears the local latch. */
+PMIX_EXPORT void pmix_name_fns_finalize(void);
+
 END_C_DECLS
 #endif

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl
 
 EXTRA_DIST = run_gds_fallback.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status client_cycle
 
 compress_SOURCES =  \
         compress.c
@@ -73,5 +73,11 @@ collective_status_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 collective_status_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+client_cycle_SOURCES = \
+        client_cycle.c
+client_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client_cycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle

--- a/test/unit/client_cycle.c
+++ b/test/unit/client_cycle.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for client-side init/finalize cycling.
+ *
+ * A client must be able to cycle PMIx_Init -> (work) -> PMIx_Finalize and
+ * then PMIx_Init again, any number of times, with each new PMIx_Init
+ * presenting a clean slate. The client library tears itself all the way
+ * down on the final PMIx_Finalize, so a subsequent PMIx_Init is a fresh
+ * library instance; nothing from one cycle may leak into the next. See
+ * docs/how-things-work/init-finalize.rst.
+ *
+ * This exercises the teardown/reinit path directly. It runs as a
+ * singleton (no server), so it needs no launcher and is safe under
+ * "make check": PMIx_Fence and PMIx_Commit short-circuit to success in
+ * singleton mode, while PMIx_Init/PMIx_Finalize, the framework
+ * open/close, the thread-specific-data keys, the event base, and the
+ * per-cycle mode flags all run for real. A cross-cycle regression -
+ * a stale one-time-init latch, a dangling event base or progress
+ * tracker, a leaked TSD key slot, or a stale singleton flag - shows up
+ * here as a failed return code, a wrong PMIx_Initialized() state, or a
+ * crash on a later cycle rather than the first.
+ *
+ * The cycle count can be overridden with a single command-line argument;
+ * the default is chosen to stay quick while still cycling enough times to
+ * shake out per-cycle resource leaks.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_CYCLES 1200
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    pmix_value_t val;
+    pmix_info_t tinfo;
+    long ncycles = DEFAULT_CYCLES;
+    long i;
+    int nfail = 0;
+
+    if (1 < argc) {
+        ncycles = strtol(argv[1], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+    }
+
+    /* force the singleton path: with no namespace or server contact
+     * information in the environment there is nothing to connect to, so
+     * each PMIx_Init comes up self-contained */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    fprintf(stdout, "\n=== client init/finalize cycling test (%ld cycles) ===\n\n",
+            ncycles);
+
+    for (i = 0; i < ncycles; i++) {
+        /* PMIx_Initialized() must report false before we init */
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true before init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        /* PMIx_Init returns PMIX_ERR_UNREACH - not a failure - when it
+         * comes up as a singleton with no reachable server; the library
+         * is fully initialized in that case. Either result is fine here. */
+        rc = PMIx_Init(&myproc, NULL, 0);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Init failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (!PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() false after init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        /* do some work that populates per-cycle state which finalize must
+         * tear down: stage a value into the datastore and commit it */
+        val.type = PMIX_UINT32;
+        val.data.uint32 = (uint32_t) i;
+        rc = PMIx_Put(PMIX_GLOBAL, "cycle.key", &val);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Put failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+        rc = PMIx_Commit();
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Commit failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        /* the operation the user's scenario names explicitly */
+        rc = PMIx_Fence(&myproc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Fence failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        /* pass PMIX_EMBED_BARRIER so finalize exercises the embedded
+         * fence path as well */
+        PMIX_INFO_LOAD(&tinfo, PMIX_EMBED_BARRIER, NULL, PMIX_BOOL);
+        rc = PMIx_Finalize(&tinfo, 1);
+        PMIX_INFO_DESTRUCT(&tinfo);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Finalize failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true after finalize\n", i);
+            nfail = 1;
+            break;
+        }
+    }
+
+    if (0 == nfail) {
+        fprintf(stdout, "Completed %ld init/finalize cycles: PASS\n\n", ncycles);
+    } else {
+        fprintf(stdout, "init/finalize cycling: FAIL\n\n");
+    }
+
+    return nfail;
+}


### PR DESCRIPTION
## Motivation

A client should be able to cycle `PMIx_Init` → *(work: fences, puts, …)* → `PMIx_Finalize` and then `PMIx_Init` again, any number of times, with each new init presenting a **clean slate** — no state from one cycle leaking into the next. This PR documents how that is intended to work and fixes the client-side defects that currently prevent it, with a regression test to lock it down.

## What's here

**1. Specification** — `docs/how-things-work/init-finalize.rst`
Defines the state lifecycle across the init/finalize boundary, in two halves:
- **Server side:** the split between job-scoped and client-scoped state, and the three teardown triggers — client finalize (recycle the peer in place via destruct/construct, keep it registered), deregister-client (remove + release the peer), and deregister-nspace (drop GDS job data, release all peers, purge all references).
- **Client side:** the symmetry requirements a `PMIx_Finalize` must meet so the next `PMIx_Init` is a clean slate (reset every one-time-init latch, null every freed global, keep the util layer's init/finalize in lockstep), plus the platform caveat for builds without destructor/`-fini` support.

**2. Client-side teardown fixes** (implemented and tested)
- **Singleton flag reset** (`client: reset the singleton flag on every fresh PMIx_Init`): the fresh-init path now clears `pmix_client_globals.singleton`, closing a double-destruct of the server-side IOF lists on a singleton→with-server cycle.
- **TSD key lifecycle** (`runtime: leave no residue or dangling state after finalize`): `pmix_thread_set_main()` was never called, so the TSD key registry was always empty and `pmix_tsd_keys_destruct` was a no-op — every `pmix_net_init` leaked a pthread key slot until `PMIx_Init` failed after `PTHREAD_KEYS_MAX` cycles. Wire `set_main` into `pmix_init_util`, delete keys on teardown, null the freed registry pointer (it was left dangling and aborted the next `realloc`), and reset the `pmix_name_fns` latch.
- **Dangling pointers**: null `pmix_globals.evbase`/`evauxbase` and the cached `shared_thread_tracker` on teardown so nothing in the between-cycles window (or a stray `PMIx_Progress`) touches freed memory.

**3. Regression test** — `test/unit/client_cycle`, wired into `make check`
Cycles `PMIx_Init` → `PMIx_Put`/`Commit` → `PMIx_Fence` → `PMIx_Finalize` 1200 times (a count deliberately above `PTHREAD_KEYS_MAX` on common platforms) and checks each transition. Runs as a singleton, so it needs no server.

## Scope note

The server-side peer-recycle behavior is **specified** here as the intended design; this PR implements the **client-side** half plus the shared spec. The server-side implementation is a natural follow-up.

## Testing
- Clean build under `--enable-debug --enable-devel-check` (zero warnings).
- `make check` in `test/unit`: 9/9 pass, including the new `client_cycle`.
- `test/simple/simptest` (server + clients) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)