### PR TITLE
Add tests for dynamic group invite/join and destruct fault paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ examples/group_destruct_die
 examples/group_invite
 examples/group_invite_timeout
 examples/group_invite_decline
+examples/group_invite_abort
 
 include/pmix_version.h
 include/pmix_rename.h
@@ -249,6 +250,7 @@ test/unit/run_grpmember.pl
 test/unit/run_grpinvite.pl
 test/unit/run_grptimeout.pl
 test/unit/run_grpdecline.pl
+test/unit/run_grpabort.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ examples/abort
 examples/group_leave
 examples/group_destruct_die
 examples/group_invite
+examples/group_invite_timeout
 
 include/pmix_version.h
 include/pmix_rename.h
@@ -245,6 +246,7 @@ test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl
 test/unit/run_grpmember.pl
 test/unit/run_grpinvite.pl
+test/unit/run_grptimeout.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ examples/group_leave
 examples/group_destruct_die
 examples/group_invite
 examples/group_invite_timeout
+examples/group_invite_decline
 
 include/pmix_version.h
 include/pmix_rename.h
@@ -247,6 +248,7 @@ test/unit/run_toolcycle.pl
 test/unit/run_grpmember.pl
 test/unit/run_grpinvite.pl
 test/unit/run_grptimeout.pl
+test/unit/run_grpdecline.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -244,6 +244,7 @@ test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl
 test/unit/run_grpmember.pl
+test/unit/run_grpinvite.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ examples/simple
 examples/simple_server
 examples/abort
 examples/group_leave
