### PR TITLE
Complete and document the PMIx_Group APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ test/simple/pmitest
 test/simple/simpcycle
 test/simple/simpgrpmember
 test/simple/simpgrpdie
+test/simple/simpgrpddie
 test/simple/simpgrpleader
 test/simple/simpgrpcabort
 test/simple/simpgrpctimeout

--- a/docs/how-things-work/sets_groups/group_construct.rst
+++ b/docs/how-things-work/sets_groups/group_construct.rst
@@ -243,12 +243,12 @@ example from the PMIx library for details):
             API as it is invoked from inside the PMIx library's progress
             thread. Doing so will cause a thread deadlock condition.
 
-* the ``PMIX_GROUP_COMPLETE`` event, which will be triggered once the
+* the ``PMIX_GROUP_CONSTRUCT_COMPLETE`` event, which will be triggered once the
   construct operation has completed. This can be used to receive the final
   group membership, along with any provided group info or other data.
 
 The construct procedure is initiated by a single "leader" that calls the
-``PMIx_Group_Invite`` API, providing (among other optional things) an array
+``PMIx_Group_invite`` API, providing (among other optional things) an array
 of process IDs that it wishes to have join the group. Prior to doing so,
 the leader may choose to register an event handler for the ``PMIX_GROUP_INVITE_FAILED``
 event. This will allow the library to notify the process should any of
@@ -260,7 +260,7 @@ a reduced final group membership).
 
 The leader will return from the ``PMIx_Group_invite`` function once all
 specified members have responded to the invitation. In addition, the leader
-will (since it is a member of the group) receive the ``PMIX_GROUP_COMPLETE``
+will (since it is a member of the group) receive the ``PMIX_GROUP_CONSTRUCT_COMPLETE``
 event specifying the status return of the operation (``PMIX_SUCCESS`` to
 indicate that the group successfully constructed, or else an appropriate
 error value) and, if successful, containing the resulting information.

--- a/docs/how-things-work/sets_groups/group_implementation.rst
+++ b/docs/how-things-work/sets_groups/group_implementation.rst
@@ -106,6 +106,16 @@ view), and delivers the results. ``PMIx_Group_destruct_nb`` mirrors this with
 server does not store it) and removing the group from the local list on
 completion.
 
+The persistent ``pmix_group_t`` also carries the group's failure policy across
+the two collectives. ``PMIX_GROUP_NOTIFY_TERMINATION`` is specified at construct
+time but governs the eventual destruct, and the server keeps no group state
+between operations — so the blocking construct wrapper captures the flag into
+the tracker, ``add_group()`` records it in the ``pmix_group_t`` (``notterm``),
+and ``PMIx_Group_destruct_nb`` re-attaches ``PMIX_GROUP_NOTIFY_TERMINATION`` to
+the destruct request (unless the caller passed it explicitly, which overrides).
+The server then reads it off the aggregated destruct block via
+``grp_notify_termination()``.
+
 ``pmix_client_proc_is_included()`` (in ``pmix_client_convert.c``) is the
 shared "is the caller covered by this participant array?" predicate — it
 matches the caller's namespace and accepts ``PMIX_RANK_WILDCARD``,
@@ -306,17 +316,26 @@ server decides between aborting and surviving:
            abort_construct(blk, PMIX_GROUP_CONSTRUCT_ABORT);
            return;
        }
-       pmix_server_set_collective_status(blk->info, blk->ninfo,
-                                         PMIX_ERR_LOST_CONNECTION);
+       if (!(PMIX_GROUP_DESTRUCT == op && grp_notify_termination(blk))) {
+           pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                             PMIX_ERR_LOST_CONNECTION);
+       }
    }
 
 * ``grp_ft_collective(blk)`` scans the aggregated directives for
-  ``PMIX_GROUP_FT_COLLECTIVE`` (``"pmix.grp.ftcoll"``, bool, default false).
-* A **construct without the flag** aborts. A construct **with the flag**, or
-  any **destruct**, survives on the survivors, recording
-  ``PMIX_ERR_LOST_CONNECTION`` into the ``PMIX_LOCAL_COLLECTIVE_STATUS`` slot
-  so the host is told the local phase was degraded (clients still receive
-  their own status through ``grpcbfunc``).
+  ``PMIX_GROUP_FT_COLLECTIVE`` (``"pmix.grp.ftcoll"``, bool, default false);
+  ``grp_notify_termination(blk)`` scans them for
+  ``PMIX_GROUP_NOTIFY_TERMINATION`` (``"pmix.grp.notterm"``, bool, default
+  false).
+* A **construct without the FT flag** aborts. Every other case survives on the
+  survivors. A **destruct with termination notification** completes cleanly:
+  the ``PMIX_LOCAL_COLLECTIVE_STATUS`` slot is left at ``PMIX_SUCCESS`` and the
+  survivors are told which member was lost via the synthesized
+  ``PMIX_GROUP_MEMBER_FAILED`` event (the event standing in place of an error).
+  Every other survive path — a fault-tolerant **construct**, or a **destruct
+  without notification** — records ``PMIX_ERR_LOST_CONNECTION`` into that slot
+  so the host is told the local phase was degraded (clients still receive their
+  own status through ``grpcbfunc``).
 
 ``abort_construct(blk, status)`` deletes any armed timer; if a host is
 present it issues ``pmix_host_server.group(PMIX_GROUP_CANCEL, blk->id, ...)``
@@ -333,16 +352,25 @@ race it.
 Synthesizing ``PMIX_GROUP_MEMBER_FAILED``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On the *survive* path, ``notify_local_members_of_loss()`` (called from
-``_grpcbfunc`` only when the construct succeeded, is a construct, and has a
-non-empty ``departed`` list) emits, for each departed process, a
-``PMIX_GROUP_MEMBER_FAILED`` event carrying ``PMIX_EVENT_AFFECTED_PROC`` (the
-lost member) and ``PMIX_GROUP_ID``. It is delivered through the internal,
-progress-thread-safe ``pmix_server_notify_client_of_event`` — never the
-public ``PMIx_Notify_event``. Because each server does this accounting for
-its own local survivors, a member lost on another node is reported by that
-node's server performing the identical logic; the feature therefore needs no
-cooperation from the host environment.
+On the *survive* path, ``notify_local_members_of_loss()`` emits, for each
+departed process, a ``PMIX_GROUP_MEMBER_FAILED`` event carrying
+``PMIX_EVENT_AFFECTED_PROC`` (the lost member) and ``PMIX_GROUP_ID``. It is
+delivered through the internal, progress-thread-safe
+``pmix_server_notify_client_of_event`` — never the public ``PMIx_Notify_event``.
+Because each server does this accounting for its own local survivors, a member
+lost on another node is reported by that node's server performing the identical
+logic; the feature therefore needs no cooperation from the host environment.
+
+``_grpcbfunc`` calls it when the operation completed successfully (status is
+``PMIX_SUCCESS``), has a non-empty ``departed`` list, and is either a construct
+(which reaches ``_grpcbfunc`` with success only on the fault-tolerant survive
+path — an aborted construct arrives with ``PMIX_GROUP_CONSTRUCT_ABORT``) or a
+destruct for which ``grp_notify_termination()`` reports that
+``PMIX_GROUP_NOTIFY_TERMINATION`` was requested. For the destruct survive path
+the two host-forward points (``pmix_server_group`` and ``account_departed``)
+deliberately leave the local-collective status at ``PMIX_SUCCESS`` when
+notification was requested (so the operation returns success, the event standing
+in place of an error) and record ``PMIX_ERR_LOST_CONNECTION`` otherwise.
 
 The local-phase timeout
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -457,10 +485,13 @@ The behaviors above are exercised at several levels:
 * ``test/unit/collective_status.c`` — white-box coverage of the by-key status
   helper (connect/fence layouts, absent slot, degenerate inputs), wired into
   ``make check``.
