### PR TITLE
Document the datatype static initializers and pmix_regex2_t

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -465,7 +465,8 @@ PMIX_MAN5 = \
         pmix_storage_access_type_t.5 \
         pmix_storage_accessibility_t.5 \
         pmix_storage_medium_t.5 \
-        pmix_storage_persistence_t.5
+        pmix_storage_persistence_t.5 \
+        pmix_regex2_t.5
 
 MAN_OUTDIR = $(OUTDIR)/man
 

--- a/docs/man/man3/PMIx_Regex2_construct.3.rst
+++ b/docs/man/man3/PMIx_Regex2_construct.3.rst
@@ -6,7 +6,7 @@ PMIx_Regex2_construct
 .. include_body
 
 ``PMIx_Regex2_construct`` |mdash| Initialize a caller-provided
-``pmix_regex2_t`` structure.
+:ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structure.
 
 
 SYNOPSIS
@@ -87,4 +87,5 @@ Construct a structure:
 .. seealso::
    :ref:`PMIx_Regex2_destruct(3) <man3-PMIx_Regex2_destruct>`,
    :ref:`PMIx_Regex2_create(3) <man3-PMIx_Regex2_create>`,
-   :ref:`PMIx_Regex2_free(3) <man3-PMIx_Regex2_free>`
+   :ref:`PMIx_Regex2_free(3) <man3-PMIx_Regex2_free>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man3/PMIx_Regex2_create.3.rst
+++ b/docs/man/man3/PMIx_Regex2_create.3.rst
@@ -6,7 +6,7 @@ PMIx_Regex2_create
 .. include_body
 
 ``PMIx_Regex2_create`` |mdash| Allocate and initialize an array of
-``pmix_regex2_t`` structures.
+:ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structures.
 
 
 SYNOPSIS
@@ -79,4 +79,5 @@ Create and later free an array:
 .. seealso::
    :ref:`PMIx_Regex2_free(3) <man3-PMIx_Regex2_free>`,
    :ref:`PMIx_Regex2_construct(3) <man3-PMIx_Regex2_construct>`,
-   :ref:`PMIx_Regex2_destruct(3) <man3-PMIx_Regex2_destruct>`
+   :ref:`PMIx_Regex2_destruct(3) <man3-PMIx_Regex2_destruct>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man3/PMIx_Regex2_destruct.3.rst
+++ b/docs/man/man3/PMIx_Regex2_destruct.3.rst
@@ -6,7 +6,7 @@ PMIx_Regex2_destruct
 .. include_body
 
 ``PMIx_Regex2_destruct`` |mdash| Release the contents of a
-``pmix_regex2_t`` structure.
+:ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structure.
 
 
 SYNOPSIS
@@ -63,4 +63,5 @@ the array storage itself |mdash| use :ref:`PMIx_Regex2_free(3)
 .. seealso::
    :ref:`PMIx_Regex2_construct(3) <man3-PMIx_Regex2_construct>`,
    :ref:`PMIx_Regex2_create(3) <man3-PMIx_Regex2_create>`,
-   :ref:`PMIx_Regex2_free(3) <man3-PMIx_Regex2_free>`
+   :ref:`PMIx_Regex2_free(3) <man3-PMIx_Regex2_free>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man3/PMIx_Regex2_free.3.rst
+++ b/docs/man/man3/PMIx_Regex2_free.3.rst
@@ -5,7 +5,7 @@ PMIx_Regex2_free
 
 .. include_body
 
-``PMIx_Regex2_free`` |mdash| Release an array of ``pmix_regex2_t`` structures.
+``PMIx_Regex2_free`` |mdash| Release an array of :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structures.
 
 
 SYNOPSIS
@@ -61,4 +61,5 @@ single caller-owned structure without freeing its storage, use
 .. seealso::
    :ref:`PMIx_Regex2_create(3) <man3-PMIx_Regex2_create>`,
    :ref:`PMIx_Regex2_construct(3) <man3-PMIx_Regex2_construct>`,
