### PR TITLE
Implement PMIx_Group_leave end-to-end

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -42,9 +42,11 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # the group example programs that exercise the construction methods; built as
 # standalone clients against the installed PMIx and launched by prterun/prun.
 # group_die and connect_die (a participant leaves before contributing) drive
-# the lost-connection accounting and are exercised separately by run-tests.sh.
+# the lost-connection accounting, and group_leave (a member voluntarily departs
+# a live group) drives the group-leave notification path; all three are
+# exercised separately by run-tests.sh.
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die"
+BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave"
 
 mode="${1:-linux}"
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -185,6 +185,34 @@ test_linux() {
         skp "connect_die not built"
     fi
     cleanup_swarm
+
+    banner "voluntary group leave (PMIX_GROUP_LEFT notification)"
+    cleanup_swarm
+    # group_leave: every rank builds a group, then the last rank calls
+    # PMIx_Group_leave. That must generate a PMIX_GROUP_LEFT event to the
+    # remaining members (across nodes, via the broadcast notification path) and
+    # return success once locally generated. Each surviving member has a handler
+    # registered for PMIX_GROUP_LEFT and reports PASS on receipt; the departing
+    # rank reports SUCCESS. Whole-job membership + --map-by node ensures the
+    # departing rank's node also hosts a survivor, exercising both local and
+    # remote delivery. The victim leaves and finalizes cleanly, so no
+    # --rtos recoverable is needed.
+    if RUN 'test -x /opt/prte/tests/group_leave'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_leave 2>&1')"
+        n=$(echo "$OUT" | grep -c 'correctly received: PASS')
+        if echo "$OUT" | grep -qiE 'timeout|timed out|DVM timeout'; then
+            bad "group_leave HUNG (notification never delivered)"
+        elif echo "$OUT" | grep -qiE 'FAILED'; then
+            bad "group_leave: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$n" -ge 3 ] && echo "$OUT" | grep -q 'Group_leave complete: SUCCESS'; then
+            ok "all 3 survivors notified of the voluntary departure"
+        else
+            bad "group_leave: only $n survivors notified: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_leave not built"
+    fi
+    cleanup_swarm
 }
 
 ########################################################################

--- a/docs/how-things-work/collectives/tracking_spec.rst
+++ b/docs/how-things-work/collectives/tracking_spec.rst
@@ -330,6 +330,21 @@ subject to the same vulnerability. They must adopt the identity-based
 model and must be traversed by the lost-connection handler, which today
 walks only the ``collectives`` list.
 
+**A voluntary group leave is the deliberate cousin of a loss.** When a
+member calls ``PMIx_Group_leave`` it will never contribute to an
+in-flight construct/destruct of that group, exactly as a lost member
+never will — the only difference is that the departure is intentional and
+scoped to one named group rather than triggered by a dropped socket. The
+group family therefore accounts a voluntary leave through the *same*
+``departed`` machinery as a loss: the per-block routine
+(``account_departed``) is reached from two entry points —
+``pmix_server_grp_peer_lost`` (walks every block for a dropped peer) and
+``pmix_server_grp_member_left`` (walks only the blocks for the named
+group, invoked when the server intercepts the ``PMIX_GROUP_LEFT`` event
+the leaving client generates). Case A / Case B and the completion
+predicate are identical; a leave that completes a block's local phase
+forwards it to the host on the survivors just as a loss does.
+
 Invariants
 ----------
 

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,15 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - PMIx_Group_leave / PMIx_Group_leave_nb are now implemented. Previously
+   the client sent a command the server never handled, so the call
+   returned PMIX_ERR_NOT_SUPPORTED and the documented PMIX_GROUP_LEFT
+   event was never generated. A voluntary leave now generates a
+   PMIX_GROUP_LEFT event notifying the remaining members of the caller's
+   departure (returning success once the event is locally generated, per
+   the API contract), updates group membership on the members and in the
+   host environment, and completes any in-flight group construct/destruct
+   collective on the survivors rather than hanging
  - Resolve a status-code value collision: PMIX_ERR_LOST_PRECISION and
    PMIX_ERR_CHANGE_SIGN shared the values -400 and -401 with the
    PMIX_ERR_PROC_KILLED_BY_CMD and PMIX_ERR_PROC_FAILED_TO_START event

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
-                  simple simple_server abort group_die connect_die
+                  simple simple_server abort group_die connect_die group_leave
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -104,6 +104,10 @@ group_die_LDADD = $(top_builddir)/src/libpmix.la
 connect_die_SOURCES = connect_die.c examples.h
 connect_die_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 connect_die_LDADD = $(top_builddir)/src/libpmix.la
