### PR TITLE
Add man pages for the server and tool APIs

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -344,7 +344,42 @@ PMIX_MAN3 = \
 	PMIx_Rank_valid.3 \
 	PMIx_Multicluster_nspace_construct.3 \
 	PMIx_Multicluster_nspace_parse.3 \
-	PMIx_Setenv.3
+	PMIx_Setenv.3 \
+	PMIx_server_init.3 \
+	PMIx_server_finalize.3 \
+	PMIx_server_register_nspace.3 \
+	PMIx_server_deregister_nspace.3 \
+	PMIx_server_register_client.3 \
+	PMIx_server_deregister_client.3 \
+	PMIx_server_setup_fork.3 \
+	PMIx_server_setup_application.3 \
+	PMIx_server_setup_local_support.3 \
+	PMIx_server_register_resources.3 \
+	PMIx_server_deregister_resources.3 \
+	PMIx_Register_attributes.3 \
+	PMIx_server_dmodex_request.3 \
+	PMIx_server_collect_inventory.3 \
+	PMIx_server_deliver_inventory.3 \
+	PMIx_server_collect_job_info.3 \
+	PMIx_server_IOF_deliver.3 \
+	PMIx_server_generate_cpuset.3 \
+	PMIx_server_generate_cpuset_string.3 \
+	PMIx_server_generate_locality_string.3 \
+	PMIx_server_define_process_set.3 \
+	PMIx_server_delete_process_set.3 \
+	PMIx_generate_regex2.3 \
+	PMIx_parse_regex2.3 \
+	PMIx_tool_init.3 \
+	PMIx_tool_finalize.3 \
+	PMIx_tool_attach_to_server.3 \
+	PMIx_tool_disconnect.3 \
+	PMIx_tool_get_servers.3 \
+	PMIx_tool_is_connected.3 \
+	PMIx_tool_set_server.3 \
+	PMIx_tool_set_server_module.3 \
+	PMIx_IOF_pull.3 \
+	PMIx_IOF_push.3 \
+	PMIx_IOF_deregister.3
 
 
 # The following section-3 pages each document both a blocking API and