-   :ref:`PMIx_Regex2_destruct(3) <man3-PMIx_Regex2_destruct>`
+   :ref:`PMIx_Regex2_destruct(3) <man3-PMIx_Regex2_destruct>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man3/PMIx_generate_regex2.3.rst
+++ b/docs/man/man3/PMIx_generate_regex2.3.rst
@@ -41,7 +41,7 @@ OUTPUT PARAMETERS
 -----------------
 
 * ``regex``: Pointer to caller-provided storage for a
-  ``pmix_regex2_t`` structure into which the
+  :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structure into which the
   encoded representation is placed. The structure carries a colon-delimited
   ``type`` string identifying the encoding method, a ``bytes`` buffer
   holding the encoded representation (which may **not** be
@@ -113,4 +113,5 @@ on the ``type`` prefix.
    :ref:`PMIx_parse_regex2(3) <man3-PMIx_parse_regex2>`,
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
-   :ref:`pmix_status_t(5) <man5-pmix_status_t>`
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man3/PMIx_parse_regex2.3.rst
+++ b/docs/man/man3/PMIx_parse_regex2.3.rst
@@ -30,7 +30,7 @@ No Python equivalent
 INPUT PARAMETERS
 ----------------
 
-* ``regex``: Pointer to a ``pmix_regex2_t`` structure as returned by
+* ``regex``: Pointer to a :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>` structure as returned by
   :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`. Its
   colon-delimited ``type`` prefix selects the decoding method.
 * ``info``: Optional array of :ref:`pmix_info_t(5) <man5-pmix_info_t>`
@@ -103,4 +103,5 @@ with ``free()`` when no longer needed.
    :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`,
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
-   :ref:`pmix_status_t(5) <man5-pmix_status_t>`
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :ref:`pmix_regex2_t(5) <man5-pmix_regex2_t>`

--- a/docs/man/man5/index.rst
+++ b/docs/man/man5/index.rst
@@ -56,3 +56,4 @@ Config file manual pages (section 5)
    pmix_storage_accessibility_t.5.rst
    pmix_storage_medium_t.5.rst
    pmix_storage_persistence_t.5.rst
+   pmix_regex2_t.5.rst

--- a/docs/man/man5/pmix_app_t.5.rst
+++ b/docs/man/man5/pmix_app_t.5.rst
@@ -63,6 +63,16 @@ The fields are:
 ``ninfo``
    The number of elements in the ``info`` array.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_app_t`` may be initialized with the
+``PMIX_APP_STATIC_INIT`` macro, which sets ``cmd``, ``argv``, ``env``, ``cwd``, and ``info`` to ``NULL`` and ``maxprocs`` and ``ninfo`` to ``0``:
+
+.. code-block:: c
+
+   pmix_app_t app = PMIX_APP_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`,

--- a/docs/man/man5/pmix_byte_object_t.5.rst
+++ b/docs/man/man5/pmix_byte_object_t.5.rst
@@ -51,6 +51,17 @@ A `pmix_byte_object_t` may be carried as the value of a
 :ref:`pmix_info_t(5) <man5-pmix_info_t>`, allowing arbitrary binary payloads to
 be exchanged through the standard PMIx information-passing mechanisms.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_byte_object_t`` may be initialized with the
+``PMIX_BYTE_OBJECT_STATIC_INIT`` macro, which sets ``bytes`` to ``NULL`` and ``size`` to ``0``:
+
+.. code-block:: c
+
+   pmix_byte_object_t bo = PMIX_BYTE_OBJECT_STATIC_INIT;
+
+
 .. seealso::
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`

--- a/docs/man/man5/pmix_coord_t.5.rst
+++ b/docs/man/man5/pmix_coord_t.5.rst
@@ -52,6 +52,16 @@ fabric coordinates are logically grouped within the *node* realm.
 The ``PMIX_COORD_STATIC_INIT`` macro is provided to statically initialize a
 `pmix_coord_t` structure.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_coord_t`` may be initialized with the