+
+group_leave_SOURCES = group_leave.c examples.h
+group_leave_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_leave_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -213,6 +217,7 @@ distclean-local:
         hello jctrl launcher log pub pubi server tool \
         abi_no_init abi_with_init group_lcl_cid pset \
         async_group group_dmodex group_bootstrap client3 \
+        group_leave \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort

--- a/examples/group_leave.c
+++ b/examples/group_leave.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise a member voluntarily leaving a live group (PMIx_Group_leave).
+ *
+ * Every rank in the job is a group member.  All ranks construct the group,
+ * then sync with a fence.  One rank (the last) then calls PMIx_Group_leave;
+ * per the API contract that generates a PMIX_GROUP_LEFT event notifying the
+ * remaining members of its departure, and returns success once the event has
+ * been locally generated (not indicative of remote receipt).  Every surviving
+ * member has registered a handler for PMIX_GROUP_LEFT and must receive that
+ * notification - if it does not, this test fails (rather than hangs) via a
+ * bounded wait.
+ *
+ * The whole job is the membership (rather than a subset) so that, when launched
+ * across nodes, the departing rank's node always also hosts a surviving member,
+ * exercising both the local and remote notification-delivery paths.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+static volatile bool left_seen = false;
+static pmix_proc_t departed;
+
+/* handler for the PMIX_GROUP_LEFT event - records that we were notified and
+ * who departed */
+static void left_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                         const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                         pmix_info_t results[], size_t nresults,
+                         pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                results, nresults);
+
+    PMIX_PROC_CONSTRUCT(&departed);
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&departed, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    fprintf(stderr, "%s:%d NOTIFIED that %s:%d left the group\n",
+            myproc.nspace, myproc.rank, departed.nspace, departed.rank);
+    left_seen = true;
+
+    /* we must always continue the event chain */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t *results;
+    size_t nresults;
+    mylock_t lock;
+    pmix_status_t code = PMIX_GROUP_LEFT;
+    int waited;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 2 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* register our handler for the group-left event */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, left_handler, errhandler_reg_callbk,
+                                (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%d: failed to register handler: %s\n", myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* sync everyone up first */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* the entire job is the group membership; the last rank is the one that
+     * will voluntarily leave */
+    victim = nprocs - 1;
+
+    fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    results = NULL;
+    nresults = 0;
+    rc = PMIx_Group_construct("lgroup", procs, nprocs, NULL, 0, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* sync so everyone has completed construction before anyone leaves */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: post-construct PMIx_Fence failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (myproc.rank == victim) {
+        /* voluntarily depart the group - this must generate the PMIX_GROUP_LEFT
+         * event to the remaining members and return success once locally
+         * generated */
+        fprintf(stderr, "%d executing Group_leave\n", myproc.rank);
+        rc = PMIx_Group_leave("lgroup", NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_leave FAILED: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "%d Group_leave complete: SUCCESS\n", myproc.rank);
+    } else {
+        /* a surviving member - wait (bounded) to be notified of the departure */
+        for (waited = 0; !left_seen && waited < 100; waited++) {
+            usleep(100000); /* 0.1s; up to 10s total */
+        }
+        if (!left_seen) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - never received PMIX_GROUP_LEFT\n",
+                    myproc.nspace, myproc.rank);
+            rc = PMIX_ERR_TIMEOUT;
+            goto done;
+        }
+        if (departed.rank != victim) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - wrong departed rank %d (expected %d)\n",
+                    myproc.nspace, myproc.rank, departed.rank, victim);
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIX_GROUP_LEFT correctly received: PASS\n", myproc.rank);
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1078,14 +1078,29 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
     return rc;
 }
 