+examples/group_destruct_die
+examples/group_invite
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1012,6 +1012,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpdecline.pl], [chmod +x test/unit/run_grpdecline.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpabort.pl], [chmod +x test/unit/run_grpabort.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1010,6 +1010,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1011,6 +1011,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpdecline.pl], [chmod +x test/unit/run_grpdecline.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1009,6 +1009,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -25,7 +25,8 @@ is only the nickname.
 | File | Purpose |
 |------|---------|
 | `build.sh` | Builds PMIx from your **live** tree (VPATH) plus PRRTE master against it: into a shared volume for the Linux swarm, or natively for macOS. Start here. |
-| `run-tests.sh` | Runs the group example programs and reports PASS/FAIL: full multi-node suite on Linux, single-host subset on macOS. |
+| `run-tests.sh` | Runs the group **construction-method** example programs (plus the construct/connect loss and voluntary-leave cases) and reports PASS/FAIL: full multi-node suite on Linux, single-host subset on macOS. |
+| `run-group-events.sh` | Runs the **dynamic, event-driven** group exercisers and their fault paths (invite/join, member lost during destruct, ...); kept separate from `run-tests.sh` so the event/fault matrix can grow independently. Same `linux`/`macos` modes. |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
 | `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. |
 
@@ -73,10 +74,12 @@ is only the nickname.
                            #   build PMIx + PRRTE + group clients into the volume
 docker compose up -d       # start pmix-node1 .. pmix-node10
 ./run-tests.sh linux       # multi-node group construction suite
+./run-group-events.sh linux # dynamic invite/join + group fault paths
 
 # ---- native macOS (single host) ----
 ./build.sh macos           # native PMIx + PRRTE build under vpath-macos-*
 ./run-tests.sh macos       # single-host group smoke
+./run-group-events.sh macos # single-host dynamic-group smoke
 ```
 
 Rebuild after editing PMIx: rerun `./build.sh` (incremental). No image rebuild

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -49,11 +49,13 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # The EVENT_EXAMPLES exercise the dynamic, event-driven group operations and
 # their fault paths, and are driven by the companion run-group-events.sh:
 # group_invite (leader invites, invitees join, the group forms and every member
-# is notified of completion) and group_destruct_die (a member is lost mid
+# is notified of completion), group_invite_timeout (an invitee never responds,
+# so the leader's PMIX_TIMEOUT fires, reports the non-responder, and forms the
+# group on those that accepted), and group_destruct_die (a member is lost mid
 # PMIx_Group_destruct, so the destruct must complete on the survivors -- the
 # destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-EVENT_EXAMPLES="group_invite group_destruct_die"
+EVENT_EXAMPLES="group_invite group_invite_timeout group_destruct_die"
 BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES"
 
 mode="${1:-linux}"

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -53,11 +53,13 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # so the leader's PMIX_TIMEOUT fires, reports the non-responder, and forms the
 # group on those that accepted), group_invite_decline (an invitee explicitly
 # declines, so the construct resolves immediately -- no timeout -- reporting the
-# decliner and forming the group on those that accepted), and group_destruct_die
-# (a member is lost mid PMIx_Group_destruct, so the destruct must complete on
-# the survivors -- the destruct analog of group_die).
+# decliner and forming the group on those that accepted), group_invite_abort (an
+# invitee declines an all-or-nothing invite -- no PMIX_GROUP_OPTIONAL -- so the
+# whole construct aborts and every participant is notified), and
+# group_destruct_die (a member is lost mid PMIx_Group_destruct, so the destruct
+# must complete on the survivors -- the destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_destruct_die"
+EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_invite_abort group_destruct_die"
 BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES"
 
 mode="${1:-linux}"

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -41,12 +41,20 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 
 # the group example programs that exercise the construction methods; built as
 # standalone clients against the installed PMIx and launched by prterun/prun.
-# group_die and connect_die (a participant leaves before contributing) drive
-# the lost-connection accounting, and group_leave (a member voluntarily departs
-# a live group) drives the group-leave notification path; all three are
-# exercised separately by run-tests.sh.
+# run-tests.sh drives the construction methods plus three fault/notification
+# exercisers: group_die and connect_die (a participant leaves before
+# contributing) drive the lost-connection accounting, and group_leave (a member
+# voluntarily departs a live group) drives the group-leave notification path.
+#
+# The EVENT_EXAMPLES exercise the dynamic, event-driven group operations and
+# their fault paths, and are driven by the companion run-group-events.sh:
+# group_invite (leader invites, invitees join, the group forms and every member
+# is notified of completion) and group_destruct_die (a member is lost mid
+# PMIx_Group_destruct, so the destruct must complete on the survivors -- the
+# destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave"
+EVENT_EXAMPLES="group_invite group_destruct_die"
+BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES"
 
 mode="${1:-linux}"
 

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -51,11 +51,13 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # group_invite (leader invites, invitees join, the group forms and every member
 # is notified of completion), group_invite_timeout (an invitee never responds,
 # so the leader's PMIX_TIMEOUT fires, reports the non-responder, and forms the
-# group on those that accepted), and group_destruct_die (a member is lost mid
-# PMIx_Group_destruct, so the destruct must complete on the survivors -- the
-# destruct analog of group_die).
+# group on those that accepted), group_invite_decline (an invitee explicitly
+# declines, so the construct resolves immediately -- no timeout -- reporting the
+# decliner and forming the group on those that accepted), and group_destruct_die
+# (a member is lost mid PMIx_Group_destruct, so the destruct must complete on
+# the survivors -- the destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-EVENT_EXAMPLES="group_invite group_invite_timeout group_destruct_die"
+EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_destruct_die"
 BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES"
 
 mode="${1:-linux}"

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -25,19 +25,27 @@
 # invitations, completion broadcasts, and fault events actually run.
 #
 # Coverage so far:
-#   * group_invite       -- invite/join happy path: a leader invites the whole
-#                           job, invitees accept via PMIx_Group_join, the group
-#                           forms, and every member receives
-#                           PMIX_GROUP_CONSTRUCT_COMPLETE and can fence across
-#                           the group.
-#   * group_destruct_die -- a member is lost mid-PMIx_Group_destruct; the
-#                           destruct must complete on the survivors rather than
-#                           hang (the destruct analog of run-tests.sh's
-#                           group_die, which covers construct).
+#   * group_invite         -- invite/join happy path: a leader invites the whole
+#                             job, invitees accept via PMIx_Group_join, the group
+#                             forms, and every member receives
+#                             PMIX_GROUP_CONSTRUCT_COMPLETE and can fence across
+#                             the group.
+#   * group_invite_timeout -- an invitee never responds; the leader's
+#                             PMIX_TIMEOUT fires, reports the non-responder via
+#                             PMIX_GROUP_INVITE_FAILED, and forms the group on
+#                             the members that accepted.
+#   * group_invite_decline -- an invitee explicitly declines; the construct
+#                             resolves immediately (no timeout), reports the
+#                             decliner via PMIX_GROUP_INVITE_FAILED, and forms
+#                             the group on the members that accepted.
+#   * group_destruct_die   -- a member is lost mid-PMIx_Group_destruct; the
+#                             destruct must complete on the survivors rather than
+#                             hang (the destruct analog of run-tests.sh's
+#                             group_die, which covers construct).
 #
-# Still to come (as the library gains support -- see issue #3936): invite
-# declined / failed / timeout, leader failure and reselection, construct abort,
-# member-failed events, and the FT-collective adjustment.
+# Still to come (as the library gains support -- see issue #3936): leader
+# failure and reselection, construct abort, member-failed events, and the
+# FT-collective adjustment.
 
 set -uo pipefail
 
@@ -142,6 +150,39 @@ test_linux() {
     cleanup_swarm
 
     #############################################################
+    # invite declined (an explicit refusal)
+    #############################################################
+    banner "invite declined (PMIX_GROUP_INVITE_FAILED, no timeout)"
+    cleanup_swarm
+    # group_invite_decline: the leader invites the whole job with NO PMIX_TIMEOUT;
+    # the last rank explicitly DECLINES via PMIx_Group_join instead of accepting.
+    # A decline is a definitive answer, so the construct must resolve immediately
+    # -- report the decliner via PMIX_GROUP_INVITE_FAILED and form the group on
+    # the members that accepted (which then receive PMIX_GROUP_CONSTRUCT_COMPLETE)
+    # -- rather than wait on a member that will never join. With no timeout, a
+    # regression cannot be broken by a timer; it simply hangs to the job timeout.
+    # The decliner stays alive and rejoins the closing barrier, so no
+    # --rtos recoverable is needed.
+    if RUN 'test -x /opt/prte/tests/group_invite_decline'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_invite_decline 2>&1')"
+        nfail=$(echo "$OUT" | grep -c 'INVITE_FAILED for decliner: PASS')
+        npass=$(echo "$OUT" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        if hung "$OUT"; then
+            bad "group_invite_decline HUNG (decline did not resolve the construct)"
+        elif echo "$OUT" | grep -qiE 'FAILED -'; then
+            bad "group_invite_decline: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$nfail" -ge 1 ] && [ "$npass" -ge 3 ]; then
+            ok "leader reported the decliner and formed the group on the 3 that accepted"
+        else
+            bad "group_invite_decline: failed=$nfail completed=$npass: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_invite_decline not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite_decline: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
     # member lost during destruct
     #############################################################
     banner "member lost during PMIx_Group_destruct (loss accounting)"
@@ -220,6 +261,23 @@ test_macos() {
         fi
     else
         skp "group_invite_timeout (not built)"
+    fi
+
+    banner "macOS: invite declined (single host)"
+    if [ -x "$prefix/bin/group_invite_decline" ]; then
+        macpk; sleep 1
+        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_decline" 2>&1)"
+        nfail=$(echo "$out" | grep -c 'INVITE_FAILED for decliner: PASS')
+        npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
+            skp "group_invite_decline: not clean (native Darwin DVM can be flaky)"
+        elif [ "$nfail" -ge 1 ] && [ "$npass" -ge 3 ]; then
+            ok "group_invite_decline: decliner reported, group formed on 3 (single host)"
+        else
+            skp "group_invite_decline: failed=$nfail completed=$npass (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_invite_decline (not built)"
     fi
 
     banner "macOS: member lost during destruct (single host)"

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -38,6 +38,10 @@
 #                             resolves immediately (no timeout), reports the
 #                             decliner via PMIX_GROUP_INVITE_FAILED, and forms
 #                             the group on the members that accepted.
+#   * group_invite_abort   -- an invitee declines an all-or-nothing invite (no
+#                             PMIX_GROUP_OPTIONAL); the whole construct aborts,
+#                             every participant receives PMIX_GROUP_CONSTRUCT_ABORT
+#                             and the leader's invite returns that status.
 #   * group_destruct_die   -- a member is lost mid-PMIx_Group_destruct; the
 #                             destruct must complete on the survivors rather than
 #                             hang (the destruct analog of run-tests.sh's
@@ -183,6 +187,37 @@ test_linux() {
     cleanup_swarm
 
     #############################################################
+    # invite aborted (all-or-nothing construct)
+    #############################################################
+    banner "invite aborted (PMIX_GROUP_CONSTRUCT_ABORT, all-or-nothing)"
+    cleanup_swarm
+    # group_invite_abort: the leader invites the whole job WITHOUT
+    # PMIX_GROUP_OPTIONAL, making the construct all-or-nothing. The last rank
+    # declines, so the lone non-accepter must abort the entire construct: every
+    # invited participant (including the members that accepted) must receive
+    # PMIX_GROUP_CONSTRUCT_ABORT, the leader's PMIx_Group_invite must return that
+    # status, and no group may form (no CONSTRUCT_COMPLETE). All ranks stay alive
+    # and rejoin the closing barrier, so no --rtos recoverable is needed.
+    if RUN 'test -x /opt/prte/tests/group_invite_abort'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_invite_abort 2>&1')"
+        nleader=$(echo "$OUT" | grep -c 'PMIx_Group_invite returned CONSTRUCT_ABORT: PASS')
+        nabort=$(echo "$OUT" | grep -c 'PMIX_GROUP_CONSTRUCT_ABORT received: PASS')
+        if hung "$OUT"; then
+            bad "group_invite_abort HUNG (abort was not propagated)"
+        elif echo "$OUT" | grep -qiE 'FAILED -'; then
+            bad "group_invite_abort: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$nleader" -ge 1 ] && [ "$nabort" -ge 4 ]; then
+            ok "leader's invite returned abort and all 4 participants were notified"
+        else
+            bad "group_invite_abort: leader=$nleader aborted=$nabort: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_invite_abort not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite_abort: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
     # member lost during destruct
     #############################################################
     banner "member lost during PMIx_Group_destruct (loss accounting)"
@@ -278,6 +313,23 @@ test_macos() {
         fi
     else
         skp "group_invite_decline (not built)"
+    fi
+
+    banner "macOS: invite aborted (single host)"
+    if [ -x "$prefix/bin/group_invite_abort" ]; then
+        macpk; sleep 1
+        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_abort" 2>&1)"
+        nleader=$(echo "$out" | grep -c 'PMIx_Group_invite returned CONSTRUCT_ABORT: PASS')
+        nabort=$(echo "$out" | grep -c 'PMIX_GROUP_CONSTRUCT_ABORT received: PASS')
+        if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
+            skp "group_invite_abort: not clean (native Darwin DVM can be flaky)"
+        elif [ "$nleader" -ge 1 ] && [ "$nabort" -ge 4 ]; then
+            ok "group_invite_abort: construct aborted, all 4 participants notified (single host)"
+        else
+            skp "group_invite_abort: leader=$nleader aborted=$nabort (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_invite_abort (not built)"
     fi
 
     banner "macOS: member lost during destruct (single host)"

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -112,6 +112,36 @@ test_linux() {
     cleanup_swarm
 
     #############################################################
+    # invite timeout (a non-responder)
+    #############################################################
+    banner "invite timeout (PMIX_GROUP_INVITE_FAILED + reduced membership)"
+    cleanup_swarm
+    # group_invite_timeout: the leader invites the whole job with a PMIX_TIMEOUT;
+    # the last rank deliberately never answers its PMIX_GROUP_INVITED event. The
+    # leader's timer must fire, report the non-responder via
+    # PMIX_GROUP_INVITE_FAILED, and form the group on the members that did accept
+    # (which then receive PMIX_GROUP_CONSTRUCT_COMPLETE). The non-responder stays
+    # alive and rejoins the closing barrier, so no --rtos recoverable is needed.
+    if RUN 'test -x /opt/prte/tests/group_invite_timeout'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_invite_timeout 2>&1')"
+        nfail=$(echo "$OUT" | grep -c 'INVITE_FAILED for non-responder: PASS')
+        npass=$(echo "$OUT" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        if hung "$OUT"; then
+            bad "group_invite_timeout HUNG (timeout never fired)"
+        elif echo "$OUT" | grep -qiE 'FAILED -'; then
+            bad "group_invite_timeout: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$nfail" -ge 1 ] && [ "$npass" -ge 3 ]; then
+            ok "leader reported the non-responder and formed the group on the 3 that accepted"
+        else
+            bad "group_invite_timeout: failed=$nfail completed=$npass: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_invite_timeout not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite_timeout: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
     # member lost during destruct
     #############################################################
     banner "member lost during PMIx_Group_destruct (loss accounting)"
@@ -173,6 +203,23 @@ test_macos() {
         fi
     else
         skp "group_invite (not built)"
+    fi
+
+    banner "macOS: invite timeout (single host)"
+    if [ -x "$prefix/bin/group_invite_timeout" ]; then
+        macpk; sleep 1
+        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_timeout" 2>&1)"
+        nfail=$(echo "$out" | grep -c 'INVITE_FAILED for non-responder: PASS')
+        npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
+            skp "group_invite_timeout: not clean (native Darwin DVM can be flaky)"
+        elif [ "$nfail" -ge 1 ] && [ "$npass" -ge 3 ]; then
+            ok "group_invite_timeout: non-responder reported, group formed on 3 (single host)"
+        else
+            skp "group_invite_timeout: failed=$nfail completed=$npass (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_invite_timeout (not built)"
     fi
 
     banner "macOS: member lost during destruct (single host)"

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise the DYNAMIC, event-driven PMIx group operations and their fault
+# paths across the container swarm produced by build.sh, driving the example
+# programs through PRRTE.  This run is kept separate from run-tests.sh (which
+# covers the group *construction methods*) so the event/fault matrix can grow
+# independently as more of the dynamic protocol gains coverage.
+#
+#   ./run-group-events.sh linux    # full suite in the 10-container swarm
+#                                  #   (requires: ./build.sh && docker compose up -d)
+#   ./run-group-events.sh macos    # single-host subset natively on this host
+#                                  #   (requires: ./build.sh macos)
+#
+# Prints PASS/FAIL per test and a summary; exits non-zero if anything failed.
+# The multi-node swarm matters because the dynamic group protocol is realized
+# through event notifications (PMIx_Notify_event) that must cross distinct PMIx
+# servers (one prted per node), so the cross-daemon notification paths for
+# invitations, completion broadcasts, and fault events actually run.
+#
+# Coverage so far:
+#   * group_invite       -- invite/join happy path: a leader invites the whole
+#                           job, invitees accept via PMIx_Group_join, the group
+#                           forms, and every member receives
+#                           PMIX_GROUP_CONSTRUCT_COMPLETE and can fence across
+#                           the group.
+#   * group_destruct_die -- a member is lost mid-PMIx_Group_destruct; the
+#                           destruct must complete on the survivors rather than
+#                           hang (the destruct analog of run-tests.sh's
+#                           group_die, which covers construct).
+#
+# Still to come (as the library gains support -- see issue #3936): invite
+# declined / failed / timeout, leader failure and reselection, construct abort,
+# member-failed events, and the FT-collective adjustment.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+########################################################################
+# Linux: the full 10-node swarm
+########################################################################
+
+# run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
+RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            pmix-node1 bash -lc ". /opt/prte/env.sh; $*"; }
+ON()  { docker exec "pmix-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+
+cleanup_swarm() {
+    for n in $(seq 1 10); do
+        docker exec "pmix-node$n" sh -c \
+            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
+             pkill -9 prterun 2>/dev/null; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix* 2>/dev/null; true'
+    done
+}
+prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+
+# common markers of a launch that hung to the DVM/job timeout
+hung() { echo "$1" | grep -qiE 'time limit for job|timed out|DVM timeout|timeout'; }
+
+test_linux() {
+    if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
+        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
+    fi
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte prun pterm >/dev/null'; then
+        ok "prterun/prte/prun/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    #############################################################
+    # invite / join happy path
+    #############################################################
+    banner "invite/join happy path (PMIX_GROUP_CONSTRUCT_COMPLETE to all members)"
+    cleanup_swarm
+    # group_invite: rank 0 (the leader) invites the whole job; ranks 1..N-1
+    # accept via PMIx_Group_join.  The group forms purely through event
+    # notification (no server collective), so spreading the ranks across nodes
+    # exercises the cross-daemon delivery of both the invitations and the
+    # completion broadcast.  Every member (leader included) must receive
+    # PMIX_GROUP_CONSTRUCT_COMPLETE, then fence across the formed group.
+    if RUN 'test -x /opt/prte/tests/group_invite'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_invite 2>&1')"
+        npass=$(echo "$OUT" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        nfence=$(echo "$OUT" | grep -c 'group fence complete')
+        if hung "$OUT"; then
+            bad "group_invite HUNG (invitation or completion never delivered)"
+        elif echo "$OUT" | grep -qiE 'FAILED|PMIX_ERROR'; then
+            bad "group_invite: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$npass" -ge 4 ] && [ "$nfence" -ge 4 ]; then
+            ok "all 4 members notified of completion and fenced across the group"
+        else
+            bad "group_invite: only $npass completed / $nfence fenced: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_invite not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
+    # member lost during destruct
+    #############################################################
+    banner "member lost during PMIx_Group_destruct (loss accounting)"
+    cleanup_swarm
+    # group_destruct_die: every rank constructs the group, syncs, then every
+    # rank EXCEPT the last calls PMIx_Group_destruct; the last leaves before
+    # contributing (and without finalizing), so the server must account for the
+    # lost member and complete the DEstruct on the survivors instead of hanging.
+    # Same two requirements as group_die/connect_die make the loss observable:
+    #   * --rtos recoverable, so PRRTE does not tear the whole job down when the
+    #     member vanishes without finalizing;
+    #   * whole-job membership + --map-by node, so the victim's node also hosts a
+    #     surviving member (the one whose call created the local tracker the loss
+    #     accounting then completes).
+    if RUN 'test -x /opt/prte/tests/group_destruct_die'; then
+        OUT="$(RUN 'prterun --rtos recoverable --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_destruct_die 2>&1')"
+        n=$(echo "$OUT" | grep -c 'destruct complete on survivors')
+        if hung "$OUT"; then
+            bad "destruct HUNG on member death (loss accounting missing)"
+        elif [ "$n" -ge 3 ]; then
+            ok "destruct completed on all 3 survivors after a member died"
+        else
+            bad "group_destruct_die: only $n survivors completed: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_destruct_die not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_destruct_die: stray prted left behind"
+    cleanup_swarm
+}
+
+########################################################################
+# macOS: native, single host (build + launch smoke)
+########################################################################
+
+test_macos() {
+    local root prefix
+    root="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+    prefix="$root/vpath-macos-prte/install"
+    if [ ! -x "$prefix/bin/prterun" ]; then
+        echo "native build missing -- run: ./build.sh macos" >&2; exit 2
+    fi
+    export PATH="$prefix/bin:$PATH"
+    export DYLD_LIBRARY_PATH="$prefix/lib:$root/vpath-macos-pmix/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    macpk() { pkill -9 prterun 2>/dev/null; pkill -9 -x prte 2>/dev/null; pkill -9 -x prted 2>/dev/null; true; }
+
+    banner "macOS: invite/join happy path (single host)"
+    if [ -x "$prefix/bin/group_invite" ]; then
+        macpk; sleep 1
+        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite" 2>&1)"
+        npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        if echo "$out" | grep -qiE 'FAILED|timeout|timed out'; then
+            skp "group_invite: not clean (native Darwin DVM can be flaky): $(echo "$out" | tr '\n' ' ' | tail -c 160)"
+        elif [ "$npass" -ge 4 ]; then
+            ok "group_invite: all 4 members notified of completion (single host)"
+        else
+            skp "group_invite: only $npass completed (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_invite (not built)"
+    fi
+
+    banner "macOS: member lost during destruct (single host)"
+    if [ -x "$prefix/bin/group_destruct_die" ]; then
+        macpk; sleep 1
+        out="$(prterun --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_destruct_die" 2>&1)"
+        n=$(echo "$out" | grep -c 'destruct complete on survivors')
+        if echo "$out" | grep -qiE 'timeout|timed out'; then
+            skp "group_destruct_die: not clean (native Darwin DVM can be flaky)"
+        elif [ "$n" -ge 3 ]; then
+            ok "group_destruct_die: destruct completed on 3 survivors (single host)"
+        else
+            skp "group_destruct_die: only $n survivors (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_destruct_die (not built)"
+    fi
+    macpk
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n================  %d passed, %d failed, %d skipped  ================\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -30,7 +30,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
                   simple simple_server abort group_die connect_die group_leave \
-                  group_destruct_die group_invite group_invite_timeout
+                  group_destruct_die group_invite group_invite_timeout group_invite_decline
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -121,6 +121,10 @@ group_invite_LDADD = $(top_builddir)/src/libpmix.la
 group_invite_timeout_SOURCES = group_invite_timeout.c examples.h
 group_invite_timeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_invite_timeout_LDADD = $(top_builddir)/src/libpmix.la
+
+group_invite_decline_SOURCES = group_invite_decline.c examples.h
+group_invite_decline_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_invite_decline_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -230,7 +234,7 @@ distclean-local:
         hello jctrl launcher log pub pubi server tool \
         abi_no_init abi_with_init group_lcl_cid pset \
         async_group group_dmodex group_bootstrap client3 \
-        group_leave group_destruct_die group_invite group_invite_timeout \
+        group_leave group_destruct_die group_invite group_invite_timeout group_invite_decline \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -29,7 +29,8 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   hello nodeinfo  abi_no_init abi_with_init group_lcl_cid pset log \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
-                  simple simple_server abort group_die connect_die group_leave
+                  simple simple_server abort group_die connect_die group_leave \
+                  group_destruct_die group_invite
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -108,6 +109,14 @@ connect_die_LDADD = $(top_builddir)/src/libpmix.la
 group_leave_SOURCES = group_leave.c examples.h
 group_leave_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_leave_LDADD = $(top_builddir)/src/libpmix.la
+
+group_destruct_die_SOURCES = group_destruct_die.c examples.h
+group_destruct_die_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_destruct_die_LDADD = $(top_builddir)/src/libpmix.la
+
+group_invite_SOURCES = group_invite.c examples.h
+group_invite_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_invite_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -217,7 +226,7 @@ distclean-local:
         hello jctrl launcher log pub pubi server tool \
         abi_no_init abi_with_init group_lcl_cid pset \
         async_group group_dmodex group_bootstrap client3 \
-        group_leave \
+        group_leave group_destruct_die group_invite \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -30,7 +30,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
                   simple simple_server abort group_die connect_die group_leave \
-                  group_destruct_die group_invite
+                  group_destruct_die group_invite group_invite_timeout
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -117,6 +117,10 @@ group_destruct_die_LDADD = $(top_builddir)/src/libpmix.la
 group_invite_SOURCES = group_invite.c examples.h
 group_invite_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_invite_LDADD = $(top_builddir)/src/libpmix.la
+
+group_invite_timeout_SOURCES = group_invite_timeout.c examples.h
+group_invite_timeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_invite_timeout_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -226,7 +230,7 @@ distclean-local:
         hello jctrl launcher log pub pubi server tool \
         abi_no_init abi_with_init group_lcl_cid pset \
         async_group group_dmodex group_bootstrap client3 \
-        group_leave group_destruct_die group_invite \
+        group_leave group_destruct_die group_invite group_invite_timeout \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -30,7 +30,8 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_bootstrap client3 client4 launcher spawn_group resolve multi_nspace_group \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
                   simple simple_server abort group_die connect_die group_leave \
-                  group_destruct_die group_invite group_invite_timeout group_invite_decline
+                  group_destruct_die group_invite group_invite_timeout group_invite_decline \
+                  group_invite_abort
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -125,6 +126,10 @@ group_invite_timeout_LDADD = $(top_builddir)/src/libpmix.la
 group_invite_decline_SOURCES = group_invite_decline.c examples.h
 group_invite_decline_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_invite_decline_LDADD = $(top_builddir)/src/libpmix.la
+
+group_invite_abort_SOURCES = group_invite_abort.c examples.h
+group_invite_abort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_invite_abort_LDADD = $(top_builddir)/src/libpmix.la
 
 group_dmodex_SOURCES = group_dmodex.c examples.h
 group_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -235,6 +240,7 @@ distclean-local:
         abi_no_init abi_with_init group_lcl_cid pset \
         async_group group_dmodex group_bootstrap client3 \
         group_leave group_destruct_die group_invite group_invite_timeout group_invite_decline \
+        group_invite_abort \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort

--- a/examples/group_destruct_die.c
+++ b/examples/group_destruct_die.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise group DEstruction when a member is lost before it contributes.
+ *
+ * This is the destruct analog of group_die.c (which covers construct).  Every
+ * rank in the job is a group member.  All ranks first construct the group and
+ * sync with a fence, so a live group exists on every server.  Then every rank
+ * EXCEPT the last calls PMIx_Group_destruct; the last rank leaves WITHOUT
+ * calling it (after a short delay, so the others have already entered the
+ * destruct and their servers have created the local trackers) and WITHOUT
+ * calling PMIx_Finalize, so the server sees a dropped connection. The server
+ * must account for the departed member and complete the DEstruct on the
+ * survivors rather than hang -- the same lost-connection accounting that
+ * completes a construct (account_departed() in src/server/pmix_server_group.c)
+ * applies to a destruct block, forwarding blk->grpop == PMIX_GROUP_DESTRUCT to
+ * the host. See docs/how-things-work/collectives.
+ *
+ * The whole job is the membership (rather than a subset) so that, when launched
+ * across nodes, the victim's node always also hosts a surviving member -- the
+ * one that creates the local tracker the loss accounting then completes. Launch
+ * with a launcher that does not kill the job when the victim exits; under PRRTE
+ * that is `prterun --rtos recoverable ...`.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t *results;
+    size_t nresults;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    /* every rank (including the victim) constructs the group so a live group
+     * exists on every server before anyone attempts to destruct it */
+    fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    results = NULL;
+    nresults = 0;
+    rc = PMIx_Group_construct("ddgroup", procs, nprocs, NULL, 0, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* sync so the group is fully constructed everywhere before anyone leaves */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: post-construct PMIx_Fence failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    if (myproc.rank == victim) {
+        /* the "victim": a member that leaves before contributing to the
+         * DEstruct.  Delay briefly so the other members have entered the
+         * destruct and their servers have built the local trackers, then leave
+         * without calling it - and without calling PMIx_Finalize, so the server
+         * sees a dropped connection and must run its lost-connection accounting.
+         * We exit with status 0 so the launcher does not abort the whole job;
+         * the dropped socket, not the exit code, is what exercises the server. */
+        fprintf(stderr, "%d leaving BEFORE group destruct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+    rc = PMIx_Group_destruct("ddgroup", NULL, 0);
+
+    /* The destruct must COMPLETE rather than hang.  It may return success or a
+     * partial-success/lost-connection status depending on how the host treats
+     * the departed member; either way, reaching here is the point of the
+     * test - the collective did not hang on the lost participant. */
+    fprintf(stderr, "%d Group destruct complete on survivors: status %s\n",
+            myproc.rank, PMIx_Error_string(rc));
+
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "Client ns %s rank %d: FINALIZED\n", myproc.nspace, myproc.rank);
+    return 0;
+}

--- a/examples/group_invite.c
+++ b/examples/group_invite.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the group invite/join happy path as a first-class test.
+ *
+ * Unlike asyncgroup.c (which uses the invite model incidentally and only has
+ * the leader report a result), this test makes the dynamic invite/join
+ * negotiation the object of the test and asserts on every participant:
+ *
+ *   - The whole job is the intended membership.  Rank 0 is the leader; it calls
+ *     PMIx_Group_invite with the full job as the desired members.
+ *   - Every other rank has registered a PMIX_GROUP_INVITED handler and responds
+ *     by accepting via PMIx_Group_join_nb (the non-blocking form is mandatory:
+ *     the handler runs on the library progress thread, so the blocking form
+ *     would deadlock).
+ *   - Every rank has registered a PMIX_GROUP_CONSTRUCT_COMPLETE handler and must
+ *     receive that event once the group forms -- the leader because it is a
+ *     member, the invitees because they joined.  A rank that never receives it
+ *     fails (via a bounded wait) rather than hanging.
+ *   - Once formed, every member executes a PMIx_Fence across the group
+ *     (identified by {grpid, PMIX_RANK_WILDCARD}) to prove the group is usable,
+ *     then the leader destructs it.
+ *
+ * The invite model relies solely on the event-notification subsystem, so
+ * launching the job across nodes exercises the cross-server notification path
+ * for both the invitations and the completion broadcast.  No member is lost in
+ * this test, so no --rtos recoverable is required.  See
+ * docs/how-things-work/sets_groups/group_construct.rst.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+#define GROUP_ID "invgroup"
+
+static pmix_proc_t myproc;
+static volatile bool complete_seen = false;
+
+/* PMIX_GROUP_INVITED handler: an invitee accepts the invitation.  The leader
+ * sees its own invitation reflected back (source == self) and ignores it. */
+static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, results, nresults);
+
+    /* if I am the leader, ignore my own invitation and let the chain proceed */
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    /* find the group id carried on the invitation and accept it */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+    fprintf(stderr, "%s:%d INVITED to group %s by %s:%d - accepting\n",
+            myproc.nspace, myproc.rank, (NULL == grp) ? "(unknown)" : grp,
+            source->nspace, source->rank);
+    rc = PMIx_Group_join_nb(grp, source, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d ERROR in PMIx_Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+
+    /* always continue the event chain */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_CONSTRUCT_COMPLETE handler: the group finished forming */
+static void complete_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                             pmix_info_t results[], size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d NOTIFIED that group construct is complete\n",
+            myproc.nspace, myproc.rank);
+    complete_seen = true;
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+/* register one event handler for a single code, blocking until registered */
+static int register_handler(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    mylock_t lock;
+    int rc;
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, errhandler_reg_callbk, (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t *results;
+    size_t nresults;
+    int waited;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 2 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* register handlers for the invitation and the completion events */
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITED, invite_handler))) {
+        fprintf(stderr, "%d: failed to register invited handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler))) {
+        fprintf(stderr, "%d: failed to register complete handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* sync so every rank has its handlers in place before anyone invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (0 == myproc.rank) {
+        /* the leader invites the whole job (itself included) to the group */
+        fprintf(stderr, "%d executing Group_invite for the whole job\n", myproc.rank);
+        PMIX_PROC_CREATE(procs, nprocs);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+        }
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, NULL, 0, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_invite FAILED: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "%d Group invite complete with status PMIX_SUCCESS\n", myproc.rank);
+    } else {
+        /* an invitee: our invite_handler accepts asynchronously.  Wait
+         * (bounded) for the group to finish forming rather than hang. */
+        fprintf(stderr, "%s:%d waiting to be invited and to join the group\n",
+                myproc.nspace, myproc.rank);
+    }
+
+    /* every member (leader and invitees) must receive CONSTRUCT_COMPLETE */
+    for (waited = 0; !complete_seen && waited < 100; waited++) {
+        usleep(100000); /* 0.1s; up to 10s total */
+    }
+    if (!complete_seen) {
+        fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                "PMIX_GROUP_CONSTRUCT_COMPLETE\n", myproc.nspace, myproc.rank);
+        rc = PMIX_ERR_TIMEOUT;
+        goto done;
+    }
+    fprintf(stderr, "%d PMIX_GROUP_CONSTRUCT_COMPLETE received: PASS\n", myproc.rank);
+
+    /* prove the group is usable: fence across it by its group id */
+    PMIX_LOAD_PROCID(&proc, GROUP_ID, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group FAILED: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    fprintf(stderr, "%d group fence complete\n", myproc.rank);
+
+    /* tear the group back down.  Destruct is a collective over the group
+     * membership, so every member (leader and invitees alike) must call it. */
+    fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+    rc = PMIx_Group_destruct(GROUP_ID, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct FAILED: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* final sync across the job */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: final PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/examples/group_invite_abort.c
+++ b/examples/group_invite_abort.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the invite/join CONSTRUCT_ABORT path.
+ *
+ * The leader (rank 0) invites the whole job to a group WITHOUT
+ * PMIX_GROUP_OPTIONAL, making the construct all-or-nothing. Every invitee
+ * accepts EXCEPT the last rank, which explicitly DECLINES via PMIx_Group_join
+ * with PMIX_GROUP_DECLINE. Because participation was not optional, that single
+ * non-accepter must abort the entire construct: no group forms. The library
+ * must:
+ *
+ *   - notify every invited participant (including the members that accepted,
+ *     so they stop waiting for a completion that will never come) with
+ *     PMIX_GROUP_CONSTRUCT_ABORT; and
+ *   - return PMIX_GROUP_CONSTRUCT_ABORT from the leader's PMIx_Group_invite.
+ *
+ * Nobody may receive PMIX_GROUP_CONSTRUCT_COMPLETE. The leader asserts its
+ * invite returned the abort status; every rank asserts it received the abort
+ * event and did NOT receive a completion. All ranks rejoin the job-level
+ * barrier so the run tears down cleanly. See src/client/pmix_client_group.c
+ * and #3936.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+#define GROUP_ID "idabortgroup"
+
+static pmix_proc_t myproc;
+static uint32_t decliner = 0;
+static volatile bool complete_seen = false;
+static volatile bool abort_seen = false;
+
+/* PMIX_GROUP_INVITED handler: accept, unless we are the designated decliner
+ * (which explicitly declines) or the leader (which ignores its own
+ * invitation). */
+static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    pmix_group_opt_t opt;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, results, nresults);
+
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        /* our own invitation - ignore */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+
+    if (myproc.rank == decliner) {
+        opt = PMIX_GROUP_DECLINE;
+        fprintf(stderr, "%s:%d INVITED - declining\n", myproc.nspace, myproc.rank);
+    } else {
+        opt = PMIX_GROUP_ACCEPT;
+        fprintf(stderr, "%s:%d INVITED - accepting\n", myproc.nspace, myproc.rank);
+    }
+    rc = PMIx_Group_join_nb(grp, source, opt, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d ERROR in PMIx_Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_CONSTRUCT_COMPLETE handler - must NOT fire in this exerciser */
+static void complete_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                             pmix_info_t results[], size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d ERROR - unexpected PMIX_GROUP_CONSTRUCT_COMPLETE\n",
+            myproc.nspace, myproc.rank);
+    complete_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_CONSTRUCT_ABORT handler - the construct was aborted */
+static void abort_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                          const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                          pmix_info_t results[], size_t nresults,
+                          pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d NOTIFIED that group construct was ABORTED\n",
+            myproc.nspace, myproc.rank);
+    abort_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static int register_handler(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    mylock_t lock;
+    int rc;
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, errhandler_reg_callbk, (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t *results;
+    size_t nresults;
+    int waited;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 3) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 3 processes\n");
+        }
+        exit(1);
+    }
+    /* the last rank is the one that will decline, aborting the construct */
+    decliner = nprocs - 1;
+    fprintf(stderr, "Client %s:%d job size %d (decliner is rank %d)\n",
+            myproc.nspace, myproc.rank, nprocs, decliner);
+
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITED, invite_handler))) {
+        fprintf(stderr, "%d: failed to register invited handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler))) {
+        fprintf(stderr, "%d: failed to register complete handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_ABORT, abort_handler))) {
+        fprintf(stderr, "%d: failed to register abort handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* sync so every rank has its handlers in place before the leader invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (0 == myproc.rank) {
+        /* invite the whole job with NO PMIX_GROUP_OPTIONAL - the construct is
+         * all-or-nothing, so the lone decliner must abort it */
+        fprintf(stderr, "%d executing Group_invite (all-or-nothing) for the whole job\n",
+                myproc.rank);
+        PMIX_PROC_CREATE(procs, nprocs);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+        }
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, NULL, 0, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        fprintf(stderr, "%d Group invite returned: %s\n", myproc.rank, PMIx_Error_string(rc));
+        if (PMIX_GROUP_CONSTRUCT_ABORT != rc) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - invite returned %s, expected "
+                    "PMIX_GROUP_CONSTRUCT_ABORT\n", myproc.nspace, myproc.rank,
+                    PMIx_Error_string(rc));
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIx_Group_invite returned CONSTRUCT_ABORT: PASS\n", myproc.rank);
+    }
+
+    /* every invited participant must receive the abort event and none may be
+     * told the (nonexistent) group completed */
+    for (waited = 0; !abort_seen && waited < 100; waited++) {
+        usleep(100000); /* 0.1s; up to 10s total */
+    }
+    if (!abort_seen) {
+        fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                "PMIX_GROUP_CONSTRUCT_ABORT\n", myproc.nspace, myproc.rank);
+        rc = PMIX_ERR_TIMEOUT;
+        goto done;
+    }
+    if (complete_seen) {
+        fprintf(stderr, "Client ns %s rank %d: FAILED - received CONSTRUCT_COMPLETE for an "
+                "aborted construct\n", myproc.nspace, myproc.rank);
+        rc = PMIX_ERROR;
+        goto done;
+    }
+    fprintf(stderr, "%d PMIX_GROUP_CONSTRUCT_ABORT received: PASS\n", myproc.rank);
+    rc = PMIX_SUCCESS;
+
+    /* final job-level sync so every rank tears down together */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: final PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/examples/group_invite_decline.c
+++ b/examples/group_invite_decline.c
@@ -19,12 +19,13 @@
  *
  * Exercise the invite/join DECLINE path.
  *
