### PR TITLE
Init/finalize cycling: clean-slate teardown for client, server, and tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ test/python/run_sched.sh
 test/python/run_server.sh
 test/simple/pmitest
 test/simple/simpcycle
+test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
 test/simple/simpvni
@@ -237,6 +238,7 @@ test/unit/client_cycle
 test/unit/tool_cycle
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
+test/unit/run_toolcycle.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -233,7 +233,9 @@ test/unit/bfrops_alloc_inherit
 test/unit/gds_fallback
 test/unit/pmix_log
 test/unit/collective_status
+test/unit/client_cycle
 test/unit/run_gds_fallback.pl
+test/unit/run_simpcycle.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,7 @@ test/unit/gds_fallback
 test/unit/pmix_log
 test/unit/collective_status
 test/unit/client_cycle
+test/unit/tool_cycle
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/util_argv

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1006,6 +1006,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests12.pl], [chmod +x test/run_tests12.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests13.pl], [chmod +x test/run_tests13.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1007,6 +1007,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests13.pl], [chmod +x test/run_tests13.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -10,6 +10,7 @@ find information on that subject here.
    :maxdepth: 2
 
    session_dirs.rst
+   init-finalize.rst
    distances.rst
    schedulers/index.rst
    sets_groups/index.rst

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -103,10 +103,12 @@ is normative: "must" denotes a required behavior.
 1. Client finalize (all clones included)
     A client, together with all of its clones, has finalized — the rank's
     ``proc_cnt`` has dropped to zero. The peer object serving that rank is
-    **released** and its client-array slot is nulled, but the rank's
-    **registration** (the ``pmix_rank_info_t`` on ``nptr->ranks``) is
-    deliberately preserved so the client can init again. See `Releasing the
-    peer on finalize`_.
+    left in place as an inert **tombstone** at its existing client-array
+    slot (it is not freed, its slot is not nulled, and ``info->peerid`` is
+    not moved), while the rank's **registration** (the ``pmix_rank_info_t``
+    on ``nptr->ranks``) is preserved so the client can init again. The
+    tombstone is reclaimed later, at the next reconnect for the rank or at
+    namespace deregistration. See `Tombstoning the peer on finalize`_.
 
 2. Host deregisters a client (``PMIx_server_deregister_client``)
     The server removes the peer object from the namespace and releases
@@ -125,50 +127,75 @@ the client or the whole job is gone for good and its objects may be
 freed.
 
 
-Releasing the Peer on Finalize
-------------------------------
+Tombstoning the Peer on Finalize
+--------------------------------
 
 When the last live process for a rank finalizes (``proc_cnt`` reaches
-zero), the server **must** release the peer object but leave the rank's
-**registration** intact:
+zero), the server **must not** free the peer object, null its client-array
+slot, or move ``info->peerid`` at socket-close time. Instead it leaves the
+peer in place as an inert **tombstone**:
 
-* Null the object's slot in ``pmix_server_globals.clients`` and
-  ``PMIX_RELEASE`` the peer. Release only drops the server's reference; if
-  a pending collective or an active sensor still holds one, the object
-  survives until that last holder frees it. Either way the peer's
-  destructor eventually tears down everything it accumulated during the
-  cycle — pending send/receive messages and queues, event registrations,
-  its ``gds`` assignment — and executes the peer-level epilog.
+* Leave the object at its existing slot in ``pmix_server_globals.clients``
+  with ``finalized == true``. By the time ``pmix_server_peer_finalized``
+  runs, ``lost_connection`` has already stopped the peer's send/receive
+  events and closed its socket, and the ``finalized`` flag short-circuits
+  every send path (the ``PMIX_PTL_SEND_*`` macros and
+  ``PMIX_SERVER_QUEUE_REPLY``). The tombstone is therefore harmless: it
+  cannot arm a doomed send on its closed socket, yet it keeps
+  ``info->peerid`` pointing at a real, resolvable peer object for the
+  rank.
 
 * Leave the rank's ``pmix_rank_info_t`` on ``nptr->ranks`` (the
-  registration), and leave the namespace's GDS job data in place. Only
-  ``info->peerid`` is updated — cleared to ``-1``, or repointed to a
-  surviving clone (see below).
+  registration), leave the namespace's GDS job data in place, and leave
+  ``info->peerid`` unchanged.
 
-The result is a registered rank with no live peer object. When the client
-calls ``PMIx_Init`` again and reconnects, the connection handler finds the
-still-valid registration and allocates a **fresh** peer for the rank — so
-the second cycle starts from a guaranteed-clean per-client state and no
-peer object is left stranded in the clients array between cycles.
+* Reduce only the rank's live-process count (``proc_cnt``). The finalized
+  count (``nfinalized``) is **left as-is** — the tombstone is still a
+  ``finalized`` peer and must keep being counted as one.
 
-Why release and reallocate rather than recycle the object in place? An
-earlier design reset the peer with an in-place ``PMIX_DESTRUCT`` /
-``PMIX_CONSTRUCT`` and parked it in the clients array for the next init to
-reuse. Reconstructing a ``pmix_peer_t`` that is still reachable from that
-array — and whose embedded libevent structures and ``rank_info`` alias
-other server state — leaves a partially reinitialized object live in a
-table other code walks; it proved fragile (an architecture-sensitive hang
-of Open MPI singleton ``MPI_Comm_spawn``). Releasing and reallocating is
-simpler and keeps no half-initialized object visible; the reuse was only
-an allocation optimization.
+The tombstone is reclaimed at a later, quiescent point:
 
-Job-scoped accounting must be reconciled at the same time so that it does
-not drift across cycles. In particular, the namespace's finalized
-accounting (``nfinalized`` relative to ``nlocalprocs``) and the rank's
-``proc_cnt`` must reflect the true, current number of connected processes
-after a release, so that a client which finalizes and re-inits is not
-double-counted and the "all local processes finalized" condition remains
-accurate for the job as a whole.
+* **On reconnect.** When the client calls ``PMIx_Init`` again, the
+  connection handler finds the stale tombstone at ``info->peerid``, frees
+  it (nulls the slot, drops the ``nfinalized`` count it was holding, and
+  ``PMIX_RELEASE``\ s it), then allocates a **fresh** peer for the rank.
+  The prior cycle has fully finalized by the time a new init arrives, so
+  no collective from it can still be in flight — this is a safe point to
+  mutate the array and the count.
+
+* **On deregistration.** If the rank never reconnects (the common case for
+  a spawned child that runs once and exits), the tombstone is freed when
+  the host deregisters the namespace.
+
+Why leave a tombstone rather than free the peer at socket-close? Two
+earlier designs freed (or destruct/reconstructed) the object the moment
+the socket dropped, from inside ``lost_connection``. Both mutated shared
+per-namespace/per-rank state — nulling the ``clients`` slot, and in
+particular clearing ``info->peerid`` to ``-1`` — while a *different*
+process's spawn/connect/disconnect collective or direct-modex get was
+still walking the ``clients`` array and resolving ranks through
+``info->peerid``. A rank whose ``peerid`` had just been cleared could no
+longer be resolved to its GDS module, so the in-flight collective or get
+stalled: an architecture- and timing-sensitive hang of multi-local-process
+``MPI_Comm_spawn``. Leaving the finalized peer in place keeps every
+``peerid`` valid and every array slot populated, so nothing a concurrent
+collective touches changes underneath it; the object is reclaimed only
+once no such operation can be in flight.
+
+A tombstone whose slot has been taken over by a newer peer for the same
+rank — a fork/exec'd clone that is still running, or a fast re-init that
+reconnected before the socket-close was processed — is no longer named by
+``info->peerid``. Such a *stranded* object is freed immediately in
+``pmix_server_peer_finalized`` (nulling only its own slot, never the live
+referenced one, and never touching ``info->peerid``), so a departing
+clone or a raced reconnect cannot leak a peer or its finalized count.
+
+Job-scoped accounting must stay honest across cycles. The rank's
+``proc_cnt`` tracks live processes and returns to zero when the last one
+departs; ``nfinalized`` counts finalized peers and is decremented only
+when a tombstone is actually reclaimed (on reconnect) or freed (stranded),
+so that ``nlocalprocs == nfinalized`` remains an accurate "all local
+processes finalized" test no matter how many times clients cycle.
 
 What finalize does **not** do
     Finalize does not remove the rank from ``nptr->ranks``, does not drop
@@ -180,19 +207,18 @@ What finalize does **not** do
     notifications targeting the client — are pruned as part of the
     teardown so they do not linger.
 
-Release mechanics
-~~~~~~~~~~~~~~~~~~
+Tombstone mechanics
+~~~~~~~~~~~~~~~~~~~~
 
-The release is driven from ``lost_connection`` in the transport layer
+The tombstone is driven from ``lost_connection`` in the transport layer
 when a cleanly-finalized client's socket drops, and its correctness rests
 on two per-namespace counters staying honest across every cycle.
 
-**Peer states.** A client peer moves through two live states, then is
-released:
+**Peer states.** A client peer moves through three states:
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 12 8 12
+   :widths: 30 12 8 12
 
    * - State
      - ``finalized``
@@ -206,9 +232,17 @@ released:
      - ``true``
      - ≥ 0
      - yes
+   * - Tombstone (socket dropped, kept at ``info->peerid``)
+     - ``true``
+     - −1
+     - no
 
-Once the socket drops the object is released; there is no idle,
-kept-in-the-array state.
+A tombstone is deliberately left with ``finalized == true`` so it stays
+inert to every ``finalized``-guarded send path while it waits at
+``info->peerid`` to be reclaimed. It is removed from ``proc_cnt`` (its
+process is gone) but remains counted in ``nfinalized`` (it is still a
+finalized peer), and it stays resolvable through ``info->peerid`` so a
+concurrent collective or get can still find the rank's GDS module.
 
 **The two counters.**
 
@@ -216,31 +250,43 @@ kept-in-the-array state.
   rank. It is incremented in the connection handler when a peer connects
   and decremented on **every** peer departure — a clean finalize drop
   *and* an abnormal termination. Decrementing on abnormal death too
-  (in ``lost_connection``) keeps a later clone's release accounting
-  correct.
+  (in ``lost_connection``) keeps a later clone's tombstone/reclaim
+  accounting correct.
 
 * ``nptr->nfinalized`` is the number of client peers currently in the
-  ``finalized == true`` state. It is incremented when ``FINALIZE_CMD`` is
-  received and decremented when the finalized peer is **released**.
+  ``finalized == true`` state, **including tombstones**. It is incremented
+  when ``FINALIZE_CMD`` is received and decremented only when a tombstone
+  is reclaimed — on reconnect, or when a stranded tombstone is freed.
   Keeping this balanced is what lets the ``nlocalprocs == nfinalized``
   test at namespace teardown fire the programming-model "all local
-  processes finalized" callback exactly once.
+  processes finalized" callback.
 
-**Release on socket drop.** When a cleanly-finalized peer's socket drops,
-``pmix_server_peer_finalized`` decrements ``proc_cnt``, decrements
-``nfinalized``, repoints ``info->peerid`` (see below), nulls the
-``clients`` slot, and ``PMIX_RELEASE``\ s the peer. Because it is a plain
-release, a reference still held by a pending non-blocking collective
-(whose caddy sits on the tracker's ``local_cbs``) or an active sensor is
-harmless: the object is not torn down until that last holder drops its
-reference, and it never reappears in the clients array in the meantime.
+**Finalize on socket drop.** When a cleanly-finalized peer's socket drops,
+``pmix_server_peer_finalized`` decrements ``proc_cnt``. If the peer is
+still the rank's referenced peer (``info->peerid == peer->index``) it is
+left in place as a tombstone and nothing else is touched. Otherwise a
+newer peer already owns the rank's slot and this object is stranded, so it
+is freed at once: its own ``clients`` slot is nulled (never the live
+referenced one), ``nfinalized`` is decremented, and it is
+``PMIX_RELEASE``\ d. A reference still held by a pending non-blocking
+collective (whose caddy sits on the tracker's ``local_cbs``) or an active
+sensor is harmless in either case: a tombstone is simply retained a while
+longer, and a released stranded object is not torn down until that last
+holder drops its reference.
 
-**Clone ``peerid`` repointing.** A local ``PMIx_Get`` for the rank
-resolves committed data only while ``info->peerid`` names a live peer
-(a negative ``peerid`` defers the get). So when the released peer happened
-to be the rank's referenced peer, ``peerid`` is repointed to a surviving
-clone (found by scanning ``clients`` for a peer sharing the same ``info``)
-if one is still connected, and otherwise set to ``-1``.
+**Reclaim on reconnect.** The connection handler, before allocating a
+fresh peer for a reconnecting rank, checks ``info->peerid``: if it names a
+``finalized`` peer and the rank has no live process (``proc_cnt == 0``),
+that tombstone is reclaimed — its slot nulled, ``nfinalized`` decremented,
+and the object released — and only then is a new peer allocated. This is
+the point at which ``info->peerid`` is repointed, by the normal
+connection-handler assignment, to the freshly allocated peer.
+
+**``peerid`` stays valid.** Because a finalize never clears
+``info->peerid`` to ``-1``, a local ``PMIx_Get`` for the rank (which
+resolves committed data only while ``info->peerid`` names a resolvable
+peer) continues to work against the tombstone until the rank either
+reconnects or is deregistered.
 
 
 Deregistering a Client
@@ -248,8 +294,8 @@ Deregistering a Client
 
 ``PMIx_server_deregister_client`` is the host's declaration that a
 specific rank is gone and will not init again. Unlike finalize — which
-releases the peer object but keeps the rank's registration so it can init
-again — deregistration also **removes the registration**:
+tombstones the peer object but keeps the rank's registration so it can
+init again — deregistration also **removes the registration**:
 
 * Remove the peer object from the namespace: release the reference the
   namespace/registration holds, null out the client-array slot
@@ -296,7 +342,8 @@ State Ownership Summary
 
 The following table classifies the state and states which trigger frees
 it. "Released" means the object is freed and its client-array slot nulled;
-"Kept" means the trigger leaves it in place.
+"Tombstoned" means it is left inert in place and reclaimed later; "Kept"
+means the trigger leaves it in place.
 
 .. list-table::
    :header-rows: 1
@@ -307,7 +354,7 @@ it. "Released" means the object is freed and its client-array slot nulled;
      - Deregister client
      - Deregister nspace
    * - Peer object (``pmix_peer_t``)
-     - Released, slot nulled
+     - Tombstoned (kept at slot; reclaimed on reconnect/deregister)
      - Released, slot nulled
      - Released, slot nulled
    * - Event / IOF / direct-modex regs, cached notifications for the peer
@@ -467,15 +514,27 @@ Invariants
 
 An implementation of the above must uphold these invariants:
 
-* **No cross-cycle carryover.** The peer object serving a rank is released
-  on finalize and a fresh one is allocated when the rank reconnects, so a
-  new cycle cannot inherit queues, event registrations, tag counters, or
-  datastore assignments from the previous one.
+* **No cross-cycle carryover.** The finalized peer serving a rank is
+  reclaimed (freed) no later than the rank's next reconnect, at which
+  point a fresh object is allocated, so a new cycle cannot inherit queues,
+  event registrations, tag counters, or datastore assignments from the
+  previous one.
 
-* **No orphaned peers.** Cycling init/finalize must not leave unreferenced
-  peer objects in the ``clients`` array. Releasing the departed peer and
-  nulling its array slot on finalize — while preserving only the rank's
-  ``pmix_rank_info_t`` registration — is what guarantees this.
+* **No orphaned peers.** Cycling init/finalize must not accumulate
+  unreferenced peer objects in the ``clients`` array. A finalized peer is
+  left as a single tombstone at ``info->peerid`` and is reclaimed when the
+  rank reconnects (or when the namespace is deregistered); a peer that a
+  newer connection has already displaced is freed immediately. Either way
+  at most one finalized object per rank is ever kept, and only while the
+  rank's registration itself persists.
+
+* **No shared-state mutation while a collective is in flight.** Finalize
+  must not free a peer, null a live ``clients`` slot, or move a live
+  ``info->peerid`` from ``lost_connection``: a concurrent
+  spawn/connect/disconnect collective or direct-modex get may be walking
+  that state for another process. All such mutation is deferred to a
+  quiescent point (reconnect or deregistration), or confined to a stranded
+  object no live ``peerid`` names.
 
 * **No counter drift.** Per-namespace finalized accounting and per-rank
   ``proc_cnt`` must return to values consistent with the actual number of

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -102,11 +102,11 @@ is normative: "must" denotes a required behavior.
 
 1. Client finalize (all clones included)
     A client, together with all of its clones, has finalized — the rank's
-    ``proc_cnt`` has dropped to zero. The peer object serving that rank
-    is **recycled in place**: the server performs an object
-    destruct/construct on it and repoints it at the namespace it belongs
-    to. The object is **not** released and is **not** removed from the
-    namespace's client list. See `Recycling the peer on finalize`_.
+    ``proc_cnt`` has dropped to zero. The peer object serving that rank is
+    **released** and its client-array slot is nulled, but the rank's
+    **registration** (the ``pmix_rank_info_t`` on ``nptr->ranks``) is
+    deliberately preserved so the client can init again. See `Releasing the
+    peer on finalize`_.
 
 2. Host deregisters a client (``PMIx_server_deregister_client``)
     The server removes the peer object from the namespace and releases
@@ -125,71 +125,70 @@ the client or the whole job is gone for good and its objects may be
 freed.
 
 
-Recycling the Peer on Finalize
+Releasing the Peer on Finalize
 ------------------------------
 
 When the last live process for a rank finalizes (``proc_cnt`` reaches
-zero), the server **must** reset the peer object rather than release it:
+zero), the server **must** release the peer object but leave the rank's
+**registration** intact:
 
-* Run the peer's destructor (``PMIX_DESTRUCT``) so that every allocation
-  and reference the object accumulated during the cycle is torn down:
-  pending send/receive messages and queues, event registrations, the
-  peer-level epilog, the reference to its namespace, its ``gds``
-  assignment, dynamic-tag state, and the ``finalized`` flag.
+* Null the object's slot in ``pmix_server_globals.clients`` and
+  ``PMIX_RELEASE`` the peer. Release only drops the server's reference; if
+  a pending collective or an active sensor still holds one, the object
+  survives until that last holder frees it. Either way the peer's
+  destructor eventually tears down everything it accumulated during the
+  cycle — pending send/receive messages and queues, event registrations,
+  its ``gds`` assignment — and executes the peer-level epilog.
 
-* Immediately reconstruct it (``PMIX_CONSTRUCT``) so it returns to the
-  pristine state a freshly allocated peer would have — in particular
-  ``finalized`` is once again ``false`` and all lists and counters are
-  empty.
+* Leave the rank's ``pmix_rank_info_t`` on ``nptr->ranks`` (the
+  registration), and leave the namespace's GDS job data in place. Only
+  ``info->peerid`` is updated — cleared to ``-1``, or repointed to a
+  surviving clone (see below).
 