+``PMIX_COORD_STATIC_INIT`` macro, which sets ``view`` to ``PMIX_COORD_VIEW_UNDEF``, ``coord`` to ``NULL``, and ``dims`` to ``0``:
+
+.. code-block:: c
+
+   pmix_coord_t coord = PMIX_COORD_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_coord_view_t(5) <man5-pmix_coord_view_t>`,

--- a/docs/man/man5/pmix_cpuset_t.5.rst
+++ b/docs/man/man5/pmix_cpuset_t.5.rst
@@ -50,6 +50,16 @@ a ``PMIX_CPUSET`` string into the structure. The
 ``PMIx_Get_cpuset`` controls which threads of a possibly multi-threaded process
 are considered.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_cpuset_t`` may be initialized with the
+``PMIX_CPUSET_STATIC_INIT`` macro, which sets both ``source`` and ``bitmap`` to ``NULL``:
+
+.. code-block:: c
+
+   pmix_cpuset_t cpuset = PMIX_CPUSET_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Get_cpuset(3) <man3-PMIx_Get_cpuset>`,

--- a/docs/man/man5/pmix_data_array_t.5.rst
+++ b/docs/man/man5/pmix_data_array_t.5.rst
@@ -43,6 +43,17 @@ or :ref:`pmix_info_t(5) <man5-pmix_info_t>`: the containing structure references
 a `pmix_data_array_t` (via the ``darray`` union member of a `pmix_value_t`),
 which in turn points at the array of individual objects.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_data_array_t`` may be initialized with the
+``PMIX_DATA_ARRAY_STATIC_INIT`` macro, which sets ``type`` to ``PMIX_UNDEF``, ``size`` to ``0``, and ``array`` to ``NULL``:
+
+.. code-block:: c
+
+   pmix_data_array_t array = PMIX_DATA_ARRAY_STATIC_INIT;
+
+
 .. seealso::
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`

--- a/docs/man/man5/pmix_data_buffer_t.5.rst
+++ b/docs/man/man5/pmix_data_buffer_t.5.rst
@@ -91,6 +91,16 @@ contents. These include:
 ``PMIx_Data_pack``, ``PMIx_Data_unpack``, and ``PMIx_Data_buffer_*``
 interfaces.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_data_buffer_t`` may be initialized with the
+``PMIX_DATA_BUFFER_STATIC_INIT`` macro, which sets the ``base_ptr``, ``pack_ptr``, and ``unpack_ptr`` pointers to ``NULL`` and both ``bytes_allocated`` and ``bytes_used`` to ``0``:
+
+.. code-block:: c
+
+   pmix_data_buffer_t buffer = PMIX_DATA_BUFFER_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Data_pack(3) <man3-PMIx_Data_pack>`,

--- a/docs/man/man5/pmix_device_distance_t.5.rst
+++ b/docs/man/man5/pmix_device_distance_t.5.rst
@@ -65,6 +65,16 @@ device locations) or other factors.
 An array of `pmix_device_distance_t` structures is returned by
 :ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_device_distance_t`` may be initialized with the
+``PMIX_DEVICE_DIST_STATIC_INIT`` macro, which sets ``uuid`` and ``osname`` to ``NULL``, ``type`` to ``PMIX_DEVTYPE_UNKNOWN``, and both ``mindist`` and ``maxdist`` to ``UINT16_MAX`` (the "unknown distance" sentinel):
+
+.. code-block:: c
+
+   pmix_device_distance_t dist = PMIX_DEVICE_DIST_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`,

--- a/docs/man/man5/pmix_device_t.5.rst
+++ b/docs/man/man5/pmix_device_t.5.rst
@@ -40,6 +40,16 @@ device resides.
 The ``type`` field is a :ref:`pmix_device_type_t(5) <man5-pmix_device_type_t>`
 bitmask identifying the type(s) of the device.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_device_t`` may be initialized with the
+``PMIX_DEVICE_STATIC_INIT`` macro, which sets ``uuid`` and ``osname`` to ``NULL`` and ``type`` to ``PMIX_DEVTYPE_UNKNOWN``:
+
+.. code-block:: c
+
+   pmix_device_t device = PMIX_DEVICE_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_device_type_t(5) <man5-pmix_device_type_t>`,

