### PR TITLE
ptl: drop redundant NULL check in lost_connection

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -238,7 +238,7 @@ static void lost_connection(pmix_peer_t *peer)
                 if (0 < peer->nptr->nlocalprocs) {
                     --peer->nptr->nlocalprocs;
                 }
-                if (NULL != peer->info && 0 < peer->info->proc_cnt) {
+                if (0 < peer->info->proc_cnt) {
                     --peer->info->proc_cnt;
                 }
             }


### PR DESCRIPTION
## Summary

Resolves Coverity CID 504653 (REVERSE_INULL) in `lost_connection()` in `src/mca/ptl/base/ptl_base_sendrecv.c`.

The abnormal-termination accounting guarded its decrement of `peer->info->proc_cnt` with a `NULL != peer->info` test. Investigation shows that guard is dead code:

- The same `!PMIX_PEER_IS_TOOL(pmix_globals.mypeer)` server branch already dereferences `peer->info->pname` **unconditionally** in the collective-accounting loop a few lines above (e.g. `ptl_base_sendrecv.c:99`), so the code already trusts `peer->info` as non-NULL on any path where a collective exists.
- Every peer that can reach `lost_connection` has `info` allocated before its send/recv events are armed — inbound clients/tools in the connection handler (`ptl_base_connection_hdlr.c`), outbound/upstream peers in `pmix_ptl_base_complete_connection()` (`ptl_base_fns.c`).
- The only site that leaves `peer->info` NULL is the failed-handshake cleanup path, which `PMIX_RELEASE`s the peer immediately; it never enters steady-state I/O and so can never trigger `lost_connection`.

This is a code-cleanliness fix, not a latent null-dereference bug: there is no reachable path where `info` is NULL at this point. Removing the guard makes the decrement consistent with the surrounding code and stops it from misleadingly implying `info` might be NULL here.

## Testing

Clean `make` with `--enable-devel-check` (warnings-as-errors); the file recompiles without warnings.