-* Repoint the reconstructed object at the namespace it serves
-  (re-establish ``peer->nptr`` with a retained reference), so the peer
-  remains associated with its job.
+The result is a registered rank with no live peer object. When the client
+calls ``PMIx_Init`` again and reconnects, the connection handler finds the
+still-valid registration and allocates a **fresh** peer for the rank — so
+the second cycle starts from a guaranteed-clean per-client state and no
+peer object is left stranded in the clients array between cycles.
 
-* Leave the object in ``pmix_server_globals.clients`` at its existing
-  slot, and leave ``info->peerid`` pointing at it. The **registration**
-  (the ``pmix_rank_info_t`` on ``nptr->ranks`` and the client-array slot)
-  is deliberately preserved.
-
-The result is a registered rank whose peer object is a clean, empty
-container ready to be repopulated. When the client calls ``PMIx_Init``
-again and reconnects, the server reuses this existing, reset peer for the
-rank instead of allocating a new one — so no peer object is orphaned and
-the second cycle starts from a guaranteed-fresh per-client state.
-
-Why destruct/construct rather than release? Releasing the peer would
-either strand ``info->peerid`` (a dangling index) or force the host to
-re-register the client before it could init again — defeating the cycling
-guarantee. Recycling in place keeps the registration valid and the
-client-array slot stable while still discarding every byte of
-client-scoped state from the previous cycle.
+Why release and reallocate rather than recycle the object in place? An
+earlier design reset the peer with an in-place ``PMIX_DESTRUCT`` /
+``PMIX_CONSTRUCT`` and parked it in the clients array for the next init to
+reuse. Reconstructing a ``pmix_peer_t`` that is still reachable from that
+array — and whose embedded libevent structures and ``rank_info`` alias
+other server state — leaves a partially reinitialized object live in a
+table other code walks; it proved fragile (an architecture-sensitive hang
+of Open MPI singleton ``MPI_Comm_spawn``). Releasing and reallocating is
+simpler and keeps no half-initialized object visible; the reuse was only
+an allocation optimization.
 
 Job-scoped accounting must be reconciled at the same time so that it does
 not drift across cycles. In particular, the namespace's finalized
 accounting (``nfinalized`` relative to ``nlocalprocs``) and the rank's
 ``proc_cnt`` must reflect the true, current number of connected processes
-after a recycle, so that a client which finalizes and re-inits is not
+after a release, so that a client which finalizes and re-inits is not
 double-counted and the "all local processes finalized" condition remains
 accurate for the job as a whole.
 
 What finalize does **not** do
-    Finalize does not remove the rank from ``nptr->ranks``, does not
-    release the peer, does not drop the namespace's GDS job data, and
-    does not touch network or programming-model resources reserved for
-    the job. Those are job-scoped and survive until the host deregisters.
-    Transient, client-scoped registrations that are keyed to the peer —
-    event registrations, I/O-forwarding requests, in-flight direct-modex
-    requests, and cached notifications targeting the client — are pruned
-    as part of the teardown so they do not linger on the reset object.
+    Finalize does not remove the rank from ``nptr->ranks``, does not drop
+    the namespace's GDS job data, and does not touch network or
+    programming-model resources reserved for the job. Those are job-scoped
+    and survive until the host deregisters. Transient, client-scoped
+    registrations that are keyed to the peer — event registrations,
+    I/O-forwarding requests, in-flight direct-modex requests, and cached
+    notifications targeting the client — are pruned as part of the
+    teardown so they do not linger.
 
-Recycle mechanics
+Release mechanics
 ~~~~~~~~~~~~~~~~~~
 
-The recycle is driven from two points in the transport layer, and its
-correctness rests on two per-namespace counters staying honest across
-every cycle.
+The release is driven from ``lost_connection`` in the transport layer
+when a cleanly-finalized client's socket drops, and its correctness rests
+on two per-namespace counters staying honest across every cycle.
 
-**Peer states.** A client peer moves through three states:
+**Peer states.** A client peer moves through two live states, then is
+released:
 
 .. list-table::
    :header-rows: 1
@@ -207,18 +206,9 @@ every cycle.
      - ``true``
      - ≥ 0
      - yes
-   * - Recycled-idle (reset in place, kept at ``info->peerid``)
-     - ``true``
-     - −1
-     - no
 
-A recycled-idle peer is deliberately left with ``finalized == true``.
-That keeps it **inert** to every ``finalized``-guarded send path (the
-``PMIX_PTL_SEND_*`` macros and ``PMIX_SERVER_QUEUE_REPLY`` all
-short-circuit on ``finalized``), so a stray asynchronous notification or
-I/O-forwarding message cannot arm a doomed send on its closed socket
-while it waits to be reused. It also uniquely identifies the object as a
-reuse candidate for the next ``PMIx_Init``.
+Once the socket drops the object is released; there is no idle,
+kept-in-the-array state.
 
 **The two counters.**
 
@@ -226,60 +216,40 @@ reuse candidate for the next ``PMIx_Init``.
   rank. It is incremented in the connection handler when a peer connects
   and decremented on **every** peer departure — a clean finalize drop
   *and* an abnormal termination. Decrementing on abnormal death too
-  (in ``lost_connection``) keeps a later clone's recycle-vs-release
-  decision correct.
+  (in ``lost_connection``) keeps a later clone's release accounting
+  correct.
 
 * ``nptr->nfinalized`` is the number of client peers currently in the
   ``finalized == true`` state. It is incremented when ``FINALIZE_CMD`` is
-  received, decremented when a recycled-idle peer is **reused** (it goes
-  back to active) or when a finalized peer is **released**, and left
-  unchanged when a peer is recycled to idle (it stays ``finalized``, so it
-  stays counted). Keeping this balanced is what lets the
-  ``nlocalprocs == nfinalized`` test at namespace teardown fire the
-  programming-model "all local processes finalized" callback exactly once.
+  received and decremented when the finalized peer is **released**.
+  Keeping this balanced is what lets the ``nlocalprocs == nfinalized``
+  test at namespace teardown fire the programming-model "all local
+  processes finalized" callback exactly once.
 
-**Recycle vs. release.** When a cleanly-finalized peer's socket drops,
-``pmix_server_peer_finalized`` decrements ``proc_cnt`` and then chooses:
-
-* **Recycle in place** when this was the last live process for the rank
-  **and** nothing else still references the peer object
-  (``proc_cnt == 0 && obj_reference_count == 1``): destruct/construct the
-  peer, repoint it at its namespace, keep it at its ``clients`` slot with
-  ``info->peerid`` pointing at it, and leave it idle. ``nfinalized`` is
-  unchanged.
-
-* **Release** otherwise. The reference count is *not* guaranteed to be one
-  at the drop: a pending non-blocking collective (whose caddy sits on the
-  tracker's ``local_cbs``) or an active sensor can retain the peer past
-  finalize. Recycling a still-aliased object would leave those references
-  pointing at a reinitialized — possibly reconnected — peer, a
-  use-after-free. In that case, and for a surplus clone
-  (``proc_cnt > 0``), the peer is released instead: ``nfinalized`` is
-  decremented, the ``clients`` slot is cleared, and ``PMIX_RELEASE`` drops
-  the reference so the last holder frees it. A subsequent ``PMIx_Init``
-  then allocates a fresh peer.
-
-**Reuse requires ``finalized``.** On reconnect, the connection handler
-reuses the peer at ``info->peerid`` only when ``proc_cnt == 0`` and that
-candidate has ``finalized == true`` — the signature of a recycled-idle
-peer. This decouples reuse safety from an abnormally-terminated peer that
-may still be lingering in the array, and from any still-active sibling.
+**Release on socket drop.** When a cleanly-finalized peer's socket drops,
+``pmix_server_peer_finalized`` decrements ``proc_cnt``, decrements
+``nfinalized``, repoints ``info->peerid`` (see below), nulls the
+``clients`` slot, and ``PMIX_RELEASE``\ s the peer. Because it is a plain
+release, a reference still held by a pending non-blocking collective
+(whose caddy sits on the tracker's ``local_cbs``) or an active sensor is
+harmless: the object is not torn down until that last holder drops its
+reference, and it never reappears in the clients array in the meantime.
 
 **Clone ``peerid`` repointing.** A local ``PMIx_Get`` for the rank
 resolves committed data only while ``info->peerid`` names a live peer
-(a negative ``peerid`` defers the get). So when a *surplus clone* is
-released and it happened to be the rank's referenced peer, ``peerid`` is
-repointed to a surviving sibling (found by scanning ``clients`` for a peer
-sharing the same ``info``) rather than left dangling or set negative while
-another process for the rank is still connected.
+(a negative ``peerid`` defers the get). So when the released peer happened
+to be the rank's referenced peer, ``peerid`` is repointed to a surviving
+clone (found by scanning ``clients`` for a peer sharing the same ``info``)
+if one is still connected, and otherwise set to ``-1``.
 
 
 Deregistering a Client
 ----------------------
 
 ``PMIx_server_deregister_client`` is the host's declaration that a
-specific rank is gone and will not init again. Here the peer is **removed
-and released**, not recycled:
+specific rank is gone and will not init again. Unlike finalize — which
+releases the peer object but keeps the rank's registration so it can init
+again — deregistration also **removes the registration**:
 
 * Remove the peer object from the namespace: release the reference the
   namespace/registration holds, null out the client-array slot
@@ -307,10 +277,10 @@ entire job is gone. This is the terminal, whole-namespace teardown and
 * Remove all GDS-registered job data for the namespace (``gds`` del of
   the namespace), so no key/value or job-info data survives.
 
-* Remove and release **all** peer objects belonging to the namespace —
-  both those still recycled/idle from a finalize and any that never
-  finalized — nulling their client-array slots and freeing every
-  ``pmix_rank_info_t`` on ``nptr->ranks``.
+* Remove and release **all** peer objects still belonging to the
+  namespace (any rank whose processes have not all finalized), nulling
+  their client-array slots and freeing every ``pmix_rank_info_t`` on
+  ``nptr->ranks``.
 
 * Release the network and programming-model resources reserved for the
   job, run the namespace epilog, and prune every remaining reference to
@@ -325,8 +295,8 @@ State Ownership Summary
 -----------------------
 
 The following table classifies the state and states which trigger frees
-it. "Recycled" means reset in place by finalize (not freed); "Released"
-means freed.
+it. "Released" means the object is freed and its client-array slot nulled;
+"Kept" means the trigger leaves it in place.
 
 .. list-table::
    :header-rows: 1
@@ -337,7 +307,7 @@ means freed.
      - Deregister client
      - Deregister nspace
    * - Peer object (``pmix_peer_t``)
-     - Recycled (destruct/construct, repointed, kept)
+     - Released, slot nulled
      - Released, slot nulled
      - Released, slot nulled
    * - Event / IOF / direct-modex regs, cached notifications for the peer
@@ -497,15 +467,15 @@ Invariants
 
 An implementation of the above must uphold these invariants:
 
-* **No cross-cycle carryover.** After a recycle, the peer object must be
-  indistinguishable from a freshly allocated one except that it is
-  already associated with its namespace. ``finalized`` is ``false``; all
-  queues, event registrations, tag counters, and datastore assignments
-  are empty/default.
+* **No cross-cycle carryover.** The peer object serving a rank is released
+  on finalize and a fresh one is allocated when the rank reconnects, so a
+  new cycle cannot inherit queues, event registrations, tag counters, or
+  datastore assignments from the previous one.
 
 * **No orphaned peers.** Cycling init/finalize must not leave unreferenced
-  peer objects in the ``clients`` array. Recycling in place, rather than
-  allocating a new peer on reconnect, is what guarantees this.
+  peer objects in the ``clients`` array. Releasing the departed peer and
+  nulling its array slot on finalize — while preserving only the rank's
+  ``pmix_rank_info_t`` registration — is what guarantees this.
 
 * **No counter drift.** Per-namespace finalized accounting and per-rank
   ``proc_cnt`` must return to values consistent with the actual number of

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -1,0 +1,300 @@
+Client Init/Finalize Lifecycle and Server-Side State
+====================================================
+
+This document specifies how the PMIx server manages the per-client and
+per-namespace state associated with a client across the ``PMIx_Init`` /
+``PMIx_Finalize`` boundary. Its purpose is to define the intended
+behavior precisely enough to implement and test it, and in particular to
+guarantee one property:
+
+.. admonition:: The cycling guarantee
+   :class: note
+
+   A client may cycle ``PMIx_Init`` → *(work: fences, gets, puts,
+   events, …)* → ``PMIx_Finalize`` and then ``PMIx_Init`` again, any
+   number of times, reusing the **same namespace and rank**, and each
+   new ``PMIx_Init`` must present a **fresh interaction state** on the
+   server. No state produced in one cycle may leak into the next. The
+   host environment is **not** required to deregister and re-register the
+   client between cycles for this to hold.
+
+For a code-oriented view of the socket connection that underlies each
+init, see :doc:`ptl`. This document is concerned with the *state
+lifecycle*, not the transport.
+
+
+The Problem
+-----------
+
+When a client calls ``PMIx_Init``, the server accumulates state on its
+behalf: a peer object holding the connection, event-loop registrations,
+tag counters, and a datastore (``gds``) module assignment; entries in
+collective trackers as the client fences; event and I/O-forwarding
+registrations; cached notifications; and committed key/value data. The
+server also carries longer-lived, job-scoped state in the namespace
+object: the roster of ranks, the count of local processes, the GDS job
+data, and network/programming-model resources reserved for the job.
+
+A single ``PMIx_Init``/``PMIx_Finalize`` pass, followed by the host
+tearing the job down, is the common case and works. The difficulty is
+the *cycling* case. ``PMIx_Finalize`` on the client side tears the client
+library all the way down (including the class system), so a subsequent
+``PMIx_Init`` is a brand-new library instance that opens a **new** socket
+and reconnects. On the server, the namespace and the rank are still
+registered — the host did not tear them down — so the second init must
+reconnect onto existing job-scoped state while starting from a clean
+per-client slate. If per-client state from the first cycle survives into
+the second, the client sees stale data, duplicated accounting, or leaked
+objects.
+
+The design below draws a sharp line between **job-scoped** state, which
+belongs to the namespace and persists until the host deregisters it, and
+**client-scoped** state, which belongs to a single init/finalize cycle
+and must not survive one.
+
+
+The Actors
+----------
+
+``pmix_namespace_t`` (``nptr``)
+    The job. Holds the ``ranks`` list, ``nlocalprocs`` (the number of
+    local clients registered for this namespace), ``nfinalized`` (how
+    many of those have finalized), the compatibility modules negotiated
+    for the job, the namespace-level epilog, and the association to the
+    GDS job data. Persists until the host calls
+    ``PMIx_server_deregister_nspace``.
+
+``pmix_rank_info_t`` (``info``)
+    One entry per rank on ``nptr->ranks``. Records the rank's identity
+    (``pname``), ``uid``/``gid``, the host's ``server_object``, the index
+    (``peerid``) of the peer object serving this rank in the server's
+    ``clients`` array, and ``proc_cnt`` — the number of live *clones* of
+    this rank (see below). This is **registration** state: it is created
+    by ``PMIx_server_register_client`` (or lazily on first connect) and
+    lives until the client or the namespace is deregistered. It is
+    **not** torn down by finalize.
+
+``pmix_peer_t`` (``peer``)
+    The per-connection object: socket, send/receive queues, event
+    registrations, dynamic-tag counters, the ``finalized`` flag, the
+    peer's assigned ``gds`` module, and the peer-level epilog. Held in
+    ``pmix_server_globals.clients`` and pointed to by ``info->peerid``.
+    This is the primary carrier of **client-scoped** state.
+
+Clones
+    A client may ``fork``/``exec`` a child that also calls ``PMIx_Init``
+    using the *same* namespace and rank as its parent — in PMIx
+    terminology, a *clone* of that client. Each clone opens its own
+    socket and is tracked by ``info->proc_cnt``. A rank is only fully
+    finalized when the original
+    client **and all of its clones** have finalized — i.e. when
+    ``proc_cnt`` returns to zero.
+
+
+The Three Teardown Triggers
+---------------------------
+
+Server-side cleanup is driven by exactly three events. Each has a
+distinct, non-overlapping responsibility. The remainder of this document
+is normative: "must" denotes a required behavior.
+
+1. Client finalize (all clones included)
+    A client, together with all of its clones, has finalized — the rank's
+    ``proc_cnt`` has dropped to zero. The peer object serving that rank
+    is **recycled in place**: the server performs an object
+    destruct/construct on it and repoints it at the namespace it belongs
+    to. The object is **not** released and is **not** removed from the
+    namespace's client list. See `Recycling the peer on finalize`_.
+
+2. Host deregisters a client (``PMIx_server_deregister_client``)
+    The server removes the peer object from the namespace and releases
+    it. See `Deregistering a client`_.
+
+3. Host deregisters the namespace (``PMIx_server_deregister_nspace``)
+    The server removes all GDS-registered job data for the namespace,
+    removes and releases all peer objects belonging to the namespace, and
+    cleans up all remaining references to the namespace. See
+    `Deregistering the namespace`_.
+
+The essential distinction is that **finalize is reversible and
+deregistration is terminal**. Finalize leaves the registration intact so
+the client can init again; only the host, by deregistering, declares that
+the client or the whole job is gone for good and its objects may be
+freed.
+
+
+Recycling the Peer on Finalize
+------------------------------
+
+When the last live process for a rank finalizes (``proc_cnt`` reaches
+zero), the server **must** reset the peer object rather than release it:
+
+* Run the peer's destructor (``PMIX_DESTRUCT``) so that every allocation
+  and reference the object accumulated during the cycle is torn down:
+  pending send/receive messages and queues, event registrations, the
+  peer-level epilog, the reference to its namespace, its ``gds``
+  assignment, dynamic-tag state, and the ``finalized`` flag.
+
+* Immediately reconstruct it (``PMIX_CONSTRUCT``) so it returns to the
+  pristine state a freshly allocated peer would have — in particular
+  ``finalized`` is once again ``false`` and all lists and counters are
+  empty.
+
+* Repoint the reconstructed object at the namespace it serves
+  (re-establish ``peer->nptr`` with a retained reference), so the peer
+  remains associated with its job.
+
+* Leave the object in ``pmix_server_globals.clients`` at its existing
+  slot, and leave ``info->peerid`` pointing at it. The **registration**
+  (the ``pmix_rank_info_t`` on ``nptr->ranks`` and the client-array slot)
+  is deliberately preserved.
+
+The result is a registered rank whose peer object is a clean, empty
+container ready to be repopulated. When the client calls ``PMIx_Init``
+again and reconnects, the server reuses this existing, reset peer for the
+rank instead of allocating a new one — so no peer object is orphaned and
+the second cycle starts from a guaranteed-fresh per-client state.
+
+Why destruct/construct rather than release? Releasing the peer would
+either strand ``info->peerid`` (a dangling index) or force the host to
+re-register the client before it could init again — defeating the cycling
+guarantee. Recycling in place keeps the registration valid and the
+client-array slot stable while still discarding every byte of
+client-scoped state from the previous cycle.
+
+Job-scoped accounting must be reconciled at the same time so that it does
+not drift across cycles. In particular, the namespace's finalized
+accounting (``nfinalized`` relative to ``nlocalprocs``) and the rank's
+``proc_cnt`` must reflect the true, current number of connected processes
+after a recycle, so that a client which finalizes and re-inits is not
+double-counted and the "all local processes finalized" condition remains
+accurate for the job as a whole.
+
+What finalize does **not** do
+    Finalize does not remove the rank from ``nptr->ranks``, does not
+    release the peer, does not drop the namespace's GDS job data, and
+    does not touch network or programming-model resources reserved for
+    the job. Those are job-scoped and survive until the host deregisters.
+    Transient, client-scoped registrations that are keyed to the peer —
+    event registrations, I/O-forwarding requests, in-flight direct-modex
+    requests, and cached notifications targeting the client — are pruned
+    as part of the teardown so they do not linger on the reset object.
+
+
+Deregistering a Client
+----------------------
+
+``PMIx_server_deregister_client`` is the host's declaration that a
+specific rank is gone and will not init again. Here the peer is **removed
+and released**, not recycled:
+
+* Remove the peer object from the namespace: release the reference the
+  namespace/registration holds, null out the client-array slot
+  identified by ``info->peerid``, and remove the ``pmix_rank_info_t``
+  from ``nptr->ranks``.
+
+* Release the peer object.
+
+* Restore any job resources that were charged to the rank (network
+  allocations, monitoring/sensors) and honor the peer's epilog, exactly
+  as when a client terminates.
+
+After a client is deregistered, the rank no longer exists on the server;
+a subsequent connection for that rank would be rejected unless the host
+re-registers it.
+
+
+Deregistering the Namespace
+---------------------------
+
+``PMIx_server_deregister_nspace`` is the host's declaration that the
+entire job is gone. This is the terminal, whole-namespace teardown and
+**must** reclaim everything the namespace owned:
+
+* Remove all GDS-registered job data for the namespace (``gds`` del of
+  the namespace), so no key/value or job-info data survives.
+
+* Remove and release **all** peer objects belonging to the namespace —
+  both those still recycled/idle from a finalize and any that never
+  finalized — nulling their client-array slots and freeing every
+  ``pmix_rank_info_t`` on ``nptr->ranks``.
+
+* Release the network and programming-model resources reserved for the
+  job, run the namespace epilog, and prune every remaining reference to
+  the namespace: event and I/O-forwarding registrations, cached
+  notifications targeting any of its procs, and finally the namespace
+  object itself.
+
+Nothing that names the namespace may remain after this call returns.
+
+
+State Ownership Summary
+-----------------------
+
+The following table classifies the state and states which trigger frees
+it. "Recycled" means reset in place by finalize (not freed); "Released"
+means freed.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 22 22
+
+   * - State
+     - Client finalize (all clones)
+     - Deregister client
+     - Deregister nspace
+   * - Peer object (``pmix_peer_t``)
+     - Recycled (destruct/construct, repointed, kept)
+     - Released, slot nulled
+     - Released, slot nulled
+   * - Event / IOF / direct-modex regs, cached notifications for the peer
+     - Pruned
+     - Pruned
+     - Pruned
+   * - Peer epilog
+     - Executed
+     - Executed
+     - Executed (peer) + namespace epilog
+   * - Rank info (``pmix_rank_info_t`` on ``nptr->ranks``)
+     - Kept (registration preserved)
+     - Removed, released
+     - Removed, released
+   * - GDS job data for the namespace
+     - Kept
+     - Kept
+     - Removed
+   * - Network / programming-model job resources
+     - Kept
+     - Rank's share restored
+     - Released (whole job)
+   * - Namespace object (``pmix_namespace_t``)
+     - Kept
+     - Kept
+     - Released; all references purged
+
+
+Invariants
+----------
+
+An implementation of the above must uphold these invariants:
+
+* **No cross-cycle carryover.** After a recycle, the peer object must be
+  indistinguishable from a freshly allocated one except that it is
+  already associated with its namespace. ``finalized`` is ``false``; all
+  queues, event registrations, tag counters, and datastore assignments
+  are empty/default.
+
+* **No orphaned peers.** Cycling init/finalize must not leave unreferenced
+  peer objects in the ``clients`` array. Recycling in place, rather than
+  allocating a new peer on reconnect, is what guarantees this.
+
+* **No counter drift.** Per-namespace finalized accounting and per-rank
+  ``proc_cnt`` must return to values consistent with the actual number of
+  connected processes after each cycle, so that the job-level "all local
+  processes finalized" condition and any resource-release keyed on it
+  remain correct no matter how many times clients cycle.
+
+* **Registration outlives finalize; only deregistration is terminal.**
+  The ``pmix_rank_info_t`` and the client-array slot persist across
+  finalize and are removed only by an explicit host deregister. GDS job
+  data and job resources persist until ``PMIx_server_deregister_nspace``.

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -444,6 +444,54 @@ Platform caveat: destructor support
     ``-fini`` support is present (the mainstream case).
 
 
+Tool-Side Teardown
+------------------
+
+The tool role has the same cycling guarantee as the client: a process
+must be able to cycle ``PMIx_tool_init`` → work → ``PMIx_tool_finalize``
+repeatedly, each init a clean slate. ``PMIx_tool_init`` /
+``PMIx_tool_finalize`` are a **separate** entry-point pair from the client
+``PMIx_Init`` / ``PMIx_Finalize`` — they do not share the client's
+finalize code — so the three symmetry requirements above have to be
+satisfied independently in the tool path. Two of them bite the tool
+specifically:
+
+The reference-count guard and the one-time latch
+    ``PMIx_tool_init`` is reference-counted through its own counter, and
+    it sets the shared one-time-init latch (``pmix_globals.init_called``).
+    ``PMIx_tool_finalize`` must decrement that counter, tear down only on
+    the last matching finalize, and **reset the latch**. Forgetting the
+    reset is the most visible cycling failure: the second
+    ``PMIx_tool_init`` sees the latch still set, concludes the library is
+    already initialized, and returns ``PMIX_ERR_INIT`` — the tool never
+    comes back up.
+
+The tool constructs server state every init
+    Because a tool may itself act as a server (a launcher connects *up* to
+    its own server while *listening* for its children), ``PMIx_tool_init``
+    unconditionally initializes the ``server_globals`` bookkeeping —
+    constructing the client array and every server-side list — on **every**
+    init, whether or not the tool will act as a server. Tool finalize must
+    therefore destruct **all** of those lists, not just the subset a
+    particular run happened to populate; any list left un-destructed leaks
+    its contents each cycle when the next init reconstructs over it. For
+    the same reason the tool must free (and ``NULL``) the ``tmpdir`` and
+    ``system_tmpdir`` strings: the init-time code refreshes them only when
+    they are ``NULL``, so a surviving pointer both leaks and silently
+    pins the previous cycle's temporary-directory choice, ignoring a
+    changed environment on the next init. The tool must likewise destruct
+    the client-side ``peers`` array backing store and the static IOF
+    sinks, exactly as the client finalize does.
+
+    The reset of the *server module* latch
+    (``pmix_server_globals.module_set``, set by
+    ``PMIx_tool_set_server_module``) is **not** part of this pair: that
+    latch is owned by a separate registration call a launcher makes
+    outside ``PMIx_tool_init``, and the server reference finalizer does
+    not clear it either. A launcher that re-registers its server module
+    between cycles is therefore out of scope here and handled separately.
+
+
 Invariants
 ----------
 

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -108,7 +108,10 @@ is normative: "must" denotes a required behavior.
     not moved), while the rank's **registration** (the ``pmix_rank_info_t``
     on ``nptr->ranks``) is preserved so the client can init again. The
     tombstone is reclaimed later, at the next reconnect for the rank or at