--- a/docs/man/man5/pmix_endpoint_t.5.rst
+++ b/docs/man/man5/pmix_endpoint_t.5.rst
@@ -47,6 +47,16 @@ bound), fabric endpoints for a process are typically returned as a
 :ref:`pmix_data_array_t(5) <man5-pmix_data_array_t>` of `pmix_endpoint_t`
 elements.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_endpoint_t`` may be initialized with the
+``PMIX_ENDPOINT_STATIC_INIT`` macro, which sets ``uuid`` and ``osname`` to ``NULL`` and initializes the embedded ``endpt`` byte object to its empty state:
+
+.. code-block:: c
+
+   pmix_endpoint_t endpoint = PMIX_ENDPOINT_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`,

--- a/docs/man/man5/pmix_envar_t.5.rst
+++ b/docs/man/man5/pmix_envar_t.5.rst
@@ -47,6 +47,16 @@ The fields are:
    The single character used as the delimiter when composing the aggregate value
    of the environment variable from its constituent arguments.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_envar_t`` may be initialized with the
+``PMIX_ENVAR_STATIC_INIT`` macro, which sets ``envar`` and ``value`` to ``NULL`` and ``separator`` to the null character ``'\0'``:
+
+.. code-block:: c
+
+   pmix_envar_t envar = PMIX_ENVAR_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,

--- a/docs/man/man5/pmix_fabric_t.5.rst
+++ b/docs/man/man5/pmix_fabric_t.5.rst
@@ -60,6 +60,16 @@ protection for accessing the information in the `pmix_fabric_t` structure.
 Callers must therefore coordinate their access to the structure with any
 updates driven by the PMIx library.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_fabric_t`` may be initialized with the
+``PMIX_FABRIC_STATIC_INIT`` macro, which sets ``name``, ``info``, and ``module`` to ``NULL``, ``index`` to ``SIZE_MAX`` (the "unset" sentinel), and ``ninfo`` to ``0``:
+
+.. code-block:: c
+
+   pmix_fabric_t fabric = PMIX_FABRIC_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Fabric_register(3) <man3-PMIx_Fabric_register>`,

--- a/docs/man/man5/pmix_geometry_t.5.rst
+++ b/docs/man/man5/pmix_geometry_t.5.rst
@@ -57,6 +57,16 @@ grouped within the *node* realm.
 The ``PMIX_GEOMETRY_STATIC_INIT`` macro is provided to statically initialize a
 `pmix_geometry_t` structure.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_geometry_t`` may be initialized with the
+``PMIX_GEOMETRY_STATIC_INIT`` macro, which sets ``fabric`` and ``ncoords`` to ``0`` and ``uuid``, ``osname``, and ``coordinates`` to ``NULL``:
+
+.. code-block:: c
+
+   pmix_geometry_t geometry = PMIX_GEOMETRY_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_coord_t(5) <man5-pmix_coord_t>`,

--- a/docs/man/man5/pmix_info_t.5.rst
+++ b/docs/man/man5/pmix_info_t.5.rst
@@ -78,6 +78,17 @@ setting flags on `pmix_info_t` structures. These include:
 The flag values that may appear in the ``flags`` field are enumerated in
 :ref:`pmix_info_directives_t(5) <man5-pmix_info_directives_t>`.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_info_t`` may be initialized with the
+``PMIX_INFO_STATIC_INIT`` macro, which clears ``key`` and ``flags`` and initializes the embedded ``value`` (with ``type`` set to ``PMIX_UNDEF``):
+
+.. code-block:: c
+
+   pmix_info_t info = PMIX_INFO_STATIC_INIT;
+
+
 .. seealso::
    :ref:`PMIx_Info_construct(3) <man3-PMIx_Info_construct>`,
    :ref:`PMIx_Info_create(3) <man3-PMIx_Info_create>`,

--- a/docs/man/man5/pmix_node_pid_t.5.rst
+++ b/docs/man/man5/pmix_node_pid_t.5.rst
@@ -46,6 +46,16 @@ The fields of the structure are:
 Either ``hostname`` or ``nodeid`` may be used to identify the node; a
 consumer must be prepared to accept whichever the producer has supplied.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_node_pid_t`` may be initialized with the
+``PMIX_NODE_PID_STATIC_INIT`` macro, which sets ``hostname`` to ``NULL``, ``nodeid`` to ``UINT32_MAX``, and ``pid`` to ``-1``:
+
+.. code-block:: c
+
+   pmix_node_pid_t npid = PMIX_NODE_PID_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Process_monitor(3) <man3-PMIx_Process_monitor>`,