+/* callback fired once the PMIX_GROUP_LEFT event has been locally
+ * generated - per the API contract, that is when the leave operation
+ * is considered complete (it is not indicative of remote receipt) */
+static void leave_cbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+
+    if (NULL != cb->opcbfunc) {
+        cb->opcbfunc(status, cb->cbdata);
+    }
+    PMIX_RELEASE(cb);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
                                               const pmix_info_t info[], size_t ninfo,
                                               pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_buffer_t *msg = NULL;
-    pmix_cmd_t cmd = PMIX_GROUP_LEAVE_CMD;
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
+    pmix_group_t *grpobj, *pgrp;
+    pmix_proc_t *range = NULL;
+    pmix_data_array_t darray;
+    size_t n, m, nrange;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_leave_nb called");
@@ -1094,7 +1109,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
+    /* if we aren't connected, then we cannot notify */
     if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
     }
@@ -1108,54 +1123,83 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         return PMIX_ERR_BAD_PARAM;
     }
 
-    msg = PMIX_NEW(pmix_buffer_t);
-    /* pack the cmd */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto done;
-    }
-
-    /* pack the group ID */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &grp, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto done;
-    }
-
-    /* pack the info structs */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(msg);
-        goto done;
-    }
-    if (0 < ninfo) {
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            goto done;
+    /* find this group in our local list - we can only leave a group
+     * we belong to, and we need its membership to know who to notify */
+    grpobj = NULL;
+    PMIX_LIST_FOREACH(pgrp, &pmix_client_globals.groups, pmix_group_t) {
+        if (0 == strcmp(grp, pgrp->grpid)) {
+            grpobj = pgrp;
+            break;
         }
     }
+    if (NULL == grpobj) {
+        return PMIX_ERR_NOT_FOUND;
+    }
 
-    /* create a callback object as we need to pass it to the
-     * recv routine so we know which callback to use when
-     * the return message is recvd */
     cb = PMIX_NEW(pmix_group_tracker_t);
     cb->opcbfunc = cbfunc;
     cb->cbdata = cbdata;
 
-    /* push the message into our event base to send to the server */
-    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, destruct_cbfunc, (void *) cb);
+    /* Per the API contract, leaving generates a PMIX_GROUP_LEFT event
+     * that notifies all members of the group of our departure. Build the
+     * event's info array: a custom range limited to the other members,
+     * the identity of the departing proc, the group ID, and any
+     * directives the caller provided. */
+    cb->ninfo = 3 + ninfo;
+    PMIX_INFO_CREATE(cb->info, cb->ninfo);
+    if (NULL == cb->info) {
+        PMIX_RELEASE(cb);
+        return PMIX_ERR_NOMEM;
+    }
+
+    /* the custom range is the membership, excluding ourselves */
+    PMIX_PROC_CREATE(range, grpobj->nmbrs);
+    if (NULL == range) {
+        PMIX_RELEASE(cb);
+        return PMIX_ERR_NOMEM;
+    }
+    nrange = 0;
+    for (m = 0; m < grpobj->nmbrs; m++) {
+        if (PMIX_CHECK_PROCID(&grpobj->members[m], &pmix_globals.myid)) {
+            continue;
+        }
+        PMIX_XFER_PROCID(&range[nrange], &grpobj->members[m]);
+        ++nrange;
+    }
+
+    n = 0;
+    darray.type = PMIX_PROC;
+    darray.array = range;
+    darray.size = nrange;
+    /* PMIX_INFO_LOAD deep-copies the array into the info */
+    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+    ++n;
+    /* identify the departing process */
+    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_AFFECTED_PROC, &pmix_globals.myid, PMIX_PROC);
+    ++n;
+    /* identify the group being left */
+    PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_ID, grp, PMIX_STRING);
+    ++n;
+    /* carry along any caller-provided directives */
+    for (m = 0; m < ninfo; m++) {
+        PMIX_INFO_XFER(&cb->info[n], &info[m]);
+        ++n;
+    }
+    PMIX_PROC_FREE(range, grpobj->nmbrs);
+
+    /* we are no longer a member - drop the group from our local list */
+    pmix_list_remove_item(&pmix_client_globals.groups, &grpobj->super);
+    PMIX_RELEASE(grpobj);
+
+    /* generate the event - the callback fires once it has been locally
+     * generated, which is when the operation is complete */
+    rc = PMIx_Notify_event(PMIX_GROUP_LEFT, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
+                           cb->info, cb->ninfo, leave_cbfunc, (void *) cb);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(cb);
     }
 