--- a/docs/man/man3/PMIx_IOF_deregister.3.rst
+++ b/docs/man/man3/PMIx_IOF_deregister.3.rst
@@ -1,0 +1,127 @@
+.. _man3-PMIx_IOF_deregister:
+
+PMIx_IOF_deregister
+===================
+
+.. include_body
+
+``PMIx_IOF_deregister`` |mdash| Deregister from output previously requested
+via ``PMIx_IOF_pull``.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_IOF_deregister(size_t iofhdlr,
+                                     const pmix_info_t directives[], size_t ndirs,
+                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # ... after a successful foo.iof_pull() that returned refid ...
+  pydirs = []
+  rc = foo.iof_deregister(refid, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``iofhdlr``: The reference identifier returned from the earlier call to
+  :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>` (delivered through that call's
+  registration callback, or as its blocking result) identifying the
+  forwarding request to be canceled.
+* ``directives``: Pointer to an array of :ref:`pmix_info_t(5)
+  <man5-pmix_info_t>` structures conveying directives that control the
+  behavior of the request |mdash| for example, directives regarding the
+  disposition of any data currently in the I/O buffer for the affected
+  processes. A ``NULL`` value is supported when no directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when
+  deregistration has completed. A ``NULL`` value makes the call blocking
+  (see `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Cancel a forwarding request previously established with
+:ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`. The request is thread-shifted
+onto the PMIx progress thread for processing.
+
+When ``cbfunc`` is non-``NULL`` the call is *non-blocking*: it returns
+immediately and the result is delivered later through ``cbfunc``. When
+``cbfunc`` is ``NULL`` the call is *blocking* and the result of the
+operation is carried in the return value.
+
+Note that any I/O being flushed as a result of the deregistration may
+continue to be received after deregistration has completed. Implementations
+are advised to flush any currently buffered I/O upon receipt of the request,
+and to discard all I/O received after that point.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When provided, ``cbfunc`` has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+It is invoked with the final ``status`` of the deregistration and the
+``cbdata`` pointer that was supplied to ``PMIx_IOF_deregister``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status is delivered to ``cbfunc``. A return of
+``PMIX_OPERATION_SUCCEEDED`` indicates that the request was processed
+immediately and successfully, in which case ``cbfunc`` will **not** be
+called.
+
+For the blocking form (``cbfunc`` is ``NULL``), the return value carries the
+result of the operation directly. Error constants that may be returned
+include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| the calling process is a server (that is
+  not also a launcher) and therefore cannot deregister I/O forwarding.
+* ``PMIX_ERR_UNREACH`` |mdash| the tool is not connected to a server.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for
+  the request.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The ``iofhdlr`` passed here must be the identifier returned by the matching
+:ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>` request; passing an unknown
+identifier results in an error.
+
+
+.. seealso::
+   :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
+   :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`,
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_IOF_pull.3.rst
+++ b/docs/man/man3/PMIx_IOF_pull.3.rst
@@ -1,0 +1,208 @@
+.. _man3-PMIx_IOF_pull:
+
+PMIx_IOF_pull
+=============
+
+.. include_body
+
+``PMIx_IOF_pull`` |mdash| Register to receive output forwarded from a set of
+remote processes.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
+                               const pmix_info_t directives[], size_t ndirs,
+                               pmix_iof_channel_t channel,
+                               pmix_iof_cbfunc_t cbfunc,
+                               pmix_hdlr_reg_cbfunc_t regcbfunc,
+                               void *regcbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # ... after a successful foo.init() and attachment to a server ...
+  # the procs is a list of Python ``pmix_proc_t`` dictionaries
+  pyprocs = [{'nspace': "target-nspace", 'rank': PMIX_RANK_WILDCARD}]
+  pydirs = [{'key': PMIX_IOF_TAG_OUTPUT,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  channel = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL
+  # myhdlr is a Python IOF delivery function
+  rc, refid = foo.iof_pull(pyprocs, channel, pydirs, myhdlr)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``procs``: Pointer to an array of :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`
+  identifiers naming the source processes whose output is being requested. A
+  rank of ``PMIX_RANK_WILDCARD`` requests the output of all processes in the
+  specified namespace.
+* ``nprocs``: Number of elements in the ``procs`` array.
+* ``directives``: Pointer to an array of :ref:`pmix_info_t(5)
+  <man5-pmix_info_t>` structures conveying directives that control the
+  behavior of the request (see `DIRECTIVES`_). A ``NULL`` value is supported
+  when no directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``channel``: A :ref:`pmix_iof_channel_t(5) <man5-pmix_iof_channel_t>`
+  bitmask identifying the I/O channels included in the request (for example,
+  ``PMIX_FWD_STDOUT_CHANNEL`` and/or ``PMIX_FWD_STDERR_CHANNEL``).
+  ``PMIX_FWD_STDIN_CHANNEL`` is **not** supported on this path and results in
+  an error.
+* ``cbfunc``: Function of type ``pmix_iof_cbfunc_t`` to be called when
+  forwarded output is received (see `CALLBACK FUNCTION`_). A ``NULL`` value
+  directs that output for the indicated channels be written to this process's
+  own ``stdout``/``stderr`` file descriptors instead of being delivered to a
+  callback.
+* ``regcbfunc``: Registration-completion callback of type
+  ``pmix_hdlr_reg_cbfunc_t``. Because registration is asynchronous, this
+  function is invoked once registration completes, delivering the final
+  status and the reference identifier assigned to the request. A ``NULL``
+  value makes the call blocking (see `DESCRIPTION`_).
+* ``regcbdata``: Opaque pointer passed, unmodified, to ``regcbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Register to receive standard output and/or standard error that the host
+environment forwards from the specified remote processes. The returned
+reference identifier must be retained by the caller; it is the value passed
+to :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>` to cancel the
+request.
+
+The forwarding request is thread-shifted onto the PMIx progress thread for
+processing. Whether the call blocks depends on ``regcbfunc``:
+
+* When ``regcbfunc`` is non-``NULL``, the call is *non-blocking*. On a
+  successful submission the function returns ``PMIX_SUCCESS`` and the
+  registration result |mdash| including the assigned reference identifier
+  |mdash| is delivered later through ``regcbfunc``. If the function returns
+  an error, the request could not be submitted and ``regcbfunc`` will
+  **not** be called.
+* When ``regcbfunc`` is ``NULL``, the call is *blocking*: it does not return
+  until registration has been processed.
+
+As with all non-blocking PMIx APIs, callers **must** keep the ``procs`` and
+``directives`` arrays valid until the registration callback has fired.
+
+
+DIRECTIVES
+----------
+
+The following attributes are required to be supported by PMIx libraries that
+provide I/O forwarding:
+
+* ``PMIX_IOF_CACHE_SIZE`` (uint32_t) |mdash| requested size, in bytes, of the
+  server cache for each specified channel.
+* ``PMIX_IOF_DROP_OLDEST`` (bool) |mdash| in an overflow situation, drop the
+  oldest cached bytes to make room for newly arriving data.
+* ``PMIX_IOF_DROP_NEWEST`` (bool) |mdash| in an overflow situation, drop newly
+  arriving bytes until room becomes available in the cache.
+
+The following attributes are optional:
+
+* ``PMIX_IOF_BUFFERING_SIZE`` (uint32_t) |mdash| control the grouping of
+  output on the specified channel(s) so that data is delivered in blocks of
+  the requested size rather than as it arrives.
+* ``PMIX_IOF_BUFFERING_TIME`` (uint32_t) |mdash| maximum time, in seconds, to
+  buffer output before delivering it, used in conjunction with the buffering
+  size.
+* ``PMIX_IOF_TAG_OUTPUT`` (bool) |mdash| tag each line of output with the
+  identity (namespace/rank) and channel from which it originated.
+* ``PMIX_IOF_TIMESTAMP_OUTPUT`` (bool) |mdash| timestamp the output.
+* ``PMIX_IOF_XML_OUTPUT`` (bool) |mdash| format the output in XML.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When forwarded output becomes available |mdash| or a specified buffering
+size and/or time has been reached |mdash| PMIx invokes the delivery callback
+``cbfunc``:
+
+.. code-block:: c
+
+   typedef void (*pmix_iof_cbfunc_t)(size_t iofhdlr,
+                                     pmix_iof_channel_t channel,
+                                     pmix_proc_t *source,
+                                     pmix_byte_object_t *payload,
+                                     pmix_info_t info[], size_t ninfo);
+
+The parameters carry:
+
+* ``iofhdlr`` |mdash| the reference identifier of the handler being invoked,
+  matching the value returned by the registration.
+* ``channel`` |mdash| a :ref:`pmix_iof_channel_t(5) <man5-pmix_iof_channel_t>`
+  bitmask identifying the channel on which the data arrived.
+* ``source`` |mdash| the namespace/rank of the process that generated the
+  data.
+* ``payload`` |mdash| a :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`
+  containing the data. Note that multiple strings may be present, and the
+  data is **not** guaranteed to be ``NULL``-terminated.
+* ``info`` / ``ninfo`` |mdash| an optional array of metadata provided by the
+  source describing the payload; for example, it may include
+  ``PMIX_IOF_COMPLETE`` to indicate that the channel has been closed.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``regcbfunc`` non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status and the assigned reference identifier are
+delivered to ``regcbfunc``. Any negative return means the request was not
+submitted and ``regcbfunc`` will not be called.
+
+For the blocking form (``regcbfunc`` is ``NULL``), a return of
+``PMIX_OPERATION_SUCCEEDED`` indicates that registration completed
+successfully; a negative value is an error constant.
+
+Error constants that may be returned include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced
+  because the library's progress engine has been stopped.
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| ``PMIX_FWD_STDIN_CHANNEL`` was included
+  in ``channel``; standard input is not supported on this path.
+* ``PMIX_ERR_UNREACH`` |mdash| the request must be sent to a server, but the
+  tool is not connected to one.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for
+  the request.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Standard input is never delivered through this path; it is always delivered
+to the ``stdin`` file descriptor. To forward standard input to a set of
+processes, use :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`.
+
+Use of ``PMIX_RANK_WILDCARD`` to request the output of all processes in a
+namespace is supported but should be used with care due to the bandwidth and
+memory footprint it can incur.
+
+
+.. seealso::
+   :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`,
+   :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>`,
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`pmix_iof_channel_t(5) <man5-pmix_iof_channel_t>`,
+   :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_IOF_push.3.rst
+++ b/docs/man/man3/PMIx_IOF_push.3.rst
@@ -1,0 +1,167 @@
+.. _man3-PMIx_IOF_push:
+
+PMIx_IOF_push
+=============
+
+.. include_body
+
+``PMIx_IOF_push`` |mdash| Push data collected locally (typically from
+standard input) to the standard input of target recipients.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
+                               pmix_byte_object_t *bo,
+                               const pmix_info_t directives[], size_t ndirs,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # ... after a successful foo.init() and attachment to a server ...
+  pytargets = [{'nspace': "target-nspace", 'rank': PMIX_RANK_WILDCARD}]
+  # data carries the bytes to be delivered to the targets' stdin
+  data = {'bytes': "some input text"}
+  pydirs = []
+  rc = foo.iof_push(pytargets, data, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``targets``: Pointer to an array of :ref:`pmix_proc_t(5)
+  <man5-pmix_proc_t>` identifiers naming the processes to which the data is
+  to be delivered. A rank of ``PMIX_RANK_WILDCARD`` directs that all
+  processes in the given namespace receive a copy of the data.
+* ``ntargets``: Number of elements in the ``targets`` array.
+* ``bo``: Pointer to a :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`
+  containing the payload (typically ``stdin`` data) to be delivered. May be
+  ``NULL`` when the call is being used solely to start or stop automatic
+  ``stdin`` collection via directives.
+* ``directives``: Pointer to an array of :ref:`pmix_info_t(5)
+  <man5-pmix_info_t>` structures conveying directives that control the
+  behavior of the request (see `DIRECTIVES`_). A ``NULL`` value is supported
+  when no directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  operation has completed. A ``NULL`` value makes the call blocking (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+``PMIx_IOF_push`` is used in one of three ways:
+
+* to push data the caller has collected itself (typically from ``stdin`` or
+  a file) to the standard input of the target recipients;
+* to request that the PMIx library automatically collect the caller's own
+  ``stdin`` and forward it to the target recipients (via the
+  ``PMIX_IOF_PUSH_STDIN`` directive); or
+* to indicate that automatic collection and transmittal of ``stdin`` is to
+  stop (via the ``PMIX_IOF_COMPLETE`` directive).
+
+The request is thread-shifted onto the PMIx progress thread for processing.
+When ``cbfunc`` is non-``NULL`` the call is *non-blocking*: it returns
+``PMIX_SUCCESS`` immediately and the result is delivered later through
+``cbfunc``. When ``cbfunc`` is ``NULL`` the call is *blocking* and the
+result of the operation is carried in the return value.
+
+Execution of ``cbfunc`` serves as notice that the PMIx library no longer
+requires the caller to maintain the ``bo`` data object; it does **not**
+indicate that the payload has been delivered to the targets. As with all
+non-blocking PMIx APIs, callers **must** keep the ``targets``, ``bo``, and
+``directives`` arguments valid until the callback has fired.
+
+
+DIRECTIVES
+----------
+
+The following attributes are required to be supported by PMIx libraries that
+provide I/O forwarding:
+
+* ``PMIX_IOF_CACHE_SIZE`` (uint32_t) |mdash| requested size, in bytes, of the
+  server cache for each specified channel.
+* ``PMIX_IOF_DROP_OLDEST`` (bool) |mdash| in an overflow situation, drop the
+  oldest cached bytes to make room for newly arriving data.
+* ``PMIX_IOF_DROP_NEWEST`` (bool) |mdash| in an overflow situation, drop newly
+  arriving bytes until room becomes available in the cache.
+
+The following attributes are optional:
+
+* ``PMIX_IOF_BUFFERING_SIZE`` (uint32_t) |mdash| control the grouping of data
+  so that it is delivered in blocks of the requested size.
+* ``PMIX_IOF_BUFFERING_TIME`` (uint32_t) |mdash| maximum time, in seconds, to
+  buffer data before delivering it.
+* ``PMIX_IOF_PUSH_STDIN`` (bool) |mdash| request that the PMIx library collect
+  the ``stdin`` of the caller and forward it to the specified targets. All
+  collected data is sent to the same targets until ``stdin`` is closed or a
+  subsequent ``PMIx_IOF_push`` call carrying ``PMIX_IOF_COMPLETE`` terminates
+  the forwarding.
+* ``PMIX_IOF_COMPLETE`` (bool) |mdash| indicate that forwarding of ``stdin``
+  to the targets is to be terminated.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When provided, ``cbfunc`` has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+It is invoked with the final ``status`` of the operation and the ``cbdata``
+pointer that was supplied to ``PMIx_IOF_push``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status is delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), the return value carries the
+result of the operation |mdash| ``PMIX_SUCCESS`` (or
+``PMIX_OPERATION_SUCCEEDED`` when the request was satisfied immediately) on
+success, or a negative error constant on failure. Error constants that may
+be returned include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Use of ``PMIX_RANK_WILDCARD`` to target all processes in a namespace is
+supported but should be used with care due to the bandwidth and memory
+footprint it can incur.
+
+
+.. seealso::
+   :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
+   :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>`,
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_Register_attributes.3.rst
+++ b/docs/man/man3/PMIx_Register_attributes.3.rst
@@ -1,0 +1,112 @@
+.. _man3-PMIx_Register_attributes:
+
+PMIx_Register_attributes
+========================
+
+.. include_body
+
+``PMIx_Register_attributes`` |mdash| Register the attributes the host
+environment supports for a given server-module function.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_Register_attributes(char *function, char *attrs[]);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # attrs is a list of attribute-name strings supported for the function
+  attrs = ["PMIX_TIMEOUT", "PMIX_WAIT"]
+  rc = foo.register_attributes("allocate", attrs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``function``: The string name of the ``pmix_server_module_t`` function whose
+  supported attributes are being registered |mdash| for example,
+  ``"register_events"``, ``"validate_credential"``, or ``"allocate"``.
+* ``attrs``: A ``NULL``-terminated ``argv``-style array of attribute-name strings
+  supported by the host environment for the specified ``function``.
+
+
+DESCRIPTION
+-----------
+
+Register with the local PMIx server library the attributes that the host
+environment supports for a specific ``pmix_server_module_t`` function. Host
+environments use this API so that, when a client or tool later queries the
+library (via :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>` with the
+``PMIX_QUERY_ATTRIBUTE_SUPPORT`` key) for the attributes supported by a
+user-facing API, the library can accurately report which attributes the host will
+honor.
+
+Attributes registered through this API are recorded at the **host** level
+(``PMIX_HOST_ATTRIBUTES``); the PMIx library separately and automatically
+registers the attributes it supports internally at the client, server, and tool
+levels during initialization. It is the library's responsibility to associate the
+host-registered attributes for a server-module function with their corresponding
+user-facing API and level when answering a query.
+
+This is a **blocking** operation: internally the request is thread-shifted onto
+the progress thread, and the call does not return until the registration has been
+recorded. The ``function`` name and ``attrs`` array are copied by the library, so
+the caller need not keep them valid after the call returns.
+
+Host environments are strongly encouraged to register all supported attributes
+immediately after initializing the library (see
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`), before servicing any user
+requests, so that attribute-support queries are correctly answered from the
+outset.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` when the attributes are successfully registered.
+Otherwise a negative PMIx error constant is returned, including:
+
+* ``PMIX_ERR_REPEAT_ATTR_REGISTRATION`` |mdash| the attributes for this function
+  have already been registered at the host level. Duplicate registration at the
+  same level for a function is not permitted; registrations at different levels
+  are tracked independently.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid registration level was specified
+  internally.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is a server-role API, available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
+
+The signature shown above is that of the OpenPMIx library. The PMIx Standard
+describes an alternative signature for this function that takes an array of
+``pmix_regattr_t`` structures together with a count; the implementation in this
+release accepts the simpler ``NULL``-terminated string array shown here.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :ref:`pmix_regattr_t(5) <man5-pmix_regattr_t>`

--- a/docs/man/man3/PMIx_generate_regex2.3.rst
+++ b/docs/man/man3/PMIx_generate_regex2.3.rst
@@ -1,0 +1,116 @@
+.. _man3-PMIx_generate_regex2:
+
+PMIx_generate_regex2
+====================
+
+.. include_body
+
+``PMIx_generate_regex2`` |mdash| Generate a compressed encoded
+representation of a list of values.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_generate_regex2(const char *input,
+                                      pmix_info_t info[], size_t ninfo,
+                                      pmix_regex2_t *regex);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``input``: A comma-separated list of values (for example, a list of node
+  names) to be encoded.
+* ``info``: Optional array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  directives influencing the encoding (see `DIRECTIVES`_). May be ``NULL``.
+* ``ninfo``: Number of elements in the ``info`` array; zero if none.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``regex``: Pointer to caller-provided storage for a
+  ``pmix_regex2_t`` structure into which the
+  encoded representation is placed. The structure carries a colon-delimited
+  ``type`` string identifying the encoding method, a ``bytes`` buffer
+  holding the encoded representation (which may **not** be
+  NULL-terminated), and a ``len`` giving the number of bytes. The caller is
+  responsible for releasing the returned data (for example, via
+  ``PMIx_Regex2_destruct``).
+
+
+DESCRIPTION
+-----------
+
+Given a comma-separated list of ``input`` values, generate a reduced-size
+representation of the input that can be passed to
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`
+for processing, or expanded again with
+:ref:`PMIx_parse_regex2(3) <man3-PMIx_parse_regex2>`. The order of the
+individual values in the ``input`` string is preserved across the
+generate/parse operation.
+
+``PMIx_generate_regex2`` replaces the deprecated ``PMIx_generate_regex``.
+Rather than returning a raw ``char*`` |mdash| which incorrectly implied a
+NULL-terminated string |mdash| the new API returns a
+``pmix_regex2_t``, which properly conveys that
+the encoded output may be an arbitrary binary byte array. The precise
+encoding is implementation specific; the leading colon-delimited ``type``
+string (e.g., ``"pmix"``, ``"raw"``, or ``"blob"``) identifies the method
+used so that a decoder can select the correct expansion algorithm.
+
+The operation is performed synchronously in the caller's thread; it does
+not thread-shift into the PMIx progress engine and does not invoke a
+callback.
+
+
+DIRECTIVES
+----------
+
+The ``info`` array is provided so that encoding behavior can be tuned or
+extended without changing the API signature. No standardized attributes
+are currently defined for this API; an implementation is free to define
+its own, and unrecognized directives are ignored. Callers that require no
+special handling may pass ``NULL`` / ``0``.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the encoded representation was generated and
+  placed in ``regex``.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| ``regex`` was ``NULL``.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The returned ``pmix_regex2_t`` is owned by the caller and must be released
+when no longer needed. To communicate the encoded representation to a
+remote peer, pack it using ``PMIx_Data_pack`` with the ``PMIX_REGEX2``
+type; the pack/unpack routines handle the encoding-specific framing based
+on the ``type`` prefix.
+
+
+.. seealso::
+   :ref:`PMIx_parse_regex2(3) <man3-PMIx_parse_regex2>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_parse_regex2.3.rst
+++ b/docs/man/man3/PMIx_parse_regex2.3.rst
@@ -1,0 +1,106 @@
+.. _man3-PMIx_parse_regex2:
+
+PMIx_parse_regex2
+=================
+
+.. include_body
+
+``PMIx_parse_regex2`` |mdash| Expand an encoded representation produced by
+``PMIx_generate_regex2`` back into its list of values.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_parse_regex2(const pmix_regex2_t *regex,
+                                   pmix_info_t info[], size_t ninfo,
+                                   char **output);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``regex``: Pointer to a ``pmix_regex2_t`` structure as returned by
+  :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`. Its
+  colon-delimited ``type`` prefix selects the decoding method.
+* ``info``: Optional array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  directives influencing the expansion (see `DIRECTIVES`_). May be
+  ``NULL``.
+* ``ninfo``: Number of elements in the ``info`` array; zero if none.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``output``: Address where a pointer to a freshly allocated,
+  NULL-terminated string containing the comma-separated list of the
+  individual values is returned. The caller is responsible for releasing
+  the returned string with ``free()``.
+
+
+DESCRIPTION
+-----------
+
+Given a ``pmix_regex2_t`` as returned by
+:ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`, expand the
+encoded representation and return a NULL-terminated string of the
+individual values in ``output``. The order of the values is identical to
+the order of the values in the original ``input`` string passed to
+``PMIx_generate_regex2``.
+
+The ``type`` prefix carried by the ``regex`` structure identifies the
+encoding method (e.g., ``"pmix"``, ``"raw"``, or ``"blob"``) so that the
+library can select the corresponding decoder. This is the reciprocal
+operation of :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`.
+
+The operation is performed synchronously in the caller's thread; it does
+not thread-shift into the PMIx progress engine and does not invoke a
+callback.
+
+
+DIRECTIVES
+----------
+
+The ``info`` array is provided so that decoding behavior can be tuned or
+extended without changing the API signature. No standardized attributes
+are currently defined for this API; an implementation is free to define
+its own, and unrecognized directives are ignored. Callers that require no
+special handling may pass ``NULL`` / ``0``.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the encoded representation was expanded and the
+  resulting string returned in ``output``.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| ``regex`` or ``output`` was ``NULL``.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The returned ``output`` string is owned by the caller and must be released
+with ``free()`` when no longer needed.
+
+
+.. seealso::
+   :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_IOF_deliver.3.rst
+++ b/docs/man/man3/PMIx_server_IOF_deliver.3.rst
@@ -1,0 +1,160 @@
+.. _man3-PMIx_server_IOF_deliver:
+
+PMIx_server_IOF_deliver
+=======================
+
+.. include_body
+
+``PMIx_server_IOF_deliver`` |mdash| Pass forwarded I/O to the PMIx server
+library for distribution to its clients.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
+                                         pmix_iof_channel_t channel,
+                                         const pmix_byte_object_t *bo,
+                                         const pmix_info_t info[], size_t ninfo,
+                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  source = {'nspace': "myapp", 'rank': 0}
+  channel = PMIX_FWD_STDOUT_CHANNEL
+  data = {'bytes': "hello world"}
+  pydirs = []
+  rc = foo.iof_deliver(source, channel, data, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``source``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` identifying
+  the process that generated the data being forwarded.
+* ``channel``: The :ref:`pmix_iof_channel_t(5) <man5-pmix_iof_channel_t>`
+  identifying the I/O channel of the data |mdash| e.g.,
+  ``PMIX_FWD_STDOUT_CHANNEL`` or ``PMIX_FWD_STDERR_CHANNEL``.
+* ``bo``: Pointer to a :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`
+  containing the payload to be delivered.
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  conveying optional metadata describing the data (see `DIRECTIVES`_). A
+  ``NULL`` value (with ``ninfo`` of zero) is supported when no metadata is
+  provided.
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+  library no longer requires access to the provided data. A ``NULL`` value makes
+  the call blocking (see `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Pass forwarded I/O |mdash| such as the ``stdout`` or ``stderr`` output of a
+remote process |mdash| into the local PMIx server library for distribution to
+its clients. The library is responsible for determining which of its clients
+have registered (via :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`) to receive
+data from the given ``source`` on the given ``channel``, and for delivering the
+payload only to those clients.
+
+``PMIx_server_IOF_deliver`` supports both blocking and non-blocking operation.
+When ``cbfunc`` is non-``NULL`` the call is **non-blocking**: it thread-shifts
+the request into the library's progress thread, returns immediately, and invokes
+``cbfunc`` once the library no longer needs the provided byte object. When
+``cbfunc`` is ``NULL`` the call is **blocking**: it does not return until the
+operation has completed.
+
+The host RM is required to retain the ``bo`` byte object (and the ``info``
+array) until the callback is executed |mdash| or, in the blocking case, until
+the function returns. If the function returns a non-success status, the library
+did not take ownership and the host may release the data immediately.
+
+
+DIRECTIVES
+----------
+
+The following attributes may appear in the ``info`` array to describe the
+forwarded data. Unrecognized attributes are ignored.
+
+* ``PMIX_IOF_COMPLETE`` (bool) |mdash| indicates that the specified source I/O
+  channel has been closed; no further data will be forwarded from it.
+* ``PMIX_IOF_TAG_OUTPUT`` (bool) |mdash| the output should be tagged with the
+  identity (namespace/rank) and channel of its source.
+* ``PMIX_IOF_RANK_OUTPUT`` (bool) |mdash| the output should be tagged with the
+  rank from which it originated.
+* ``PMIX_IOF_XML_OUTPUT`` (bool) |mdash| the output should be formatted in XML.
+* ``PMIX_IOF_OUTPUT_RAW`` (bool) |mdash| deliver the output without buffering it
+  into complete lines.
+
+
+CALLBACK FUNCTION
+-----------------
+
+For the non-blocking form, the ``cbfunc`` has the signature
+``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` with the final ``status`` and the original
+``cbdata`` once it no longer requires access to the ``bo`` byte object and the
+``info`` array, allowing the host to release them.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` is non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing;
+the final status is delivered through ``cbfunc``. For the blocking form
+(``cbfunc`` is ``NULL``), a return of ``PMIX_OPERATION_SUCCEEDED`` indicates
+that the request was immediately processed and completed successfully |mdash|
+``cbfunc`` is not called. Possible return values include:
+
+* ``PMIX_SUCCESS`` |mdash| (non-blocking form) the request was accepted for
+  processing.
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (blocking form) the operation completed
+  successfully.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  request.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This function is the server-side counterpart to the client I/O-forwarding
+registration API :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`: the host RM
+collects output from remote processes and injects it here, and the library
+routes it to whichever local clients requested it.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
+   :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`,
+   :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`,
+   :ref:`pmix_iof_channel_t(5) <man5-pmix_iof_channel_t>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_collect_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_collect_inventory.3.rst
@@ -1,0 +1,152 @@
+.. _man3-PMIx_server_collect_inventory:
+
+PMIx_server_collect_inventory
+=============================
+
+.. include_body
+
+``PMIx_server_collect_inventory`` |mdash| Collect an inventory of local
+resources through the PMIx server library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                               pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # directives is a list of Python ``pmix_info_t`` dictionaries (may be empty)
+  pydirs = []
+  rc, results = foo.collect_inventory(pydirs)
+  # results is a list of Python ``pmix_info_t`` dictionaries describing the inventory
+
+
+INPUT PARAMETERS
+----------------
+
+* ``directives``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  conveying directives that scope or refine the collection request (see
+  `DIRECTIVES`_). A ``NULL`` value (with ``ndirs`` of zero) is supported when no
+  directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+  collected inventory once the operation completes (see `CALLBACK FUNCTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request that the local PMIx server library collect an inventory of the
+resources available on its node. The set of resources reported depends on the
+PMIx implementation and the plugins built into the library, but typically
+includes network fabric interfaces and GPU devices; the underlying ``pnet`` and
+``pgpu`` frameworks are queried in turn and their contributions aggregated into
+a single result array.
+
+Servers designated as *gateways* (via the ``PMIX_SERVER_GATEWAY`` attribute at
+server initialization) whose plugins support collection of infrastructure
+information |mdash| for example, switch and fabric topology or connectivity
+maps |mdash| shall return that broader information. Plugins on non-gateway
+servers return only the node-local inventory.
+
+``PMIx_server_collect_inventory`` is a **non-blocking** operation: it
+thread-shifts the request into the library's progress thread and returns
+immediately, because gathering inventory may involve lengthy operations. The
+provided ``cbfunc`` is invoked with the assembled inventory once collection is
+complete. Inventory collection is expected to be a rare event |mdash| performed
+at system startup or on command from a system administrator |mdash| with later
+changes handled through smaller, incremental inventory updates.
+
+
+DIRECTIVES
+----------
+
+The ``directives`` array scopes and refines the collection. The specific
+directives honored are determined by the active ``pnet`` and ``pgpu`` plugins
+and are therefore implementation-defined; an unrecognized directive is ignored.
+Directives that are commonly meaningful include:
+
+* ``PMIX_HOSTNAME`` (char*) |mdash| restrict or label the request with respect
+  to a specific host.
+* ``PMIX_NODEID`` (uint32_t) |mdash| restrict or label the request with respect
+  to a specific node identifier.
+
+Whether a server returns node-local inventory only, or also infrastructure
+inventory, is governed by whether it was initialized as a gateway rather than
+by a directive to this call (see `DESCRIPTION`_).
+
+
+CALLBACK FUNCTION
+-----------------
+
+The ``cbfunc`` has the signature ``pmix_info_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_info_cbfunc_t)(pmix_status_t status,
+                                      pmix_info_t *info, size_t ninfo,
+                                      void *cbdata,
+                                      pmix_release_cbfunc_t release_fn,
+                                      void *release_cbdata);
+
+When collection completes, the library invokes ``cbfunc`` with the final
+``status``, an ``info`` array of ``ninfo`` elements describing the collected
+inventory, and the original ``cbdata``. If the node contributed no inventory,
+``info`` is ``NULL`` and ``ninfo`` is zero with a ``status`` of
+``PMIX_SUCCESS``.
+
+The ``info`` array is owned by the PMIx server library. When the host has
+finished consuming it, it **must** invoke the provided ``release_fn`` (passing
+``release_cbdata``) so the library can free the array; the host must not free
+the array itself.
+
+
+RETURN VALUE
+------------
+
+A return of ``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status and the collected inventory are delivered through
+``cbfunc``. Possible immediate return values include:
+
+* ``PMIX_SUCCESS`` |mdash| the request was accepted for processing.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  request.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+
+When an error is returned immediately, ``cbfunc`` is **not** called. Any other
+negative value indicates an appropriate error condition. PMIx error constants
+are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+Collected inventory is intended to be delivered to the library (typically on a
+gateway associated with the system scheduler) via
+:ref:`PMIx_server_deliver_inventory(3) <man3-PMIx_server_deliver_inventory>`
+for storage and subsequent use during allocation and application setup.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_deliver_inventory(3) <man3-PMIx_server_deliver_inventory>`,
+   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_collect_job_info.3.rst
+++ b/docs/man/man3/PMIx_server_collect_job_info.3.rst
@@ -1,0 +1,104 @@
+.. _man3-PMIx_server_collect_job_info:
+
+PMIx_server_collect_job_info
+============================
+
+.. include_body
+
+``PMIx_server_collect_job_info`` |mdash| Collect the job-level information for
+an array of processes into a data buffer.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_collect_job_info(pmix_proc_t *procs, size_t nprocs,
+                                              pmix_data_buffer_t *dbuf);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``procs``: Array of :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structures
+  identifying the processes whose job-level information is to be collected. The
+  library reduces the array to its set of unique namespaces and collects the
+  job-level data for each.
+* ``nprocs``: Number of elements in the ``procs`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``dbuf``: Pointer to a :ref:`pmix_data_buffer_t(5) <man5-pmix_data_buffer_t>`
+  provided by the caller. On success, the buffer is loaded with the packed
+  job-level information |mdash| for each participating namespace, the namespace
+  name followed by its job-level key-value data, wrapped as a byte object. The
+  caller owns the resulting buffer contents and must release them with
+  ``PMIx_Data_buffer_destruct`` (or ``PMIx_Data_buffer_release``) when no longer
+  needed.
+
+
+DESCRIPTION
+-----------
+
+Collect the job-level information already held by the local PMIx server library
+for the namespaces represented in the ``procs`` array, packing it into the
+caller-provided data buffer for transmission or later replay. This is used, for
+example, to bootstrap a peer server with the job-level data it needs for a set
+of processes without requiring a separate registration for each namespace.
+
+For each unique namespace in ``procs``, the library locates the namespace in its
+internal tables and fetches its job-level data |mdash| preferring a local
+client's data store when one exists, otherwise falling back to the server's own
+storage. Namespaces the server does not know are silently skipped. The packed
+result for each namespace is appended to ``dbuf`` as a byte object.
+
+Unlike most server APIs, ``PMIx_server_collect_job_info`` is a **blocking**
+operation and does not take a callback: internally it thread-shifts the request
+into the library's progress thread, waits for completion, and returns the final
+status directly. The output buffer is populated only on a ``PMIX_SUCCESS``
+return.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the job-level information was collected and loaded
+  into ``dbuf``.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| the requested job-level information could not
+  be located for the specified namespace(s).
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+
+On any non-success return, the contents of ``dbuf`` are unspecified and must
+not be used. Any other negative value indicates an appropriate error condition.
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is an OpenPMIx server-library extension; it is not part of the PMIx
+Standard. It is available only after the server library has been initialized
+with :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_data_buffer_t(5) <man5-pmix_data_buffer_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_define_process_set.3.rst
+++ b/docs/man/man3/PMIx_server_define_process_set.3.rst
@@ -1,0 +1,108 @@
+.. _man3-PMIx_server_define_process_set:
+
+PMIx_server_define_process_set
+==============================
+
+.. include_body
+
+``PMIx_server_define_process_set`` |mdash| Define a PMIx process set.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members,
+                                                size_t nmembers,
+                                                const char *pset_name);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # members is a list of proc dicts, each {'nspace': ns, 'rank': r}
+  members = [{'nspace': 'myjob', 'rank': 0},
+             {'nspace': 'myjob', 'rank': 1}]
+  rc = foo.define_process_set(members, 'myset')
+
+
+INPUT PARAMETERS
+----------------
+
+* ``members``: Pointer to an array of :ref:`pmix_proc_t(5)
+  <man5-pmix_proc_t>` structures containing the identifiers of the
+  processes that are members of the process set.
+* ``nmembers``: Number of elements in the ``members`` array.
+* ``pset_name``: NULL-terminated string name of the process set being
+  defined.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment can create a named
+*process set* |mdash| a user-defined grouping of processes identified by a
+string name and an associated membership list. Unlike a PMIx group (see
+``PMIx_Group_construct``), a process set is purely a label applied by the
+host environment; it establishes no collective context and requires no
+participation by the member processes.
+
+When called, the PMIx server library records the process set (name and
+membership) so that it can later respond to client queries such as
+``PMIX_QUERY_NUM_PSETS`` and ``PMIX_QUERY_PSET_NAMES``, and it alerts all
+local clients to the new process set by generating a
+``PMIX_PROCESS_SET_DEFINE`` event. The event carries the ``PMIX_PSET_NAME``
+attribute (the set name) and the ``PMIX_PSET_MEMBERS`` attribute (a
+``pmix_data_array_t`` of the member ``pmix_proc_t`` identifiers).
+
+``PMIx_server_define_process_set`` is a blocking call. Internally it
+thread-shifts the request onto the PMIx progress thread, records the set,
+emits the local notification, and returns once that processing is
+complete. The input ``members`` array need only remain valid for the
+duration of the call; the library retains its own copy of the membership.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the process set was defined and the local
+  notification was issued.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been
+  initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the library's progress engine has
+  been stopped, so the request cannot be serviced.
+
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This API is restricted to the server role and must be called only after a
+successful :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
+
+The host environment is responsible for ensuring consistent knowledge of
+process set membership across all involved PMIx servers, and for ensuring
+that process set names do not conflict with system-assigned namespaces
+within the scope of the set. The PMIx library only records and advertises
+the definition on the local server; it does not propagate it to peer
+servers.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_delete_process_set(3) <man3-PMIx_server_delete_process_set>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_delete_process_set.3.rst
+++ b/docs/man/man3/PMIx_server_delete_process_set.3.rst
@@ -1,0 +1,94 @@
+.. _man3-PMIx_server_delete_process_set:
+
+PMIx_server_delete_process_set
+==============================
+
+.. include_body
+
+``PMIx_server_delete_process_set`` |mdash| Delete a PMIx process set name.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_delete_process_set(char *pset_name);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  rc = foo.delete_process_set('myset')
+
+
+INPUT PARAMETERS
+----------------
+
+* ``pset_name``: NULL-terminated string name of the process set being
+  deleted.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment can delete a process set
+name previously created with
+:ref:`PMIx_server_define_process_set(3)
+<man3-PMIx_server_define_process_set>`. Deleting the name has no impact on
+the member processes themselves |mdash| it simply removes the label and
+its associated membership record from the local PMIx server.
+
+When called, the PMIx server library alerts all local clients to the
+deletion by generating a ``PMIX_PROCESS_SET_DELETE`` event carrying the
+``PMIX_PSET_NAME`` attribute (the name of the deleted set), then removes
+the corresponding entry from its internal list of process sets. If no set
+with the given name is currently recorded, the notification is still
+issued and the call completes successfully.
+
+``PMIx_server_delete_process_set`` is a blocking call. Internally it
+thread-shifts the request onto the PMIx progress thread, emits the local
+notification, removes the recorded set, and returns once that processing
+is complete.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the deletion was processed and the local
+  notification was issued.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been
+  initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the library's progress engine has
+  been stopped, so the request cannot be serviced.
+
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This API is restricted to the server role and must be called only after a
+successful :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
+
+The host environment is responsible for ensuring consistent knowledge of
+process set membership across all involved PMIx servers. The PMIx library
+only removes the definition on the local server; it does not propagate the
+deletion to peer servers.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_define_process_set(3) <man3-PMIx_server_define_process_set>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_deliver_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_deliver_inventory.3.rst
@@ -1,0 +1,146 @@
+.. _man3-PMIx_server_deliver_inventory:
+
+PMIx_server_deliver_inventory
+=============================
+
+.. include_body
+
+``PMIx_server_deliver_inventory`` |mdash| Deliver collected inventory to the
+PMIx server library for storage.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_deliver_inventory(pmix_info_t info[], size_t ninfo,
+                                               pmix_info_t directives[], size_t ndirs,
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # info carries the inventory to store; directives scope the request
+  pyinfo = [{'key': PMIX_HOSTNAME,
+             'value': {'value': "node01", 'val_type': PMIX_STRING}}]
+  pydirs = []
+  rc = foo.deliver_inventory(pyinfo, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  containing the inventory to be stored |mdash| typically the data previously
+  returned by
+  :ref:`PMIx_server_collect_inventory(3) <man3-PMIx_server_collect_inventory>`.
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``directives``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  conveying directives that scope or refine the storage request (see
+  `DIRECTIVES`_). A ``NULL`` value (with ``ndirs`` of zero) is supported when no
+  directives are desired.
+* ``ndirs``: Number of elements in the ``directives`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+  library no longer requires access to the provided data. A ``NULL`` value makes
+  the call blocking (see `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Deliver inventory information |mdash| obtained from a node via a prior call to
+:ref:`PMIx_server_collect_inventory(3) <man3-PMIx_server_collect_inventory>`
+|mdash| to the PMIx server library for storage by the corresponding plugins.
+The library forwards the data to its ``pnet`` and ``pgpu`` frameworks for
+archiving.
+
+This function is typically executed on a *gateway* server associated with the
+system scheduler, so that the stored inventory can be used by the scheduling
+algorithm and by the library when responding to
+:ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`.
+It may also be used on compute nodes to store a broader picture of the system
+for access by applications (for example, via the
+:ref:`PMIx_Get(3) <man3-PMIx_Get>` API, depending on the implementation).
+
+``PMIx_server_deliver_inventory`` supports both blocking and non-blocking
+operation. When ``cbfunc`` is non-``NULL`` the call is **non-blocking**: it
+thread-shifts the request into the library's progress thread, returns
+immediately, and invokes ``cbfunc`` once the library no longer needs the
+provided data. When ``cbfunc`` is ``NULL`` the call is **blocking**: it does
+not return until the operation has completed. In either case the caller must
+keep the ``info`` and ``directives`` arrays valid until the library has
+finished with them |mdash| until ``cbfunc`` fires in the non-blocking case, or
+until the function returns in the blocking case.
+
+
+DIRECTIVES
+----------
+
+The ``directives`` array scopes and refines the storage request. The specific
+directives honored are determined by the active ``pnet`` and ``pgpu`` plugins
+and are therefore implementation-defined; an unrecognized directive is ignored.
+Directives that are commonly meaningful include:
+
+* ``PMIX_HOSTNAME`` (char*) |mdash| associate the delivered inventory with a
+  specific host.
+* ``PMIX_NODEID`` (uint32_t) |mdash| associate the delivered inventory with a
+  specific node identifier.
+
+
+CALLBACK FUNCTION
+-----------------
+
+For the non-blocking form, the ``cbfunc`` has the signature
+``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` with the final ``status`` of the storage
+operation and the original ``cbdata`` once it no longer requires access to the
+``info`` and ``directives`` arrays.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` is non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing;
+the final status is delivered through ``cbfunc``. For the blocking form
+(``cbfunc`` is ``NULL``), a return of ``PMIX_OPERATION_SUCCEEDED`` indicates
+that the request was immediately processed and completed successfully |mdash|
+``cbfunc`` is not called. Possible return values include:
+
+* ``PMIX_SUCCESS`` |mdash| (non-blocking form) the request was accepted for
+  processing.
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| (blocking form) the operation completed
+  successfully.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  request.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_collect_inventory(3) <man3-PMIx_server_collect_inventory>`,
+   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_deregister_client.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_client.3.rst
@@ -1,0 +1,105 @@
+.. _man3-PMIx_server_deregister_client:
+
+PMIx_server_deregister_client
+=============================
+
+.. include_body
+
+``PMIx_server_deregister_client`` |mdash| Deregister a local client and purge
+all data relating to it.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   void PMIx_server_deregister_client(const pmix_proc_t *proc,
+                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after registering the client ...
+  foo.deregister_client({'nspace': "myjob", 'rank': 0})
+
+
+INPUT PARAMETERS
+----------------
+
+* ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure
+  identifying the client by namespace and rank.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  deregistration completes. A ``NULL`` value makes the call *blocking* (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Deregister the specified client and purge all data relating to it from the PMIx
+server library.
+
+This API is intended primarily for *exception cases*. In normal operation,
+:ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`
+deletes all client information for a namespace, and the PMIx server library
+automatically performs that cleanup once all local clients of a namespace have
+disconnected. ``PMIx_server_deregister_client`` is therefore needed only when a
+single client must be removed while its namespace remains active |mdash| though
+it may be called in non-exception cases if desired.
+
+Like other server registration APIs, this call thread-shifts the request onto
+the library's internal progress thread and supports both a non-blocking and a
+blocking mode, selected by the ``cbfunc`` argument:
+
+* When ``cbfunc`` is **non-**\ ``NULL``, the call is *non-blocking*: the
+  request is posted to the progress thread and the function returns
+  immediately, with ``cbfunc`` invoked once the client has been removed.
+* When ``cbfunc`` is ``NULL``, the call is *blocking*: the function does not
+  return until the deregistration is complete.
+
+Because the function returns ``void``, callers that need to know the outcome
+must supply a ``cbfunc`` and inspect the status delivered to it.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` from its progress thread once the client has
+been purged. ``status`` is ``PMIX_SUCCESS`` on success (including the case in
+which the named client or namespace was not found, which is treated as nothing
+to do). If the library was never initialized, the callback (if provided) is
+invoked with ``PMIX_ERR_INIT``; if memory for the request could not be
+allocated, it is invoked with ``PMIX_ERR_NOMEM``. ``cbdata`` is the opaque
+pointer passed to ``PMIx_server_deregister_client``.
+
+
+NOTES
+-----
+
+If the PMIx server library's progress engine has already been stopped (for
+example, during finalize), the request is silently dropped and any provided
+``cbfunc`` is not invoked.
+
+
+.. seealso::
+   :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,
+   :ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`,
+   :ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_deregister_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_nspace.3.rst
@@ -1,0 +1,107 @@
+.. _man3-PMIx_server_deregister_nspace:
+
+PMIx_server_deregister_nspace
+=============================
+
+.. include_body
+
+``PMIx_server_deregister_nspace`` |mdash| Deregister a namespace and purge all
+data relating to it.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   void PMIx_server_deregister_nspace(const pmix_nspace_t nspace,
+                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after registering the namespace ...
+  foo.deregister_nspace("myjob")
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nspace``: The namespace (a character array of maximum length
+  ``PMIX_MAX_NSLEN``) to deregister.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  deregistration completes. A ``NULL`` value makes the call *blocking* (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Deregister the specified namespace and purge all objects relating to it,
+including any client information for processes in that namespace. This is
+intended to support persistent PMIx servers by giving the host resource manager
+an opportunity to tell the PMIx server library to release all memory associated
+with a completed job.
+
+Like :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+this call thread-shifts the request onto the library's internal progress
+thread, where the purge is actually performed. It supports both a non-blocking
+and a blocking mode, selected by the ``cbfunc`` argument:
+
+* When ``cbfunc`` is **non-**\ ``NULL``, the call is *non-blocking*: the
+  request is posted to the progress thread and the function returns
+  immediately, with ``cbfunc`` invoked once the namespace has been purged. The
+  caller need not retain any data across the call.
+* When ``cbfunc`` is ``NULL``, the call is *blocking*: the function does not
+  return until the deregistration is complete.
+
+Because the function returns ``void``, callers that need to know the outcome
+must supply a ``cbfunc`` and inspect the status delivered to it.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` from its progress thread once the namespace has
+been purged. ``status`` is ``PMIX_SUCCESS`` on success, or a negative PMIx
+error constant otherwise. In particular, if the library was never initialized
+the callback (if provided) is invoked with ``PMIX_ERR_INIT``. ``cbdata`` is the
+opaque pointer passed to ``PMIx_server_deregister_nspace``.
+
+
+NOTES
+-----
+
+Deregistering a namespace automatically deletes all client information for that
+namespace |mdash| there is no need to individually deregister its clients
+first. Use
+:ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`
+only for exception cases where a single client must be removed while the
+namespace remains active.
+
+If the PMIx server library's progress engine has already been stopped (for
+example, during finalize), the request is silently dropped and any provided
+``cbfunc`` is not invoked.
+
+
+.. seealso::
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`,
+   :ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`,
+   :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -1,0 +1,147 @@
+.. _man3-PMIx_server_deregister_resources:
+
+PMIx_server_deregister_resources
+================================
+
+.. include_body
+
+``PMIx_server_deregister_resources`` |mdash| Remove non-namespace-related
+information from the local PMIx server library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
+                                                  pmix_op_cbfunc_t cbfunc,
+                                                  void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # only the keys of the directives are significant here
+  directives = [{'key': PMIX_CLUSTER_ID,
+                 'value': {'value': "cluster-a", 'val_type': PMIX_STRING}}]
+  rc = foo.deregister_resources(directives)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  identifying the information to be removed. Only the ``key`` field of each element
+  is used to select what to remove; the associated values are ignored except where
+  they serve as qualifiers (see `DIRECTIVES`_).
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  operation completes. A ``NULL`` value makes the call **blocking** (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Remove information about resources not associated with a given namespace |mdash|
+previously registered with
+:ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`
+|mdash| from the local PMIx server library. Only the ``key`` fields of the
+provided ``info`` array are used to identify the entries to remove; the
+associated values are ignored except where they serve as qualifiers to the
+request. Each matching entry is located in the server's global data cache and
+deleted.
+
+For example, to remove a specific fabric device from a given node, the ``info``
+array might include a ``PMIX_NODE_INFO_ARRAY`` containing the ``PMIX_NODEID`` or
+``PMIX_HOSTNAME`` that identifies the node hosting the device, together with a
+``PMIX_FABRIC_DEVICE_NAME`` specifying the device. Alternatively, the device may
+be removed using only its ``PMIX_DEVICE_ID``, which is unique across the entire
+system.
+
+``PMIx_server_deregister_resources`` supports both calling conventions. When
+``cbfunc`` is non-``NULL`` the function is **non-blocking**: the request is
+thread-shifted onto the progress thread, the function returns ``PMIX_SUCCESS``,
+and ``cbfunc`` is invoked with the completion status. When ``cbfunc`` is ``NULL``
+the function is **blocking**: it does not return until the operation completes,
+returning ``PMIX_OPERATION_SUCCEEDED`` on success.
+
+As with all non-blocking PMIx APIs, when a callback is supplied the caller
+**must** keep the ``info`` array valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The ``key`` of each ``info`` element selects the entry to remove. Qualifiers may
+be included to scope the removal, for example:
+
+* ``PMIX_NODE_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| scope the removal to a
+  specific node, identified within the array by ``PMIX_NODEID`` or
+  ``PMIX_HOSTNAME``.
+* ``PMIX_FABRIC_DEVICE_NAME`` (char*) |mdash| the name of a fabric device to
+  remove.
+* ``PMIX_DEVICE_ID`` (char*) |mdash| a system-unique device identifier; sufficient
+  on its own to remove the corresponding device.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+It is invoked with the completion ``status`` of the deregistration and the
+``cbdata`` originally passed to ``PMIx_server_deregister_resources``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` non-``NULL``), a return of ``PMIX_SUCCESS``
+indicates only that the request was accepted for processing; the final status is
+delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), a return of
+``PMIX_OPERATION_SUCCEEDED`` indicates that the operation completed successfully
+and no callback is invoked. Other returns include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is a server-role API, available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. Because non-namespace
+resource information is static, deregistration is **not** required before
+finalizing the library |mdash| the library cleans up such information as part of
+its normal finalize operations. Deregistration is needed only when the host
+environment determines that client processes should no longer have access to the
+information.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_dmodex_request.3.rst
+++ b/docs/man/man3/PMIx_server_dmodex_request.3.rst
@@ -1,0 +1,143 @@
+.. _man3-PMIx_server_dmodex_request:
+
+PMIx_server_dmodex_request
+==========================
+
+.. include_body
+
+``PMIx_server_dmodex_request`` |mdash| Request locally posted modex data
+for a specified process on behalf of a remote peer.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
+                                            pmix_dmodex_response_fn_t cbfunc,
+                                            void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # proc identifies the process whose posted data is being requested
+  proc = {'nspace': "myapp", 'rank': 3}
+  rc, (data, sz) = foo.dmodex_request(proc, {})
+  # data/sz carry the returned blob when rc is PMIX_SUCCESS
+
+
+INPUT PARAMETERS
+----------------
+
+* ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` identifying
+  the process whose posted data is being requested. A rank of
+  ``PMIX_RANK_WILDCARD`` requests the job-level information for the namespace
+  rather than the data posted by a specific process. Must not be ``NULL``.
+* ``cbfunc``: Callback function of type ``pmix_dmodex_response_fn_t`` that is
+  invoked with the requested data once it becomes available. Must not be
+  ``NULL``.
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Request that the local PMIx server library return the modex data (endpoint
+and other connection information posted via :ref:`PMIx_Put(3) <man3-PMIx_Put>`
+and committed via :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`) for a specified
+process on behalf of a remote peer.
+
+PMIx supports an alternative wireup method known as *Direct Modex* that
+replaces the barrier-based global exchange of all process-posted information
+(the :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` operation) with an on-demand fetch
+of a peer's data. Data posted by each process is cached on its local PMIx
+server. When a process requests information posted by a peer that is not in its
+local cache, the request is passed to the local PMIx server, which asks its
+host resource manager (RM) to obtain the data from the RM daemon on the node
+where the target process resides. Upon receiving such a request, that RM daemon
+passes it into its own PMIx server library via ``PMIx_server_dmodex_request``.
+
+``PMIx_server_dmodex_request`` is a **non-blocking** operation: it thread-shifts
+the request into the library's progress thread and returns immediately. The
+provided ``cbfunc`` is invoked once the target process has posted its
+information |mdash| which may be some time after the call returns, since the
+data may not yet be available when the request arrives. Requests that cannot be
+satisfied immediately (because the namespace or rank is not yet known, or the
+process has not yet committed its data) are deferred internally and completed
+when the data arrives.
+
+
+CALLBACK FUNCTION
+-----------------
+
+The ``cbfunc`` has the signature ``pmix_dmodex_response_fn_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_dmodex_response_fn_t)(pmix_status_t status,
+                                             char *data, size_t sz,
+                                             void *cbdata);
+
+When the requested information becomes available, the library invokes
+``cbfunc`` with:
+
+* ``status`` |mdash| ``PMIX_SUCCESS`` if the data was successfully collected,
+  or an error constant describing why it could not be returned.
+* ``data`` |mdash| pointer to a data blob containing the requested information,
+  or ``NULL`` if none is available.
+* ``sz`` |mdash| number of bytes in the ``data`` blob.
+* ``cbdata`` |mdash| the opaque pointer passed to
+  ``PMIx_server_dmodex_request``.
+
+The ``data`` blob is owned by the PMIx server library and is **freed upon
+return** from ``cbfunc``. The host RM must therefore copy, transmit, or
+otherwise consume the blob before the callback returns; it must not retain the
+pointer afterward.
+
+
+RETURN VALUE
+------------
+
+A return of ``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status and any data are delivered through ``cbfunc``.
+Possible immediate return values include:
+
+* ``PMIX_SUCCESS`` |mdash| the request was accepted for processing.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| ``proc`` or ``cbfunc`` was ``NULL``.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+
+When an error is returned immediately, ``cbfunc`` is **not** called. Any other
+negative value indicates an appropriate error condition. PMIx error constants
+are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This function is available only after the PMIx server library has been
+initialized with :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. It is
+intended for use by a host RM daemon acting on behalf of a remote peer; the
+data returned reflects the information posted by the library's own local
+clients.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
+   :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
+   :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_finalize.3.rst
+++ b/docs/man/man3/PMIx_server_finalize.3.rst
@@ -1,0 +1,85 @@
+.. _man3-PMIx_server_finalize:
+
+PMIx_server_finalize
+====================
+
+.. include_body
+
+``PMIx_server_finalize`` |mdash| Finalize the PMIx server support library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_finalize(void);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init(pydirs, map) ...
+  rc = foo.finalize()
+
+
+DESCRIPTION
+-----------
+
+Finalize the PMIx server support library, terminating all connections to
+attached tools and any local clients. If internal communications are in use,
+the server shuts them down at this time, and all memory usage by the library is
+released.
+
+The PMIx server library is reference counted. Because multiple calls to
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>` are permitted, each must be
+balanced by a matching call to ``PMIx_server_finalize``. Only the final call
+|mdash| the one that drops the reference count to zero |mdash| actually tears
+down the library; earlier calls simply decrement the count and return
+``PMIX_SUCCESS`` without releasing resources.
+
+As part of teardown, the final call stops the internal progress thread, flushes
+any residual forwarded I/O to its channels, stops listening for new
+connections, releases all per-client and per-namespace state (executing any
+registered cleanup epilogs), and closes the frameworks opened during
+initialization.
+
+``PMIx_server_finalize`` is a blocking call that completes synchronously; it
+does not take a callback.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding
+to a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library was not initialized, so
+  there is nothing to finalize.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_server_finalize`` is intended for use only by processes that previously
+called :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. It should be the last
+PMIx server call made by the host; no server-side PMIx operations should be
+issued after the reference count reaches zero and the library has been torn
+down.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`,
+   :ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_generate_cpuset.3.rst
+++ b/docs/man/man3/PMIx_server_generate_cpuset.3.rst
@@ -1,0 +1,103 @@
+.. _man3-PMIx_server_generate_cpuset:
+
+PMIx_server_generate_cpuset
+===========================
+
+.. include_body
+
+``PMIx_server_generate_cpuset`` |mdash| Generate a cpuset from a PMIx
+string representation.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_generate_cpuset(const char *cpuset_string,
+                                             pmix_cpuset_t *cpuset);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``cpuset_string``: NULL-terminated PMIx string representation of a
+  cpuset, as produced by :ref:`PMIx_server_generate_cpuset_string(3)
+  <man3-PMIx_server_generate_cpuset_string>`. The string must begin with
+  a colon-delimited ``source`` prefix (e.g., ``"hwloc:0-3"``) identifying
+  the subsystem able to decode the remainder.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``cpuset``: Pointer to caller-provided storage for a
+  :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>` structure. On success, the
+  ``source`` and ``bitmap`` fields are populated with a decoded copy of
+  the bitmap. The caller must provide the storage for the structure
+  itself; the library allocates the internal ``source`` string and
+  ``bitmap`` object, which the caller is responsible for releasing (for
+  example, via ``PMIx_Cpuset_destruct``).
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment can convert a PMIx
+string representation of a cpuset into the corresponding cpuset bitmap.
+This is the reciprocal of :ref:`PMIx_server_generate_cpuset_string(3)
+<man3-PMIx_server_generate_cpuset_string>`: the ``source`` prefix embedded
+in the string is used to route the request to the subsystem (e.g.,
+``hwloc``) that can decode it, and the decoded bitmap is returned in the
+caller-supplied structure.
+
+The operation is performed synchronously in the caller's thread; it does
+not thread-shift into the PMIx progress engine and does not invoke a
+callback.
+
+This API is a PMIx library convenience routine; it is not part of the
+PMIx Standard.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the string was parsed and the bitmap returned
+  in ``cpuset``.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been
+  initialized.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| the string was malformed |mdash| for
+  example, it lacked a colon-delimited ``source`` prefix or the encoded
+  bitmap could not be decoded.
+* another non-success PMIx error constant |mdash| no configured provider
+  recognized the ``source`` prefix of the supplied string, so no cpuset
+  could be generated.
+
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This API is restricted to the server role and must be called only after a
+successful :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. The caller
+owns the contents populated into the ``cpuset`` structure and must release
+them when no longer needed.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_generate_cpuset_string(3) <man3-PMIx_server_generate_cpuset_string>`,
+   :ref:`PMIx_server_generate_locality_string(3) <man3-PMIx_server_generate_locality_string>`,
+   :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_generate_cpuset_string.3.rst
+++ b/docs/man/man3/PMIx_server_generate_cpuset_string.3.rst
@@ -1,0 +1,112 @@
+.. _man3-PMIx_server_generate_cpuset_string:
+
+PMIx_server_generate_cpuset_string
+==================================
+
+.. include_body
+
+``PMIx_server_generate_cpuset_string`` |mdash| Generate a PMIx string
+representation of a provided cpuset.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_generate_cpuset_string(const pmix_cpuset_t *cpuset,
+                                                    char **cpuset_string);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # cpuset is a Python dict describing the bitmap (e.g. as
+  # returned by foo.get_cpuset())
+  rc, cpuset_string = foo.generate_cpuset_string(cpuset)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``cpuset``: Pointer to a :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>`
+  structure containing the bitmap of assigned processing units (PUs). The
+  ``source`` field identifies the subsystem (e.g., ``"hwloc"``) that
+  produced the bitmap, and the ``bitmap`` field points to the
+  corresponding implementation-specific object.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``cpuset_string``: Address where a pointer to a freshly allocated,
+  NULL-terminated string representation of the input bitmap is returned.
+  The caller is responsible for releasing the string with ``free()``.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment can generate a string
+representation of a cpuset bitmap for inclusion in the call to
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`.
+This function shall only be called for local client processes, with the
+returned string included in the job-level information (via the
+``PMIX_CPUSET`` attribute) provided to local clients. Local clients can
+use these strings to obtain their PU bindings via the
+``PMIx_Parse_cpuset_string`` API.
+
+The returned string is prefixed by the ``source`` field of the provided
+``cpuset`` followed by a colon (e.g., ``"hwloc:0-3"``); the remainder of
+the string represents the PUs to which the process is bound as expressed
+by the underlying implementation. This prefix allows the reciprocal
+operation, :ref:`PMIx_server_generate_cpuset(3)
+<man3-PMIx_server_generate_cpuset>`, to route the string back to the
+subsystem that can decode it.
+
+The operation is performed synchronously in the caller's thread; it does
+not thread-shift into the PMIx progress engine and does not invoke a
+callback.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the string was generated and returned in
+  ``cpuset_string``.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been
+  initialized.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| ``cpuset`` was ``NULL`` or its ``bitmap``
+  field was ``NULL``. In this case ``cpuset_string`` is set to ``NULL``.
+* another non-success PMIx error constant |mdash| no configured provider
+  recognized the ``source`` of the supplied cpuset, so no string could be
+  generated.
+
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This API is restricted to the server role and must be called only after a
+successful :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. The
+returned string is owned by the caller.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_generate_cpuset(3) <man3-PMIx_server_generate_cpuset>`,
+   :ref:`PMIx_server_generate_locality_string(3) <man3-PMIx_server_generate_locality_string>`,
+   :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_generate_locality_string.3.rst
+++ b/docs/man/man3/PMIx_server_generate_locality_string.3.rst
@@ -1,0 +1,108 @@
+.. _man3-PMIx_server_generate_locality_string:
+
+PMIx_server_generate_locality_string
+====================================
+
+.. include_body
+
+``PMIx_server_generate_locality_string`` |mdash| Generate a PMIx locality
+string from a given cpuset.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_generate_locality_string(const pmix_cpuset_t *cpuset,
+                                                      char **locality);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # cpuset is a Python dict describing the bitmap
+  rc, locality = foo.generate_locality_string(cpuset)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``cpuset``: Pointer to a :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>`
+  structure containing the bitmap of assigned processing units (PUs). The
+  ``source`` field identifies the subsystem (e.g., ``"hwloc"``) that
+  produced the bitmap.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``locality``: Address where a pointer to a freshly allocated,
+  NULL-terminated string representation of the PMIx locality corresponding
+  to the input bitmap is returned. The caller is responsible for releasing
+  the string with ``free()``. If the process is not bound (the bitmap is
+  ``NULL`` or fully set), ``locality`` is set to ``NULL`` and
+  ``PMIX_SUCCESS`` is returned.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment can generate a PMIx
+locality string for inclusion in the call to
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`.
+This function shall only be called for local client processes, with the
+returned locality included in the job-level information (via the
+``PMIX_LOCALITY_STRING`` attribute) provided to local clients. Local
+clients can use these strings as input to determine the relative locality
+of their local peers via the ``PMIx_Get_relative_locality`` API.
+
+The returned string is prefixed by the ``source`` field of the provided
+``cpuset`` followed by a colon; the remainder of the string represents the
+corresponding locality (the set of topology levels |mdash| package, NUMA
+domain, cache levels, core, PU |mdash| the process shares) as expressed by
+the underlying implementation.
+
+The operation is performed synchronously in the caller's thread; it does
+not thread-shift into the PMIx progress engine and does not invoke a
+callback.
+
+
+RETURN VALUE
+------------
+
+Returns one of the following:
+
+* ``PMIX_SUCCESS`` |mdash| the locality string was generated and returned
+  in ``locality`` (which may be ``NULL`` when the process is unbound).
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been
+  initialized.
+* another non-success PMIx error constant |mdash| no configured provider
+  recognized the ``source`` of the supplied cpuset, so no locality string
+  could be generated.
+
+PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This API is restricted to the server role and must be called only after a
+successful :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. The
+returned string is owned by the caller.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_generate_cpuset_string(3) <man3-PMIx_server_generate_cpuset_string>`,
+   :ref:`pmix_cpuset_t(5) <man5-pmix_cpuset_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_init.3.rst
+++ b/docs/man/man3/PMIx_server_init.3.rst
@@ -1,0 +1,198 @@
+.. _man3-PMIx_server_init:
+
+PMIx_server_init
+================
+
+.. include_body
+
+``PMIx_server_init`` |mdash| Initialize the PMIx server support library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_init(pmix_server_module_t *module,
+                                  pmix_info_t info[], size_t ninfo);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_SERVER_NSPACE,
+             'value': {'value': "SERVER", 'val_type': PMIX_STRING}}]
+  # map is a dictionary of server-module-function keys to Python
+  # callback implementations (e.g. {'clientconnected': myconnfn, ...})
+  rc = foo.init(pydirs, map)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``module``: Pointer to a ``pmix_server_module_t`` structure containing the
+  host environment's callback functions |mdash| the "function-shipped" server
+  module through which client requests are relayed to the resource manager.
+  Any function the host does not support is indicated by leaving its function
+  pointer ``NULL``; client calls to an unsupported operation return a
+  "not supported" error. Passing ``NULL`` for ``module`` (or an empty
+  structure) is permitted and indicates that the host will not support
+  multi-node operations such as :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`, but
+  still intends to give local clients access to job information.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify server initialization (see
+  `DIRECTIVES`_). A ``NULL`` value is supported when no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+DESCRIPTION
+-----------
+
+Initialize the PMIx server support library and register the host environment's
+callback module. ``PMIx_server_init`` is called by the process that hosts the
+PMIx server |mdash| typically a resource manager daemon, launcher, or tool
+that will accept client and/or tool connections.
+
+The PMIx server provides a *function-shipping* approach to the server side of
+the protocol: each client-visible PMIx operation is mirrored by an entry in the
+``pmix_server_module_t`` structure. When a client request arrives, the PMIx
+server library invokes the corresponding host function so that resource
+managers can implement server behavior without being burdened with PMIx
+internal details. For performance and scalability, host module functions are
+required to return quickly and to execute their work asynchronously, completing
+each operation by invoking the callback function supplied to them.
+
+Ownership rules for the module functions are important: all data passed *to* a
+host server function is owned by the PMIx server library and must not be freed
+by the host, while data returned by the host via a module callback is owned by
+the host and may be released once the callback returns.
+
+The ``info`` array supplies additional information the server may need when
+initializing |mdash| for example, the namespace and rank to assign to the
+server itself, the temporary directory in which to place the rendezvous socket,
+or the ``PMIX_SERVER_TOOL_SUPPORT`` directive announcing that the daemon is
+willing to accept connection requests from tools (see `DIRECTIVES`_).
+
+The PMIx server library is reference counted. Repeated calls to
+``PMIx_server_init`` are permitted and simply increment the reference count;
+if a ``module`` is provided on a later call and none had been set previously,
+the library adopts it. Each successful call must be balanced by a matching call
+to :ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`.
+
+``PMIx_server_init`` is a blocking call that completes synchronously; it does
+not take a callback.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. Support for any given
+attribute is optional and depends on how the PMIx implementation was built and
+on the capabilities of the host environment. All are passed in the ``info``
+array.
+
+Server identity and directories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_SERVER_NSPACE`` (char\*) |mdash| namespace to assign to this PMIx
+  server.
+* ``PMIX_SERVER_RANK`` (pmix_rank_t) |mdash| rank to assign to this PMIx server.
+* ``PMIX_SERVER_TMPDIR`` (char\*) |mdash| temporary directory in which the
+  server is to place client rendezvous points and contact information.
+* ``PMIX_SYSTEM_TMPDIR`` (char\*) |mdash| temporary directory in which the
+  server is to place tool rendezvous points and system-level contact
+  information.
+
+Role and support attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_SERVER_TOOL_SUPPORT`` (bool) |mdash| the host is willing to accept
+  connection requests from tools.
+* ``PMIX_SERVER_SYSTEM_SUPPORT`` (bool) |mdash| the host is willing to accept
+  connections from system-level tools (a system-level rendezvous point is
+  established).
+* ``PMIX_SERVER_SESSION_SUPPORT`` (bool) |mdash| the host is willing to accept
+  connections from session-level tools.
+* ``PMIX_SERVER_GATEWAY`` (bool) |mdash| the server is acting as a gateway that
+  can relay operations (e.g., logging) requiring routing to other nodes.
+* ``PMIX_SERVER_SCHEDULER`` (bool) |mdash| the server is hosting the system
+  scheduler (workload manager) and expects to receive scheduler-related
+  requests.
+* ``PMIX_SERVER_SYS_CONTROLLER`` (bool) |mdash| the server is hosting the
+  system controller.
+* ``PMIX_SERVER_REMOTE_CONNECTIONS`` (bool) |mdash| allow (or disable)
+  connections from remote tools.
+
+Topology and behavior attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_TOPOLOGY2`` (pmix_topology_t) |mdash| pointer to an
+  implementation-specific description of the local node topology.
+* ``PMIX_SERVER_SHARE_TOPOLOGY`` (bool) |mdash| the server is to scalably
+  expose the node topology to its local clients (for example, via shared-memory
+  backing stores), cleaning up any artifacts at finalize.
+* ``PMIX_HOMOGENEOUS_SYSTEM`` (bool) |mdash| the nodes in the system are
+  topologically identical, so the server need not compute or exchange
+  per-node topology descriptions.
+* ``PMIX_SERVER_ENABLE_MONITORING`` (bool) |mdash| enable the internal
+  monitoring capabilities of the PMIx server.
+* ``PMIX_EXTERNAL_PROGRESS`` (bool) |mdash| the host will progress the PMIx
+  library as needed via calls to ``PMIx_Progress`` rather than PMIx spawning
+  its own internal progress thread.
+* ``PMIX_SINGLETON`` (char\*) |mdash| the server is operating in support of a
+  singleton process; the value is the ``nspace.rank`` string of that singleton.
+* ``PMIX_IOF_LOCAL_OUTPUT`` (bool) |mdash| write output streams to the server's
+  own stdout/stderr.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding
+to a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library could not be initialized
+  (for example, a required transport was explicitly disabled, or a tight race
+  between concurrent ``PMIx_server_init`` calls left the library in an unusable
+  state).
+* ``PMIX_ERR_NOT_SUPPORTED`` |mdash| a provided directive requested behavior the
+  implementation does not support.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_server_init`` is intended for use only by processes acting as a PMIx
+*server* |mdash| processes that host the server support library on behalf of a
+resource manager or launcher. Client processes call
+:ref:`PMIx_Init(3) <man3-PMIx_Init>` and tools call
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>` instead.
+
+After a successful ``PMIx_server_init``, the host is expected to register each
+participating namespace with
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>` and
+each local client with
+:ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>` before
+launching that client, then set up the client's environment with
+``PMIx_server_setup_fork``.
+
+
+.. seealso::
+   :ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_register_client.3.rst
+++ b/docs/man/man3/PMIx_server_register_client.3.rst
@@ -1,0 +1,148 @@
+.. _man3-PMIx_server_register_client:
+
+PMIx_server_register_client
+===========================
+
+.. include_body
+
+``PMIx_server_register_client`` |mdash| Register a local client process with
+the PMIx server library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
+                                             uid_t uid, gid_t gid,
+                                             void *server_object,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after registering the namespace ...
+  rc = foo.register_client({'nspace': "myjob", 'rank': 0}, 1000, 1000)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure
+  identifying the client by namespace and rank.
+* ``uid``: The expected user ID of the child process.
+* ``gid``: The expected group ID of the child process.
+* ``server_object``: An optional opaque pointer the host wishes to associate
+  with this client. If provided, the library returns it to the host whenever a
+  server-module function is invoked in relation to this specific process,
+  letting the host access its tracking object without a namespace/rank lookup.
+  May be ``NULL``.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  registration completes. A ``NULL`` value makes the call *blocking* (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Register a local client process with the PMIx server library. The host resource
+manager is required to execute this operation *prior to starting the client
+process*, so that the library is prepared for the connection the client will
+make when it calls :ref:`PMIx_Init(3) <man3-PMIx_Init>`.
+
+The expected ``uid`` and ``gid`` allow the server library to authenticate a
+client as it connects by requiring the detected user and group IDs of the
+connecting process to match the registered values. Because this check is
+performed at registration time, the detected user and group IDs are not passed
+to the host again in the ``pmix_server_client_connected2_fn_t`` server module
+function.
+
+The optional ``server_object`` provides a convenience for the host: any object
+passed here is handed back to the host in subsequent server-module callbacks
+that pertain to this client (for example, ``client_connected2`` or
+``client_finalized``), allowing the host to track per-client state without an
+internal lookup.
+
+Like other server registration APIs, this call thread-shifts the request onto
+the library's internal progress thread and supports both a non-blocking and a
+blocking mode, selected by the ``cbfunc`` argument:
+
+* When ``cbfunc`` is **non-**\ ``NULL``, the call is *non-blocking*: the
+  request is posted to the progress thread and the function returns
+  ``PMIX_SUCCESS`` immediately, with ``cbfunc`` invoked once the client has
+  been registered.
+* When ``cbfunc`` is ``NULL``, the call is *blocking*: the function does not
+  return until registration is complete, and on success returns
+  ``PMIX_OPERATION_SUCCEEDED``.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` from its progress thread once the client has
+been registered. ``status`` is ``PMIX_SUCCESS`` on success, or a negative PMIx
+error constant otherwise. ``cbdata`` is the opaque pointer passed to
+``PMIx_server_register_client``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` is non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing;
+the final status is delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), the return value carries the
+result directly:
+
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| the client was registered successfully
+  inline; no callback is or will be invoked.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  registration.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+There is no requirement that the namespace be registered before its clients.
+If the namespace named in ``proc`` has not yet been registered, the library
+creates a placeholder namespace and appends this client to it, in anticipation
+of an eventual
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>` call.
+After registering the client, the host must call ``PMIx_server_setup_fork`` to
+inject the environment the client needs to connect back to this server.
+
+For security, PMIx server implementations should verify the user and group IDs
+of a connecting process against those registered here before completing the
+connection.
+
+
+.. seealso::
+   :ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_register_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_register_nspace.3.rst
@@ -1,0 +1,219 @@
+.. _man3-PMIx_server_register_nspace:
+
+PMIx_server_register_nspace
+===========================
+
+.. include_body
+
+``PMIx_server_register_nspace`` |mdash| Register a namespace and its job-level
+information with the PMIx server library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace, int nlocalprocs,
+                                             pmix_info_t info[], size_t ninfo,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init(pydirs, map) ...
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_UNIV_SIZE,
+             'value': {'value': 4, 'val_type': PMIX_UINT32}},
+            {'key': PMIX_JOB_SIZE,
+             'value': {'value': 4, 'val_type': PMIX_UINT32}}]
+  rc = foo.register_nspace("myjob", 4, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nspace``: The namespace (a character array of maximum length
+  ``PMIX_MAX_NSLEN``) of the job being registered.
+* ``nlocalprocs``: The number of processes from this namespace that will be
+  launched locally |mdash| i.e., that will connect to this PMIx server. This
+  count is required so that the server library can correctly determine when a
+  collective operation is locally complete, even if the collective is called
+  before all local processes have started.
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying the session-, job-, application-, node-, and
+  process-realm information for the namespace (see `DIRECTIVES`_). A ``NULL``
+  value is supported when no data is to be registered (for example, when using
+  the ``PMIX_REGISTER_NODATA`` directive).
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  registration completes. A ``NULL`` value makes the call *blocking* (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Register a namespace (job) with the PMIx server library so that its job-level
+information can be provided to the processes in that job as they connect. The
+PMIx connection procedure gives the host PMIx server an opportunity to pass
+job-related information down to each child process |mdash| for example, the
+number of processes in the job, the relative local ranks of the processes, and
+the node and process maps. The host is free to determine which of the supported
+elements it provides; the defined values are described in `DIRECTIVES`_.
+
+The host **must** register *every* namespace that will participate in
+collective operations involving local processes |mdash| even a namespace from
+which this server hosts no local processes |mdash| if any local process might
+at some point perform a collective operation involving one or more processes
+from that namespace. This is required so the collective can determine when it
+is locally complete.
+
+Blocking and non-blocking forms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``PMIx_server_register_nspace`` supports both a non-blocking and a blocking
+mode of operation, selected by the ``cbfunc`` argument. This function is the
+canonical example of the PMIx thread-shifting pattern: in both modes the
+request parameters are packaged and posted to the library's internal progress
+thread, where the actual registration work is performed.
+
+When ``cbfunc`` is **non-**\ ``NULL``, the call is *non-blocking*: the function
+posts the request to the progress thread and returns ``PMIX_SUCCESS``
+immediately, and the provided ``cbfunc`` is invoked with the final status once
+registration completes. As with all non-blocking PMIx APIs, the caller **must**
+keep the ``info`` array valid until ``cbfunc`` has been invoked.
+
+When ``cbfunc`` is ``NULL``, the call is *blocking*: the library substitutes an
+internal callback, posts the request, and waits for the progress thread to
+finish before returning. In this case the result is carried by the return value
+itself, and on success the function returns ``PMIX_OPERATION_SUCCEEDED`` to
+indicate that the operation completed inline and no callback will fire.
+
+
+DIRECTIVES
+----------
+
+Information is passed through the ``info`` array, organized by *data realm*.
+Realm information may be passed either as individual
+:ref:`pmix_info_t(5) <man5-pmix_info_t>` entries or grouped inside a
+``pmix_data_array_t`` labeled with the corresponding ``*_INFO_ARRAY``
+attribute. The following attributes are required to be supported by all PMIx
+libraries for use with this API:
+
+* ``PMIX_REGISTER_NODATA`` (bool) |mdash| the registration is for the namespace
+  only; do not copy any job data. Used to pre-register a namespace whose data
+  will follow later.
+* ``PMIX_SESSION_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array of
+  session-realm information for the session containing this job.
+* ``PMIX_JOB_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array of job-realm
+  information for this namespace.
+* ``PMIX_APP_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array of
+  application-realm information; required (one array per application) when the
+  job contains more than one application.
+* ``PMIX_PROC_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array of
+  process-realm information for a process in the job.
+* ``PMIX_NODE_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array of node-realm
+  information for a node participating in the job.
+
+Session-realm information
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_UNIV_SIZE`` (uint32_t) |mdash| number of process slots allocated to
+  the session.
+* ``PMIX_MAX_PROCS`` (uint32_t) |mdash| maximum number of processes; must be
+  provided if ``PMIX_UNIV_SIZE`` is not given.
+* ``PMIX_SESSION_ID`` (uint32_t) |mdash| session identifier; required whenever
+  the PMIx server library may host multiple sessions.
+
+Job-realm information
+^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_NSPACE`` (char\*) |mdash| namespace of the job being registered.
+* ``PMIX_JOBID`` (char\*) |mdash| job identifier assigned by the resource
+  manager.
+* ``PMIX_JOB_SIZE`` (uint32_t) |mdash| total number of processes in the job.
+* ``PMIX_NODE_MAP`` (char\*) |mdash| regular-expression representation of the
+  nodes hosting the job (see ``PMIx_generate_regex2``).
+* ``PMIX_PROC_MAP`` (char\*) |mdash| regular-expression representation of the
+  process-to-node mapping.
+* ``PMIX_JOB_NUM_APPS`` (uint32_t) |mdash| number of applications in the job;
+  required when the job contains more than one application.
+* ``PMIX_SERVER_NSPACE`` (char\*) |mdash| namespace of the PMIx server itself.
+* ``PMIX_SERVER_RANK`` (pmix_rank_t) |mdash| rank of the PMIx server itself.
+
+The host environment is expected to supply a broad range of additional
+session-, job-, application-, node-, and process-realm information as required
+by the job. See the "Reserved Keys" chapter of the PMIx Standard for the full
+list and for the rules governing how each key is retrieved.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The library invokes ``cbfunc`` from its progress thread once registration
+completes. ``status`` is ``PMIX_SUCCESS`` if the namespace and its data were
+registered successfully, or a negative PMIx error constant otherwise.
+``cbdata`` is the opaque pointer passed to ``PMIx_server_register_nspace``,
+allowing the host to correlate the completion with its originating request.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` is non-``NULL``), a return of
+``PMIX_SUCCESS`` indicates only that the request was accepted for processing;
+the final status is delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), the return value carries the
+result directly:
+
+* ``PMIX_OPERATION_SUCCEEDED`` |mdash| the registration completed successfully
+  inline; no callback is or will be invoked.
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because
+  the library's progress engine has been stopped.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+There is no requirement that a namespace be registered before its clients are
+registered; if
+:ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>` is
+called for an as-yet-unregistered namespace, the library creates a placeholder
+namespace in anticipation of the eventual ``PMIx_server_register_nspace`` call.
+However, collective operations cannot complete locally until the namespace has
+been registered with its ``nlocalprocs`` count.
+
+Large ``PMIX_NODE_MAP`` and ``PMIX_PROC_MAP`` values are commonly generated in
+compressed form using ``PMIx_generate_regex2`` prior to registration.
+
+
+.. seealso::
+   :ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`,
+   :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,
+   :ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`,
+   :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`,
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_register_resources.3.rst
+++ b/docs/man/man3/PMIx_server_register_resources.3.rst
@@ -1,0 +1,171 @@
+.. _man3-PMIx_server_register_resources:
+
+PMIx_server_register_resources
+==============================
+
+.. include_body
+
+``PMIx_server_register_resources`` |mdash| Register non-namespace-related
+information with the local PMIx server library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
+                                                pmix_op_cbfunc_t cbfunc,
+                                                void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # directives is a list of pmix_info_t dictionaries describing the
+  # resources to register (this binding is blocking)
+  directives = [{'key': PMIX_CLUSTER_ID,
+                 'value': {'value': "cluster-a", 'val_type': PMIX_STRING}}]
+  rc = foo.register_resources(directives)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures carrying
+  the information to be registered (see `DIRECTIVES`_).
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  operation completes. A ``NULL`` value makes the call **blocking** (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Register information about resources that are **not** associated with any
+particular namespace with the local PMIx server library, for distribution to
+local client processes. This includes information about the physical cluster
+(such as its identifier, hostname, or resource-manager name), fabric devices,
+GPUs, and similar resources. All information provided through this API is made
+available to every job as part of its job-level information. Duplicate
+information provided through
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>` overrides
+what was registered here, but only for that specific namespace.
+
+This API can also be used to store data collected during operations that have no
+natural namespace callback |mdash| for example, the group and endpoint
+information returned during a
+:ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>` bootstrap, where a
+local server may host only "add-member" participants and thus has no registered
+callback in which to store the returned endpoint, group, and job data.
+
+Information registered as non-namespace resources is considered **static** and is
+provided here as a logical alternative to including it in every
+``PMIx_server_register_nspace`` call |mdash| useful for code clarity and to avoid
+repeatedly registering the same static resource information where a single server
+instance supports multiple jobs.
+
+``PMIx_server_register_resources`` supports both calling conventions. When
+``cbfunc`` is non-``NULL`` the function is **non-blocking**: the request is
+thread-shifted onto the progress thread, the function returns ``PMIX_SUCCESS``,
+and ``cbfunc`` is invoked with the completion status. When ``cbfunc`` is ``NULL``
+the function is **blocking**: it does not return until the operation completes,
+returning ``PMIX_OPERATION_SUCCEEDED`` on success.
+
+As with all non-blocking PMIx APIs, when a callback is supplied the caller
+**must** keep the ``info`` array valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+Any attribute conveying non-namespace resource information may be registered; the
+values are cached and returned to jobs as job-level data. Commonly used
+attributes include:
+
+* ``PMIX_CLUSTER_ID`` (char*) |mdash| a string name for the cluster this
+  allocation is on.
+* ``PMIX_RM_NAME`` (char*) |mdash| the name of the resource manager.
+* ``PMIX_RM_VERSION`` (char*) |mdash| the resource-manager version.
+* ``PMIX_SERVER_HOSTNAME`` (char*) |mdash| the host where the target server is
+  located.
+* ``PMIX_NODE_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| an array describing a
+  node and the resources it hosts (for example, its ``PMIX_HOSTNAME``,
+  ``PMIX_HOSTNAME_ALIASES``, ``PMIX_NODEID``, ``PMIX_AVAIL_PHYS_MEMORY``, and
+  fabric-device descriptions).
+
+In addition, this API is used internally to convey group bootstrap data via the
+following attributes, which receive special handling:
+
+* ``PMIX_GROUP_INFO_ARRAY`` / ``PMIX_GROUP_INFO`` (pmix_data_array_t\*) |mdash|
+  group information to be stored in the server's hash table. Requires a
+  ``PMIX_GROUP_CONTEXT_ID`` to also be provided.
+* ``PMIX_GROUP_ENDPT_DATA`` (pmix_data_array_t\*) |mdash| per-process endpoint
+  information to be stored for the group.
+* ``PMIX_GROUP_CONTEXT_ID`` (size_t) |mdash| the context identifier associated
+  with the group information being stored.
+* ``PMIX_GROUP_JOB_INFO`` (pmix_byte_object_t) |mdash| packed job-level
+  information associated with the group.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+It is invoked with the completion ``status`` of the registration and the
+``cbdata`` originally passed to ``PMIx_server_register_resources``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` non-``NULL``), a return of ``PMIX_SUCCESS``
+indicates only that the request was accepted for processing; the final status is
+delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), a return of
+``PMIX_OPERATION_SUCCEEDED`` indicates that the registration completed
+successfully and no callback is invoked. Other returns include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied (for example,
+  group information provided without an accompanying context identifier).
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is a server-role API, available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. Because the registered
+information is static, there is no requirement to deregister it before finalizing
+the library; the library cleans it up as part of normal finalization. Use
+:ref:`PMIx_server_deregister_resources(3) <man3-PMIx_server_deregister_resources>`
+only when client processes should no longer have access to the information.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_deregister_resources(3) <man3-PMIx_server_deregister_resources>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_setup_application.3.rst
+++ b/docs/man/man3/PMIx_server_setup_application.3.rst
@@ -1,0 +1,198 @@
+.. _man3-PMIx_server_setup_application:
+
+PMIx_server_setup_application
+=============================
+
+.. include_body
+
+``PMIx_server_setup_application`` |mdash| Obtain application-specific setup
+data (environment, fabric configuration, security credentials) prior to
+launching a job.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_setup_application(const pmix_nspace_t nspace,
+                                               pmix_info_t info[], size_t ninfo,
+                                               pmix_setup_application_cbfunc_t cbfunc,
+                                               void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # dicts is a list of pmix_info_t dictionaries describing the job
+  # (must include the process and node maps)
+  dicts = [{'key': PMIX_SETUP_APP_ALL,
+            'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc, dataout = foo.setup_application("myapp", dicts)
+  # dataout is a list of pmix_info_t dictionaries to be distributed
+  # with the application
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nspace``: The namespace of the job being set up. May be ``NULL`` if the
+  request is not scoped to a specific namespace.
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures
+  describing the job and directing what setup data is desired (see `DIRECTIVES`_).
+  The array **must** include a description of the job via the ``PMIX_NODE_MAP`` and
+  ``PMIX_PROC_MAP`` attributes.
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_setup_application_cbfunc_t`` invoked
+  when the setup data is ready (see `CALLBACK FUNCTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the host environment (typically a launcher or
+resource manager) can request application-specific setup data from the
+supporting PMIx server-library subsystems prior to initiating launch of a job.
+For example, network libraries may opt to allocate fabric resources and provide
+security credentials for the application, and programming-model support may
+harvest relevant environment variables.
+
+``PMIx_server_setup_application`` is a **non-blocking** operation |mdash| it is
+defined this way because a contributing subsystem may need to perform a
+potentially time-consuming action (such as querying a remote fabric-manager
+service) before it can respond. Internally the request is thread-shifted onto the
+progress thread, where the network (``pnet``) and programming-model (``pmdl``)
+subsystems are given the opportunity to contribute. Whatever data they return is
+assembled into a ``pmix_info_t`` array and handed to ``cbfunc``.
+
+The data returned through the callback must be distributed by the host
+environment and subsequently delivered, via
+:ref:`PMIx_server_setup_local_support(3) <man3-PMIx_server_setup_local_support>`,
+to the local PMIx server on each node where the application's processes will
+execute, prior to spawning those processes.
+
+The function may be called on a per-application basis if the ``PMIX_PROC_MAP`` and
+``PMIX_NODE_MAP`` describe only the corresponding application rather than the
+entire job.
+
+As with all non-blocking PMIx APIs, the caller **must** keep the ``info`` array
+valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. PMIx libraries that
+support this operation are **required** to support:
+
+* ``PMIX_SETUP_APP_ENVARS`` (bool) |mdash| harvest and include relevant
+  environment variables.
+* ``PMIX_SETUP_APP_NONENVARS`` (bool) |mdash| include all relevant data other than
+  environment variables.
+* ``PMIX_SETUP_APP_ALL`` (bool) |mdash| include all relevant data.
+* ``PMIX_ALLOC_FABRIC`` (pmix_data_array_t\*) |mdash| request fabric allocations,
+  described by the accompanying fabric attributes below.
+* ``PMIX_ALLOC_FABRIC_ID`` (char*) |mdash| a string identifier for the requested
+  fabric allocation.
+* ``PMIX_ALLOC_FABRIC_SEC_KEY`` (bool) |mdash| a fabric security key is requested.
+* ``PMIX_ALLOC_FABRIC_TYPE`` (char*) |mdash| type of desired fabric transport.
+* ``PMIX_ALLOC_FABRIC_PLANE`` (char*) |mdash| identifier of the fabric plane to be
+  used for the allocation.
+* ``PMIX_ALLOC_FABRIC_ENDPTS`` (size_t) |mdash| number of endpoints to allocate
+  per process.
+* ``PMIX_ALLOC_FABRIC_ENDPTS_NODE`` (size_t) |mdash| number of endpoints to
+  allocate per node.
+* ``PMIX_PROC_MAP`` (char*) |mdash| regular expression describing the process
+  placement (ranks to nodes) for the job or application.
+* ``PMIX_NODE_MAP`` (char*) |mdash| regular expression describing the nodes
+  involved in the job or application.
+
+PMIx libraries **may** additionally support:
+
+* ``PMIX_ALLOC_BANDWIDTH`` (float) |mdash| fabric bandwidth (in Mbits/sec) being
+  requested.
+* ``PMIX_ALLOC_FABRIC_QOS`` (char*) |mdash| fabric quality-of-service level being
+  requested.
+* ``PMIX_SESSION_INFO`` (bool) |mdash| in this context, indicates that the
+  ``PMIX_NODE_MAP`` describes the entire session rather than just this namespace,
+  allowing subsequent calls to omit node-level information.
+
+The following optional attributes identify the programming model being executed,
+which the library may use to harvest or forward model-specific environment
+variables:
+
+* ``PMIX_PROGRAMMING_MODEL`` (char*) |mdash| the programming model (e.g., "MPI").
+* ``PMIX_MODEL_LIBRARY_NAME`` (char*) |mdash| the model library name.
+* ``PMIX_MODEL_LIBRARY_VERSION`` (char*) |mdash| the model library version.
+
+
+CALLBACK FUNCTION
+-----------------
+
+The ``cbfunc`` has the signature ``pmix_setup_application_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
+                                                   pmix_info_t info[], size_t ninfo,
+                                                   void *provided_cbdata,
+                                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+When the setup data is ready, PMIx invokes ``cbfunc`` with the completion
+``status``, the ``info`` array of setup data to be distributed with the
+application, and ``provided_cbdata`` |mdash| the ``cbdata`` originally passed to
+``PMIx_server_setup_application``.
+
+The returned ``info`` array is **owned by the PMIx server library** and remains
+valid only until the recipient calls the ``cbfunc`` (of type ``pmix_op_cbfunc_t``)
+that is passed along with it; the library frees the array at that point.
+Accordingly, the host must copy any data it needs to retain and then invoke that
+completion function so the library can release its memory. If no data is returned,
+the ``info`` array is ``NULL``, its count is zero, and the trailing ``cbfunc`` may
+be ``NULL``.
+
+
+RETURN VALUE
+------------
+
+A return of ``PMIX_SUCCESS`` indicates only that the request was accepted for
+processing; the final status and the setup data are delivered to ``cbfunc``. An
+immediate error return means the request was not accepted and ``cbfunc`` will not
+be invoked. Possible immediate errors include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  request.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is a server-role API, available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. Support for harvesting
+environment variables and providing local configuration information is optional
+per the Standard; a conforming library may return no data.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_setup_local_support(3) <man3-PMIx_server_setup_local_support>`,
+   :ref:`PMIx_server_setup_fork(3) <man3-PMIx_server_setup_fork>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_setup_fork.3.rst
+++ b/docs/man/man3/PMIx_server_setup_fork.3.rst
@@ -1,0 +1,119 @@
+.. _man3-PMIx_server_setup_fork:
+
+PMIx_server_setup_fork
+======================
+
+.. include_body
+
+``PMIx_server_setup_fork`` |mdash| Set up the environment of a child
+process that is about to be forked by the host environment.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char ***env);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  proc = {'nspace': "myapp", 'rank': 0}
+  # envin is a dict that will be updated in place with the
+  # PMIx environment variables the child requires
+  envin = {}
+  rc = foo.setup_fork(proc, envin)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` identifying
+  the namespace and rank of the client process that is about to be launched.
+
+
+INPUT/OUTPUT PARAMETERS
+-----------------------
+
+* ``env``: Address of the environment array (a ``NULL``-terminated ``argv``-style
+  array of ``"name=value"`` strings) for the child process. The array is updated
+  in place: the required PMIx environment variables are added (existing values of
+  the same name are overwritten). The updated array is what the host must pass to
+  the child at ``fork``/``exec``.
+
+
+DESCRIPTION
+-----------
+
+Set up the environment of a child process that the host environment is about to
+fork so that the child's PMIx client library can correctly connect back to, and
+interact with, this PMIx server. The host environment is **required** to call
+this function for each local client prior to starting that client process.
+
+A PMIx client needs a modest amount of setup information in its environment in
+order to find and rendezvous with its local server. ``PMIx_server_setup_fork``
+populates ``env`` with the necessary variables, including (among others) the
+client's namespace and rank, the server's rendezvous connection URI, the active
+security mode, the buffer type and generalized-datastore module in use, the
+server's hostname, and the library version. It additionally appends any
+contributions from the transport, network (``pnet``), datastore (``gds``), and
+programming-model (``pmdl``) subsystems |mdash| for example, temporary-directory
+settings or the variables a fabric library requires for "instant on" addressing
+|mdash| along with any global environment variables the host registered for
+distribution to all clients.
+
+This is a **blocking** operation performed entirely within the local library; it
+does not involve the host environment or a callback. The variables added here are
+the counterpart to those the client library consumes during
+:ref:`PMIx_Init(3) <man3-PMIx_Init>`.
+
+Calling ``PMIx_server_setup_fork`` for the first local client of a namespace is
+also the signal that causes any operations cached by a prior call to
+:ref:`PMIx_server_setup_local_support(3) <man3-PMIx_server_setup_local_support>`
+to be executed.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success, with ``env`` updated in place. Otherwise a
+negative PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized (see
+  :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`).
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+
+Any other negative value indicates that one of the contributing subsystems
+(transport, network, datastore, or programming model) failed to add its
+environmental contribution. PMIx error constants are defined in
+``pmix_common.h``.
+
+
+NOTES
+-----
+
+This function is a server-role API and is available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. The host environment owns the
+``env`` array and is responsible for freeing it.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,
+   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,
+   :ref:`PMIx_server_setup_local_support(3) <man3-PMIx_server_setup_local_support>`,
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_server_setup_local_support.3.rst
+++ b/docs/man/man3/PMIx_server_setup_local_support.3.rst
@@ -1,0 +1,149 @@
+.. _man3-PMIx_server_setup_local_support:
+
+PMIx_server_setup_local_support
+===============================
+
+.. include_body
+
+``PMIx_server_setup_local_support`` |mdash| Perform application-specific
+local setup operations prior to spawning local clients of a namespace.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_server.h>
+
+   pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace,
+                                                 pmix_info_t info[], size_t ninfo,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # ilist is the list of pmix_info_t dictionaries returned by the
+  # earlier setup_application call and distributed by the host
+  rc = foo.setup_local_support("myapp", ilist)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``nspace``: The namespace whose local support is being set up. May be ``NULL``
+  if the operation is not scoped to a specific namespace.
+* ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures. This is
+  the data returned to the host by the callback of the corresponding
+  :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`
+  call and distributed to this node. May be ``NULL`` with ``ninfo`` of zero.
+* ``ninfo``: Number of elements in the ``info`` array.
+* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+  operation completes. A ``NULL`` value makes the call **blocking** (see
+  `DESCRIPTION`_).
+* ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
+
+
+DESCRIPTION
+-----------
+
+Provide a function by which the local PMIx server can perform any
+application-specific operations required before spawning local clients of a given
+namespace. For example, a fabric library might need to program the local driver
+for "instant on" addressing. The ``info`` array delivered here is the data that
+was produced on some node by
+:ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>` and
+then distributed by the host environment to every node that will run the
+application's processes.
+
+Data provided in the ``info`` array is stored in the job-information region for
+the namespace. Operations implied by that data are **cached** until the server
+first calls
+:ref:`PMIx_server_setup_fork(3) <man3-PMIx_server_setup_fork>` for the namespace,
+thereby indicating that a local client of the namespace is actually about to be
+started. Such operations are executed **only once** per namespace |mdash| for the
+first local client |mdash| not once per client.
+
+Internally the request is thread-shifted onto the progress thread, where the
+network (``pnet``) subsystem is given the opportunity to set up the local network
+support. The completion status of that subsystem operation is delivered as the
+result.
+
+``PMIx_server_setup_local_support`` supports both calling conventions. When
+``cbfunc`` is non-``NULL`` the function is **non-blocking**: it returns
+immediately, and ``cbfunc`` is invoked with the completion status. When
+``cbfunc`` is ``NULL`` the function is **blocking**: it does not return until the
+operation completes and the result is carried by the return value (see `RETURN
+VALUE`_).
+
+The host environment is **required** to execute this operation prior to starting
+any local application process of the namespace if setup data was obtained from a
+call to ``PMIx_server_setup_application``. The host must also have registered the
+namespace with
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>` before
+calling this API, so that all namespace-related information the library needs is
+already available.
+
+As with all non-blocking PMIx APIs, when a callback is supplied the caller
+**must** keep the ``info`` array valid until ``cbfunc`` is invoked.
+
+
+CALLBACK FUNCTION
+-----------------
+
+When ``cbfunc`` is provided, it has the signature ``pmix_op_cbfunc_t``:
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+It is invoked with the completion ``status`` of the local-support operation and
+the ``cbdata`` originally passed to ``PMIx_server_setup_local_support``.
+
+
+RETURN VALUE
+------------
+
+For the non-blocking form (``cbfunc`` non-``NULL``), a return of ``PMIX_SUCCESS``
+indicates only that the request was accepted for processing; the final status is
+delivered to ``cbfunc``.
+
+For the blocking form (``cbfunc`` is ``NULL``), a return of
+``PMIX_OPERATION_SUCCEEDED`` indicates that the operation completed successfully
+and no callback is (or was) invoked. Other returns include:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx server library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
+  library's progress engine has been stopped.
+* ``PMIX_ERR_NOMEM`` |mdash| the library was unable to allocate memory for the
+  request.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This is a server-role API, available only after
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`. Because the implied
+operations are executed only for the first local client of a namespace, calling
+this API has no additional effect once
+:ref:`PMIx_server_setup_fork(3) <man3-PMIx_server_setup_fork>` has already fired
+those operations for that namespace.
+
+
+.. seealso::
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,
+   :ref:`PMIx_server_setup_fork(3) <man3-PMIx_server_setup_fork>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_attach_to_server.3.rst
+++ b/docs/man/man3/PMIx_tool_attach_to_server.3.rst
@@ -1,0 +1,163 @@
+.. _man3-PMIx_tool_attach_to_server:
+
+PMIx_tool_attach_to_server
+==========================
+
+.. include_body
+
+``PMIx_tool_attach_to_server`` |mdash| Establish a connection from a tool to a
+PMIx server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc,
+                                            pmix_proc_t *server,
+                                            pmix_info_t info[], size_t ninfo);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  rc, myname = foo.init(None)
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_CONNECT_TO_SYSTEM,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc, myname, mysrvr = foo.attach_to_server(pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures identifying the target server and qualifying the connection (see
+  `DIRECTIVES`_). Passing a ``NULL`` value for the ``info`` array pointer, or a
+  zero ``ninfo``, is **not** allowed and results in return of
+  ``PMIX_ERR_BAD_PARAM``.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``myproc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure in
+  which the tool's own namespace and rank are returned. PMIx does not currently
+  support on-the-fly changes to the tool's identifier, so this is filled with the
+  tool's existing identity; ``NULL`` may be passed if it is not required.
+* ``server``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure in
+  which the identifier of the server that was attached is returned. ``NULL`` may
+  be passed if the server's identity is not required.
+
+
+DESCRIPTION
+-----------
+
+Establish a connection from an already-initialized tool to a PMIx server. The
+target server is identified by one of the attributes in the ``info`` array (see
+`DIRECTIVES`_).
+
+This routine replaces the older ``PMIx_tool_connect_to_server`` entry point,
+adding the ability to return the identifier of the server to which the tool
+attached via the ``server`` output parameter.
+
+By default, attaching to a server registers the connection but does not change
+the tool's *primary* server |mdash| the one used for subsequent operations. To
+make the newly attached server the primary (and mark the tool as connected),
+include the ``PMIX_PRIMARY_SERVER`` attribute in the ``info`` array.
+
+.. note::
+
+   PMIx does not currently support on-the-fly changes to the tool's identifier.
+   The new server must therefore be under the same namespace manager (e.g., the
+   same host resource manager) as any prior server, so that the tool's original
+   namespace remains a unique assignment. The ``myproc`` parameter is provided
+   for obsolescence protection in case this constraint is ever removed; for now
+   it is simply filled with the tool's existing namespace and rank.
+
+This is a **blocking** call: internally the request is thread-shifted onto the
+progress thread, and the caller waits for the connection attempt to complete
+before the routine returns.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. At least one server-
+identifying attribute must be supplied.
+
+Target server attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_CONNECT_TO_SYSTEM`` (bool) |mdash| connect solely to the system-level
+  PMIx server.
+* ``PMIX_CONNECT_SYSTEM_FIRST`` (bool) |mdash| preferentially look for a
+  system-level PMIx server first, and then fall back to a server identified by
+  another attribute.
+* ``PMIX_SERVER_URI`` (char\*) |mdash| connect to the server at the given URI.
+* ``PMIX_SERVER_NSPACE`` (char\*) |mdash| connect to the server of the given
+  namespace.
+* ``PMIX_SERVER_PIDINFO`` (pid_t) |mdash| connect to the server embedded in the
+  process with the given PID.
+* ``PMIX_TCP_URI`` (char\*) |mdash| URI of the server to connect to, or a file
+  name containing it in the form ``file:<name of file>``.
+* ``PMIX_TOOL_ATTACHMENT_FILE`` (char\*) |mdash| file containing the connection
+  information to be used for attaching to the server.
+
+Connection-control attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_PRIMARY_SERVER`` (bool) |mdash| designate the server being attached as
+  the tool's primary server. When set, the tool's active server is switched to
+  the new connection and the tool is marked as connected.
+* ``PMIX_TIMEOUT`` (int) |mdash| time, in seconds, to wait for the connection to
+  be established before returning an error (0 implies no timeout).
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` when the connection has been established. On error, a
+negative value corresponding to a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the tool library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the internal progress thread has been
+  stopped, so the operation cannot be serviced.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| the ``info`` array was ``NULL`` or ``ninfo`` was
+  zero, so no target server was specified.
+* ``PMIX_ERR_UNREACH`` |mdash| the specified server could not be reached.
+
+Other negative values indicate an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The tool must already have been initialized via
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>` before calling this routine. A tool
+may hold connections to multiple servers simultaneously; use
+:ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>` to enumerate them,
+:ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>` to select the active
+server among them, and
+:ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>` to drop a connection.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`,
+   :ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>`,
+   :ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_disconnect.3.rst
+++ b/docs/man/man3/PMIx_tool_disconnect.3.rst
@@ -1,0 +1,96 @@
+.. _man3-PMIx_tool_disconnect:
+
+PMIx_tool_disconnect
+====================
+
+.. include_body
+
+``PMIx_tool_disconnect`` |mdash| Disconnect a tool from a specified PMIx server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_disconnect(const pmix_proc_t *server);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  rc, myname = foo.init(None)
+  # ... attach to one or more servers ...
+  srvr = {'nspace': "myserver", 'rank': 0}
+  rc = foo.disconnect(srvr)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``server``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure
+  giving the process identifier of the server from which the tool is to be
+  disconnected.
+
+
+DESCRIPTION
+-----------
+
+Disconnect the tool from the specified server connection while leaving the tool
+library itself initialized. The tool remains free to continue operating and to
+establish new connections via
+:ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`.
+
+If the identified server is the tool's current *primary* (active) server, the
+tool transitions to a "disconnected" state: the active server is pointed back at
+the tool itself |mdash| effectively the same condition as when a tool is
+initialized without connecting to a server |mdash| and
+:ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>` will subsequently
+report ``false``. Connections to any other servers are unaffected.
+
+This is a **blocking** call: internally the request is thread-shifted onto the
+progress thread, which locates the matching server, drops the connection, and
+wakes the caller.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` when the tool has been disconnected from the specified
+server. On error, a negative value corresponding to a PMIx error constant is
+returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the tool library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the internal progress thread has been
+  stopped, so the operation cannot be serviced.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| the tool has no connection to a server matching
+  the supplied identifier.
+
+Other negative values indicate an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+To close *all* connections and release the library, call
+:ref:`PMIx_tool_finalize(3) <man3-PMIx_tool_finalize>` instead. Use
+:ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>` to obtain the set of
+currently connected servers before selecting one to disconnect.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_finalize(3) <man3-PMIx_tool_finalize>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`,
+   :ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_finalize.3.rst
+++ b/docs/man/man3/PMIx_tool_finalize.3.rst
@@ -1,0 +1,93 @@
+.. _man3-PMIx_tool_finalize:
+
+PMIx_tool_finalize
+==================
+
+.. include_body
+
+``PMIx_tool_finalize`` |mdash| Finalize the PMIx tool library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_finalize(void);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  rc, myname = foo.init(None)
+  # ... use the tool ...
+  rc = foo.finalize()
+
+
+DESCRIPTION
+-----------
+
+Finalize the PMIx tool library, closing any open connection to a PMIx server and
+releasing the resources allocated by
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`. An error code is returned if, for
+some reason, the connection cannot be cleanly closed.
+
+If the tool is currently connected to a server, ``PMIx_tool_finalize`` sends a
+finalize synchronization to that server and waits for the acknowledgment. This
+wait is protected by an internal timeout so the call cannot block indefinitely
+should the server become unresponsive. Any output still buffered for the tool's
+local ``stdout``/``stderr`` sinks is flushed before those sinks are torn down.
+
+If the tool was acting as a launcher or server, any children it started are
+cleanly terminated before the progress thread is stopped and the server-side
+infrastructure is released.
+
+Reference counting
+^^^^^^^^^^^^^^^^^^
+
+Because :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>` is reference counted, a
+tool that initialized the library more than once must call ``PMIx_tool_finalize``
+a matching number of times. Only the final call |mdash| the one that drops the
+reference count to zero |mdash| actually tears the library down; earlier calls
+simply decrement the count and return ``PMIX_SUCCESS``. The one-time-init latch
+is reset by the final finalize, so a subsequent ``PMIx_tool_init`` in the same
+process starts a fresh library instance.
+
+This is a **blocking** call.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx tool library was not initialized, so there is
+  nothing to finalize.
+
+Other negative values indicate a failure to cleanly complete the finalize
+handshake with the server. PMIx error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_tool_finalize`` must only be called by processes that initialized via
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`. Client processes must instead call
+:ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`, and server processes must call
+:ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,
+   :ref:`PMIx_server_finalize(3) <man3-PMIx_server_finalize>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_get_servers.3.rst
+++ b/docs/man/man3/PMIx_tool_get_servers.3.rst
@@ -1,0 +1,96 @@
+.. _man3-PMIx_tool_get_servers:
+
+PMIx_tool_get_servers
+=====================
+
+.. include_body
+
+``PMIx_tool_get_servers`` |mdash| Return the process identifiers of all servers
+to which a tool is currently connected.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[],
+                                       size_t *nservers);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  rc, myname = foo.init(None)
+  # ... attach to one or more servers ...
+  rc, servers = foo.get_servers()
+  # servers is a list of {'nspace':..., 'rank':...} dictionaries
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``servers``: Address at which the pointer to a newly allocated array of
+  :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structures is returned, one entry per
+  connected server. The tool's current *primary* (active) server, if any, is
+  placed at the front of the array.
+* ``nservers``: Address at which the number of elements in the returned
+  ``servers`` array is stored.
+
+
+DESCRIPTION
+-----------
+
+Obtain the set of PMIx servers to which the tool currently holds a connection.
+On success the routine allocates an array of
+:ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structures and returns its address and
+element count through the two output parameters. If the tool has an active
+primary server, that server's identifier is returned as the first element of the
+array.
+
+This is a **blocking** call: internally the request is thread-shifted onto the
+progress thread, which walks the tool's list of server connections and builds the
+returned array.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` and a non-empty array when the tool is connected to at
+least one server. On error, a negative value corresponding to a PMIx error
+constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the tool library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the internal progress thread has been
+  stopped, so the operation cannot be serviced.
+* ``PMIX_ERR_UNREACH`` |mdash| the tool is not currently connected to any server;
+  in this case no array is returned and ``nservers`` is set to zero.
+
+Other negative values indicate an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+The caller assumes ownership of the returned ``servers`` array and is responsible
+for releasing it. In C, the array is allocated with the PMIx allocation macros
+and should be freed with ``PMIX_PROC_FREE(servers, nservers)``; the Python
+binding returns an ordinary list and frees the underlying array automatically.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>`,
+   :ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_init.3.rst
+++ b/docs/man/man3/PMIx_tool_init.3.rst
@@ -1,0 +1,208 @@
+.. _man3-PMIx_tool_init:
+
+PMIx_tool_init
+==============
+
+.. include_body
+
+``PMIx_tool_init`` |mdash| Initialize the PMIx tool library.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
+                                pmix_info_t info[], size_t ninfo);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # the directives is a list of Python ``pmix_info_t`` dictionaries
+  pydirs = [{'key': PMIX_TOOL_NSPACE,
+             'value': {'value': "mytool", 'val_type': PMIX_STRING}},
+            {'key': PMIX_TOOL_RANK,
+             'value': {'value': 0, 'val_type': PMIX_PROC_RANK}}]
+  rc, myname = foo.init(pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the initialization and any
+  subsequent server connection (see `DIRECTIVES`_). A ``NULL`` value is
+  supported if no directives are desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+OUTPUT PARAMETERS
+-----------------
+
+* ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure in
+  which the tool's namespace and rank are to be returned. Unlike
+  :ref:`PMIx_Init(3) <man3-PMIx_Init>`, the *initial* call to ``PMIx_tool_init``
+  requires a non-``NULL`` value here so that the assigned identifier can be
+  returned; passing ``NULL`` on the first call returns ``PMIX_ERR_BAD_PARAM``.
+
+
+DESCRIPTION
+-----------
+
+Initialize the PMIx tool library, returning the process identifier assigned to
+this tool in the provided ``pmix_proc_t`` struct.
+
+When called, the PMIx tool library will check for the required connection
+information of a local PMIx server and, unless directed otherwise, will attempt
+to establish a connection to it. If the information is not found, or the server
+connection fails, then an appropriate error constant will be returned |mdash|
+unless the caller has requested that the connection be treated as optional (see
+``PMIX_TOOL_CONNECT_OPTIONAL``) or has requested that no connection be attempted
+at all (see ``PMIX_TOOL_DO_NOT_CONNECT``).
+
+If successful, the function will return ``PMIX_SUCCESS`` and will fill the
+provided structure with the server-assigned namespace and rank of the tool. If
+the tool self-assigns its identity (because it is not connecting to a server, or
+because connection was optional and failed), the returned namespace is
+synthesized from the tool's hostname and process ID and the rank is set to zero.
+
+A process may declare itself to be a *launcher* (via ``PMIX_LAUNCHER``) or the
+system *scheduler* (via ``PMIX_SERVER_SCHEDULER``), in which case the tool
+library additionally initializes the server-side infrastructure so the process
+can host its own PMIx server and spawn or accept connections from clients.
+
+Reference counting
+^^^^^^^^^^^^^^^^^^
+
+The PMIx tool library is reference counted, and so multiple calls to
+``PMIx_tool_init`` are allowed. Thus, one way to obtain the namespace and rank of
+the process is to simply call ``PMIx_tool_init`` with a non-``NULL`` ``proc``
+parameter. Each call must be balanced by a matching call to
+:ref:`PMIx_tool_finalize(3) <man3-PMIx_tool_finalize>`; only the last such
+finalize actually tears the library down.
+
+
+DIRECTIVES
+----------
+
+The following attributes are relevant to this operation. Support for any given
+attribute is optional and depends on how the PMIx implementation was built and on
+the capabilities of the host environment.
+
+Tool identity attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_TOOL_NSPACE`` (char\*) |mdash| namespace to use for this tool. Must be
+  accompanied by ``PMIX_TOOL_RANK``; providing one without the other returns an
+  error. If not given, the identity is taken from the ``PMIX_NAMESPACE``
+  environment variable (set when the tool was launched by a PMIx-enabled daemon)
+  or is self-assigned.
+* ``PMIX_TOOL_RANK`` (uint32_t) |mdash| rank of this tool within its namespace.
+* ``PMIX_LAUNCHER`` (bool) |mdash| the tool is a launcher and needs rendezvous
+  files created; causes the server-side infrastructure to be initialized.
+* ``PMIX_SERVER_SCHEDULER`` (bool) |mdash| the process is hosted by the system
+  scheduler and intends to act as the system-level server.
+
+Connection attributes
+^^^^^^^^^^^^^^^^^^^^^^
+
+These attributes govern whether and how the tool rendezvous with a PMIx server
+during initialization.
+
+* ``PMIX_TOOL_DO_NOT_CONNECT`` (bool) |mdash| the tool wants to use internal PMIx
+  support but does not want to connect to a server. The tool self-assigns its
+  identity.
+* ``PMIX_TOOL_CONNECT_OPTIONAL`` (bool) |mdash| the tool shall connect to a
+  server if one is available, but otherwise shall continue (self-assigning its
+  identity) rather than returning an error.
+* ``PMIX_CONNECT_TO_SYSTEM`` (bool) |mdash| connect solely to the system-level
+  PMIx server.
+* ``PMIX_CONNECT_SYSTEM_FIRST`` (bool) |mdash| preferentially look for a
+  system-level PMIx server first, then fall back to a server identified by
+  another attribute.
+* ``PMIX_SERVER_URI`` (char\*) |mdash| connect to the server at the given URI.
+* ``PMIX_SERVER_NSPACE`` (char\*) |mdash| connect to the server of the given
+  namespace.
+* ``PMIX_SERVER_PIDINFO`` (pid_t) |mdash| connect to the server embedded in the
+  process with the given PID.
+* ``PMIX_TCP_URI`` (char\*) |mdash| URI of the server to connect to, or a file
+  name containing it in the form ``file:<name of file>``.
+* ``PMIX_TOOL_ATTACHMENT_FILE`` (char\*) |mdash| file containing the connection
+  information to be used for attaching to a server.
+
+Behavioral attributes
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PMIX_FWD_STDIN`` (bool) |mdash| forward this process's ``stdin`` to the
+  target processes.
+* ``PMIX_IOF_LOCAL_OUTPUT`` (bool) |mdash| write forwarded output streams to the
+  local ``stdout``/``stderr`` (the default for tools).
+* ``PMIX_SERVER_TMPDIR`` (char\*) |mdash| temporary directory where the PMIx
+  server places its rendezvous connection files. Defaults to the
+  ``PMIX_SERVER_TMPDIR`` environment variable, if set.
+* ``PMIX_SYSTEM_TMPDIR`` (char\*) |mdash| temporary directory used for the
+  system-level server rendezvous point. Defaults to the ``PMIX_SYSTEM_TMPDIR``
+  environment variable, if set.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` on success. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx library could not be initialized (for
+  example, a usock-only transport was requested, or a tight race between
+  concurrent init calls left the library in an unusable state).
+* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid combination of directives was
+  supplied (e.g., a namespace without a rank), or ``proc`` was ``NULL`` on the
+  initial call.
+* ``PMIX_ERR_UNREACH`` |mdash| the requested PMIx server could not be reached and
+  the connection was not optional.
+* ``PMIX_ERR_NOMEM`` |mdash| the library could not allocate required internal
+  storage.
+
+Any other negative value indicates an appropriate error condition. PMIx error
+constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+``PMIx_tool_init`` is intended for use by *tool* processes |mdash| debuggers,
+profilers, and workflow managers |mdash| that may or may not have been registered
+with a PMIx server before being started. Processes that were registered as
+*clients* before being started should instead call
+:ref:`PMIx_Init(3) <man3-PMIx_Init>`, and processes hosting a PMIx server on
+behalf of a resource manager should call
+:ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
+
+A tool is restricted to the ``hash`` component of the GDS framework for
+interacting with a server's data store.
+
+After initialization, a tool may establish additional server connections with
+:ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>` and select
+among them with :ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>`.
+
+
+.. seealso::
+   :ref:`PMIx_tool_finalize(3) <man3-PMIx_tool_finalize>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`,
+   :ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>`,
+   :ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>`,
+   :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
+   :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_is_connected.3.rst
+++ b/docs/man/man3/PMIx_tool_is_connected.3.rst
@@ -1,0 +1,70 @@
+.. _man3-PMIx_tool_is_connected:
+
+PMIx_tool_is_connected
+======================
+
+.. include_body
+
+``PMIx_tool_is_connected`` |mdash| Test whether the tool is connected to a PMIx
+server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   bool PMIx_tool_is_connected(void);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  rc, myname = foo.init(None)
+  if foo.is_connected():
+      # the tool currently has an active server connection
+      ...
+
+
+DESCRIPTION
+-----------
+
+Return ``true`` if the tool currently has an active connection to a PMIx server,
+and ``false`` otherwise.
+
+A tool is *connected* when it has an active primary-server connection |mdash| for
+example, immediately after a successful
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>` that contacted a server, or after a
+successful :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`
+that designated the new server as primary. A tool is *not* connected when it was
+initialized with ``PMIX_TOOL_DO_NOT_CONNECT``, when an optional connection
+attempt failed, or after
+:ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>` has dropped the primary
+server (which leaves the tool pointing its active server back at itself).
+
+This test reflects only the *primary* server association. A tool may still retain
+connections to other servers (retrievable via
+:ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`) even when it reports
+as not connected to a primary server.
+
+
+RETURN VALUE
+------------
+
+Returns the boolean connection state as described above. This routine does not
+return a ``pmix_status_t`` and never fails; if the tool library has not been
+initialized the returned value is simply ``false``.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`

--- a/docs/man/man3/PMIx_tool_set_server.3.rst
+++ b/docs/man/man3/PMIx_tool_set_server.3.rst
@@ -1,0 +1,125 @@
+.. _man3-PMIx_tool_set_server:
+
+PMIx_tool_set_server
+====================
+
+.. include_body
+
+``PMIx_tool_set_server`` |mdash| Designate a server as the tool's
+*primary* server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
+                                      pmix_info_t info[], size_t ninfo);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # ... after a successful foo.init() and attachment to one or more servers ...
+  server = {'nspace': "server-nspace", 'rank': 0}
+  pydirs = [{'key': PMIX_WAIT_FOR_CONNECTION,
+             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+  rc = foo.set_server(server, pydirs)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``server``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`
+  structure containing the namespace and rank of the target server. The
+  server **must** be one to which the tool is already connected (for
+  example, via :ref:`PMIx_tool_attach_to_server(3)
+  <man3-PMIx_tool_attach_to_server>`).
+* ``info``: Pointer to an array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+  structures conveying directives that qualify the operation (see
+  `DIRECTIVES`_). A ``NULL`` value is supported when no directives are
+  desired.
+* ``ninfo``: Number of elements in the ``info`` array.
+
+
+DESCRIPTION
+-----------
+
+Designate the specified server to be the tool's *primary* server for all
+subsequent PMIx API calls. A tool may be connected to several PMIx servers
+simultaneously; the primary server is the one to which non-directed
+requests (queries, spawns, event notifications, and the like) are routed by
+default. ``PMIx_tool_set_server`` changes that default to the indicated
+server.
+
+This is a *blocking* call. Internally, the request is thread-shifted onto
+the PMIx progress thread so that it may safely access the library's global
+connection state, and the function does not return until the operation has
+completed. The return value carries the result.
+
+If the tool is not yet connected to the named server, the behavior depends
+on the directives supplied. When ``PMIX_WAIT_FOR_CONNECTION`` is given, the
+library will wait |mdash| up to any specified ``PMIX_TIMEOUT`` |mdash| for
+the connection to be established before designating it as primary.
+
+
+DIRECTIVES
+----------
+
+The following attributes are required to be supported by all PMIx libraries.
+
+* ``PMIX_WAIT_FOR_CONNECTION`` (bool) |mdash| wait until the specified
+  connection has been made before completing the operation.
+* ``PMIX_TIMEOUT`` (int) |mdash| time, in seconds, before the operation
+  should time out and return an error. A value of zero indicates that the
+  operation should never time out.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` when the designated server has successfully been
+made the tool's primary server. On error, a negative value corresponding to
+a PMIx error constant is returned, including:
+
+* ``PMIX_ERR_INIT`` |mdash| the PMIx tool library has not been initialized.
+* ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced
+  because the library's progress engine has been stopped.
+* ``PMIX_ERR_UNREACH`` |mdash| the specified server could not be reached.
+* ``PMIX_ERR_TIMEOUT`` |mdash| the operation did not complete within the
+  time specified by ``PMIX_TIMEOUT``.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+PMIx does not currently support on-the-fly changes to a tool's own
+identifier. Accordingly, any server designated as primary must be under the
+same namespace manager (e.g., the same host resource manager) as the tool's
+original server, so that the tool's assigned namespace and rank remain a
+unique, valid assignment.
+
+This function is available only to processes that initialized as *tools*
+via :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_tool_get_servers(3) <man3-PMIx_tool_get_servers>`,
+   :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,
+   :ref:`PMIx_tool_is_connected(3) <man3-PMIx_tool_is_connected>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/PMIx_tool_set_server_module.3.rst
+++ b/docs/man/man3/PMIx_tool_set_server_module.3.rst
@@ -1,0 +1,109 @@
+.. _man3-PMIx_tool_set_server_module:
+
+PMIx_tool_set_server_module
+===========================
+
+.. include_body
+
+``PMIx_tool_set_server_module`` |mdash| Install a server function module so
+that a tool can also act as a PMIx server.
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix_tool.h>
+
+   pmix_status_t PMIx_tool_set_server_module(pmix_server_module_t *module);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxTool()
+  # ... after a successful foo.init() ...
+  # map server module entry-point names to Python callback functions
+  modmap = {'clientconnected': myclientconnected,
+            'iofpull': myiofpull}
+  rc = foo.set_server_module(modmap)
+
+
+INPUT PARAMETERS
+----------------
+
+* ``module``: Pointer to a ``pmix_server_module_t`` structure whose fields
+  point at the host-provided functions the PMIx library is to call when it
+  needs the tool (acting as a server) to perform a corresponding operation.
+  Any field left ``NULL`` indicates that the tool does not provide that
+  particular function.
+
+
+DESCRIPTION
+-----------
+
+Provide an entry point by which a tool can supply a server function-pointer
+module. Some tools (for example, launchers and workflow orchestrators) need
+to act as PMIx servers to their own child processes while simultaneously
+operating as tools with respect to a higher-level server. Calling
+``PMIx_tool_set_server_module`` installs the host callbacks that the PMIx
+library will invoke to satisfy client requests, and marks the process as
+being of *server* type in addition to its tool role.
+
+This is a purely local, *non-blocking* operation: the provided ``module``
+structure is copied into the library's internal server state and the
+function returns immediately. Because the library retains its own copy of
+the structure contents, the caller is not required to keep the ``module``
+storage alive after the call returns; however, any objects referenced by
+the module's function pointers must remain valid for as long as the tool
+acts as a server.
+
+The module may be set only once. A second call, after a module has already
+been installed, is rejected.
+
+
+CALLBACK FUNCTION
+-----------------
+
+The ``pmix_server_module_t`` structure is a collection of function pointers,
+each corresponding to a server operation that the host environment may be
+asked to perform |mdash| for example, ``client_connected2``, ``fence_nb``,
+``direct_modex``, ``spawn``, ``notify_event``, and the I/O forwarding
+entry points. The full set of typedefs and their calling conventions is
+defined in ``pmix_server.h``. The order of fields in this structure is part
+of the PMIx ABI and never changes; new operations are only ever appended.
+
+
+RETURN VALUE
+------------
+
+Returns ``PMIX_SUCCESS`` when the module has been installed successfully. On
+error, a negative value corresponding to a PMIx error constant is returned,
+including:
+
+* ``PMIX_ERR_INIT`` |mdash| a server module has already been set for this
+  process; the module cannot be replaced.
+
+Any other negative value indicates an appropriate error condition. PMIx
+error constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+This function is available only to processes that initialized as *tools*
+via :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`. A process whose sole
+role is that of a PMIx server should instead supply its module through
+``PMIx_server_init``.
+
+
+.. seealso::
+   :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
+   :ref:`PMIx_tool_set_server(3) <man3-PMIx_tool_set_server>`,
+   PMIx_server_init(3),
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -253,3 +253,38 @@ APIs (section 3)
    PMIx_Multicluster_nspace_construct.3.rst
    PMIx_Multicluster_nspace_parse.3.rst
    PMIx_Setenv.3.rst
+   PMIx_server_init.3.rst
+   PMIx_server_finalize.3.rst
+   PMIx_server_register_nspace.3.rst
+   PMIx_server_deregister_nspace.3.rst
+   PMIx_server_register_client.3.rst
+   PMIx_server_deregister_client.3.rst
+   PMIx_server_setup_fork.3.rst
+   PMIx_server_setup_application.3.rst
+   PMIx_server_setup_local_support.3.rst
+   PMIx_server_register_resources.3.rst
+   PMIx_server_deregister_resources.3.rst
+   PMIx_Register_attributes.3.rst
+   PMIx_server_dmodex_request.3.rst
+   PMIx_server_collect_inventory.3.rst
+   PMIx_server_deliver_inventory.3.rst
+   PMIx_server_collect_job_info.3.rst
+   PMIx_server_IOF_deliver.3.rst
+   PMIx_server_generate_cpuset.3.rst
+   PMIx_server_generate_cpuset_string.3.rst
+   PMIx_server_generate_locality_string.3.rst
+   PMIx_server_define_process_set.3.rst
+   PMIx_server_delete_process_set.3.rst
+   PMIx_generate_regex2.3.rst
+   PMIx_parse_regex2.3.rst
+   PMIx_tool_init.3.rst
+   PMIx_tool_finalize.3.rst
+   PMIx_tool_attach_to_server.3.rst
+   PMIx_tool_disconnect.3.rst
+   PMIx_tool_get_servers.3.rst
+   PMIx_tool_is_connected.3.rst
+   PMIx_tool_set_server.3.rst
+   PMIx_tool_set_server_module.3.rst
+   PMIx_IOF_pull.3.rst
+   PMIx_IOF_push.3.rst
+   PMIx_IOF_deregister.3.rst


### PR DESCRIPTION
Create section-3 reference man pages for the 35 public server- and
tool-facing APIs declared in `include/pmix_server.h` and
`include/pmix_tool.h`, completing the man3 coverage of the public API
headers (the `pmix.h` client and datatype-support APIs are already
documented).

## Coverage

- **Server lifecycle & registration:** `PMIx_server_init`, `_finalize`,
  `_register_nspace`, `_deregister_nspace`, `_register_client`,
  `_deregister_client`.
- **Setup & resources:** `_setup_fork`, `_setup_application`,
  `_setup_local_support`, `_register_resources`, `_deregister_resources`,
  `PMIx_Register_attributes`.
- **Data & inventory:** `_dmodex_request`, `_collect_inventory`,
  `_deliver_inventory`, `_collect_job_info`, `_IOF_deliver`.
- **Generators & regex:** `_generate_cpuset`, `_generate_cpuset_string`,
  `_generate_locality_string`, `_define_process_set`,
  `_delete_process_set`, `PMIx_generate_regex2`, `PMIx_parse_regex2`.
- **Tool:** `PMIx_tool_init`, `_finalize`, `_attach_to_server`,
  `_disconnect`, `_get_servers`, `_is_connected`, `_set_server`,
  `_set_server_module`, and the IOF interface `PMIx_IOF_pull`,
  `PMIx_IOF_push`, `PMIx_IOF_deregister`.

## Approach

Each page uses the fuller treatment of the client API pages (e.g.
`PMIx_Init`): the exact signature from the header, the directive
attributes the call consumes, the callback contract and blocking vs.
non-blocking behavior, the return codes, and the Python binding where the
`PMIxServer`/`PMIxTool` class provides one.

Behavior is documented from the implementation, which is authoritative
where the header comment or the Standard disagree — e.g.
`PMIx_server_collect_job_info` is a blocking, buffer-return call rather
than the callback form its neighbors use; the blocking registration forms
return `PMIX_OPERATION_SUCCEEDED`. Attributes cited were confirmed present
in `include/pmix_common.h.in`; deprecated-only attributes were omitted.
Return-value prose avoids naming internal-only status codes (e.g. the
hwloc `PMIX_ERR_TAKE_NEXT_OPTION`, which lives in a private header) in
favor of a generic description users can act on.

## Verification

- New pages wired into the man3 toctree and the `PMIX_MAN3` install list.
- Clean Sphinx build with zero warnings; every `:ref:` resolves and all
  cited `PMIX_` constants exist in the public headers.