### PR TITLE
client: expand groups and verify caller in Group_construct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ test/python/run_sched.sh
 test/python/run_server.sh
 test/simple/pmitest
 test/simple/simpcycle
+test/simple/simpgrpmember
 test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
@@ -240,6 +241,7 @@ test/unit/tool_cycle
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl
+test/unit/run_grpmember.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1008,6 +1008,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -61,7 +61,6 @@
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
                         void *cbdata);
 static void op_cbfunc(pmix_status_t status, void *cbdata);
-static bool connect_client_is_included(const pmix_proc_t *procs, size_t nprocs);
 
 PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
                                        const pmix_info_t info[], size_t ninfo)
@@ -158,7 +157,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
 
     /* PMIx_Connect requires that all participants be listed in the
      * input array, so verify that the calling process is among them */
-    if (!connect_client_is_included(rgs, nrg)) {
+    if (!pmix_client_proc_is_included(rgs, nrg)) {
         PMIX_PROC_FREE(rgs, nrg);
         return PMIX_ERR_NOT_A_MEMBER;
     }
@@ -445,7 +444,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
 
     /* PMIx_Disconnect requires that all participants be listed in the
      * input array, so verify that the calling process is among them */
-    if (!connect_client_is_included(rgs, nrg)) {
+    if (!pmix_client_proc_is_included(rgs, nrg)) {
         PMIX_PROC_FREE(rgs, nrg);
         return PMIX_ERR_NOT_A_MEMBER;
     }
@@ -606,22 +605,4 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     cb->status = status;
     PMIX_POST_OBJECT(cb);
     PMIX_WAKEUP_THREAD(&cb->lock);
-}
-
-static bool connect_client_is_included(const pmix_proc_t *procs, size_t nprocs)
-{
-    size_t n;
-
-    for (n = 0; n < nprocs; n++) {
-        if (!PMIX_CHECK_NSPACE(procs[n].nspace, pmix_globals.myid.nspace)) {
-            continue;
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank ||
-            PMIX_RANK_LOCAL_NODE == procs[n].rank ||
-            PMIX_RANK_LOCAL_PEERS == procs[n].rank ||
-            procs[n].rank == pmix_globals.myid.rank) {
-            return true;
-        }
-    }
-    return false;
 }

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -167,3 +167,27 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
     *outsize = sz;
     return PMIX_SUCCESS;
 }
+
+/* Return true if pmix_globals.myid is covered by the resolved procs array.
+ * Should be called after group expansion, so every entry carries a real
+ * nspace. PMIX_RANK_WILDCARD, PMIX_RANK_LOCAL_NODE, and PMIX_RANK_LOCAL_PEERS
+ * all cover the calling process when the nspace matches. Used by the
+ * collective APIs (fence, connect/disconnect, group construct) that require
+ * the caller to be among the listed participants. */
+bool pmix_client_proc_is_included(const pmix_proc_t *procs, size_t nprocs)
+{
+    size_t n;
+
+    for (n = 0; n < nprocs; n++) {
+        if (!PMIX_CHECK_NSPACE(procs[n].nspace, pmix_globals.myid.nspace)) {
+            continue;
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank ||
+            PMIX_RANK_LOCAL_NODE == procs[n].rank ||
+            PMIX_RANK_LOCAL_PEERS == procs[n].rank ||
+            procs[n].rank == pmix_globals.myid.rank) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -61,7 +61,6 @@ static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd, const pmix_p
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
                         void *cbdata);
 static void op_cbfunc(pmix_status_t status, void *cbdata);
-static bool fence_client_is_included(const pmix_proc_t *procs, size_t nprocs);
 
 PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
                                      const pmix_info_t info[], size_t ninfo)
@@ -115,28 +114,6 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
                         "pmix: fence released");
 
     return rc;