-done:
-    if (PMIX_SUCCESS != rc && NULL != msg) {
-        PMIX_RELEASE(msg);
-    }
     return rc;
 }
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -738,7 +738,8 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     bool found;
     pmix_group_t *grp, *gp;
     pmix_proc_t *members = NULL;
-    size_t n, nmembers = 0;
+    pmix_proc_t *affected = NULL;
+    size_t n, m, k, nmembers = 0;
     char *grpid = NULL;
     size_t ctxid = SIZE_MAX;
 
@@ -817,6 +818,38 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
                 grp->grpid = strdup(grpid);
                 grp->ctxid = ctxid;
                 pmix_list_append(&pmix_client_globals.groups, &grp->super);
+            }
+        }
+    }
+
+    /* if this is the "group_left" event, then a member has voluntarily
+     * departed the group - update our local membership to drop it */
+    if (PMIX_GROUP_LEFT == chain->status) {
+        // find the group ID and the departing proc
+        for (n = 0; n < chain->ninfo; n++) {
+            if (PMIX_CHECK_KEY(&chain->info[n], PMIX_GROUP_ID)) {
+                grpid = chain->info[n].value.data.string;
+
+            } else if (PMIX_CHECK_KEY(&chain->info[n], PMIX_EVENT_AFFECTED_PROC)) {
+                affected = chain->info[n].value.data.proc;
+            }
+        }
+        if (NULL != grpid && NULL != affected) {
+            PMIX_LIST_FOREACH(gp, &pmix_client_globals.groups, pmix_group_t) {
+                if (0 != strcmp(grpid, gp->grpid)) {
+                    continue;
+                }
+                // remove the departed proc from this group's membership
+                for (m = 0; m < gp->nmbrs; m++) {
+                    if (PMIX_CHECK_PROCID(&gp->members[m], affected)) {
+                        for (k = m + 1; k < gp->nmbrs; k++) {
+                            PMIX_XFER_PROCID(&gp->members[k - 1], &gp->members[k]);
+                        }
+                        --gp->nmbrs;
+                        break;
+                    }
+                }
+                break;
             }
         }
     }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -1019,18 +1019,19 @@ error:
     return rc;
 }
 
-/* Account for a lost peer across all in-flight group construct/destruct blocks.
- * This is the group-family analog of the fence/connect/disconnect accounting in
- * lost_connection(), expressed in the group's two-level structure, and is
- * called from that same handler. Participation is tracked by identity: if the
- * departing peer's rank has already contributed (a member tracker holds a caddy
- * with its name) its contribution stands and the loss is ignored (Case A);
- * otherwise the rank is recorded as departed so the construct can complete on
- * the surviving participants instead of hanging (Case B). See
+/* Account for a single departed participant in one in-flight group block, where
+ * "departed" means the named rank will never contribute to this block - either
+ * because its connection was lost (pmix_server_grp_peer_lost) or because it
+ * voluntarily left the group (pmix_server_grp_member_left). Participation is
+ * tracked by identity: if the rank has already contributed (a member tracker
+ * holds a caddy with its name) its contribution stands and the departure is
+ * ignored (Case A); otherwise the rank is recorded as departed so the block can
+ * complete on the surviving participants instead of hanging (Case B), and if
+ * that completes the local phase the block is forwarded to the host. The block
+ * may be released (on error) - callers must iterate with FOREACH_SAFE. See
  * docs/how-things-work/collectives. */
