### PR TITLE
Group construct fault tolerance: member/leader/daemon loss, FT-collective gating, and cancel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,7 @@ test/python/run_server.sh
 test/simple/pmitest
 test/simple/simpcycle
 test/simple/simpgrpmember
+test/simple/simpgrpdie
 test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
@@ -251,6 +252,7 @@ test/unit/run_grpinvite.pl
 test/unit/run_grptimeout.pl
 test/unit/run_grpdecline.pl
 test/unit/run_grpabort.pl
+test/unit/run_grpmemberfail.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,8 @@ examples/group_invite
 examples/group_invite_timeout
 examples/group_invite_decline
 examples/group_invite_abort
+examples/group_construct_abort
+examples/group_daemon_fail
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ test/simple/simpgrpmember
 test/simple/simpgrpdie
 test/simple/simpgrpleader
 test/simple/simpgrpcabort
+test/simple/simpgrpctimeout
 test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
@@ -257,6 +258,7 @@ test/unit/run_grpabort.pl
 test/unit/run_grpmemberfail.pl
 test/unit/run_grpleader.pl
 test/unit/run_grpcabort.pl
+test/unit/run_grpctimeout.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ test/simple/pmitest
 test/simple/simpcycle
 test/simple/simpgrpmember
 test/simple/simpgrpdie
+test/simple/simpgrpleader
 test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
@@ -253,6 +254,7 @@ test/unit/run_grptimeout.pl
 test/unit/run_grpdecline.pl
 test/unit/run_grpabort.pl
 test/unit/run_grpmemberfail.pl
+test/unit/run_grpleader.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ test/simple/simpcycle
 test/simple/simpgrpmember
 test/simple/simpgrpdie
 test/simple/simpgrpleader
+test/simple/simpgrpcabort
 test/simple/simptoolcycle
 test/simple/simpfabric
 test/simple/get_put_example
@@ -255,6 +256,7 @@ test/unit/run_grpdecline.pl
 test/unit/run_grpabort.pl
 test/unit/run_grpmemberfail.pl
 test/unit/run_grpleader.pl
+test/unit/run_grpcabort.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1015,6 +1015,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpabort.pl], [chmod +x test/unit/run_grpabort.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmemberfail.pl], [chmod +x test/unit/run_grpmemberfail.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpleader.pl], [chmod +x test/unit/run_grpleader.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpcabort.pl], [chmod +x test/unit/run_grpcabort.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1013,6 +1013,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpdecline.pl], [chmod +x test/unit/run_grpdecline.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpabort.pl], [chmod +x test/unit/run_grpabort.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmemberfail.pl], [chmod +x test/unit/run_grpmemberfail.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1014,6 +1014,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpdecline.pl], [chmod +x test/unit/run_grpdecline.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpabort.pl], [chmod +x test/unit/run_grpabort.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmemberfail.pl], [chmod +x test/unit/run_grpmemberfail.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpleader.pl], [chmod +x test/unit/run_grpleader.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1016,6 +1016,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmemberfail.pl], [chmod +x test/unit/run_grpmemberfail.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpleader.pl], [chmod +x test/unit/run_grpleader.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpcabort.pl], [chmod +x test/unit/run_grpcabort.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpctimeout.pl], [chmod +x test/unit/run_grpctimeout.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -59,7 +59,7 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # group_destruct_die (a member is lost mid PMIx_Group_destruct, so the destruct
 # must complete on the survivors -- the destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_invite_abort group_destruct_die"
+EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_invite_abort group_destruct_die group_construct_abort group_daemon_fail"
 BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES"
 
 mode="${1:-linux}"

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -46,10 +46,26 @@
 #                             destruct must complete on the survivors rather than
 #                             hang (the destruct analog of run-tests.sh's
 #                             group_die, which covers construct).
+#   * group_construct_abort-- a required member is lost mid-construct (its client
+#                             exits before contributing) with no
+#                             PMIX_GROUP_FT_COLLECTIVE; the construct must ABORT
+#                             on every survivor. The victim shares a server with a
+#                             survivor and the other survivors are on other nodes,
+#                             so the victim's server aborts locally AND issues
+#                             PMIX_GROUP_CANCEL to abort the cross-server
+#                             collective (else the remote survivors would hang).
+#   * group_daemon_fail    -- a whole daemon is lost mid-construct: the victim is
+#                             placed alone on a node and the harness kills that
+#                             node's prted while the construct is pending. PRRTE's
+#                             grpcomm fault handler must abort the pending
+#                             construct on the surviving servers (rather than tear
+#                             the DVM down), so every survivor sees
+#                             PMIX_GROUP_CONSTRUCT_ABORT. Requires --rtos
+#                             recoverable.
 #
 # Still to come (as the library gains support -- see issue #3936): leader
-# failure and reselection, construct abort, member-failed events, and the
-# FT-collective adjustment.
+# failure and reselection, member-failed events, and the FT-collective
+# survival adjustment (openpmix/prrte#2510).
 
 set -uo pipefail
 
@@ -78,8 +94,11 @@ cleanup_swarm() {
 }
 prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
 
-# common markers of a launch that hung to the DVM/job timeout
-hung() { echo "$1" | grep -qiE 'time limit for job|timed out|DVM timeout|timeout'; }
+# Markers of a launch that hung until the DVM/job timeout fired. Match only the
+# launcher's genuine timeout-expiry text -- NOT the bare word "timeout", which
+# appears benignly in some tests' own output (e.g. group_invite_timeout prints
+# "(timeout 3 s)" and group_invite_decline prints "(optional, no timeout)").
+hung() { echo "$1" | grep -qiE 'time limit for job|timed out|DVM timeout'; }
 
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
@@ -247,6 +266,110 @@ test_linux() {
     fi
     [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_destruct_die: stray prted left behind"
     cleanup_swarm
+
+    #############################################################
+    # member lost mid-construct (cross-server cancel)
+    #############################################################
+    banner "member lost mid-construct (PMIX_GROUP_CANCEL across servers)"
+    cleanup_swarm
+    # group_construct_abort: the whole job is the membership; every rank EXCEPT
+    # the last enters PMIx_Group_construct WITHOUT PMIX_GROUP_FT_COLLECTIVE, and
+    # the last rank (the victim) exits before contributing (and without
+    # finalizing). Because fault-tolerant collective tracking was not requested,
+    # the loss of a required member must ABORT the construct on every survivor
+    # rather than form a reduced group.
+    #
+    # The layout puts the victim (rank 3) on node1 alongside a survivor (rank 0),
+    # with the other survivors on node2 and node3 (--host node1:2,node2:1,node3:1
+    # --map-by node). So the victim's server has a local construct participant to
+    # abort directly AND must issue PMIX_GROUP_CANCEL to the host to abort the
+    # cross-server collective the node2/node3 servers already joined -- if the
+    # cancel were not propagated those survivors would hang forever. --rtos
+    # recoverable keeps the job alive when the victim vanishes.
+    if RUN 'test -x /opt/prte/tests/group_construct_abort'; then
+        OUT="$(RUN 'prterun --rtos recoverable --host node1:2,node2:1,node3:1 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_construct_abort 2>&1')"
+        n=$(echo "$OUT" | grep -c 'construct ABORT on member loss: PASS')
+        if hung "$OUT"; then
+            bad "group_construct_abort HUNG (cancel not propagated across servers)"
+        elif echo "$OUT" | grep -qiE 'expected PMIX_GROUP_CONSTRUCT_ABORT: FAILED'; then
+            bad "group_construct_abort: a survivor got the wrong status: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$n" -ge 3 ]; then
+            ok "all 3 survivors across servers aborted the construct on member loss"
+        else
+            bad "group_construct_abort: only $n survivors aborted: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_construct_abort not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_construct_abort: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
+    # daemon lost mid-construct (recover + abort the construct)
+    #############################################################
+    banner "daemon lost mid-construct (recover, abort the pending construct)"
+    cleanup_swarm
+    # group_daemon_fail: the whole job is the membership; every rank EXCEPT the
+    # last enters PMIx_Group_construct and blocks. The victim (rank 3) stays alive
+    # but never contributes, and is placed ALONE on its own node
+    # (--host node1:1,node2:1,node3:1,node4:1 --map-by node puts rank 3 on node4
+    # by itself). Once the construct is pending, the harness kills node4's prted.
+    # PRRTE's grpcomm fault handler (on the HNP) aborts the pending construct so
+    # every survivor's PMIx_Group_construct returns PMIX_GROUP_CONSTRUCT_ABORT
+    # -- the clean-abort scope of issue #3936 (item #6). This is what the test
+    # verifies.
+    #
+    # NOTE: losing a whole daemon (as opposed to a client process) is a failure
+    # PRRTE currently treats as fatal -- even under --rtos recoverable it prints
+    # "cannot recover ... will terminate the job" and tears the DVM down. Keeping
+    # the DVM alive on a daemon loss (degraded survival) is the separate effort
+    # tracked as openpmix/prrte#2510. During that fatal teardown prterun trips a
+    # PRE-EXISTING PRRTE assertion (prte_job_destruct, a prte_proc_t double-free)
+    # that has nothing to do with the group code -- it reproduces with a plain
+    # `prterun ... sleep` job whose daemon is killed, no PMIx group involved. So
+    # this test asserts ONLY the survivor abort markers (which are emitted before
+    # that teardown) and does not treat the crash-marred, non-clean teardown
+    # (orphaned prteds) as a failure of the group path.
+    if RUN 'test -x /opt/prte/tests/group_daemon_fail'; then
+        RUN 'rm -f /tmp/gdf.out; nohup prterun --rtos recoverable --host node1:1,node2:1,node3:1,node4:1 -np 4 --map-by node --timeout 90 /opt/prte/tests/group_daemon_fail >/tmp/gdf.out 2>&1 </dev/null & disown; echo launched' >/dev/null
+        # wait for the construct to be pending: the victim announces it is waiting
+        reached=0
+        for _ in $(seq 1 40); do
+            if RUN 'grep -q "awaiting daemon kill" /tmp/gdf.out 2>/dev/null'; then reached=1; break; fi
+            sleep 1
+        done
+        # let the survivors settle into the collective, then kill the victim's daemon
+        sleep 3
+        ON 4 'pkill -9 -x prted' >/dev/null 2>&1 || true
+        # wait for the launch to wind down (bounded); the pre-existing teardown
+        # crash may leave prterun dead and some prteds orphaned -- either way we
+        # stop waiting once prterun is gone or the window elapses
+        for _ in $(seq 1 60); do
+            RUN 'pgrep -x prterun >/dev/null 2>&1' || break
+            sleep 1
+        done
+        # strip NULs: the captured launcher log can carry binary debug bytes,
+        # which bash command substitution would warn about otherwise
+        OUT="$(RUN 'tr -d "\000" < /tmp/gdf.out 2>/dev/null')"
+        n=$(echo "$OUT" | grep -c 'construct ABORT after daemon loss: PASS')
+        if [ "$reached" = 0 ]; then
+            bad "group_daemon_fail: construct never became pending (victim never reached wait)"
+        elif echo "$OUT" | grep -qiE 'expected PMIX_GROUP_CONSTRUCT_ABORT: FAILED'; then
+            bad "group_daemon_fail: a survivor got the wrong status: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$n" -ge 3 ]; then
+            ok "all 3 survivors aborted the construct after the daemon was killed"
+            if echo "$OUT" | grep -q 'prte_job_destruct: Assertion'; then
+                printf '       (note: pre-existing PRRTE daemon-loss teardown assertion fired -- see openpmix/prrte#2510)\n'
+            fi
+        else
+            bad "group_daemon_fail: only $n survivors aborted: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_daemon_fail not built"
+    fi
+    # unconditional cleanup: the fatal daemon-loss teardown is not guaranteed to
+    # reap every prted, so tidy up rather than assert on strays for this case
+    cleanup_swarm
 }
 
 ########################################################################