-* ``test/simple`` drivers — ``simpgrpdie`` (survive on loss +
+* ``test/simple`` drivers — ``simpgrpdie`` (construct survives loss +
   ``PMIX_GROUP_MEMBER_FAILED``, with ``PMIX_GROUP_FT_COLLECTIVE``),
-  ``simpgrpcabort`` (default abort with ``PMIX_GROUP_CONSTRUCT_ABORT``), and
-  ``simpgrpctimeout`` (``PMIX_ERR_TIMEOUT`` on a hung live member).
+  ``simpgrpddie`` (destruct survives loss +
+  ``PMIX_GROUP_MEMBER_FAILED`` and returns success, with
+  ``PMIX_GROUP_NOTIFY_TERMINATION``), ``simpgrpcabort`` (default abort with
+  ``PMIX_GROUP_CONSTRUCT_ABORT``), and ``simpgrpctimeout``
+  (``PMIX_ERR_TIMEOUT`` on a hung live member).
 * ``examples/`` exercisers driven by the dockerswarm harness
   (``contrib/dockerswarm/run-group-events.sh``) across a multi-node swarm, so
   the cross-server notification and cancel paths actually run:

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -1,0 +1,259 @@
+.. _man3-PMIx_Group_construct:
+
+PMIx_Group_construct
+====================
+
+.. include_body
+
+``PMIx_Group_construct``, ``PMIx_Group_construct_nb`` |mdash| Construct a new
+PMIx group from a specified set of processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Group_construct(const char grp[],
+                                      const pmix_proc_t procs[], size_t nprocs,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_t **results, size_t *nresults);
+
+   pmix_status_t PMIx_Group_construct_nb(const char grp[],
+                                         const pmix_proc_t procs[], size_t nprocs,
+                                         const pmix_info_t info[], size_t ninfo,
+                                         pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries
+  peers = [{'nspace': "testnspace", 'rank': 0},
+           {'nspace': "testnspace", 'rank': 1}]
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_GROUP_ASSIGN_CONTEXT_ID,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc, results = foo.group_construct("mygroup", peers, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``grp``: A NULL-terminated character string identifying the group. The string
+  must be of length less than or equal to ``PMIX_MAX_NSLEN`` and may contain
+  only characters accepted by the standard string comparison functions (e.g.,
+  ``strncmp``). Each simultaneously-active group construct operation must use a
+  unique identifier.
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming the
+  processes that are to compose the group.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``directives`` (``info`` for the non-blocking form): Pointer to an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs conveying user directives that
+  qualify the operation (see `DIRECTIVES`_).
+* ``ndirs`` (``ninfo`` for the non-blocking form): Number of elements in the
+  ``directives`` array.
+
+The blocking form returns results directly:
+
+* ``results``: Address of a pointer that, upon successful return, is set to an
+  array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs containing any values
+  returned by the operation (e.g., an assigned context ID). May be ``NULL`` if
+  the caller does not want the returned values. The caller is responsible for
+  releasing the array with ``PMIX_INFO_FREE``.
+* ``nresults``: Address of a ``size_t`` that is set to the number of elements in
+  the returned ``results`` array.
+
+The non-blocking form takes two additional parameters in place of ``results``
+and ``nresults``:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+  the group has been constructed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Construct a new group composed of the specified processes and identified with
+the provided group identifier. A *group* is a collection of processes desiring a
+unified identifier for a purpose such as a group-wide event notification, or for
+efficient collective operations across a subset of the processes in one or more
+jobs. Upon completion of the construct procedure, each group member has access
+to the job-level information of all namespaces represented in the group and the
+contact information for every group member.
+
+``PMIx_Group_construct`` is the blocking form: it does not return until all
+specified processes have joined the group (or the operation fails). Returned
+values are delivered in the ``results`` array. ``PMIx_Group_construct_nb`` is the
+non-blocking form: it returns immediately, and the provided ``cbfunc`` is invoked
+with the final status and any returned values once the operation completes.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Group_construct_nb`` **must**
+keep the ``grp``, ``procs``, and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+Processes may engage in multiple simultaneous group construct operations, so long
+as each is provided with a unique group ID. Processes in a group under
+construction are not allowed to leave the group until construction is complete.
+
+Construction methods
+^^^^^^^^^^^^^^^^^^^^^
+
+For purposes of construction, PMIx distinguishes two classes of group member.
+*Leaders* have some global view of the group at construction time |mdash| for
+example, the number of leaders or the process IDs of all leaders. *Members* know
+only the group ID they are to join, with no other knowledge of the group's size
+or membership. ``PMIx_Group_construct`` supports two collective construction
+methods, selected by how the caller populates the ``procs`` array and the
+directives; the fully asynchronous *invite* method is handled by the separate
+:ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>` API.
+
+* **Collective method.** Every leader knows the process IDs of all other leaders
+  and calls ``PMIx_Group_construct`` with the full array of leader process IDs.
+  All leaders must call the API, but the ``procs`` array need not be ordered
+  identically across leaders. This is the traditional form of the operation.
+
+* **Bootstrap method.** Each leader knows only *how many* leaders will participate,
+  not their identities |mdash| the common case when two or more collections of
+  processes join together (e.g., an MPI connect/accept) and only the "root"
+  process of each collection knows of the others. Each leader passes only its own
+  process ID in ``procs`` and **must** provide the ``PMIX_GROUP_BOOTSTRAP``
+  attribute with a value equal to the number of leaders in the operation.
+  Construction completes once the specified number of leaders (plus any added
+  members) have called the API.
+
+In either method, a leader may name additional processes that are to end up in the
+final group |mdash| but that are not among the leaders |mdash| by supplying the
+``PMIX_GROUP_ADD_MEMBERS`` attribute with an array of their process IDs. The PMIx
+server library and host jointly aggregate the added members contributed across
+leaders. Every process on an "additional member" list **must** itself call
+``PMIx_Group_construct`` with ``NULL`` in the ``procs`` argument; this marks the
+caller as an added member (rather than a leader) and lets the library register the
+necessary events on its behalf. The construct operation cannot complete until all
+leaders **and** all added members have called ``PMIx_Group_construct``, so that any
+group or endpoint information provided by the added members is included in the
+returned ``results`` array.
+
+When a call names its participants explicitly (i.e., it uses neither
+``PMIX_GROUP_ADD_MEMBERS`` nor ``PMIX_GROUP_BOOTSTRAP``), the client library first
+expands any group identifier appearing in the ``procs`` array into that group's
+member processes and then verifies that the caller is itself among the resolved
+participants, returning ``PMIX_ERR_NOT_A_MEMBER`` immediately if it is not. This
+check is intentionally skipped for the add-members and bootstrap methods, since
+those deliberately omit participants from the ``procs`` array.
+
+These methods and the responsibilities of the client library, server, and host are
+described in full in
+:ref:`Group Construction, Destruction, and Fault Tolerance <group-construction-label>`.
+
+Membership changes and failures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If ``PMIX_GROUP_LEADER`` is provided, the declared leader (and only the leader)
+will receive a ``PMIX_GROUP_MEMBER_FAILED`` event whenever a process fails or
+terminates prior to calling ``PMIx_Group_construct(_nb)``. In the absence of a
+declared leader, all participants that registered for the event receive it. The
+event contains the identifier of the failed process plus any other information
+the resource manager provided, giving the leader an opportunity to react |mdash|
+for example, to invite an alternative member or to proceed with a smaller group.
+The decision to proceed with a smaller group is communicated back to the PMIx
+library in the results array returned at the end of the event handler, allowing
+PMIx to adjust its accounting for completion of the procedure.
+
+When construct is complete, the participating PMIx servers are alerted to any
+change in participants, and each group member that registered for the
+``PMIX_GROUP_MEMBERSHIP_UPDATE`` event receives it with the final membership.
+
+Failure of the leader at any time causes a ``PMIX_GROUP_LEADER_FAILED`` event to
+be delivered to all participants so they can optionally declare a new leader. A
+new leader is identified by providing the ``PMIX_GROUP_LEADER`` attribute in the
+results array returned from the event handler; only one process is permitted to
+do so. The outcome of leader selection is communicated to all participants via a
+``PMIX_GROUP_LEADER_SELECTED`` event. If no leader was selected, the status code
+in that event carries an error value so participants can take appropriate action.
+
+Any participant that returns ``PMIX_GROUP_CONSTRUCT_ABORT`` from the leader-failed
+event handler aborts the construct procedure. Processes engaged in the blocking
+form return with the ``PMIX_GROUP_CONSTRUCT_ABORT`` status; non-blocking
+participants have their callback function invoked with that status.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation:
+
+* ``PMIX_GROUP_LEADER`` (bool) |mdash| declare this process to be the leader of
+  the construction procedure. If a process provides this attribute, failure
+  notification for any participating process goes only to that process. In the
+  absence of a declared leader, failure events go to all participants.
+* ``PMIX_GROUP_OPTIONAL`` (bool) |mdash| participation is optional; do not return
+  an error if any of the specified processes terminate without having joined
+  (default: ``false``).
+* ``PMIX_GROUP_NOTIFY_TERMINATION`` (bool) |mdash| establishes the group's failure
+  policy for the eventual teardown: when a member is lost before it calls destruct,
+  report the loss to the survivors via a ``PMIX_GROUP_MEMBER_FAILED`` event and
+  complete the destruct with success, rather than reporting an error (default:
+  ``false``). This directive is supplied here at construct time but governs
+  :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>`; the library remembers it
+  and re-applies it to the destruct automatically.
+* ``PMIX_GROUP_ASSIGN_CONTEXT_ID`` (bool) |mdash| request that the resource
+  manager assign a unique numerical (``size_t``) context ID to the group. The
+  value is returned in the ``results`` array (or in the callback) and is also
+  delivered in the ``PMIX_GROUP_CONTEXT_ID_ASSIGNED`` event.
+* ``PMIX_GROUP_BOOTSTRAP`` (size_t) |mdash| select the *bootstrap* construction
+  method (see `DESCRIPTION`_). The value is the number of leaders that will start
+  the construction. Each leader passes only its own process ID in ``procs``.
+  Required of every leader participating in a bootstrap operation.
+* ``PMIX_GROUP_ADD_MEMBERS`` (pmix_data_array_t\*) |mdash| an array of
+  ``pmix_proc_t`` naming processes that are not included in the ``procs`` array but
+  are to be part of the final group. May be supplied by any leader in either the
+  collective or bootstrap method. Each named process must itself call
+  ``PMIx_Group_construct`` with ``NULL`` for ``procs``.
+* ``PMIX_GROUP_FT_COLLECTIVE`` (bool) |mdash| if true, complete the construct on
+  the surviving members when a required member is lost, delivering a
+  ``PMIX_GROUP_MEMBER_FAILED`` event for each loss, instead of aborting the
+  operation (default: ``false``).
+* ``PMIX_TIMEOUT`` (int) |mdash| return an error if the group does not assemble
+  within the specified number of seconds. This targets the scenario where a
+  process fails to participate due to hanging.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the group was successfully
+constructed and any returned values are available in ``results``. For the
+non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the request
+was successfully accepted for processing; the final status is delivered to
+``cbfunc``, and the callback is not invoked if any other value is returned.
+
+* ``PMIX_SUCCESS`` |mdash| the group was successfully constructed.
+* ``PMIX_GROUP_CONSTRUCT_ABORT`` |mdash| a participant aborted the construct
+  procedure in response to a member or leader failure.
+* ``PMIX_ERR_NOT_A_MEMBER`` |mdash| the caller named its participants explicitly
+  but is not itself among them. Returned only for the collective method, since the
+  add-members and bootstrap methods skip this check.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| a required argument was invalid (e.g., a ``NULL``
+  or over-length group identifier).
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support group
+  operations.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other value indicates an appropriate error condition.
+
+
+.. seealso::
+   :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,
+   :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,
+   :ref:`PMIx_Group_leave(3) <man3-PMIx_Group_leave>`,
+   :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Group_destruct.3.rst
+++ b/docs/man/man3/PMIx_Group_destruct.3.rst
@@ -1,0 +1,155 @@
+.. _man3-PMIx_Group_destruct:
+
+PMIx_Group_destruct
+===================
+
+.. include_body
+
+``PMIx_Group_destruct``, ``PMIx_Group_destruct_nb`` |mdash| Collectively destruct
+a PMIx group.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Group_destruct(const char grp[],
+                                     const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Group_destruct_nb(const char grp[],
+                                        const pmix_info_t info[], size_t ninfo,
+                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the info is a list of Python ``pmix_info_t`` dictionaries
+  pyinfo = []
+  rc = foo.group_destruct("mygroup", pyinfo)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``grp``: A NULL-terminated character string identifying the group to be
+  destructed. The string must be of length less than or equal to
+  ``PMIX_MAX_NSLEN``.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs
+  conveying user directives that qualify the operation (see `DIRECTIVES`_).
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form takes two additional parameters:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be executed once all
+  members of the group have called destruct.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Destruct a group identified by the provided group identifier. Destruct is a
+collective over the *current* membership: the blocking form does not return, and the
+non-blocking form does not invoke its callback, until all members of the group have
+called destruct (or a fault-handling rule resolves the operation). This is the
+recommended, scalable way to tear down a group and should be preferred over
+:ref:`PMIx_Group_leave(3) <man3-PMIx_Group_leave>` in all cases except the
+asynchronous departure of an individual process.
+
+Because the group identifier and its membership are held by the client libraries
+|mdash| not the host |mdash| the destruct call carries the membership to its local
+server so the server knows how many local participants to await. On completion, the
+group identifier and any assigned context ID are released, and the group is removed
+from each member's local group list.
+
+Processes may engage in multiple simultaneous group destruct operations, so long as
+each involves a unique group ID. As with all non-blocking PMIx APIs, callers of
+``PMIx_Group_destruct_nb`` **must** keep the ``grp`` and ``info`` arrays valid until
+``cbfunc`` is invoked. These behaviors are described in full in
+:ref:`Group Construction, Destruction, and Fault Tolerance <group-construction-label>`.
+
+Member failure
+^^^^^^^^^^^^^^
+
+The destruct operation completes on the surviving members if any group process
+fails or terminates prior to calling ``PMIx_Group_destruct`` (or its non-blocking
+form) |mdash| it does not hang waiting on the lost member. How that completion is
+reported depends on ``PMIX_GROUP_NOTIFY_TERMINATION``:
+
+* **Default (no notification).** The teardown is reported as an error: the degraded
+  status (``PMIX_ERR_LOST_CONNECTION``) is recorded for the host, and no event is
+  generated.
+* **With ``PMIX_GROUP_NOTIFY_TERMINATION``.** A ``PMIX_GROUP_MEMBER_FAILED`` event
+  naming the departed process is delivered to each surviving member, the destruct
+  tracker is updated to account for the lack of participation, and
+  ``PMIx_Group_destruct`` returns ``PMIX_SUCCESS`` once the remaining processes have
+  all called destruct |mdash| i.e., the event serves in place of the return of an
+  error.
+
+``PMIX_GROUP_NOTIFY_TERMINATION`` is a property of the group's failure policy and is
+supplied at *construct* time (see
+:ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`). The library remembers
+it and re-applies it to this destruct on the caller's behalf, so it need not be
+passed to ``PMIx_Group_destruct`` again; passing it directly here is also honored
+and overrides the remembered policy.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation:
+
+* ``PMIX_GROUP_NOTIFY_TERMINATION`` (bool) |mdash| report, rather than error, a
+  member lost before it calls destruct (see `Member failure`_). Supplied at
+  construct time and re-applied here automatically; may also be passed directly to
+  this call.
+* ``PMIX_TIMEOUT`` (int) |mdash| return an error if the group does not destruct
+  within the specified number of seconds. This targets the scenario where a process
+  fails to call ``PMIx_Group_destruct`` due to hanging.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the group was successfully
+destructed. For the non-blocking form, a return of ``PMIX_SUCCESS`` indicates only
+that the request was successfully accepted for processing; the final status is
+delivered to ``cbfunc``, and the callback is not invoked if any other value is
+returned.
+
+* ``PMIX_SUCCESS`` |mdash| the group was successfully destructed. Also returned on
+  the loss of a member when ``PMIX_GROUP_NOTIFY_TERMINATION`` was in effect, with the
+  loss reported via a ``PMIX_GROUP_MEMBER_FAILED`` event instead (see
+  `Member failure`_).
+* ``PMIX_ERR_LOST_CONNECTION`` |mdash| a member was lost before calling destruct and
+  ``PMIX_GROUP_NOTIFY_TERMINATION`` was not in effect; the destruct still completed
+  on the surviving members. (The exact status a caller observes for this degraded
+  case is determined by the host environment.)
+* ``PMIX_ERR_BAD_PARAM`` |mdash| a required argument was invalid (e.g., a ``NULL``
+  or over-length group identifier).
+* ``PMIX_ERR_TIMEOUT`` |mdash| the group did not destruct within the time specified
+  by ``PMIX_TIMEOUT``.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support group
+  operations.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other value indicates an appropriate error condition, such as the failure of a
+member process when ``PMIX_GROUP_NOTIFY_TERMINATION`` was not requested.
+
+
+.. seealso::
+   :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
+   :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,
+   :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,
+   :ref:`PMIx_Group_leave(3) <man3-PMIx_Group_leave>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Group_invite.3.rst
+++ b/docs/man/man3/PMIx_Group_invite.3.rst
@@ -1,0 +1,192 @@
+.. _man3-PMIx_Group_invite:
+
+PMIx_Group_invite
+=================
+
+.. include_body
+
+``PMIx_Group_invite``, ``PMIx_Group_invite_nb`` |mdash| Invite specified
+processes to asynchronously join a PMIx group.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Group_invite(const char grp[],
+                                   const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_info_t **results, size_t *nresult);
+
+   pmix_status_t PMIx_Group_invite_nb(const char grp[],
+                                      const pmix_proc_t procs[], size_t nprocs,
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries
+  peers = [{'nspace': "testnspace", 'rank': 1},
+           {'nspace': "testnspace", 'rank': 2}]
+  # the info is a list of Python ``pmix_info_t`` dictionaries
+  pyinfo = []
+  rc, results = foo.group_invite("mygroup", peers, pyinfo)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``grp``: A NULL-terminated character string identifying the group. The string
+  must be of length less than or equal to ``PMIX_MAX_NSLEN`` and may contain only
+  characters accepted by the standard string comparison functions (e.g.,
+  ``strncmp``).
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming the
+  processes being invited to join the group.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs
+  conveying user directives that qualify the operation (see `DIRECTIVES`_).
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The blocking form returns results directly:
+
+* ``results``: Address of a pointer that, upon successful return, is set to an
+  array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs containing any values
+  returned by the operation. May be ``NULL`` if the caller does not want the
+  returned values. The caller is responsible for releasing the array with
+  ``PMIX_INFO_FREE``.
+* ``nresult``: Address of a ``size_t`` that is set to the number of elements in
+  the returned ``results`` array.
+
+The non-blocking form takes two additional parameters in place of ``results``
+and ``nresult``:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+  the group has been fully assembled.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Explicitly invite the specified processes to join a group. This is the most
+dynamic form of group construction, in contrast to the collective
+:ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>` in which all members
+call the API to assemble the group. The invite method involves no collective
+operation: it is executed in an ad hoc manner around a single leader (the inviting
+process) and relies solely on the event notification subsystem for its underlying
+execution.
+
+Each invited process is notified of the invitation via the ``PMIX_GROUP_INVITED``
+event. Invited processes **must** have registered for that event in order to be
+notified; the handler retrieves the ``PMIX_GROUP_ID`` from the event and, when
+ready to respond, replies using the non-blocking
+:ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>` (the blocking form cannot be used
+from within the handler). This notifies the inviting process that the invitation
+was either accepted (via the ``PMIX_GROUP_INVITE_ACCEPTED`` event) or declined (via
+the ``PMIX_GROUP_INVITE_DECLINED`` event). To receive the final membership, each
+participant should also register for the ``PMIX_GROUP_CONSTRUCT_COMPLETE`` event,
+which is delivered once the group has assembled.
+
+Upon acceptance of the invitation, both the inviting and the invited process gain
+access to the job-level information of each other's namespaces and the contact
+information of the other process.
+
+The inviting process may register for the ``PMIX_GROUP_INVITE_FAILED`` event to be
+notified whenever an invited process declines, terminates before responding, or
+fails to respond within a supplied ``PMIX_TIMEOUT``. In response, the leader can
+replace the failed invitee with another, abort the construct, or (with
+``PMIX_GROUP_OPTIONAL``) allow the group to form with reduced membership |mdash|
+see `DIRECTIVES`_.
+
+This method, and the responsibilities of the client library, server, and host, are
+described in full in
+:ref:`Group Construction, Destruction, and Fault Tolerance <group-construction-label>`.
+
+``PMIx_Group_invite`` is the blocking form; ``PMIx_Group_invite_nb`` is the
+non-blocking form, returning immediately and delivering the final status and any
+returned values through ``cbfunc``. As with all non-blocking PMIx APIs, callers of
+``PMIx_Group_invite_nb`` **must** keep the ``grp``, ``procs``, and ``info`` arrays
+valid until ``cbfunc`` is invoked.
+
+Leadership
+^^^^^^^^^^
+
+The inviting process is automatically considered the leader of the asynchronous
+group construction procedure and receives all failure or termination events for
+invited members prior to completion. Once the group has been fully assembled, the
+client library assembles the completion payload and distributes a
+``PMIX_GROUP_CONSTRUCT_COMPLETE`` event to all participants along with the final
+membership; the leader returns from ``PMIx_Group_invite`` (or has its callback
+invoked) at that point.
+
+Failure of the leader at any time causes a ``PMIX_GROUP_LEADER_FAILED`` event to be
+delivered to all participants so they can optionally declare a new leader. A new
+leader is identified by providing the ``PMIX_GROUP_LEADER`` attribute in the
+results array returned from the event handler; only one process is permitted to do
+so. The outcome of leader selection is communicated to all participants via a
+``PMIX_GROUP_LEADER_SELECTED`` event. If no leader was selected, the status code in
+that event carries an error value so participants can take appropriate action.
+
+Any participant that returns ``PMIX_GROUP_CONSTRUCT_ABORT`` from the event handler
+causes all participants to receive an event notifying them of that status.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation:
+
+* ``PMIX_GROUP_OPTIONAL`` (bool) |mdash| govern the outcome when an invitee fails
+  to accept (declines, terminates, or times out). By default (``false``) the
+  construct is all-or-nothing: any such failure aborts the whole operation, every
+  participant receives ``PMIX_GROUP_CONSTRUCT_ABORT``, and no group forms. When set
+  to ``true``, the failed invitees are simply excluded and the group forms on those
+  that accepted, each receiving ``PMIX_GROUP_CONSTRUCT_COMPLETE`` with the reduced
+  membership.
+* ``PMIX_GROUP_ASSIGN_CONTEXT_ID`` (bool) |mdash| request that the resource
+  manager assign a unique numerical (``size_t``) context ID to the group. The
+  value is returned in the ``PMIX_GROUP_CONSTRUCT_COMPLETE`` event.
+* ``PMIX_TIMEOUT`` (int) |mdash| bound how long the leader's library waits for a
+  live invitee to respond. An invitee that does not respond within the specified
+  number of seconds is treated as a failed invitation (see
+  ``PMIX_GROUP_OPTIONAL``).
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the group was successfully
+assembled and any returned values are available in ``results``. For the
+non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the request
+was successfully accepted for processing; the final status is delivered to
+``cbfunc``, and the callback is not invoked if any other value is returned.
+
+* ``PMIX_SUCCESS`` |mdash| the group was successfully assembled.
+* ``PMIX_GROUP_CONSTRUCT_ABORT`` |mdash| a participant aborted the construction
+  procedure.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| a required argument was invalid (e.g., a ``NULL``
+  or over-length group identifier).
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support group
+  operations.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other value indicates an appropriate error condition.
+
+
+.. seealso::
+   :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
+   :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,
+   :ref:`PMIx_Group_leave(3) <man3-PMIx_Group_leave>`,
+   :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Group_join.3.rst
+++ b/docs/man/man3/PMIx_Group_join.3.rst
@@ -1,0 +1,154 @@
+.. _man3-PMIx_Group_join:
+
+PMIx_Group_join
+===============
+
+.. include_body
+
+``PMIx_Group_join``, ``PMIx_Group_join_nb`` |mdash| Respond to an invitation to
+join an asynchronously-constructed PMIx group.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Group_join(const char grp[],
+                                 const pmix_proc_t *leader,
+                                 pmix_group_opt_t opt,
+                                 const pmix_info_t info[], size_t ninfo,
+                                 pmix_info_t **results, size_t *nresult);
+
+   pmix_status_t PMIx_Group_join_nb(const char grp[],
+                                    const pmix_proc_t *leader,
+                                    pmix_group_opt_t opt,
+                                    const pmix_info_t info[], size_t ninfo,
+                                    pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the leader is a Python ``pmix_proc_t`` dictionary
+  leader = {'nspace': "testnspace", 'rank': 0}
+  # opt is PMIX_GROUP_ACCEPT or PMIX_GROUP_DECLINE
+  # the info is a list of Python ``pmix_info_t`` dictionaries
+  pyinfo = []
+  rc, results = foo.group_join("mygroup", leader, PMIX_GROUP_ACCEPT, pyinfo)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``grp``: A NULL-terminated character string identifying the group named in the
+  invitation. The string must be of length less than or equal to
+  ``PMIX_MAX_NSLEN``.
+* ``leader``: Pointer to a ``pmix_proc_t`` structure identifying the process that
+  issued the invitation (the leader of the asynchronous construction procedure).
+* ``opt``: A ``pmix_group_opt_t`` value indicating the response |mdash|
+  ``PMIX_GROUP_ACCEPT`` to join the group or ``PMIX_GROUP_DECLINE`` to reject the
+  invitation.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs
+  conveying user directives that qualify the operation.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The blocking form returns results directly:
+
+* ``results``: Address of a pointer that, upon successful return, is set to an
+  array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs containing any values
+  returned by the operation. May be ``NULL`` if the caller does not want the
+  returned values. The caller is responsible for releasing the array with
+  ``PMIX_INFO_FREE``.
+* ``nresult``: Address of a ``size_t`` that is set to the number of elements in
+  the returned ``results`` array.
+
+The non-blocking form takes two additional parameters in place of ``results``
+and ``nresult``:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+  the group has been completely constructed or its construction has failed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Respond to an invitation to join a group that is being asynchronously constructed
+via :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`. The process must have
+registered for the ``PMIX_GROUP_INVITED`` event in order to have been notified of
+the invitation.
+
+Calling this function causes the group leader to be notified that the process has
+either accepted or declined the request (the ``opt`` argument) |mdash| via a
+``PMIX_GROUP_INVITE_ACCEPTED`` or ``PMIX_GROUP_INVITE_DECLINED`` event,
+respectively. The blocking form returns once the group has been completely
+constructed or its construction has failed (as determined by the leader); likewise,
+the callback function of the non-blocking form is executed upon the same
+conditions. As with all non-blocking PMIx APIs, callers of ``PMIx_Group_join_nb``
+**must** keep the ``grp``, ``leader``, and ``info`` arrays valid until ``cbfunc`` is
+invoked. The invite/join handshake is described in full in
+:ref:`Group Construction, Destruction, and Fault Tolerance <group-construction-label>`.
+
+.. caution::
+
+   Because the process is alerted to the invitation in a PMIx event handler, it
+   **must not** use the blocking form of this call unless it first "thread shifts"
+   out of the handler and into its own thread context. Likewise, while it is safe
+   to call the non-blocking form from the event handler, the process must not block
+   in the handler while waiting for the callback function to be invoked.
+
+Leadership
+^^^^^^^^^^
+
+Failure of the leader at any time causes a ``PMIX_GROUP_LEADER_FAILED`` event to be
+delivered to all participants so they can optionally declare a new leader. A new
+leader is identified by providing the ``PMIX_GROUP_LEADER`` attribute in the results
+array returned from the event handler; only one process is permitted to do so. The
+outcome of leader selection is communicated to all participants via a
+``PMIX_GROUP_LEADER_SELECTED`` event. If no leader was selected, the status code in
+that event carries an error value so participants can take appropriate action.
+
+Any participant that returns ``PMIX_GROUP_CONSTRUCT_ABORT`` from the leader-failed
+event handler causes all participants to receive an event notifying them of that
+status. Similarly, the leader may elect to abort the procedure |mdash| either by
+returning ``PMIX_GROUP_CONSTRUCT_ABORT`` from the handler assigned to the
+``PMIX_GROUP_INVITE_ACCEPTED`` or ``PMIX_GROUP_INVITE_DECLINED`` codes, or by
+generating an event for the abort code. Abort events are sent to all invited
+participants.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the group was successfully
+constructed and any returned values are available in ``results``. For the
+non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the request was
+successfully accepted for processing; the final status is delivered to ``cbfunc``,
+and the callback is not invoked if any other value is returned.
+
+* ``PMIX_SUCCESS`` |mdash| the group was successfully constructed.
+* ``PMIX_GROUP_CONSTRUCT_ABORT`` |mdash| construction of the group was aborted.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| a required argument was invalid (e.g., a ``NULL``
+  or over-length group identifier).
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support group
+  operations.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other value indicates an appropriate error condition.
+
+
+.. seealso::
+   :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
+   :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,
+   :ref:`PMIx_Group_leave(3) <man3-PMIx_Group_leave>`,
+   :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Group_leave.3.rst
+++ b/docs/man/man3/PMIx_Group_leave.3.rst
@@ -1,0 +1,122 @@
+.. _man3-PMIx_Group_leave:
+
+PMIx_Group_leave
+================
+
+.. include_body
+
+``PMIx_Group_leave``, ``PMIx_Group_leave_nb`` |mdash| Asynchronously depart from a
+PMIx group.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Group_leave(const char grp[],
+                                  const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Group_leave_nb(const char grp[],
+                                     const pmix_info_t info[], size_t ninfo,
+                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the info is a list of Python ``pmix_info_t`` dictionaries
+  pyinfo = []
+  rc = foo.group_leave("mygroup", pyinfo)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``grp``: A NULL-terminated character string identifying the group the caller
+  wishes to leave. The string must be of length less than or equal to
+  ``PMIX_MAX_NSLEN``.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structs
+  conveying user directives that qualify the operation.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form takes two additional parameters:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be executed once the
+  departure event has been locally generated.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Leave a PMIx group. A call to ``PMIx_Group_leave`` (or its non-blocking form)
+causes a ``PMIX_GROUP_LEFT`` event to be generated, ranged to the group's current
+membership and naming the departing process. The function returns (or the
+non-blocking form executes the specified callback) once the event has been locally
+generated; the return is *not* indicative of remote receipt. The departing process
+drops the group from its own local list immediately, and each remaining member, on
+receiving ``PMIX_GROUP_LEFT``, updates its local record of the group membership to
+remove the departed process.
+
+A leave is realized entirely through the event subsystem. A voluntary leave is
+treated by the library as the deliberate cousin of a lost member: if a group
+construct or destruct for that same group is still in flight when the leave
+arrives, the leaving process is accounted as "departed" so the in-flight collective
+can complete on the survivors rather than block on a process that will never call
+in. More generally, all PMIx-based collectives (such as ``PMIx_Fence``) in action
+across the group are automatically adjusted if the collective was invoked with the
+``PMIX_GROUP_FT_COLLECTIVE`` attribute (default is ``false``); otherwise, the
+standard error-return behavior is provided.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Group_leave_nb`` **must** keep
+the ``grp`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+.. note::
+
+   The ``PMIx_Group_leave`` API is intended solely for the asynchronous departure
+   of individual processes from a group, and is not a scalable operation |mdash|
+   i.e., for the case where a single process determines it should no longer be part
+   of a group while the remainder of the group retains a valid reason to continue
+   in existence. For all other scenarios |mdash| especially coordinated teardown
+   |mdash| developers are advised to use
+   :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>` (or its non-blocking
+   form), which represents a more scalable operation.
+
+This behavior is described in full in
+:ref:`Group Construction, Destruction, and Fault Tolerance <group-construction-label>`.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the departure event was
+successfully generated locally. For the non-blocking form, a return of
+``PMIX_SUCCESS`` indicates only that the request was successfully accepted for
+processing; the final status is delivered to ``cbfunc``, and the callback is not
+invoked if any other value is returned.
+
+* ``PMIX_SUCCESS`` |mdash| the departure was successfully processed.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| a required argument was invalid (e.g., a ``NULL``
+  or over-length group identifier).
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support group
+  operations.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other value indicates an appropriate error condition.
+
+
+.. seealso::
+   :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
+   :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,
+   :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,
+   :ref:`PMIx_Group_destruct(3) <man3-PMIx_Group_destruct>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -13,6 +13,11 @@ APIs (section 3)
    PMIx_Init.3.rst
    PMIx_Finalize.3.rst
    PMIx_Log.3.rst
+   PMIx_Group_construct.3.rst
+   PMIx_Group_invite.3.rst
+   PMIx_Group_join.3.rst
+   PMIx_Group_leave.3.rst
+   PMIx_Group_destruct.3.rst
    PMIx_Info_construct.3.rst
    PMIx_Info_create.3.rst
    PMIx_Value_unload.3.rst

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -16,6 +16,16 @@ Detailed changes since v6.1.0:
    PMIX_GROUP_MEMBER_FAILED event naming the lost member. The server
    synthesizes PMIX_GROUP_MEMBER_FAILED itself, so this works with any
    host environment
+ - Group destruct fault handling. When a member is lost before
+   contributing to a PMIx_Group_destruct, the server now consults the
+   PMIX_GROUP_NOTIFY_TERMINATION directive (previously ignored, so the
+   documented behavior never occurred): by default the teardown completes
+   on the survivors but is reported as an error, while with the directive
+   set each survivor receives a PMIX_GROUP_MEMBER_FAILED event naming the
+   lost member and the destruct returns PMIX_SUCCESS - the event serving
+   in place of an error. The directive is supplied at construct time but
+   governs the destruct; the library remembers it and re-applies it
+   automatically (it may also be passed directly to PMIx_Group_destruct)
  - Group leader failure. A process that accepts an invitation with
    PMIx_Group_join_nb now watches the group leader; if the leader
    terminates before the construct completes, the library delivers a

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -877,12 +877,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
  * The destruct API will return an error if any group process fails or terminates
  * prior to calling PMIx_Group_destruct or its non-blocking version unless the
  * PMIX_GROUP_NOTIFY_TERMINATION attribute was provided (with a value of true) at
- * time of group construction. If notification was requested, then a event will
- * be delivered (using PMIX_GROUP_MEMBER_FAILED) for each process that fails to
- * call destruct and the destruct tracker updated to account for the lack of
- * participation. The PMIx_Group_destruct operation will subsequently return
- * PMIX_SUCCESS when the remaining processes have all called destruct – i.e., the
- * event will serve in place of return of an error.
+ * time of group construction. If notification was requested, then an event will
+ * be delivered (using PMIX_GROUP_MEMBER_FAILED) to each surviving member for
+ * each process that fails to call destruct, and the destruct tracker updated to
+ * account for the lack of participation. The PMIx_Group_destruct operation will
+ * subsequently return PMIX_SUCCESS when the remaining processes have all called
+ * destruct – i.e., the event will serve in place of return of an error. The
+ * PMIX_GROUP_NOTIFY_TERMINATION directive is provided at construct time but
+ * governs this destruct; the library remembers it and re-applies it here on the
+ * caller's behalf, as the server retains no group state between the two
+ * collectives.
  */
 PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
                                               const pmix_info_t info[], size_t ninfo);

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -741,8 +741,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
  * process provides a response using the appropriate form of PMIx_Group_join. This will
  * notify the inviting process that the invitation was either accepted (via the
  * PMIX_GROUP_INVITE_ACCEPTED event) or declined (via the PMIX_GROUP_INVITE_DECLINED event).
- * The inviting process will also receive PMIX_GROUP_MEMBER_FAILED events whenever a
- * process fails or terminates prior to responding to the invitation.
+ * The inviting process will also receive a PMIX_GROUP_INVITE_FAILED event for any
+ * invited process that fails to accept - i.e., one that declines, terminates, or
+ * fails to respond within a provided PMIX_TIMEOUT prior to responding.
  *
  * Upon accepting the invitation, both the inviting and invited process will receive
  * access to the job-level information of each other’s nspaces and the contact
@@ -758,10 +759,10 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
  *
  * The inviting process is automatically considered the leader of the asynchronous
  * group construction procedure and will receive all failure or termination events
- * for invited members prior to completion. The inviting process is required to
- * provide a PMIX_GROUP_CONSTRUCT_COMPLETE event once the group has been fully
- * assembled – this event will be distributed to all participants along with the
- * final membership.
+ * for invited members prior to completion. Once the group has been fully assembled,
+ * the PMIx library assembles the completion payload and distributes a
+ * PMIX_GROUP_CONSTRUCT_COMPLETE event to all participants along with the final
+ * membership.
  *
  * Failure of the leader at any time will cause a PMIX_GROUP_LEADER_FAILED event
  * to be delivered to all participants so they can optionally declare a new leader.

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -87,6 +87,10 @@ typedef struct {
     bool *answered;
     size_t nanswered;
     bool optional;
+    /* whether PMIX_GROUP_NOTIFY_TERMINATION was requested at construct time;
+     * carried into the persistent pmix_group_t so it can be re-applied to the
+     * later destruct (see add_group / PMIx_Group_destruct_nb). */
+    bool notterm;
     pmix_event_t ev;
     bool timer_active;
     bool completed;
@@ -111,6 +115,7 @@ static void gtcon(pmix_group_tracker_t *p)
     p->answered = NULL;
     p->nanswered = 0;
     p->optional = false;
+    p->notterm = false;
     p->timer_active = false;
     p->completed = false;
     p->info = NULL;
@@ -163,7 +168,7 @@ static void invite_wake(pmix_group_tracker_t *cb, pmix_status_t status);
 static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
                         pmix_release_cbfunc_t release_fn, void *release_cbdata);
 static pmix_status_t add_group(const char *grpid,
-                               size_t ctxid,
+                               size_t ctxid, bool notterm,
                                pmix_proc_t *members, size_t nmembers);
 
 static pmix_status_t get_endpts(pmix_info_t *xfer,
@@ -330,6 +335,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
 {
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
+    size_t n;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_construct called");
@@ -351,6 +357,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_group_tracker_t);
+    /* capture the group's failure policy now, while we have the construct
+     * directives, so info_cbfunc can record it in the persistent group and the
+     * later destruct can honor PMIX_GROUP_NOTIFY_TERMINATION on the caller's
+     * behalf (the server keeps no group state between the two collectives) */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
+            cb->notterm = PMIX_INFO_TRUE(&info[n]);
+            break;
+        }
+    }
 
     /* push the message into our event base to send to the server */
     rc = PMIx_Group_construct_nb(grp, procs, nprocs, info, ninfo, info_cbfunc, cb);
@@ -518,6 +534,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     pmix_status_t rc;
     pmix_group_tracker_t *cb = NULL;
     pmix_group_t *grp, *pgrp;
+    pmix_info_t *dinfo = (pmix_info_t *) info;
+    size_t ndinfo = ninfo, n;
+    bool freeinfo = false, notterm = false;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_destruct_nb called");
@@ -552,6 +571,31 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
         return PMIX_ERR_NOT_FOUND;
     }
 
+    /* the group's failure policy was chosen at construct time; re-apply
+     * PMIX_GROUP_NOTIFY_TERMINATION here so the server (which keeps no group
+     * state between the two collectives) honors it for this destruct. If the
+     * group was constructed with the flag and the caller did not itself provide
+     * it, append it to the info we send. A caller that explicitly passes the
+     * attribute overrides the remembered policy. */
+    if (grp->notterm) {
+        for (n = 0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
+                notterm = true;
+                break;
+            }
+        }
+        if (!notterm) {
+            bool flag = true;
+            ndinfo = ninfo + 1;
+            PMIX_INFO_CREATE(dinfo, ndinfo);
+            for (n = 0; n < ninfo; n++) {
+                PMIX_INFO_XFER(&dinfo[n], (pmix_info_t *) &info[n]);
+            }
+            PMIX_INFO_LOAD(&dinfo[ninfo], PMIX_GROUP_NOTIFY_TERMINATION, &flag, PMIX_BOOL);
+            freeinfo = true;
+        }
+    }
+
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
@@ -582,14 +626,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     }
 
     /* pack the info structs */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ndinfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         goto done;
     }
-    if (0 < ninfo) {
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
+    if (0 < ndinfo) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, dinfo, ndinfo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
@@ -614,6 +658,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
 done:
     if (PMIX_SUCCESS != rc && NULL != msg) {
         PMIX_RELEASE(msg);
+    }
+    if (freeinfo) {
+        PMIX_INFO_FREE(dinfo, ndinfo);
     }
     return rc;
 }
@@ -1943,7 +1990,7 @@ static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
         }
     }
     if (NULL != members && NULL != grpid) {
-        add_group(grpid, ctxid, members, nmembers);
+        add_group(grpid, ctxid, cb->notterm, members, nmembers);
     }
 
     if (NULL != release_fn) {
@@ -1954,7 +2001,7 @@ static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
 }
 
 static pmix_status_t add_group(const char *grpid,
-                               size_t ctxid,
+                               size_t ctxid, bool notterm,
                                pmix_proc_t *members, size_t nmembers)
 {
     pmix_group_t *grp;
@@ -1969,6 +2016,9 @@ static pmix_status_t add_group(const char *grpid,
     grp->nmbrs = nmembers;
     grp->grpid = strdup(grpid);
     grp->ctxid = ctxid;
+    /* remember the construct-time failure policy so the later destruct can
+     * re-apply PMIX_GROUP_NOTIFY_TERMINATION on the caller's behalf */
+    grp->notterm = notterm;
     pmix_list_append(&pmix_client_globals.groups, &grp->super);
 
     return PMIX_SUCCESS;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -618,6 +618,7 @@ static void grcon(pmix_group_t *p)
     p->ctxid = SIZE_MAX;
     p->members = NULL;
     p->nmbrs = 0;
+    p->notterm = false;
 }
 static void grdes(pmix_group_t *p)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -566,6 +566,11 @@ typedef struct {
     size_t ctxid;
     pmix_proc_t *members;
     size_t nmbrs;
+    /* the group's failure policy is chosen at construct time but governs the
+     * later destruct; the server holds no group state between the two
+     * collectives, so we remember here whether PMIX_GROUP_NOTIFY_TERMINATION was
+     * requested and re-attach it to the destruct request. */
+    bool notterm;
 } pmix_group_t;
 PMIX_CLASS_DECLARATION(pmix_group_t);
 

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -215,6 +215,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(grp_shifter_t,
 
 /* DEFINE LOCAL FUNCTIONS */
 static pmix_status_t aggregate_info(grp_block_t *blk);
+static bool grp_notify_termination(grp_block_t *blk);
 
 static void check_definition_complete(grp_block_t *blk)
 {
@@ -427,9 +428,10 @@ pmix_status_t pmix_server_process_grpinfo(size_t ctxid,
 }
 
 /* Synthesize a PMIX_GROUP_MEMBER_FAILED event for each member that was lost
- * before contributing to this group construct. This is done entirely within
- * the PMIx server so it works with any host environment, not just one that
- * knows how to generate the event: the loss is recorded in blk->departed by
+ * before contributing to this group operation (a surviving construct or a
+ * destruct that requested PMIX_GROUP_NOTIFY_TERMINATION). This is done entirely
+ * within the PMIx server so it works with any host environment, not just one
+ * that knows how to generate the event: the loss is recorded in blk->departed by
  * the server's own lost-connection / voluntary-leave accounting (see
  * account_departed), so the event is produced the same way regardless of which
  * host runs the collective. It is delivered to the surviving local group
@@ -653,17 +655,20 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                 }
             }
         }
-        /* if any expected member was lost before contributing but the construct
-         * still completed successfully on the survivors (fault-tolerant
-         * collective tracking was requested), tell the survivors which members
-         * failed so fault-aware applications can react. Skip this when the
-         * construct aborted (status is not SUCCESS): there is no surviving group
-         * to inform, and the participants already learn of the abort through the
-         * operation status. Only meaningful for a construct; a destruct is
-         * tearing the group down regardless. */
+        /* if any expected member was lost before contributing but the operation
+         * still completed successfully on the survivors, tell the survivors
+         * which members failed so fault-aware applications can react. This
+         * applies to a construct that was allowed to survive the loss
+         * (fault-tolerant collective tracking was requested) and to a destruct
+         * for which termination notification was requested
+         * (PMIX_GROUP_NOTIFY_TERMINATION). Skip it when the operation did not
+         * complete successfully (status is not SUCCESS - e.g., a construct that
+         * aborted): there is no surviving group to inform, and the participants
+         * already learn of the outcome through the operation status. */
         if (PMIX_SUCCESS == scd->status &&
-            PMIX_GROUP_CONSTRUCT == bk->grpop &&
-            0 < pmix_list_get_size(&bk->departed)) {
+            0 < pmix_list_get_size(&bk->departed) &&
+            (PMIX_GROUP_CONSTRUCT == bk->grpop ||
+             (PMIX_GROUP_DESTRUCT == bk->grpop && grp_notify_termination(bk)))) {
             notify_local_members_of_loss(bk);
         }
         /* remove the block from the list */
@@ -732,6 +737,29 @@ static bool grp_ft_collective(grp_block_t *blk)
 
     for (n = 0; n < blk->ninfo; n++) {
         if (PMIX_CHECK_KEY(&blk->info[n], PMIX_GROUP_FT_COLLECTIVE)) {
+            return PMIX_INFO_TRUE(&blk->info[n]);
+        }
+    }
+    return false;
+}
+
+/* Did any participant request termination notification via
+ * PMIX_GROUP_NOTIFY_TERMINATION? The group's failure policy is chosen at
+ * construct time, but the server holds no group state between operations, so
+ * the client re-attaches the flag to the destruct request (see
+ * PMIx_Group_destruct_nb). When true, a member lost before contributing to a
+ * destruct is reported to the survivors via a synthesized
+ * PMIX_GROUP_MEMBER_FAILED event and the destruct completes on the survivors
+ * with success - the event serving in place of an error return. When false (the
+ * default), the loss is recorded as a degraded local-collective status so the
+ * teardown is reported as an error. Only meaningful once the block's info has
+ * been aggregated. */
+static bool grp_notify_termination(grp_block_t *blk)
+{
+    size_t n;
+
+    for (n = 0; n < blk->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&blk->info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
             return PMIX_INFO_TRUE(&blk->info[n]);
         }
     }
@@ -1134,12 +1162,16 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         return rc;
     }
     /* if an expected member was lost before contributing, how we proceed
-     * depends on whether fault-tolerant collective tracking was requested. For a
-     * construct without PMIX_GROUP_FT_COLLECTIVE (the default), the group cannot
-     * form as requested, so abort it rather than silently reduce the membership.
-     * Otherwise (the flag is set, or this is a destruct that is tearing the
-     * group down regardless) complete on the survivors, recording the degraded
-     * status in the block's info so the host sees it - matching the
+     * depends on the operation and its directives. For a construct without
+     * PMIX_GROUP_FT_COLLECTIVE (the default), the group cannot form as
+     * requested, so abort it rather than silently reduce the membership.
+     * Otherwise the operation completes on the survivors. A destruct for which
+     * PMIX_GROUP_NOTIFY_TERMINATION was requested completes cleanly (success),
+     * with the survivors told which member was lost via a synthesized
+     * PMIX_GROUP_MEMBER_FAILED event (see _grpcbfunc) - the event serving in
+     * place of an error return. Every other survive path (a fault-tolerant
+     * construct, or a destruct without notification) records the degraded status
+     * in the block's info so the host sees it - matching the
      * fence/connect/disconnect families. The status slot is located by key (see
      * pmix_server_set_collective_status). */
     if (0 < pmix_list_get_size(&blk->departed)) {
@@ -1147,8 +1179,10 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             abort_construct(blk, PMIX_GROUP_CONSTRUCT_ABORT);
             return PMIX_SUCCESS;
         }
-        pmix_server_set_collective_status(blk->info, blk->ninfo,
-                                          PMIX_ERR_LOST_CONNECTION);
+        if (!(PMIX_GROUP_DESTRUCT == op && grp_notify_termination(blk))) {
+            pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                              PMIX_ERR_LOST_CONNECTION);
+        }
     }
     /* local phase complete - delete the local-phase timer before handing the
      * block to the host, so a late internal timeout cannot race the host's
@@ -1263,16 +1297,20 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
         /* a member departed before contributing (that is why we are here).
          * For a construct without PMIX_GROUP_FT_COLLECTIVE (the default), the
          * group cannot form as requested, so abort it rather than silently
-         * reduce the membership. Otherwise (the flag is set, or this is a
-         * destruct) complete on the survivors, recording the degraded status in
-         * the block's info so the host sees it, matching the
-         * fence/connect/disconnect families. */
+         * reduce the membership. Otherwise complete on the survivors. A destruct
+         * for which PMIX_GROUP_NOTIFY_TERMINATION was requested completes cleanly
+         * (the survivors are told which member was lost via a synthesized
+         * PMIX_GROUP_MEMBER_FAILED event in _grpcbfunc); every other survive path
+         * records the degraded status in the block's info so the host sees it,
+         * matching the fence/connect/disconnect families. */
         if (PMIX_GROUP_CONSTRUCT == blk->grpop && !grp_ft_collective(blk)) {
             abort_construct(blk, PMIX_GROUP_CONSTRUCT_ABORT);
             return;
         }