- * The leader (rank 0) invites the whole job to a group and - unlike the timeout
- * exerciser - passes NO PMIX_TIMEOUT. Every invitee accepts EXCEPT the last
- * rank, which explicitly DECLINES via PMIx_Group_join with PMIX_GROUP_DECLINE.
- * A decline is a definitive answer, so the leader must resolve the construct
- * immediately - it must NOT hang waiting for the decliner (there is no timeout
- * to rescue it). The library must:
+ * The leader (rank 0) invites the whole job to a group with PMIX_GROUP_OPTIONAL
+ * (so a non-accepter yields a reduced group rather than aborting the construct)
+ * and - unlike the timeout exerciser - passes NO PMIX_TIMEOUT. Every invitee
+ * accepts EXCEPT the last rank, which explicitly DECLINES via PMIx_Group_join
+ * with PMIX_GROUP_DECLINE. A decline is a definitive answer, so the leader must
+ * resolve the construct immediately - it must NOT hang waiting for the decliner
+ * (there is no timeout to rescue it). The library must:
  *
  *   - report the decliner to the leader via PMIX_GROUP_INVITE_FAILED; and
  *   - complete PMIx_Group_invite on the members that accepted (reduced
@@ -226,16 +227,22 @@ int main(int argc, char **argv)
     }
 
     if (0 == myproc.rank) {
+        pmix_info_t dirs[1];
         /* invite the whole job - deliberately with NO timeout, so the decline
-         * itself (not a timer) must resolve the construct */
-        fprintf(stderr, "%d executing Group_invite (no timeout) for the whole job\n", myproc.rank);
+         * itself (not a timer) must resolve the construct. Mark participation
+         * PMIX_GROUP_OPTIONAL so the decline yields a reduced group rather than
+         * aborting the construct. */
+        fprintf(stderr, "%d executing Group_invite (optional, no timeout) for the whole job\n",
+                myproc.rank);
         PMIX_PROC_CREATE(procs, nprocs);
         for (n = 0; n < nprocs; n++) {
             PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
         }
         results = NULL;
         nresults = 0;
-        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, NULL, 0, &results, &nresults);
+        PMIX_INFO_LOAD(&dirs[0], PMIX_GROUP_OPTIONAL, NULL, PMIX_BOOL);
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, dirs, 1, &results, &nresults);
+        PMIX_INFO_DESTRUCT(&dirs[0]);
         PMIX_PROC_FREE(procs, nprocs);
         if (NULL != results) {
             PMIX_INFO_FREE(results, nresults);

--- a/examples/group_invite_decline.c
+++ b/examples/group_invite_decline.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the invite/join DECLINE path.
+ *
+ * The leader (rank 0) invites the whole job to a group and - unlike the timeout
+ * exerciser - passes NO PMIX_TIMEOUT. Every invitee accepts EXCEPT the last
+ * rank, which explicitly DECLINES via PMIx_Group_join with PMIX_GROUP_DECLINE.
+ * A decline is a definitive answer, so the leader must resolve the construct
+ * immediately - it must NOT hang waiting for the decliner (there is no timeout
+ * to rescue it). The library must:
+ *
+ *   - report the decliner to the leader via PMIX_GROUP_INVITE_FAILED; and
+ *   - complete PMIx_Group_invite on the members that accepted (reduced
+ *     membership), delivering PMIX_GROUP_CONSTRUCT_COMPLETE only to them.
+ *
+ * The leader asserts it saw the INVITE_FAILED for the decliner and that the
+ * invite returned; the accepting members assert they were notified of
+ * completion. The decliner rejoins the job-level barrier so the run tears down
+ * cleanly. See src/client/pmix_client_group.c and #3936.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+#define GROUP_ID "idclgroup"
+
+static pmix_proc_t myproc;
+static uint32_t decliner = 0;
+static volatile bool complete_seen = false;
+static volatile bool failed_seen = false;
+static pmix_proc_t failed_proc;
+
+/* PMIX_GROUP_INVITED handler: accept, unless we are the designated decliner
+ * (which explicitly declines) or the leader (which ignores its own
+ * invitation). */
+static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    pmix_group_opt_t opt;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, results, nresults);
+
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        /* our own invitation - ignore */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+
+    if (myproc.rank == decliner) {
+        opt = PMIX_GROUP_DECLINE;
+        fprintf(stderr, "%s:%d INVITED - declining\n", myproc.nspace, myproc.rank);
+    } else {
+        opt = PMIX_GROUP_ACCEPT;
+        fprintf(stderr, "%s:%d INVITED - accepting\n", myproc.nspace, myproc.rank);
+    }
+    rc = PMIx_Group_join_nb(grp, source, opt, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d ERROR in PMIx_Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_CONSTRUCT_COMPLETE handler */
+static void complete_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                             pmix_info_t results[], size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d NOTIFIED that group construct is complete\n",
+            myproc.nspace, myproc.rank);
+    complete_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_INVITE_FAILED handler (leader) - records who declined */
+static void failed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    PMIX_PROC_CONSTRUCT(&failed_proc);
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&failed_proc, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    fprintf(stderr, "%s:%d NOTIFIED that %s:%d declined the invitation\n",
+            myproc.nspace, myproc.rank, failed_proc.nspace, failed_proc.rank);
+    failed_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static int register_handler(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    mylock_t lock;
+    int rc;
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, errhandler_reg_callbk, (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t *results;
+    size_t nresults;
+    int waited;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 3) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 3 processes\n");
+        }
+        exit(1);
+    }
+    /* the last rank is the one that will decline */
+    decliner = nprocs - 1;
+    fprintf(stderr, "Client %s:%d job size %d (decliner is rank %d)\n",
+            myproc.nspace, myproc.rank, nprocs, decliner);
+
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITED, invite_handler))) {
+        fprintf(stderr, "%d: failed to register invited handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler))) {
+        fprintf(stderr, "%d: failed to register complete handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (0 == myproc.rank) {
+        if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITE_FAILED, failed_handler))) {
+            fprintf(stderr, "%d: failed to register invite-failed handler: %s\n", myproc.rank,
+                    PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+
+    /* sync so every rank has its handlers in place before the leader invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (0 == myproc.rank) {
+        /* invite the whole job - deliberately with NO timeout, so the decline
+         * itself (not a timer) must resolve the construct */
+        fprintf(stderr, "%d executing Group_invite (no timeout) for the whole job\n", myproc.rank);
+        PMIX_PROC_CREATE(procs, nprocs);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+        }
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, NULL, 0, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        fprintf(stderr, "%d Group invite returned: %s\n", myproc.rank, PMIx_Error_string(rc));
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_invite FAILED: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        if (!failed_seen) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                    "PMIX_GROUP_INVITE_FAILED\n", myproc.nspace, myproc.rank);
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        if (failed_proc.rank != decliner) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - wrong declined rank %d (expected %d)\n",
+                    myproc.nspace, myproc.rank, failed_proc.rank, decliner);
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIX_GROUP_INVITE_FAILED for decliner: PASS\n", myproc.rank);
+    } else if (myproc.rank == decliner) {
+        fprintf(stderr, "%d declined the group (not a member)\n", myproc.rank);
+    }
+
+    /* the leader and the accepting members must be notified of completion; the
+     * decliner must NOT be (it is not part of the group) */
+    if (myproc.rank != decliner) {
+        for (waited = 0; !complete_seen && waited < 100; waited++) {
+            usleep(100000); /* 0.1s; up to 10s total */
+        }
+        if (!complete_seen) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                    "PMIX_GROUP_CONSTRUCT_COMPLETE\n", myproc.nspace, myproc.rank);
+            rc = PMIX_ERR_TIMEOUT;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIX_GROUP_CONSTRUCT_COMPLETE received: PASS\n", myproc.rank);
+    }
+
+    /* final job-level sync so every rank (including the decliner) tears down
+     * together */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: final PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/examples/group_invite_timeout.c
+++ b/examples/group_invite_timeout.c
@@ -19,10 +19,12 @@
  *
  * Exercise the invite/join TIMEOUT path.
  *
