### PR TITLE
Change suppression of deprecated var warning to on by default

### DIFF
--- a/.github/workflows/pmix_mpi4py.yaml
+++ b/.github/workflows/pmix_mpi4py.yaml
@@ -113,7 +113,7 @@ jobs:
         echo mapby = :oversubscribe >> "$mca_params"
         mca_params="$HOME/.pmix/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
-        echo pmix_mca_base_var_suppress_deprecated_warning = true >> "$mca_params"
+        echo mca_base_suppress_deprecated_warning = true >> "$mca_params"
 
     - name: Show MPI
       run:  ompi_info

--- a/.github/workflows/pmix_mpi4py.yaml
+++ b/.github/workflows/pmix_mpi4py.yaml
@@ -111,6 +111,9 @@ jobs:
         mca_params="$HOME/.prte/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
         echo mapby = :oversubscribe >> "$mca_params"
+        mca_params="$HOME/.pmix/mca-params.conf"
+        mkdir -p "$(dirname "$mca_params")"
+        echo pmix_mca_base_var_suppress_deprecated_warning = true >> "$mca_params"
 
     - name: Show MPI
       run:  ompi_info

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ examples/monitor_multi
 examples/simple
 examples/simple_server
 examples/abort
+examples/group_leave
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -363,34 +363,13 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
         return ret;
     }
 
-    /* Suppress warnings emitted when a deprecated MCA parameter is set.
-     * Defaults to false to surface the warnings, set to true so that
-     * deprecated-but-still-functional parameters
-     * do not spam users */
-    pmix_mca_base_var_suppress_deprecated_warning = false;
-    ret = pmix_mca_base_var_register(
-        "pmix", "mca", "base", "suppress_deprecated_warning",
-        "Suppress warnings when a deprecated MCA parameter is set (default: false)",
-        PMIX_MCA_BASE_VAR_TYPE_BOOL,
-        &pmix_mca_base_var_suppress_deprecated_warning);
-    if (0 > ret) {
-        return ret;
-    }
-
-    /* Disable reading MCA parameter files. */
+    /* Disable reading MCA parameter files. The suppression variables
+     * registered below still need to be created in this case so their
+     * values can be picked up from the environment, so jump past the
+     * file handling rather than returning here. */
     if (NULL == pmix_mca_base_var_files ||
         0 == strcmp(pmix_mca_base_var_files, "none")) {
-        return PMIX_SUCCESS;
-    }
-
-    pmix_mca_base_var_suppress_override_warning = false;
-    ret = pmix_mca_base_var_register(
-        "pmix", "mca", "base", "suppress_override_warning",
-        "Suppress warnings when attempting to set an overridden value (default: false)",
-        PMIX_MCA_BASE_VAR_TYPE_BOOL,
-        &pmix_mca_base_var_suppress_override_warning);
-    if (0 > ret) {
-        return ret;
+        goto register_suppress;
     }
 
     /* Aggregate MCA parameter files
@@ -459,6 +438,38 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     ret = read_files(pmix_mca_base_var_override_file, &pmix_mca_base_var_override_values, PMIX_ENV_SEP);
     if (PMIX_SUCCESS != ret && PMIX_ERR_NOT_FOUND != ret) {
         // it is okay if the file isn't found
+        return ret;
+    }
+
+register_suppress:
+    /* Register the warning-suppression variables only after the MCA
+     * parameter files have been read and cached above. Registration
+     * applies any value found in those files to the variable's backing
+     * store; registering these before the files were read left the
+     * store at its default and silently ignored a user's setting in
+     * their mca-params.conf. */
+
+    /* Suppress warnings emitted when a deprecated MCA parameter is set.
+     * Defaults to false to surface the warnings, set to true so that
+     * deprecated-but-still-functional parameters
+     * do not spam users */
+    pmix_mca_base_var_suppress_deprecated_warning = false;
+    ret = pmix_mca_base_var_register(
+        "pmix", "mca", "base", "suppress_deprecated_warning",
+        "Suppress warnings when a deprecated MCA parameter is set (default: false)",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_mca_base_var_suppress_deprecated_warning);
+    if (0 > ret) {
+        return ret;
+    }
+
+    pmix_mca_base_var_suppress_override_warning = false;
+    ret = pmix_mca_base_var_register(
+        "pmix", "mca", "base", "suppress_override_warning",
+        "Suppress warnings when attempting to set an overridden value (default: false)",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_mca_base_var_suppress_override_warning);
+    if (0 > ret) {
         return ret;
     }
 

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -76,7 +76,7 @@ static char *pmix_mca_base_var_override_file = NULL;
 static char *pmix_mca_base_var_file_prefix = NULL;
 static char *pmix_mca_base_param_file_path = NULL;
 static bool pmix_mca_base_var_suppress_override_warning = false;
-static bool pmix_mca_base_var_suppress_deprecated_warning = true;
+static bool pmix_mca_base_var_suppress_deprecated_warning = false;
 static int pmix_mca_base_var_count = 0;
 static pmix_hash_table_t pmix_mca_base_var_index_hash = PMIX_HASH_TABLE_STATIC_INIT;
 
@@ -364,12 +364,13 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     }
 
     /* Suppress warnings emitted when a deprecated MCA parameter is set.
-     * Defaults to true so that deprecated-but-still-functional parameters
-     * do not spam users; set to false to surface the warnings. */
-    pmix_mca_base_var_suppress_deprecated_warning = true;
+     * Defaults to false to surface the warnings, set to true so that
+     * deprecated-but-still-functional parameters
+     * do not spam users */
+    pmix_mca_base_var_suppress_deprecated_warning = false;
     ret = pmix_mca_base_var_register(
         "pmix", "mca", "base", "suppress_deprecated_warning",
-        "Suppress warnings when a deprecated MCA parameter is set (default: true)",
+        "Suppress warnings when a deprecated MCA parameter is set (default: false)",
         PMIX_MCA_BASE_VAR_TYPE_BOOL,
         &pmix_mca_base_var_suppress_deprecated_warning);
     if (0 > ret) {


### PR DESCRIPTION
We really want to show deprecated variable warnings so users are aware of them, but mpi4py can't handle it. So adjust that workflow to explicitly turn them off.

This changes `pmix_mca_base_suppress_deprecated_warning` (and the companion `pmix_mca_base_suppress_override_warning`) to default to showing the warnings, and updates the mpi4py CI workflow to explicitly suppress them.

While making that change, a related bug surfaced: those two suppression MCA variables were registered in `pmix_mca_base_var_cache_files()` *before* that function read and cached the MCA parameter files. Because a variable's value is pulled from the file cache during registration, registering them early meant the file-values list was still empty and the backing stores kept the compiled-in default — so a user who set `mca_base_suppress_deprecated_warning = true` in `mca-params.conf` was silently ignored and the warnings still appeared.

The final commit moves both suppression-variable registrations to the end of `pmix_mca_base_var_cache_files()`, after the parameter files have been cached, so a value set in a file is now honored. The file-reading-disabled ("none") path jumps to the same registration block, keeping the variables available for environment-based configuration.