-        pmix_server_set_collective_status(blk->info, blk->ninfo,
-                                          PMIX_ERR_LOST_CONNECTION);
+        if (!(PMIX_GROUP_DESTRUCT == blk->grpop && grp_notify_termination(blk))) {
+            pmix_server_set_collective_status(blk->info, blk->ninfo,
+                                              PMIX_ERR_LOST_CONNECTION);
+        }
         /* delete the local-phase timer before handing the block to the host,
          * so a late internal timeout cannot race the host's completion */
         if (blk->event_active) {

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -30,7 +30,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
                   hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader \
-                  simpgrpcabort simpgrpctimeout
+                  simpgrpcabort simpgrpctimeout simpgrpddie
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -156,6 +156,12 @@ simpgrpdie_SOURCES = $(headers) \
         simpgrpdie.c
 simpgrpdie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpgrpdie_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpgrpddie_SOURCES = $(headers) \
+        simpgrpddie.c
+simpgrpddie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpgrpddie_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simpgrpleader_SOURCES = $(headers) \

--- a/test/simple/simpgrpddie.c
+++ b/test/simple/simpgrpddie.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the PMIX_GROUP_MEMBER_FAILED event synthesized by the PMIx server
+ * when a member is lost before contributing to a group DEstruct that was
+ * constructed with PMIX_GROUP_NOTIFY_TERMINATION.
+ *
+ * This is the destruct analog of simpgrpdie.c (which covers construct). The
+ * whole job is the group membership. Every rank registers a handler for
+ * PMIX_GROUP_MEMBER_FAILED and constructs the group with
+ * PMIX_GROUP_NOTIFY_TERMINATION, then all ranks sync with a fence so a live
+ * group exists everywhere. The last rank is the victim: it leaves WITHOUT
+ * calling PMIx_Group_destruct and WITHOUT calling PMIx_Finalize (after a short
+ * delay so the survivors have entered the destruct and their server has built
+ * the local tracker), so the server sees a dropped connection. Every surviving
+ * rank calls PMIx_Group_destruct; because the group requested termination
+ * notification, the server accounts for the departed member, completes the
+ * destruct on the survivors with SUCCESS, and notifies each survivor with a
+ * PMIX_GROUP_MEMBER_FAILED event naming the victim. Each survivor verifies it
+ * received that event for the victim and that the destruct returned success,
+ * then prints a distinctive success line.
+ *
+ * Without PMIX_GROUP_NOTIFY_TERMINATION the destruct would instead complete
+ * with a degraded (lost-connection) status and no event - see group_destruct_die.
+ *
+ * See src/server/pmix_server_group.c (notify_local_members_of_loss,
+ * grp_notify_termination) and docs/how-things-work/collectives.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/pmix_output.h"
+
+static pmix_proc_t myproc;
+static volatile int member_failed = 0;
+static pmix_proc_t failed_proc;
+static volatile int reg_active = -1;
+
+static void memfailed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                              const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                              pmix_info_t results[], size_t nresults,
+                              pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            memcpy(&failed_proc, info[n].value.data.proc, sizeof(pmix_proc_t));
+        }
+    }
+    member_failed = 1;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void regcbfunc(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref, cbdata);
+    reg_active = status;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n, victim;
+    pmix_info_t info[2];
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t code = PMIX_GROUP_MEMBER_FAILED;
+    int i;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* get our job size */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client %s:%d PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 2) {
+        fprintf(stderr, "Client %s:%d FAIL: this test requires at least 2 processes\n",
+                myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    /* register a handler for the member-failed event */
+    reg_active = -1;
+    PMIx_Register_event_handler(&code, 1, NULL, 0, memfailed_handler, regcbfunc, NULL);
+    while (-1 == reg_active) {
+        usleep(10000);
+    }
+    if (PMIX_SUCCESS != reg_active) {
+        fprintf(stderr, "Client %s:%d FAIL: could not register handler: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(reg_active));
+        exit(1);
+    }
+
+    /* the entire job is the group membership; the last rank is the victim */
+    victim = nprocs - 1;
+
+    /* every rank (including the victim) constructs the group, requesting
+     * termination notification so that a member lost before the later destruct
+     * is reported to the survivors via PMIX_GROUP_MEMBER_FAILED rather than
+     * causing the destruct to report an error */
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_GROUP_NOTIFY_TERMINATION, NULL, PMIX_BOOL);
+    rc = PMIx_Group_construct("ddgroup", procs, nprocs, info, 2, &results, &nresults);
+    PMIX_PROC_FREE(procs, nprocs);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client %s:%d PMIx_Group_construct failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* sync so the group is fully constructed everywhere before anyone leaves */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client %s:%d post-construct PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    if (myproc.rank == victim) {
+        /* leave before contributing to the destruct, without finalizing, so the
+         * server sees a dropped connection and must run its lost-connection
+         * accounting. Exit 0 so the harness does not treat this as a real
+         * failure. */
+        fprintf(stderr, "%d leaving BEFORE group destruct (simulated failure)\n", myproc.rank);
+        sleep(2);
+        _exit(0);
+    }
+
+    fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+    rc = PMIx_Group_destruct("ddgroup", NULL, 0);
+
+    /* with PMIX_GROUP_NOTIFY_TERMINATION, the destruct completes on the
+     * survivors with SUCCESS - the member-failed event stands in place of an
+     * error return */
+    fprintf(stderr, "%d Group destruct complete on survivors: status %s\n", myproc.rank,
+            PMIx_Error_string(rc));
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client %s:%d FAIL: destruct with NOTIFY_TERMINATION returned %s, "
+                "expected SUCCESS\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    /* the member-failed event is delivered asynchronously right after the
+     * destruct completes - give it a bounded window to arrive */
+    for (i = 0; i < 500 && 0 == member_failed; i++) {
+        usleep(10000);
+    }
+
+    if (!member_failed) {
+        fprintf(stderr, "Client %s:%d FAIL: never received PMIX_GROUP_MEMBER_FAILED\n",
+                myproc.nspace, myproc.rank);
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+    if (failed_proc.rank != victim ||
+        0 != strncmp(failed_proc.nspace, myproc.nspace, PMIX_MAX_NSLEN)) {
+        fprintf(stderr, "Client %s:%d FAIL: member-failed named %s:%d, expected victim rank %d\n",
+                myproc.nspace, myproc.rank, failed_proc.nspace, failed_proc.rank, victim);
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client %s:%d PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    fprintf(stderr, "Client %s:%d saw member-failed for victim rank %d OK\n",
+            myproc.nspace, myproc.rank, victim);
+    fflush(stderr);
+    return 0;
+}


### PR DESCRIPTION
This branch rounds out the PMIx_Group family so the APIs are functionally
complete and accurately documented across the man pages, the
how-things-work spec, and the `pmix.h` comments.

### 1. Man pages for the PMIx_Group APIs
New section-3 man pages for `PMIx_Group_construct`, `_invite`, `_join`,
`_leave`, and `_destruct` (each covering the blocking and non-blocking
form), modeled on the existing `PMIx_Log(3)` page and wired into the man3
index. The construct page documents the collective, bootstrap, and
add-members methods; the invite/join pages document the event-driven
method; the leave/destruct pages document departure and teardown,
including the fault-tolerance behavior.

### 2. Doc/comment accuracy fixes
Corrected event-name inaccuracies found while writing the man pages and
verified against the code:
- The `PMIx_Group_invite` comment named `PMIX_GROUP_MEMBER_FAILED` for
  invitee failures; the invite method actually reports non-accepters via
  `PMIX_GROUP_INVITE_FAILED`. It also claimed the app must "provide" the
  completion event, but the library distributes
  `PMIX_GROUP_CONSTRUCT_COMPLETE` itself.
- The spec used `PMIX_GROUP_COMPLETE` (not a defined constant; it is
  `PMIX_GROUP_CONSTRUCT_COMPLETE`) and misspelled `PMIx_Group_invite`.

### 3. Implement `PMIX_GROUP_NOTIFY_TERMINATION` for destruct
This directive was documented but never consumed (it existed only in the
attribute dictionary), so a member lost before a `PMIx_Group_destruct`
always completed on the survivors with a degraded status and no event.

It is now honored: with the directive in effect, a member lost before
contributing to a destruct causes each surviving member to receive a
`PMIX_GROUP_MEMBER_FAILED` event naming the departed process, and the
destruct returns success — the event standing in place of an error.
Without it, the prior degraded-status behavior is retained. The directive
is set at construct time but governs the destruct; since the server keeps
no group state between the two collectives, the client remembers it in its
persistent `pmix_group_t` and re-applies it to the destruct automatically
(a flag passed directly to destruct is also honored and overrides).

Added `test/simple/simpgrpddie` (destruct analog of `simpgrpdie`) which
verifies survivors receive `PMIX_GROUP_MEMBER_FAILED` and the destruct
returns success on member loss.

### Testing
- New `simpgrpddie` passes; `simpgrpdie`, `simpgrpcabort`, `simpgrpmember`
  pass (no regression); `collective_status` and the `util_*` unit tests
  pass.
- Library builds warning-free under `--enable-devel-check` (`-Werror`).
- Docs build clean under `sphinx-build -W`.

### Related
Python bindings for the non-blocking group APIs are still missing and are
tracked separately in #3949; they are out of scope for this PR.