- * The leader (rank 0) invites the whole job to a group, passing PMIX_TIMEOUT.
- * Every invitee accepts EXCEPT the last rank, which deliberately never responds
- * to its PMIX_GROUP_INVITED event.  Without a timeout the leader would wait
- * forever for that missing acceptance; with one, the library must:
+ * The leader (rank 0) invites the whole job to a group, passing PMIX_TIMEOUT
+ * and PMIX_GROUP_OPTIONAL (so a non-responder yields a reduced group rather than
+ * aborting the construct).  Every invitee accepts EXCEPT the last rank, which
+ * deliberately never responds to its PMIX_GROUP_INVITED event.  Without a
+ * timeout the leader would wait forever for that missing acceptance; with one,
+ * the library must:
  *
  *   - fire PMIX_GROUP_INVITE_FAILED at the leader naming the non-responder;
  *   - complete PMIx_Group_invite on the members that DID accept (reduced
@@ -175,7 +177,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = NULL;
     pmix_proc_t proc, *procs;
     uint32_t nprocs, n;
-    pmix_info_t *results, tinfo;
+    pmix_info_t *results, tinfo[2];
     size_t nresults;
     int waited, timeout = INVITE_TIMEOUT;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
@@ -237,12 +239,16 @@ int main(int argc, char **argv)
         for (n = 0; n < nprocs; n++) {
             PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
         }
-        PMIX_INFO_LOAD(&tinfo, PMIX_TIMEOUT, &timeout, PMIX_INT);
+        /* mark participation PMIX_GROUP_OPTIONAL so a non-responder yields a
+         * reduced group rather than aborting the construct */
+        PMIX_INFO_LOAD(&tinfo[0], PMIX_TIMEOUT, &timeout, PMIX_INT);
+        PMIX_INFO_LOAD(&tinfo[1], PMIX_GROUP_OPTIONAL, NULL, PMIX_BOOL);
         results = NULL;
         nresults = 0;
-        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, &tinfo, 1, &results, &nresults);
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, tinfo, 2, &results, &nresults);
         PMIX_PROC_FREE(procs, nprocs);
-        PMIX_INFO_DESTRUCT(&tinfo);
+        PMIX_INFO_DESTRUCT(&tinfo[0]);
+        PMIX_INFO_DESTRUCT(&tinfo[1]);
         if (NULL != results) {
             PMIX_INFO_FREE(results, nresults);
         }