-    namespace deregistration. See `Tombstoning the peer on finalize`_.
+    namespace deregistration. See `Tombstoning the peer on finalize`_. A
+    **tool** peer takes a lighter path — it is freed at socket-close rather
+    than tombstoned, because nothing resolves a tool through
+    ``info->peerid``; see `Tombstone mechanics`_.
 
 2. Host deregisters a client (``PMIx_server_deregister_client``)
     The server removes the peer object from the namespace and releases
@@ -130,10 +133,14 @@ freed.
 Tombstoning the Peer on Finalize
 --------------------------------
 
-When the last live process for a rank finalizes (``proc_cnt`` reaches
-zero), the server **must not** free the peer object, null its client-array
-slot, or move ``info->peerid`` at socket-close time. Instead it leaves the
-peer in place as an inert **tombstone**:
+This section describes the **client** peer path, where the tombstone is
+required; a tool peer is retired more simply (freed at socket-close) and
+is covered under `Tombstone mechanics`_ below.
+
+When the last live process for a client rank finalizes (``proc_cnt``
+reaches zero), the server **must not** free the peer object, null its
+client-array slot, or move ``info->peerid`` at socket-close time. Instead
+it leaves the peer in place as an inert **tombstone**:
 
 * Leave the object at its existing slot in ``pmix_server_globals.clients``
   with ``finalized == true``. By the time ``pmix_server_peer_finalized``
@@ -259,34 +266,69 @@ concurrent collective or get can still find the rank's GDS module.
   is reclaimed — on reconnect, or when a stranded tombstone is freed.
   Keeping this balanced is what lets the ``nlocalprocs == nfinalized``
   test at namespace teardown fire the programming-model "all local
-  processes finalized" callback.
+  processes finalized" callback. Because a tombstone stays counted in
+  ``nfinalized`` until it is reclaimed, that equality is already satisfied
+  before namespace teardown begins and holds for **every** rank the
+  teardown then walks. The callback must therefore be fired only **once**
+  per namespace — a ``local_app_fini_fired`` latch on the namespace guards
+  it — rather than once per rank as the ranks are removed.
 