--- a/docs/man/man5/pmix_pdata_t.5.rst
+++ b/docs/man/man5/pmix_pdata_t.5.rst
@@ -44,6 +44,19 @@ Data is placed into the PMIx datastore with
 :ref:`PMIx_Publish(3) <man3-PMIx_Publish>` and later removed with
 :ref:`PMIx_Unpublish(3) <man3-PMIx_Unpublish>`.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_pdata_t`` may be initialized with the
+``PMIX_LOOKUP_STATIC_INIT`` macro, which initializes the embedded ``proc`` (with ``rank`` set to ``PMIX_RANK_UNDEF``), clears ``key``, and initializes the embedded ``value`` (with ``type`` set to ``PMIX_UNDEF``):
+
+.. code-block:: c
+
+   pmix_pdata_t pdata = PMIX_LOOKUP_STATIC_INIT;
+
+For historical reasons this macro is named ``PMIX_LOOKUP_STATIC_INIT`` rather than ``PMIX_PDATA_STATIC_INIT``.
+
+
 .. seealso::
    :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`,
    :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,

--- a/docs/man/man5/pmix_proc_info_t.5.rst
+++ b/docs/man/man5/pmix_proc_info_t.5.rst
@@ -51,6 +51,16 @@ the fields of a `pmix_proc_info_t` structure. PMIx also provides the
 ``PMIx_Proc_info_create``, and ``PMIx_Proc_info_free`` support functions for
 initializing, releasing, allocating, and freeing these structures.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_proc_info_t`` may be initialized with the
+``PMIX_PROC_INFO_STATIC_INIT`` macro, which initializes the embedded ``proc`` (with ``rank`` set to ``PMIX_RANK_UNDEF``), sets ``hostname`` and ``executable_name`` to ``NULL`` and ``pid`` and ``exit_code`` to ``0``, and sets ``state`` to ``PMIX_PROC_STATE_UNDEF``:
+
+.. code-block:: c
+
+   pmix_proc_info_t pinfo = PMIX_PROC_INFO_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,

--- a/docs/man/man5/pmix_proc_t.5.rst
+++ b/docs/man/man5/pmix_proc_t.5.rst
@@ -44,6 +44,16 @@ The macro ``PMIX_PROC_STATIC_INIT`` is provided to statically initialize the
 fields of a `pmix_proc_t` structure, setting ``nspace`` to all zeroes and
 ``rank`` to ``PMIX_RANK_UNDEF``.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_proc_t`` may be initialized with the
+``PMIX_PROC_STATIC_INIT`` macro, which clears ``nspace`` and sets ``rank`` to ``PMIX_RANK_UNDEF``:
+
+.. code-block:: c
+
+   pmix_proc_t proc = PMIX_PROC_STATIC_INIT;
+
 
 .. seealso::
    :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`,