--- a/examples/group_invite_timeout.c
+++ b/examples/group_invite_timeout.c
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the invite/join TIMEOUT path.
+ *
+ * The leader (rank 0) invites the whole job to a group, passing PMIX_TIMEOUT.
+ * Every invitee accepts EXCEPT the last rank, which deliberately never responds
+ * to its PMIX_GROUP_INVITED event.  Without a timeout the leader would wait
+ * forever for that missing acceptance; with one, the library must:
+ *
+ *   - fire PMIX_GROUP_INVITE_FAILED at the leader naming the non-responder;
+ *   - complete PMIx_Group_invite on the members that DID accept (reduced
+ *     membership) rather than hang or error; and
+ *   - deliver PMIX_GROUP_CONSTRUCT_COMPLETE only to those members (the
+ *     non-responder is not part of the group).
+ *
+ * The leader asserts it saw the INVITE_FAILED for the right proc and that the
+ * invite returned; the accepting members assert they were notified of
+ * completion.  The non-responder simply declines to answer and then rejoins the
+ * job-level barrier so the run tears down cleanly.  See
+ * src/client/pmix_client_group.c and #3936.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+#define GROUP_ID "itogroup"
+#define INVITE_TIMEOUT 3
+
+static pmix_proc_t myproc;
+static uint32_t victim = 0;
+static volatile bool complete_seen = false;
+static volatile bool failed_seen = false;
+static pmix_proc_t failed_proc;
+
+/* PMIX_GROUP_INVITED handler: accept, unless we are the designated
+ * non-responder (which stays silent to drive the timeout) or the leader
+ * (which ignores its own invitation). */
+static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, results, nresults);
+
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        /* our own invitation - ignore */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    if (myproc.rank == victim) {
+        /* the non-responder: deliberately do NOT answer so the leader's timeout
+         * fires */
+        fprintf(stderr, "%s:%d INVITED but deliberately NOT responding (drives timeout)\n",
+                myproc.nspace, myproc.rank);
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+    fprintf(stderr, "%s:%d INVITED - accepting\n", myproc.nspace, myproc.rank);
+    rc = PMIx_Group_join_nb(grp, source, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d ERROR in PMIx_Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_CONSTRUCT_COMPLETE handler */
+static void complete_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                             pmix_info_t results[], size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d NOTIFIED that group construct is complete\n",
+            myproc.nspace, myproc.rank);
+    complete_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* PMIX_GROUP_INVITE_FAILED handler (leader) - records who failed to respond */
+static void failed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    PMIX_PROC_CONSTRUCT(&failed_proc);
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&failed_proc, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    fprintf(stderr, "%s:%d NOTIFIED that %s:%d failed to respond to the invitation\n",
+            myproc.nspace, myproc.rank, failed_proc.nspace, failed_proc.rank);
+    failed_seen = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static int register_handler(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    mylock_t lock;
+    int rc;
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, errhandler_reg_callbk, (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t *results, tinfo;
+    size_t nresults;
+    int waited, timeout = INVITE_TIMEOUT;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 3) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 3 processes\n");
+        }
+        exit(1);
+    }
+    /* the last rank is the one that will not answer the invitation */
+    victim = nprocs - 1;
+    fprintf(stderr, "Client %s:%d job size %d (non-responder is rank %d)\n",
+            myproc.nspace, myproc.rank, nprocs, victim);
+
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITED, invite_handler))) {
+        fprintf(stderr, "%d: failed to register invited handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler))) {
+        fprintf(stderr, "%d: failed to register complete handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (0 == myproc.rank) {
+        if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITE_FAILED, failed_handler))) {
+            fprintf(stderr, "%d: failed to register invite-failed handler: %s\n", myproc.rank,
+                    PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+
+    /* sync so every rank has its handlers in place before the leader invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (0 == myproc.rank) {
+        fprintf(stderr, "%d executing Group_invite (timeout %d s) for the whole job\n",
+                myproc.rank, timeout);
+        PMIX_PROC_CREATE(procs, nprocs);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+        }
+        PMIX_INFO_LOAD(&tinfo, PMIX_TIMEOUT, &timeout, PMIX_INT);
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs, &tinfo, 1, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs);
+        PMIX_INFO_DESTRUCT(&tinfo);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        fprintf(stderr, "%d Group invite returned: %s\n", myproc.rank, PMIx_Error_string(rc));
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_invite FAILED: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        /* we must have been told the non-responder failed to answer */
+        if (!failed_seen) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                    "PMIX_GROUP_INVITE_FAILED\n", myproc.nspace, myproc.rank);
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        if (failed_proc.rank != victim) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - wrong failed rank %d (expected %d)\n",
+                    myproc.nspace, myproc.rank, failed_proc.rank, victim);
+            rc = PMIX_ERROR;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIX_GROUP_INVITE_FAILED for non-responder: PASS\n", myproc.rank);
+    } else if (myproc.rank == victim) {
+        /* the non-responder does not join; it only reports and waits at the
+         * closing barrier */
+        fprintf(stderr, "%d not joining the group (non-responder)\n", myproc.rank);
+    }
+
+    /* the leader and the accepting members must be notified of completion; the
+     * non-responder must NOT be (it is not part of the group) */
+    if (myproc.rank != victim) {
+        for (waited = 0; !complete_seen && waited < 100; waited++) {
+            usleep(100000); /* 0.1s; up to 10s total */
+        }
+        if (!complete_seen) {
+            fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                    "PMIX_GROUP_CONSTRUCT_COMPLETE\n", myproc.nspace, myproc.rank);
+            rc = PMIX_ERR_TIMEOUT;
+            goto done;
+        }
+        fprintf(stderr, "%d PMIX_GROUP_CONSTRUCT_COMPLETE received: PASS\n", myproc.rank);
+    }
+
+    /* final job-level sync so every rank (including the non-responder) tears
+     * down together */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: final PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -74,13 +74,19 @@ typedef struct {
      * that a member has responded definitively (accepted OR declined/
      * terminated); the invitation resolves once every member has answered, or
      * the timeout fires. "responded" marks the members that specifically
-     * ACCEPTED - those form the group; every other member (a decliner, a
-     * terminated proc, or, on timeout, a non-responder) is reported to the
-     * leader via PMIX_GROUP_INVITE_FAILED and excluded. The timer bounds how
-     * long the leader waits, and is armed only when PMIX_TIMEOUT is provided. */
+     * ACCEPTED - those form the group. Whether a non-accepter is fatal depends
+     * on "optional" (the PMIX_GROUP_OPTIONAL directive): when set, participation
+     * is optional, so every non-accepter (a decliner, a terminated proc, or, on
+     * timeout, a non-responder) is reported to the leader via
+     * PMIX_GROUP_INVITE_FAILED and excluded, and the group forms on the reduced
+     * membership. When not set (the default), the construct is all-or-nothing:
+     * any non-accepter aborts it via PMIX_GROUP_CONSTRUCT_ABORT and no group
+     * forms. The timer bounds how long the leader waits, and is armed only when
+     * PMIX_TIMEOUT is provided. */
     bool *responded;
     bool *answered;
     size_t nanswered;
+    bool optional;
     pmix_event_t ev;
     bool timer_active;
     bool completed;
@@ -104,6 +110,7 @@ static void gtcon(pmix_group_tracker_t *p)
     p->responded = NULL;
     p->answered = NULL;
     p->nanswered = 0;
+    p->optional = false;
     p->timer_active = false;
     p->completed = false;
     p->info = NULL;
@@ -849,7 +856,9 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     }
 
     /* check for directives - a timeout bounds how long we wait for the
-     * invitees to respond */
+     * invitees to respond, and PMIX_GROUP_OPTIONAL selects reduced membership
+     * (form the group on whoever accepts) over the default all-or-nothing
+     * construct (abort if any invitee fails to join) */
     if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
@@ -857,7 +866,8 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
                 if (PMIX_SUCCESS != rc) {
                     timeout = 0;
                 }
-                break;
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_OPTIONAL)) {
+                cb->optional = PMIX_INFO_TRUE(&info[n]);
             }
         }
     }
@@ -910,20 +920,59 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
 }
 
 /* Once an invitation has resolved, announce the outcome. Runs on the caller's
- * (non-progress) thread: report each non-responder to the leader via
- * PMIX_GROUP_INVITE_FAILED, then announce the group to the members that
- * accepted via PMIX_GROUP_CONSTRUCT_COMPLETE (only sent to members; servers
- * intercept it to update their membership lists). The membership is the full
- * invited list in the common case, or a reduced list if some invitees
- * declined, terminated, or timed out. */
+ * (non-progress) thread. If any invitee failed to join (declined, terminated,
+ * or timed out) and participation was not marked PMIX_GROUP_OPTIONAL, the
+ * construct is all-or-nothing: abort it by notifying every invited participant
+ * with PMIX_GROUP_CONSTRUCT_ABORT and return that status, forming no group.
+ * Otherwise report each non-responder to the leader via PMIX_GROUP_INVITE_FAILED
+ * and announce the group to the members that accepted via
+ * PMIX_GROUP_CONSTRUCT_COMPLETE (only sent to members; servers intercept it to
+ * update their membership lists). The membership is the full invited list in
+ * the common case, or a reduced list if some invitees declined, terminated, or
+ * timed out. */
 static pmix_status_t invite_announce(pmix_group_tracker_t *cb)
 {
     pmix_proc_t *members = NULL;
-    size_t i, nmembers = 0;
+    size_t i, nmembers = 0, nfailed = 0;
     pmix_data_array_t darray;
     pmix_info_t finfo, cinfo[4];
     pmix_group_tracker_t lock;
     pmix_status_t rc = PMIX_SUCCESS;
+
+    /* count the invitees that did not accept */
+    for (i = 0; i < cb->nmembers; i++) {
+        if (!cb->responded[i]) {
+            ++nfailed;
+        }
+    }
+
+    /* default (not optional): the construct is all-or-nothing. If any invitee
+     * failed to join, abort the whole construct - notify every invited
+     * participant (the full membership, so those that accepted stop waiting for
+     * a completion that will never come) with PMIX_GROUP_CONSTRUCT_ABORT, and
+     * return that status. No group forms. */
+    if (0 < nfailed && !cb->optional) {
+        darray.type = PMIX_PROC;
+        darray.array = cb->members;
+        darray.size = cb->nmembers;
+        PMIX_INFO_LOAD(&cinfo[0], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+        /* this only goes to non-default handlers */
+        PMIX_INFO_LOAD(&cinfo[1], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&cinfo[2], PMIX_GROUP_ID, cb->grpid, PMIX_STRING);
+        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+        rc = PMIx_Notify_event(PMIX_GROUP_CONSTRUCT_ABORT, &pmix_globals.myid,
+                               PMIX_RANGE_CUSTOM, cinfo, 3, op_cbfunc, (void *) &lock);
+        if (PMIX_SUCCESS == rc) {
+            PMIX_WAIT_THREAD(&lock.lock);
+        }
+        PMIX_DESTRUCT(&lock);
+        PMIX_INFO_DESTRUCT(&cinfo[0]);
+        PMIX_INFO_DESTRUCT(&cinfo[1]);
+        PMIX_INFO_DESTRUCT(&cinfo[2]);
+        /* the outcome of the invitation is the abort, even if the notification
+         * itself failed - the group did not form */
+        return PMIX_GROUP_CONSTRUCT_ABORT;
+    }
 
     /* report each proc that did not accept the invitation */
     for (i = 0; i < cb->nmembers; i++) {

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -66,17 +66,21 @@ typedef struct {
     pmix_lock_t lock;
     pmix_status_t status;
     size_t ref;
-    size_t accepted;
     char *grpid;
     pmix_proc_t *members;
     size_t nmembers;
     /* for the invite/join model: the concrete (wildcard-expanded) list of
-     * invited processes, a parallel flag marking which have responded with an
-     * acceptance, and a timer that bounds how long the leader waits for the
-     * invitees to respond (armed only when PMIX_TIMEOUT is provided). On
-     * expiry the non-responders are reported via PMIX_GROUP_INVITE_FAILED and
-     * the construct completes on the members that did accept. */
+     * invited processes and two parallel per-member flags. "answered" marks
+     * that a member has responded definitively (accepted OR declined/
+     * terminated); the invitation resolves once every member has answered, or
+     * the timeout fires. "responded" marks the members that specifically
+     * ACCEPTED - those form the group; every other member (a decliner, a
+     * terminated proc, or, on timeout, a non-responder) is reported to the
+     * leader via PMIX_GROUP_INVITE_FAILED and excluded. The timer bounds how
+     * long the leader waits, and is armed only when PMIX_TIMEOUT is provided. */
     bool *responded;
+    bool *answered;
+    size_t nanswered;
     pmix_event_t ev;
     bool timer_active;
     bool completed;
@@ -94,11 +98,12 @@ static void gtcon(pmix_group_tracker_t *p)
     PMIX_CONSTRUCT_LOCK(&p->lock);
     p->status = PMIX_SUCCESS;
     p->ref = SIZE_MAX;
-    p->accepted = 0;
     p->grpid = NULL;
     p->members = NULL;
     p->nmembers = 0;
     p->responded = NULL;
+    p->answered = NULL;
+    p->nanswered = 0;
     p->timer_active = false;
     p->completed = false;
     p->info = NULL;
@@ -118,6 +123,10 @@ static void gtdes(pmix_group_tracker_t *p)
     if (NULL != p->responded) {
         free(p->responded);
         p->responded = NULL;
+    }
+    if (NULL != p->answered) {
+        free(p->answered);
+        p->answered = NULL;
     }
     if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
@@ -608,14 +617,18 @@ static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     pmix_group_tracker_t *cb = NULL;
+    const pmix_proc_t *responder = source;
     size_t n;
     PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, results, nresults);
 
-    /* find the tracker we asked to be returned with the event */
+    /* find the tracker we asked to be returned with the event, and the identity
+     * of the responding proc. An accept/decline names itself as the event
+     * source; a termination names the departed proc as the affected proc. */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_RETURN_OBJECT)) {
             cb = (pmix_group_tracker_t *) info[n].value.data.ptr;
-            break;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            responder = info[n].value.data.proc;
         }
     }
     if (NULL == cb) {
@@ -625,28 +638,30 @@ static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
         return;
     }
 
