### PR TITLE
Return false, not a status code, from the compress wrappers

### DIFF
--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -493,11 +493,11 @@ pmix_status_t PMIx_Data_embed(pmix_data_buffer_t *buffer, const pmix_byte_object
 bool PMIx_Data_compress(const uint8_t *inbytes, size_t size, uint8_t **outbytes, size_t *nbytes)
 {
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
-        return PMIX_ERR_INIT;
+        return false;
     }
 
     if (NULL == inbytes) {
-        return PMIX_ERR_BAD_PARAM;
+        return false;
     }
 
     return pmix_compress.compress(inbytes, size, outbytes, nbytes);
@@ -507,11 +507,11 @@ bool PMIx_Data_decompress(const uint8_t *inbytes, size_t size,
                           uint8_t **outbytes, size_t *nbytes)
 {
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
-        return PMIX_ERR_INIT;
+        return false;
     }
 
     if (NULL == inbytes) {
-        return PMIX_ERR_BAD_PARAM;
+        return false;
     }
 
     return pmix_compress.decompress(outbytes, nbytes, inbytes, size);


### PR DESCRIPTION
`PMIx_Data_compress()` and `PMIx_Data_decompress()` are declared to
return `bool` — `true` if the data was (de)compressed, `false`
otherwise (per the header's `@retval` documentation). Their guard
clauses, however, returned `PMIX_ERR_INIT` and `PMIX_ERR_BAD_PARAM`.

Those are negative integers, so converting them to `bool` yields
`true`: an uninitialized-library or `NULL`-input call reported success
while leaving the caller's `*outbytes` and `*nbytes` untouched. A caller
that trusts the `true` return then reads an uninitialized output pointer
and length.

### Fix

Return `false` from both guards in both functions, so the
"was not (de)compressed" contract documented in the header is honored.

### Testing

A full `make` completes cleanly with no new warnings under the default
`--enable-devel-check` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)