### PR TITLE
Add section-3 man pages for the core PMIx client APIs

### DIFF
--- a/docs/man/man3/PMIx_Abort.3.rst
+++ b/docs/man/man3/PMIx_Abort.3.rst
@@ -3,7 +3,10 @@
 PMIx_Abort
 ==========
 
-PMIx_Abort - Abort the specified processes
+.. include_body
+
+``PMIx_Abort`` |mdash| Abort the specified processes.
+
 
 SYNOPSIS
 --------
@@ -15,65 +18,102 @@ SYNOPSIS
    pmix_status_t PMIx_Abort(int status, const char msg[],
                             pmix_proc_t procs[], size_t nprocs);
 
-ARGUMENTS
----------
 
-* ``status``: Status value to be returned. A value of zero is
-  permitted by PMIx, but may not be returned by some resource
-  managers.
+Python Syntax
+^^^^^^^^^^^^^
 
-* ``msg``: A string message to be displayed.
+.. code-block:: python3
 
-* ``procs``: An array of ``pmix_proc_t`` structures defining the
-  processes to be aborted. A NULL for the proc array indicates that
-  all processes in the caller's namespace are to be aborted. A
-  wildcard value for the rank in any structure indicates that all
-  processes in that namespace are to be aborted.
+  from pmix import *
 
-* ``nprocs``: Number of ``pmix_proc_t`` structures in the ``procs``
-  array.
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries
+  peers = [{'nspace': "testnspace", 'rank': 0},
+           {'nspace': "testnspace", 'rank': 1}]
+  rc = foo.abort(-1, "abort message", peers)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``status``: Error code to be returned to the invoking environment. A value of
+  zero is permitted by PMIx, but may be ignored by some resource managers unless
+  they are specifically configured to honor it.
+* ``msg``: A NULL-terminated string message to be displayed or logged in
+  association with the operation. Passing ``NULL`` is allowed.
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming the
+  processes that are to be aborted. A ``NULL`` value indicates that all processes
+  in the caller's namespace |mdash| including the caller itself |mdash| are to be
+  aborted; this is equivalent to passing a single ``pmix_proc_t`` containing the
+  caller's namespace and a rank of ``PMIX_RANK_WILDCARD``. A wildcard rank in any
+  element indicates that all processes in that namespace are to be aborted.
+* ``nprocs``: Number of elements in the ``procs`` array.
+
 
 DESCRIPTION
 -----------
 
-Request that the provided array of procs be aborted, returning the
-provided status and printing the provided message. A NULL for the
-``procs`` array indicates that all processes in the caller's namespace
-are to be aborted.
+Request that the host resource manager abort the provided array of processes,
+returning the provided ``status`` and printing the provided ``msg``. If the
+design of the host resource manager allows, the message should be associated with
+any record it prints or logs of the operation. If the processes were launched by
+an application that exists for the lifetime of the processes, that application
+should terminate with the provided ``status`` if the system allows.
 
-The response to this request is somewhat dependent on the specific
-resource manager and its configuration (e.g., some resource managers
-will not abort the application if the provided status is zero unless
-specifically configured to do so), and thus lies outside the control
-of PMIx itself. However, the client will inform the RM of the request
-that the application be aborted, regardless of the value of the
-provided status.
+A ``NULL`` for the ``procs`` array indicates that all processes in the caller's
+namespace are to be aborted, including the caller itself. While a caller is
+permitted to request the abort of processes from namespaces other than its own,
+not all environments will support such requests.
 
-Passing a NULL ``msg`` parameter is allowed. Note that race conditions
-caused by multiple processes calling ``PMIx_Abort`` are left to the server
-implementation to resolve with regard to which status is returned and
-what messages (if any) are printed.
+``PMIx_Abort`` is a blocking call: it does not return until the host environment
+has carried out the operation on the specified processes. A successful return
+therefore indicates that the requested processes are in a terminated state. If
+the caller's own process is included in the array of targets, the function does
+**not** return in the success case |mdash| it returns only if the host is unable
+to execute the operation.
+
+.. note::
+   The response to this request is somewhat dependent on the specific resource
+   manager and its configuration. For example, some resource managers will not
+   abort the application if the provided ``status`` is zero unless specifically
+   configured to do so; some cannot abort subsets of processes in an application;
+   and some may not permit termination of processes outside the caller's own
+   namespace. This behavior lies outside the control of PMIx itself. Regardless
+   of the value of ``status``, the PMIx client library will inform the resource
+   manager of the request that the specified processes be aborted.
+
+   Race conditions caused by multiple processes calling ``PMIx_Abort`` are left to
+   the server implementation to resolve with regard to which status is returned
+   and what messages (if any) are printed.
+
 
 RETURN VALUE
 ------------
 
-Returns ``PMIX_SUCCESS`` on success. On error, a negative value
-corresponding to a PMIx ``errno`` is returned.
+Returns ``PMIX_SUCCESS`` when the requested processes are in a terminated state.
+On error, a negative value corresponding to a PMIx error constant is returned,
+including:
 
-ERRORS
-------
+* ``PMIX_ERR_PARAM_VALUE_NOT_SUPPORTED`` |mdash| the PMIx implementation and host
+  environment support this API, but the request names processes the host cannot
+  abort (e.g., a subset of a namespace, or processes outside the caller's own
+  namespace, where the host does not permit such operations). In this case none
+  of the specified processes are terminated.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not provide an
+  abort operation.
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
 
-PMIx errno values are defined in ``pmix_common.h``.
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
 
-.. JMS COMMENT When more man pages are added, they can be :ref:'ed
-   appropriately, so that HTML hyperlinks are created to link to the
-   corresponding pages.
 
 .. seealso::
-   PMIx_Commit(3),
-   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
-   PMIx_Initialized(3),
-   PMIx_Put(3),
-   pmiAddInstance(3),
-   pmiAddMetric(3)
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_Initialized(3) <man3-PMIx_Initialized>`,
+   pmix_proc_t(5),
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -1,0 +1,211 @@
+.. _man3-PMIx_Allocation_request:
+
+PMIx_Allocation_request
+=======================
+
+.. include_body
+
+``PMIx_Allocation_request``, ``PMIx_Allocation_request_nb`` |mdash| Request an
+allocation operation from the host resource manager or scheduler.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Allocation_request(pmix_alloc_directive_t directive,
+                                         pmix_info_t *info, size_t ninfo,
+                                         pmix_info_t **results, size_t *nresults);
+
+   pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t directive,
+                                            pmix_info_t *info, size_t ninfo,
+                                            pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pyinfo = [{'key': PMIX_ALLOC_NUM_NODES,
+             'value': {'value': 4, 'val_type': PMIX_UINT64}}]
+  rc, results = foo.allocation_request(PMIX_ALLOC_EXTEND, pyinfo)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``directive``: An allocation directive of type ``pmix_alloc_directive_t``
+  identifying the requested operation (see `DIRECTIVES`_).
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures describing and qualifying the request (see `ATTRIBUTES`_). A
+  ``NULL`` value is supported when no attributes are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``results`` (blocking form): Address where a pointer to an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures containing the results of
+  the request is returned. Set to ``NULL`` when no data is returned. The caller
+  is responsible for releasing the returned array with ``PMIX_INFO_FREE`` when
+  done.
+* ``nresults`` (blocking form): Address where the number of elements in the
+  returned ``results`` array is stored.
+
+The non-blocking form replaces ``results`` and ``nresults`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+  final status and any returned data once the request has been processed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request an allocation operation from the host resource manager or scheduler.
+Several broad categories of operation are envisioned, including the ability to:
+
+* Request allocation of additional resources, including memory, bandwidth, and
+  compute. Note that the new allocation will be disjoint from (i.e., not
+  affiliated with) the allocation of the requestor |mdash| thus the termination
+  of one allocation will not impact the other.
+* Extend the reservation on currently allocated resources, subject to
+  scheduling availability and priorities. This includes extending the time
+  limit on current resources and/or requesting that additional resources be
+  allocated to the requesting job. Any additional allocated resources will be
+  considered part of the current allocation, and thus will be released at the
+  same time.
+* Release currently allocated resources that are no longer required. This is
+  intended to support partial release of resources, since all resources are
+  normally released upon termination of the job.
+* "Lend" resources back to the scheduler with an expectation of getting them
+  back at some later time in the job, together with the corresponding ability
+  to "reacquire" resources previously released.
+
+``PMIx_Allocation_request`` is the blocking form: it does not return until the
+operation is complete. If successful, results are returned in the ``results``
+and ``nresults`` parameters. ``PMIx_Allocation_request_nb`` is the non-blocking
+form: it returns immediately, and the provided ``cbfunc`` is invoked with the
+final status and any returned data once the operation has been processed.
+
+If the request is for additional resources and it succeeds, the returned
+results include the host environment's allocation identifier
+(``PMIX_ALLOC_ID``) that the requester can use to reference the resulting
+resources in, for example, a later spawn request.
+
+As with all non-blocking PMIx APIs, callers of
+``PMIx_Allocation_request_nb`` **must** keep the ``info`` array valid until
+``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The ``directive`` argument is a value of type ``pmix_alloc_directive_t`` that
+identifies the requested operation:
+
+* ``PMIX_ALLOC_NEW`` |mdash| a new allocation is being requested. The resulting
+  allocation will be disjoint (i.e., not connected in a job sense) from the
+  requesting allocation.
+* ``PMIX_ALLOC_EXTEND`` |mdash| extend the existing allocation, either in time
+  or by adding resources.
+* ``PMIX_ALLOC_RELEASE`` |mdash| release part or all of the existing
+  allocation. Attributes in the accompanying ``info`` array may be used to
+  specify "lending" of those resources for some period of time.
+* ``PMIX_ALLOC_REAQUIRE`` |mdash| reacquire resources that were previously
+  "lent" back to the scheduler.
+* ``PMIX_ALLOC_REQ_CANCEL`` |mdash| cancel the indicated allocation request.
+
+Values at or above ``PMIX_ALLOC_EXTERNAL`` are reserved for
+implementer-defined directives.
+
+
+ATTRIBUTES
+----------
+
+PMIx libraries are not required to directly support any attributes for this
+operation. However, any provided attributes must be passed to the host
+environment for processing, and the PMIx library is required to add the
+``PMIX_USERID`` and ``PMIX_GRPID`` attributes of the client process making the
+request.
+
+Host environments that implement support for this operation are required to
+support the following attributes:
+
+* ``PMIX_ALLOC_REQ_ID`` (char*) |mdash| user-provided string identifier for
+  this allocation request, which can later be used to query its status.
+* ``PMIX_ALLOC_NUM_NODES`` (uint64_t) |mdash| number of nodes being requested.
+* ``PMIX_ALLOC_NUM_CPUS`` (uint64_t) |mdash| number of CPUs being requested.
+* ``PMIX_ALLOC_TIME`` (uint32_t) |mdash| time (in seconds) for which the
+  resources are being requested.
+
+The following attributes are optional for host environments that support this
+operation:
+
+* ``PMIX_ALLOC_NODE_LIST`` (char*) |mdash| regular expression of the specific
+  nodes being requested.
+* ``PMIX_ALLOC_NUM_CPU_LIST`` (char*) |mdash| regular expression of the number
+  of CPUs being requested on each node.
+* ``PMIX_ALLOC_CPU_LIST`` (char*) |mdash| regular expression of the specific
+  CPUs being requested on each node.
+* ``PMIX_ALLOC_MEM_SIZE`` (float) |mdash| amount of memory being requested.
+* ``PMIX_ALLOC_FABRIC``, ``PMIX_ALLOC_FABRIC_ID``, ``PMIX_ALLOC_BANDWIDTH``,
+  ``PMIX_ALLOC_FABRIC_QOS``, ``PMIX_ALLOC_FABRIC_TYPE``,
+  ``PMIX_ALLOC_FABRIC_PLANE``, ``PMIX_ALLOC_FABRIC_ENDPTS``,
+  ``PMIX_ALLOC_FABRIC_ENDPTS_NODE``, ``PMIX_ALLOC_FABRIC_SEC_KEY`` |mdash|
+  attributes describing fabric resources being requested.
+
+On successful completion of a request for additional resources, the returned
+data includes ``PMIX_ALLOC_ID`` (char*), a host-provided string identifier for
+the resulting allocation.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the request was
+processed and any results were returned in ``results`` and ``nresults``. For
+the non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the
+request was accepted for processing; the final status and any data are
+delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the request was successfully processed.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the operation is not supported in the
+  caller's role or environment |mdash| for example, the caller is itself the
+  scheduler, or is a system controller with no scheduler attached.
+* ``PMIX_ERR_UNREACH`` |mdash| the caller is not connected to a server capable
+  of servicing the request.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This operation is only meaningful when the caller can reach a scheduler, either
+because the caller's server is the scheduler or because the caller is a server
+whose host environment provides an allocation entry point that can forward the
+request. A process hosted directly by the scheduler cannot issue an allocation
+request against itself and will receive ``PMIX_ERR_NOT_SUPPORTED``.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Resource_block(3) <man3-PMIx_Resource_block>`,
+   :ref:`PMIx_Session_control(3) <man3-PMIx_Session_control>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Commit.3.rst
+++ b/docs/man/man3/PMIx_Commit.3.rst
@@ -1,0 +1,89 @@
+.. _man3-PMIx_Commit:
+
+PMIx_Commit
+===========
+
+.. include_body
+
+``PMIx_Commit`` |mdash| Make previously staged key/value pairs available to other
+processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Commit(void);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after one or more foo.put() calls ...
+  rc = foo.commit()
+
+
+DESCRIPTION
+-----------
+
+Make available to other processes all key-value pairs previously staged by this
+process via :ref:`PMIx_Put(3) <man3-PMIx_Put>`.
+
+A PMIx implementation may locally cache non-reserved keys in the client library
+until they are committed. ``PMIx_Commit`` initiates the operation of making those
+staged key-value pairs available; depending on the implementation, this may
+involve transmitting the entire collection of data posted by the process to the
+local PMIx server. ``PMIx_Commit`` is an asynchronous operation: it returns to the
+caller immediately while the data is staged to the server in the background.
+
+.. note::
+   Users are advised to always include the call to ``PMIx_Commit`` in case the
+   local implementation requires it. Committing does not by itself circulate the
+   posted data to other processes: availability of the data to peers still relies
+   on the exchange mechanisms |mdash| typically a synchronization such as
+   ``PMIx_Fence`` (see PMIx_Fence(3)) |mdash| that govern data sharing.
+
+``PMIx_Commit`` takes no arguments. As a convenience, it is a no-op that returns
+``PMIX_SUCCESS`` when there is nothing to commit |mdash| for example, when the
+caller is a singleton process with no local server to receive the data.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Because commitment does not guarantee that peers can immediately retrieve the
+data, a typical publication sequence is one or more
+:ref:`PMIx_Put(3) <man3-PMIx_Put>` calls, followed by ``PMIx_Commit``, followed by
+a collective synchronization such as ``PMIx_Fence`` (see PMIx_Fence(3)) before the
+peers issue ``PMIx_Get`` (see PMIx_Get(3)).
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
+   PMIx_Get(3),
+   PMIx_Fence(3),
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Commit.3.rst
+++ b/docs/man/man3/PMIx_Commit.3.rst
@@ -78,12 +78,12 @@ Because commitment does not guarantee that peers can immediately retrieve the
 data, a typical publication sequence is one or more
 :ref:`PMIx_Put(3) <man3-PMIx_Put>` calls, followed by ``PMIx_Commit``, followed by
 a collective synchronization such as :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` before
-the peers issue ``PMIx_Get`` (see PMIx_Get(3)).
+the peers issue :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
-   PMIx_Get(3),
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Commit.3.rst
+++ b/docs/man/man3/PMIx_Commit.3.rst
@@ -49,7 +49,7 @@ caller immediately while the data is staged to the server in the background.
    local implementation requires it. Committing does not by itself circulate the
    posted data to other processes: availability of the data to peers still relies
    on the exchange mechanisms |mdash| typically a synchronization such as
-   ``PMIx_Fence`` (see PMIx_Fence(3)) |mdash| that govern data sharing.
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` |mdash| that govern data sharing.
 
 ``PMIx_Commit`` takes no arguments. As a convenience, it is a no-op that returns
 ``PMIX_SUCCESS`` when there is nothing to commit |mdash| for example, when the
@@ -77,13 +77,13 @@ NOTES
 Because commitment does not guarantee that peers can immediately retrieve the
 data, a typical publication sequence is one or more
 :ref:`PMIx_Put(3) <man3-PMIx_Put>` calls, followed by ``PMIx_Commit``, followed by