-    /* Record an acceptance by identity so we can later build the (possibly
-     * reduced) final membership and know who has yet to respond. A decline or a
-     * termination is simply left as a non-responder: when the invitation
-     * resolves (all accepted, or the timeout fires) the leader reports every
-     * non-responder via PMIX_GROUP_INVITE_FAILED and excludes it from the
-     * group. Those notifications, and the completion broadcast, are issued by
-     * PMIx_Group_invite on its own thread - PMIx_Notify_event must not be
-     * called from this progress thread, where it would deadlock. */
-    if (PMIX_GROUP_INVITE_ACCEPTED == status) {
-        for (n = 0; n < cb->nmembers; n++) {
-            if (PMIX_CHECK_PROCID(&cb->members[n], source)) {
-                if (!cb->responded[n]) {
+    /* Record this response by identity. A member that ACCEPTS joins the group
+     * (responded); one that DECLINES or TERMINATES definitively will not, and
+     * is left out of "responded" so it is reported to the leader via
+     * PMIX_GROUP_INVITE_FAILED and excluded when the invitation resolves. Either
+     * way the member has now "answered", so a decline resolves the construct
+     * immediately rather than waiting out the timeout. The notifications and the
+     * completion broadcast are issued by PMIx_Group_invite on its own thread -
+     * PMIx_Notify_event must not be called from this progress thread, where it
+     * would deadlock. */
+    for (n = 0; n < cb->nmembers; n++) {
+        if (PMIX_CHECK_PROCID(&cb->members[n], responder)) {
+            if (!cb->answered[n]) {
+                cb->answered[n] = true;
+                cb->nanswered++;
+                if (PMIX_GROUP_INVITE_ACCEPTED == status) {
                     cb->responded[n] = true;
-                    cb->accepted++;
                 }
-                break;
             }
+            break;
         }
     }
 
-    /* if every invited member has now accepted, the invitation has resolved */
-    if (cb->accepted == cb->nmembers) {
+    /* once every invited member has answered, the invitation has resolved */
+    if (cb->nanswered == cb->nmembers) {
         invite_wake(cb, PMIX_SUCCESS);
     }
 
@@ -695,7 +710,7 @@ static pmix_status_t invite_job_size(const pmix_proc_t *proc, uint32_t *jsize)
     return rc;
 }
 
-/* An invitation has resolved - either every invitee accepted, or the timeout
+/* An invitation has resolved - either every invitee answered, or the timeout
  * fired. Cancel the timer (if still pending) and wake the operation. The
  * notifications (PMIX_GROUP_INVITE_FAILED for any non-responder and the
  * PMIX_GROUP_CONSTRUCT_COMPLETE broadcast) are deliberately NOT done here:
@@ -758,7 +773,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     struct timeval tv;
 
     cb->grpid = strdup(grp);
-    cb->accepted = 1; // obviously, we accept
+    cb->nanswered = 1; // we have obviously answered (by accepting)
 
     /* compute the number of proposed members, expanding any wildcard ranks */
     for (n = 0; n < nprocs; n++) {
@@ -773,17 +788,22 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         }
     }
 
-    /* build the concrete (wildcard-expanded) list of invited members plus a
-     * parallel flag marking who has responded with an acceptance. We track
-     * identities - not just a count - so that, on a timeout, we can name the
-     * non-responders in the PMIX_GROUP_INVITE_FAILED events and construct the
-     * group on the members that did accept. */
+    /* build the concrete (wildcard-expanded) list of invited members plus the
+     * parallel per-member "answered"/"responded" flags. We track identities -
+     * not just a count - so that we can name the non-accepters (decliners,
+     * terminated procs, and, on a timeout, non-responders) in the
+     * PMIX_GROUP_INVITE_FAILED events and construct the group on the members
+     * that did accept. */
     PMIX_PROC_CREATE(cb->members, cb->nmembers);
     if (NULL == cb->members) {
         return PMIX_ERR_NOMEM;
     }
     cb->responded = (bool *) calloc(cb->nmembers, sizeof(bool));
     if (NULL == cb->responded) {
+        return PMIX_ERR_NOMEM;
+    }
+    cb->answered = (bool *) calloc(cb->nmembers, sizeof(bool));
+    if (NULL == cb->answered) {
         return PMIX_ERR_NOMEM;
     }
     m = 0;
@@ -802,10 +822,12 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
             m++;
         }
     }
-    /* we (the leader) are a member and have obviously already accepted */
+    /* we (the leader) are a member and have obviously already answered by
+     * accepting (this matches the nanswered = 1 seed above) */
     for (m = 0; m < cb->nmembers; m++) {
         if (PMIX_CHECK_PROCID(&cb->members[m], &pmix_globals.myid)) {
             cb->responded[m] = true;
+            cb->answered[m] = true;
             break;
         }
     }
@@ -874,7 +896,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
 
     /* if a timeout was requested, arm a timer so a non-responding invitee
      * cannot hang the leader indefinitely. The handler runs on the progress
-     * thread; it is cancelled by invite_wake() on a full acceptance. */
+     * thread; it is cancelled by invite_wake() once every invitee answers. */
     if (0 < timeout) {
         pmix_event_assign(&cb->ev, pmix_globals.evbase, -1, 0, invite_timeout, (void *) cb);
         cb->timer_active = true;
@@ -1017,9 +1039,10 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
         return rc;
     }
 
-    /* wait for the invitation to resolve - every invitee accepted, or the
-     * timeout fired (invite_wake, on the progress thread, only wakes us; it does
-     * not notify, as PMIx_Notify_event cannot be called from that thread) */
+    /* wait for the invitation to resolve - every invitee answered (accept or
+     * decline), or the timeout fired (invite_wake, on the progress thread, only
+     * wakes us; it does not notify, as PMIx_Notify_event cannot be called from
+     * that thread) */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
 

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -70,6 +70,16 @@ typedef struct {
     char *grpid;
     pmix_proc_t *members;
     size_t nmembers;
+    /* for the invite/join model: the concrete (wildcard-expanded) list of
+     * invited processes, a parallel flag marking which have responded with an
+     * acceptance, and a timer that bounds how long the leader waits for the
+     * invitees to respond (armed only when PMIX_TIMEOUT is provided). On
+     * expiry the non-responders are reported via PMIX_GROUP_INVITE_FAILED and
+     * the construct completes on the members that did accept. */
+    bool *responded;
+    pmix_event_t ev;
+    bool timer_active;
+    bool completed;
     pmix_info_t *info;
     size_t ninfo;
     pmix_info_t *results;
@@ -88,6 +98,9 @@ static void gtcon(pmix_group_tracker_t *p)
     p->grpid = NULL;
     p->members = NULL;
     p->nmembers = 0;
+    p->responded = NULL;
+    p->timer_active = false;
+    p->completed = false;
     p->info = NULL;
     p->ninfo = 0;
     p->results = NULL;
@@ -101,6 +114,10 @@ static void gtdes(pmix_group_tracker_t *p)
     PMIX_DESTRUCT_LOCK(&p->lock);
     if (NULL != p->members) {
         PMIX_PROC_FREE(p->members, p->nmembers);
+    }
+    if (NULL != p->responded) {
+        free(p->responded);
+        p->responded = NULL;
     }
     if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
@@ -124,6 +141,8 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
                             void *cbdata);
 static void op_cbfunc(pmix_status_t status, void *cbdata);
 static void op_cbfunc_rel(pmix_status_t status, void *cbdata);
+static void invite_timeout(int sd, short args, void *cbdata);
+static void invite_wake(pmix_group_tracker_t *cb, pmix_status_t status);
 
 static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
                         pmix_release_cbfunc_t release_fn, void *release_cbdata);
@@ -583,112 +602,56 @@ done:
     return rc;
 }
 
-static void chaincbfunc(pmix_status_t status, void *cbdata)
-{
-    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(status);
-
-    if (NULL != cb) {
-        PMIX_RELEASE(cb);
-    }
-}
-
-static void relcbfunc(void *cbdata)
-{
-    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
-
-    PMIX_RELEASE(cb);
-}
-
 static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
                            pmix_info_t *results, size_t nresults,
                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     pmix_group_tracker_t *cb = NULL;
-    pmix_proc_t *affected = NULL;
     size_t n;
-    pmix_status_t rc = PMIX_GROUP_INVITE_DECLINED;
-    size_t contextid;
-    bool gotctxid = false;
-    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, results, nresults);
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, results, nresults);
 
-    /* find the object we asked to be returned with event */
+    /* find the tracker we asked to be returned with the event */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_RETURN_OBJECT)) {
-            if (PMIX_POINTER != info[n].value.type) {
-                /* this is an unrecoverable error - need to abort */
-            }
             cb = (pmix_group_tracker_t *) info[n].value.data.ptr;
-
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
-            if (PMIX_PROC != info[n].value.type) {
-                /* this is an unrecoverable error - need to abort */
-            }
-            affected = info[n].value.data.proc;
-
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_CONTEXT_ID)) {
-            rc = PMIx_Value_get_number(&info[n].value, &contextid, PMIX_SIZE);
-            gotctxid = true;
+            break;
         }
     }
     if (NULL == cb) {
-        pmix_output(0, "%s: INVITE HANDLER NULL OBJECT",
-                    PMIX_NAME_PRINT(&pmix_globals.myid));
-        /* this is an unrecoverable error - need to abort */
+        pmix_output(0, "%s: INVITE HANDLER NULL OBJECT", PMIX_NAME_PRINT(&pmix_globals.myid));
         /* always must continue the chain */
-        cbfunc(rc, NULL, 0, chaincbfunc, NULL, cbdata);
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
         return;
     }
 
-    /* if the status is accepted, then record it */
+    /* Record an acceptance by identity so we can later build the (possibly
+     * reduced) final membership and know who has yet to respond. A decline or a
+     * termination is simply left as a non-responder: when the invitation
+     * resolves (all accepted, or the timeout fires) the leader reports every
+     * non-responder via PMIX_GROUP_INVITE_FAILED and excludes it from the
+     * group. Those notifications, and the completion broadcast, are issued by
+     * PMIx_Group_invite on its own thread - PMIx_Notify_event must not be
+     * called from this progress thread, where it would deadlock. */
     if (PMIX_GROUP_INVITE_ACCEPTED == status) {
-        cb->accepted++;
-        /* allow the chain to continue */
-        rc = PMIX_SUCCESS;
-        goto complete;
+        for (n = 0; n < cb->nmembers; n++) {
+            if (PMIX_CHECK_PROCID(&cb->members[n], source)) {
+                if (!cb->responded[n]) {
+                    cb->responded[n] = true;
+                    cb->accepted++;
+                }
+                break;
+            }
+        }
     }
 
-    /* if the reporting process terminated, then issue the corresponding
-     * group event - it only goes to this process */
-    if (PMIX_PROC_TERMINATED == status) {
-        if (gotctxid) {
-            cb->ninfo = 2;
-        } else {
-            cb->ninfo = 1;
-        }
-        PMIX_INFO_CREATE(cb->info, cb->ninfo);
-        PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_AFFECTED_PROC, affected, PMIX_PROC);
-        if (gotctxid) {
-            PMIX_INFO_LOAD(&cb->info[1], PMIX_GROUP_CONTEXT_ID, &contextid, PMIX_SIZE);
-        }
-        rc = PMIx_Notify_event(PMIX_GROUP_INVITE_FAILED, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL,
-                               cb->info, cb->ninfo, chaincbfunc, (void *) cb);
-        if (PMIX_SUCCESS != rc) {
-            /* this is an unrecoverable error - need to abort */
-            pmix_output(0, "%s: INVITE HANDLER ERROR",
-                        PMIX_NAME_PRINT(&pmix_globals.myid));
-        }
-        PMIX_INFO_FREE(cb->info, cb->ninfo);
-        goto complete;
-    }
-
-    /* otherwise, we consider the process as having "declined" and
-     * ignore it here - if the user registered a handler for that
-     * case, then the chain will eventually call it
-     */
-
-complete:
-    /* check for complete */
+    /* if every invited member has now accepted, the invitation has resolved */
     if (cb->accepted == cb->nmembers) {
-        /* execute the completion callback */
-        if (NULL != cb->cbfunc) {
-            cb->cbfunc(PMIX_SUCCESS, info, ninfo, cb->cbdata, relcbfunc, cb->cbdata);
-        }
+        invite_wake(cb, PMIX_SUCCESS);
     }
 
     /* always must continue the chain */
-    cbfunc(PMIX_EVENT_ACTION_COMPLETE, cb->results, cb->nresults, NULL, NULL, cbdata);
+    cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     return;
 }
 