-**Finalize on socket drop.** When a cleanly-finalized peer's socket drops,
-``pmix_server_peer_finalized`` decrements ``proc_cnt``. If the peer is
-still the rank's referenced peer (``info->peerid == peer->index``) it is
-left in place as a tombstone and nothing else is touched. Otherwise a
-newer peer already owns the rank's slot and this object is stranded, so it
-is freed at once: its own ``clients`` slot is nulled (never the live
-referenced one), ``nfinalized`` is decremented, and it is
-``PMIX_RELEASE``\ d. A reference still held by a pending non-blocking
-collective (whose caddy sits on the tracker's ``local_cbs``) or an active
-sensor is harmless in either case: a tombstone is simply retained a while
-longer, and a released stranded object is not torn down until that last
-holder drops its reference.
+**Finalize on socket drop.** ``lost_connection`` in the transport layer
+routes a cleanly-finalized peer whose socket has now dropped to
+``pmix_server_peer_finalized`` — a **pure client** so it can be tombstoned,
+and a **pure tool** so it can be freed (a peer that is *both* a client and
+a tool is left for its tool reconnect/deregistration reclaim; see below).
+``pmix_server_peer_finalized`` decrements ``proc_cnt``, then, if the peer
+is still the rank's referenced peer (``info->peerid == peer->index``),
+retires it according to its role:
 
-**Reclaim on reconnect.** The connection handler, before allocating a
-fresh peer for a reconnecting rank, checks ``info->peerid``: if it names a
-``finalized`` peer and the rank has no live process (``proc_cnt == 0``),
-that tombstone is reclaimed — its slot nulled, ``nfinalized`` decremented,
-and the object released — and only then is a new peer allocated. This is
-the point at which ``info->peerid`` is repointed, by the normal
-connection-handler assignment, to the freshly allocated peer.
+* An **application client** (``PMIX_PEER_IS_CLIENT``) is left in place as a
+  tombstone and nothing else is touched — a concurrent collective or get
+  belonging to another local process may still resolve this rank through
+  ``info->peerid`` (see below), so its shared state must not change here.
 
-**``peerid`` stays valid.** Because a finalize never clears
-``info->peerid`` to ``-1``, a local ``PMIx_Get`` for the rank (which
-resolves committed data only while ``info->peerid`` names a resolvable
-peer) continues to work against the tombstone until the rank either
-reconnects or is deregistered.
+* A **pure tool** is instead freed at once, and ``info->peerid`` is
+  repointed — to a surviving tool sibling sharing the same ``info`` if one
+  is still live, else to ``-1``. A tool is not an application-job member:
+  it has its own namespace and is never the peer a job collective or
+  direct-modex get resolves through ``info->peerid``, so the tombstone that
+  protects that race is unnecessary. And because each tool init is assigned
+  a fresh namespace, a finalized tool never reconnects onto the same rank
+  to be reclaimed there — leaving it would leak one peer per init/finalize
+  cycle. Freeing it also restores the post-finalize ``info->peerid == -1``
+  state that ``process_tool_request`` relies on to recognize a reconnecting
+  tool.
+
+Otherwise a newer peer already owns the rank's slot and this object is
+stranded, so it is freed at once regardless of role: its own ``clients``
+slot is nulled (never the live referenced one), ``nfinalized`` is
+decremented, and it is ``PMIX_RELEASE``\ d. A reference still held by a
+pending non-blocking collective (whose caddy sits on the tracker's
+``local_cbs``) or an active sensor is harmless in every case: a tombstone
+is simply retained a while longer, and a released object is not torn down
+until that last holder drops its reference.
+
+**Reclaim on reconnect.** Before allocating a fresh peer for a
+reconnecting rank, the connection path reclaims any tombstone the rank
+left behind. For a client this is the main connection handler, which
+checks ``info->peerid``: if it names a ``finalized`` peer and the rank has
+no live process (``proc_cnt == 0``), that tombstone is reclaimed — its
+slot nulled, ``nfinalized`` decremented, and the object released — and
+only then is a new peer allocated. A tool that was registered as a client
+(a launcher child) keeps the client tombstone semantics above but
+reconnects through ``process_tool_request`` rather than the client
+handler; that path performs the same reclaim on the finalized peer at
+``info->peerid`` before assigning the reconnecting tool its fresh slot.
+Either way ``info->peerid`` is then repointed, by the normal connection
+assignment, to the freshly allocated peer.
+
+**``peerid`` stays valid for clients.** Because a client finalize never
+clears ``info->peerid`` to ``-1``, a local ``PMIx_Get`` for the rank
+(which resolves committed data only while ``info->peerid`` names a
+resolvable peer) continues to work against the client tombstone until the
+rank either reconnects or is deregistered. A pure tool, freed at
+socket-close, instead leaves ``info->peerid == -1`` — which is correct,
+because no other process resolves a tool's rank this way.
 
 
 Deregistering a Client
@@ -521,12 +563,15 @@ An implementation of the above must uphold these invariants:
   previous one.
 
 * **No orphaned peers.** Cycling init/finalize must not accumulate
-  unreferenced peer objects in the ``clients`` array. A finalized peer is
-  left as a single tombstone at ``info->peerid`` and is reclaimed when the
-  rank reconnects (or when the namespace is deregistered); a peer that a
-  newer connection has already displaced is freed immediately. Either way
-  at most one finalized object per rank is ever kept, and only while the
-  rank's registration itself persists.
+  unreferenced peer objects in the ``clients`` array. A finalized client
+  peer is left as a single tombstone at ``info->peerid`` and is reclaimed
+  when the rank reconnects (or when the namespace is deregistered); a peer
+  that a newer connection has already displaced, and a finalized **tool**
+  peer, are freed immediately. Either way at most one finalized object per
+  rank is ever kept, and only while the rank's registration itself
+  persists — including across repeated tool init/finalize cycles that
+  reuse the same namespace and rank, whose reconnect reclaim runs in
+  ``process_tool_request``.
 
 * **No shared-state mutation while a collective is in flight.** Finalize
   must not free a peer, null a live ``clients`` slot, or move a live

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -182,6 +182,97 @@ What finalize does **not** do
     requests, and cached notifications targeting the client — are pruned
     as part of the teardown so they do not linger on the reset object.
 
+Recycle mechanics
+~~~~~~~~~~~~~~~~~~
+
+The recycle is driven from two points in the transport layer, and its
+correctness rests on two per-namespace counters staying honest across
+every cycle.
+
+**Peer states.** A client peer moves through three states:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 12 8 12
+
+   * - State
+     - ``finalized``
+     - ``sd``
+     - in ``proc_cnt``?
+   * - Active
+     - ``false``
+     - ≥ 0
+     - yes
+   * - Finalizing (``FINALIZE_CMD`` seen, socket not yet dropped)
+     - ``true``
+     - ≥ 0
+     - yes
+   * - Recycled-idle (reset in place, kept at ``info->peerid``)
+     - ``true``
+     - −1
+     - no
+
+A recycled-idle peer is deliberately left with ``finalized == true``.
+That keeps it **inert** to every ``finalized``-guarded send path (the
+``PMIX_PTL_SEND_*`` macros and ``PMIX_SERVER_QUEUE_REPLY`` all
+short-circuit on ``finalized``), so a stray asynchronous notification or
+I/O-forwarding message cannot arm a doomed send on its closed socket
+while it waits to be reused. It also uniquely identifies the object as a
+reuse candidate for the next ``PMIx_Init``.
+
+**The two counters.**
+
+* ``info->proc_cnt`` is the number of **live** processes (clones) for the
+  rank. It is incremented in the connection handler when a peer connects
+  and decremented on **every** peer departure — a clean finalize drop
+  *and* an abnormal termination. Decrementing on abnormal death too
+  (in ``lost_connection``) keeps a later clone's recycle-vs-release
+  decision correct.
+
+* ``nptr->nfinalized`` is the number of client peers currently in the
+  ``finalized == true`` state. It is incremented when ``FINALIZE_CMD`` is
+  received, decremented when a recycled-idle peer is **reused** (it goes
+  back to active) or when a finalized peer is **released**, and left
+  unchanged when a peer is recycled to idle (it stays ``finalized``, so it
+  stays counted). Keeping this balanced is what lets the
+  ``nlocalprocs == nfinalized`` test at namespace teardown fire the
+  programming-model "all local processes finalized" callback exactly once.
+
+**Recycle vs. release.** When a cleanly-finalized peer's socket drops,
+``pmix_server_peer_finalized`` decrements ``proc_cnt`` and then chooses:
+
+* **Recycle in place** when this was the last live process for the rank
+  **and** nothing else still references the peer object
+  (``proc_cnt == 0 && obj_reference_count == 1``): destruct/construct the
+  peer, repoint it at its namespace, keep it at its ``clients`` slot with
+  ``info->peerid`` pointing at it, and leave it idle. ``nfinalized`` is
+  unchanged.
+
+* **Release** otherwise. The reference count is *not* guaranteed to be one
+  at the drop: a pending non-blocking collective (whose caddy sits on the
+  tracker's ``local_cbs``) or an active sensor can retain the peer past
+  finalize. Recycling a still-aliased object would leave those references
+  pointing at a reinitialized — possibly reconnected — peer, a
+  use-after-free. In that case, and for a surplus clone
+  (``proc_cnt > 0``), the peer is released instead: ``nfinalized`` is
+  decremented, the ``clients`` slot is cleared, and ``PMIX_RELEASE`` drops
+  the reference so the last holder frees it. A subsequent ``PMIx_Init``
+  then allocates a fresh peer.
+
+**Reuse requires ``finalized``.** On reconnect, the connection handler
+reuses the peer at ``info->peerid`` only when ``proc_cnt == 0`` and that
+candidate has ``finalized == true`` — the signature of a recycled-idle
+peer. This decouples reuse safety from an abnormally-terminated peer that
+may still be lingering in the array, and from any still-active sibling.
+
+**Clone ``peerid`` repointing.** A local ``PMIx_Get`` for the rank
+resolves committed data only while ``info->peerid`` names a live peer
+(a negative ``peerid`` defers the get). So when a *surplus clone* is
+released and it happened to be the rank's referenced peer, ``peerid`` is
+repointed to a surviving sibling (found by scanning ``clients`` for a peer
+sharing the same ``info``) rather than left dangling or set negative while
+another process for the rank is still connected.
+
 
 Deregistering a Client
 ----------------------

--- a/docs/how-things-work/init-finalize.rst
+++ b/docs/how-things-work/init-finalize.rst
@@ -1,11 +1,13 @@
-Client Init/Finalize Lifecycle and Server-Side State
-====================================================
+Client Init/Finalize Lifecycle and State Management
+===================================================
 
-This document specifies how the PMIx server manages the per-client and
-per-namespace state associated with a client across the ``PMIx_Init`` /
-``PMIx_Finalize`` boundary. Its purpose is to define the intended
-behavior precisely enough to implement and test it, and in particular to
-guarantee one property:
+This document specifies how PMIx manages the state associated with a
+client across the ``PMIx_Init`` / ``PMIx_Finalize`` boundary. It has two
+halves: the **server-side** management of the per-client and
+per-namespace state the server holds on a client's behalf, and the
+**client-side** teardown of the client library itself. Its purpose is to
+define the intended behavior precisely enough to implement and test it,
+and in particular to guarantee one property:
 
 .. admonition:: The cycling guarantee
    :class: note
@@ -273,6 +275,84 @@ means freed.
      - Released; all references purged
 
 
+Client-Side Teardown
+--------------------
+
+Everything above concerns the state a *server* holds for a client. The
+cycling guarantee has a second half: the client's own library must tear
+itself down on ``PMIx_Finalize`` so that a subsequent ``PMIx_Init`` in
+the same process starts from a clean slate. Unlike the server side —
+where finalize deliberately *preserves* registration state — the client
+side has no such asymmetry to manage: a client ``PMIx_Finalize`` (once
+the init reference count reaches zero) is a full teardown of the library,
+and a later ``PMIx_Init`` is a brand-new library instance that opens a
+fresh socket and reconnects.
+
+The teardown runs ``PMIx_Finalize`` → ``pmix_rte_finalize`` → framework
+closes plus ``pmix_finalize_util`` and the release of the progress
+thread; it is the mirror image of ``PMIx_Init`` → ``pmix_rte_init`` →
+``pmix_init_util`` plus the framework opens. The governing principle is
+**symmetry**: finalize must undo exactly what init did, leaving no
+residue that the next init would either trip over or skip.
+
+The reference-count guard
+    ``PMIx_Init`` is reference-counted: nested init/init/…/finalize
+    sequences only tear down on the *last* finalize, when the counter
+    returns to zero. The full teardown described here applies to that
+    final finalize. A nested (non-final) finalize must leave the library
+    running and untouched.
+
+Three requirements make the symmetry real, and an implementation **must**
+uphold all three:
+
+1. **Every one-time-init latch must be reset.** Any ``static`` boolean or
+   counter that guards a "do this once" step in init (module
+   registration, key creation, subsystem setup) must be cleared by the
+   corresponding finalize, so the step runs again on the next init.
+   Leaving a latch set silently *skips* re-initialization on the second
+   cycle — the failure is not a crash at finalize but wrong or missing
+   state later. The multi-select framework ``initialized`` flags, the MCA
+   parameter-registration latch, and the attribute/output/show-help
+   subsystems all follow this rule and are the model to copy.
+
+2. **Every freed global must be nulled, and every per-cycle flag reset.**
+   A global pointer whose target is freed during finalize must be set to
+   ``NULL`` in the same step. Two hazards follow from not doing so:
+
+   * **Dangling reuse.** A non-``NULL`` pointer to freed memory defeats
+     the ``if (NULL == p)`` guards that would otherwise make a
+     between-cycles access safe; it reads as "still valid" and yields a
+     use-after-free. The event base, the shared progress-thread tracker,
+     and the cached server peer are pointers of this kind.
+
+   * **Stale mode flags.** A flag that records *how* this cycle was set
+     up — most importantly the singleton indicator, which records that
+     the process came up with no server and therefore constructed the
+     server-side I/O-forwarding lists — must be reset on every fresh
+     init, not only when it happens to be toggled. A stale singleton flag
+     carried from a no-server cycle into a with-server cycle drives
+     finalize to tear down lists the with-server path never built.
+
+3. **Init and finalize of the utility layer must stay in lockstep.**
+   ``pmix_init_util`` opens a fixed set of low-level subsystems (output,
+   install-dirs, show-help, the keyval parser, the MCA base and its
+   variable system, the network and interface helpers). Each must be
+   closed on finalize. Whether the close lives in ``pmix_finalize_util``
+   or inline in ``pmix_rte_finalize`` is an implementation choice, but the
+   two lists must be kept in correspondence: a subsystem added to init
+   without a matching teardown persists across a cycle and breaks the
+   clean-slate guarantee for the next init.
+
+Platform caveat: destructor support
+    On platforms that provide neither a compiler ``destructor``
+    attribute nor linker ``-fini`` support, the library cannot guarantee
+    cleanup at unload, and re-initialization after finalize is
+    **explicitly unsupported** — a second ``PMIx_Init`` returns
+    ``PMIX_ERR_NOT_SUPPORTED`` rather than risk an inconsistent restart.
+    The cycling guarantee therefore applies only where destructor or
+    ``-fini`` support is present (the mainstream case).
+
+
 Invariants
 ----------
 
@@ -298,3 +378,9 @@ An implementation of the above must uphold these invariants:
   The ``pmix_rank_info_t`` and the client-array slot persist across
   finalize and are removed only by an explicit host deregister. GDS job
   data and job resources persist until ``PMIx_server_deregister_nspace``.
+
+* **The client library reinitializes from a clean slate.** After the
+  final ``PMIx_Finalize``, no ``static`` init-once latch remains set, no
+  global pointer references freed memory, and no per-cycle mode flag
+  retains a value from the previous cycle. The next ``PMIx_Init`` behaves
+  exactly as the first.

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -64,10 +64,13 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    /* init us */
-    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
-                rc);
+    /* init us - a singleton comes up without a server and so PMIx_Init
+     * returns PMIX_ERR_UNREACH rather than PMIX_SUCCESS. That is not a
+     * fatal error: the library is fully usable, so accept it and carry on. */
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
         exit(0);
     }
     fprintf(stderr, "Client ns %s rank %d: Running on host %s\n", myproc.nspace, myproc.rank, hostname);

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -207,6 +207,7 @@ error:
 pmix_client_globals_t pmix_client_globals = {
     .myserver = NULL,
     .singleton = false,
+    .local_iof = false,
     .pending_requests = PMIX_LIST_STATIC_INIT,
     .peers = PMIX_POINTER_ARRAY_STATIC_INIT,
     .groups = PMIX_LIST_STATIC_INIT,
@@ -688,12 +689,17 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                          PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* setup the globals */
-    /* reset the singleton indicator on every fresh init: it is a static
-     * that records how *this* cycle came up, and is only set true below
-     * if we fail to find a server. Leaving a stale "true" from a prior
-     * singleton cycle would cause finalize to tear down the server-side
-     * IOF lists that a subsequent with-server cycle never constructed. */
+    /* reset these indicators on every fresh init: they are statics that
+     * record how *this* cycle came up. "singleton" is set true below only
+     * if we fail to find a server; "local_iof" is set true only if we
+     * construct the server-side IOF lists. They are independent - a client
+     * given a PMIX_NAMESPACE that fails to connect is a singleton without
+     * those lists, and a no-namespace process that does find a (system)
+     * server constructs them yet is not a singleton - so finalize must key
+     * the IOF teardown off local_iof, not off singleton. Leaving either as
+     * a stale "true" from a prior cycle would mis-tear-down on finalize. */
     pmix_client_globals.singleton = false;
+    pmix_client_globals.local_iof = false;
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
@@ -734,6 +740,10 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         pmix_globals.iof_flags.local_output = true;
         PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_list_t);
         PMIX_CONSTRUCT(&pmix_server_globals.iof_residuals, pmix_list_t);
+        /* record that we built these so finalize tears them down - note
+         * this is independent of whether we ultimately connect to a
+         * server below (a system server may accept us as a singleton) */
+        pmix_client_globals.local_iof = true;
     } else {
         if (NULL != proc) {
             PMIX_LOAD_NSPACE(proc->nspace, evar);
@@ -1242,9 +1252,15 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         }
     }
     PMIX_DESTRUCT(&pmix_client_globals.peers);
-    if (pmix_client_globals.singleton) {
+    /* tear down the server-side IOF lists only if we actually constructed
+     * them during init (no PMIX_NAMESPACE was present). This is tracked by
+     * local_iof rather than the singleton flag: the two are independent
+     * (see PMIx_Init) and keying off singleton either destructs lists that
+     * were never built - a crash - or leaks lists that were. */
+    if (pmix_client_globals.local_iof) {
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
+        pmix_client_globals.local_iof = false;
     }
 
     if (0 <= pmix_client_globals.myserver->sd) {

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -688,6 +688,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                          PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
 
     /* setup the globals */
+    /* reset the singleton indicator on every fresh init: it is a static
+     * that records how *this* cycle came up, and is only set true below
+     * if we fail to find a server. Leaving a stale "true" from a prior
+     * singleton cycle would cause finalize to tear down the server-side
+     * IOF lists that a subsequent with-server cycle never constructed. */
+    pmix_client_globals.singleton = false;
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +24,8 @@ BEGIN_C_DECLS
 typedef struct {
     pmix_peer_t *myserver;        // messaging support to/from my server
     bool singleton;               // no server
+    bool local_iof;               // we constructed the server-side IOF lists
+                                  // (pmix_server_globals.iof/iof_residuals)
     pmix_list_t pending_requests; // list of pmix_cb_t pending data requests
     pmix_pointer_array_t peers;   // array of pmix_peer_t cached for data ops
     pmix_list_t groups;           // list of groups this client is part of

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -142,6 +142,7 @@ static void nscon(pmix_namespace_t *p)
     p->jobbkt = NULL;
     p->ndelivered = 0;
     p->nfinalized = 0;
+    p->local_app_fini_fired = false;
     PMIX_CONSTRUCT(&p->ranks, pmix_list_t);
     memset(&p->compat, 0, sizeof(p->compat));
     PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -379,6 +379,9 @@ typedef struct {
     pmix_buffer_t *jobbkt; // packed version of jobinfo
     size_t ndelivered;     // count of #local clients that have received the jobinfo
     size_t nfinalized;     // count of #local clients that have finalized
+    bool local_app_fini_fired; // the "all local processes finalized" callback has been
+                               // fired for this nspace; guards against re-firing it once
+                               // per rank while the nspace is torn down
     pmix_list_t ranks;     // list of pmix_rank_info_t for connection support of my clients
     /* all members of an nspace are required to have the
      * same personality, but it can differ between nspaces.

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Jeff Squyres  All rights reserved.
  * $COPYRIGHT$
  *
@@ -181,6 +181,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     cnct_hdlr_t *ch;
     void *ilist;
     pmix_data_array_t darray;
+    bool reuse = false;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -414,10 +415,32 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
 
     /* a peer can connect on multiple sockets since it can fork/exec
      * a child that also calls PMIX_Init, so add it here if necessary.
-     * Create the tracker for this peer */
-    peer = PMIX_NEW(pmix_peer_t);
-    if (NULL == peer) {
-        goto error;
+     * If this rank previously finalized and its peer was recycled in
+     * place (left idle with finalized==true and no live processes), reuse
+     * that object rather than leaking it and allocating a new one - see
+     * docs/how-things-work/init-finalize.rst. We require finalized==true
+     * on the candidate so we never reuse a still-active peer or one left
+     * behind by an abnormal termination. */
+    if (0 == info->proc_cnt && 0 <= info->peerid) {
+        peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
+                                                           info->peerid);
+        if (NULL != peer && peer->finalized) {
+            reuse = true;
+        } else {
+            peer = NULL;
+        }
+    }
+    if (!reuse) {
+        peer = PMIX_NEW(pmix_peer_t);
+        if (NULL == peer) {
+            goto error;
+        }
+    } else {
+        /* reactivate the recycled peer - it was left counted as finalized */
+        peer->finalized = false;
+        if (0 < nptr->nfinalized) {
+            --nptr->nfinalized;
+        }
     }
 
     /* Assign the upper half of the tag space for sendrecvs */
@@ -428,9 +451,11 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     memcpy(&peer->proc_type, &pnd->proc_type, sizeof(pmix_proc_type_t));
     /* save the protocol */
     peer->protocol = pnd->protocol;
-    /* add in the nspace pointer */
-    PMIX_RETAIN(nptr);
-    peer->nptr = nptr;
+    /* add in the nspace pointer - a recycled peer is already pointed at it */
+    if (!reuse) {
+        PMIX_RETAIN(nptr);
+        peer->nptr = nptr;
+    }
     PMIX_RETAIN(info);
     peer->info = info;
     /* update the epilog fields */
@@ -441,10 +466,13 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     peer->sd = pnd->sd;
-    if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
-        goto error;
+    /* a recycled peer keeps its clients-array slot and peerid */
+    if (!reuse) {
+        if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
+            goto error;
+        }
+        info->peerid = peer->index;
     }
-    info->peerid = peer->index;
 
     /* set the sec module to match this peer */
     peer->nptr->compat.psec = pmix_psec_base_assign_module(pnd->psec);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -181,6 +181,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     cnct_hdlr_t *ch;
     void *ilist;
     pmix_data_array_t darray;
+    pmix_peer_t *stale;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -410,6 +411,31 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         nptr->version.major = pnd->proc_type.major;
         nptr->version.minor = pnd->proc_type.minor;
         nptr->version.release = pnd->proc_type.release;
+    }
+
+    /* If this rank previously finalized, a harmless finalized "tombstone"
+     * peer from that prior cycle may still occupy its clients-array slot -
+     * pmix_server_peer_finalized leaves it in place at socket-close rather
+     * than mutating shared state amid concurrent collectives. Now that the
+     * rank is reconnecting we are at a safe point (no collective from the
+     * prior cycle can still be in flight), so reclaim that tombstone
+     * before allocating a fresh peer for this connection: null its slot,
+     * drop the finalized count it was still contributing, and release it.
+     * This is what keeps the clients array and nptr->nfinalized from
+     * drifting across repeated init/finalize cycles. We only reclaim when
+     * no live process remains for the rank (proc_cnt == 0) so a surviving
+     * fork/exec'd clone is never disturbed. See
+     * docs/how-things-work/init-finalize.rst. */
+    if (0 <= info->peerid && 0 == info->proc_cnt) {
+        stale = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
+                                                            info->peerid);
+        if (NULL != stale && stale->finalized) {
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, info->peerid, NULL);
+            if (0 < nptr->nfinalized) {
+                --nptr->nfinalized;
+            }
+            PMIX_RELEASE(stale);
+        }
     }
 
     /* a peer can connect on multiple sockets since it can fork/exec

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -181,7 +181,6 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     cnct_hdlr_t *ch;
     void *ilist;
     pmix_data_array_t darray;
-    bool reuse = false;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -415,32 +414,10 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
 
     /* a peer can connect on multiple sockets since it can fork/exec
      * a child that also calls PMIX_Init, so add it here if necessary.
-     * If this rank previously finalized and its peer was recycled in
-     * place (left idle with finalized==true and no live processes), reuse
-     * that object rather than leaking it and allocating a new one - see
-     * docs/how-things-work/init-finalize.rst. We require finalized==true
-     * on the candidate so we never reuse a still-active peer or one left
-     * behind by an abnormal termination. */
-    if (0 == info->proc_cnt && 0 <= info->peerid) {
-        peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
-                                                           info->peerid);
-        if (NULL != peer && peer->finalized) {
-            reuse = true;
-        } else {
-            peer = NULL;
-        }
-    }
-    if (!reuse) {
-        peer = PMIX_NEW(pmix_peer_t);
-        if (NULL == peer) {
-            goto error;
-        }
-    } else {
-        /* reactivate the recycled peer - it was left counted as finalized */
-        peer->finalized = false;
-        if (0 < nptr->nfinalized) {
-            --nptr->nfinalized;
-        }
+     * Create the tracker for this peer */
+    peer = PMIX_NEW(pmix_peer_t);
+    if (NULL == peer) {
+        goto error;
     }
 
     /* Assign the upper half of the tag space for sendrecvs */
@@ -451,11 +428,9 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     memcpy(&peer->proc_type, &pnd->proc_type, sizeof(pmix_proc_type_t));
     /* save the protocol */
     peer->protocol = pnd->protocol;
-    /* add in the nspace pointer - a recycled peer is already pointed at it */
-    if (!reuse) {
-        PMIX_RETAIN(nptr);
-        peer->nptr = nptr;
-    }
+    /* add in the nspace pointer */
+    PMIX_RETAIN(nptr);
+    peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
     /* update the epilog fields */
@@ -466,13 +441,10 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     peer->sd = pnd->sd;
-    /* a recycled peer keeps its clients-array slot and peerid */
-    if (!reuse) {
-        if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
-            goto error;
-        }
-        info->peerid = peer->index;
+    if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
+        goto error;
     }