@@ -347,6 +470,29 @@ test_macos() {
     else
         skp "group_destruct_die (not built)"
     fi
+
+    banner "macOS: member lost mid-construct (single host)"
+    if [ -x "$prefix/bin/group_construct_abort" ]; then
+        macpk; sleep 1
+        out="$(prterun --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_construct_abort" 2>&1)"
+        n=$(echo "$out" | grep -c 'construct ABORT on member loss: PASS')
+        if echo "$out" | grep -qiE 'timeout|timed out'; then
+            skp "group_construct_abort: not clean (native Darwin DVM can be flaky)"
+        elif [ "$n" -ge 3 ]; then
+            ok "group_construct_abort: construct aborted on 3 survivors (single host)"
+        else
+            skp "group_construct_abort: only $n survivors (native Darwin DVM can be flaky)"
+        fi
+    else
+        skp "group_construct_abort (not built)"
+    fi
+
+    # group_daemon_fail is a multi-node test: it needs the victim alone on a node
+    # whose prted the harness can kill without taking a survivor with it. A native
+    # single-host DVM has one prted for the whole job, so killing it kills every
+    # rank -- there is nothing to recover. Exercise it in the Linux swarm only.
+    banner "macOS: daemon lost mid-construct (multi-node only)"
+    skp "group_daemon_fail: requires the multi-node swarm (run ./run-group-events.sh linux)"
     macpk
 }
 

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,28 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Group construct fault handling. When a member is lost before
+   contributing to a PMIx_Group_construct, the server now consults the
+   PMIX_GROUP_FT_COLLECTIVE directive (previously ignored): by default
+   the construct aborts with PMIX_GROUP_CONSTRUCT_ABORT rather than
+   silently forming a reduced group, while with the directive set it
+   completes on the survivors and notifies each of them via a
+   PMIX_GROUP_MEMBER_FAILED event naming the lost member. The server
+   synthesizes PMIX_GROUP_MEMBER_FAILED itself, so this works with any
+   host environment
+ - Group leader failure. A process that accepts an invitation with
+   PMIx_Group_join_nb now watches the group leader; if the leader
+   terminates before the construct completes, the library delivers a
+   PMIX_GROUP_LEADER_FAILED event to the waiting process (naming the
+   leader) so the application can drive reselection, rather than
+   blocking indefinitely
+ - Group construct timeout. A PMIX_TIMEOUT supplied to
+   PMIx_Group_construct is now enforced by the server for the local
+   phase: if a live participant never contributes, the construct
+   completes with PMIX_ERR_TIMEOUT instead of hanging
+ - Added the PMIX_GROUP_CANCEL group operation (a host callback used to
+   abort an in-flight cross-server construct) and the PMIX_CAP_GROUP_FT
+   capability flag advertising the group fault-tolerance feature set
  - PMIx_Group_leave / PMIx_Group_leave_nb are now implemented. Previously
    the client sent a command the server never handled, so the call
    returned PMIX_ERR_NOT_SUPPORTED and the documented PMIX_GROUP_LEFT

--- a/examples/group_construct_abort.c
+++ b/examples/group_construct_abort.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the cross-server group construct abort (PMIX_GROUP_CANCEL path).
+ *
+ * Every rank in the job is a group member. All ranks fence, then every rank
+ * EXCEPT the last calls PMIx_Group_construct WITHOUT PMIX_GROUP_FT_COLLECTIVE;
+ * the last rank leaves before contributing (and without finalizing), so its
+ * server sees a dropped connection. Because fault-tolerant collective tracking
+ * was not requested, the construct must ABORT rather than form a reduced group.
+ *
+ * The point of running this across nodes (the whole job is the membership,
+ * launched --map-by node) is that the lost member's server aborts its own local
+ * participants directly AND issues PMIX_GROUP_CANCEL to the host, which aborts
+ * the cross-server collective the other servers already joined. Every surviving
+ * member on every node must therefore see its PMIx_Group_construct return
+ * PMIX_GROUP_CONSTRUCT_ABORT - if the cancel were not propagated, the survivors
+ * on the other nodes would hang forever. Each survivor prints a distinctive
+ * success line.
+ *
+ * Launch with a launcher that does not kill the job when the victim exits;
+ * under PRRTE that is `prterun --rtos recoverable ...`.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t *results;
+    size_t nresults;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        /* leave before contributing, without finalizing, so the server sees a
+         * dropped connection. Exit 0 so the launcher does not abort the job. */
+        fprintf(stderr, "%d leaving BEFORE group construct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    fprintf(stderr, "%d executing Group_construct (no FT_COLLECTIVE)\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    /* No PMIX_GROUP_FT_COLLECTIVE: the loss of a required member must abort the
+     * construct on every surviving member, across all servers. */
+    results = NULL;
+    nresults = 0;
+    rc = PMIx_Group_construct("cabortgroup", procs, nprocs, NULL, 0, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+
+    if (PMIX_GROUP_CONSTRUCT_ABORT == rc) {
+        fprintf(stderr, "%d construct ABORT on member loss: PASS\n", myproc.rank);
+    } else {
+        fprintf(stderr, "%d construct returned %s, expected PMIX_GROUP_CONSTRUCT_ABORT: FAILED\n",
+                myproc.rank, PMIx_Error_string(rc));
+    }
+
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "Client ns %s rank %d: FINALIZED\n", myproc.nspace, myproc.rank);
+    return 0;
+}

--- a/examples/group_daemon_fail.c
+++ b/examples/group_daemon_fail.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise group construct recovery when a whole DAEMON is lost mid-construct.
+ *
+ * This is the daemon-death companion to group_construct_abort (which drops a
+ * client). Every rank in the job is a group member. All ranks fence, then every
+ * rank EXCEPT the last enters PMIx_Group_construct and blocks; the last rank
+ * (which the harness places alone on its own node) never contributes - it just
+ * stays alive - so the construct is pending across servers. The harness then
+ * kills that node's prted. PRRTE's grpcomm fault handler must abort the pending
+ * construct on the surviving servers (rather than tear down the whole DVM, its
+ * former behavior), so every surviving member's PMIx_Group_construct returns
+ * PMIX_GROUP_CONSTRUCT_ABORT. Each survivor prints a distinctive success line.
+ *
+ * Requires a launcher that keeps the job alive across a daemon loss; under PRRTE
+ * that is `prterun --rtos recoverable ...`. The victim must be alone on its node
+ * so that killing that node's daemon does not also remove a surviving member.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t *results;
+    size_t nresults;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim - it
+     * stays alive but never contributes, so the construct is pending when the
+     * harness kills its daemon */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        fprintf(stderr, "%d alive but NOT joining the construct - awaiting daemon kill\n",
+                myproc.rank);
+        sleep(60);
+        /* if we are still here, the harness never killed our daemon */
+        goto done;
+    }
+
+    fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    results = NULL;
+    nresults = 0;
+    rc = PMIx_Group_construct("faultgroup", procs, nprocs, NULL, 0, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+
+    if (PMIX_GROUP_CONSTRUCT_ABORT == rc) {
+        fprintf(stderr, "%d construct ABORT after daemon loss: PASS\n", myproc.rank);
+    } else {
+        fprintf(stderr, "%d construct returned %s, expected PMIX_GROUP_CONSTRUCT_ABORT: FAILED\n",
+                myproc.rank, PMIx_Error_string(rc));
+    }
+
+done:
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "Client ns %s rank %d: FINALIZED\n", myproc.nspace, myproc.rank);
+    return 0;
+}

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1999,13 +1999,15 @@ typedef enum {
     PMIX_GROUP_ACCEPT
 } pmix_group_opt_t;
 