@@ -701,14 +664,325 @@ static void regcbfunc(pmix_status_t status, size_t refid, void *cbdata)
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
+/* fetch the number of processes in the given proc's namespace so a
+ * PMIX_RANK_WILDCARD entry in an invitation can be expanded into concrete
+ * ranks */
+static pmix_status_t invite_job_size(const pmix_proc_t *proc, uint32_t *jsize)
+{
+    pmix_cb_t cb2;
+    pmix_info_t optional;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+    PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+    cb2.proc = (pmix_proc_t *) proc;
+    cb2.key = PMIX_JOB_SIZE;
+    cb2.info = &optional;
+    cb2.ninfo = 1;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        PMIX_DESTRUCT(&cb2);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    kv = (pmix_kval_t *) pmix_list_remove_first(&cb2.kvs);
+    PMIX_DESTRUCT(&cb2);
+    if (NULL == kv) { // should never be NULL
+        return PMIX_ERR_BAD_PARAM;
+    }
+    rc = PMIx_Value_get_number(kv->value, jsize, PMIX_UINT32);
+    PMIX_RELEASE(kv);
+    return rc;
+}
+
+/* An invitation has resolved - either every invitee accepted, or the timeout
+ * fired. Cancel the timer (if still pending) and wake the operation. The
+ * notifications (PMIX_GROUP_INVITE_FAILED for any non-responder and the
+ * PMIX_GROUP_CONSTRUCT_COMPLETE broadcast) are deliberately NOT done here:
+ * this runs on the progress thread, where PMIx_Notify_event would deadlock.
+ * The blocking PMIx_Group_invite issues them on its own thread after it wakes;
+ * the non-blocking form hands the result to the caller's callback. Guarded so
+ * a late (post-timeout) acceptance cannot resolve the invite twice. */
+static void invite_wake(pmix_group_tracker_t *cb, pmix_status_t status)
+{
+    if (cb->completed) {
+        return;
+    }
+    cb->completed = true;
+    if (cb->timer_active) {
+        pmix_event_del(&cb->ev);
+        cb->timer_active = false;
+    }
+    cb->status = status;
+    if (NULL != cb->cbfunc) {
+        /* non-blocking form: deliver the result to the caller's callback */
+        cb->cbfunc(status, NULL, 0, cb->cbdata, NULL, NULL);
+    }
+    /* wake the blocking PMIx_Group_invite (if any) */
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
+/* Timeout handler: some invitees did not respond within the caller-provided
+ * PMIX_TIMEOUT. Resolve the invitation on whoever did accept - PMIx_Group_invite
+ * reports the non-responders once it wakes. */
+static void invite_timeout(int sd, short args, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* the timer has fired, so it is no longer pending */
+    cb->timer_active = false;
+    invite_wake(cb, PMIX_SUCCESS);
+}
+
+/* Perform the shared setup for an invitation on a caller-provided tracker
+ * (with cbfunc/cbdata already set for the non-blocking form): build the
+ * concrete membership, register the response handler, notify the invitees, and
+ * arm the optional timeout timer. Runs on the caller's thread. On error the
+ * caller releases the tracker. */
+static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
+                                  const pmix_proc_t *procs, size_t nprocs,
+                                  const pmix_info_t *info, size_t ninfo)
+{
+    pmix_group_tracker_t lock;
+    pmix_status_t codes[] = {
+        PMIX_GROUP_INVITE_ACCEPTED,
+        PMIX_GROUP_INVITE_DECLINED,
+        PMIX_PROC_TERMINATED
+    };
+    size_t ncodes, n, m;
+    pmix_info_t myinfo[2];
+    pmix_status_t rc;
+    uint32_t jsize, j;
+    int timeout = 0;
+    struct timeval tv;
+
+    cb->grpid = strdup(grp);
+    cb->accepted = 1; // obviously, we accept
+
+    /* compute the number of proposed members, expanding any wildcard ranks */
+    for (n = 0; n < nprocs; n++) {
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            rc = invite_job_size(&procs[n], &jsize);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            cb->nmembers += jsize;
+        } else {
+            cb->nmembers++;
+        }
+    }
+
+    /* build the concrete (wildcard-expanded) list of invited members plus a
+     * parallel flag marking who has responded with an acceptance. We track
+     * identities - not just a count - so that, on a timeout, we can name the
+     * non-responders in the PMIX_GROUP_INVITE_FAILED events and construct the
+     * group on the members that did accept. */
+    PMIX_PROC_CREATE(cb->members, cb->nmembers);
+    if (NULL == cb->members) {
+        return PMIX_ERR_NOMEM;
+    }
+    cb->responded = (bool *) calloc(cb->nmembers, sizeof(bool));
+    if (NULL == cb->responded) {
+        return PMIX_ERR_NOMEM;
+    }
+    m = 0;
+    for (n = 0; n < nprocs; n++) {
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            rc = invite_job_size(&procs[n], &jsize);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            for (j = 0; j < jsize; j++) {
+                PMIX_LOAD_PROCID(&cb->members[m], procs[n].nspace, j);
+                m++;
+            }
+        } else {
+            PMIX_LOAD_PROCID(&cb->members[m], procs[n].nspace, procs[n].rank);
+            m++;
+        }
+    }
+    /* we (the leader) are a member and have obviously already accepted */
+    for (m = 0; m < cb->nmembers; m++) {
+        if (PMIX_CHECK_PROCID(&cb->members[m], &pmix_globals.myid)) {
+            cb->responded[m] = true;
+            break;
+        }
+    }
+
+    /* register an event handler specifically to respond to accept responses */
+    PMIX_INFO_LOAD(&myinfo[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
+    PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
+    ncodes = sizeof(codes) / sizeof(pmix_status_t);
+    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+    PMIx_Register_event_handler(codes, ncodes, myinfo, 2, invite_handler, regcbfunc, &lock);
+    PMIX_WAIT_THREAD(&lock.lock);
+    rc = lock.status;
+    cb->ref = lock.ref;
+    PMIX_DESTRUCT(&lock);
+    PMIX_INFO_DESTRUCT(&myinfo[0]);
+    PMIX_INFO_DESTRUCT(&myinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* check for directives - a timeout bounds how long we wait for the
+     * invitees to respond */
+    if (NULL != info) {
+        for (n = 0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                rc = PMIx_Value_get_number(&info[n].value, &timeout, PMIX_INT);
+                if (PMIX_SUCCESS != rc) {
+                    timeout = 0;
+                }
+                break;
+            }
+        }
+    }
+
+    /* limit the range to just the procs we are inviting */
+    PMIX_INFO_CREATE(cb->info, 3);
+    if (NULL == cb->info) {
+        return PMIX_ERR_NOMEM;
+    }
+    cb->ninfo = 3;
+    n = 0;
+    (void) strncpy(cb->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN);
+    cb->info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(cb->info[n].value.data.darray, nprocs, PMIX_PROC);
+    if (NULL == cb->info[n].value.data.darray || NULL == cb->info[n].value.data.darray->array) {
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(cb->info[n].value.data.darray->array, procs, nprocs * sizeof(pmix_proc_t));
+    ++n;
+    /* mark that this only goes to non-default handlers */
+    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    ++n;
+    /* provide the group ID */
+    PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_ID, grp, PMIX_STRING);
+
+    /* notify everyone of the invitation */
+    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+    rc = PMIx_Notify_event(PMIX_GROUP_INVITED, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
+                           cb->info, cb->ninfo, op_cbfunc, (void *) &lock);
+    PMIX_WAIT_THREAD(&lock.lock);
+    rc = lock.status;
+    PMIX_DESTRUCT(&lock);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* if a timeout was requested, arm a timer so a non-responding invitee
+     * cannot hang the leader indefinitely. The handler runs on the progress
+     * thread; it is cancelled by invite_wake() on a full acceptance. */
+    if (0 < timeout) {
+        pmix_event_assign(&cb->ev, pmix_globals.evbase, -1, 0, invite_timeout, (void *) cb);
+        cb->timer_active = true;
+        tv.tv_sec = timeout;
+        tv.tv_usec = 0;
+        PMIX_POST_OBJECT(cb);
+        pmix_event_add(&cb->ev, &tv);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* Once an invitation has resolved, announce the outcome. Runs on the caller's
+ * (non-progress) thread: report each non-responder to the leader via
+ * PMIX_GROUP_INVITE_FAILED, then announce the group to the members that
+ * accepted via PMIX_GROUP_CONSTRUCT_COMPLETE (only sent to members; servers
+ * intercept it to update their membership lists). The membership is the full
+ * invited list in the common case, or a reduced list if some invitees
+ * declined, terminated, or timed out. */
+static pmix_status_t invite_announce(pmix_group_tracker_t *cb)
+{
+    pmix_proc_t *members = NULL;
+    size_t i, nmembers = 0;
+    pmix_data_array_t darray;
+    pmix_info_t finfo, cinfo[4];
+    pmix_group_tracker_t lock;
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    /* report each proc that did not accept the invitation */
+    for (i = 0; i < cb->nmembers; i++) {
+        if (cb->responded[i]) {
+            continue;
+        }
+        PMIX_INFO_LOAD(&finfo, PMIX_EVENT_AFFECTED_PROC, &cb->members[i], PMIX_PROC);
+        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+        rc = PMIx_Notify_event(PMIX_GROUP_INVITE_FAILED, &pmix_globals.myid,
+                               PMIX_RANGE_PROC_LOCAL, &finfo, 1, op_cbfunc, (void *) &lock);
+        if (PMIX_SUCCESS == rc) {
+            PMIX_WAIT_THREAD(&lock.lock);
+        }
+        PMIX_DESTRUCT(&lock);
+        PMIX_INFO_DESTRUCT(&finfo);
+    }
+
+    /* build the final membership from the members that accepted */
+    PMIX_PROC_CREATE(members, cb->nmembers);
+    if (NULL == members) {
+        return PMIX_ERR_NOMEM;
+    }
+    for (i = 0; i < cb->nmembers; i++) {
+        if (cb->responded[i]) {
+            PMIX_LOAD_PROCID(&members[nmembers], cb->members[i].nspace, cb->members[i].rank);
+            ++nmembers;
+        }
+    }
+    darray.type = PMIX_PROC;
+    darray.array = members;
+    darray.size = nmembers;
+    // limit the range to, and report, the final membership
+    PMIX_INFO_LOAD(&cinfo[0], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+    PMIX_INFO_LOAD(&cinfo[1], PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
+    /* this only goes to non-default handlers */
+    PMIX_INFO_LOAD(&cinfo[2], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&cinfo[3], PMIX_GROUP_ID, cb->grpid, PMIX_STRING);
+    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+    rc = PMIx_Notify_event(PMIX_GROUP_CONSTRUCT_COMPLETE, &pmix_globals.myid,
+                           PMIX_RANGE_CUSTOM, cinfo, 4, op_cbfunc, (void *) &lock);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&lock.lock);
+        rc = lock.status;
+    }
+    PMIX_DESTRUCT(&lock);
+    PMIX_INFO_DESTRUCT(&cinfo[0]);
+    PMIX_INFO_DESTRUCT(&cinfo[1]);
+    PMIX_INFO_DESTRUCT(&cinfo[2]);
+    PMIX_INFO_DESTRUCT(&cinfo[3]);
+    PMIX_PROC_FREE(members, nmembers);
+    return rc;
+}
+
+/* Deregister the invitation handler (if it was ever registered), cancel any
+ * pending timer, and release the tracker. Safe to call whether or not
+ * invite_setup got as far as registering, and used both to clean up a failed
+ * setup and to tear down after a blocking invite completes. */
+static void invite_teardown(pmix_group_tracker_t *cb)
+{
+    pmix_group_tracker_t lock;
+
+    if (cb->timer_active) {
+        pmix_event_del(&cb->ev);
+        cb->timer_active = false;
+    }
+    if (SIZE_MAX != cb->ref) {
+        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+        PMIx_Deregister_event_handler(cb->ref, op_cbfunc, &lock);
+        PMIX_WAIT_THREAD(&lock.lock);
+        PMIX_DESTRUCT(&lock);
+        cb->ref = SIZE_MAX;
+    }
+    PMIX_RELEASE(cb);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t procs[],
                                             size_t nprocs, const pmix_info_t info[], size_t ninfo,
                                             pmix_info_t **results, size_t *nresults)
 {
     pmix_group_tracker_t *cb;
     pmix_status_t rc;
-    size_t n;
-    pmix_data_array_t darray;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -728,64 +1002,36 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
         return PMIX_ERR_BAD_PARAM;
     }
 
-    cb = PMIX_NEW(pmix_group_tracker_t);
-    /* we have to bump the reference count of this object
-     * because the invite_nb function involves a release
-     * and we need the object after the invite completes */
-    PMIX_RETAIN(cb);
-    rc = PMIx_Group_invite_nb(grp, procs, nprocs, info, ninfo, info_cbfunc, (void *)cb);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(cb);
-        return rc;
-    }
+    *results = NULL;
+    *nresults = 0;
 
-    /* wait for the group construction to complete or fail */
-    PMIX_WAIT_THREAD(&cb->lock);
-    rc = cb->status;
-    *results = cb->results;
-    *nresults = cb->nresults;
-    cb->results = NULL;
-    cb->nresults = 0;
-    PMIX_RELEASE(cb);
-
-    /* announce group completion, including list of final
-     * members - only sent to members. Servers will intercept
-     * and update their membership lists */
     cb = PMIX_NEW(pmix_group_tracker_t);
-    cb->ninfo = 4;
-    PMIX_INFO_CREATE(cb->info, cb->ninfo);
-    if (NULL == cb->info) {
-        PMIX_RELEASE(cb);
+    if (NULL == cb) {
         return PMIX_ERR_NOMEM;
     }
-    n = 0;
-    darray.type = PMIX_PROC;
-    darray.array = (pmix_proc_t*)procs;
-    darray.size = nprocs;
-    // load the custom range
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
-    ++n;
-    // provide final group membership
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
-    ++n;
-    /* mark that this only goes to non-default handlers */
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    ++n;
-    /* provide the group ID */
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_ID, grp, PMIX_STRING);
-
-    /* notify members */
-    rc = PMIx_Notify_event(PMIX_GROUP_CONSTRUCT_COMPLETE, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
-                           cb->info, cb->ninfo, op_cbfunc, (void *)cb);
+    /* leave cb->cbfunc NULL: this is the blocking form, so we wait on the
+     * tracker's lock rather than being handed the result via a callback */
+    rc = invite_setup(cb, grp, procs, nprocs, info, ninfo);
     if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(cb);
+        invite_teardown(cb);
         return rc;
     }
 
-    /* wait for the notify to get out */
+    /* wait for the invitation to resolve - every invitee accepted, or the
+     * timeout fired (invite_wake, on the progress thread, only wakes us; it does
+     * not notify, as PMIx_Notify_event cannot be called from that thread) */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
-    PMIX_RELEASE(cb);
+
+    /* now on our own thread, announce the outcome to the group */
+    if (PMIX_SUCCESS == rc) {
+        rc = invite_announce(cb);
+    }
+
+    /* deregister the invitation handler now that the invite has resolved (so a
+     * late response cannot fire it against the released tracker) and release
+     * the tracker */
+    invite_teardown(cb);
     return rc;
 }
 
@@ -795,19 +1041,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
                                                void *cbdata)
 {
     pmix_group_tracker_t *cb;
-    pmix_group_tracker_t lock;
-    pmix_status_t codes[] = {
-        PMIX_GROUP_INVITE_ACCEPTED,
-        PMIX_GROUP_INVITE_DECLINED,
-        PMIX_PROC_TERMINATED
-    };
-    size_t ncodes, n;
-    pmix_info_t myinfo[2];
     pmix_status_t rc;
-    pmix_cb_t cb2;
-    pmix_info_t optional;
-    pmix_kval_t *kv;
-    uint32_t jsize;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -833,118 +1067,10 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
     }
     cb->cbfunc = cbfunc;
     cb->cbdata = cbdata;