--- a/docs/man/man5/pmix_query_t.5.rst
+++ b/docs/man/man5/pmix_query_t.5.rst
@@ -49,6 +49,16 @@ The fields are:
 ``nqual``
    The number of elements in the ``qualifiers`` array.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_query_t`` may be initialized with the
+``PMIX_QUERY_STATIC_INIT`` macro, which sets ``keys`` and ``qualifiers`` to ``NULL`` and ``nqual`` to ``0``:
+
+.. code-block:: c
+
+   pmix_query_t query = PMIX_QUERY_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,

--- a/docs/man/man5/pmix_regattr_t.5.rst
+++ b/docs/man/man5/pmix_regattr_t.5.rst
@@ -57,6 +57,16 @@ Although not strictly required, both PMIx library implementers and host
 environments are strongly encouraged to provide both human-readable and
 machine-parsable descriptions of supported attributes when registering them.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_regattr_t`` may be initialized with the
+``PMIX_REGATTR_STATIC_INIT`` macro, which sets ``name`` and ``description`` to ``NULL``, clears the ``string`` key, and sets ``type`` to ``PMIX_UNDEF``:
+
+.. code-block:: c
+
+   pmix_regattr_t attr = PMIX_REGATTR_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,

--- a/docs/man/man5/pmix_regex2_t.5.rst
+++ b/docs/man/man5/pmix_regex2_t.5.rst
@@ -1,0 +1,82 @@
+.. _man5-pmix_regex2_t:
+
+pmix_regex2_t
+=============
+
+.. include_body
+
+``pmix_regex2_t`` |mdash| A compact, self-describing encoding of an ordered
+list of values (for example, node or process names).
+
+
+SYNTAX
+------
+
+C Syntax
+^^^^^^^^
+
+.. code-block:: c
+
+   #include <pmix_common.h>
+
+   typedef struct pmix_regex2 {
+       char *type;         // colon-delimited identifier of the encoding method (e.g., "pmix" or "blob")
+       uint8_t *bytes;     // encoded representation (may not be NULL-terminated)
+       size_t len;         // number of bytes in the encoded representation
+   } pmix_regex2_t;
+
+
+DESCRIPTION
+-----------
+
+The ``pmix_regex2_t`` structure holds a reduced-size, encoded representation of
+an ordered list of values |mdash| most commonly the set of node names, or the
+set of process names, that participate in a job. Encoding a long, regular list
+(such as ``node000,node001,...,node511``) into this compact form greatly
+reduces the volume of data that must be exchanged when a namespace is
+registered or distributed.
+
+The fields are:
+
+* ``type`` |mdash| A colon-delimited string naming the encoding method used to
+  produce the representation (for example, ``"pmix"`` for the built-in regular
+  expression generator, or ``"blob"`` for an opaque payload). The parser uses
+  this identifier to select the matching decoder.
+* ``bytes`` |mdash| The encoded representation itself. This is a raw byte buffer
+  and is **not** guaranteed to be ``NULL``-terminated; its length is given by
+  ``len``.
+* ``len`` |mdash| The number of bytes in the ``bytes`` buffer.
+
+A ``pmix_regex2_t`` is produced by :ref:`PMIx_generate_regex2(3)
+<man3-PMIx_generate_regex2>` from a comma-separated input string, and is
+expanded back into the original list by :ref:`PMIx_parse_regex2(3)
+<man3-PMIx_parse_regex2>`. The order of the individual values is preserved
+across the generate/parse round trip. The encoded form may also be passed to
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>` for
+processing. In all cases the caller is responsible for releasing the data the
+structure references.
+
+The ``pmix_regex2_t`` type supersedes the older raw ``char*`` regular-expression
+form. It also appears as a member of the :ref:`pmix_value_t(5)
+<man5-pmix_value_t>` union so that an encoded list can be carried as a typed
+value.
+
+
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_regex2_t`` may be initialized with the
+``PMIX_REGEX2_STATIC_INIT`` macro, which sets ``type`` and ``bytes`` to ``NULL``
+and ``len`` to ``0``:
+
+.. code-block:: c
+
+   pmix_regex2_t regex = PMIX_REGEX2_STATIC_INIT;
+
+
+.. seealso::
+   :ref:`PMIx_generate_regex2(3) <man3-PMIx_generate_regex2>`,
+   :ref:`PMIx_parse_regex2(3) <man3-PMIx_parse_regex2>`,
+   :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
+   :ref:`pmix_byte_object_t(5) <man5-pmix_byte_object_t>`

--- a/docs/man/man5/pmix_resource_unit_t.5.rst
+++ b/docs/man/man5/pmix_resource_unit_t.5.rst
@@ -42,6 +42,16 @@ as ``PMIX_ALLOC_MAU`` (the minimum allocatable unit for the system) passed to
 The :ref:`PMIx_Resource_unit_string(3) <man3-PMIx_Resource_unit_string>`
 function returns a string representation of a `pmix_resource_unit_t` value.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_resource_unit_t`` may be initialized with the
+``PMIX_RESOURCE_UNIT_STATIC_INIT`` macro, which sets ``type`` to ``PMIX_DEVTYPE_UNKNOWN`` and ``count`` to ``0``:
+
+.. code-block:: c
+
+   pmix_resource_unit_t unit = PMIX_RESOURCE_UNIT_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Resource_unit_string(3) <man3-PMIx_Resource_unit_string>`,