-void pmix_server_grp_peer_lost(pmix_peer_t *peer)
+static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
 {
-    grp_block_t *blk, *bnext;
     grp_trk_t *trk;
     pmix_server_caddy_t *scd;
     pmix_proclist_t *dp;
@@ -1038,80 +1039,113 @@ void pmix_server_grp_peer_lost(pmix_peer_t *peer)
     bool ismbr, contributed, known;
     size_t n;
 
+    /* bootstrap/follower blocks are passed up per-call and never wait on a
+     * local count (nlocal == 0), so nothing here can hang; and a block that
+     * has already been forwarded to the host has a frozen local phase.
+     * Skip both. */
+    if (0 == blk->nlocal || blk->host_called) {
+        return;
+    }
+    /* is this proc an expected member of this group, and has its rank
+     * already contributed? */
+    ismbr = false;
+    contributed = false;
+    PMIX_LIST_FOREACH (trk, &blk->mbrs, grp_trk_t) {
+        for (n = 0; n < trk->npcs; n++) {
+            if (PMIX_CHECK_NAMES(&trk->pcs[n], proc)) {
+                ismbr = true;
+                break;
+            }
+        }
+        PMIX_LIST_FOREACH (scd, &trk->local_cbs, pmix_server_caddy_t) {
+            if (PMIX_CHECK_NAMES(&scd->peer->info->pname, proc)) {
+                contributed = true;
+                break;
+            }
+        }
+        if (contributed) {
+            break;
+        }
+    }
+    if (!ismbr || contributed) {
+        /* not a participant, or Case A (already contributed - its
+         * contribution and data stand, so ignore the departure) */
+        return;
+    }
+    /* Case B: the rank had not yet contributed and never will. Record it as
+     * departed (once) so the block can complete on the survivors. */
+    known = false;
+    PMIX_LIST_FOREACH (dp, &blk->departed, pmix_proclist_t) {
+        if (PMIX_CHECK_NAMES(&dp->proc, proc)) {
+            known = true;
+            break;
+        }
+    }
+    if (!known) {
+        dp = PMIX_NEW(pmix_proclist_t);
+        PMIX_LOAD_PROCID(&dp->proc, proc->nspace, proc->rank);
+        pmix_list_append(&blk->departed, &dp->super);
+    }
+    /* did that complete the local phase? if so we must forward to the host
+     * now - no further participant call will arrive to do it for us. All
+     * non-bootstrap members carry the same membership, so use the first. */
+    if (grp_blk_locally_complete(blk)) {
+        trk = (grp_trk_t *) pmix_list_get_first(&blk->mbrs);
+        rc = aggregate_info(blk);
+        if (PMIX_SUCCESS != rc) {
+            pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
+            PMIX_RELEASE(blk);
+            return;
+        }
+        /* a member departed before contributing (that is why we are here):
+         * record the degraded status in the block's info so the host sees
+         * it, matching the fence/connect/disconnect families */
+        pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                          PMIX_ERR_LOST_CONNECTION);
+        blk->host_called = true;
+        rc = pmix_host_server.group(blk->grpop, blk->id, trk->pcs, trk->npcs,
+                                    blk->info, blk->ninfo, grpcbfunc, blk);
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* the host will not call back - drive completion ourselves */
+            grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
+        } else if (PMIX_SUCCESS != rc) {
+            pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
+            PMIX_RELEASE(blk);
+        }
+    }
+}
+
+/* Account for a lost peer across all in-flight group construct/destruct blocks.
+ * This is the group-family analog of the fence/connect/disconnect accounting in
+ * lost_connection(), expressed in the group's two-level structure, and is
+ * called from that same handler. See account_departed(). */
+void pmix_server_grp_peer_lost(pmix_peer_t *peer)
+{
+    grp_block_t *blk, *bnext;
+    pmix_proc_t proc;
+
+    /* the peer's identity is carried as a pmix_name_t; account_departed works
+     * in terms of pmix_proc_t (as the group membership arrays do), so convert */
+    PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
     PMIX_LIST_FOREACH_SAFE (blk, bnext, &pmix_server_globals.grp_collectives, grp_block_t) {
-        /* bootstrap/follower blocks are passed up per-call and never wait on a
-         * local count (nlocal == 0), so nothing here can hang; and a block that
-         * has already been forwarded to the host has a frozen local phase.
-         * Skip both. */
-        if (0 == blk->nlocal || blk->host_called) {
+        account_departed(blk, &proc);
+    }
+}
+
+/* Account for a member voluntarily leaving a group (via PMIx_Group_leave, which
+ * generates a PMIX_GROUP_LEFT event that the server intercepts). A voluntary
+ * leave is the deliberate cousin of a lost participant: any in-flight
+ * construct/destruct block for that group that was still waiting on the departed
+ * member must complete on the survivors rather than hang. Unlike a lost
+ * connection, this is scoped to the one named group. See account_departed(). */
+void pmix_server_grp_member_left(const char *grpid, const pmix_proc_t *proc)
+{
+    grp_block_t *blk, *bnext;
+
+    PMIX_LIST_FOREACH_SAFE (blk, bnext, &pmix_server_globals.grp_collectives, grp_block_t) {
+        if (0 != strcmp(grpid, blk->id)) {
             continue;
         }
-        /* is this peer an expected member of this group, and has its rank
-         * already contributed? */
-        ismbr = false;
-        contributed = false;
-        PMIX_LIST_FOREACH (trk, &blk->mbrs, grp_trk_t) {
-            for (n = 0; n < trk->npcs; n++) {
-                if (PMIX_CHECK_NAMES(&trk->pcs[n], &peer->info->pname)) {
-                    ismbr = true;
-                    break;
-                }
-            }
-            PMIX_LIST_FOREACH (scd, &trk->local_cbs, pmix_server_caddy_t) {
-                if (PMIX_CHECK_NAMES(&scd->peer->info->pname, &peer->info->pname)) {
-                    contributed = true;
-                    break;
-                }
-            }
-            if (contributed) {
-                break;
-            }
-        }
-        if (!ismbr || contributed) {
-            /* not a participant, or Case A (already contributed - its
-             * contribution and data stand, so ignore the loss) */
-            continue;
-        }
-        /* Case B: the rank had not yet contributed and never will. Record it as
-         * departed (once) so the construct can complete on the survivors. */
-        known = false;
-        PMIX_LIST_FOREACH (dp, &blk->departed, pmix_proclist_t) {
-            if (PMIX_CHECK_NAMES(&dp->proc, &peer->info->pname)) {
-                known = true;
-                break;
-            }
-        }
-        if (!known) {
-            dp = PMIX_NEW(pmix_proclist_t);
-            PMIX_LOAD_PROCID(&dp->proc, peer->info->pname.nspace, peer->info->pname.rank);
-            pmix_list_append(&blk->departed, &dp->super);
-        }
-        /* did that complete the local phase? if so we must forward to the host
-         * now - no further participant call will arrive to do it for us. All
-         * non-bootstrap members carry the same membership, so use the first. */
-        if (grp_blk_locally_complete(blk)) {
-            trk = (grp_trk_t *) pmix_list_get_first(&blk->mbrs);
-            rc = aggregate_info(blk);
-            if (PMIX_SUCCESS != rc) {
-                pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-                PMIX_RELEASE(blk);
-                continue;
-            }
-            /* a member was lost before contributing (that is why we are here):
-             * record the degraded status in the block's info so the host sees
-             * it, matching the fence/connect/disconnect families */
-            pmix_server_set_collective_status(blk->info, blk->ninfo,
-                                              PMIX_ERR_LOST_CONNECTION);
-            blk->host_called = true;
-            rc = pmix_host_server.group(blk->grpop, blk->id, trk->pcs, trk->npcs,
-                                        blk->info, blk->ninfo, grpcbfunc, blk);
-            if (PMIX_OPERATION_SUCCEEDED == rc) {
-                /* the host will not call back - drive completion ourselves */
-                grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
-            } else if (PMIX_SUCCESS != rc) {
-                pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-                PMIX_RELEASE(blk);
-            }
-        }
+        account_departed(blk, proc);
     }
 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1356,6 +1356,29 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer, pmix_buffer
         }
     }
 
