### PR TITLE
Fix a batch of Coverity-reported defects

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -434,7 +434,7 @@ static void cycle_events(int sd, short args, void *cbdata)
     }
 
     /* save this handler's returned status */
-    if (NULL != chain->evhdlr && NULL != chain->evhdlr->name) {
+    if (NULL != chain->evhdlr->name) {
         pmix_strncpy(newinfo[cnt].key, chain->evhdlr->name, PMIX_MAX_KEYLEN);
     } else {
         pmix_strncpy(newinfo[cnt].key, "UNKNOWN", PMIX_MAX_KEYLEN);

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -500,7 +500,7 @@ void pmix_info_do_path(bool wall, pmix_cli_result_t *cmd_line,
         pmix_info_show_path(pmix_info_path_pkgdatadir, dirs->pmixdatadir);
         pmix_info_show_path(pmix_info_path_pkglibdir, dirs->pmixlibdir);
         pmix_info_show_path(pmix_info_path_pkgincludedir, dirs->pmixincludedir);
-    } else {
+    } else if (NULL != opt) {
         for (i = 0; NULL != opt->values[i]; ++i) {
             scope = opt->values[i];
 

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -242,8 +242,7 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
         }
         rc = pthread_setaffinity_np(trk->engine.t_handle, sizeof(cpu_set_t), &cpuset);
         if (0 != rc && pmix_bind_progress_thread_reqd) {
-            pmix_output(0, "Failed to bind progress thread %s",
-                        (NULL == trk->name) ? "NULL" : trk->name);
+            pmix_output(0, "Failed to bind progress thread %s", trk->name);
             rc = PMIX_ERR_NOT_SUPPORTED;
         } else {
             rc = PMIX_SUCCESS;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -951,7 +951,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        return rc;
+        goto cleanup;
     }
     /* unpack the array of info objects */
     if (0 < ninfo) {
@@ -1130,7 +1130,19 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
              * thus guaranteeing that the client will get their registration
              * callback prior to delivery of an event notification */
             if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+                /* the caddy carries the codes and info arrays, but its
+                 * destructor does not free them - so release them here,
+                 * along with the affected array that was never attached */
+                if (NULL != scd->codes) {
+                    free(scd->codes);
+                }
+                if (NULL != scd->info) {
+                    PMIX_INFO_FREE(scd->info, scd->ninfo);
+                }
                 PMIX_RELEASE(scd);
+                if (NULL != affected) {
+                    PMIX_PROC_FREE(affected, naffected);
+                }
                 return PMIX_ERR_NOT_AVAILABLE;
             }
 
@@ -1160,7 +1172,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
          * thus guaranteeing that the client will get their registration
          * callback prior to delivery of an event notification */
         if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-            return PMIX_ERR_NOT_AVAILABLE;
+            rc = PMIX_ERR_NOT_AVAILABLE;
+            goto cleanup;
         }
 
         scd = PMIX_NEW(pmix_setup_caddy_t);

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -341,7 +341,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
         pmix_output_verbose(verbose_level, output_id, "dump data at %p %d bytes\n", ptr, buflen);
         for (i = 0; i < buflen; i += 16) {
             out_pos = 0;
-            ret = snprintf(out_buf + out_pos, 1024, "%06x: ", i);
+            ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "%06x: ", i);
             if (ret < 0) {
                 return;
             }
@@ -351,9 +351,9 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
                     return;
                 }
                 if (i + j < buflen) {
-                    ret = snprintf(out_buf + out_pos, 1024, "%02x ", buf[i + j]);
+                    ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "%02x ", buf[i + j]);
                 } else {
-                    ret = snprintf(out_buf + out_pos, 1024, "   ");
+                    ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "   ");
                 }
                 if (ret < 0) {
                     return;
@@ -363,7 +363,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
             if (1023 < (out_pos+1)) {
                 return;
             }
-            ret = snprintf(out_buf + out_pos, 1024, " ");
+            ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, " ");
             if (ret < 0) {
                 return;
             }
@@ -373,7 +373,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
                     return;
                 }
                 if (i + j < buflen) {
-                    ret = snprintf(out_buf + out_pos, 1024, "%c", isprint(buf[i + j]) ? buf[i + j] : '.');
+                    ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "%c", isprint(buf[i + j]) ? buf[i + j] : '.');
                     if (ret < 0) {
                         return;
                     }
@@ -383,7 +383,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
             if (1023 < (out_pos+1)) {
                 return;
             }
-            ret = snprintf(out_buf + out_pos, 1024, "\n");
+            ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "\n");
             if (ret < 0) {
                 return;
             }


### PR DESCRIPTION
This branch resolves a set of static-analysis (Coverity) findings across
several subsystems. Each is an independent, self-contained commit.

- **pmix_server_register_events** (CID: OVERRUN of allocations): plug
  memory leaks on the info-count unpack error path and on the two
  progress-thread-stopped teardown paths, where the `codes`, `info`, and
  `affected` arrays could be dropped.

- **pmix_output_hexdump** (CID 501134, OVERRUN): pass the remaining
  buffer size to `snprintf` instead of the fixed `1024`, which claimed a
  full buffer starting at a non-zero write offset.

- **start_progress_engine** (CID 503841, REVERSE_INULL): drop the
  impossible `NULL == trk->name` check; the name is dereferenced
  unconditionally just above and is guaranteed non-NULL for any listed
  tracker.

- **pmix_info_do_path** (CID 501307, FORWARD_NULL): guard the per-value
  loop with `NULL != opt` so a call with no path option and `want_all`
  false cannot dereference a NULL option.

- **cycle_events** (CID 454412, FORWARD_NULL): drop the lone
  `NULL != chain->evhdlr` check that contradicted the non-NULL invariant
  relied on everywhere else in the routine.

None of these change externally visible behavior; they correct latent
defects and make the code consistent with its own invariants.