-a collective synchronization such as ``PMIx_Fence`` (see PMIx_Fence(3)) before the
-peers issue ``PMIx_Get`` (see PMIx_Get(3)).
+a collective synchronization such as :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` before
+the peers issue ``PMIx_Get`` (see PMIx_Get(3)).
 
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
    PMIx_Get(3),
-   PMIx_Fence(3),
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Connect.3.rst
+++ b/docs/man/man3/PMIx_Connect.3.rst
@@ -1,0 +1,185 @@
+.. _man3-PMIx_Connect:
+
+PMIx_Connect
+============
+
+.. include_body
+
+``PMIx_Connect``, ``PMIx_Connect_nb`` |mdash| Record a set of processes as
+"connected" so that the host environment treats them as a single assemblage for
+fault and event-notification purposes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
+                              const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
+                                 const pmix_info_t info[], size_t ninfo,
+                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries naming all
+  # participants (including the caller)
+  peers = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD},
+           {'nspace': "othernspace", 'rank': PMIX_RANK_WILDCARD}]
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_TIMEOUT,
+             'value': {'value': 10, 'val_type': PMIX_INT}}]
+  rc = foo.connect(peers, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming **all** of
+  the processes that are to be connected. A rank of ``PMIX_RANK_WILDCARD`` in any
+  element indicates that all processes in that namespace are participating. Unlike
+  the collective APIs that default to the caller's own namespace, ``procs`` must
+  be non-``NULL`` and ``nprocs`` must be greater than zero; otherwise the call
+  returns ``PMIX_ERR_BAD_PARAM``.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form takes two additional parameters:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+  connect operation completes.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Record the processes specified by the ``procs`` array as *connected*.
+``PMIx_Connect`` is the blocking form: it does not return until all processes
+identified in ``procs`` have called either ``PMIx_Connect`` or ``PMIx_Connect_nb``
+**and** the host environment has completed any supporting operations required to
+meet the terms of the PMIx definition of *connected* processes (or the operation
+fails). ``PMIx_Connect_nb`` is the non-blocking form: it returns immediately, and
+the provided ``cbfunc`` is invoked with the final status once the operation
+completes.
+
+The PMIx definition of *connected* solely implies that the host environment should
+treat the failure of any process in the assemblage as a reportable event, taking
+action on the assemblage as if it were a single application. For example, if the
+environment defaults (in the absence of any application directives) to terminating
+an application upon failure of any process in that application, then it should
+terminate all processes in the connected assemblage upon failure of any member.
+The host environment may choose to assign a new namespace to the connected
+assemblage and/or assign new ranks to its members for its own internal tracking
+purposes; whether such namespaces are exposed to clients is implementation
+defined.
+
+Every element of ``procs`` must name a participant, and the calling process must
+itself be among them; if it is not, the operation returns
+``PMIX_ERR_NOT_A_MEMBER``. The ordering of the entries in ``procs`` has no
+significance. However, all processes engaged in a given connect operation must use
+the same method to identify the participants: callers that describe the target set
+using ``PMIX_RANK_WILDCARD`` are not matched with callers that list the individual
+processes of a namespace explicitly. A group identifier appearing in ``procs`` is
+first expanded into that group's member processes.
+
+Upon completion, the server returns any job-level information that participating
+processes do not already possess. When the connect request spans processes from
+different namespaces, each participant receives the job-level information for the
+namespaces other than its own, so that subsequent :ref:`PMIx_Get(3)
+<man3-PMIx_Get>` queries against the connected peers can be satisfied locally.
+
+A process can only engage in one connect operation involving the identical
+``procs`` array at a time. However, a process can be simultaneously engaged in
+multiple connect operations, each involving a different ``procs`` array.
+
+``PMIx_Connect`` and ``PMIx_Connect_nb`` are *collective* operations. The PMIx
+server library aggregates the participation of its local clients, passing a single
+request to the host environment once all local participants have called the API;
+the host then executes the collective across all participating nodes.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Connect_nb`` **must** keep
+the ``procs`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+PMIx libraries are not required to directly support any attributes for this
+operation, but any provided attributes are passed to the host environment for
+processing. The following attributes are optional and depend on the
+implementation and host environment:
+
+* ``PMIX_ALL_CLONES_PARTICIPATE`` (bool) |mdash| all clones of the calling process
+  must participate in the collective operation.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the connect to
+  complete before the host declares an error. This helps avoid "hangs" caused by a
+  programming error that prevents one or more processes from reaching the connect.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that all participants have
+connected and any returned job-level data is available. For the non-blocking form,
+a return of ``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing and the final status will be delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the connect operation completed successfully.
+* ``PMIX_ERR_NOT_A_MEMBER`` |mdash| the calling process is not among the named
+  participants.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied (e.g., a ``NULL``
+  ``procs`` array or a zero ``nprocs``).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Attempting to *connect* processes solely within the same namespace is essentially
+a no-op operation. While not explicitly prohibited, a PMIx implementation or host
+environment may return an error in such cases.
+
+Once processes are connected, the host environment is required to generate a
+``PMIX_ERR_PROC_TERM_WO_SYNC`` event should any process in the assemblage
+terminate or call :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>` without first
+disconnecting from the assemblage via :ref:`PMIx_Disconnect(3)
+<man3-PMIx_Disconnect>`. If a job is terminated as a result of that action, the
+host environment is also required to generate ``PMIX_ERR_JOB_TERM_WO_SYNC`` for
+all jobs that were terminated as a result.
+
+By default, the processes created by :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>` are
+connected to the parent process upon successful launch, following the same
+semantics described here.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_Disconnect(3) <man3-PMIx_Disconnect>`,
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Disconnect.3.rst
+++ b/docs/man/man3/PMIx_Disconnect.3.rst
@@ -1,0 +1,170 @@
+.. _man3-PMIx_Disconnect:
+
+PMIx_Disconnect
+===============
+
+.. include_body
+
+``PMIx_Disconnect``, ``PMIx_Disconnect_nb`` |mdash| Disconnect a previously
+connected set of processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
+                                 const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t nprocs,
+                                    const pmix_info_t info[], size_t ninfo,
+                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() and a matching foo.connect() ...
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries naming the same
+  # set of participants that were connected
+  peers = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD},
+           {'nspace': "othernspace", 'rank': PMIX_RANK_WILDCARD}]
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_TIMEOUT,
+             'value': {'value': 10, 'val_type': PMIX_INT}}]
+  rc = foo.disconnect(peers, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming **all** of
+  the processes that are to be disconnected. This must identify a set that was
+  previously connected via :ref:`PMIx_Connect(3) <man3-PMIx_Connect>`. A rank of
+  ``PMIX_RANK_WILDCARD`` in any element indicates that all processes in that
+  namespace are participating. ``procs`` must be non-``NULL`` and ``nprocs`` must
+  be greater than zero; otherwise the call returns ``PMIX_ERR_BAD_PARAM``.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form takes two additional parameters:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+  disconnect operation completes.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Disconnect a set of processes that were previously connected via
+:ref:`PMIx_Connect(3) <man3-PMIx_Connect>`. ``PMIx_Disconnect`` is the blocking
+form: it does not return until all processes identified in ``procs`` have called
+either ``PMIx_Disconnect`` or ``PMIx_Disconnect_nb`` **and** the host environment
+has completed any required supporting operations (or the operation fails).
+``PMIx_Disconnect_nb`` is the non-blocking form: it returns immediately, and the
+provided ``cbfunc`` is invoked with the final status once the operation completes.
+
+Disconnecting dissolves the *connected* relationship: the host environment ceases
+to treat the assemblage as a single application for the purposes of fault handling
+and event notification. As part of the operation, the local library releases the
+cached job-level data it was holding for any namespace, other than the caller's
+own, that was involved in the connect. After a successful disconnect the members
+are free to reconnect.
+
+Every element of ``procs`` must name a participant, and the calling process must
+itself be among them; if it is not, the operation returns
+``PMIX_ERR_NOT_A_MEMBER``. The ordering of the entries in ``procs`` has no
+significance. However, all processes engaged in a given disconnect operation must
+use the same method to identify the participants: callers that describe the target
+set using ``PMIX_RANK_WILDCARD`` are not matched with callers that list the
+individual processes of a namespace explicitly. A group identifier appearing in
+``procs`` is first expanded into that group's member processes.
+
+A process can only engage in one disconnect operation involving the identical
+``procs`` array at a time. However, a process can be simultaneously engaged in
+multiple disconnect operations, each involving a different ``procs`` array. A
+process is not allowed to reconnect to a set of processes that has not fully
+completed disconnect |mdash| the disconnect must complete before the same set of
+processes can be reconnected.
+
+``PMIx_Disconnect`` and ``PMIx_Disconnect_nb`` are *collective* operations. The
+PMIx server library aggregates the participation of its local clients, passing a
+single request to the host environment once all local participants have called the
+API; the host then executes the collective across all participating nodes.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Disconnect_nb`` **must** keep
+the ``procs`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+PMIx libraries are not required to directly support any attributes for this
+operation, but any provided attributes are passed to the host environment for
+processing. The following attributes are optional and depend on the
+implementation and host environment:
+
+* ``PMIX_ALL_CLONES_PARTICIPATE`` (bool) |mdash| all clones of the calling process
+  must participate in the collective operation.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the disconnect to
+  complete before the host declares an error. This helps avoid "hangs" caused by a
+  programming error that prevents one or more processes from reaching the
+  disconnect.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that all participants have
+disconnected. For the non-blocking form, a return of ``PMIX_SUCCESS`` indicates
+only that the request was accepted for processing and the final status will be
+delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the disconnect operation completed successfully.
+* ``PMIX_ERR_INVALID_OPERATION`` |mdash| the specified set of ``procs`` was not
+  previously connected via :ref:`PMIx_Connect(3) <man3-PMIx_Connect>` or its
+  non-blocking form.
+* ``PMIX_ERR_NOT_A_MEMBER`` |mdash| the calling process is not among the named
+  participants.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied (e.g., a ``NULL``
+  ``procs`` array or a zero ``nprocs``).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Disconnecting is the required counterpart to :ref:`PMIx_Connect(3)
+<man3-PMIx_Connect>`. If a connected process terminates or calls
+:ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>` without first disconnecting, the host
+environment generates a ``PMIX_ERR_PROC_TERM_WO_SYNC`` event; if a job is
+terminated as a result, the host also generates ``PMIX_ERR_JOB_TERM_WO_SYNC`` for
+every job terminated as a result. Calling ``PMIx_Disconnect`` before finalizing
+avoids these events.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_Connect(3) <man3-PMIx_Connect>`,
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -1,0 +1,165 @@
+.. _man3-PMIx_Fence:
+
+PMIx_Fence
+==========
+
+.. include_body
+
+``PMIx_Fence``, ``PMIx_Fence_nb`` |mdash| Execute a barrier synchronization across
+a set of processes, optionally collecting data posted via ``PMIx_Put``.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
+                            const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the peers is a list of Python ``pmix_proc_t`` dictionaries
+  peers = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD}]
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_COLLECT_DATA,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc = foo.fence(peers, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``procs``: Pointer to an array of ``pmix_proc_t`` structures naming the
+  processes that are to participate in the barrier. A ``NULL`` value indicates
+  that the fence is to span all processes in the caller's own namespace. A rank of
+  ``PMIX_RANK_WILDCARD`` in any element indicates that all processes in that
+  namespace are participating.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form takes two additional parameters:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+  fence completes.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Execute a barrier across the specified processes. ``PMIx_Fence`` is the blocking
+form: it does not return until all participating processes have entered the fence
+(or the operation fails). ``PMIx_Fence_nb`` is the non-blocking form: it returns
+immediately, and the provided ``cbfunc`` is invoked with the final status once the
+operation completes.
+
+Passing ``NULL`` for ``procs`` indicates that the fence is to span all processes in
+the caller's namespace, equivalent to passing a single ``pmix_proc_t`` containing
+the caller's namespace and a rank of ``PMIX_RANK_WILDCARD``. The ordering of
+entries in ``procs`` has no significance. However, all processes engaged in a given
+fence operation must use the same method to identify the participants: callers that
+describe the target set using ``PMIX_RANK_WILDCARD`` are not matched with callers
+that list the individual processes of a namespace explicitly. A group identifier
+appearing in ``procs`` is first expanded into that group's member processes.
+
+The calling process must itself be among the participants; if it is not, the
+operation returns ``PMIX_ERR_NOT_A_MEMBER``.
+
+By default, and for scalability reasons, ``PMIx_Fence`` performs only
+synchronization and does **not** return the data posted by participants. Setting
+the ``PMIX_COLLECT_DATA`` directive causes the barrier to additionally collect all
+committed :ref:`PMIx_Put(3) <man3-PMIx_Put>` data from the participants, making it
+locally available to each participant at the end of the operation. Collected data
+is cached at the server to reduce memory footprint and is retrieved as needed via
+``PMIx_Get`` (see PMIx_Get(3)).
+
+``PMIx_Fence`` and ``PMIx_Fence_nb`` are *collective* operations. The PMIx server
+library aggregates the participation of its local clients, passing a single request
+to the host environment once all local participants have called the API; the host
+then executes the collective across all participating nodes.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Fence_nb`` **must** keep the
+``procs`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. The first two are
+required to be supported by all PMIx libraries; the remainder are optional and
+depend on the implementation and host environment.
+
+* ``PMIX_COLLECT_DATA`` (bool) |mdash| collect all data posted by the participants
+  via :ref:`PMIx_Put(3) <man3-PMIx_Put>` and committed via ``PMIx_Commit``, making
+  the collection locally available to each participant at the end of the
+  operation. By default this also includes job-level information locally generated
+  by the PMIx servers, unless excluded via ``PMIX_COLLECT_GENERATED_JOB_INFO``.
+  The default behavior of the fence is **not** to collect data.
+* ``PMIX_COLLECT_GENERATED_JOB_INFO`` (bool) |mdash| collect all job-level
+  information (reserved keys) that was locally generated by the PMIx servers.
+* ``PMIX_ALL_CLONES_PARTICIPATE`` (bool) |mdash| all clones of the calling process
+  must participate in the collective operation.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the fence to
+  execute before the host declares an error. This helps avoid "hangs" caused by a
+  programming error that prevents one or more processes from reaching the fence.
+
+.. note::
+   The ``PMIX_COLLECTIVE_ALGO`` and ``PMIX_COLLECTIVE_ALGO_REQD`` attributes, used
+   in earlier releases to request specific collective algorithms, are deprecated
+   and should not be used in new code.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the barrier completed
+successfully and any collected data is available for retrieval. For the
+non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the request was
+accepted for processing and the final status will be delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the fence completed successfully.
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (non-blocking form) the request was
+  satisfied immediately |mdash| for example, when the collective involved only
+  processes on the local node |mdash| and ``cbfunc`` will **not** be called.
+* ``PMIX_ERR_NOT_A_MEMBER`` |mdash| the calling process is not among the named
+  participants.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied (e.g., a ``NULL``
+  ``procs`` array with a non-zero ``nprocs``).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+For a singleton process there are no peers to synchronize with, so the blocking
+form returns ``PMIX_SUCCESS`` (and the non-blocking form
+``PMIX_OPERATION_SUCCEEDED``) immediately without contacting a server.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
+   :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
+   PMIx_Get(3),
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -89,7 +89,7 @@ the ``PMIX_COLLECT_DATA`` directive causes the barrier to additionally collect a
 committed :ref:`PMIx_Put(3) <man3-PMIx_Put>` data from the participants, making it
 locally available to each participant at the end of the operation. Collected data
 is cached at the server to reduce memory footprint and is retrieved as needed via
-``PMIx_Get`` (see PMIx_Get(3)).
+:ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
 ``PMIx_Fence`` and ``PMIx_Fence_nb`` are *collective* operations. The PMIx server
 library aggregates the participation of its local clients, passing a single request
@@ -160,6 +160,6 @@ constants are defined in ``pmix_common.h``.
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
    :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
-   PMIx_Get(3),
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Finalize.3.rst
+++ b/docs/man/man3/PMIx_Finalize.3.rst
@@ -3,7 +3,10 @@
 PMIx_Finalize
 =============
 
-PMIx_Finalize - Finalize the PMIx Client
+.. include_body
+
+``PMIx_Finalize`` |mdash| Finalize the PMIx client library.
+
 
 SYNOPSIS
 --------
@@ -12,30 +15,96 @@ SYNOPSIS
 
    #include <pmix.h>
 
-   pmix_status_t PMIx_Finalize(void);
+   pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_EMBED_BARRIER,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc = foo.finalize(pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
 
 DESCRIPTION
 -----------
 
-Finalize the PMIx client, closing the connection with the local PMIx
-server.
+Finalize the PMIx client, closing the connection with the local PMIx server.
+An error code is returned if, for some reason, the connection cannot be closed.
+
+Because the PMIx client library is reference counted (see
+:ref:`PMIx_Init(3) <man3-PMIx_Init>`), ``PMIx_Finalize`` decrements the library
+reference count. Each call to ``PMIx_Init`` must be balanced with a matching call
+to ``PMIx_Finalize``. Only when the reference count reaches zero |mdash| i.e., on
+the call that balances the first ``PMIx_Init`` |mdash| does the library actually
+finalize the client, close the connection to the local server, and release all
+internally allocated memory. Intermediate calls simply decrement the count and
+return ``PMIX_SUCCESS``.
+
+By default, ``PMIx_Finalize`` does **not** include an internal barrier operation:
+it returns as soon as the local bookkeeping and (on the final call) the
+server-side termination handshake are complete. Callers that require all
+participating processes to synchronize before disconnecting may request an
+embedded barrier via the ``PMIX_EMBED_BARRIER`` directive (see `DIRECTIVES`_).
+
+
+DIRECTIVES
+----------
+
+The following attribute is relevant to this operation. Support for it is optional
+and depends on how the PMIx implementation was built.
+
+* ``PMIX_EMBED_BARRIER`` (bool) |mdash| execute a blocking fence operation across
+  the caller's namespace as part of the finalize operation. ``PMIx_Finalize``
+  performs no internal barrier by default; setting this attribute to ``true``
+  directs it to run the equivalent of a ``PMIx_Fence`` (see PMIx_Fence(3)) over
+  the caller's namespace before disconnecting from the local server.
+
 
 RETURN VALUE
 ------------
 
-Returns ``PMIX_SUCCESS`` on success. On error, a negative value
-corresponding to a PMIx ``errno`` is returned.
+Returns ``PMIX_SUCCESS`` on success, including on intermediate calls that only
+decrement the reference count. On error, a negative value corresponding to a
+PMIx error constant is returned, including:
 
-ERRORS
-------
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized, so there is
+  nothing to finalize.
 
-PMIx ``errno`` values are defined in ``pmix_common.h``.
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_Finalize`` is the counterpart to :ref:`PMIx_Init(3) <man3-PMIx_Init>` and
+is intended for use by *client* processes. Processes that initialized as *tools*
+should instead call ``PMIx_tool_finalize``, and processes hosting a PMIx server
+should call ``PMIx_server_finalize``.
+
 
 .. seealso::
-   :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
-   PMIx_Commit(3),
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
    PMIx_Initialized(3),
-   PMIx_Put(3),
-   pmiAddInstance(3),
-   pmiAddMetric(3)
+   PMIx_tool_finalize(3),
+   PMIx_server_finalize(3),
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Finalize.3.rst
+++ b/docs/man/man3/PMIx_Finalize.3.rst
@@ -73,8 +73,8 @@ and depends on how the PMIx implementation was built.
 * ``PMIX_EMBED_BARRIER`` (bool) |mdash| execute a blocking fence operation across
   the caller's namespace as part of the finalize operation. ``PMIx_Finalize``
   performs no internal barrier by default; setting this attribute to ``true``
-  directs it to run the equivalent of a ``PMIx_Fence`` (see PMIx_Fence(3)) over
-  the caller's namespace before disconnecting from the local server.
+  directs it to run the equivalent of a :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`
+  over the caller's namespace before disconnecting from the local server.
 
 
 RETURN VALUE
@@ -103,7 +103,7 @@ should call ``PMIx_server_finalize``.
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
-   PMIx_Initialized(3),
+   :ref:`PMIx_Initialized(3) <man3-PMIx_Initialized>`,
    PMIx_tool_finalize(3),
    PMIx_server_finalize(3),
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -1,0 +1,182 @@
+.. _man3-PMIx_Get:
+
+PMIx_Get
+========
+
+.. include_body
+
+``PMIx_Get``, ``PMIx_Get_nb`` |mdash| Retrieve a value posted by a process against
+a specified key.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
+                          const pmix_info_t info[], size_t ninfo,
+                          pmix_value_t **val);
+
+   pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
+                             const pmix_info_t info[], size_t ninfo,
+                             pmix_value_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the proc is a Python ``pmix_proc_t`` dictionary
+  proc = {'nspace': "testnspace", 'rank': 0}
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_TIMEOUT,
+             'value': {'value': 10, 'val_type': PMIX_INT}}]
+  rc, value = foo.get(proc, "mykey", pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``proc``: Pointer to a ``pmix_proc_t`` identifying the process whose posted data
+  is to be retrieved. A ``NULL`` value is used in place of the caller's own
+  identifier. A rank of ``PMIX_RANK_WILDCARD`` retrieves job-level information for
+  the process's namespace.
+* ``key``: A NULL-terminated string, no longer than ``PMIX_MAX_KEYLEN``
+  characters, naming the value to retrieve. A ``NULL`` key requests **all** data
+  associated with the identified process.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``val`` (blocking form): Address of a ``pmix_value_t`` pointer. On success it is
+  set as described under `DESCRIPTION`_. When the ``PMIX_GET_STATIC_VALUES``
+  directive is used, the caller must instead provide storage and pass a pointer to
+  it here as an input.
+
+The non-blocking form replaces ``val`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_value_cbfunc_t`` invoked with the
+  retrieved value once it is available.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Retrieve information for the specified ``key`` as posted by the process identified
+in ``proc``. ``PMIx_Get`` is the blocking form: it does not return until the data
+is available (or the operation fails or times out). ``PMIx_Get_nb`` is the
+non-blocking form: it returns immediately, and the provided ``cbfunc`` is invoked
+with the final status and value once the data has been retrieved by the local
+server.
+
+The precedence rules governing where the library looks for the data |mdash| the
+local client cache, the local PMIx server, and the host resource manager |mdash|
+differ for reserved keys (those provided by the host environment, beginning with
+``"pmix"``) and non-reserved keys (those posted by the application via
+:ref:`PMIx_Put(3) <man3-PMIx_Put>`). Those rules are governed by the directives
+described below.
+
+Return of the value (blocking form) is controlled by the directives:
+
+* In the absence of any directive, the returned ``pmix_value_t`` is a freshly
+  allocated memory object. The caller is responsible for releasing it with
+  ``PMIX_VALUE_RELEASE`` when done.
+* With ``PMIX_GET_POINTER_VALUES``, the function returns a pointer directly into
+  the PMIx library's key-value store. The caller **must not** release the returned
+  data.
+* With ``PMIX_GET_STATIC_VALUES``, the value is returned in caller-provided
+  storage: the caller must pass a pointer to a ``pmix_value_t`` it owns in ``val``
+  and destruct it with ``PMIX_VALUE_DESTRUCT`` when done. If the implementation
+  cannot return a static value, ``PMIx_Get`` returns ``PMIX_ERR_NOT_SUPPORTED``.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Get_nb`` **must** keep the
+``proc`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. All but ``PMIX_TIMEOUT``
+are required to be supported by all PMIx libraries; ``PMIX_TIMEOUT`` is optional
+for host environments.
+
+* ``PMIX_OPTIONAL`` (bool) |mdash| look only in the client's local data store; do
+  not request the data from the PMIx server if it is not found locally.
+* ``PMIX_IMMEDIATE`` (bool) |mdash| direct the PMIx server to immediately return an
+  error if the requested data is not in its store, rather than requesting it from
+  the host resource manager.
+* ``PMIX_GET_REFRESH_CACHE`` (bool) |mdash| refresh the local cache for the target
+  process from the server before returning, picking up values put and committed
+  since the last refresh. A ``NULL`` key refreshes all values for the process; a
+  rank of ``PMIX_RANK_WILDCARD`` refreshes job-related information.
+* ``PMIX_DATA_SCOPE`` (pmix_scope_t) |mdash| restrict the scope of data to be
+  searched (see :ref:`PMIx_Put(3) <man3-PMIx_Put>`).
+* ``PMIX_GET_POINTER_VALUES`` (bool) |mdash| return a pointer to the value in the
+  library's key-value store instead of a copy; the caller must not free it.
+* ``PMIX_GET_STATIC_VALUES`` (bool) |mdash| return the value in storage provided by
+  the caller via the ``val`` parameter.
+* ``PMIX_SESSION_INFO`` / ``PMIX_JOB_INFO`` / ``PMIX_APP_INFO`` /
+  ``PMIX_NODE_INFO`` (bool) |mdash| direct that the requested key be retrieved from
+  the session-, job-, application-, or node-level information, respectively.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the get to complete
+  before returning an error. Helps avoid "hangs" when the target process never
+  exposes the requested data.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the requested data was
+returned in the manner requested. For the non-blocking form, a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing; the
+final status and value are delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the requested data has been returned.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| the requested data was not available.
+* ``PMIX_ERR_EXISTS_OUTSIDE_SCOPE`` |mdash| the requested key exists, but was
+  posted in a scope that does not include the requester.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, an over-length key, or the ``PMIX_GET_STATIC_VALUES`` directive with a
+  ``NULL`` storage location.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the implementation cannot satisfy a requested
+  directive (e.g., ``PMIX_GET_STATIC_VALUES``).
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+For non-reserved keys, retrieval blocks until the target process has posted the
+key with :ref:`PMIx_Put(3) <man3-PMIx_Put>`, committed it with
+:ref:`PMIx_Commit(3) <man3-PMIx_Commit>`, and the data has been circulated |mdash|
+typically via a :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` |mdash| unless the
+``PMIX_OPTIONAL`` or ``PMIX_IMMEDIATE`` directives are used to bound the search.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
+   :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Heartbeat.3.rst
+++ b/docs/man/man3/PMIx_Heartbeat.3.rst
@@ -1,0 +1,66 @@
+.. _man3-PMIx_Heartbeat:
+
+PMIx_Heartbeat
+==============
+
+.. include_body
+
+``PMIx_Heartbeat`` |mdash| Send a heartbeat to the local PMIx server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   void PMIx_Heartbeat(void);
+
+
+DESCRIPTION
+-----------
+
+Send a single heartbeat to the local PMIx server. ``PMIx_Heartbeat`` is a
+convenience wrapper around :ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>`
+(equivalent to passing the ``PMIX_SEND_HEARTBEAT`` attribute as the monitor action):
+it transmits a lightweight, one-way message to the server and returns immediately.
+
+Heartbeats feed the server-side liveness monitoring that is configured through
+:ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>` with the
+``PMIX_MONITOR_HEARTBEAT`` action. A process that has registered to be watched for
+heartbeats is expected to call ``PMIx_Heartbeat`` often enough to satisfy the
+window established by the ``PMIX_MONITOR_HEARTBEAT_TIME`` and
+``PMIX_MONITOR_HEARTBEAT_DROPS`` directives. If the server does not receive the
+expected heartbeats within that window, it generates the monitoring event
+(e.g., ``PMIX_MONITOR_HEARTBEAT_ALERT``) that the requestor set up.
+
+``PMIx_Heartbeat`` takes no arguments. If the library's progress engine has been
+stopped, or the message cannot be built or sent, the call silently returns without
+emitting a heartbeat.
+
+
+RETURN VALUE
+------------
+
+``PMIx_Heartbeat`` returns no value (``void``). Any failure to send the heartbeat
+|mdash| for example, because the progress engine has been stopped |mdash| is not
+reported to the caller.
+
+
+NOTES
+-----
+
+Because the heartbeat is delivered as a best-effort, one-way message and the
+function returns no status, callers cannot detect a failed transmission from the
+call itself. Detection of a missing heartbeat is instead surfaced through the
+monitoring event registered via
+:ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>`.
+
+Sending heartbeats is only meaningful for a process (client or tool) connected to a
+local server; a server does not send heartbeats to itself.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>`

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -69,7 +69,7 @@ If successful, the function will return ``PMIX_SUCCESS`` and will fill the
 provided structure (if non-``NULL``) with the server-assigned namespace and rank
 of the process within the application. In addition, all startup information
 provided by the resource manager is made available to the client process via
-subsequent calls to ``PMIx_Get`` (see PMIx_Get(3)).
+subsequent calls to :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
 The ``info`` array is used to pass user directives pertaining to the
 initialization and subsequent operations. These commonly describe the transport
@@ -105,7 +105,7 @@ Connection attributes
 
 These attributes describe how the client is to rendezvous with the local PMIx
 server. They are consumed during connection establishment and are not typically
-retrievable via ``PMIx_Get`` (see PMIx_Get(3)).
+retrievable via :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
 * ``PMIX_TCP_URI`` (char\*) |mdash| the URI of the PMIx server to connect to, or
   a file name containing it in the form ``file:<name of file>``.
@@ -218,7 +218,7 @@ were registered with a PMIx server before being started. Processes acting as
    :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
    :ref:`PMIx_Initialized(3) <man3-PMIx_Initialized>`,
    PMIx_Progress(3),
-   PMIx_Get(3),
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    PMIx_tool_init(3),
    PMIx_server_init(3),
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -3,7 +3,10 @@
 PMIx_Init
 =========
 
-PMIx_Init - Initialize the PMIx Client
+.. include_body
+
+``PMIx_Init`` |mdash| Initialize the PMIx client library.
+
 
 SYNOPSIS
 --------
@@ -12,57 +15,211 @@ SYNOPSIS
 
    #include <pmix.h>
 
-   pmix_status_t PMIx_Init(pmix_proc_t *proc);
+   pmix_status_t PMIx_Init(pmix_proc_t *proc,
+                           pmix_info_t info[], size_t ninfo);
 
-ARGUMENTS
----------
 
-* ``proc``: Pointer to a ``pmix_proc_t`` object in which the client's
-  namespace and rank are to be returned.
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_PROGRAMMING_MODEL,
+             'value': {'value': "MPI", 'val_type': PMIX_STRING}}]
+  rc, myname = foo.init(pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the initialization (see
+  `DIRECTIVES`_). A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+INPUT/OUTPUT PARAMETERS
+-----------------------
+
+* ``proc``: Pointer to a ``pmix_proc_t`` structure in which the client's
+  namespace and rank are to be returned. Passing ``NULL`` is allowed if the
+  caller only wishes to initialize the PMIx system and does not require the
+  identifier at this time.
+
 
 DESCRIPTION
 -----------
 
-Initialize the PMIx client, returning the process identifier assigned
-to this client's application in the provided ``pmix_proc_t``
-struct. Passing a parameter of NULL for this parameter is allowed if
-the user wishes solely to initialize the PMIx system and does not
-require return of the identifier at that time.
+Initialize the PMIx client, returning the process identifier assigned to this
+client's application in the provided ``pmix_proc_t`` struct. Passing a value of
+``NULL`` for the ``proc`` parameter is allowed if the caller wishes solely to
+initialize the PMIx system and does not require return of the identifier at that
+time.
 
-When called, the PMIx client will check for the required connection
-information of the local PMIx server and will establish the
-connection. If the information is not found, or the server connection
-fails, then an appropriate error constant will be returned.
+When called, the PMIx client will check for the required connection information
+of the local PMIx server and will establish the connection. If the information
+is not found, or the server connection fails, then an appropriate error constant
+will be returned.
 
-If successful, the function will return ``PMIX_SUCCESS`` and will fill
-the provided structure with the server-assigned namespace and rank of
-the process within the application.
+If successful, the function will return ``PMIX_SUCCESS`` and will fill the
+provided structure (if non-``NULL``) with the server-assigned namespace and rank
+of the process within the application. In addition, all startup information
+provided by the resource manager is made available to the client process via
+subsequent calls to ``PMIx_Get`` (see PMIx_Get(3)).
 
-Note that the PMIx client library is reference counted, and so
-multiple calls to ``PMIx_Init`` are allowed. Thus, one way to obtain
-the namespace and rank of the process is to simply call ``PMIx_Init``
-with a non-NULL parameter.
+The ``info`` array is used to pass user directives pertaining to the
+initialization and subsequent operations. These commonly describe the transport
+by which the client is to rendezvous with the local server, or announce the
+programming model and threading model being initialized so that the event
+notification system can coordinate among cooperating libraries within the same
+process (see `DIRECTIVES`_).
+
+Reference counting
+^^^^^^^^^^^^^^^^^^
+
+The PMIx client library is reference counted, and so multiple calls to
+``PMIx_Init`` are allowed. Thus, one way for an application process to obtain its
+namespace and rank is to simply call ``PMIx_Init`` with a non-``NULL`` ``proc``
+parameter. Each call to ``PMIx_Init`` must be balanced with a matching call to
+:ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>` so that the connection to the local
+server is only torn down once every initializing caller has finalized.
+
+Multiple calls to ``PMIx_Init`` must not include conflicting directives; an error
+is returned when directives that conflict with those of a prior call are
+encountered.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. Support for any given
+attribute is optional and depends on how the PMIx implementation was built and
+on the capabilities of the host environment.
+
+Connection attributes
+^^^^^^^^^^^^^^^^^^^^^^
+
+These attributes describe how the client is to rendezvous with the local PMIx
+server. They are consumed during connection establishment and are not typically
+retrievable via ``PMIx_Get`` (see PMIx_Get(3)).
+
+* ``PMIX_TCP_URI`` (char\*) |mdash| the URI of the PMIx server to connect to, or
+  a file name containing it in the form ``file:<name of file>``.
+* ``PMIX_TCP_REPORT_URI`` (char\*) |mdash| direct that the client's TCP URI be
+  reported, and indicate the method: ``'-'`` for stdout, ``'+'`` for stderr, or
+  a filename.
+* ``PMIX_TCP_IF_INCLUDE`` (char\*) |mdash| comma-delimited list of devices and/or
+  CIDR notation to include when establishing the TCP connection.
+* ``PMIX_TCP_IF_EXCLUDE`` (char\*) |mdash| comma-delimited list of devices and/or
+  CIDR notation to exclude when establishing the TCP connection.
+* ``PMIX_TCP_IPV4_PORT`` (int) |mdash| the IPv4 port to be used.
+* ``PMIX_TCP_IPV6_PORT`` (int) |mdash| the IPv6 port to be used.
+* ``PMIX_TCP_DISABLE_IPV4`` (bool) |mdash| set to ``true`` to disable the IPv4
+  family of addresses.
+* ``PMIX_TCP_DISABLE_IPV6`` (bool) |mdash| set to ``true`` to disable the IPv6
+  family of addresses.
+* ``PMIX_USOCK_DISABLE`` (bool) |mdash| if the library supports Unix socket
+  connections, disable their use.
+* ``PMIX_SOCKET_MODE`` (uint32_t) |mdash| set the mode of the rendezvous socket.
+* ``PMIX_SINGLE_LISTENER`` (bool) |mdash| if the library supports more than one
+  method for clients to connect to servers, use only one of them.
+
+Runtime attributes
+^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_GDS_MODULE`` (char\*) |mdash| select the generalized data store (GDS)
+  component(s) the client is to use for storing and retrieving job-level and
+  peer data. If not provided, the value of the ``PMIX_GDS_MODULE`` environment
+  variable is honored, defaulting to the ``hash`` component.
+* ``PMIX_EVENT_BASE`` (void\*) |mdash| pointer to an ``event_base`` to use in
+  place of the internal progress thread. The event base **must** be compatible
+  with the event library (e.g., libevent or libev) the PMIx implementation was
+  built against.
+* ``PMIX_EXTERNAL_PROGRESS`` (bool) |mdash| the host will progress the PMIx
+  library as needed via calls to ``PMIx_Progress`` (see PMIx_Progress(3)),
+  rather than PMIx spawning its own internal progress thread.
+
+Programming-model attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When provided, the following attributes are used by the event notification
+system for inter-library coordination |mdash| for example, so that an MPI and an
+OpenMP runtime co-located in the same process can discover one another via a
+``PMIX_MODEL_DECLARED`` event.
+
+* ``PMIX_PROGRAMMING_MODEL`` (char\*) |mdash| programming model being initialized
+  (e.g., ``"MPI"`` or ``"OpenMP"``).
+* ``PMIX_MODEL_LIBRARY_NAME`` (char\*) |mdash| programming model implementation ID
+  (e.g., ``"OpenMPI"`` or ``"MPICH"``).
+* ``PMIX_MODEL_LIBRARY_VERSION`` (char\*) |mdash| programming model version string
+  (e.g., ``"2.1.1"``).
+* ``PMIX_THREADING_MODEL`` (char\*) |mdash| threading model used (e.g.,
+  ``"pthreads"``).
+* ``PMIX_MODEL_NUM_THREADS`` (uint64_t) |mdash| number of active threads being
+  used by the model.
+* ``PMIX_MODEL_NUM_CPUS`` (uint64_t) |mdash| number of CPUs being used by the
+  model.
+* ``PMIX_MODEL_CPU_TYPE`` (char\*) |mdash| granularity: ``"hwthread"``,
+  ``"core"``, etc.
+* ``PMIX_MODEL_AFFINITY_POLICY`` (char\*) |mdash| thread affinity policy, e.g.
+  ``"master"``, ``"close"``, or ``"spread"``.
+
+
+INITIALIZATION EVENTS
+---------------------
+
+The following events are typically associated with calls to ``PMIx_Init`` and may
+be delivered to processes that have registered for them via
+``PMIx_Register_event_handler`` (see PMIx_Register_event_handler(3)):
+
+* ``PMIX_MODEL_DECLARED`` |mdash| a programming model has been declared by a call
+  to ``PMIx_Init`` that carried the programming-model attributes above.
+* ``PMIX_MODEL_RESOURCES`` |mdash| resource usage by a programming model has
+  changed.
+* ``PMIX_OPENMP_PARALLEL_ENTERED`` |mdash| an OpenMP parallel code region has been
+  entered.
+* ``PMIX_OPENMP_PARALLEL_EXITED`` |mdash| an OpenMP parallel code region has
+  completed.
+
 
 RETURN VALUE
 ------------
 
-Returns ``PMIX_SUCCESS`` on success. On error, a negative value
-corresponding to a PMIx ``errno`` is returned.
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
 
-ERRORS
-------
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library could not be initialized (for
+  example, a required transport was explicitly disabled, or a tight race between
+  concurrent ``PMIx_Init`` calls left the library in an unusable state).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| a provided directive requested behavior the
+  implementation does not support.
 
-PMIx ``errno`` values are defined in ``pmix_common.h``.
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
 
-.. JMS COMMENT When more man pages are added, they can be :ref:'ed
-   appropriately, so that HTML hyperlinks are created to link to the
-   corresponding pages.
+
+NOTES
+-----
+
+``PMIx_Init`` is intended for use by *client* processes |mdash| processes that
+were registered with a PMIx server before being started. Processes acting as
+*tools* (debuggers, profilers, workflow managers) should instead call
+``PMIx_tool_init``, and processes hosting a PMIx server should call
+``PMIx_server_init``.
+
 
 .. seealso::
-   PMIx_Initialized(3),
-   :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
-   PMIx_Commit(3),
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
-   PMIx_Put(3),
-   pmiAddInstance(3),
-   pmiAddMetric(3)
+   :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
+   PMIx_Initialized(3),
+   PMIx_Progress(3),
+   PMIx_Get(3),
+   PMIx_tool_init(3),
+   PMIx_server_init(3),
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -216,7 +216,7 @@ were registered with a PMIx server before being started. Processes acting as
 .. seealso::
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
    :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,
-   PMIx_Initialized(3),
+   :ref:`PMIx_Initialized(3) <man3-PMIx_Initialized>`,
    PMIx_Progress(3),
    PMIx_Get(3),
    PMIx_tool_init(3),

--- a/docs/man/man3/PMIx_Initialized.3.rst
+++ b/docs/man/man3/PMIx_Initialized.3.rst
@@ -1,0 +1,61 @@
+.. _man3-PMIx_Initialized:
+
+PMIx_Initialized
+================
+
+.. include_body
+
+``PMIx_Initialized`` |mdash| Determine whether the PMIx library has been
+initialized.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   int PMIx_Initialized(void);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  state = foo.initialized()
+
+
+DESCRIPTION
+-----------
+
+Check whether the PMIx library has been initialized by any of the initialization
+functions |mdash| :ref:`PMIx_Init(3) <man3-PMIx_Init>`, ``PMIx_server_init``, or
+``PMIx_tool_init``. This function may be called outside of the initialized and
+finalized region, and is usable by servers and tools in addition to clients.
+
+The function only reports the internal state of the PMIx library. It does **not**
+verify that an active connection with the local server exists, nor that the
+server is functional.
+
+
+RETURN VALUE
+------------
+
+Returns ``1`` (true) if the PMIx library has been initialized, and ``0`` (false)
+otherwise.
+
+.. note::
+   The return value is an ``int`` rather than a ``bool`` for historical reasons:
+   this matches the signature of prior PMI libraries.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   PMIx_tool_init(3),
+   PMIx_server_init(3)

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -1,0 +1,219 @@
+.. _man3-PMIx_Job_control:
+
+PMIx_Job_control
+================
+
+.. include_body
+
+``PMIx_Job_control``, ``PMIx_Job_control_nb`` |mdash| Request a job control
+action be applied to a set of target processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Job_control(const pmix_proc_t targets[], size_t ntargets,
+                                  const pmix_info_t directives[], size_t ndirs,
+                                  pmix_info_t **results, size_t *nresults);
+
+   pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_t ntargets,
+                                     const pmix_info_t directives[], size_t ndirs,
+                                     pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the targets is a list of Python ``pmix_proc_t`` dictionaries
+  targets = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD}]
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_JOB_CTRL_KILL,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc, results = foo.job_control(targets, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``targets``: Pointer to an array of ``pmix_proc_t`` structures identifying the
+  processes to which the requested job control action is to be applied. A
+  ``NULL`` value indicates that the action is to be applied to all processes in
+  the caller's own namespace. A rank of ``PMIX_RANK_WILDCARD`` in any element
+  indicates that all processes in that namespace are to be included. All
+  *clones* of an identified process have the requested action applied to them.
+* ``ntargets``: Number of elements in the ``targets`` array.
+* ``directives``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures describing the job control action(s) being requested (see
+  `DIRECTIVES`_). A ``NULL`` value is supported when no directives are desired,
+  though a request with no directives has no defined action.
+* ``ndirs``: Number of elements in the ``directives`` array.
+
+The blocking form returns any results directly:
+
+* ``results``: Address at which a pointer to an array of ``pmix_info_t``
+  structures containing the results of the request is returned. May be ``NULL``
+  if the caller does not wish to receive returned data.
+* ``nresults``: Address at which the number of elements in the returned
+  ``results`` array is stored. May be ``NULL`` if ``results`` is ``NULL``.
+
+The non-blocking form replaces ``results`` and ``nresults`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+  final status and any returned data once the request has been processed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request a job control action. ``PMIx_Job_control`` is the blocking form: it does
+not return until the request has been processed (or fails), returning any
+resulting data in the ``results`` array. ``PMIx_Job_control_nb`` is the
+non-blocking form: it returns immediately, and the provided ``cbfunc`` is invoked
+with the final status and any returned data once the request completes.
+
+The ``targets`` array identifies the processes to which the requested action is
+to be applied. Passing ``NULL`` for ``targets`` indicates that the action is to
+be applied to all processes in the caller's namespace, equivalent to passing a
+single ``pmix_proc_t`` containing the caller's namespace and a rank of
+``PMIX_RANK_WILDCARD``. All clones of an identified process receive the action.
+
+The requested action itself is expressed entirely through the ``directives``
+array: each entry names a job control operation (for example, terminate, pause,
+signal, or checkpoint) and any qualifying values. The PMIx library is not
+required to interpret these directives itself |mdash| it passes them to the host
+environment for processing |mdash| but it is required to add the
+``PMIX_USERID`` and ``PMIX_GRPID`` of the requesting process so the host can
+apply appropriate authorization. Actual support for any given directive depends
+on the host environment.
+
+The returned status indicates whether or not the request was granted; when a
+request is denied, information as to the reason is returned in the ``results``
+array (blocking form) or delivered to ``cbfunc`` (non-blocking form).
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Job_control_nb`` **must**
+keep the ``targets`` and ``directives`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The following attributes are used to describe the requested job control action.
+PMIx libraries are not required to directly support any of these; they are passed
+to the host environment, and support therefore depends on the implementation and
+host. Host environments that implement this operation are required to support the
+first group; the remainder are optional.
+
+Required of supporting host environments:
+
+* ``PMIX_JOB_CTRL_ID`` (char*) |mdash| a string identifier for this request,
+  allowing its status to later be queried or the operation to be cancelled.
+* ``PMIX_JOB_CTRL_PAUSE`` (bool) |mdash| pause the specified processes.
+* ``PMIX_JOB_CTRL_RESUME`` (bool) |mdash| resume ("un-pause") the specified
+  processes.
+* ``PMIX_JOB_CTRL_KILL`` (bool) |mdash| forcibly terminate the specified
+  processes and clean up.
+* ``PMIX_JOB_CTRL_TERMINATE`` (bool) |mdash| politely terminate the specified
+  processes.
+* ``PMIX_JOB_CTRL_SIGNAL`` (int) |mdash| send the given signal to the specified
+  processes.
+* ``PMIX_REGISTER_CLEANUP`` (char*) |mdash| comma-delimited list of files to be
+  removed upon termination of the specified processes.
+* ``PMIX_REGISTER_CLEANUP_DIR`` (char*) |mdash| comma-delimited list of
+  directories to be removed upon termination of the specified processes.
+* ``PMIX_CLEANUP_RECURSIVE`` (bool) |mdash| recursively clean up all
+  subdirectories under the specified one(s).
+* ``PMIX_CLEANUP_EMPTY`` (bool) |mdash| only remove empty subdirectories.
+* ``PMIX_CLEANUP_IGNORE`` (char*) |mdash| comma-delimited list of filenames that
+  are not to be removed.
+* ``PMIX_CLEANUP_LEAVE_TOPDIR`` (bool) |mdash| when recursively cleaning
+  subdirectories, do not remove the top-level directory.
+
+Optional for supporting host environments:
+
+* ``PMIX_JOB_CTRL_CANCEL`` (char*) |mdash| cancel the request whose
+  ``PMIX_JOB_CTRL_ID`` matches the provided value; a ``NULL`` value cancels all
+  requests from this requestor.
+* ``PMIX_JOB_CTRL_RESTART`` (char*) |mdash| restart the specified processes using
+  the given checkpoint ID.
+* ``PMIX_JOB_CTRL_CHECKPOINT`` (char*) |mdash| checkpoint the specified processes
+  and assign the given ID to it.
+* ``PMIX_JOB_CTRL_CHECKPOINT_EVENT`` (bool) |mdash| use event notification to
+  trigger the process checkpoint.
+* ``PMIX_JOB_CTRL_CHECKPOINT_SIGNAL`` (int) |mdash| use the given signal to
+  trigger the process checkpoint.
+* ``PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT`` (int) |mdash| time, in seconds, to wait
+  for the checkpoint to complete.
+* ``PMIX_JOB_CTRL_CHECKPOINT_METHOD`` (pmix_data_array_t*) |mdash| array of
+  ``pmix_info_t`` declaring each checkpoint method and value supported by the
+  application.
+* ``PMIX_JOB_CTRL_PROVISION`` (char*) |mdash| regular expression identifying nodes
+  that are to be provisioned.
+* ``PMIX_JOB_CTRL_PROVISION_IMAGE`` (char*) |mdash| name of the image that is to
+  be provisioned.
+* ``PMIX_JOB_CTRL_PREEMPTIBLE`` (bool) |mdash| register the job as available for
+  preemption.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the request was granted;
+any accompanying data is returned in the ``results`` array. For the non-blocking
+form, a return of ``PMIX_SUCCESS`` indicates only that the request was accepted
+for processing and the final status will be delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the request was granted (or accepted for processing,
+  for the non-blocking form).
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (non-blocking form) the request was
+  processed immediately and returned success; ``cbfunc`` will **not** be called.
+* ``PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`` |mdash| conflicting directives were
+  given for job or process cleanup.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the operation is not supported (for example,
+  a server whose host environment provides no job control module).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_COMM_FAILURE`` |mdash| the connection to the server was lost before
+  a response was received.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Job control is a request to the host environment, not a guarantee: the PMIx
+library forwards the directives (annotated with the requester's ``PMIX_USERID``
+and ``PMIX_GRPID``) to the host resource manager, which decides whether and how
+to honor them. A request may therefore be denied for authorization or policy
+reasons even when the named directives are individually supported.
+
+The job control APIs are frequently used together with event notification and
+the allocation APIs to build coordinated responses to failures and other events
+|mdash| for example, requesting replacement resources with
+``PMIx_Allocation_request(3)`` while directing that a checkpoint event be
+delivered to the affected processes.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>`,
+   :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`,
+   :ref:`PMIx_Session_control(3) <man3-PMIx_Session_control>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Lookup.3.rst
+++ b/docs/man/man3/PMIx_Lookup.3.rst
@@ -1,0 +1,185 @@
+.. _man3-PMIx_Lookup:
+
+PMIx_Lookup
+===========
+
+.. include_body
+
+``PMIx_Lookup``, ``PMIx_Lookup_nb`` |mdash| Retrieve data published by this or
+another process via :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Lookup(pmix_pdata_t data[], size_t ndata,
+                             const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], size_t ninfo,
+                                pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # data is a list of Python ``pmix_pdata_t`` dictionaries; only the
+  # ``key`` field is used on input to name the values to retrieve
+  data = [{'key': "mykey", 'value': {'value': None, 'val_type': PMIX_UNDEF},
+           'proc': {'nspace': "", 'rank': 0}}]
+  # directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_RANGE,
+             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+  rc, data = foo.lookup(data, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+Blocking form:
+
+* ``data``: Pointer to an array of ``pmix_pdata_t`` structures. On input, the
+  ``key`` field of each element names a value to retrieve; the array must not be
+  ``NULL``. See `OUTPUT PARAMETERS`_ for how results are returned.
+* ``ndata``: Number of elements in the ``data`` array.
+
+Non-blocking form:
+
+* ``keys``: A ``NULL``-terminated array of key strings naming the values to
+  retrieve. Must not be ``NULL``.
+
+Both forms:
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``data`` (blocking form): For each element whose key was found, the ``value``
+  field is populated with the published value and the ``proc`` field is set to
+  the namespace/rank of the process that published it. Any key that cannot be
+  found is left with a value of type ``PMIX_UNDEF``. The caller must therefore
+  check each element to determine which were returned.
+
+The non-blocking form replaces ``data`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_lookup_cbfunc_t`` invoked with an
+  array of ``pmix_pdata_t`` structures for the found keys once the lookup
+  completes.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Look up information previously published by this or another process with
+:ref:`PMIx_Publish(3) <man3-PMIx_Publish>`. The lookup is resolved solely by
+key |mdash| the requester need not know the identity of the publisher.
+
+By default, the search is constrained to publishers within the
+``PMIX_RANGE_SESSION`` range (which disambiguates duplicate keys published on
+different ranges). The range may be changed |mdash| for example, expanded to all
+potential publishers via ``PMIX_RANGE_GLOBAL`` |mdash| and other directives
+added through the ``info`` array. The search is additionally constrained to data
+published by the current user ID: it will not return data published by an
+application running under a different user. There is currently no option to
+override that behavior.
+
+``PMIx_Lookup`` is the blocking form. It returns ``PMIX_SUCCESS`` if *any* of the
+requested keys are found, so the caller must inspect each ``data`` element to
+learn which values were actually returned. ``PMIx_Lookup_nb`` is the non-blocking
+form: it returns immediately and delivers the found data to ``cbfunc``. As with
+all non-blocking PMIx APIs, the caller **must** keep the ``keys`` and ``info``
+arrays valid until ``cbfunc`` is invoked.
+
+By default, a lookup does **not** wait for the requested data to be published;
+it blocks only for the time the datastore needs to search its current contents
+and return any matches. The caller is therefore responsible for ensuring that
+the data is published before the lookup, for using the ``PMIX_WAIT`` directive to
+instruct the datastore to wait until the data becomes available, or for retrying
+until the requested data is found.
+
+
+DIRECTIVES
+----------
+
+The following attributes qualify this operation. PMIx libraries are not required
+to support any of them directly, but must pass any that are provided to the host
+environment; where supported, they are optional for host environments.
+
+* ``PMIX_RANGE`` (pmix_data_range_t) |mdash| restrict the search to publishers
+  within the specified range (e.g., ``PMIX_RANGE_SESSION``,
+  ``PMIX_RANGE_NAMESPACE``, ``PMIX_RANGE_GLOBAL``). Defaults to
+  ``PMIX_RANGE_SESSION``.
+* ``PMIX_WAIT`` (int) |mdash| direct the datastore to wait until the requested
+  data has been published rather than returning immediately with whatever is
+  currently available. The datastore waits until all requested data is available.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, to wait for the data
+  to become available before returning an error (0 => infinite). Helps avoid
+  indefinite waits when combined with ``PMIX_WAIT``.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that at least one requested key
+was found and returned. For the non-blocking form, a return of ``PMIX_SUCCESS``
+indicates only that the request was accepted for processing; the final status and
+data are delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| all (blocking form: at least one) requested keys were
+  found and returned.
+* ``PMIX_ERR_PARTIAL_SUCCESS`` |mdash| only some of the requested data was found.
+  In the non-blocking form only the found data is included in the returned array;
+  the specific reason a particular item is missing (e.g., lack of permissions)
+  cannot be communicated back.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| none of the requested data could be found within
+  the requester's range.
+* ``PMIX_ERR_NO_PERMISSIONS`` |mdash| all requested data was found and the range
+  restrictions were met, but none could be returned due to lack of access
+  permissions.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| no datastore on this system supports this
+  function.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, a ``NULL`` ``data`` array (blocking) or ``NULL`` ``keys`` array
+  (non-blocking).
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Because a successful blocking return does not guarantee that every key was found,
+always examine each returned ``pmix_pdata_t`` element: an element left with a
+value type of ``PMIX_UNDEF`` was not resolved. Data is only visible to a
+requester whose user ID matches the publisher and whose process falls within the
+publication range.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,
+   :ref:`PMIx_Unpublish(3) <man3-PMIx_Unpublish>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -1,0 +1,233 @@
+.. _man3-PMIx_Process_monitor:
+
+PMIx_Process_monitor
+====================
+
+.. include_body
+
+``PMIx_Process_monitor``, ``PMIx_Process_monitor_nb`` |mdash| Request that
+processes, files, or resources be monitored for activity or usage.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Process_monitor(const pmix_info_t *monitor,
+                                      pmix_status_t error,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_t **results, size_t *nresults);
+
+   pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor,
+                                         pmix_status_t error,
+                                         const pmix_info_t directives[], size_t ndirs,
+                                         pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the monitor action is a single Python ``pmix_info_t`` dictionary
+  monitor = {'key': PMIX_MONITOR_HEARTBEAT,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}
+  # the directives are a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_MONITOR_HEARTBEAT_TIME,
+             'value': {'value': 5, 'val_type': PMIX_UINT32}}]
+  rc, results = foo.monitor(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``monitor``: Pointer to a single :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structure whose key specifies the monitoring **action** being requested |mdash|
+  for example ``PMIX_MONITOR_HEARTBEAT`` to have the server watch the requestor for
+  periodic heartbeats, or ``PMIX_MONITOR_FILE`` to monitor a file for signs of
+  life. A ``NULL`` value returns ``PMIX_ERR_BAD_PARAM``.
+* ``error``: The ``pmix_status_t`` code the monitor is to use when generating an
+  event notification alerting that the monitored condition has been triggered (or
+  to carry a periodic resource-usage update). The default range of the resulting
+  event is ``PMIX_RANGE_NAMESPACE``; this can be changed with a ``PMIX_RANGE``
+  directive.
+* ``directives``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures characterizing the request |mdash| e.g., the checking frequency or the
+  set of target processes, nodes, or files (see `DIRECTIVES`_). A ``NULL`` value is
+  supported when no directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``results`` (blocking form): Address where a pointer to an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures containing the results of the
+  request is returned. Initialized to ``NULL`` on entry; any returned array must be
+  released by the caller with ``PMIX_INFO_FREE``.
+* ``nresults`` (blocking form): Address where the number of elements in the
+  ``results`` array is returned.
+
+The non-blocking form replaces ``results``/``nresults`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+  final status and any returned data once the request has been processed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request that application processes, files, and/or resources be monitored.
+``PMIx_Process_monitor`` is the blocking form: it does not return until the
+request has been processed, at which point any measured values are returned in the
+``results`` array. ``PMIx_Process_monitor_nb`` is the non-blocking form: it returns
+immediately, and the provided ``cbfunc`` is invoked with the final status and any
+returned data.
+
+This API serves two purposes:
+
+* **Liveness monitoring.** Request that the server watch a process or file for
+  activity |mdash| for example, that it monitor a given process for periodic
+  heartbeats as an indication that the process has not become "wedged". When a
+  monitor detects the specified alarm condition, it generates an event
+  notification using the provided ``error`` code and passes along any relevant
+  information. It is up to the caller to register a corresponding event handler
+  (e.g., for ``PMIX_MONITOR_HEARTBEAT_ALERT`` or ``PMIX_MONITOR_FILE_ALERT``).
+* **Resource-usage reporting.** Report resource-usage statistics for processes,
+  nodes, disks, or network interfaces. This can be done on a per-request basis, or
+  updated periodically on a time interval specified by the
+  ``PMIX_MONITOR_RESOURCE_RATE`` directive.
+
+The ``monitor`` argument is an attribute naming the type of monitor being
+requested. The ``directives`` argument characterizes the request (e.g., which file
+to monitor, or the checking interval and number of allowed misses).
+
+A process that is being watched for heartbeats emits them with the companion
+:ref:`PMIx_Heartbeat(3) <man3-PMIx_Heartbeat>` function; a heartbeat may also be
+sent by passing the ``PMIX_SEND_HEARTBEAT`` attribute as the ``monitor`` action.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Process_monitor_nb`` **must**
+keep the ``monitor`` and ``directives`` arrays valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The ``monitor`` argument may carry any of the following actions:
+
+* ``PMIX_MONITOR_HEARTBEAT`` (bool) |mdash| register to have the server monitor the
+  requestor for heartbeats.
+* ``PMIX_SEND_HEARTBEAT`` (bool) |mdash| send a heartbeat to the local server
+  (equivalent to calling :ref:`PMIx_Heartbeat(3) <man3-PMIx_Heartbeat>`). A server
+  is not permitted to use this action and receives ``PMIX_ERR_BAD_PARAM``.
+* ``PMIX_MONITOR_FILE`` (char*) |mdash| register to monitor the named file for signs
+  of life.
+* ``PMIX_MONITOR_PROC_RESOURCE_USAGE`` / ``PMIX_MONITOR_NODE_RESOURCE_USAGE`` /
+  ``PMIX_MONITOR_DISK_RESOURCE_USAGE`` / ``PMIX_MONITOR_NET_RESOURCE_USAGE``
+  (pmix_data_array_t*) |mdash| report usage of the resources specified in the
+  provided array for processes, nodes, disks, or network interfaces respectively.
+* ``PMIX_MONITOR_CANCEL`` (char*) |mdash| cancel a previously requested monitoring
+  action, identified by the string supplied via ``PMIX_MONITOR_ID`` (``NULL``
+  cancels all).
+
+Action-specific directives (placed in the ``directives`` array) include:
+
+* ``PMIX_MONITOR_HEARTBEAT_TIME`` (uint32_t) |mdash| time, in seconds, before a
+  missed heartbeat is declared.
+* ``PMIX_MONITOR_HEARTBEAT_DROPS`` (uint32_t) |mdash| number of heartbeats that may
+  be missed before the alarm is raised.
+* ``PMIX_MONITOR_FILE_SIZE`` (bool) |mdash| track whether the file's size is growing
+  to determine that the application is running.
+* ``PMIX_MONITOR_FILE_ACCESS`` (char*) |mdash| track time since the file was last
+  accessed.
+* ``PMIX_MONITOR_FILE_MODIFY`` (char*) |mdash| track time since the file was last
+  modified.
+* ``PMIX_MONITOR_FILE_CHECK_TIME`` (uint32_t) |mdash| time, in seconds, between file
+  checks.
+* ``PMIX_MONITOR_FILE_DROPS`` (uint32_t) |mdash| number of file checks that may be
+  missed before the alarm is raised.
+* ``PMIX_MONITOR_RESOURCE_RATE`` (uint32_t) |mdash| report resource usage every N
+  seconds.
+* ``PMIX_MONITOR_TARGET_PROCS`` (pmix_data_array_t*) |mdash| array of process IDs
+  identifying the processes to be monitored.
+* ``PMIX_MONITOR_TARGET_PIDS`` (pmix_data_array_t*) |mdash| array of
+  ``pmix_node_pid_t`` structures to be monitored.
+* ``PMIX_MONITOR_TARGET_NODES`` (pmix_data_array_t*) |mdash| array of string host
+  names to be monitored.
+* ``PMIX_MONITOR_TARGET_NODEIDS`` (pmix_data_array_t*) |mdash| array of ``uint32_t``
+  node IDs to be monitored.
+* ``PMIX_MONITOR_TARGET_DISKS`` (pmix_data_array_t*) |mdash| array of disk
+  identifiers to be monitored.
+* ``PMIX_MONITOR_TARGET_NETS`` (pmix_data_array_t*) |mdash| array of network
+  identifiers to be monitored.
+
+General directives that may accompany any action include:
+
+* ``PMIX_MONITOR_ID`` (char*) |mdash| string identifier for this request, used later
+  to cancel it.
+* ``PMIX_MONITOR_APP_CONTROL`` (bool) |mdash| the application wishes to control the
+  response when the monitor is triggered.
+* ``PMIX_MONITOR_LOCAL_ONLY`` (bool) |mdash| restrict data collection to the local
+  host, regardless of any provided targets.
+* ``PMIX_MONITOR_PROXY`` (pmix_proc_t*) |mdash| the process on whose behalf the
+  monitoring is being requested, if different from the caller.
+* ``PMIX_RANGE`` (pmix_data_range_t) |mdash| non-default range to use when
+  generating the associated event for this monitoring action.
+
+When a monitoring request involves other nodes, the library adds the
+``PMIX_USERID`` and ``PMIX_GRPID`` of the requesting process to the directives it
+passes to its host environment.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the request was processed
+without error and that any results have been placed in the ``results`` array. For
+the non-blocking form, a return of ``PMIX_SUCCESS`` indicates only that the request
+was accepted for processing; the final status and any data are delivered to
+``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the request was processed successfully.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, a ``NULL`` ``monitor``, or a server attempting to use
+  ``PMIX_SEND_HEARTBEAT``.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the request involves other nodes but the host
+  environment provides no monitoring support.
+* ``PMIX_ERR_UNREACH`` |mdash| the caller is not a server and its local PMIx server
+  could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+A ``PMIX_SUCCESS`` return only indicates that the request was executed without
+error; it does not guarantee a non-``NULL`` ``results`` array when requesting
+resource-usage statistics. For example, a request for the resource usage of
+processes on a node that is not currently running any user-level processes returns
+success with an empty ``results`` array because no statistics were produced.
+
+Support for individual monitoring actions and directives is implementation- and
+host-environment-dependent.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Heartbeat(3) <man3-PMIx_Heartbeat>`,
+   :ref:`PMIx_Log(3) <man3-PMIx_Log>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Publish.3.rst
+++ b/docs/man/man3/PMIx_Publish.3.rst
@@ -1,0 +1,161 @@
+.. _man3-PMIx_Publish:
+
+PMIx_Publish
+============
+
+.. include_body
+
+``PMIx_Publish``, ``PMIx_Publish_nb`` |mdash| Publish data for later access by
+other processes via :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
+                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the data to publish is a list of Python ``pmix_info_t`` dictionaries;
+  # each entry carries the key/value to publish, plus any directives
+  pydata = [{'key': "mykey",
+             'value': {'value': "myvalue", 'val_type': PMIX_STRING}},
+            {'key': PMIX_RANGE,
+             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+  rc = foo.publish(pydata)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures. Each entry conveys either a key/value pair to be published or a
+  directive that qualifies the operation (see `DIRECTIVES`_). A ``NULL`` value is
+  not permitted |mdash| there must be at least one item to publish.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form adds a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+  datastore confirms that the data has been posted.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Publish the data in the ``info`` array for subsequent lookup. Each entry in the
+array that is not a recognized directive is treated as a key/value pair to be
+made available to other processes. Once published, the data can be retrieved by
+any process that meets the access constraints by referring solely to its key
+via :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>` |mdash| neither the publisher nor
+the eventual recipient need know the identity of the other in advance.
+
+By default, the data is published into the ``PMIX_RANGE_SESSION`` range with
+``PMIX_PERSIST_APP`` persistence. Those defaults, and any additional directives,
+may be changed by including the appropriate attributes in the ``info`` array.
+Attempts to access the data by processes that fall outside the specified range
+are rejected. The ``PMIX_PERSISTENCE`` attribute instructs the datastore how
+long the information is to be retained.
+
+Keys must be unique within the specified data range |mdash| the first published
+value wins. Publishing a duplicate key on the *same* range returns
+``PMIX_ERR_DUPLICATE_KEY``; publishing the same key on *different* ranges is
+permitted.
+
+``PMIx_Publish`` is the blocking form: it does not return until the datastore
+has confirmed that the data is available for lookup. The ``info`` array may be
+released as soon as the blocking call returns.
+
+``PMIx_Publish_nb`` is the non-blocking form: it returns immediately and invokes
+``cbfunc`` when the datastore confirms availability of the data. As with all
+non-blocking PMIx APIs, the caller **must** keep the ``info`` array valid until
+``cbfunc`` is invoked.
+
+The PMIx library automatically adds the publishing process's ``PMIX_USERID`` and
+``PMIX_GRPID`` to the information passed to the host environment; published data
+is constrained to access by that user ID.
+
+
+DIRECTIVES
+----------
+
+The following attributes qualify this operation. PMIx libraries are not required
+to support any of them directly, but must pass any that are provided to the host
+environment; where supported, they are optional for host environments.
+
+* ``PMIX_RANGE`` (pmix_data_range_t) |mdash| define the constraint on which
+  processes may access the published data (e.g., ``PMIX_RANGE_SESSION``,
+  ``PMIX_RANGE_NAMESPACE``, ``PMIX_RANGE_GLOBAL``). Only processes that meet the
+  constraint are allowed to access it. Defaults to ``PMIX_RANGE_SESSION``.
+* ``PMIX_PERSISTENCE`` (pmix_persistence_t) |mdash| declare how long the
+  datastore is to retain the data (e.g., ``PMIX_PERSIST_FIRST_READ``,
+  ``PMIX_PERSIST_PROC``, ``PMIX_PERSIST_APP``, ``PMIX_PERSIST_SESSION``,
+  ``PMIX_PERSIST_INDEF``). Defaults to ``PMIX_PERSIST_APP``.
+* ``PMIX_ACCESS_PERMISSIONS`` (pmix_data_array_t) |mdash| define access
+  permissions for the published data. The value contains an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures specifying the permissions.
+* ``PMIX_ACCESS_USERIDS`` (pmix_data_array_t) |mdash| array of effective user IDs
+  that are allowed to access the published data.
+* ``PMIX_ACCESS_GRPIDS`` (pmix_data_array_t) |mdash| array of effective group IDs
+  that are allowed to access the published data.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the operation to
+  complete before returning an error (0 => infinite).
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the data has been posted
+and is available for lookup. For the non-blocking form, a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing; the
+final status is delivered to ``cbfunc``. A non-blocking call may instead return
+``PMIX_OPERATION_SUCCEEDED`` to indicate that the request was immediately
+processed and succeeded, in which case ``cbfunc`` will **not** be called.
+
+* ``PMIX_SUCCESS`` |mdash| the data has been published.
+* ``PMIX_ERR_DUPLICATE_KEY`` |mdash| a provided key has already been published on
+  the same data range.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, a ``NULL`` ``info`` array.
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Because published data is constrained by both range and user ID,
+:ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>` will only return data published by the
+same user whose range includes the requesting process. Choose the publication
+range deliberately so the intended recipients fall within it.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`,
+   :ref:`PMIx_Unpublish(3) <man3-PMIx_Unpublish>`,
+   :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -1,0 +1,127 @@
+.. _man3-PMIx_Put:
+
+PMIx_Put
+========
+
+.. include_body
+
+``PMIx_Put`` |mdash| Stage a key/value pair for distribution to other processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Put(pmix_scope_t scope,
+                          const char key[],
+                          pmix_value_t *val);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the value is a Python ``pmix_value_t`` dictionary
+  rc = foo.put(PMIX_GLOBAL, "mykey",
+               {'value': 42, 'val_type': PMIX_UINT32})
+
+
+INPUT PARAMETERS
+----------------
+
+* ``scope``: A ``pmix_scope_t`` value describing the distribution scope of the
+  posted data |mdash| i.e., which processes are to be able to access it (see
+  `SCOPE`_).
+* ``key``: A NULL-terminated string identifying the value. The string must be no
+  longer than ``PMIX_MAX_KEYLEN`` characters and must not begin with the reserved
+  prefix ``"pmix"``.
+* ``val``: Pointer to a ``pmix_value_t`` structure containing the value to be
+  posted.
+
+
+DESCRIPTION
+-----------
+
+Post a key-value pair for distribution. The provided value is copied into
+internal memory before ``PMIx_Put`` returns, so the caller may modify or free
+``val`` immediately afterward. The client PMIx library caches the posted value
+locally until ``PMIx_Commit`` (see PMIx_Commit(3)) is called, at which point the
+committed values are pushed to the local PMIx server, which distributes the data
+as directed by each value's scope.
+
+The ``pmix_value_t`` structure supports both string and binary values. PMIx
+implementations support heterogeneous environments by properly converting binary
+values between host architectures.
+
+.. note::
+   Keys beginning with the string ``"pmix"`` are reserved for use by the PMIx
+   Standard and the library. Applications must never use a defined ``PMIX_``
+   attribute |mdash| or any other ``"pmix"``-prefixed string |mdash| as the
+   ``key`` in a call to ``PMIx_Put``; doing so returns ``PMIX_ERR_BAD_PARAM``.
+
+
+SCOPE
+-----
+
+The ``pmix_scope_t`` value passed as ``scope`` determines which processes are
+able to access the posted data. It is a ``uint8_t`` type taking one of the
+following values:
+
+* ``PMIX_LOCAL`` |mdash| the data is intended only for other application
+  processes on the same node. It is not included in data packages sent to remote
+  requesters.
+* ``PMIX_REMOTE`` |mdash| the data is intended solely for application processes on
+  remote nodes. It is not shared with other processes on the same node.
+* ``PMIX_GLOBAL`` |mdash| the data is to be shared with all other requesting
+  processes, regardless of location.
+* ``PMIX_INTERNAL`` |mdash| the data is intended solely for this process and is
+  not shared with any other process. Typically used to cache data the process
+  obtained by means outside of PMIx.
+
+A specific implementation may support additional scope values, but all
+implementations support at least ``PMIX_GLOBAL``. If a specified scope value is
+not supported, ``PMIx_Put`` returns ``PMIX_ERR_NOT_SUPPORTED``.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_BAD_PARAM`` |mdash| the ``key`` is ``NULL``, exceeds
+  ``PMIX_MAX_KEYLEN``, or uses the reserved ``"pmix"`` prefix.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the requested ``scope`` is not supported by
+  the implementation.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_Put`` only stages data locally; the values are not made available to other
+processes until they are committed with ``PMIx_Commit`` (see PMIx_Commit(3)) and,
+typically, a subsequent synchronization such as ``PMIx_Fence`` (see PMIx_Fence(3))
+has completed.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   PMIx_Commit(3),
+   PMIx_Get(3),
+   PMIx_Fence(3),
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :ref:`pmix_value_t(5) <man5-pmix_value_t>`

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -121,7 +121,7 @@ and, typically, a subsequent synchronization such as
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
-   PMIx_Get(3),
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -53,9 +53,9 @@ DESCRIPTION
 Post a key-value pair for distribution. The provided value is copied into
 internal memory before ``PMIx_Put`` returns, so the caller may modify or free
 ``val`` immediately afterward. The client PMIx library caches the posted value
-locally until ``PMIx_Commit`` (see PMIx_Commit(3)) is called, at which point the
-committed values are pushed to the local PMIx server, which distributes the data
-as directed by each value's scope.
+locally until :ref:`PMIx_Commit(3) <man3-PMIx_Commit>` is called, at which point
+the committed values are pushed to the local PMIx server, which distributes the
+data as directed by each value's scope.
 
 The ``pmix_value_t`` structure supports both string and binary values. PMIx
 implementations support heterogeneous environments by properly converting binary
@@ -113,15 +113,15 @@ NOTES
 -----
 
 ``PMIx_Put`` only stages data locally; the values are not made available to other
-processes until they are committed with ``PMIx_Commit`` (see PMIx_Commit(3)) and,
-typically, a subsequent synchronization such as ``PMIx_Fence`` (see PMIx_Fence(3))
-has completed.
+processes until they are committed with :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`
+and, typically, a subsequent synchronization such as
+:ref:`PMIx_Fence(3) <man3-PMIx_Fence>` has completed.
 
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
-   PMIx_Commit(3),
+   :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
    PMIx_Get(3),
-   PMIx_Fence(3),
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -1,0 +1,210 @@
+.. _man3-PMIx_Query_info:
+
+PMIx_Query_info
+===============
+
+.. include_body
+
+``PMIx_Query_info``, ``PMIx_Query_info_nb`` |mdash| Query information about the
+system in general.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nqueries,
+                                 pmix_info_t **results, size_t *nresults);
+
+   pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
+                                    pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # each query is a dict with a list of key strings and a list of
+  # ``pmix_info_t`` qualifier dictionaries
+  pyq = [{'keys': [PMIX_QUERY_NAMESPACES],
+          'qualifiers': []}]
+  rc, results = foo.query(pyq)
+  # results is a list of Python ``pmix_info_t`` dictionaries
+
+
+INPUT PARAMETERS
+----------------
+
+* ``queries``: Array of ``pmix_query_t`` structures. Each structure carries a
+  NULL-terminated array of string ``keys`` identifying the information being
+  requested, plus an optional array of ``qualifiers`` (a ``pmix_info_t`` array
+  with ``nqual`` elements) that refine or scope those keys (see `DIRECTIVES`_).
+* ``nqueries``: Number of elements in the ``queries`` array. Must be non-zero, and
+  ``queries`` must be non-``NULL``.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``results`` (blocking form): Address where a pointer to a freshly allocated
+  array of ``pmix_info_t`` holding the results is returned. Set to ``NULL`` when no
+  data is returned. The caller must release the array with ``PMIX_INFO_FREE``.
+* ``nresults`` (blocking form): Address where the number of elements in
+  ``results`` is returned; set to zero when no data is returned.
+
+The non-blocking form replaces ``results``/``nresults`` with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+  status and result array once the query completes.
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Query information about the system in general. This can include a list of active
+namespaces, the fabric topology, or node-specific information such as the list of
+peers executing on a given node. Unlike :ref:`PMIx_Get(3) <man3-PMIx_Get>`, which
+retrieves a single key value scoped to a specific session, job, application,
+process, or node, ``PMIx_Query_info`` supports multiple keys per request, complex
+search criteria expressed through qualifiers, and dynamic system-level information
+that is not part of the job data provided at start of execution.
+
+``PMIx_Query_info`` is the blocking form: it does not return until the query has
+completed, at which point ``results`` and ``nresults`` are set. ``PMIx_Query_info_nb``
+is the non-blocking form: it returns immediately after accepting the request for
+processing, and the provided ``cbfunc`` is invoked with the final status and result
+array. The blocking form is implemented in terms of the non-blocking form.
+
+The library first attempts to satisfy each key from its local cache. Keys that
+cannot be resolved locally are forwarded to the host environment (via the PMIx
+server) for resolution. A small number of keys |mdash| notably the ABI version
+queries |mdash| are always resolved locally. Results returned from the host
+environment are cached so that subsequent retrievals can succeed with minimal
+overhead; include the ``PMIX_QUERY_REFRESH_CACHE`` qualifier to bypass the cache
+and obtain fresh values.
+
+``PMIx_Query_info`` is normally called between initialization
+(:ref:`PMIx_Init(3) <man3-PMIx_Init>`) and finalization
+(:ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`). As an exception, the blocking form
+may be called **before** initialization when used exclusively with the
+``PMIX_QUERY_STABLE_ABI_VERSION`` and/or ``PMIX_QUERY_PROVISIONAL_ABI_VERSION``
+keys, which are computed entirely within the local library.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Query_info_nb`` **must** keep
+the ``queries`` array valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+Each ``pmix_query_t`` combines a list of **keys** (the information requested) with
+a list of **qualifiers** (attributes that scope or refine the request). The keys
+and qualifiers below are representative of the most commonly used values; an
+implementation is not required to support any particular key, and an unsupported
+key is handled the same way as a key that could not be found.
+
+Commonly used **keys**:
+
+* ``PMIX_QUERY_NAMESPACES`` |mdash| return a comma-delimited list of the active
+  namespaces known to the server.
+* ``PMIX_QUERY_JOB_STATUS`` |mdash| return the status of a specified, currently
+  executing job.
+* ``PMIX_QUERY_QUEUE_LIST`` |mdash| return a list of scheduler queues.
+* ``PMIX_QUERY_PROC_TABLE`` / ``PMIX_QUERY_LOCAL_PROC_TABLE`` |mdash| return the
+  process table (all processes, or only those local to a node) for a namespace.
+* ``PMIX_QUERY_SPAWN_SUPPORT`` |mdash| return a list of the attributes supported by
+  the ``PMIx_Spawn`` API.
+* ``PMIX_QUERY_MEMORY_USAGE`` |mdash| return memory usage statistics.
+* ``PMIX_QUERY_ATTRIBUTE_SUPPORT`` |mdash| return the attributes supported by a
+  named function. Must appear first in the ``keys`` array, followed by the
+  user-level API names (e.g., ``"PMIx_Get"``) whose support is being queried.
+* ``PMIX_QUERY_NUM_PSETS`` / ``PMIX_QUERY_PSET_NAMES`` |mdash| return the number,
+  or the names, of the defined process sets.
+* ``PMIX_QUERY_AVAIL_SERVERS`` |mdash| scan the local node for PMIx servers the
+  caller could connect to.
+* ``PMIX_QUERY_STABLE_ABI_VERSION`` / ``PMIX_QUERY_PROVISIONAL_ABI_VERSION``
+  |mdash| return the stable or provisional Standard ABI version supported by the
+  library. These are resolved locally and may be queried before initialization.
+
+Commonly used **qualifiers**:
+
+* ``PMIX_QUERY_REFRESH_CACHE`` (bool) |mdash| bypass the local cache and retrieve a
+  fresh value, refreshing the cache on return. Required on each query for which
+  current (non-cached) data is needed.
+* ``PMIX_SESSION_INFO`` / ``PMIX_JOB_INFO`` / ``PMIX_APP_INFO`` /
+  ``PMIX_NODE_INFO`` / ``PMIX_PROC_INFO`` (bool) |mdash| scope the query to
+  session-, job-, application-, node-, or process-level information, respectively.
+* ``PMIX_PROCID`` (pmix_proc_t) |mdash| identify the specific process whose
+  information is being requested. The identifier applies to every key in that
+  ``pmix_query_t``.
+* ``PMIX_NSPACE`` (char*) / ``PMIX_RANK`` (pmix_rank_t) |mdash| identify a specific
+  process by namespace and rank. These must be used together. Combining
+  ``PMIX_PROCID`` with either ``PMIX_NSPACE`` or ``PMIX_RANK`` in the same query
+  yields ``PMIX_ERR_BAD_PARAM``.
+* ``PMIX_CLIENT_ATTRIBUTES`` / ``PMIX_SERVER_ATTRIBUTES`` /
+  ``PMIX_HOST_ATTRIBUTES`` / ``PMIX_TOOL_ATTRIBUTES`` (bool) |mdash| when used with
+  ``PMIX_QUERY_ATTRIBUTE_SUPPORT``, select the level(s) of attribute support to
+  report. Omitting all levels is equivalent to requesting every level.
+
+Qualifiers that are not applicable to a given key are ignored.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that all requested data was found
+and returned in ``results``. For the non-blocking form, ``PMIX_SUCCESS`` indicates
+only that the request was accepted for processing; the final status and results are
+delivered to ``cbfunc``. In both cases the possible completion statuses include:
+
+* ``PMIX_SUCCESS`` |mdash| all requested data was found and returned.
+* ``PMIX_ERR_PARTIAL_SUCCESS`` |mdash| only some of the requested data was found;
+  the result array contains an element for each key that returned a value.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| none of the requested data was available.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the host environment does not support this
+  operation.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, ``nqueries`` of zero, a ``NULL`` ``queries`` array, or a conflicting
+  combination of process-identifier qualifiers.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized (and the
+  query was not one of the locally resolvable ABI-version queries).
+
+When a value other than ``PMIX_SUCCESS`` or ``PMIX_ERR_PARTIAL_SUCCESS`` is the
+completion status, the result array is ``NULL`` and its count is zero. Any other
+negative value indicates an appropriate error condition. PMIx error constants are
+defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The returned ``results`` array (blocking form) or the array delivered to ``cbfunc``
+(non-blocking form) is owned by the caller and must be released with
+``PMIX_INFO_FREE`` when no longer needed.
+
+Because a query can carry multiple keys and qualifiers, it is well suited to
+retrieving a multi-attribute block of data in a single request |mdash| something
+the single-key :ref:`PMIx_Get(3) <man3-PMIx_Get>` API cannot do. For a single
+static key value, however, ``PMIx_Get`` is typically faster because it avoids the
+overhead of constructing and processing the ``pmix_query_t`` structure.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`PMIx_Resolve_peers(3) <man3-PMIx_Resolve_peers>`,
+   :ref:`PMIx_Resolve_nodes(3) <man3-PMIx_Resolve_nodes>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Resolve_nodes.3.rst
+++ b/docs/man/man3/PMIx_Resolve_nodes.3.rst
@@ -1,0 +1,114 @@
+.. _man3-PMIx_Resolve_nodes:
+
+PMIx_Resolve_nodes
+==================
+
+.. include_body
+
+``PMIx_Resolve_nodes`` |mdash| Return the list of nodes hosting processes within a
+given namespace.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **nodelist);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # nspace is a string; it may be None to request all namespaces
+  rc, nodes = foo.resolve_nodes("testnspace")
+  # nodes is a comma-delimited string of node names
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nspace``: The namespace whose hosting nodes are to be resolved. A ``NULL``
+  (zero-length) namespace requests the aggregate list of nodes across **all**
+  namespaces known to the library.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``nodelist``: Address of a ``char`` pointer. On success it is set to a freshly
+  allocated, comma-delimited string of the names of the nodes hosting processes in
+  the specified namespace. If no such nodes are found, it is set to ``NULL``. The
+  caller is responsible for releasing the string with ``free`` (or, from Python,
+  the binding releases it automatically).
+
+
+DESCRIPTION
+-----------
+
+Given an ``nspace``, return the list of nodes hosting processes within that
+namespace. The returned string contains a comma-delimited list of node names. If
+``nspace`` is ``NULL``, the returned list is the union of the nodes hosting
+processes across every namespace known to the library, with duplicate node names
+removed. If no matching nodes are found, ``nodelist`` is set to ``NULL`` and the
+call still returns ``PMIX_SUCCESS``.
+
+``PMIx_Resolve_nodes`` is a blocking operation and is provided only in blocking
+form. It is a convenience routine that gives simplified access to a commonly
+requested query; because of that simplified interface it accepts no attributes and
+cannot be further customized. When more specialized control is required, the same
+information can typically be obtained through
+:ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>` using the
+``PMIX_QUERY_RESOLVE_NODE`` key.
+
+As with :ref:`PMIx_Resolve_peers(3) <man3-PMIx_Resolve_peers>`, the library answers
+the request from the most authoritative source available. When the caller is a
+PMIx server, the request is first passed to the host environment; when the caller
+is a client connected to its local server, the request is forwarded to that server.
+If the authoritative source cannot satisfy the request |mdash| for example, an
+older peer that does not recognize the operation |mdash| the library falls back to
+computing the answer from its own local knowledge. A caller that is not connected
+to a server is answered entirely from local data.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success, in which case ``nodelist`` has been set as
+described above (possibly to ``NULL`` if no matching nodes were found). On error, a
+negative value corresponding to a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_UNREACH`` |mdash| the connection to the local PMIx server was lost
+  while servicing the request.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid response was received while servicing
+  the request.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The returned ``nodelist`` string is owned by the caller and must be released with
+``free`` when no longer needed. A ``NULL`` result accompanied by ``PMIX_SUCCESS``
+is the normal indication that no nodes host processes in the requested namespace
+|mdash| it is not an error.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`PMIx_Resolve_peers(3) <man3-PMIx_Resolve_peers>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Resolve_peers.3.rst
+++ b/docs/man/man3/PMIx_Resolve_peers.3.rst
@@ -1,0 +1,120 @@
+.. _man3-PMIx_Resolve_peers:
+
+PMIx_Resolve_peers
+==================
+
+.. include_body
+
+``PMIx_Resolve_peers`` |mdash| Return the array of processes within a specified
+namespace that are executing on a given node.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Resolve_peers(const char *nodename,
+                                    const pmix_nspace_t nspace,
+                                    pmix_proc_t **procs, size_t *nprocs);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # nodename and nspace are strings; either may be None
+  rc, peers = foo.resolve_peers("node01", "testnspace")
+  # peers is a list of Python ``pmix_proc_t`` dictionaries
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nodename``: NULL-terminated name of the node to query. A ``NULL`` value
+  denotes the caller's own local node.
+* ``nspace``: The namespace whose processes are to be resolved on the node. A
+  ``NULL`` (zero-length) namespace requests **all** processes on the node,
+  regardless of namespace.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``procs``: Address of a ``pmix_proc_t`` pointer. On success it is set to a
+  freshly allocated array of process identifiers executing on the specified node.
+  If the node currently hosts no matching processes, the array is set to ``NULL``.
+  The caller is responsible for releasing the array with ``PMIX_PROC_FREE``.
+* ``nprocs``: Address where the number of elements in the ``procs`` array is
+  returned. It is set to zero when no matching processes are found.
+
+
+DESCRIPTION
+-----------
+
+Given a ``nodename``, return the array of processes within the specified
+``nspace`` that are executing on that node. If ``nspace`` is ``NULL``, then all
+processes on the node are returned, aggregated across every namespace known to the
+library. If the specified node does not currently host any matching processes,
+then ``procs`` is set to ``NULL`` and ``nprocs`` to zero |mdash| this is reported
+as ``PMIX_SUCCESS``, not an error.
+
+``PMIx_Resolve_peers`` is a blocking operation and is provided only in blocking
+form. It is a convenience routine that gives simplified access to a commonly
+requested query; because of that simplified interface it accepts no attributes and
+cannot be further customized. When more specialized control is required, the same
+information can typically be obtained through
+:ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>` using the
+``PMIX_QUERY_RESOLVE_PEERS`` key.
+
+The library answers the request from the most authoritative source available. When
+the caller is a PMIx server, the request is first passed to the host environment
+(which has a more global view); when the caller is a client that is connected to
+its local server, the request is forwarded to that server. In either case, if the
+authoritative source cannot satisfy the request |mdash| for example, an older peer
+that does not recognize the operation |mdash| the library falls back to computing
+the answer from its own local knowledge. A caller that is not connected to a server
+is answered entirely from local data.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success, in which case ``procs`` and ``nprocs`` have
+been set as described above (possibly to ``NULL`` and zero if the node hosts no
+matching processes). On error, a negative value corresponding to a PMIx error
+constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_UNREACH`` |mdash| the connection to the local PMIx server was lost
+  while servicing the request.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid response was received while servicing
+  the request.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The returned ``procs`` array is owned by the caller and must be released with
+``PMIX_PROC_FREE`` when no longer needed. An empty result (``NULL`` array,
+``nprocs`` of zero) accompanied by ``PMIX_SUCCESS`` is the normal indication that
+the node hosts no processes in the requested namespace |mdash| it is not an error.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`PMIx_Resolve_nodes(3) <man3-PMIx_Resolve_nodes>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -1,0 +1,134 @@
+.. _man3-PMIx_Resource_block:
+
+PMIx_Resource_block
+===================
+
+.. include_body
+
+``PMIx_Resource_block``, ``PMIx_Resource_block_nb`` |mdash| Define or modify a
+named resource block for use in allocation operations.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t directive,
+                                     char *block,
+                                     const pmix_resource_unit_t *res, size_t nres,
+                                     const pmix_info_t *info, size_t ninfo);
+
+   pmix_status_t PMIx_Resource_block_nb(pmix_resource_block_directive_t directive,
+                                        char *block,
+                                        const pmix_resource_unit_t *res, size_t nres,
+                                        const pmix_info_t *info, size_t ninfo,
+                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+INPUT PARAMETERS
+----------------
+
+* ``directive``: A directive of type ``pmix_resource_block_directive_t``
+  identifying the requested operation on the block (see `DIRECTIVES`_).
+* ``block``: NULL-terminated string naming the resource block. The name must be
+  unique within the requestor's current session.
+* ``res``: Pointer to an array of ``pmix_resource_unit_t`` structures, each of
+  which pairs a device type (``type``, a ``pmix_device_type_t``) with a count
+  (``count``), describing the resources to which the operation applies. A
+  ``NULL`` value is supported when no resource units are required |mdash| for
+  example, when deleting a block.
+* ``nres``: Number of elements in the ``res`` array.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying attributes that qualify the operation. A ``NULL`` value
+  is supported when no attributes are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form adds a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked with the
+  final status once the operation has been processed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Define a named resource "block" that can subsequently be referenced in
+allocation operations, including the ability to define, extend, reduce, and
+delete block definitions. A resource block associates a caller-chosen name with
+a set of resource units (device type and count pairs); the name must be unique
+within the requestor's current session.
+
+``PMIx_Resource_block`` is the blocking form: it does not return until the
+operation is complete, and the return status reflects the outcome.
+``PMIx_Resource_block_nb`` is the non-blocking form: it returns immediately, and
+the provided ``cbfunc`` is invoked with the final status once the operation has
+been processed.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Resource_block_nb``
+**must** keep the ``block``, ``res``, and ``info`` arguments valid until
+``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The ``directive`` argument is a value of type
+``pmix_resource_block_directive_t`` that identifies the requested operation:
+
+* ``PMIX_RESOURCE_BLOCK_DEFINE`` |mdash| define a new resource block.
+* ``PMIX_RESOURCE_BLOCK_EXTEND`` |mdash| extend an existing block definition by
+  adding the specified resources to the block.
+* ``PMIX_RESOURCE_BLOCK_REMOVE`` |mdash| remove the specified resources from the
+  block definition.
+* ``PMIX_RESOURCE_BLOCK_DELETE`` |mdash| delete the resource block definition.
+
+Values at or above ``PMIX_RESOURCE_BLOCK_EXTERNAL`` are reserved for
+implementer-defined directives.
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the operation completed
+successfully. For the non-blocking form, a return of ``PMIX_SUCCESS`` indicates
+only that the request was accepted for processing; the final status is
+delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the operation was successfully processed.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the operation is not supported in the
+  caller's role or environment |mdash| for example, the caller is itself the
+  scheduler, or is a system controller with no scheduler attached.
+* ``PMIX_ERR_UNREACH`` |mdash| the caller is not connected to a server capable
+  of servicing the request.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This operation is only meaningful when the caller can reach a scheduler, either
+because the caller's server is the scheduler or because the caller is a server
+whose host environment provides a resource-block entry point that can forward
+the request. A process hosted directly by the scheduler cannot issue a
+resource-block request against itself and will receive
+``PMIX_ERR_NOT_SUPPORTED``.
+
+``PMIx_Resource_block`` is a PMIx library extension and is not part of the
+published PMIx Standard.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`,
+   :ref:`PMIx_Session_control(3) <man3-PMIx_Session_control>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -1,0 +1,123 @@
+.. _man3-PMIx_Session_control:
+
+PMIx_Session_control
+====================
+
+.. include_body
+
+``PMIx_Session_control`` |mdash| Request a control action be applied to a
+session.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Session_control(uint32_t sessionID,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_SESSION_APP,
+             'value': {'value': "myapp", 'val_type': PMIX_STRING}}]
+  rc = foo.session_control(1, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``sessionID``: A ``uint32_t`` identifying the session to which the control
+  action is to be applied. A value of ``UINT32_MAX`` indicates that the action
+  applies to all sessions under the caller's control.
+* ``directives``: Pointer to an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures describing the control
+  action(s) to be taken. A ``NULL`` value is supported when no directives are
+  desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t``. If ``NULL``, the
+  call is treated as a blocking operation; otherwise it is non-blocking and the
+  callback is invoked once the request has been processed.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request that a control action be applied to the session identified by
+``sessionID``. The specific action(s) to be taken are conveyed as attributes in
+the ``directives`` array.
+
+``PMIx_Session_control`` supports both blocking and non-blocking operation
+through a single entry point, selected by the ``cbfunc`` argument:
+
+* If ``cbfunc`` is ``NULL``, the call is **blocking**: it does not return until
+  the request has been processed, and the return status reflects the overall
+  outcome of the operation.
+* If ``cbfunc`` is non-``NULL``, the call is **non-blocking**: it returns
+  immediately, and ``cbfunc`` is invoked with the final status and any returned
+  information once the request has been processed. The callback reports whether
+  the request was granted and may supply additional information |mdash| for
+  example, the reason for any denial |mdash| in its array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures.
+
+As with all non-blocking PMIx APIs, when a ``cbfunc`` is supplied the caller
+**must** keep the ``directives`` array valid until ``cbfunc`` is invoked.
+
+
+RETURN VALUE
+------------
+
+For the blocking form (``cbfunc == NULL``), a successful request returns
+``PMIX_OPERATION_SUCCEEDED``. For the non-blocking form, a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing;
+the final status and any data are delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| (non-blocking form) the request was accepted for
+  processing.
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (blocking form) the request was processed
+  successfully.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the operation is not supported in the
+  caller's role or environment |mdash| for example, the caller is a system
+  controller that is not connected to the scheduler.
+* ``PMIX_ERR_UNREACH`` |mdash| the caller is not connected to a server capable
+  of servicing the request.
+* ``PMIX_ERR_COMM_FAILURE`` |mdash| the connection to the server was lost before
+  a result could be returned.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Unlike most PMIx operations, ``PMIx_Session_control`` does not provide a
+separate ``_nb`` entry point; the single API selects blocking versus
+non-blocking behavior based on whether ``cbfunc`` is ``NULL``.
+
+``PMIx_Session_control`` is a PMIx library extension and is not part of the
+published PMIx Standard.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`,
+   :ref:`PMIx_Resource_block(3) <man3-PMIx_Resource_block>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -1,0 +1,283 @@
+.. _man3-PMIx_Spawn:
+
+PMIx_Spawn
+==========
+
+.. include_body
+
+``PMIx_Spawn``, ``PMIx_Spawn_nb`` |mdash| Spawn a new job consisting of one or
+more applications.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
+                            const pmix_app_t apps[], size_t napps,
+                            pmix_nspace_t nspace);
+
+   pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
+                               const pmix_app_t apps[], size_t napps,
+                               pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # jobInfo is a list of Python ``pmix_info_t`` dictionaries
+  jobInfo = [{'key': PMIX_NOTIFY_COMPLETION,
+              'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  # pyapps is a list of Python ``pmix_app_t`` dictionaries; each app
+  # provides at least a command and its argv, plus optional per-app info
+  pyapps = [{'cmd': "hello", 'argv': ["hello", "world"],
+             'maxprocs': 4, 'info': []}]
+  rc, nspace = foo.spawn(jobInfo, pyapps)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``job_info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying job-level directives that apply to the spawned job as a
+  whole (see `DIRECTIVES`_). A ``NULL`` value is supported when no job-level
+  directives are desired.
+* ``ninfo``: Number of elements in the ``job_info`` array.
+* ``apps``: Pointer to an array of ``pmix_app_t`` structures, one per application
+  to be launched. Each ``pmix_app_t`` describes a single application via the
+  following fields:
+
+  * ``cmd`` (char\*) |mdash| the executable to launch.
+  * ``argv`` (char\*\*) |mdash| the ``NULL``-terminated argument vector.
+  * ``env`` (char\*\*) |mdash| a ``NULL``-terminated array of environment
+    variables (in ``name=value`` form) to be set for this application.
+  * ``cwd`` (char\*) |mdash| the working directory in which to start the
+    application's processes.
+  * ``maxprocs`` (int) |mdash| the number of processes to start for this
+    application.
+  * ``info`` / ``ninfo`` |mdash| an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+    structures conveying per-application directives (see `DIRECTIVES`_), and the
+    number of elements in it.
+
+  At least one of ``cmd`` or ``argv`` must be provided in every element; an
+  element that supplies neither causes the operation to fail with
+  ``PMIX_ERR_BAD_PARAM``.
+* ``napps``: Number of elements in the ``apps`` array.
+
+The non-blocking form replaces the ``nspace`` output parameter with a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_spawn_cbfunc_t`` invoked when the
+  applications have been launched (or the launch has failed).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``nspace`` (blocking form): A ``pmix_nspace_t`` (a fixed-size character array of
+  at least ``PMIX_MAX_NSLEN + 1`` bytes) into which the namespace assigned to the
+  newly spawned job is copied on success. Because ``pmix_nspace_t`` is an array,
+  this parameter cannot itself be ``NULL``.
+
+For the non-blocking form, the assigned namespace is instead delivered as the
+``nspace`` argument to ``cbfunc``. That value is not protected after the callback
+returns, so the receiver must copy it if it needs to be retained.
+
+
+DESCRIPTION
+-----------
+
+Spawn a new job consisting of the applications described in the ``apps`` array.
+``PMIx_Spawn`` is the blocking form: it does not return until the job has been
+launched (or the operation fails), at which point the namespace assigned to the
+new job is returned in ``nspace``. ``PMIx_Spawn_nb`` is the non-blocking form: it
+returns immediately, and the provided ``cbfunc`` is invoked with the final status
+and the assigned namespace once the launch completes.
+
+Each element of the ``apps`` array describes one application (multiple elements
+therefore describe an MPMD job launched as a single unit). Directives that apply
+to the job as a whole are passed in ``job_info``; directives that apply to only a
+single application are passed in that application's ``info`` array. Where an
+attribute is meaningful at both levels, a value in an application's ``info`` array
+applies to that application only, while a value in ``job_info`` applies to every
+application in the job.
+
+By default, the spawned processes will be PMIx "connected" to the parent process
+upon successful launch (see :ref:`PMIx_Connect(3) <man3-PMIx_Connect>` for
+details). In practice this means the parent process is given a copy of the new
+job's job-level information |mdash| so it can query that information without
+incurring communication penalties |mdash| and that both the parent and the members
+of the child job receive notification of errors arising anywhere in their combined
+assemblage.
+
+Behavior of individual resource managers may differ, but it is expected that
+failure of any application process to start will result in termination and cleanup
+of *all* processes in the newly spawned job and return of an error code to the
+caller.
+
+As with all non-blocking PMIx APIs, callers of ``PMIx_Spawn_nb`` **must** keep the
+``job_info`` and ``apps`` arrays (and everything they reference) valid until
+``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+PMIx libraries are not required to directly support any attributes for this
+operation; any provided attributes are passed to the host environment for
+processing. Unless otherwise noted, each attribute below may be placed either in
+the ``job_info`` array (to apply to the whole job) or in the ``info`` array of an
+individual ``pmix_app_t`` (to apply to that application only).
+
+Host environments are **required** to support the following attributes when
+present:
+
+* ``PMIX_WDIR`` (char\*) |mdash| working directory in which to start the spawned
+  processes.
+* ``PMIX_SET_SESSION_CWD`` (bool) |mdash| set the application's current working
+  directory to the session working directory assigned by the RM.
+* ``PMIX_PREFIX`` (char\*) |mdash| prefix directory to use when looking for the
+  application's executables and libraries.
+* ``PMIX_HOST`` (char\*) |mdash| comma-delimited list of hosts to use for the
+  spawned processes.
+* ``PMIX_HOSTFILE`` (char\*) |mdash| hostfile naming the resources to use for the
+  spawned processes.
+
+The following attributes are **optional** for host environments that support this
+operation. Placement, mapping, and resource selection:
+
+* ``PMIX_ADD_HOST`` (char\*) / ``PMIX_ADD_HOSTFILE`` (char\*) |mdash| add the named
+  hosts, or the hosts named in the given hostfile, to the existing allocation.
+* ``PMIX_PRELOAD_BIN`` (bool) |mdash| preload the application binaries onto the
+  target nodes.
+* ``PMIX_PRELOAD_FILES`` (char\*) |mdash| comma-delimited list of files to
+  pre-position on the target nodes.
+* ``PMIX_PERSONALITY`` (char\*) |mdash| name of the programming-model personality
+  to assume for the application (e.g., ``"ompi"``).
+* ``PMIX_MAPBY`` (char\*) / ``PMIX_RANKBY`` (char\*) / ``PMIX_BINDTO`` (char\*)
+  |mdash| mapping, ranking, and binding policies for the spawned processes.
+* ``PMIX_PPR`` (char\*) |mdash| number of processes to spawn on each identified
+  resource.
+* ``PMIX_DISPLAY_MAP`` (bool) |mdash| display the resulting process placement map
+  upon spawn.
+* ``PMIX_STDIN_TGT`` (pmix_proc_t\*) |mdash| the process that is to receive
+  forwarded stdin.
+
+Environment control:
+
+* ``PMIX_SET_ENVAR`` / ``PMIX_ADD_ENVAR`` / ``PMIX_PREPEND_ENVAR`` /
+  ``PMIX_APPEND_ENVAR`` (pmix_envar_t\*) |mdash| set, add, prepend to, or append to
+  an environment variable in the spawned processes' environment.
+* ``PMIX_ENVARS_HARVESTED`` (bool) |mdash| indicates that the requestor has already
+  harvested and included the relevant environment variables.
+
+Behavior, restart, and tool support:
+
+* ``PMIX_JOB_RECOVERABLE`` (bool) |mdash| the application supports recoverable
+  operations.
+* ``PMIX_MAX_RESTARTS`` (uint32_t) |mdash| maximum number of times to restart a
+  failed process.
+* ``PMIX_COSPAWN_APP`` (bool) |mdash| the designated application is to be spawned
+  as a disconnected job.
+* ``PMIX_SPAWN_TOOL`` (bool) |mdash| the job being spawned is a tool.
+
+Timeouts:
+
+* ``PMIX_TIMEOUT`` (int) |mdash| time, in seconds, before the operation should be
+  declared to have timed out (``0`` means infinite).
+* ``PMIX_JOB_TIMEOUT`` (int) |mdash| time, in seconds, before the spawned job
+  should time out.
+* ``PMIX_SPAWN_TIMEOUT`` (int) |mdash| time, in seconds, before the spawn operation
+  itself should time out.
+
+Completion and termination notification:
+
+* ``PMIX_NOTIFY_COMPLETION`` (bool) |mdash| notify the parent process when the
+  spawned job terminates, either normally or with an error.
+* ``PMIX_NOTIFY_PROC_TERMINATION`` (bool) |mdash| request that the launcher
+  generate an event when any process in the spawned job terminates.
+
+.. note::
+   Several attributes historically used with ``PMIx_Spawn`` to control output
+   forwarding |mdash| ``PMIX_TAG_OUTPUT``, ``PMIX_TIMESTAMP_OUTPUT``,
+   ``PMIX_MERGE_STDERR_STDOUT``, and ``PMIX_OUTPUT_TO_FILE`` |mdash| as well as
+   ``PMIX_NON_PMI`` (indicating that the spawned processes will not call
+   ``PMIx_Init``) are now deprecated and should not be used in new code. Tools
+   requesting that the spawned job's output be forwarded to them may use
+   ``PMIX_FWD_STDOUT`` / ``PMIX_FWD_STDERR`` (bool), and may forward their own
+   stdin to the spawned processes with ``PMIX_FWD_STDIN`` (bool).
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the job was successfully
+launched and its namespace has been returned in ``nspace``. For the non-blocking
+form, a return of ``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status and assigned namespace are delivered to ``cbfunc``.
+
+* ``PMIX_SUCCESS`` |mdash| the job was successfully launched.
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (non-blocking form) the spawn completed
+  atomically; ``cbfunc`` will **not** be called. In this case ``PMIx_Spawn``
+  returns the assigned namespace in ``nspace``.
+* ``PMIX_ERR_JOB_ALLOC_FAILED`` |mdash| the job could not be executed due to
+  failure to obtain the specified allocation.
+* ``PMIX_ERR_JOB_APP_NOT_EXECUTABLE`` |mdash| the specified executable could not be
+  found or lacks execution privileges.
+* ``PMIX_ERR_JOB_NO_EXE_SPECIFIED`` |mdash| the request did not specify an
+  executable.
+* ``PMIX_ERR_JOB_FAILED_TO_MAP`` |mdash| the launcher was unable to map the
+  processes for the request.
+* ``PMIX_ERR_JOB_FAILED_TO_LAUNCH`` |mdash| one or more processes failed to launch.
+* ``PMIX_ERR_JOB_EXE_NOT_FOUND`` |mdash| the specified executable was not found.
+* ``PMIX_ERR_JOB_INSUFFICIENT_RESOURCES`` |mdash| insufficient resources to spawn
+  the job.
+* ``PMIX_ERR_JOB_SYS_OP_FAILED`` |mdash| a system library operation failed.
+* ``PMIX_ERR_JOB_WDIR_NOT_FOUND`` |mdash| the specified working directory was not
+  found.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
+  example, an ``apps`` element supplying neither a ``cmd`` nor an ``argv``.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the PMIx server has no host environment
+  capable of servicing the spawn request.
+* ``PMIX_ERR_UNREACH`` |mdash| the caller is a tool or client that is not connected
+  to a PMIx server, and no local fork/exec fallback is available.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+A launcher process (such as an intermediate launcher started by a tool) that is
+not connected to a PMIx server defaults to launching the applications via a local
+fork/exec, allowing tools to maintain a single code path for both the connected
+and disconnected cases. A tool or client that is not so privileged and cannot
+reach a server receives ``PMIX_ERR_UNREACH``.
+
+When ``PMIx_Spawn_nb`` returns ``PMIX_OPERATION_SUCCEEDED``, the spawn was
+satisfied atomically and no callback will be made; callers must handle this status
+distinctly from ``PMIX_SUCCESS``. The blocking ``PMIx_Spawn`` absorbs this case
+internally and simply returns ``PMIX_SUCCESS`` with the namespace populated.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Connect(3) <man3-PMIx_Connect>`,
+   :ref:`PMIx_Disconnect(3) <man3-PMIx_Disconnect>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`PMIx_Job_control(3) <man3-PMIx_Job_control>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Unpublish.3.rst
+++ b/docs/man/man3/PMIx_Unpublish.3.rst
@@ -1,0 +1,136 @@
+.. _man3-PMIx_Unpublish:
+
+PMIx_Unpublish
+==============
+
+.. include_body
+
+``PMIx_Unpublish``, ``PMIx_Unpublish_nb`` |mdash| Remove data previously posted
+via :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   pmix_status_t PMIx_Unpublish(char **keys,
+                                const pmix_info_t info[], size_t ninfo);
+
+   pmix_status_t PMIx_Unpublish_nb(char **keys,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # pykeys is a list of key strings to remove (None removes all)
+  pykeys = ["mykey"]
+  # directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_RANGE,
+             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+  rc = foo.unpublish(pykeys, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``keys``: A ``NULL``-terminated array of key strings identifying the published
+  data to remove. A ``NULL`` value instructs the server to remove **all** data
+  published by the calling process.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see `DIRECTIVES`_).
+  A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+The non-blocking form adds a callback:
+
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+  server confirms removal of the specified data.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Remove data previously posted by this process with
+:ref:`PMIx_Publish(3) <man3-PMIx_Publish>`, using the provided ``keys``. A
+``NULL`` ``keys`` array removes all data published by the calling process within
+the specified range.
+
+By default, the range is assumed to be ``PMIX_RANGE_SESSION``. That default, and
+any additional directives, may be changed by including the appropriate attributes
+in the ``info`` array. The range supplied here must match the range under which
+the data was published.
+
+``PMIx_Unpublish`` is the blocking form: it does not return until the server has
+confirmed removal of the data |mdash| after which it is safe to publish the same
+key again within the specified range. ``PMIx_Unpublish_nb`` is the non-blocking
+form: it returns immediately and invokes ``cbfunc`` once the server confirms
+removal. As with all non-blocking PMIx APIs, the caller **must** keep the
+``keys`` and ``info`` arrays valid until ``cbfunc`` is invoked.
+
+The PMIx library automatically adds the requesting process's ``PMIX_USERID`` and
+``PMIX_GRPID`` to the information passed to the host environment; a process can
+only unpublish data that it published.
+
+
+DIRECTIVES
+----------
+
+The following attributes qualify this operation. PMIx libraries are not required
+to support any of them directly, but must pass any that are provided to the host
+environment; where supported, they are optional for host environments.
+
+* ``PMIX_RANGE`` (pmix_data_range_t) |mdash| the range from which the data is to
+  be removed (e.g., ``PMIX_RANGE_SESSION``, ``PMIX_RANGE_NAMESPACE``,
+  ``PMIX_RANGE_GLOBAL``). Must match the range under which the data was
+  published. Defaults to ``PMIX_RANGE_SESSION``.
+* ``PMIX_TIMEOUT`` (int) |mdash| maximum time, in seconds, for the operation to
+  complete before returning an error (0 => infinite).
+
+
+RETURN VALUE
+------------
+
+For the blocking form, ``PMIX_SUCCESS`` indicates that the specified data has
+been removed. For the non-blocking form, a return of ``PMIX_SUCCESS`` indicates
+only that the request was accepted for processing; the final status is delivered
+to ``cbfunc``. A non-blocking call may instead return
+``PMIX_OPERATION_SUCCEEDED`` to indicate that the request was immediately
+processed and succeeded, in which case ``cbfunc`` will **not** be called.
+
+* ``PMIX_SUCCESS`` |mdash| the specified data has been removed.
+* ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Unpublishing is scoped to the publishing process and to the specified range: a
+process cannot remove data published by another process, and the range supplied
+must match the one used at publication time. After a successful unpublish, the
+same key may be published again within that range.
+
+
+.. seealso::
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,
+   :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -13,6 +13,7 @@ APIs (section 3)
    PMIx_Init.3.rst
    PMIx_Initialized.3.rst
    PMIx_Finalize.3.rst
+   PMIx_Put.3.rst
    PMIx_Log.3.rst
    PMIx_Group_construct.3.rst
    PMIx_Group_invite.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -11,6 +11,7 @@ APIs (section 3)
 
    PMIx_Abort.3.rst
    PMIx_Init.3.rst
+   PMIx_Initialized.3.rst
    PMIx_Finalize.3.rst
    PMIx_Log.3.rst
    PMIx_Group_construct.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -15,6 +15,7 @@ APIs (section 3)
    PMIx_Finalize.3.rst
    PMIx_Put.3.rst
    PMIx_Commit.3.rst
+   PMIx_Fence.3.rst
    PMIx_Log.3.rst
    PMIx_Group_construct.3.rst
    PMIx_Group_invite.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -16,6 +16,7 @@ APIs (section 3)
    PMIx_Put.3.rst
    PMIx_Commit.3.rst
    PMIx_Fence.3.rst
+   PMIx_Get.3.rst
    PMIx_Log.3.rst
    PMIx_Group_construct.3.rst
    PMIx_Group_invite.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -17,7 +17,22 @@ APIs (section 3)
    PMIx_Commit.3.rst
    PMIx_Fence.3.rst
    PMIx_Get.3.rst
+   PMIx_Publish.3.rst
+   PMIx_Lookup.3.rst
+   PMIx_Unpublish.3.rst
+   PMIx_Spawn.3.rst
+   PMIx_Connect.3.rst
+   PMIx_Disconnect.3.rst
+   PMIx_Resolve_peers.3.rst
+   PMIx_Resolve_nodes.3.rst
+   PMIx_Query_info.3.rst
    PMIx_Log.3.rst
+   PMIx_Allocation_request.3.rst
+   PMIx_Resource_block.3.rst
+   PMIx_Session_control.3.rst
+   PMIx_Job_control.3.rst
+   PMIx_Process_monitor.3.rst
+   PMIx_Heartbeat.3.rst
    PMIx_Group_construct.3.rst
    PMIx_Group_invite.3.rst
    PMIx_Group_join.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -14,6 +14,7 @@ APIs (section 3)
    PMIx_Initialized.3.rst
    PMIx_Finalize.3.rst
    PMIx_Put.3.rst
+   PMIx_Commit.3.rst
    PMIx_Log.3.rst
    PMIx_Group_construct.3.rst
    PMIx_Group_invite.3.rst


### PR DESCRIPTION
This branch fills in the section-3 (`docs/man/man3`) reference man pages
for the core PMIx client APIs, working down the declarations in
`include/pmix.h` from `PMIx_Init` through `PMIx_Heartbeat`.

Each page is built by combining three sources:

- the header comments and signatures in `include/pmix.h`,
- the actual library implementation under `src/`, and
- the corresponding section of the PMIx Standard.

Where the sources disagree, the **library** behavior is documented (with
the divergence noted where useful). Non-blocking (`_nb`) variants are
documented alongside their blocking forms, and a Python Syntax section is
included wherever `bindings/python` provides a binding.

### Pages added or expanded

Expanded existing stubs: `PMIx_Init`, `PMIx_Finalize`, `PMIx_Abort`.

New pages: `PMIx_Initialized`, `PMIx_Put`, `PMIx_Commit`, `PMIx_Fence`,
`PMIx_Get`, `PMIx_Publish`, `PMIx_Lookup`, `PMIx_Unpublish`, `PMIx_Spawn`,
`PMIx_Connect`, `PMIx_Disconnect`, `PMIx_Resolve_peers`,
`PMIx_Resolve_nodes`, `PMIx_Query_info`, `PMIx_Allocation_request`,
`PMIx_Resource_block`, `PMIx_Session_control`, `PMIx_Job_control`,
`PMIx_Process_monitor`, `PMIx_Heartbeat`.

All new pages are wired into the man3 index and cross-link to sibling
pages via `:ref:`.

### Notes

- `PMIx_Resource_block` and `PMIx_Session_control` are library extensions
  not yet in the Standard; they are documented from `pmix.h` and the code
  alone, each noting that status.
- Deprecated attributes cited by the header or Standard (e.g. the older
  stdout/stderr forwarding keys on `PMIx_Spawn`) are collected into notes
  marking them deprecated rather than presented as current directives.
- Every referenced `PMIX_*` constant was verified against
  `include/pmix_common.h`.
- The docs build cleanly under Sphinx with no new warnings, and all pages
  render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)