+/* Group operations. New values must be appended after the existing ones to
+ * preserve their numeric values - this enum crosses the PMIx-to-host callback
+ * boundary (pmix_server_module_t.group). Keep the body free of comment lines:
+ * the Python bindings generator (bindings/python/construct.py) treats every
+ * line inside a typedef enum as an enumerator. */
 typedef enum {
     PMIX_GROUP_CONSTRUCT,
     PMIX_GROUP_DESTRUCT,
     PMIX_GROUP_NONE,
-    // new values must be appended here to preserve the numeric value of the
-    // existing operations - this enum crosses the PMIx-to-host callback
-    // boundary (pmix_server_module_t.group)
     PMIX_GROUP_CANCEL
 } pmix_group_operation_t;
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2002,7 +2002,11 @@ typedef enum {
 typedef enum {
     PMIX_GROUP_CONSTRUCT,
     PMIX_GROUP_DESTRUCT,
-    PMIX_GROUP_NONE
+    PMIX_GROUP_NONE,
+    // new values must be appended here to preserve the numeric value of the
+    // existing operations - this enum crosses the PMIx-to-host callback
+    // boundary (pmix_server_module_t.group)
+    PMIX_GROUP_CANCEL
 } pmix_group_operation_t;
 
 /* define storage medium values

--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -51,6 +51,7 @@
 #define PMIX_CAP_STOP_PRGTHRD    4
 #define PMIX_CAP_GET_NUMBER_FN   5
 #define PMIX_CAP_REGEX2          6
+#define PMIX_CAP_GROUP_FT        7
 
 
 /*****    DEPRECATED    *****/

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1146,6 +1146,198 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
     return rc;
 }
 
+/* ---- invitee-side leader-failure watch ----------------------------------
+ *
+ * A process that accepts an invitation is depending on the leader to drive the
+ * construct to completion. If the leader is lost before the construct resolves,
+ * the acceptor would otherwise wait forever. The library therefore watches the
+ * leader for the life of an in-progress join and, when it is lost, delivers a
+ * PMIX_GROUP_LEADER_FAILED event to this process's own handlers. Reselection of
+ * a new leader is left to the application (it declares a replacement via
+ * PMIX_GROUP_LEADER in its handler and announces it with
+ * PMIX_GROUP_LEADER_SELECTED); the library's job is only to surface the loss.
+ *
+ * The watch is a pmix_group_tracker_t carrying the group id and the leader (in
+ * members[0]); it is handed to its own event handler as the return object, so
+ * no global registry is needed. The handler runs on the progress thread. */
+
+/* Free the heap info used to carry a locally-injected event; used as the
+ * completion callback so the info outlives the non-blocking notification. */
+static void leader_failed_relcb(pmix_status_t status, void *cbdata)
+{
+    pmix_info_t *info = (pmix_info_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_INFO_FREE(info, 2);
+}
+
+/* Deliver PMIX_GROUP_LEADER_FAILED to this process's own handlers, naming the
+ * failed leader and the group. Runs on the progress thread (from the watch
+ * handler), so it must use the non-blocking form of PMIx_Notify_event - the
+ * blocking form would deadlock here - and let leader_failed_relcb free the info
+ * once the local delivery completes. */
+static void emit_leader_failed(const char *grpid, const pmix_proc_t *leader)
+{
+    pmix_info_t *info;
+    pmix_status_t rc;
+
+    PMIX_INFO_CREATE(info, 2);
+    if (NULL == info) {
+        return;
+    }
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, leader, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_GROUP_ID, grpid, PMIX_STRING);
+    rc = PMIx_Notify_event(PMIX_GROUP_LEADER_FAILED, &pmix_globals.myid,
+                           PMIX_RANGE_PROC_LOCAL, info, 2, leader_failed_relcb, info);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_INFO_FREE(info, 2);
+    }
+}
+
+/* Release the watch tracker once its handler has been deregistered. */
+static void watch_deregcb(pmix_status_t status, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(status);
+    PMIX_RELEASE(cb);
+}
+
+/* Tear down the watch: deregister its handler (non-blocking, since we reach
+ * this from the progress thread by way of a threadshift) and release the
+ * tracker when that completes. Deferring via a threadshift also avoids
+ * deregistering a handler from within its own callback. */
+static void watch_teardown(int sd, short args, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    if (SIZE_MAX != cb->ref) {
+        PMIx_Deregister_event_handler(cb->ref, watch_deregcb, cb);
+        cb->ref = SIZE_MAX;
+    } else {
+        PMIX_RELEASE(cb);
+    }
+}
+
+/* Watch handler: fires on a termination-type event (to catch the leader's
+ * loss) or on the construct resolving (to end the watch). */
+static void leader_watch_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                                 const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                 pmix_info_t *results, size_t nresults,
+                                 pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    pmix_group_tracker_t *cb = NULL;
+    const pmix_proc_t *affected = NULL;
+    const char *grpid = NULL;
+    size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_RETURN_OBJECT)) {
+            cb = (pmix_group_tracker_t *) info[n].value.data.ptr;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            affected = info[n].value.data.proc;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grpid = info[n].value.data.string;
+        }
+    }
+    if (NULL == cb || cb->completed) {
+        goto done;
+    }
+
+    /* the construct resolved - the leader is no longer critical, so end the
+     * watch. A CONSTRUCT_COMPLETE/ABORT with no group id is treated as ours. */
+    if (PMIX_GROUP_CONSTRUCT_COMPLETE == status || PMIX_GROUP_CONSTRUCT_ABORT == status) {
+        if (NULL == grpid || 0 == strcmp(grpid, cb->grpid)) {
+            cb->completed = true;
+            PMIX_POST_OBJECT(cb);
+            PMIX_THREADSHIFT(cb, watch_teardown);
+        }
+        goto done;
+    }
+
+    /* a termination-type event - if the departed proc is our leader, surface
+     * the loss as PMIX_GROUP_LEADER_FAILED and end the watch */
+    if (PMIX_PROC_TERMINATED == status || PMIX_ERR_PROC_ABORTED == status ||
+        PMIX_ERR_PROC_TERM_WO_SYNC == status) {
+        if (NULL != affected && PMIX_CHECK_PROCID(affected, &cb->members[0])) {
+            cb->completed = true;
+            emit_leader_failed(cb->grpid, &cb->members[0]);
+            PMIX_POST_OBJECT(cb);
+            PMIX_THREADSHIFT(cb, watch_teardown);
+        }
+    }
+
+done:
+    /* this watch is a passive observer - it must never terminate the event
+     * chain, or it would swallow the very CONSTRUCT_COMPLETE (or termination)
+     * the application registered to see. Report NO_ACTION_TAKEN so the chain
+     * continues to the caller's own handlers. */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_NO_ACTION_TAKEN, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* Registration callback for the leader watch. Runs on the progress thread when
+ * the handler has been registered; caches the returned handler id on the watch
+ * tracker so it can later be deregistered. On failure there is no handler, so
+ * release the tracker. */
+static void watch_regcb(pmix_status_t status, size_t refid, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        PMIX_RELEASE(cb);
+        return;
+    }
+    cb->ref = refid;
+    PMIX_POST_OBJECT(cb);
+}
+
+/* Register a leader-failure watch for a process that has accepted an
+ * invitation. This is normally reached from within the application's
+ * PMIX_GROUP_INVITED handler (PMIx_Group_join_nb called from an event handler),
+ * so it runs on the progress thread - the handler registration MUST therefore
+ * be non-blocking; a blocking wait here would deadlock the progress thread.
+ * Best-effort: on failure the acceptor simply has no watch, exactly as before
+ * this facility existed. */
+static void setup_leader_watch(const char *grp, const pmix_proc_t *leader)
+{
+    pmix_group_tracker_t *cb;
+    pmix_status_t codes[] = {
+        PMIX_PROC_TERMINATED,
+        PMIX_ERR_PROC_ABORTED,
+        PMIX_ERR_PROC_TERM_WO_SYNC,
+        PMIX_GROUP_CONSTRUCT_COMPLETE,
+        PMIX_GROUP_CONSTRUCT_ABORT
+    };
+    size_t ncodes = sizeof(codes) / sizeof(codes[0]);
+
+    cb = PMIX_NEW(pmix_group_tracker_t);
+    cb->grpid = strdup(grp);
+    PMIX_PROC_CREATE(cb->members, 1);
+    if (NULL == cb->members) {
+        PMIX_RELEASE(cb);
+        return;
+    }
+    cb->nmembers = 1;
+    PMIX_LOAD_PROCID(&cb->members[0], leader->nspace, leader->rank);
+
+    /* the registration references (does not copy) this info array and consumes
+     * it asynchronously on the progress thread, so it must outlive this call.
+     * Carry it on the tracker - which lives until the watch is torn down and is
+     * freed by the tracker destructor - rather than on the stack. */
+    PMIX_INFO_CREATE(cb->info, 2);
+    if (NULL == cb->info) {
+        PMIX_RELEASE(cb);
+        return;
+    }
+    cb->ninfo = 2;
+    PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
+    PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
+    PMIx_Register_event_handler(codes, ncodes, cb->info, cb->ninfo,
+                                leader_watch_handler, watch_regcb, cb);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *leader,
                                           pmix_group_opt_t opt, const pmix_info_t info[],
                                           size_t ninfo, pmix_info_t **results, size_t *nresults)