+    /* if a local member is voluntarily leaving a group, account for its
+     * departure in any in-flight group construct/destruct collective for
+     * that group so the collective completes on the survivors rather than
+     * hanging - the deliberate cousin of a lost participant. We do this
+     * before the loop-detection check below because only the originating
+     * server (the one that received the leave from its client) sees this
+     * command; peer servers receive the relayed event with the
+     * PMIX_SERVER_INTERNAL_NOTIFY marker and bail out. */
+    if (PMIX_GROUP_LEFT == cd->status) {
+        char *grpid = NULL;
+        pmix_proc_t *affected = NULL;
+        for (n = 0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_ID)) {
+                grpid = cd->info[n].value.data.string;
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_AFFECTED_PROC)) {
+                affected = cd->info[n].value.data.proc;
+            }
+        }
+        if (NULL != grpid && NULL != affected) {
+            pmix_server_grp_member_left(grpid, affected);
+        }
+    }
+
     /* check to see if we already processed this event - it is possible
      * that a local client "echoed" it back to us and we want to avoid
      * a potential infinite loop */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -431,4 +431,6 @@ PMIX_EXPORT void pmix_server_set_collective_status(pmix_info_t *info, size_t nin
 
 PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);
 
+PMIX_EXPORT void pmix_server_grp_member_left(const char *grpid, const pmix_proc_t *proc);
+
 #endif // PMIX_SERVER_OPS_H