-}
-
-/* Return true if pmix_globals.myid is covered by the resolved procs array.
- * Called after group expansion, so every entry carries a real nspace.
- * PMIX_RANK_WILDCARD, PMIX_RANK_LOCAL_NODE, and PMIX_RANK_LOCAL_PEERS all
- * cover the calling process when the nspace matches. */
-static bool fence_client_is_included(const pmix_proc_t *procs, size_t nprocs)
-{
-    size_t n;
-
-    for (n = 0; n < nprocs; n++) {
-        if (!PMIX_CHECK_NSPACE(procs[n].nspace, pmix_globals.myid.nspace)) {
-            continue;
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank ||
-            PMIX_RANK_LOCAL_NODE == procs[n].rank ||
-            PMIX_RANK_LOCAL_PEERS == procs[n].rank ||
-            procs[n].rank == pmix_globals.myid.rank) {
-            return true;
-        }
-    }
-    return false;
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
@@ -194,7 +171,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     }
 
     /* verify that the calling process is among the fence participants */
-    if (!fence_client_is_included(rgs, nrg)) {
+    if (!pmix_client_proc_is_included(rgs, nrg)) {
         if (created) {
             PMIX_PROC_FREE(rgs, nrg);
         }

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -369,6 +369,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     rc = construct_msg(msg, grp, procs, nprocs, info, ninfo);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
         return rc;
     }
 

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -347,6 +347,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     pmix_buffer_t *msg = NULL;
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
+    pmix_proc_t *rgs = NULL;
+    size_t nrg = 0, n;
+    bool partial = false;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_construct_nb called");
@@ -364,9 +367,42 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* An "add members" or "bootstrap" construct does not list all
+     * participants in the procs array - the remaining members are
+     * supplied separately (via PMIX_GROUP_ADD_MEMBERS) or join later,
+     * and an individual caller (e.g., a non-bootstrap participant that
+     * passes a NULL procs array) may not appear in its own procs array.
+     * We therefore cannot validate membership for those operations. */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ADD_MEMBERS) ||
+            PMIX_CHECK_KEY(&info[n], PMIX_GROUP_BOOTSTRAP)) {
+            partial = true;
+            break;
+        }
+    }
+
+    if (!partial && NULL != procs && 0 < nprocs) {
+        /* every participant must be listed in the procs array, so
+         * replace any PMIx group reference with its actual member
+         * proc(s) and verify that the caller is among them */
+        rc = pmix_client_convert_group_procs(procs, nprocs, &rgs, &nrg);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        if (!pmix_client_proc_is_included(rgs, nrg)) {
+            PMIX_PROC_FREE(rgs, nrg);
+            return PMIX_ERR_NOT_A_MEMBER;
+        }
+    }
+
     // send any data to our server
     msg = PMIX_NEW(pmix_buffer_t);
-    rc = construct_msg(msg, grp, procs, nprocs, info, ninfo);
+    if (NULL != rgs) {
+        rc = construct_msg(msg, grp, rgs, nrg, info, ninfo);
+        PMIX_PROC_FREE(rgs, nrg);
+    } else {
+        rc = construct_msg(msg, grp, procs, nprocs, info, ninfo);
+    }
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -68,6 +68,8 @@ PMIX_EXPORT void pmix_parse_localquery(int sd, short args, void *cbdata);
 PMIX_EXPORT pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t insize,
                                                           pmix_proc_t **outprocs, size_t *outsize);
 
+PMIX_EXPORT bool pmix_client_proc_is_included(const pmix_proc_t *procs, size_t nprocs);
+
 END_C_DECLS
 
 #endif /* PMIX_CLIENT_OPS_H */

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid simpqual simpdist legacy refresh
+                  hybrid simpqual simpdist legacy refresh simpgrpmember
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -143,6 +143,12 @@ simpcycle_SOURCES = $(headers) \
         simpcycle.c
 simpcycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpcycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpmember_SOURCES = $(headers) \
+        simpgrpmember.c
+simpgrpmember_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpmember_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simptoolcycle_SOURCES = $(headers) \