-    cb->accepted = 1; // obviously, we accept
-
-    /* compute the number of proposed members */
-    for (n = 0; n < nprocs; n++) {
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            /* must get the number of procs in this nspace */
-            PMIX_CONSTRUCT(&cb2, pmix_cb_t);
-            PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
-            cb2.proc = (pmix_proc_t*)&procs[n];
-            cb2.key = PMIX_JOB_SIZE;
-            cb2.info = &optional;
-            cb2.ninfo = 1;
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-            if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
-                kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                PMIX_DESTRUCT(&cb2);
-                if (NULL != kv) {  // should never be NULL
-                    rc = PMIx_Value_get_number(kv->value, &jsize, PMIX_UINT32);
-                    PMIX_RELEASE(kv);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_RELEASE(cb);
-                        PMIX_DESTRUCT(&cb2);
-                        return PMIX_ERR_BAD_PARAM;
-                    }
-                    cb->nmembers += jsize;
-                }
-            } else {
-                PMIX_RELEASE(cb);
-                PMIX_DESTRUCT(&cb2);
-                return PMIX_ERR_BAD_PARAM;
-            }
-        } else {
-            cb->nmembers++;
-        }
-    }
-
-    /* register an event handler specifically to respond
-     * to accept responses */
-    PMIX_INFO_LOAD(&myinfo[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
-    PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
-    ncodes = sizeof(codes) / sizeof(pmix_status_t);
-    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-    PMIx_Register_event_handler(codes, ncodes, myinfo, 2, invite_handler, regcbfunc, &lock);
-    PMIX_WAIT_THREAD(&lock.lock);
-    rc = lock.status;
-    cb->ref = lock.ref;
-    PMIX_DESTRUCT(&lock);
-    PMIX_INFO_DESTRUCT(&myinfo[0]);
-    PMIX_INFO_DESTRUCT(&myinfo[1]);
+    rc = invite_setup(cb, grp, procs, nprocs, info, ninfo);
     if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(cb);
-        return rc;
+        invite_teardown(cb);
     }
-
-    /* check for directives */
-    if (NULL != info) {
-        for (n = 0; n < ninfo; n++) {
-            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
-                /* setup a timer */
-                break;
-            }
-        }
-    }
-
-    /* limit the range to just the procs we are inviting */
-    PMIX_INFO_CREATE(cb->info, 3);
-    if (NULL == cb->info) {
-        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-        PMIx_Deregister_event_handler(cb->ref, op_cbfunc, &lock);
-        PMIX_WAIT_THREAD(&lock.lock);
-        PMIX_DESTRUCT(&lock);
-        PMIX_RELEASE(cb);
-        return PMIX_ERR_NOMEM;
-    }
-    cb->ninfo = 3;
-    n = 0;
-    (void) strncpy(cb->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN);
-    cb->info[n].value.type = PMIX_DATA_ARRAY;
-    PMIX_DATA_ARRAY_CREATE(cb->info[n].value.data.darray, nprocs, PMIX_PROC);
-    if (NULL == cb->info[n].value.data.darray || NULL == cb->info[n].value.data.darray->array) {
-        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-        PMIx_Deregister_event_handler(cb->ref, op_cbfunc, &lock);
-        PMIX_WAIT_THREAD(&lock.lock);
-        PMIX_DESTRUCT(&lock);
-        PMIX_RELEASE(cb);
-        return PMIX_ERR_NOMEM;
-    }
-    memcpy(cb->info[n].value.data.darray->array, procs, nprocs * sizeof(pmix_proc_t));
-    ++n;
-    /* mark that this only goes to non-default handlers */
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    ++n;
-    /* provide the group ID */
-    PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_ID, grp, PMIX_STRING);
-
-    /* notify everyone of the invitation */
-    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-    rc = PMIx_Notify_event(PMIX_GROUP_INVITED, &pmix_globals.myid,
-                           PMIX_RANGE_CUSTOM,
-                           cb->info, cb->ninfo,
-                           op_cbfunc, (void *) &lock);
-    PMIX_WAIT_THREAD(&lock.lock);
-    rc = lock.status;
-    PMIX_DESTRUCT(&lock);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-        PMIx_Deregister_event_handler(cb->ref, op_cbfunc, &lock);
-        PMIX_WAIT_THREAD(&lock.lock);
-        PMIX_DESTRUCT(&lock);
-        PMIX_RELEASE(cb);
-    }
-
     return rc;
 }
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_grpabort.pl.in
+++ b/test/unit/run_grpabort.pl.in
@@ -1,0 +1,133 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the group invite CONSTRUCT_ABORT path deterministically in "make
+# check". A single persistent server (test/simple/simptest) forks four clients
+# (examples/group_invite_abort). Rank 0 is the leader: it invites the whole job
+# to a group WITHOUT PMIX_GROUP_OPTIONAL, so the construct is all-or-nothing.
+# Every invitee accepts EXCEPT the last rank, which explicitly DECLINES via
+# PMIx_Group_join. Because participation was not optional, that lone non-accepter
+# must abort the entire construct: the library must notify every invited
+# participant (including the members that accepted) with
+# PMIX_GROUP_CONSTRUCT_ABORT and return that status from the leader's
+# PMIx_Group_invite, forming no group and delivering no CONSTRUCT_COMPLETE. A
+# regression makes a client exit non-zero - either the invite did not return the
+# abort status, a participant never saw the abort event, or a bogus completion
+# arrived. See src/client/pmix_client_group.c, examples/group_invite_abort.c,
+# and #3936.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen hands us
+# every possible component directory in PMIX_COMPONENT_LIBRARY_PATHS; turn each
+# into an absolute path to the built component so the MCA base can find them
+# without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from its own directory; run from there and name the
+# client (built under examples/) by absolute path so simptest can exec it.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+my $client = $mybuilddir . "/examples/group_invite_abort";
+my $nprocs = 4;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise arm a
+# Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "$nprocs", "-e", "$client");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and slurp
+# the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed (the leader did not get the abort
+# return, a participant never saw the abort event, or a bogus completion fired)
+# drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: the leader's invite must have
+# returned the abort status, every one of the four invited participants must
+# have received the abort event, and simptest must finish cleanly.
+my $leader = ($output =~ /PMIx_Group_invite returned CONSTRUCT_ABORT: PASS/);
+my $nabort = () = ($output =~ /PMIX_GROUP_CONSTRUCT_ABORT received: PASS/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (!$leader) {
+    print "FAIL: leader's PMIx_Group_invite did not return CONSTRUCT_ABORT\n";
+    exit(1);
+}
+if ($nabort < 4) {
+    print "FAIL: only $nabort/4 participants received the abort event\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: an all-or-nothing invite aborted the construct for every participant\n";
+exit(0);

--- a/test/unit/run_grpdecline.pl.in
+++ b/test/unit/run_grpdecline.pl.in
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the group invite DECLINE path deterministically in "make check". A
+# single persistent server (test/simple/simptest) forks four clients
+# (examples/group_invite_decline). Rank 0 is the leader: it invites the whole
+# job to a group with NO timeout. Every invitee accepts EXCEPT the last rank,
+# which explicitly DECLINES via PMIx_Group_join. A decline is a definitive
+# answer, so the library must resolve the construct immediately - report the
+# decliner to the leader via PMIX_GROUP_INVITE_FAILED and form the group on the
+# members that accepted (which then receive PMIX_GROUP_CONSTRUCT_COMPLETE) -
+# rather than hang waiting for a member that will never join. A regression makes
+# a client exit non-zero, or (since there is no timeout to break a hang) wedges
+# the run until the bounded harness timeout fires. See
+# src/client/pmix_client_group.c, examples/group_invite_decline.c, and #3936.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen hands us
+# every possible component directory in PMIX_COMPONENT_LIBRARY_PATHS; turn each
+# into an absolute path to the built component so the MCA base can find them
+# without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from its own directory; run from there and name the
+# client (built under examples/) by absolute path so simptest can exec it.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+my $client = $mybuilddir . "/examples/group_invite_decline";
+my $nprocs = 4;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise arm a
+# Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "$nprocs", "-e", "$client");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and slurp
+# the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed (the leader never saw the
+# INVITE_FAILED, a member never got CONSTRUCT_COMPLETE, or the invite hung on
+# the decliner) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: the leader must have been told
+# the invitee declined, the three members that accepted must have been notified
+# of completion, and simptest must finish cleanly.
+my $failed = ($output =~ /INVITE_FAILED for decliner: PASS/);
+my $ncomplete = () = ($output =~ /CONSTRUCT_COMPLETE received: PASS/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (!$failed) {
+    print "FAIL: leader was not notified of the decline\n";
+    exit(1);
+}
+if ($ncomplete < 3) {
+    print "FAIL: only $ncomplete/3 accepting members were notified of completion\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: invite decline reported the decliner and formed the group on the rest\n";
+exit(0);

--- a/test/unit/run_grpinvite.pl.in
+++ b/test/unit/run_grpinvite.pl.in
@@ -1,0 +1,128 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the dynamic group invite/join happy path, deterministically, in
+# "make check". A single persistent server (test/simple/simptest) forks four
+# clients (examples/group_invite). Rank 0 is the leader: it invites the whole
+# job to a group; ranks 1..3 accept via PMIx_Group_join_nb from their
+# PMIX_GROUP_INVITED handlers; the group forms purely through the event
+# notification subsystem (no server collective). Every member must then receive
+# PMIX_GROUP_CONSTRUCT_COMPLETE, fence across the formed group, and collectively
+# destruct it. A regression in the invite/join negotiation or in the completion
+# broadcast makes a client exit non-zero, or wedges the run until the timeout
+# fires. See src/client/pmix_client_group.c, examples/group_invite.c, and #3936.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen hands us
+# every possible component directory in PMIX_COMPONENT_LIBRARY_PATHS; turn each
+# into an absolute path to the built component so the MCA base can find them
+# without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from its own directory; run from there and name the
+# client (built under examples/) by absolute path so simptest can exec it.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+my $client = $mybuilddir . "/examples/group_invite";
+my $nprocs = 4;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise arm a
+# Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "$nprocs", "-e", "$client");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and slurp
+# the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed (never invited, never notified of
+# completion, or could not fence/destruct) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path rather than passing vacuously:
+# every one of the four members must report it was notified of construct
+# completion and then fenced across the group, and simptest must finish cleanly.
+my $npass  = () = ($output =~ /CONSTRUCT_COMPLETE received: PASS/g);
+my $nfence = () = ($output =~ /group fence complete/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if ($npass < $nprocs) {
+    print "FAIL: only $npass/$nprocs members notified of construct completion\n";
+    exit(1);
+}
+if ($nfence < $nprocs) {
+    print "FAIL: only $nfence/$nprocs members fenced across the group\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: invite/join happy path formed the group across all $nprocs members\n";
+exit(0);

--- a/test/unit/run_grptimeout.pl.in
+++ b/test/unit/run_grptimeout.pl.in
@@ -1,0 +1,130 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the group invite TIMEOUT path deterministically in "make check". A
+# single persistent server (test/simple/simptest) forks four clients
+# (examples/group_invite_timeout). Rank 0 is the leader: it invites the whole
+# job to a group with a PMIX_TIMEOUT. Every invitee accepts EXCEPT the last
+# rank, which deliberately never answers its PMIX_GROUP_INVITED event. The
+# library must fire the leader's timer, report the non-responder to the leader
+# via PMIX_GROUP_INVITE_FAILED, and form the group on the members that DID
+# accept (which then receive PMIX_GROUP_CONSTRUCT_COMPLETE) rather than hang.
+# A regression makes a client exit non-zero, or wedges the run until the
+# timeout fires. See src/client/pmix_client_group.c, examples/group_invite_timeout.c,
+# and #3936.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen hands us
+# every possible component directory in PMIX_COMPONENT_LIBRARY_PATHS; turn each
+# into an absolute path to the built component so the MCA base can find them
+# without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from its own directory; run from there and name the
+# client (built under examples/) by absolute path so simptest can exec it.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+my $client = $mybuilddir . "/examples/group_invite_timeout";
+my $nprocs = 4;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise arm a
+# Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "$nprocs", "-e", "$client");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and slurp
+# the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed (the leader never saw the
+# INVITE_FAILED, a member never got CONSTRUCT_COMPLETE, or the invite hung)
+# drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: the leader must have been told
+# the non-responder failed to answer, the three members that accepted must have
+# been notified of completion, and simptest must finish cleanly.
+my $failed = ($output =~ /INVITE_FAILED for non-responder: PASS/);
+my $ncomplete = () = ($output =~ /CONSTRUCT_COMPLETE received: PASS/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (!$failed) {
+    print "FAIL: leader was not notified of the non-responder\n";
+    exit(1);
+}
+if ($ncomplete < 3) {
+    print "FAIL: only $ncomplete/3 accepting members were notified of completion\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: invite timeout reported the non-responder and formed the group on the rest\n";
+exit(0);


### PR DESCRIPTION
Work on #3936, in the stepwise fashion agreed on the issue: first tests for the
already-supported dynamic-group paths, then fill the gaps one at a time.

## 1. Tests for already-supported paths

**Exercisers + companion harness**
- `examples/group_invite.c` — the invite/join happy path as a first-class test.
- `examples/group_destruct_die.c` — the destruct analog of `group_die` (a member
  is lost mid-`PMIx_Group_destruct`; the destruct completes on the survivors).
- `contrib/dockerswarm/run-group-events.sh` — companion harness, separate from
  `run-tests.sh` so the event/fault matrix can grow independently.

**Deterministic make check**
- `test/unit/run_grpinvite.pl` drives `group_invite` under `simptest -n 4`.

## 2. First gap filled: the invite timeout

`PMIx_Group_invite` accepted `PMIX_TIMEOUT` but never armed a timer, so a
non-responding invitee hung the leader forever. This implements it:

- Report each non-responder to the leader via `PMIX_GROUP_INVITE_FAILED` and
  form the group on the members that accepted (reduced membership).
- Restructured the completion flow to make that correct: track invitees by
  identity; do all `PMIx_Notify_event` calls on the caller's thread (they
  deadlock on the progress thread — this also removes a latent deadlock in the
  existing `PROC_TERMINATED` branch); collapse the two-tracker split into one and
  deregister the handler before releasing the tracker.
- Coverage: `examples/group_invite_timeout.c` (+ `run-group-events.sh` scenario)
  and a deterministic `test/unit/run_grptimeout.pl`.

## Testing

Full `test/unit` `make check` is green (15/15), including the invite happy-path
and timeout tests. All exercisers build clean under `--enable-devel-check` and
pass end-to-end under `simptest`; the timeout is stable across repeated runs.

## Still to come (per #3936)

Invite-declined resolution, leader failure/reselection, construct abort,
`PMIX_GROUP_MEMBER_FAILED`, and `PMIX_GROUP_FT_COLLECTIVE` remain; some require
coordination with PRRTE master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)