+    info->peerid = peer->index;
 
     /* set the sec module to match this peer */
     peer->nptr->compat.psec = pmix_psec_base_assign_module(pnd->psec);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -876,6 +876,27 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     /* set the socket non-blocking for all further operations */
     pmix_ptl_base_set_nonblocking(pnd->sd);
 
+    /* If this rank previously finalized and left a tombstone peer behind
+     * (a tool registered as a client keeps the client tombstone semantics,
+     * which pmix_server_peer_finalized does not free at socket-close), the
+     * stale finalized peer may still occupy the rank's clients slot. We are
+     * now at a safe reconnect point, so reclaim it before allocating this
+     * connection's fresh peer - mirroring the client path in the main
+     * connection handler. Without this a tool that reuses its identity
+     * across init/finalize cycles would leak one peer (and one nfinalized
+     * count) per cycle. See docs/how-things-work/init-finalize.rst. */
+    if (NULL != peer->info && 0 <= peer->info->peerid) {
+        pr2 = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
+                                                          peer->info->peerid);
+        if (NULL != pr2 && pr2 != peer && pr2->finalized) {
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->info->peerid, NULL);
+            if (NULL != peer->nptr && 0 < peer->nptr->nfinalized) {
+                --peer->nptr->nfinalized;
+            }
+            PMIX_RELEASE(pr2);
+        }
+    }
+
     if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
         goto error;
     }

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -230,9 +230,17 @@ static void lost_connection(pmix_peer_t *peer)
             pmix_server_grp_peer_lost(peer);
 
             /* if the peer simply died without finalizing,
-             * then reduce the number of local procs */
-            if (!peer->finalized && 0 < peer->nptr->nlocalprocs) {
-                --peer->nptr->nlocalprocs;
+             * then reduce the number of local procs, and reduce the
+             * rank's live-process count so a later clone recycle decision
+             * remains correct (the finalize path decrements proc_cnt in
+             * pmix_server_peer_finalized; the abnormal path must too) */
+            if (!peer->finalized) {
+                if (0 < peer->nptr->nlocalprocs) {
+                    --peer->nptr->nlocalprocs;
+                }
+                if (NULL != peer->info && 0 < peer->info->proc_cnt) {
+                    --peer->info->proc_cnt;
+                }
             }
         }
 
@@ -253,6 +261,16 @@ static void lost_connection(pmix_peer_t *peer)
              * an event. If an abnormal termination, then we do */
             PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION, peer,
                               PMIX_RANGE_PROC_LOCAL, _notify_complete);
+        }
+
+        /* if a local client finalized cleanly and its socket has now
+         * dropped, recycle or release its peer object so it does not leak
+         * until the nspace is deregistered. This MUST be the last use of
+         * peer here: the object may be destructed/reconstructed or freed.
+         * The callers only issue a write barrier afterward (they never
+         * dereference peer), so doing it inline is safe. */
+        if (peer->finalized && PMIX_PEER_IS_CLIENT(peer) && !PMIX_PEER_IS_TOOL(peer)) {
+            pmix_server_peer_finalized(peer);
         }
 
     } else if (peer == pmix_client_globals.myserver) {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -263,13 +263,23 @@ static void lost_connection(pmix_peer_t *peer)
                               PMIX_RANGE_PROC_LOCAL, _notify_complete);
         }
 
-        /* if a local client finalized cleanly and its socket has now
-         * dropped, recycle or release its peer object so it does not leak
-         * until the nspace is deregistered. This MUST be the last use of
-         * peer here: the object may be destructed/reconstructed or freed.
-         * The callers only issue a write barrier afterward (they never
-         * dereference peer), so doing it inline is safe. */
+        /* if a local peer finalized cleanly and its socket has now dropped,
+         * retire its peer object so it does not leak until the nspace is
+         * deregistered. This MUST be the last use of peer here: the object
+         * may be freed. The callers only issue a write barrier afterward
+         * (they never dereference peer), so doing it inline is safe. */
         if (peer->finalized && PMIX_PEER_IS_CLIENT(peer) && !PMIX_PEER_IS_TOOL(peer)) {
+            /* a pure client is tombstoned - reclaimed on reconnect or
+             * namespace deregistration */
+            pmix_server_peer_finalized(peer);
+        } else if (peer->finalized && PMIX_PEER_IS_TOOL(peer) && !PMIX_PEER_IS_CLIENT(peer)) {
+            /* a pure tool is freed outright: nothing resolves a tool through
+             * info->peerid, so it needs no tombstone, and it never reconnects
+             * onto the same rank (each tool init is assigned a fresh nspace),
+             * so leaving it would leak one peer per init/finalize cycle. A
+             * tool the host registered as a client keeps the client tombstone
+             * path above and is reclaimed by its tool reconnect (or namespace
+             * deregistration) instead. */
             pmix_server_peer_finalized(peer);
         }
 

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -46,6 +46,7 @@
 #include "src/mca/ptl/base/base.h"
 #include "src/threads/pmix_tsd.h"
 #include "src/util/pmix_keyval_parse.h"
+#include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_net.h"
@@ -161,8 +162,18 @@ void pmix_rte_finalize(void)
         pmix_var_dump_color[i] = NULL;
     }
     pmix_tsd_keys_destruct();
+    /* clear the print-buffer TSD latch now that its key has been deleted,
+     * so a subsequent PMIx_Init recreates it */
+    pmix_name_fns_finalize();
 
     pmix_finalize_util();
     // release the event base
     pmix_progress_thread_stop(NULL);
+    /* the event base has now been freed - clear our cached pointers so a
+     * subsequent PMIx_Init starts from a clean slate and nothing in the
+     * gap dereferences freed memory. evauxbase either aliased evbase or
+     * was supplied externally by the caller (who owns it); in both cases
+     * we only drop our reference, we do not free it here */
+    pmix_globals.evbase = NULL;
+    pmix_globals.evauxbase = NULL;
 }

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -68,6 +68,7 @@
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/runtime/pmix_init_util.h"
+#include "src/threads/pmix_threads.h"
 
 const char pmix_version_string[] = PMIX_IDENT_STRING;
 const char* pmix_tool_basename = NULL;
@@ -158,6 +159,14 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
     if (pmix_atomic_check_bool(&pmix_globals.util_initialized)) {
         return PMIX_SUCCESS;
     }
+
+    /* record the initializing thread as "main" so that thread-specific
+     * data keys it creates (e.g., in pmix_net_init) are registered for
+     * cleanup. Without this the registry stays empty and every key -
+     * and its pthread slot - leaks across an init/finalize cycle,
+     * eventually exhausting PTHREAD_KEYS_MAX. init and finalize run on
+     * this same thread, so it is also where pmix_tsd_keys_destruct runs. */
+    pmix_thread_set_main();
 
     /* initialize the output system */
     if (!pmix_output_init()) {

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -380,6 +380,12 @@ pmix_status_t pmix_progress_thread_stop(const char *name)
                 stop_progress_engine(trk);
             }
             pmix_list_remove_item(&tracking, &trk->super);
+            /* if this is the shared tracker, clear the cached pointer so a
+             * PMIx_Progress call between finalize and the next init does
+             * not dereference freed memory */
+            if (trk == shared_thread_tracker) {
+                shared_thread_tracker = NULL;
+            }
             PMIX_RELEASE(trk);
             return PMIX_SUCCESS;
         }
@@ -415,6 +421,9 @@ pmix_status_t pmix_progress_thread_finalize(const char *name)
             }
 
             pmix_list_remove_item(&tracking, &trk->super);
+            if (trk == shared_thread_tracker) {
+                shared_thread_tracker = NULL;
+            }
             PMIX_RELEASE(trk);
             return PMIX_SUCCESS;
         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1496,46 +1496,69 @@ void pmix_server_peer_finalized(pmix_peer_t *peer)
 {
     pmix_rank_info_t *info = peer->info;
     pmix_namespace_t *nptr = peer->nptr;
+    pmix_peer_t *sib;
+    int i;
 
-    /* This is a cleanly-finalized local client whose socket has now
-     * dropped. lost_connection has already stopped the peer's events and
-     * closed its socket, and peer->finalized is true, so the object is
-     * inert to every finalized-guarded send path.
+    /* This is a cleanly-finalized local peer whose socket has now dropped.
+     * lost_connection has already stopped the peer's events and closed its
+     * socket, and peer->finalized is true, so the object is inert to every
+     * finalized-guarded send path.
      *
      * First, reduce the rank's live-process count. */
     if (NULL != info && 0 < info->proc_cnt) {
         --info->proc_cnt;
     }
 
-    /* If this peer is still the rank's referenced peer (info->peerid names
-     * it), we deliberately leave it in place as a harmless finalized
-     * "tombstone" at its existing clients slot rather than freeing it,
-     * nulling the slot, or repointing info->peerid here. Mutating that
-     * shared per-namespace/per-rank state at socket-close time races with
-     * concurrent spawn/connect/disconnect collectives and direct-modex
-     * gets that walk the clients array and the rank list (via
-     * info->peerid) while a peer is departing - an architecture- and
-     * timing-sensitive hang of multi-local-process MPI_Comm_spawn. The
-     * tombstone is reclaimed at a safe point instead: when the rank
-     * reconnects on the next PMIx_Init (the connection handler frees the
-     * stale tombstone before allocating a fresh peer) or when the
-     * namespace is deregistered. Leaving it counted as finalized
-     * (nfinalized untouched) is what keeps nfinalized honest across
-     * init/finalize cycles. See docs/how-things-work/init-finalize.rst. */
     if (NULL != info && info->peerid == peer->index) {
-        return;
+        /* This peer is still the rank's referenced peer. How we retire it
+         * depends on whether it is an application client or a tool. */
+        if (PMIX_PEER_IS_CLIENT(peer)) {
+            /* A client can be resolved through info->peerid by a *different*
+             * local process's spawn/connect/disconnect collective or
+             * direct-modex get that is still walking the clients array and
+             * the rank list while this peer departs. Freeing it, nulling the
+             * slot, or repointing info->peerid here would mutate that shared
+             * state underneath such an in-flight operation - an architecture-
+             * and timing-sensitive hang of multi-local-process
+             * MPI_Comm_spawn. So we deliberately leave the client in place as
+             * a harmless finalized "tombstone" at its existing clients slot,
+             * counted as finalized (nfinalized untouched), and reclaim it at
+             * a safe point instead: when the rank reconnects on the next
+             * PMIx_Init (the connection handler frees the stale tombstone
+             * before allocating a fresh peer) or when the namespace is
+             * deregistered. See docs/how-things-work/init-finalize.rst. */
+            return;
+        }
+        /* A tool is not an application-job member: it has its own namespace
+         * and is never resolved through info->peerid by a concurrent job
+         * collective or direct-modex get, so it needs no tombstone. Free it
+         * now and repoint the rank's referenced peerid - to a surviving tool
+         * sibling sharing this info if one is still live, else to -1. This
+         * both restores the post-finalize info->peerid == -1 state that
+         * process_tool_request relies on to recognize a reconnecting tool,
+         * and keeps tool peers from accumulating in the clients array across
+         * tool init/finalize cycles that reuse the same namespace and rank.
+         * Fall through to the shared free below. */
+        info->peerid = -1;
+        if (0 < info->proc_cnt) {
+            for (i = 0; i < pmix_server_globals.clients.size; i++) {
+                sib = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, i);
+                if (NULL != sib && sib != peer && sib->info == info) {
+                    info->peerid = i;
+                    break;
+                }
+            }
+        }
     }
 
-    /* Otherwise a newer peer has already taken over this rank's slot - a
-     * fork/exec'd clone that is still running, or a fast re-init that
-     * reconnected before this socket-close was processed. This finalized
-     * object is stranded: info->peerid no longer names it, so nothing
-     * references it as the rank's peer. It is therefore safe to free it
-     * now - we only null its OWN clients slot (never the live referenced
-     * one) and never touch info->peerid, so no collective or get that
-     * resolves the rank through info->peerid is disturbed. Freeing here
-     * keeps the stranded object, and the finalized count it still holds,
-     * from leaking. */
+    /* We reach here either for a just-retired tool referenced peer (handled
+     * above) or for a stranded peer that a newer connection already took
+     * over - a fork/exec'd clone still running, or a fast re-init that
+     * reconnected before this socket-close was processed. In the stranded
+     * case info->peerid no longer names this object, so nothing references
+     * it as the rank's peer. Either way it is safe to free it now: we null
+     * only its OWN clients slot (never the live referenced one), drop the
+     * finalized count it was still holding, and release it. */
     if (NULL != nptr && 0 < nptr->nfinalized) {
         --nptr->nfinalized;
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1496,47 +1496,50 @@ void pmix_server_peer_finalized(pmix_peer_t *peer)
 {
     pmix_rank_info_t *info = peer->info;
     pmix_namespace_t *nptr = peer->nptr;
-    int idx = peer->index;
-    pmix_peer_t *sib;
-    int i;
 
-    /* this process is gone - reduce the rank's live-process count */
+    /* This is a cleanly-finalized local client whose socket has now
+     * dropped. lost_connection has already stopped the peer's events and
+     * closed its socket, and peer->finalized is true, so the object is
+     * inert to every finalized-guarded send path.
+     *
+     * First, reduce the rank's live-process count. */
     if (NULL != info && 0 < info->proc_cnt) {
         --info->proc_cnt;
     }
 
-    /* Release the departed peer so it does not stay stranded in the
-     * clients array until the nspace is deregistered. We deliberately do
-     * NOT recycle the object in place: destructing and reconstructing a
-     * pmix_peer_t that is still reachable from the clients array (and
-     * whose embedded libevent structures and rank_info alias other state)
-     * is fragile - the reuse was only an allocation optimization, and a
-     * subsequent PMIx_Init for this rank simply allocates a fresh peer.
-     * PMIX_RELEASE only drops our reference; if a pending collective or an
-     * active sensor still holds one, the object survives until that last
-     * holder frees it.
-     *
-     * Releasing undoes the finalized state, so undo the count that
-     * FINALIZE_CMD added. */
-    if (0 < nptr->nfinalized) {
+    /* If this peer is still the rank's referenced peer (info->peerid names
+     * it), we deliberately leave it in place as a harmless finalized
+     * "tombstone" at its existing clients slot rather than freeing it,
+     * nulling the slot, or repointing info->peerid here. Mutating that
+     * shared per-namespace/per-rank state at socket-close time races with
+     * concurrent spawn/connect/disconnect collectives and direct-modex
+     * gets that walk the clients array and the rank list (via
+     * info->peerid) while a peer is departing - an architecture- and
+     * timing-sensitive hang of multi-local-process MPI_Comm_spawn. The
+     * tombstone is reclaimed at a safe point instead: when the rank
+     * reconnects on the next PMIx_Init (the connection handler frees the
+     * stale tombstone before allocating a fresh peer) or when the
+     * namespace is deregistered. Leaving it counted as finalized
+     * (nfinalized untouched) is what keeps nfinalized honest across
+     * init/finalize cycles. See docs/how-things-work/init-finalize.rst. */
+    if (NULL != info && info->peerid == peer->index) {
+        return;
+    }
+
+    /* Otherwise a newer peer has already taken over this rank's slot - a
+     * fork/exec'd clone that is still running, or a fast re-init that
+     * reconnected before this socket-close was processed. This finalized
+     * object is stranded: info->peerid no longer names it, so nothing
+     * references it as the rank's peer. It is therefore safe to free it
+     * now - we only null its OWN clients slot (never the live referenced
+     * one) and never touch info->peerid, so no collective or get that
+     * resolves the rank through info->peerid is disturbed. Freeing here
+     * keeps the stranded object, and the finalized count it still holds,
+     * from leaking. */
+    if (NULL != nptr && 0 < nptr->nfinalized) {
         --nptr->nfinalized;
     }
-    /* If this peer was the rank's referenced peer, repoint peerid so a
-     * concurrent local PMIx_Get for the rank still resolves: to a
-     * surviving sibling if one is still live (a clone), else to -1. */
-    if (NULL != info && info->peerid == idx) {
-        info->peerid = -1;
-        if (0 < info->proc_cnt) {
-            for (i = 0; i < pmix_server_globals.clients.size; i++) {
-                sib = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, i);
-                if (NULL != sib && sib != peer && sib->info == info) {
-                    info->peerid = i;
-                    break;
-                }
-            }
-        }
-    }
-    pmix_pointer_array_set_item(&pmix_server_globals.clients, idx, NULL);
+    pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
     PMIX_RELEASE(peer);
 }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1492,6 +1492,70 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
     }
 }
 
