### PR TITLE
Initialize every element in pmix_bfrops_base_tma_coord_create

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -747,14 +747,16 @@ pmix_coord_t* pmix_bfrops_base_tma_coord_create(size_t dims,
     if (PMIX_UNLIKELY(NULL == m)) {
         return NULL;
     }
-    m->view = PMIX_COORD_VIEW_UNDEF;
-    m->dims = dims;
-    if (0 == dims) {
-        m->coord = NULL;
-    } else {
-        m->coord = (uint32_t *)pmix_tma_malloc(tma, dims * sizeof(uint32_t));
-        if (PMIX_LIKELY(NULL != m->coord)) {
-            memset(m->coord, 0, dims * sizeof(uint32_t));
+    for (size_t i = 0; i < number; i++) {
+        m[i].view = PMIX_COORD_VIEW_UNDEF;
+        m[i].dims = dims;
+        if (0 == dims) {
+            m[i].coord = NULL;
+        } else {
+            m[i].coord = (uint32_t *)pmix_tma_malloc(tma, dims * sizeof(uint32_t));
+            if (PMIX_LIKELY(NULL != m[i].coord)) {
+                memset(m[i].coord, 0, dims * sizeof(uint32_t));
+            }
         }
     }
     return m;


### PR DESCRIPTION
## Problem

The array constructor for `pmix_coord_t`
(`pmix_bfrops_base_tma_coord_create`, backing `PMIx_Coord_create`)
allocated storage for `number` elements but only initialized the first
one. Elements `[1 .. number-1]` were left with indeterminate contents.

When such an array was later released with `PMIx_Coord_free`
(`pmix_bfrops_base_tma_coord_free`), the destruct routine read the
uninitialized `coord` pointer of each trailing element and passed the
garbage value to `free()` — undefined behavior, and a likely crash for
any caller that created a multi-element coordinate array.

## Fix

Loop over all `number` elements, giving each the same initialization the
original code applied only to element zero: `view` set to
`PMIX_COORD_VIEW_UNDEF`, `dims` recorded, and a zeroed `coord` array of
the requested dimensionality allocated (or `NULL` when `dims` is zero).
This matches the per-element construct pattern used by the sibling array
constructors, e.g. `pmix_bfrops_base_tma_device_create`.

Full library build is clean with no new warnings.