--- a/docs/man/man5/pmix_topology_t.5.rst
+++ b/docs/man/man5/pmix_topology_t.5.rst
@@ -45,6 +45,16 @@ A `pmix_topology_t` may be populated by
 :ref:`PMIx_Load_topology(3) <man3-PMIx_Load_topology>` and is consumed by
 operations such as :ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_topology_t`` may be initialized with the
+``PMIX_TOPOLOGY_STATIC_INIT`` macro, which sets both ``source`` and ``topology`` to ``NULL``:
+
+.. code-block:: c
+
+   pmix_topology_t topology = PMIX_TOPOLOGY_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Load_topology(3) <man3-PMIx_Load_topology>`,

--- a/docs/man/man5/pmix_value_t.5.rst
+++ b/docs/man/man5/pmix_value_t.5.rst
@@ -113,6 +113,16 @@ A collection of values may be specified under a single key by passing a
 :ref:`pmix_data_array_t(5) <man5-pmix_data_array_t>`, with each array element
 containing its own object.
 
+STATIC INITIALIZER
+------------------
+
+A statically declared ``pmix_value_t`` may be initialized with the
+``PMIX_VALUE_STATIC_INIT`` macro, which sets ``type`` to ``PMIX_UNDEF`` and clears the data union:
+
+.. code-block:: c
+
+   pmix_value_t value = PMIX_VALUE_STATIC_INIT;
+
 
 .. seealso::
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,


### PR DESCRIPTION
Add a STATIC INITIALIZER section to each section-5 datatype page, documenting the PMIX_<TYPE>_STATIC_INIT macro that initializes a statically declared instance of that structure -- the counterpart to the PMIx_<Type>_construct routine. Each section states, concisely, which fields the macro sets and to what, and shows the usage:

    pmix_proc_t proc = PMIX_PROC_STATIC_INIT;

The pmix_pdata_t initializer is, for historical reasons, named PMIX_LOOKUP_STATIC_INIT; that is noted on its page. The mindist/maxdist (UINT16_MAX) and fabric index (SIZE_MAX) sentinels documented here match the values set by the corresponding construct routines.

Also add a section-5 page for pmix_regex2_t, the encoded list representation produced by PMIx_generate_regex2 and consumed by PMIx_parse_regex2. It is a public-facing structure (it appears in those APIs and as a member of pmix_value_t) but previously had no datatype page. The plain-text pmix_regex2_t references in the PMIx_Regex2_* and PMIx_*_regex2 pages are upgraded to resolvable links, and the new page is wired into the man5 toctree and the PMIX_MAN5 install list.