+void pmix_server_peer_finalized(pmix_peer_t *peer)
+{
+    pmix_rank_info_t *info = peer->info;
+    pmix_namespace_t *nptr = peer->nptr;
+    int idx = peer->index;
+    pmix_peer_t *sib;
+    int i;
+
+    /* this process is gone - reduce the rank's live-process count */
+    if (NULL != info && 0 < info->proc_cnt) {
+        --info->proc_cnt;
+    }
+
+    /* Recycle the peer object in place only when this was the last live
+     * process for the rank AND nothing else still references the object.
+     * A pending collective (its caddy sits on the tracker's local_cbs) or
+     * a sensor can retain the peer past finalize; recycling a still-aliased
+     * object would leave those references pointing at a reinitialized (and
+     * possibly reconnected) peer - a use-after-free. In that case we fall
+     * through to release, which only decrements the refcount and lets the
+     * last holder free it; a subsequent PMIx_Init then allocates fresh. */
+    if (NULL != info && 0 == info->proc_cnt &&
+        1 == peer->super.obj_reference_count) {
+        /* retain the nspace across the destruct so pdes's release of it
+         * does not free it, then hand that reference back to the peer */
+        PMIX_RETAIN(nptr);
+        PMIX_DESTRUCT(peer);
+        PMIX_CONSTRUCT(peer, pmix_peer_t);
+        peer->nptr = nptr;
+        peer->index = idx;
+        /* keep the recycled peer counted as finalized: this leaves it
+         * inert to every finalized-guarded send path while idle, keeps
+         * nfinalized honest, and identifies it as available for reuse on
+         * the next PMIx_Init. info stays on nptr->ranks and is reattached
+         * to peer->info when the rank reconnects. */
+        peer->finalized = true;
+        info->peerid = idx;
+        return;
+    }
+
+    /* Releasing a finalized peer: it leaves the finalized state, so undo
+     * the count that FINALIZE_CMD added. */
+    if (0 < nptr->nfinalized) {
+        --nptr->nfinalized;
+    }
+    /* If this peer was the rank's referenced peer, repoint peerid so a
+     * concurrent local PMIx_Get for the rank still resolves: to a
+     * surviving sibling if one is still live (a clone), else to -1. */
+    if (NULL != info && info->peerid == idx) {
+        info->peerid = -1;
+        if (0 < info->proc_cnt) {
+            for (i = 0; i < pmix_server_globals.clients.size; i++) {
+                sib = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, i);
+                if (NULL != sib && sib != peer && sib->info == info) {
+                    info->peerid = i;
+                    break;
+                }
+            }
+        }
+    }
+    pmix_pointer_array_set_item(&pmix_server_globals.clients, idx, NULL);
+    PMIX_RELEASE(peer);
+}
+
 static void remove_client(pmix_namespace_t *nptr, pmix_proc_t *p)
 {
     pmix_rank_info_t *info, *inext;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1505,35 +1505,19 @@ void pmix_server_peer_finalized(pmix_peer_t *peer)
         --info->proc_cnt;
     }
 
-    /* Recycle the peer object in place only when this was the last live
-     * process for the rank AND nothing else still references the object.
-     * A pending collective (its caddy sits on the tracker's local_cbs) or
-     * a sensor can retain the peer past finalize; recycling a still-aliased
-     * object would leave those references pointing at a reinitialized (and
-     * possibly reconnected) peer - a use-after-free. In that case we fall
-     * through to release, which only decrements the refcount and lets the
-     * last holder free it; a subsequent PMIx_Init then allocates fresh. */
-    if (NULL != info && 0 == info->proc_cnt &&
-        1 == peer->super.obj_reference_count) {
-        /* retain the nspace across the destruct so pdes's release of it
-         * does not free it, then hand that reference back to the peer */
-        PMIX_RETAIN(nptr);
-        PMIX_DESTRUCT(peer);
-        PMIX_CONSTRUCT(peer, pmix_peer_t);
-        peer->nptr = nptr;
-        peer->index = idx;
-        /* keep the recycled peer counted as finalized: this leaves it
-         * inert to every finalized-guarded send path while idle, keeps
-         * nfinalized honest, and identifies it as available for reuse on
-         * the next PMIx_Init. info stays on nptr->ranks and is reattached
-         * to peer->info when the rank reconnects. */
-        peer->finalized = true;
-        info->peerid = idx;
-        return;
-    }
-
-    /* Releasing a finalized peer: it leaves the finalized state, so undo
-     * the count that FINALIZE_CMD added. */
+    /* Release the departed peer so it does not stay stranded in the
+     * clients array until the nspace is deregistered. We deliberately do
+     * NOT recycle the object in place: destructing and reconstructing a
+     * pmix_peer_t that is still reachable from the clients array (and
+     * whose embedded libevent structures and rank_info alias other state)
+     * is fragile - the reuse was only an allocation optimization, and a
+     * subsequent PMIx_Init for this rank simply allocates a fresh peer.
+     * PMIX_RELEASE only drops our reference; if a pending collective or an
+     * active sensor still holds one, the object survives until that last
+     * holder frees it.
+     *
+     * Releasing undoes the finalized state, so undo the count that
+     * FINALIZE_CMD added. */
     if (0 < nptr->nfinalized) {
         --nptr->nfinalized;
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1619,7 +1619,15 @@ static void remove_client(pmix_namespace_t *nptr, pmix_proc_t *p)
                 pmix_pointer_array_set_item(&pmix_server_globals.clients, info->peerid, NULL);
                 PMIX_RELEASE(peer);
             }
-            if (nptr->nlocalprocs == nptr->nfinalized) {
+            /* Fire the "all local processes finalized" callback exactly
+             * once. In the tombstone model a finalized peer stays counted in
+             * nfinalized until it is reclaimed, so nfinalized is already
+             * saturated at nlocalprocs here and this equality holds on every
+             * rank we iterate; without the guard the callback would fire once
+             * per rank as the nspace is torn down. */
+            if (!nptr->local_app_fini_fired &&
+                nptr->nlocalprocs == nptr->nfinalized) {
+                nptr->local_app_fini_fired = true;
                 pmix_pnet.local_app_finalized(nptr);
             }
             pmix_list_remove_item(&nptr->ranks, &info->super);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -348,10 +348,10 @@ PMIX_EXPORT void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hd
 PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc);
 
 /* Handle the departure of a cleanly-finalized local client peer whose
- * socket has dropped: decrement the rank's live-process count and either
- * recycle the peer object in place (when it was the last live process for
- * the rank and nothing else still references it) so a subsequent
- * PMIx_Init reuses it, or release it. See
+ * socket has dropped: decrement the rank's live-process count, undo the
+ * nfinalized bump that FINALIZE_CMD added, repoint the rank's referenced
+ * peerid, and release the peer so it does not stay stranded in the clients
+ * array until the nspace is deregistered. See
  * docs/how-things-work/init-finalize.rst. */
 PMIX_EXPORT void pmix_server_peer_finalized(pmix_peer_t *peer);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -348,10 +348,15 @@ PMIX_EXPORT void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hd
 PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc);
 
 /* Handle the departure of a cleanly-finalized local client peer whose
- * socket has dropped: decrement the rank's live-process count, undo the
- * nfinalized bump that FINALIZE_CMD added, repoint the rank's referenced
- * peerid, and release the peer so it does not stay stranded in the clients
- * array until the nspace is deregistered. See
+ * socket has dropped: decrement the rank's live-process count and leave
+ * the peer in place as an inert finalized "tombstone" at its existing
+ * clients slot (info->peerid unchanged, slot not nulled), to be reclaimed
+ * at the next reconnect for the rank or at namespace deregistration. Only
+ * a stranded peer that a newer connection has already displaced
+ * (info->peerid no longer names it) is freed here. Deferring the free and
+ * never moving a live peerid keeps concurrent spawn/connect/disconnect
+ * collectives and direct-modex gets - which resolve ranks through
+ * info->peerid - from racing peer teardown. See
  * docs/how-things-work/init-finalize.rst. */
 PMIX_EXPORT void pmix_server_peer_finalized(pmix_peer_t *peer);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -347,6 +347,14 @@ PMIX_EXPORT void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hd
 
 PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc);
 
+/* Handle the departure of a cleanly-finalized local client peer whose
+ * socket has dropped: decrement the rank's live-process count and either
+ * recycle the peer object in place (when it was the last live process for
+ * the rank and nothing else still references it) so a subsequent
+ * PMIx_Init reuses it, or release it. See
+ * docs/how-things-work/init-finalize.rst. */
+PMIX_EXPORT void pmix_server_peer_finalized(pmix_peer_t *peer);
+
 PMIX_EXPORT pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
                                                       pmix_info_cbfunc_t cbfunc);
 

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -117,9 +117,16 @@ int pmix_tsd_keys_destruct(void)
                 pmix_tsd_setspecific(pmix_tsd_key_values[i].key, NULL);
             }
         }
+        /* delete the key itself so its slot is not leaked across an
+         * init/finalize cycle - callers that created it will recreate
+         * it on the next PMIx_Init */
+        pmix_tsd_key_delete(pmix_tsd_key_values[i].key);
     }
     if (0 < pmix_tsd_key_values_count) {
         free(pmix_tsd_key_values);
+        /* null the registry so the next pmix_tsd_key_create reallocs from
+         * a clean base rather than a freed pointer */
+        pmix_tsd_key_values = NULL;
         pmix_tsd_key_values_count = 0;
     }
     return PMIX_SUCCESS;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1504,7 +1504,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     pmix_status_t rc;
     pmix_tool_timeout_t tev;
     struct timeval tv = {5, 0};
-    int n;
+    int n, i;
     pmix_peer_t *peer;
     pmix_pfexec_child_t *child, *nxt;
     pmix_lock_t lock;
@@ -1512,7 +1512,17 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
+    /* PMIx_tool_init is reference counted (a tool may init more than once);
+     * only the last matching finalize tears the library down */
+    i = pmix_atomic_fetch_add(&tool_init_cntr, -1);
+    if (1 < i) {
+        return PMIX_SUCCESS;
+    }
     pmix_atomic_unset_bool(&pmix_globals.initialized);
+    /* reset the one-time-init latch so a subsequent PMIx_tool_init in this
+     * process starts a fresh library instance rather than short-circuiting
+     * on the still-set flag and returning PMIX_ERR_INIT */
+    pmix_globals.init_called = false;
     pmix_globals.mypeer->finalized = true;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -1579,9 +1589,13 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     /* wait here until all active events have been processed */
     PMIx_Progress_thread_stop(NULL, 0);
 
-    /* flush anything that is still trying to be written out */
+    /* flush anything that is still trying to be written out, then tear
+     * down the static IOF sinks so their buffered-output and write-event
+     * state does not leak across a re-init (matches the client finalize) */
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stdout);
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     for (n = 0; n < pmix_client_globals.peers.size; n++) {
@@ -1590,6 +1604,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
             PMIX_RELEASE(peer);
         }
     }
+    /* release the peers array's backing store, matching the client
+     * finalize - the loop above only released the items it held */
+    PMIX_DESTRUCT(&pmix_client_globals.peers);
 
     pmix_ptl_base_stop_listening();
 
@@ -1601,16 +1618,36 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     }
 
     (void) pmix_mca_base_framework_close(&pmix_pnet_base_framework);
+    /* tear down every server_globals list that pmix_server_initialize
+     * constructs on each init, so none of their contents leak across a
+     * cycle. pmix_server_initialize (called unconditionally from
+     * PMIx_tool_init) reconstructs all of these on the next init. */
     PMIX_DESTRUCT(&pmix_server_globals.clients);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.iof_residuals);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.psets);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.grp_collectives);
 
     (void) pmix_mca_base_framework_close(&pmix_pmdl_base_framework);
-    (void) pmix_mca_base_framework_close(&pmix_pnet_base_framework);
+
+    /* free the tmpdir strings so they neither leak nor carry a stale
+     * value into the next init: the init-time guards only refresh them
+     * when they are NULL, so a surviving pointer would silently ignore a
+     * changed PMIX_SERVER_TMPDIR/PMIX_SYSTEM_TMPDIR on the next cycle */
+    if (NULL != pmix_server_globals.tmpdir) {
+        free(pmix_server_globals.tmpdir);
+        pmix_server_globals.tmpdir = NULL;
+    }
+    if (NULL != pmix_server_globals.system_tmpdir) {
+        free(pmix_server_globals.system_tmpdir);
+        pmix_server_globals.system_tmpdir = NULL;
+    }
 
     pmix_rte_finalize();
     if (NULL != pmix_globals.mypeer) {

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -65,6 +65,15 @@ static void buffer_cleanup(void *value)
     }
 }
 
+void pmix_name_fns_finalize(void)
+{
+    /* the TSD key (and the per-thread buffers hung off it) are torn down
+     * by pmix_tsd_keys_destruct during finalize; clear our latch here so
+     * that a subsequent PMIx_Init recreates and re-registers the key
+     * rather than reusing one that no longer exists. */
+    fns_init = false;
+}
+
 static pmix_print_args_buffers_t *get_print_name_buffer(void)
 {
     pmix_print_args_buffers_t *ptr;

--- a/src/util/pmix_name_fns.h
+++ b/src/util/pmix_name_fns.h
@@ -58,5 +58,10 @@ PMIX_EXPORT char *pmix_util_print_rank(const pmix_rank_t vpid);
 
 PMIX_EXPORT int pmix_util_compare_proc(const void *a, const void *b);
 
+/* reset the one-time initialization of the print-buffer TSD key so that
+ * a subsequent PMIx_Init recreates it. The key itself is deleted by
+ * pmix_tsd_keys_destruct; this only clears the local latch. */
+PMIX_EXPORT void pmix_name_fns_finalize(void);
+
 END_C_DECLS
 #endif

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -28,7 +28,7 @@ headers = simptest.h
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
-                  simpcoord simpcycle doubleget simpfabric get_put_example simpvni \
+                  simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
                   hybrid simpqual simpdist legacy refresh
 
 simptest_SOURCES = $(headers) \
@@ -143,6 +143,12 @@ simpcycle_SOURCES = $(headers) \
         simpcycle.c
 simpcycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpcycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simptoolcycle_SOURCES = $(headers) \
+        simptoolcycle.c
+simptoolcycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simptoolcycle_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 doubleget_SOURCES = $(headers) \

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -109,10 +109,13 @@ int main(int argc, char **argv)
 
     /* Cycle PMIx_Init -> work -> PMIx_Finalize repeatedly against the same
      * persistent server, reusing our namespace and rank each time. Each
-     * finalize drops our connection; the server must recycle our peer object
-     * in place so the next Init reuses it rather than leaking a fresh one.
-     * Exercising many cycles here is a regression guard on that server-side
-     * recycle path - see docs/how-things-work/init-finalize.rst. */
+     * finalize drops our connection; the server releases our peer object and
+     * the next Init allocates a fresh one. Exercising many cycles here is a
+     * regression guard on the server-side finalize teardown: the departed
+     * peer must not strand in the clients array, and the per-rank accounting
+     * (nfinalized, proc_cnt) must stay balanced so the "all local processes
+     * finalized" condition keeps evaluating correctly across cycles - see
+     * docs/how-things-work/init-finalize.rst. */
     for (cycle = 0; cycle < MAXCNT; cycle++) {
 
         /* init us and declare we are a test programming model */
@@ -166,9 +169,9 @@ int main(int argc, char **argv)
         free(tmp);
 
         /* participate in a fence - this drives a server-side collective
-         * tracker that retains our peer, so it also verifies that the peer's
-         * refcount is back to 1 by the time we finalize (a precondition for
-         * recycle-in-place rather than release) */
+         * tracker that retains our peer, so it also exercises the teardown
+         * path where that reference must be dropped before the peer can be
+         * released on finalize */
         pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -41,7 +41,7 @@
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
 
-#define MAXCNT 1
+#define MAXCNT 25
 
 static volatile bool completed = false;
 static pmix_proc_t myproc;
@@ -104,93 +104,98 @@ int main(int argc, char **argv)
     pmix_info_t *iptr;
     size_t ninfo;
     pmix_status_t code;
+    int cycle;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
-    /* init us and declare we are a test programming model */
-    PMIX_INFO_CREATE(iptr, 2);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_PROGRAMMING_MODEL, "TEST", PMIX_STRING);
-    PMIX_INFO_LOAD(&iptr[1], PMIX_MODEL_LIBRARY_NAME, "PMIX", PMIX_STRING);
-    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, iptr, 2))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s", myproc.nspace, myproc.rank,
-                    PMIx_Error_string(rc));
-        exit(rc);
-    }
-    PMIX_INFO_FREE(iptr, 2);
-    pmix_output(0, "Client ns %s rank %d: Running on node %s", myproc.nspace, myproc.rank,
-                pmix_globals.hostname);
+    /* Cycle PMIx_Init -> work -> PMIx_Finalize repeatedly against the same
+     * persistent server, reusing our namespace and rank each time. Each
+     * finalize drops our connection; the server must recycle our peer object
+     * in place so the next Init reuses it rather than leaking a fresh one.
+     * Exercising many cycles here is a regression guard on that server-side
+     * recycle path - see docs/how-things-work/init-finalize.rst. */
+    for (cycle = 0; cycle < MAXCNT; cycle++) {
 
-    /* test something */
-    pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
-        exit(rc);
-    }
-    nprocs = val->data.uint32;
-    PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
+        /* init us and declare we are a test programming model */
+        PMIX_INFO_CREATE(iptr, 2);
+        PMIX_INFO_LOAD(&iptr[0], PMIX_PROGRAMMING_MODEL, "TEST", PMIX_STRING);
+        PMIX_INFO_LOAD(&iptr[1], PMIX_MODEL_LIBRARY_NAME, "PMIX", PMIX_STRING);
+        if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, iptr, 2))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Init(%d) failed: %s", myproc.nspace,
+                        myproc.rank, cycle, PMIx_Error_string(rc));
+            exit(rc);
+        }
+        PMIX_INFO_FREE(iptr, 2);
+        pmix_output(0, "Client ns %s rank %d: Init(%d) on node %s", myproc.nspace, myproc.rank,
+                    cycle, pmix_globals.hostname);
 