### PR DESCRIPTION
Fixes #3935.

`PMIx_Group_leave` / `PMIx_Group_leave_nb` were declared, documented, and
callable, but never implemented end-to-end: the client sent a
`PMIX_GROUP_LEAVE_CMD` the server switchyard did not handle, so the call
returned `PMIX_ERR_NOT_SUPPORTED`, the documented `PMIX_GROUP_LEFT` event was
never generated, and the remaining members were never told of the departure.

## Approach

Realize leave the way its documented contract describes — as an **event**,
matching the existing invite/join model rather than a server round-trip.

- **Client** (`pmix_client_group.c`): `PMIx_Group_leave_nb` now generates a
  `PMIX_GROUP_LEFT` event ranged to the current membership (identifying the
  group and the departing proc), returns success once the event is locally
  generated (not indicative of remote receipt), and drops the group from its
  own local list. The dead `SEND_RECV` path is removed.
- **Members** (`pmix_event_notification.c`): update local group membership on
  `PMIX_GROUP_LEFT` receipt, alongside the existing group-construct-complete
  handling.
- **Server** (`pmix_server_group.c` / `pmix_server_ops.c`): the originating
  server intercepts the leave and, reusing the lost-participant accounting
  added for group collectives (#3934), accounts the departing member as
  "departed" in any in-flight construct/destruct block for that group so the
  collective completes on the survivors rather than hanging. The per-block
  routine is factored into `account_departed()`, reached from both
  `pmix_server_grp_peer_lost()` (a dropped peer) and the new
  `pmix_server_grp_member_left()` (a named-group voluntary leave).

## Companion PRRTE PR

The host-side group registry is updated in a companion PRRTE PR
(rhc54/prrte `topic/group-leave-membership`) so `PMIX_QUERY_GROUP_MEMBERSHIP`
reflects the departure. This PMIx PR is functional on its own (event
generation + delivery + in-flight completion); the PRRTE PR adds the
persistent-membership update.

## Acceptance criteria (from #3935)

- [x] `PMIx_Group_leave[_nb]` generates `PMIX_GROUP_LEFT` to all current members
      and returns success once locally generated
- [x] Server-side group membership reflects the departure (member clients here;
      host registry in the companion PRRTE PR)
- [x] In-flight group construct/destruct collective completes on the remaining
      members rather than hanging or erroring
- [x] Regression test (`examples/group_leave.c`, wired into the dockerswarm
      harness)

## Testing

Built PMIx + PRRTE in the `contrib/dockerswarm` harness (clean, `-Werror`) and
ran the full suite across the 10-node swarm: **11 passed, 0 failed**, including
the new `group_leave` (a member leaves a live group; all survivors notified via
both local and remote delivery) with no regression in the existing
construct/destruct and `group_die`/`connect_die` loss-accounting tests.

## Follow-ups (out of scope here)

- General in-flight `PMIx_Fence`-across-group FT adjustment under
  `PMIX_GROUP_FT_COLLECTIVE` remains a larger change.
- The FT accounting reuses the `PMIX_ERR_LOST_CONNECTION` degraded status for a
  clean leave (consistent with #3934); a distinct "member left" status could be
  cleaner later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)