### PR TITLE
Fix static initializers to match the construct sentinels

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2298,8 +2298,8 @@ typedef struct pmix_device_distance {
     .uuid = NULL,                       \
     .osname = NULL,                     \
     .type = PMIX_DEVTYPE_UNKNOWN,       \
-    .mindist = 0,                       \
-    .maxdist = 0                        \
+    .mindist = UINT16_MAX,              \
+    .maxdist = UINT16_MAX               \
 }
 
 
@@ -2647,7 +2647,7 @@ typedef struct pmix_fabric_s {
 #define PMIX_FABRIC_STATIC_INIT \
 {                               \
     .name = NULL,               \
-    .index = 0,                 \
+    .index = SIZE_MAX,          \
     .info = NULL,               \
     .ninfo = 0,                 \
     .module = NULL              \


### PR DESCRIPTION
Two datatype static initializers set their "unset" sentinel fields to
`0` rather than the value their construct routine uses, so a statically
declared instance did not match one initialized via the corresponding
`PMIx_<Type>_construct` call.

## The defects

- **`PMIX_DEVICE_DIST_STATIC_INIT`** set `mindist` and `maxdist` to `0`,
  whereas `pmix_bfrops_base_tma_device_distance_construct` sets them to
  `UINT16_MAX`. Zero is a meaningful distance ("same device"), so a
  statically initialized `pmix_device_distance_t` wrongly reported zero
  minimum and maximum distance instead of the "unknown/unset"
  `UINT16_MAX` sentinel that consumers test for.

- **`PMIX_FABRIC_STATIC_INIT`** set `index` to `0`, whereas
  `PMIx_Fabric_construct` sets it to `SIZE_MAX`. Zero is a valid fabric
  index, so the static initializer collided with a real index rather
  than using the `SIZE_MAX` "unset" sentinel.

## The fix

Set both initializers to the same sentinels their construct routines
use. The change is to the `include/pmix_common.h.in` template; the
generated `include/pmix_common.h` was regenerated and the full library
builds cleanly with no new warnings.

These were surfaced while documenting the `PMIX_*_STATIC_INIT` macros
for the man pages.