@@ -1198,7 +1390,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     pmix_status_t code;
     size_t n;
     pmix_data_range_t range;
-    PMIX_HIDE_UNUSED_PARAMS(grp, cbfunc);
+    PMIX_HIDE_UNUSED_PARAMS(cbfunc);
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "[%s:%d] pmix: join nb called",
@@ -1261,6 +1453,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(cb);
     }
+
+    /* an acceptor now depends on the leader to complete the construct; watch
+     * the leader so its loss is surfaced as PMIX_GROUP_LEADER_FAILED rather
+     * than leaving this process waiting forever */
+    if (PMIX_SUCCESS == rc && PMIX_GROUP_ACCEPT == opt && NULL != leader) {
+        setup_leader_watch(grp, leader);
+    }
+
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "[%s:%d] pmix: group invite %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -542,6 +542,8 @@ const char* PMIx_Group_operation_string(pmix_group_operation_t op)
             return "DESTRUCT";
         case PMIX_GROUP_NONE:
             return "NONE";
+        case PMIX_GROUP_CANCEL:
+            return "CANCEL";
         default:
             return "UNKNOWN VALUE";
     }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -732,16 +732,41 @@ static bool grp_ft_collective(grp_block_t *blk)
     return false;
 }
 
+/* Completion callback for a server-issued PMIX_GROUP_CANCEL to the host. The
+ * cancel is fire-and-forget from our side - our own local participants are
+ * completed directly (see abort_construct), and the host's resulting abort of
+ * the cross-server collective reaches the other servers through the normal
+ * group release path - so here we need only honor the release contract. */
+static void cancel_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                          void *cbdata, pmix_release_cbfunc_t release_fn,
+                          void *release_cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, info, ninfo, cbdata);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
 /* Abort an in-flight group construct because a required member was lost and
  * fault-tolerant collective tracking (PMIX_GROUP_FT_COLLECTIVE) was not
- * requested. The block was never forwarded to the host, so no host involvement
- * is needed: freeze it and complete it on the participants with
- * PMIX_GROUP_CONSTRUCT_ABORT as the operation status, so each participant's
- * PMIx_Group_construct returns that abort rather than silently forming a reduced
- * group. grpcbfunc consumes (releases) the block via its threadshift, matching
- * the survive path. */
+ * requested. Complete our own local participants with PMIX_GROUP_CONSTRUCT_ABORT
+ * as the operation status, so each participant's PMIx_Group_construct returns
+ * that abort rather than silently forming a reduced group; grpcbfunc consumes
+ * (releases) the block via its threadshift, matching the survive path.
+ *
+ * If a host is present, also ask it to cancel the cross-server collective:
+ * other servers may already have forwarded their local phase, leaving the
+ * host's collective waiting for a contribution this server will never send. The
+ * cancel unsticks the host, which aborts the collective on the remaining
+ * servers through their own group releases. We deliberately complete our local
+ * participants directly here rather than through that release - this block is
+ * removed below, so the host's abort release is a no-op back on this server. */
 static void abort_construct(grp_block_t *blk)
 {
+    if (NULL != pmix_host_server.group) {
+        pmix_host_server.group(PMIX_GROUP_CANCEL, blk->id, NULL, 0, NULL, 0,
+                               cancel_cbfunc, NULL);
+    }
     blk->host_called = true;
     grpcbfunc(PMIX_GROUP_CONSTRUCT_ABORT, NULL, 0, blk, NULL, NULL);
 }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -120,6 +120,12 @@ static void gbcon(grp_block_t *p)
 }
 static void gbdes(grp_block_t *p)
 {
+    /* safety net: stop any still-armed local-phase timeout so it cannot fire
+     * on freed memory (the normal paths delete it before releasing the block) */
+    if (p->event_active) {
+        pmix_event_del(&p->ev);
+        p->event_active = false;
+    }
     if (NULL != p->id) {
         free(p->id);
     }
@@ -747,12 +753,13 @@ static void cancel_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
     }
 }
 
-/* Abort an in-flight group construct because a required member was lost and
- * fault-tolerant collective tracking (PMIX_GROUP_FT_COLLECTIVE) was not
- * requested. Complete our own local participants with PMIX_GROUP_CONSTRUCT_ABORT
- * as the operation status, so each participant's PMIx_Group_construct returns
- * that abort rather than silently forming a reduced group; grpcbfunc consumes
- * (releases) the block via its threadshift, matching the survive path.
+/* Abort an in-flight group construct during its local phase, completing our own
+ * local participants with the given status (PMIX_GROUP_CONSTRUCT_ABORT when a
+ * required member was lost and fault-tolerant collective tracking was not
+ * requested, PMIX_ERR_TIMEOUT when the local-phase timer expired). Each
+ * participant's PMIx_Group_construct returns that status rather than silently
+ * forming a reduced group; grpcbfunc consumes (releases) the block via its
+ * threadshift, matching the survive path.
  *
  * If a host is present, also ask it to cancel the cross-server collective:
  * other servers may already have forwarded their local phase, leaving the
@@ -760,15 +767,39 @@ static void cancel_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
  * cancel unsticks the host, which aborts the collective on the remaining
  * servers through their own group releases. We deliberately complete our local
  * participants directly here rather than through that release - this block is
- * removed below, so the host's abort release is a no-op back on this server. */
-static void abort_construct(grp_block_t *blk)
+ * removed below, so the host's abort release is a no-op back on this server.
+ *
+ * Called only before the block is forwarded to the host (host_called is still
+ * false), so no host completion can be in flight for it. */
+static void abort_construct(grp_block_t *blk, pmix_status_t st)
 {
+    /* the local phase is ending - stop any pending local-phase timeout */
+    if (blk->event_active) {
+        pmix_event_del(&blk->ev);
+        blk->event_active = false;
+    }
     if (NULL != pmix_host_server.group) {
         pmix_host_server.group(PMIX_GROUP_CANCEL, blk->id, NULL, 0, NULL, 0,
                                cancel_cbfunc, NULL);
     }
     blk->host_called = true;
-    grpcbfunc(PMIX_GROUP_CONSTRUCT_ABORT, NULL, 0, blk, NULL, NULL);
+    grpcbfunc(st, NULL, 0, blk, NULL, NULL);
+}
+
+/* Local-phase timeout handler for a group construct. Armed (only when the
+ * caller supplied PMIX_TIMEOUT) while we wait for all local participants to
+ * contribute, and deleted the moment the local phase completes and the block is
+ * forwarded to the host - so if it fires, the block has not been forwarded and
+ * aborting it here cannot race a host completion. */
+static void group_timeout(int sd, short args, void *cbdata)
+{
+    grp_block_t *blk = (grp_block_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    pmix_output_verbose(2, pmix_server_globals.group_output,
+                        "group construct timed out for %s", blk->id);
+    blk->event_active = false;
+    abort_construct(blk, PMIX_ERR_TIMEOUT);
 }
 
 static pmix_status_t aggregate_info(grp_block_t *blk)
@@ -950,6 +981,7 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     bool need_cxtid = false;
     bool bootstrap = false;
     bool follower = false;
+    uint32_t tmo = 0;
 
     pmix_output_verbose(2, pmix_server_globals.group_output,
                         "recvd grpconstruct cmd from %s",
@@ -1023,6 +1055,10 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             // we don't care what the number is, we only care that
             // bootstrap is being given
             bootstrap = true;
+
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+            // bound how long we wait for all local participants to contribute
+            PMIx_Value_get_number(&info[n].value, &tmo, PMIX_UINT32);
         }
     }
 
@@ -1070,6 +1106,15 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         return PMIX_SUCCESS;
     }
 
+    /* arm the local-phase timeout if one was requested and not already set. It
+     * bounds how long we wait for all local participants to contribute; once the
+     * local phase completes and we forward to the host, the timer is deleted and
+     * the host owns any further timeout (mirroring the fence family). */
+    if (0 < tmo && !blk->event_active) {
+        PMIX_THREADSHIFT_DELAY(blk, group_timeout, tmo);
+        blk->event_active = true;
+    }
+
     /* are we locally complete? */
     if (blk->host_called || !grp_blk_locally_complete(blk)) {
         /* if we are not locally complete, then we are done */
@@ -1099,11 +1144,18 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
      * pmix_server_set_collective_status). */
     if (0 < pmix_list_get_size(&blk->departed)) {
         if (PMIX_GROUP_CONSTRUCT == op && !grp_ft_collective(blk)) {
-            abort_construct(blk);
+            abort_construct(blk, PMIX_GROUP_CONSTRUCT_ABORT);
             return PMIX_SUCCESS;
         }
         pmix_server_set_collective_status(blk->info, blk->ninfo,
                                           PMIX_ERR_LOST_CONNECTION);
+    }
+    /* local phase complete - delete the local-phase timer before handing the
+     * block to the host, so a late internal timeout cannot race the host's
+     * completion (which could return the block after we released it) */
+    if (blk->event_active) {
+        pmix_event_del(&blk->ev);
+        blk->event_active = false;
     }
     // the local phase is complete - freeze it and pass up to the host
     blk->host_called = true;
@@ -1216,11 +1268,17 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
          * the block's info so the host sees it, matching the
          * fence/connect/disconnect families. */
         if (PMIX_GROUP_CONSTRUCT == blk->grpop && !grp_ft_collective(blk)) {
-            abort_construct(blk);
+            abort_construct(blk, PMIX_GROUP_CONSTRUCT_ABORT);
             return;
         }
         pmix_server_set_collective_status(blk->info, blk->ninfo,
                                           PMIX_ERR_LOST_CONNECTION);