--- a/test/simple/simpgrpmember.c
+++ b/test/simple/simpgrpmember.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+/* A PMIx_Group_construct that is not an "add members" or "bootstrap"
+ * operation must list every participant in its procs array, and the caller
+ * must be one of them. Verify the client rejects a construct in which the
+ * caller does not appear: the membership check runs entirely on the client
+ * side, before anything is sent to the server, and must return
+ * PMIX_ERR_NOT_A_MEMBER. */
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_proc_t myproc;
+    pmix_proc_t others[2];
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+    pmix_output(0, "Client %s:%d Init", myproc.nspace, myproc.rank);
+
+    /* build a participant array that deliberately excludes us: a foreign
+     * namespace, plus a non-wildcard rank in our own namespace that is not
+     * our rank. Neither entry covers the calling process. */
+    PMIx_Load_procid(&others[0], "not-a-real-namespace", 0);
+    PMIx_Load_procid(&others[1], myproc.nspace, myproc.rank + 100);
+
+    rc = PMIx_Group_construct("simpgrpmember", others, 2, NULL, 0, &results, &nresults);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    pmix_output(0, "Client %s:%d Group_construct returned %s", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+
+    if (PMIX_ERR_NOT_A_MEMBER != rc) {
+        fprintf(stderr,
+                "Client %s:%d FAIL: expected PMIX_ERR_NOT_A_MEMBER, got %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    fprintf(stderr, "Client %s:%d rejected the not-a-member group construct OK\n",
+            myproc.nspace, myproc.rank);
+    fflush(stderr);
+    return 0;
+}

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_grpmember.pl.in
+++ b/test/unit/run_grpmember.pl.in
@@ -1,0 +1,123 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the client-side group-construct membership check. A single
+# persistent server (test/simple/simptest) forks one client
+# (test/simple/simpgrpmember) that connects and calls PMIx_Group_construct
+# with a participant array that deliberately excludes itself. Because the
+# construct is not an "add members" or "bootstrap" operation, every
+# participant must be listed and the caller must be among them; the client
+# must reject the call locally with PMIX_ERR_NOT_A_MEMBER before anything is
+# sent to the server. A regression that drops the check (or wrongly rejects
+# a legitimate caller) makes the client exit non-zero, or wedges the run
+# until the timeout fires. See src/client/pmix_client_group.c and #3850.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its client from the current directory using a relative
+# path ("./simpgrpmember"), so run from the directory that holds both
+# binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-e", "./simpgrpmember");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed the assertion (or could not
+# connect/finalize) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the check rather than passing
+# vacuously: the client only prints this line after PMIx_Group_construct
+# returned PMIX_ERR_NOT_A_MEMBER, and simptest only prints its own line
+# after the client has gone.
+my $client_ok  = ($output =~ /rejected the not-a-member group construct OK/);
+my $server_done = ($output =~ /Test finished OK!/);
+if (!$client_ok) {
+    print "FAIL: client did not reject the not-a-member group construct\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the client ran\n";
+    exit(1);
+}
+print "PASS: client rejected the not-a-member group construct\n";
+exit(0);


### PR DESCRIPTION
## Summary

Continues the work under #3850. `PMIx_Group_construct` that is not an
"add members" or "bootstrap" operation must list every participant in
the `procs` array passed to the API, and the calling process must be one
of them — the same contract already enforced for `PMIx_Fence` and
`PMIx_Connect/Disconnect`. This PR brings group construct in line and
removes the duplication that had accumulated across those three call
sites.

Three commits:

1. **Release the send buffer on a group construct pack error** —
   incidental fix: `PMIx_Group_construct_nb` returned directly on a
   `construct_msg()` failure without releasing its freshly-allocated
   buffer.

2. **Hoist the collective membership check into a shared helper** —
   Fence and Connect/Disconnect each carried an identical static
   "is the caller among these participants" routine. Promote it to a
   single exported `pmix_client_proc_is_included()` next to
   `pmix_client_convert_group_procs()` (the two are always used
   together) and drop the private copies. No functional change.

3. **Expand groups and verify caller in Group_construct** — run the
   participant array through `pmix_client_convert_group_procs()` so a
   PMIx group reference is replaced by its actual member proc(s) (the
   expanded array is what gets sent to the server), and verify the
   caller is among them via the shared helper, returning
   `PMIX_ERR_NOT_A_MEMBER` otherwise. Both steps are skipped when the
   info array carries `PMIX_GROUP_ADD_MEMBERS` or `PMIX_GROUP_BOOTSTRAP`,
   since those operations intentionally omit participants from the
   `procs` array (a non-bootstrap participant even passes a NULL array),
   so membership cannot be validated locally.

## Testing

Clean `make` (devel-check, warnings-as-errors) with no new warnings.

References #3850