-    /* register a handler specifically for when models declare */
-    ninfo = 1;
-    PMIX_INFO_CREATE(iptr, ninfo);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "SIMPCLIENT-MODEL", PMIX_STRING);
-    code = PMIX_MODEL_DECLARED;
-    PMIx_Register_event_handler(&code, 1, iptr, ninfo, model_callback, NULL, NULL);
-    PMIX_INFO_FREE(iptr, ninfo);
+        /* test something */
+        pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+        proc.rank = PMIX_RANK_WILDCARD;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Get job size failed: %s", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+            exit(rc);
+        }
+        nprocs = val->data.uint32;
+        PMIX_VALUE_RELEASE(val);
+        pmix_output(0, "Client %s:%d job size %d", myproc.nspace, myproc.rank, nprocs);
 
-    /* register our errhandler */
-    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, NULL, NULL);
+        /* register a handler specifically for when models declare */
+        ninfo = 1;
+        PMIX_INFO_CREATE(iptr, ninfo);
+        PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "SIMPCLIENT-MODEL", PMIX_STRING);
+        code = PMIX_MODEL_DECLARED;
+        PMIx_Register_event_handler(&code, 1, iptr, ninfo, model_callback, NULL, NULL);
+        PMIX_INFO_FREE(iptr, ninfo);
 
-    /* put a few values */
-    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
-        errno = ENOMEM;
-        abort();
-    }
-    value.type = PMIX_UINT32;
-    value.data.uint32 = 1234;
-    if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
-        exit(rc);
+        /* register our errhandler */
+        PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, NULL, NULL);
+
+        /* put a few values */
+        if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+            errno = ENOMEM;
+            abort();
+        }
+        value.type = PMIX_UINT32;
+        value.data.uint32 = 1234;
+        if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %s", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+            exit(rc);
+        }
+        free(tmp);
+
+        /* participate in a fence - this drives a server-side collective
+         * tracker that retains our peer, so it also verifies that the peer's
+         * refcount is back to 1 by the time we finalize (a precondition for
+         * recycle-in-place rather than release) */
+        pmix_strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+        proc.rank = PMIX_RANK_WILDCARD;
+        if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %s", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+            exit(rc);
+        }
+
+        /* get a list of our local peers */
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
+                        myproc.rank, PMIx_Error_string(rc));
+            exit(rc);
+        }
+        PMIX_VALUE_RELEASE(val);
+
+        /* finalize us */
+        pmix_output(0, "Client ns %s rank %d: Finalizing(%d)", myproc.nspace, myproc.rank, cycle);
+        if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+            fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize(%d) failed: %s\n", myproc.nspace,
+                    myproc.rank, cycle, PMIx_Error_string(rc));
+            exit(rc);
+        }
     }
 
-    /* get a list of our local peers */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get local peers failed: %s", myproc.nspace,
-                    myproc.rank, PMIx_Error_string(rc));
-        exit(rc);
-    }
-    PMIX_VALUE_RELEASE(val);
-
-    /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing(1)", myproc.nspace, myproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
-        exit(rc);
-    } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
-                myproc.nspace, myproc.rank);
-    }
-
-    /* initialize us again */
-    fprintf(stderr, "Client Init(2)\n");
-    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s", myproc.nspace, myproc.rank,
-                    PMIx_Error_string(rc));
-        exit(rc);
-    }
-    pmix_output(0, "Client ns %s rank %d: Finalizing(2)", myproc.nspace, myproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
-        exit(rc);
-    } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n",
-                myproc.nspace, myproc.rank);
-    }
-
+    fprintf(stderr, "Client ns %s rank %d: completed %d init/finalize cycles OK\n", myproc.nspace,
+            myproc.rank, MAXCNT);
     fflush(stderr);
     return (rc);
 }

--- a/test/simple/simpcycle.c
+++ b/test/simple/simpcycle.c
@@ -109,10 +109,11 @@ int main(int argc, char **argv)
 
     /* Cycle PMIx_Init -> work -> PMIx_Finalize repeatedly against the same
      * persistent server, reusing our namespace and rank each time. Each
-     * finalize drops our connection; the server releases our peer object and
-     * the next Init allocates a fresh one. Exercising many cycles here is a
-     * regression guard on the server-side finalize teardown: the departed
-     * peer must not strand in the clients array, and the per-rank accounting
+     * finalize drops our connection; the server leaves our peer object as a
+     * finalized tombstone and reclaims it when the next Init reconnects,
+     * allocating a fresh one. Exercising many cycles here is a regression
+     * guard on the server-side finalize teardown: finalized peers must not
+     * accumulate in the clients array, and the per-rank accounting
      * (nfinalized, proc_cnt) must stay balanced so the "all local processes
      * finalized" condition keeps evaluating correctly across cycles - see
      * docs/how-things-work/init-finalize.rst. */