+        /* delete the local-phase timer before handing the block to the host,
+         * so a late internal timeout cannot race the host's completion */
+        if (blk->event_active) {
+            pmix_event_del(&blk->ev);
+            blk->event_active = false;
+        }
         blk->host_called = true;
         rc = pmix_host_server.group(blk->grpop, blk->id, trk->pcs, trk->npcs,
                                     blk->info, blk->ninfo, grpcbfunc, blk);

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -420,6 +420,39 @@ pmix_status_t pmix_server_process_grpinfo(size_t ctxid,
     return PMIX_SUCCESS;
 }
 
+/* Synthesize a PMIX_GROUP_MEMBER_FAILED event for each member that was lost
+ * before contributing to this group construct. This is done entirely within
+ * the PMIx server so it works with any host environment, not just one that
+ * knows how to generate the event: the loss is recorded in blk->departed by
+ * the server's own lost-connection / voluntary-leave accounting (see
+ * account_departed), so the event is produced the same way regardless of which
+ * host runs the collective. It is delivered to the surviving local group
+ * members registered for the event; members on other nodes are notified by
+ * their own local server, which performs the identical accounting on its half
+ * of the collective. Runs on the progress thread, so it uses the internal
+ * notification path (pmix_server_notify_client_of_event thread-shifts) and
+ * never the public PMIx_Notify_event, which cannot be called from the progress
+ * thread. */
+static void notify_local_members_of_loss(grp_block_t *blk)
+{
+    pmix_proclist_t *dp;
+    pmix_info_t info[2];
+    pmix_status_t rc;
+
+    PMIX_LIST_FOREACH (dp, &blk->departed, pmix_proclist_t) {
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, &dp->proc, PMIX_PROC);
+        PMIX_INFO_LOAD(&info[1], PMIX_GROUP_ID, blk->id, PMIX_STRING);
+        rc = pmix_server_notify_client_of_event(PMIX_GROUP_MEMBER_FAILED,
+                                                &pmix_globals.myid, PMIX_RANGE_LOCAL,
+                                                info, 2, NULL, NULL);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+}
+
 static void _grpcbfunc(int sd, short args, void *cbdata)
 {
     grp_shifter_t *scd = (grp_shifter_t *) cbdata;
@@ -613,6 +646,14 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                     PMIX_RELEASE(reply);
                 }
             }
+        }
+        /* if any expected member was lost before contributing, the construct
+         * completed on the survivors - tell them which members failed so
+         * fault-aware applications can react. Only meaningful for a construct;
+         * a destruct is tearing the group down regardless. */
+        if (PMIX_GROUP_CONSTRUCT == bk->grpop &&
+            0 < pmix_list_get_size(&bk->departed)) {
+            notify_local_members_of_loss(bk);
         }
         /* remove the block from the list */
         pmix_list_remove_item(&pmix_server_globals.grp_collectives, &bk->super);

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -647,11 +647,16 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                 }
             }
         }
-        /* if any expected member was lost before contributing, the construct
-         * completed on the survivors - tell them which members failed so
-         * fault-aware applications can react. Only meaningful for a construct;
-         * a destruct is tearing the group down regardless. */
-        if (PMIX_GROUP_CONSTRUCT == bk->grpop &&
+        /* if any expected member was lost before contributing but the construct
+         * still completed successfully on the survivors (fault-tolerant
+         * collective tracking was requested), tell the survivors which members
+         * failed so fault-aware applications can react. Skip this when the
+         * construct aborted (status is not SUCCESS): there is no surviving group
+         * to inform, and the participants already learn of the abort through the
+         * operation status. Only meaningful for a construct; a destruct is
+         * tearing the group down regardless. */
+        if (PMIX_SUCCESS == scd->status &&
+            PMIX_GROUP_CONSTRUCT == bk->grpop &&
             0 < pmix_list_get_size(&bk->departed)) {
             notify_local_members_of_loss(bk);
         }
@@ -707,6 +712,38 @@ static void grpcbfunc(pmix_status_t status,
     scd->relfn = relfn;
     scd->cbdata = relcbd;
     PMIX_THREADSHIFT(scd, _grpcbfunc);
+}
+
+/* Did any participant request fault-tolerant collective tracking via
+ * PMIX_GROUP_FT_COLLECTIVE? When true, a construct completes on the surviving
+ * membership if an expected member is lost before contributing. When false (the
+ * default), the loss of a required member means the group cannot form as
+ * requested and the construct is aborted instead. Only meaningful once the
+ * block's info has been aggregated. */
+static bool grp_ft_collective(grp_block_t *blk)
+{
+    size_t n;
+
+    for (n = 0; n < blk->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&blk->info[n], PMIX_GROUP_FT_COLLECTIVE)) {
+            return PMIX_INFO_TRUE(&blk->info[n]);
+        }
+    }
+    return false;
+}
+
+/* Abort an in-flight group construct because a required member was lost and
+ * fault-tolerant collective tracking (PMIX_GROUP_FT_COLLECTIVE) was not
+ * requested. The block was never forwarded to the host, so no host involvement
+ * is needed: freeze it and complete it on the participants with
+ * PMIX_GROUP_CONSTRUCT_ABORT as the operation status, so each participant's
+ * PMIx_Group_construct returns that abort rather than silently forming a reduced
+ * group. grpcbfunc consumes (releases) the block via its threadshift, matching
+ * the survive path. */
+static void abort_construct(grp_block_t *blk)
+{
+    blk->host_called = true;
+    grpcbfunc(PMIX_GROUP_CONSTRUCT_ABORT, NULL, 0, blk, NULL, NULL);
 }
 
 static pmix_status_t aggregate_info(grp_block_t *blk)
@@ -1026,12 +1063,20 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_RELEASE(blk);
         return rc;
     }
-    /* if an expected member was lost before contributing, the block still
-     * completes on the survivors - but record the degraded status in the
-     * block's info so the host sees it, matching the fence/connect/disconnect
-     * families. The status slot is located by key (see
+    /* if an expected member was lost before contributing, how we proceed
+     * depends on whether fault-tolerant collective tracking was requested. For a
+     * construct without PMIX_GROUP_FT_COLLECTIVE (the default), the group cannot
+     * form as requested, so abort it rather than silently reduce the membership.
+     * Otherwise (the flag is set, or this is a destruct that is tearing the
+     * group down regardless) complete on the survivors, recording the degraded
+     * status in the block's info so the host sees it - matching the
+     * fence/connect/disconnect families. The status slot is located by key (see
      * pmix_server_set_collective_status). */
     if (0 < pmix_list_get_size(&blk->departed)) {
+        if (PMIX_GROUP_CONSTRUCT == op && !grp_ft_collective(blk)) {
+            abort_construct(blk);
+            return PMIX_SUCCESS;
+        }
         pmix_server_set_collective_status(blk->info, blk->ninfo,
                                           PMIX_ERR_LOST_CONNECTION);
     }
@@ -1138,9 +1183,17 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
             PMIX_RELEASE(blk);
             return;
         }
-        /* a member departed before contributing (that is why we are here):
-         * record the degraded status in the block's info so the host sees
-         * it, matching the fence/connect/disconnect families */
+        /* a member departed before contributing (that is why we are here).
+         * For a construct without PMIX_GROUP_FT_COLLECTIVE (the default), the
+         * group cannot form as requested, so abort it rather than silently
+         * reduce the membership. Otherwise (the flag is set, or this is a
+         * destruct) complete on the survivors, recording the degraded status in
+         * the block's info so the host sees it, matching the
+         * fence/connect/disconnect families. */
+        if (PMIX_GROUP_CONSTRUCT == blk->grpop && !grp_ft_collective(blk)) {
+            abort_construct(blk);
+            return;
+        }
         pmix_server_set_collective_status(blk->info, blk->ninfo,
                                           PMIX_ERR_LOST_CONNECTION);
         blk->host_called = true;

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie
+                  hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -155,6 +155,12 @@ simpgrpdie_SOURCES = $(headers) \
         simpgrpdie.c
 simpgrpdie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpgrpdie_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpleader_SOURCES = $(headers) \
+        simpgrpleader.c
+simpgrpleader_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpleader_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simptoolcycle_SOURCES = $(headers) \

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -29,7 +29,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid simpqual simpdist legacy refresh simpgrpmember
+                  hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -149,6 +149,12 @@ simpgrpmember_SOURCES = $(headers) \
         simpgrpmember.c
 simpgrpmember_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpgrpmember_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpdie_SOURCES = $(headers) \
+        simpgrpdie.c
+simpgrpdie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpdie_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simptoolcycle_SOURCES = $(headers) \

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -29,7 +29,8 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
-                  hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader
+                  hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader \
+                  simpgrpcabort
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -161,6 +162,12 @@ simpgrpleader_SOURCES = $(headers) \
         simpgrpleader.c
 simpgrpleader_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpgrpleader_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpcabort_SOURCES = $(headers) \
+        simpgrpcabort.c
+simpgrpcabort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpcabort_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simptoolcycle_SOURCES = $(headers) \

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -30,7 +30,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
                   hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader \
-                  simpgrpcabort
+                  simpgrpcabort simpgrpctimeout
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -168,6 +168,12 @@ simpgrpcabort_SOURCES = $(headers) \
         simpgrpcabort.c
 simpgrpcabort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpgrpcabort_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpctimeout_SOURCES = $(headers) \
+        simpgrpctimeout.c
+simpgrpctimeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpctimeout_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simptoolcycle_SOURCES = $(headers) \

--- a/test/simple/simpgrpcabort.c
+++ b/test/simple/simpgrpcabort.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the default (non-fault-tolerant) group construct abort path: when a
+ * member is lost before contributing and PMIX_GROUP_FT_COLLECTIVE was NOT
+ * requested, the construct cannot form as requested and the PMIx server aborts
+ * it rather than silently forming a reduced group.
+ *
+ * The whole job is the group membership. All ranks sync with a fence. The last
+ * rank is the victim: it leaves WITHOUT calling PMIx_Group_construct and WITHOUT
+ * calling PMIx_Finalize (after a short delay so the survivors have entered the
+ * construct and their server has built the local tracker), so the server sees a
+ * dropped connection. Every surviving rank calls PMIx_Group_construct with no
+ * fault-tolerance flag; the server accounts for the departed member and - the
+ * behavior under test - completes the construct with PMIX_GROUP_CONSTRUCT_ABORT.
+ * Each survivor verifies its PMIx_Group_construct returned that abort status and
+ * prints a distinctive success line. Contrast with simpgrpdie, which sets
+ * PMIX_GROUP_FT_COLLECTIVE and completes on the survivors instead.
+ *
+ * See src/server/pmix_server_group.c (abort_construct / grp_ft_collective) and
+ * docs/how-things-work/collectives.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client %s:%d PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        fprintf(stderr, "Client %s:%d FAIL: this test requires at least 2 processes\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        /* leave before contributing, without finalizing, so the server sees a
+         * dropped connection and must run its lost-connection accounting. Exit
+         * 0 so the harness does not treat this as a real failure. */
+        fprintf(stderr, "%d leaving BEFORE group construct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    /* No PMIX_GROUP_FT_COLLECTIVE: the loss of a required member must abort the
+     * construct rather than form a reduced group. */
+    rc = PMIx_Group_construct("abortgroup", procs, nprocs, NULL, 0, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+
+    if (PMIX_GROUP_CONSTRUCT_ABORT != rc) {
+        fprintf(stderr, "Client %s:%d FAIL: construct returned %s, expected "
+                "PMIX_GROUP_CONSTRUCT_ABORT\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    fprintf(stderr, "Client %s:%d saw construct ABORT on loss of rank %d OK\n",
+            myproc.nspace, myproc.rank, victim);
+    fflush(stderr);
+    return 0;
+}

--- a/test/simple/simpgrpctimeout.c
+++ b/test/simple/simpgrpctimeout.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the server-armed group construct timeout. Unlike simpgrpcabort - in
+ * which the missing member DROPS its connection (a lost participant) - here the
+ * last rank stays ALIVE but simply never calls PMIx_Group_construct. The
+ * survivors call PMIx_Group_construct with a PMIX_TIMEOUT; because the local
+ * phase can never complete (a live member never contributes), the PMIx server's
+ * local-phase timer must fire and complete the construct with PMIX_ERR_TIMEOUT
+ * rather than hanging forever. Each survivor verifies its PMIx_Group_construct
+ * returned PMIX_ERR_TIMEOUT and prints a distinctive success line.
+ *
+ * See src/server/pmix_server_group.c (group_timeout / abort_construct) and
+ * docs/how-things-work/collectives.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, absentee;
+    pmix_info_t tmo;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    int timeout = 2;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client %s:%d PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        fprintf(stderr, "Client %s:%d FAIL: this test requires at least 2 processes\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    /* sync everyone up first */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the absentee */
+    absentee = nprocs - 1;
+
+    if (myproc.rank == absentee) {
+        /* stay ALIVE but never contribute to the construct. Sleep well past the
+         * survivors' timeout so their construct times out on a live (not lost)
+         * member, then finalize cleanly. */
+        fprintf(stderr, "%d NOT joining the construct (staying alive)\n", myproc.rank);
+        sleep(timeout + 3);
+        goto done;
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    /* bound the wait: a live member never contributes, so the server's
+     * local-phase timer must complete us with PMIX_ERR_TIMEOUT */
+    PMIX_INFO_LOAD(&tmo, PMIX_TIMEOUT, &timeout, PMIX_INT);
+    rc = PMIx_Group_construct("timeoutgroup", procs, nprocs, &tmo, 1, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    PMIX_INFO_DESTRUCT(&tmo);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+
+    if (PMIX_ERR_TIMEOUT != rc) {
+        fprintf(stderr, "Client %s:%d FAIL: construct returned %s, expected "
+                "PMIX_ERR_TIMEOUT\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d saw construct TIMEOUT (live member %d absent) OK\n",
+            myproc.nspace, myproc.rank, absentee);
+
+done:
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    fflush(stderr);
+    return 0;
+}

--- a/test/simple/simpgrpdie.c
+++ b/test/simple/simpgrpdie.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the PMIX_GROUP_MEMBER_FAILED event synthesized by the PMIx server
+ * when a member is lost before contributing to a group construct.
+ *
+ * The whole job is the group membership. Every rank registers a handler for
+ * PMIX_GROUP_MEMBER_FAILED, then all ranks sync with a fence. The last rank is
+ * the victim: it leaves WITHOUT calling PMIx_Group_construct and WITHOUT
+ * calling PMIx_Finalize (after a short delay so the survivors have entered the
+ * construct and their server has built the local tracker), so the server sees
+ * a dropped connection. Every surviving rank calls PMIx_Group_construct; the
+ * server accounts for the departed member, completes the construct on the
+ * survivors, and - the behavior under test - notifies each survivor with a
+ * PMIX_GROUP_MEMBER_FAILED event naming the victim. Each survivor verifies it
+ * received that event for the victim and prints a distinctive success line.
+ *
+ * See src/server/pmix_server_group.c (notify_local_members_of_loss) and
+ * docs/how-things-work/collectives.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+static pmix_proc_t myproc;
+static volatile int member_failed = 0;
+static pmix_proc_t failed_proc;
+static volatile int reg_active = -1;
+
+static void memfailed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                              const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                              pmix_info_t results[], size_t nresults,
+                              pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&failed_proc, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    member_failed = 1;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void regcbfunc(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref, cbdata);
+    reg_active = status;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t info;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t code = PMIX_GROUP_MEMBER_FAILED;
+    int i;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client %s:%d PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        fprintf(stderr, "Client %s:%d FAIL: this test requires at least 2 processes\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    /* register a handler for the member-failed event */
+    reg_active = -1;
+    PMIx_Register_event_handler(&code, 1, NULL, 0, memfailed_handler, regcbfunc, NULL);
+    while (-1 == reg_active) {
+        usleep(10000);
+    }
+    if (PMIX_SUCCESS != reg_active) {
+        fprintf(stderr, "Client %s:%d FAIL: could not register handler: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(reg_active));
+        exit(1);
+    }
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    if (myproc.rank == victim) {
+        /* leave before contributing, without finalizing, so the server sees a
+         * dropped connection and must run its lost-connection accounting. Exit
+         * 0 so the harness does not treat this as a real failure. */
+        fprintf(stderr, "%d leaving BEFORE group construct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    PMIX_INFO_LOAD(&info, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+
+    rc = PMIx_Group_construct("diegroup", procs, nprocs, &info, 1, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* The construct must complete on the survivors (success or a
+     * lost-connection/partial status), not hang. */
+    fprintf(stderr, "%d Group construct complete on survivors: status %s\n",
+            myproc.rank, PMIx_Error_string(rc));
+
+    /* the member-failed event is delivered asynchronously right after the
+     * construct completes - give it a bounded window to arrive */
+    for (i = 0; i < 500 && 0 == member_failed; i++) {
+        usleep(10000);
+    }
+
+    if (!member_failed) {
+        fprintf(stderr, "Client %s:%d FAIL: never received PMIX_GROUP_MEMBER_FAILED\n",
+                myproc.nspace, myproc.rank);
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+    if (failed_proc.rank != victim ||
+        0 != strncmp(failed_proc.nspace, myproc.nspace, PMIX_MAX_NSLEN)) {
+        fprintf(stderr, "Client %s:%d FAIL: member-failed named %s:%d, expected victim rank %d\n",
+                myproc.nspace, myproc.rank, failed_proc.nspace, failed_proc.rank, victim);
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    fprintf(stderr, "Client %s:%d saw member-failed for victim rank %d OK\n",
+            myproc.nspace, myproc.rank, victim);
+    fflush(stderr);
+    return 0;
+}

--- a/test/simple/simpgrpdie.c
+++ b/test/simple/simpgrpdie.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = NULL;
     pmix_proc_t proc, *procs;
     uint32_t nprocs, n, victim;
-    pmix_info_t info;
+    pmix_info_t *info;
     pmix_info_t *results = NULL;
     size_t nresults = 0;
     pmix_status_t code = PMIX_GROUP_MEMBER_FAILED;
@@ -145,14 +145,20 @@ int main(int argc, char **argv)
     for (n = 0; n < nprocs; n++) {
         PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
     }
-    PMIX_INFO_LOAD(&info, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    /* request fault-tolerant collective tracking so the construct completes on
+     * the survivors (and each learns of the loss via PMIX_GROUP_MEMBER_FAILED)
+     * when the victim drops before contributing. Without this flag the construct
+     * would instead abort - see simpgrpcabort. */
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_GROUP_FT_COLLECTIVE, NULL, PMIX_BOOL);
 
-    rc = PMIx_Group_construct("diegroup", procs, nprocs, &info, 1, &results, &nresults);
+    rc = PMIx_Group_construct("diegroup", procs, nprocs, info, 2, &results, &nresults);
     PMIX_PROC_FREE(procs, nprocs);
     if (NULL != results) {
         PMIX_INFO_FREE(results, nresults);
     }
-    PMIX_INFO_DESTRUCT(&info);
+    PMIX_INFO_FREE(info, 2);
 
     /* The construct must complete on the survivors (success or a
      * lost-connection/partial status), not hang. */

--- a/test/simple/simpgrpleader.c
+++ b/test/simple/simpgrpleader.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise leader failure and app-driven reselection in the invite/join model.
+ *
+ * Rank 0 is the leader. Each other rank joins the group led by rank 0 with
+ * PMIx_Group_join_nb(..., PMIX_GROUP_ACCEPT), which arms the library's
+ * leader-failure watch on the leader. The leader then dies before the construct
+ * completes. Because each joiner is waiting on the leader, the library surfaces
+ * the loss to each of them as a PMIX_GROUP_LEADER_FAILED event naming the
+ * leader. The application then drives reselection (a policy the library leaves
+ * to it): the lowest surviving joiner (rank 1) declares itself the new leader
+ * and announces that with PMIX_GROUP_LEADER_SELECTED; the remaining joiners
+ * receive it. Every joiner asserts it saw LEADER_FAILED for rank 0, and the
+ * non-electing joiners assert they saw LEADER_SELECTED naming rank 1.
+ *
+ * See src/client/pmix_client_group.c (setup_leader_watch / leader_watch_handler)
+ * and docs/how-things-work/collectives.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+static pmix_proc_t myproc;
+static const char *thegrp = "leadergroup";
+
+static volatile int reg_count = 0;
+static volatile int leader_failed_seen = 0;
+static pmix_proc_t failed_leader;
+static volatile int leader_selected_seen = 0;
+static pmix_proc_t new_leader;
+
+static void regcbfunc(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, evhandler_ref, cbdata);
+    reg_count++;
+}
+
+static void leaderfailed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                                 const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                 pmix_info_t *results, size_t nresults,
+                                 pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&failed_leader, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    leader_failed_seen = 1;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void leaderselected_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                                   const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                   pmix_info_t *results, size_t nresults,
+                                   pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&new_leader, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    leader_selected_seen = 1;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, leader;
+    uint32_t nprocs, n;
+    pmix_status_t code;
+    int i;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client %s:%d PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 3) {
+        fprintf(stderr, "Client %s:%d FAIL: this test requires at least 3 processes\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    /* register the leader-failure and leader-selected handlers */
+    code = PMIX_GROUP_LEADER_FAILED;
+    PMIx_Register_event_handler(&code, 1, NULL, 0, leaderfailed_handler, regcbfunc, NULL);
+    code = PMIX_GROUP_LEADER_SELECTED;
+    PMIx_Register_event_handler(&code, 1, NULL, 0, leaderselected_handler, regcbfunc, NULL);
+    while (reg_count < 2) {
+        usleep(10000);
+    }
+
+    /* sync everyone up first - all ranks are alive for this fence */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* rank 0 is the leader */
+    PMIX_LOAD_PROCID(&leader, myproc.nspace, 0);
+
+    if (0 == myproc.rank) {
+        /* the leader: give the joiners time to arm their watch on us, then die
+         * before the construct completes. Exit 0 so the harness does not treat
+         * this as a real failure - the dropped connection is what drives the
+         * test. */
+        fprintf(stderr, "%d is the leader, now leaving (simulated leader failure)\n",
+                myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    /* a joiner: accept into the group led by rank 0. This arms the library's
+     * leader-failure watch on the leader. (No prior invitation is required to
+     * join a group whose leader is known.) */
+    rc = PMIx_Group_join_nb(thegrp, &leader, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client %s:%d FAIL: Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* wait for the library to surface the leader's loss */
+    for (i = 0; i < 1000 && 0 == leader_failed_seen; i++) {
+        usleep(10000);
+    }
+    if (!leader_failed_seen) {
+        fprintf(stderr, "Client %s:%d FAIL: never received PMIX_GROUP_LEADER_FAILED\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+    if (0 != failed_leader.rank) {
+        fprintf(stderr, "Client %s:%d FAIL: leader-failed named rank %d, expected 0\n",
+                myproc.nspace, myproc.rank, failed_leader.rank);
+        exit(1);
+    }
+    fprintf(stderr, "rank %d saw LEADER_FAILED for leader %d\n", myproc.rank, failed_leader.rank);
+
+    /* reselection policy (the application's, not the library's): the lowest
+     * surviving joiner becomes the new leader and announces it */
+    if (1 == myproc.rank) {
+        pmix_proc_t *others;
+        pmix_data_array_t darray;
+        pmix_info_t cinfo[4];
+        uint32_t k = 0;
+
+        PMIX_PROC_CREATE(others, nprocs - 2);
+        for (n = 2; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&others[k], myproc.nspace, n);
+            k++;
+        }
+        darray.type = PMIX_PROC;
+        darray.array = others;
+        darray.size = nprocs - 2;
+        PMIX_INFO_LOAD(&cinfo[0], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+        PMIX_INFO_LOAD(&cinfo[1], PMIX_EVENT_AFFECTED_PROC, &myproc, PMIX_PROC);
+        PMIX_INFO_LOAD(&cinfo[2], PMIX_GROUP_ID, thegrp, PMIX_STRING);
+        PMIX_INFO_LOAD(&cinfo[3], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        rc = PMIx_Notify_event(PMIX_GROUP_LEADER_SELECTED, &myproc, PMIX_RANGE_CUSTOM,
+                               cinfo, 4, NULL, NULL);
+        PMIX_PROC_FREE(others, nprocs - 2);
+        PMIX_INFO_DESTRUCT(&cinfo[0]);
+        PMIX_INFO_DESTRUCT(&cinfo[1]);
+        PMIX_INFO_DESTRUCT(&cinfo[2]);
+        PMIX_INFO_DESTRUCT(&cinfo[3]);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client %s:%d FAIL: could not announce LEADER_SELECTED: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            exit(1);
+        }
+        fprintf(stderr, "rank %d elected as new leader\n", myproc.rank);
+    } else {
+        for (i = 0; i < 1000 && 0 == leader_selected_seen; i++) {
+            usleep(10000);
+        }
+        if (!leader_selected_seen) {
+            fprintf(stderr, "Client %s:%d FAIL: never received PMIX_GROUP_LEADER_SELECTED\n",
+                    myproc.nspace, myproc.rank);
+            exit(1);
+        }
+        if (1 != new_leader.rank) {
+            fprintf(stderr, "Client %s:%d FAIL: leader-selected named rank %d, expected 1\n",
+                    myproc.nspace, myproc.rank, new_leader.rank);
+            exit(1);
+        }
+        fprintf(stderr, "rank %d saw LEADER_SELECTED new leader %d\n", myproc.rank, new_leader.rank);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    fflush(stderr);
+    return 0;
+}

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -30,6 +30,7 @@
 #include "src/include/pmix_config.h"
 #include "include/pmix_server.h"
 #include "src/include/pmix_globals.h"
+#include "src/event/pmix_event.h"
 #include "src/include/pmix_types.h"
 
 #include <errno.h>
@@ -761,17 +762,28 @@ static void errhandler(size_t evhdlr_registration_id, pmix_status_t status,
                        pmix_info_t results[], size_t nresults,
                        pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
-    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, info, ninfo, results, nresults);
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, info, ninfo, results, nresults);
 
     pmix_output(0, "SERVER: ERRHANDLER CALLED WITH STATUS %s", PMIx_Error_string(status));
 
     if (PMIX_ERR_LOST_CONNECTION == status) {
         // give the procs a chance to do something
         usleep(10000);
-        /* let the other clients know */
-        PMIx_Notify_event(PMIX_ERR_PROC_ABORTED, &pmix_globals.myid,
-                          PMIX_RANGE_LOCAL, NULL, 0,
-                          NULL, NULL);
+        /* Let the other clients know a peer was lost, identifying it so a
+         * handler (e.g. a group leader-failure watch) can tell who died. Use
+         * the server-to-client delivery path directly: this process is a
+         * server+tool, so the public PMIx_Notify_event would route the event
+         * up toward our own server rather than down to our clients. */
+        if (NULL != source && PMIX_RANK_UNDEF != source->rank) {
+            pmix_info_t xinfo;
+            PMIX_INFO_LOAD(&xinfo, PMIX_EVENT_AFFECTED_PROC, source, PMIX_PROC);
+            pmix_server_notify_client_of_event(PMIX_ERR_PROC_ABORTED, &pmix_globals.myid,
+                                               PMIX_RANGE_LOCAL, &xinfo, 1, NULL, NULL);
+            PMIX_INFO_DESTRUCT(&xinfo);
+        } else {
+            pmix_server_notify_client_of_event(PMIX_ERR_PROC_ABORTED, &pmix_globals.myid,
+                                               PMIX_RANGE_LOCAL, NULL, 0, NULL, NULL);
+        }
     }
 
     /* we must NOT tell the event handler state machine that we

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_grpcabort.pl.in
+++ b/test/unit/run_grpcabort.pl.in
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the default (non-fault-tolerant) group construct abort path. A single
+# persistent server (test/simple/simptest) forks four clients
+# (test/simple/simpgrpcabort); the whole job is the group membership. Every
+# client syncs with a fence, then the last rank leaves without contributing (and
+# without finalizing) so the server sees a dropped connection. The survivors
+# call PMIx_Group_construct WITHOUT PMIX_GROUP_FT_COLLECTIVE; because the loss of
+# a required member cannot be tolerated, the server must complete the construct
+# with PMIX_GROUP_CONSTRUCT_ABORT rather than forming a reduced group. A
+# regression that silently reduces the membership (or hangs the construct) makes
+# a client exit non-zero, or wedges the run until the timeout fires. See
+# src/server/pmix_server_group.c (abort_construct / grp_ft_collective) and
+# docs/how-things-work/collectives.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from the current directory using a relative
+# path ("./simpgrpcabort"), so run from the directory that holds both
+# binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "4", "-e", "./simpgrpcabort");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed an assertion (or could not
+# connect/finalize) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: every survivor prints the
+# "saw construct ABORT" line only after PMIx_Group_construct returned
+# PMIX_GROUP_CONSTRUCT_ABORT, and simptest prints its own line after all
+# clients are gone.
+my @saw = ($output =~ /saw construct ABORT on loss of rank/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (3 != scalar(@saw)) {
+    printf("FAIL: expected 3 survivors to see the construct abort, saw %d\n", scalar(@saw));
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: all survivors saw PMIX_GROUP_CONSTRUCT_ABORT on member loss\n";
+exit(0);

--- a/test/unit/run_grpctimeout.pl.in
+++ b/test/unit/run_grpctimeout.pl.in
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the default (non-fault-tolerant) group construct timeout path. A single
+# persistent server (test/simple/simptest) forks four clients
+# (test/simple/simpgrpctimeout); the whole job is the group membership. Every
+# client syncs with a fence, then the last rank leaves without contributing (and
+# without finalizing) so the server sees a dropped connection. The survivors
+# call PMIx_Group_construct WITHOUT PMIX_GROUP_FT_COLLECTIVE; because the loss of
+# a required member cannot be tolerated, the server must complete the construct
+# with PMIX_ERR_TIMEOUT rather than hanging. A
+# regression that silently reduces the membership (or hangs the construct) makes
+# a client exit non-zero, or wedges the run until the timeout fires. See
+# src/server/pmix_server_group.c (abort_construct / grp_ft_collective) and
+# docs/how-things-work/collectives.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from the current directory using a relative
+# path ("./simpgrpctimeout"), so run from the directory that holds both
+# binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "4", "-e", "./simpgrpctimeout");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed an assertion (or could not
+# connect/finalize) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: every survivor prints the
+# "saw construct ABORT" line only after PMIx_Group_construct returned
+# PMIX_GROUP_CONSTRUCT_ABORT, and simptest prints its own line after all
+# clients are gone.
+my @saw = ($output =~ /saw construct TIMEOUT/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (3 != scalar(@saw)) {
+    printf("FAIL: expected 3 survivors to see the construct timeout, saw %d\n", scalar(@saw));
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: all survivors saw PMIX_ERR_TIMEOUT on a live absent member\n";
+exit(0);

--- a/test/unit/run_grpleader.pl.in
+++ b/test/unit/run_grpleader.pl.in
@@ -1,0 +1,135 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise leader failure and app-driven reselection in the invite/join model.
+# A single persistent server (test/simple/simptest) forks four clients
+# (test/simple/simpgrpleader). Rank 0 is the leader; each other rank joins the
+# group led by rank 0, which arms the library's leader-failure watch. Rank 0
+# then dies, and the library must surface the loss to each joiner as a
+# PMIX_GROUP_LEADER_FAILED event naming the leader. The application drives
+# reselection: rank 1 declares itself the new leader and announces it via
+# PMIX_GROUP_LEADER_SELECTED, which the other joiners receive. A regression that
+# fails to arm the watch or generate the event makes a joiner exit non-zero, or
+# wedges the run until the timeout fires. See src/client/pmix_client_group.c
+# (setup_leader_watch / leader_watch_handler).
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from the current directory using a relative
+# path ("./simpgrpleader"), so run from the directory that holds both
+# binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "4", "-e", "./simpgrpleader");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed an assertion (or could not
+# connect/finalize) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: every joiner prints the
+# "saw LEADER_FAILED" line only after the library surfaced the leader's loss;
+# the non-electing joiners print "saw LEADER_SELECTED" only after receiving the
+# reselection announcement; and simptest prints its own line once all clients
+# are gone.
+my @failed = ($output =~ /saw LEADER_FAILED for leader 0/g);
+my @selected = ($output =~ /saw LEADER_SELECTED new leader 1/g);
+my $elected = ($output =~ /rank 1 elected as new leader/);
+my $server_done = ($output =~ /Test finished OK!/);
+if (3 != scalar(@failed)) {
+    printf("FAIL: expected 3 joiners to see LEADER_FAILED, saw %d\n", scalar(@failed));
+    exit(1);
+}
+if (!$elected) {
+    print "FAIL: rank 1 did not elect itself as the new leader\n";
+    exit(1);
+}
+if (2 != scalar(@selected)) {
+    printf("FAIL: expected 2 joiners to see LEADER_SELECTED, saw %d\n", scalar(@selected));
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: leader failure surfaced and reselection completed\n";
+exit(0);

--- a/test/unit/run_grpmemberfail.pl.in
+++ b/test/unit/run_grpmemberfail.pl.in
@@ -1,0 +1,124 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the PMIX_GROUP_MEMBER_FAILED event the PMIx server synthesizes when
+# a member is lost before contributing to a group construct. A single
+# persistent server (test/simple/simptest) forks four clients
+# (test/simple/simpgrpdie); the whole job is the group membership. Every client
+# registers a handler for PMIX_GROUP_MEMBER_FAILED and syncs with a fence, then
+# the last rank leaves without contributing (and without finalizing) so the
+# server sees a dropped connection. The survivors call PMIx_Group_construct; the
+# server must complete the construct on the survivors AND notify each of them
+# with a PMIX_GROUP_MEMBER_FAILED event naming the victim. A regression that
+# fails to synthesize the event (or hangs the construct) makes a client exit
+# non-zero, or wedges the run until the timeout fires. See
+# src/server/pmix_server_group.c and docs/how-things-work/collectives.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from the current directory using a relative
+# path ("./simpgrpdie"), so run from the directory that holds both
+# binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "4", "-e", "./simpgrpdie");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed an assertion (or could not
+# connect/finalize) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path: every survivor prints the
+# "saw member-failed" line only after receiving PMIX_GROUP_MEMBER_FAILED for
+# the victim, and simptest prints its own line after all clients are gone.
+my @saw = ($output =~ /saw member-failed for victim rank/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (3 != scalar(@saw)) {
+    printf("FAIL: expected 3 survivors to see member-failed, saw %d\n", scalar(@saw));
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: all survivors received PMIX_GROUP_MEMBER_FAILED for the victim\n";
+exit(0);


### PR DESCRIPTION
This series completes the fault-handling story for dynamic PMIx group
operations (issue #3936). It adds first-class producers and gating for
the group fault attributes/events that were previously defined but inert,
introduces a real cross-server construct-cancel operation, and backs the
whole thing with deterministic unit tests plus a multi-daemon runtime
harness.

## What changed

- **`PMIX_GROUP_MEMBER_FAILED` synthesized** by the server when a group
  member is lost, instead of surfacing only as
  `PMIX_ERR_LOST_CONNECTION` on the collective.
- **Leader-failure detection during join** (`PMIX_GROUP_LEADER_FAILED`):
  `PMIx_Group_join` arms a watch on the leader; if the leader dies before
  the construct resolves, the library emits the event locally and the app
  drives reselection. The registration is fully non-blocking so it is safe
  to call from within the app's `PMIX_GROUP_INVITED` handler (progress
  thread).
- **`PMIX_GROUP_FT_COLLECTIVE` gating**: the survive-on-loss behavior that
  used to happen unconditionally now requires the flag. The default (flag
  unset) aborts the construct with `PMIX_GROUP_CONSTRUCT_ABORT`.
- **`PMIX_GROUP_CANCEL`** — a new group operation the server issues over
  the existing host `group` callback to abort an in-flight *cross-server*
  construct. It is derived from the command (not on the client<->server
  wire), so it is appended after `PMIX_GROUP_NONE` in the enum and does
  not affect wire compatibility.
- **Local-abort propagation**: when a server aborts a construct it also
  issues `PMIX_GROUP_CANCEL` to the host so the collective the *other*
  servers already joined is unstuck (they would otherwise hang, since the
  host has no timer of its own).
- **Server-armed construct timeout**: honored only when `PMIX_TIMEOUT` is
  supplied. It follows the fence family's model — the timer covers only
  the local phase and is deleted before the request is forwarded to the
  host, so it cannot race host completion.
- **`PMIX_CAP_GROUP_FT` capability flag** so companion projects (PRRTE)
  can detect this support at build time.

## Testing

- `make check` in `test/unit`: 21/21 (new `simpgrpcabort`,
  `simpgrpctimeout`, plus the earlier group tests and their `run_*.pl`
  drivers).
- New multi-daemon dockerswarm harness (`contrib/dockerswarm`,
  `run-group-events.sh`): 8/8 across a ten-node swarm, including
  cross-server construct abort via `PMIX_GROUP_CANCEL` and construct
  recovery on a whole-daemon loss.

## Companion PRRTE work

The daemon-loss and cross-server cancel paths require launcher support. A
companion PRRTE PR implements the grpcomm fault handler and the
`PMIX_GROUP_CANCEL` host handling, gated on `PMIX_CAP_GROUP_FT`. That PR
depends on this one (it needs the capability flag in the installed
`pmix_version.h`). Full degraded-mode *survival* on daemon loss (keeping
the DVM alive with a reduced-membership group) is deliberately deferred
and tracked as openpmix/prrte#2510.