--- a/test/simple/simptoolcycle.c
+++ b/test/simple/simptoolcycle.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for the SERVER-side handling of a tool that cycles
+ * PMIx_tool_init -> (work) -> PMIx_tool_finalize against a persistent
+ * server.
+ *
+ * This is the server-side companion to test/unit/tool_cycle.c, which
+ * exercises only the tool *library* teardown (with DO_NOT_CONNECT and no
+ * server). Here a real tool connects to a real server every cycle, so the
+ * server runs its finalized-peer teardown on each finalize and allocates a
+ * fresh tool peer on each re-init. A correct server never accumulates
+ * finalized tool peers in pmix_server_globals.clients; a per-cycle leak (a
+ * never-reclaimed peer) grows that array by one per cycle.
+ *
+ * Two distinct server-side tool shapes are exercised, in two phases:
+ *
+ *   pure    - a standalone tool that gets a server-assigned nspace each
+ *             init (a fresh nspace per cycle, never reused). Its finalized
+ *             peer is freed at socket-close, so the live count returns to
+ *             zero.
+ *
+ *   client  - a tool the host registered as a client (a launcher-child
+ *             shape) that reuses one nspace and rank across cycles. Its
+ *             finalized peer is left in place and reclaimed when the tool
+ *             reconnects, so at most one lingers at a time.
+ *
+ * The process forks a fresh child (re-exec, so it starts from a clean
+ * library state) for each phase; after the child exits, the parent counts
+ * the peers left in its clients array and requires the count to stay within
+ * a small bound no matter how many cycles ran. A crash, a failed re-init,
+ * or a hang shows up as a non-zero child exit or a timeout.
+ *
+ * The parent advertises itself as the scheduler so the pure tool can init
+ * without us registering a job for it (PMIx_tool_init skips its job-info
+ * request when it reaches the scheduler), and it registers one job so the
+ * client-tool has real job info to retrieve.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "include/pmix_tool.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/util/pmix_argv.h"
+
+#define DEFAULT_CYCLES 50
+
+/* a phase may leave at most this many live peers behind while its final
+ * socket-close is still settling; a per-cycle leak blows past it */
+#define PEER_LEAK_BOUND 5
+
+static volatile int regdone;
+static void reg_cbfunc(pmix_status_t status, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, cbdata);
+    regdone = 1;
+}
+static void wait_reg(void)
+{
+    struct timespec ts = {0, 1000000};
+    while (0 == regdone) {
+        nanosleep(&ts, NULL);
+    }
+    regdone = 0;
+}
+
+static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
+                            pmix_tool_connection_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_proc_t proc;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    /* hand every standalone tool the same identity so the server has to
+     * cope with the identifier being reused cycle after cycle */
+    pmix_strncpy(proc.nspace, "TOOL", PMIX_MAX_NSLEN);
+    proc.rank = 0;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, &proc, cbdata);
+    }
+}
+
+static pmix_server_module_t mymodule = {
+    .tool_connected = tool_connect_fn
+};
+
+/* register a minimal but complete job so the client-tool phase can pull
+ * real job info; a bare, unregistered nspace hands back an empty job blob
+ * that PMIx_tool_init cannot unpack */
+static pmix_status_t register_job(const char *nspace)
+{
+    pmix_status_t rc;
+    char *nodes, *ppn;
+    pmix_info_t *iptr;
+    pmix_info_t jinfo[1];
+    pmix_proc_t client;
+    uint32_t one = 1;
+
+    PMIx_generate_regex(pmix_globals.hostname, &nodes);
+    PMIx_generate_ppn("0", &ppn);
+
+    PMIX_LOAD_KEY(jinfo[0].key, PMIX_JOB_INFO_ARRAY);
+    jinfo[0].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(jinfo[0].value.data.darray, 4, PMIX_INFO);
+    iptr = (pmix_info_t *) jinfo[0].value.data.darray->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NODE_MAP, nodes, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_JOB_SIZE, &one, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[3], PMIX_UNIV_SIZE, &one, PMIX_UINT32);
+    free(nodes);
+    free(ppn);
+
+    regdone = 0;
+    rc = PMIx_server_register_nspace(nspace, 1, jinfo, 1, reg_cbfunc, NULL);
+    PMIX_INFO_DESTRUCT(&jinfo[0]);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        return rc;
+    }
+    if (PMIX_SUCCESS == rc) {
+        wait_reg();
+    }
+
+    PMIX_LOAD_PROCID(&client, nspace, 0);
+    rc = PMIx_server_register_client(&client, geteuid(), getegid(), NULL, reg_cbfunc, NULL);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        return rc;
+    }
+    if (PMIX_SUCCESS == rc) {
+        wait_reg();
+    }
+    return PMIX_SUCCESS;
+}
+
+/* count the live (non-NULL) peer objects in the server's clients array */
+static int count_live_peers(void)
+{
+    int n, count = 0;
+    pmix_peer_t *peer;
+
+    for (n = 0; n < pmix_server_globals.clients.size; n++) {
+        peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients, n);
+        if (NULL != peer) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+static int run_tool_child(const char *mode, long ncycles)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    pmix_info_t tinfo[1];
+    bool pure = (0 == strcmp(mode, "pure"));
+    long i;
+
+    if (pure) {
+        /* a standalone tool: drop the client-identity vars so we come up
+         * with a server-assigned nspace/rank each cycle */
+        unsetenv("PMIX_NAMESPACE");
+        unsetenv("PMIX_RANK");
+    }
+
+    for (i = 0; i < ncycles; i++) {
+        if (pure) {
+            /* connect to the parent as the scheduler; PMIx_tool_init then
+             * skips its job-info request, so no job need be registered */
+            PMIX_INFO_LOAD(&tinfo[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
+            rc = PMIx_tool_init(&myproc, tinfo, 1);
+            PMIX_INFO_DESTRUCT(&tinfo[0]);
+        } else {
+            /* keep the PMIX_NAMESPACE/PMIX_RANK the parent seeded, so we
+             * connect as the registered tool-client identity and retrieve
+             * its job info */
+            rc = PMIx_tool_init(&myproc, NULL, 0);
+        }
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "%s child cycle %ld: PMIx_tool_init failed: %s\n", mode, i,
+                    PMIx_Error_string(rc));
+            return 1;
+        }
+        if (!PMIx_Initialized()) {
+            fprintf(stderr, "%s child cycle %ld: PMIx_Initialized() false after init\n", mode, i);
+            return 1;
+        }
+        rc = PMIx_tool_finalize();
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "%s child cycle %ld: PMIx_tool_finalize failed: %s\n", mode, i,
+                    PMIx_Error_string(rc));
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* fork+exec a fresh tool child in the given mode, wait for it, and confirm
+ * the server did not accumulate a peer per cycle. Returns 0 on success. */
+static int run_phase(const char *self, const char *mode, long ncycles, char **base_env)
+{
+    pmix_status_t rc;
+    pmix_proc_t proc;
+    char **child_env = NULL;
+    char **child_argv = NULL;
+    char cycles_str[32];
+    pid_t pid;
+    int n, wstatus, live, settled;
+    struct timespec ts;
+
+    /* each child needs the rendezvous env plus, for the client phase, the
+     * foobar:0 identity - both delivered through setup_fork on top of the
+     * base (build-tree component path) env */
+    for (n = 0; NULL != base_env[n]; n++) {
+        PMIx_Argv_append_nosize(&child_env, base_env[n]);
+    }
+    PMIX_LOAD_PROCID(&proc, "foobar", 0);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, &child_env))) {
+        fprintf(stderr, "PMIx_server_setup_fork failed: %s\n", PMIx_Error_string(rc));
+        PMIx_Argv_free(child_env);
+        return 1;
+    }
+
+    snprintf(cycles_str, sizeof(cycles_str), "%ld", ncycles);
+    PMIx_Argv_append_nosize(&child_argv, (char *) self);
+    PMIx_Argv_append_nosize(&child_argv, "--tool-child");
+    PMIx_Argv_append_nosize(&child_argv, (char *) mode);
+    PMIx_Argv_append_nosize(&child_argv, cycles_str);
+
+    pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "fork failed: %s\n", strerror(errno));
+        PMIx_Argv_free(child_env);
+        PMIx_Argv_free(child_argv);
+        return 1;
+    }
+    if (0 == pid) {
+        execve(self, child_argv, child_env);
+        fprintf(stderr, "execve failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    PMIx_Argv_free(child_env);
+    PMIx_Argv_free(child_argv);
+
+    if (pid != waitpid(pid, &wstatus, 0)) {
+        fprintf(stderr, "waitpid failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (!WIFEXITED(wstatus) || 0 != WEXITSTATUS(wstatus)) {
+        fprintf(stderr, "%s tool child exited abnormally (status %d)\n", mode, wstatus);
+        return 1;
+    }
+
+    /* let the progress thread process the child's final socket-close, then
+     * confirm the client array did not accumulate a peer per cycle */
+    ts.tv_sec = 0;
+    ts.tv_nsec = 200 * 1000 * 1000; /* 200ms */
+    nanosleep(&ts, NULL);
+    live = count_live_peers();
+    nanosleep(&ts, NULL);
+    settled = count_live_peers();
+
+    fprintf(stdout, "  %-6s phase: %ld cycles, live server peers = %d (settled %d)\n",
+            mode, ncycles, live, settled);
+
+    if (settled > PEER_LEAK_BOUND) {
+        fprintf(stdout,
+                "  %-6s phase: FAIL - %d live peers after %ld cycles (bound %d)\n",
+                mode, settled, ncycles, PEER_LEAK_BOUND);
+        return 1;
+    }
+    return 0;
+}
+
+static int run_server(char *self, long ncycles)
+{
+    pmix_status_t rc;
+    pmix_info_t info[2];
+    extern char **environ;
+
+    fprintf(stdout, "\n=== server-side tool init/finalize cycling test (%ld cycles) ===\n\n",
+            ncycles);
+
+    /* A minimal server that accepts tool connections and advertises itself
+     * as the scheduler (so the pure tool can init with no job registered
+     * for it). */
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 2))) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* register one job so the client-tool phase has job info to retrieve */
+    if (PMIX_SUCCESS != (rc = register_job("foobar"))) {
+        fprintf(stderr, "register_job failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    if (0 != run_phase(self, "pure", ncycles, environ) ||
+        0 != run_phase(self, "client", ncycles, environ)) {
+        PMIx_server_finalize();
+        fprintf(stdout, "\nserver-side tool init/finalize cycling: FAIL\n\n");
+        return 1;
+    }
+
+    PMIx_server_finalize();
+    fprintf(stdout, "\nserver-side tool init/finalize cycling: PASS\n\n");
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    long ncycles = DEFAULT_CYCLES;
+
+    if (3 < argc && 0 == strcmp(argv[1], "--tool-child")) {
+        ncycles = strtol(argv[3], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+        return run_tool_child(argv[2], ncycles);
+    }
+
+    if (1 < argc) {
+        ncycles = strtol(argv[1], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+    }
+    return run_server(argv[0], ncycles);
+}

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl
 
 EXTRA_DIST = run_gds_fallback.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status client_cycle
 
 compress_SOURCES =  \
         compress.c
@@ -73,5 +73,11 @@ collective_status_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 collective_status_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+client_cycle_SOURCES = \
+        client_cycle.c
+client_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client_cycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl pmix_log collective_status client_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl pmix_log collective_status client_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl pmix_log collective_status client_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c
@@ -79,5 +79,11 @@ client_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 client_cycle_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+tool_cycle_SOURCES = \
+        tool_cycle.c
+tool_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_cycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle

--- a/test/unit/client_cycle.c
+++ b/test/unit/client_cycle.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for client-side init/finalize cycling.
+ *
+ * A client must be able to cycle PMIx_Init -> (work) -> PMIx_Finalize and
+ * then PMIx_Init again, any number of times, with each new PMIx_Init
+ * presenting a clean slate. The client library tears itself all the way
+ * down on the final PMIx_Finalize, so a subsequent PMIx_Init is a fresh
+ * library instance; nothing from one cycle may leak into the next. See
+ * docs/how-things-work/init-finalize.rst.
+ *
+ * This exercises the teardown/reinit path directly. It runs as a
+ * singleton (no server), so it needs no launcher and is safe under
+ * "make check": PMIx_Fence and PMIx_Commit short-circuit to success in
+ * singleton mode, while PMIx_Init/PMIx_Finalize, the framework
+ * open/close, the thread-specific-data keys, the event base, and the
+ * per-cycle mode flags all run for real. A cross-cycle regression -
+ * a stale one-time-init latch, a dangling event base or progress
+ * tracker, a leaked TSD key slot, or a stale singleton flag - shows up
+ * here as a failed return code, a wrong PMIx_Initialized() state, or a
+ * crash on a later cycle rather than the first.
+ *
+ * The cycle count can be overridden with a single command-line argument;
+ * the default is chosen to stay quick while still cycling enough times to
+ * shake out per-cycle resource leaks.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_CYCLES 1200
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    pmix_value_t val;
+    pmix_info_t tinfo;
+    long ncycles = DEFAULT_CYCLES;
+    long i;
+    int nfail = 0;
+
+    if (1 < argc) {
+        ncycles = strtol(argv[1], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+    }
+
+    /* force the singleton path: with no namespace or server contact
+     * information in the environment there is nothing to connect to, so
+     * each PMIx_Init comes up self-contained */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    fprintf(stdout, "\n=== client init/finalize cycling test (%ld cycles) ===\n\n",
+            ncycles);
+
+    for (i = 0; i < ncycles; i++) {
+        /* PMIx_Initialized() must report false before we init */
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true before init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        /* PMIx_Init returns PMIX_ERR_UNREACH - not a failure - when it
+         * comes up as a singleton with no reachable server; the library
+         * is fully initialized in that case. Either result is fine here. */
+        rc = PMIx_Init(&myproc, NULL, 0);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Init failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (!PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() false after init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        /* do some work that populates per-cycle state which finalize must
+         * tear down: stage a value into the datastore and commit it */
+        val.type = PMIX_UINT32;
+        val.data.uint32 = (uint32_t) i;
+        rc = PMIx_Put(PMIX_GLOBAL, "cycle.key", &val);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Put failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+        rc = PMIx_Commit();
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Commit failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        /* the operation the user's scenario names explicitly */
+        rc = PMIx_Fence(&myproc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Fence failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        /* pass PMIX_EMBED_BARRIER so finalize exercises the embedded
+         * fence path as well */
+        PMIX_INFO_LOAD(&tinfo, PMIX_EMBED_BARRIER, NULL, PMIX_BOOL);
+        rc = PMIx_Finalize(&tinfo, 1);
+        PMIX_INFO_DESTRUCT(&tinfo);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_Finalize failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true after finalize\n", i);
+            nfail = 1;
+            break;
+        }
+    }
+
+    if (0 == nfail) {
+        fprintf(stdout, "Completed %ld init/finalize cycles: PASS\n\n", ncycles);
+    } else {
+        fprintf(stdout, "init/finalize cycling: FAIL\n\n");
+    }
+
+    return nfail;
+}

--- a/test/unit/run_simpcycle.pl.in
+++ b/test/unit/run_simpcycle.pl.in
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the server-side peer recycle. A single persistent server
+# (test/simple/simptest) forks one client (test/simple/simpcycle) that
+# loops PMIx_Init -> work (Get/Store/Fence) -> PMIx_Finalize many times,
+# reusing the same namespace and rank every cycle. Each finalize drops the
+# client's socket; the server must recycle the departed peer object in
+# place so the next Init reuses it rather than leaking a fresh peer and
+# drifting the nspace's nfinalized/proc_cnt bookkeeping. A regression in
+# that path (use-after-free, double free, hang, or a failed reconnect)
+# makes either the client or the server exit non-zero, or wedges the run
+# until the timeout fires. See docs/how-things-work/init-finalize.rst.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its client from the current directory using a relative
+# path ("./simpcycle"), so run from the directory that holds both binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-e", "./simpcycle");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: any crash or non-completion in the recycle path
+# (or a client that could not reconnect) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually cycled rather than passing vacuously: the client
+# only prints this line after it has completed every init/finalize cycle,
+# and simptest only prints its own line after the client has gone.
+my $client_cycled = ($output =~ /completed \d+ init\/finalize cycles OK/);
+my $server_done   = ($output =~ /Test finished OK!/);
+if (!$client_cycled) {
+    print "FAIL: client did not complete its init/finalize cycles\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the client cycled\n";
+    exit(1);
+}
+print "PASS: client recycled through the server across all cycles\n";
+exit(0);

--- a/test/unit/run_toolcycle.pl.in
+++ b/test/unit/run_toolcycle.pl.in
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the SERVER side of a tool that cycles PMIx_tool_init ->
+# PMIx_tool_finalize against a persistent server. simptoolcycle forks into
+# a minimal server (parent) and a tool child that re-execs itself and loops
+# init/finalize while reusing one identity. After the child exits, the
+# parent counts the peers left in its clients array: a correct server
+# retires each finalized tool peer, so the count stays small and bounded no
+# matter how many cycles ran. A per-cycle leak (a never-reclaimed finalized
+# "tombstone" peer), a use-after-free, a failed reconnect, or a hang makes
+# the run exit non-zero or wedge until the timeout fires. See
+# docs/how-things-work/init-finalize.rst.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+# simptoolcycle re-execs itself as the tool child and seeds that child's
+# environment from its own, so this search path reaches the child too.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptoolcycle re-execs itself by argv[0], so run from its directory.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptoolcycle");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run in a child we control, merging stderr into stdout, and slurp it.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptoolcycle: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptoolcycle exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The harness must exit 0: a crash, a failed tool re-init, or a per-cycle
+# peer leak (client count over the bound) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptoolcycle did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm both phases actually cycled and the server judged itself clean, so
+# a vacuous pass (e.g. a child never connected) cannot slip through.
+my $pure_ran   = ($output =~ /pure\s+phase: \d+ cycles/);
+my $client_ran = ($output =~ /client phase: \d+ cycles/);
+my $passed     = ($output =~ /server-side tool init\/finalize cycling: PASS/);
+if (!$pure_ran || !$client_ran) {
+    print "FAIL: a tool phase did not complete its init/finalize cycles\n";
+    exit(1);
+}
+if (!$passed) {
+    print "FAIL: server reported a peer leak or did not finish cleanly\n";
+    exit(1);
+}
+print "PASS: tool recycled through the server across all cycles\n";
+exit(0);

--- a/test/unit/tool_cycle.c
+++ b/test/unit/tool_cycle.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for tool-side init/finalize cycling.
+ *
+ * A tool must be able to cycle PMIx_tool_init -> (work) ->
+ * PMIx_tool_finalize and then PMIx_tool_init again, any number of times,
+ * with each new init presenting a clean slate. The tool library tears
+ * itself all the way down on the final PMIx_tool_finalize, so a
+ * subsequent PMIx_tool_init is a fresh library instance; nothing from one
+ * cycle may leak into the next. See docs/how-things-work/init-finalize.rst.
+ *
+ * The tool is initialized with PMIX_TOOL_DO_NOT_CONNECT so it comes up
+ * self-contained, with no server to reach - which makes the test safe
+ * under "make check" (no launcher or rendezvous is needed) while still
+ * running the whole tool-library teardown/reinit path for real: the
+ * one-time-init latch and reference counter, the framework open/close,
+ * the thread-specific-data keys, the event base and progress thread, and
+ * the server_globals bookkeeping the tool always constructs. A
+ * cross-cycle regression - a stale one-time-init latch (PMIX_ERR_INIT on
+ * the second init), a leaked TSD key slot, a dangling event base, or a
+ * destructed-but-not-reconstructed list/array - shows up here as a failed
+ * return code, a wrong PMIx_Initialized() state, or a crash on a later
+ * cycle rather than the first.
+ *
+ * The cycle count can be overridden with a single command-line argument;
+ * the default is chosen to cycle past the per-process pthread-key limit
+ * (macOS ~512, Linux ~1024) so a leaked TSD key slot is caught, while
+ * still finishing quickly.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_tool.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_CYCLES 1200
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    pmix_info_t tinfo;
+    long ncycles = DEFAULT_CYCLES;
+    long i;
+    int nfail = 0;
+
+    if (1 < argc) {
+        ncycles = strtol(argv[1], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+    }
+
+    /* make sure nothing in the environment points us at a server: with
+     * PMIX_TOOL_DO_NOT_CONNECT set below we will not try to connect, but
+     * clearing these keeps the run hermetic regardless of the caller's
+     * environment */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    fprintf(stdout, "\n=== tool init/finalize cycling test (%ld cycles) ===\n\n",
+            ncycles);
+
+    for (i = 0; i < ncycles; i++) {
+        /* PMIx_Initialized() must report false before we init */
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true before init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+        rc = PMIx_tool_init(&myproc, &tinfo, 1);
+        PMIX_INFO_DESTRUCT(&tinfo);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_tool_init failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (!PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() false after init\n", i);
+            nfail = 1;
+            break;
+        }
+
+        rc = PMIx_tool_finalize();
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "cycle %ld: PMIx_tool_finalize failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+
+        if (PMIx_Initialized()) {
+            fprintf(stderr, "cycle %ld: PMIx_Initialized() true after finalize\n", i);
+            nfail = 1;
+            break;
+        }
+    }
+
+    if (0 == nfail) {
+        fprintf(stdout, "Completed %ld tool init/finalize cycles: PASS\n\n", ncycles);
+    } else {
+        fprintf(stdout, "tool init/finalize cycling: FAIL\n\n");
+    }
+
+    return nfail;
+}


### PR DESCRIPTION
## Overview

Make the PMIx init/finalize cycle leak-free across **all three roles**. A process must be able to cycle init → work → finalize → init repeatedly — reusing the same namespace/rank — with each new init presenting a clean slate, on the client, the server, and the tool. This is a single self-contained PR covering the whole effort.

The intended lifecycle is captured in a new spec, `docs/how-things-work/init-finalize.rst`, added and extended by the commits below.

Closes #3931

## 1. Client half

A client `PMIx_Finalize` must tear the library all the way down so the next `PMIx_Init` in the same process is a brand-new instance. Fixes a set of cross-cycle residue defects found by cycling a singleton client past the per-process pthread-key limit (it crashed around cycle ~505 on the leaked key slot, and earlier on a stale singleton flag).

- **`docs: specify the client init/finalize state lifecycle`** — the cycling guarantee, the three server teardown triggers, and the state-ownership table.
- **`docs: specify client-side init/finalize teardown`** — the symmetry requirements a clean finalize must uphold.
- **`client: reset the singleton flag on every fresh PMIx_Init`** — a stale singleton flag carried from a no-server cycle into a with-server cycle drove finalize to tear down lists the with-server path never built.
- **`runtime: leave no residue or dangling state after finalize`** — the root-cause fixes: call `pmix_thread_set_main()` so the TSD registry is live (else every cycle leaked a pthread key to exhaustion); delete TSD keys and NULL the registry on teardown; reset the name-fns latch; NULL the event base and the shared progress-thread tracker.
- **`client: tear down singleton IOF lists based on actual construction`** — a singleton's IOF lists must be destructed according to what the singleton path actually built, not a fixed assumption, so a cycle cannot double-destruct or leak them.
- **`examples/dynamic: tolerate a singleton PMIx_Init`** — the dynamic example no longer assumes it was launched with a server, so it runs cleanly as a singleton.
- **`test: add an init/finalize cycling regression test`** — `test/unit/client_cycle`, a singleton cycler wired into `make check`, default count past the key limit.

## 2. Server half

When a client and all its clones finalize, the server must reclaim per-client state rather than leaking the peer until the namespace is deregistered. Fixes orphaned peers accumulating in the `clients` array and `nfinalized` drift that broke the "all local processes finalized" condition.

The retirement mechanism converged over the course of the branch — recycle-in-place, then release, then finally the **tombstone** model, which is what ships here. The intermediate commits are retained so the reasoning is bisectable; the net design is the tombstone.

- **`server: recycle a client peer object on clean finalize`** — first cut: new `pmix_server_peer_finalized()` that recycled the peer in place. *(Superseded below.)*
- **`server: release a finalized peer instead of recycling in place`** — recycling a still-reachable `pmix_peer_t` proved fragile; switched to releasing and reallocating a fresh peer on reconnect. *(Superseded below.)*
- **`server: leave a finalized peer as a tombstone instead of releasing it`** — the shipping design. Both prior forms mutated shared per-namespace/per-rank state (nulled the `clients` slot, cleared/repointed `info->peerid`) from `lost_connection` the instant a cleanly-finalized socket dropped — racing a *different* local process's in-flight spawn/connect/disconnect collective or direct-modex get that resolves ranks through `info->peerid`, an architecture- and timing-sensitive hang of multi-local-process `MPI_Comm_spawn`. A finalized **client** peer is now left in place as an inert, `finalized`-guarded **tombstone** (kept at its slot, `peerid` unchanged), reclaimed at a quiescent point instead: on the rank's next reconnect, or at namespace deregistration. A stranded peer a newer connection already displaced is still freed immediately.
- **`server: free finalized tool peers instead of leaving them stranded`** — the tombstone protects *clients*; `lost_connection` previously retired only pure clients, so finalized **tool** peers leaked (a tool is assigned a fresh namespace each init, so it never reconnects onto the same rank to be reclaimed). A tool is not a job member and is never resolved through `info->peerid`, so it needs no tombstone: `lost_connection` now routes a finalized pure tool to `pmix_server_peer_finalized`, which frees it outright and repoints `peerid` (to a live tool sibling, else `-1`, restoring the state `process_tool_request` uses to recognize a reconnecting tool). A tool the host registered as a client keeps client tombstone semantics and is reclaimed on its tool reconnect via `process_tool_request` (the same reclaim the client connection handler does).
- **`server: fire the "all local processes finalized" callback once per nspace`** — because a tombstone stays counted in `nfinalized` until reclaimed, `nlocalprocs == nfinalized` is already satisfied when the host deregisters the namespace and holds for every rank the teardown walks — firing `pmix_pnet.local_app_finalized` once per rank instead of once for the job. A `local_app_fini_fired` latch on the namespace fires it exactly once. (Single-rank cycling hid this, since "once per rank" and "once" coincide when `nlocalprocs == 1`.)
- **`docs: describe the server-side peer recycle mechanics`** — the peer states and the `proc_cnt`/`nfinalized` invariants (rewritten by the tombstone doc updates below).
- **`test: exercise the server-side peer recycle in make check`** — a persistent `simptest` server forks a `simpcycle` client that loops init → Get/Store/Fence → finalize many times; driven by `run_simpcycle.pl`.

## 3. Tool half

`PMIx_tool_init`/`PMIx_tool_finalize` are a separate entry-point pair from the client's and must satisfy the same symmetry independently. A bare tool init/finalize loop **failed at cycle 1** with `PMIX_ERR_INIT`.

- **`tool: tear the library fully down on PMIx_tool_finalize`** — reset the one-time-init latch + reference-count the finalize (the fix that unbreaks cycling); destruct the `server_globals` lists the tool constructs on every init (`nspaces`, `iof_residuals`, `psets`, `grp_collectives`); free + NULL `tmpdir`/`system_tmpdir` (they leaked and silently pinned the prior cycle's tmpdir); destruct the client-side `peers` array and IOF sinks; drop a duplicate pnet close. (`module_set`, owned by the separate `PMIx_tool_set_server_module` call, is left as a documented follow-up.)
- **`docs: describe tool-side init/finalize teardown`** — a "Tool-Side Teardown" section.
- **`test: add a tool init/finalize cycling test to make check`** — `test/unit/tool_cycle`, the tool analog of `client_cycle`, exercising the tool *library* teardown standalone via `PMIX_TOOL_DO_NOT_CONNECT`.
- **`test: add a server-side tool init/finalize cycling test to make check`** — `test/simple/simptoolcycle` (driven by `run_toolcycle.pl`) covers what `tool_cycle` cannot: the *server's* retirement of a tool peer across cycles. It forks a minimal server that is both the scheduler and the owner of one registered job, then runs two phases, each a fresh re-exec'd child looping init/finalize — a **pure** tool (fresh namespace each cycle; connects as the scheduler so `tool_init` skips its job-info request) and a **client-registered** tool (reuses one namespace/rank). After each phase the parent asserts its `clients` array did not accumulate a peer per cycle.
- **`docs: describe tool finalize and once-per-nspace app-finalized firing`** — updates the lifecycle spec for the pure-tool free path (routed via `lost_connection`) and the once-per-nspace `local_app_finalized` firing.

## Testing

- Zero-warning `--enable-devel-check` build; `make check` fully green across all suites (12/12 in `test/unit`).
- Regression tests in `make check`: `client_cycle`, `run_simpcycle.pl` (server client cycling), `tool_cycle` (tool library), `run_toolcycle.pl` (server-side tool cycling, pure + client-registered).
- Each server-side leak reproduces without its fix and is closed by it: client cycling (25 cycles, server exits 0), pure-tool cycling (was +1 peer/cycle → 0 leak at 50 cycles), client-tool cycling (was +1 peer/cycle → bounded), and `local_app_finalized` firing once per nspace (was once per rank).
- Client singleton: 1200+ cycles. Tool standalone: 1500 cycles.
- `test/simple/simptest` smoke test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
