### PR TITLE
Add a consolidated man page for the PMIx callback functions

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -418,7 +418,26 @@ PMIX_MAN3_NB_ALIASES = \
 # <target>.5 so that, e.g., "man pmix_server_module" resolves to the
 # pmix_server_module_t page.
 PMIX_MAN5_ALIASES = \
-	pmix_server_module:pmix_server_module_t
+	pmix_server_module:pmix_server_module_t \
+	pmix_release_cbfunc_t:pmix_callback_functions \
+	pmix_op_cbfunc_t:pmix_callback_functions \
+	pmix_info_cbfunc_t:pmix_callback_functions \
+	pmix_modex_cbfunc_t:pmix_callback_functions \
+	pmix_value_cbfunc_t:pmix_callback_functions \
+	pmix_lookup_cbfunc_t:pmix_callback_functions \
+	pmix_spawn_cbfunc_t:pmix_callback_functions \
+	pmix_credential_cbfunc_t:pmix_callback_functions \
+	pmix_validation_cbfunc_t:pmix_callback_functions \
+	pmix_device_dist_cbfunc_t:pmix_callback_functions \
+	pmix_hdlr_reg_cbfunc_t:pmix_callback_functions \
+	pmix_evhdlr_reg_cbfunc_t:pmix_callback_functions \
+	pmix_notification_fn_t:pmix_callback_functions \
+	pmix_event_notification_cbfunc_fn_t:pmix_callback_functions \
+	pmix_setup_application_cbfunc_t:pmix_callback_functions \
+	pmix_connection_cbfunc_t:pmix_callback_functions \
+	pmix_tool_connection_cbfunc_t:pmix_callback_functions \
+	pmix_dmodex_response_fn_t:pmix_callback_functions \
+	pmix_iof_cbfunc_t:pmix_callback_functions
 
 PMIX_MAN5 = \
         openpmix.5 \
@@ -474,7 +493,8 @@ PMIX_MAN5 = \
         pmix_storage_medium_t.5 \
         pmix_storage_persistence_t.5 \
         pmix_regex2_t.5 \
-        pmix_server_module_t.5
+        pmix_server_module_t.5 \
+        pmix_callback_functions.5
 
 MAN_OUTDIR = $(OUTDIR)/man
 

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -64,7 +64,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``results`` and ``nresults`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` invoked with the
   final status and any returned data once the request has been processed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Compute_distances.3.rst
+++ b/docs/man/man3/PMIx_Compute_distances.3.rst
@@ -71,7 +71,7 @@ INPUT PARAMETERS
 
 For :ref:`PMIx_Compute_distances_nb(3) <man3-PMIx_Compute_distances>`:
 
-* ``cbfunc``: Callback function of type ``pmix_device_dist_cbfunc_t`` to be
+* ``cbfunc``: Callback function of type :ref:`pmix_device_dist_cbfunc_t <man5-pmix_device_dist_cbfunc_t>` to be
   invoked when the operation is complete.
 * ``cbdata``: Opaque data pointer to be passed to ``cbfunc`` when invoked.
 

--- a/docs/man/man3/PMIx_Connect.3.rst
+++ b/docs/man/man3/PMIx_Connect.3.rst
@@ -61,7 +61,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when the
   connect operation completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Deregister_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Deregister_event_handler.3.rst
@@ -40,7 +40,7 @@ INPUT PARAMETERS
 * ``evhdlr_ref``: The reference identifier (a ``size_t``) that was returned by
   the corresponding call to :ref:`PMIx_Register_event_handler(3)
   <man3-PMIx_Register_event_handler>` when the handler was registered.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when
   the deregistration completes. A ``NULL`` value makes the call blocking (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_Disconnect.3.rst
+++ b/docs/man/man3/PMIx_Disconnect.3.rst
@@ -60,7 +60,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when the
   disconnect operation completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Fabric_deregister.3.rst
+++ b/docs/man/man3/PMIx_Fabric_deregister.3.rst
@@ -43,7 +43,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when
   the deregistration completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Fabric_register.3.rst
+++ b/docs/man/man3/PMIx_Fabric_register.3.rst
@@ -56,7 +56,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when
   the registration completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Fabric_update.3.rst
+++ b/docs/man/man3/PMIx_Fabric_update.3.rst
@@ -43,7 +43,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when
   the update completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -57,7 +57,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked when the
   fence completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -68,7 +68,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``val`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_value_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_value_cbfunc_t <man5-pmix_value_cbfunc_t>` invoked with the
   retrieved value once it is available.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Get_credential.3.rst
+++ b/docs/man/man3/PMIx_Get_credential.3.rst
@@ -61,7 +61,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``credential`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_credential_cbfunc_t`` invoked with
+* ``cbfunc``: Callback function of type :ref:`pmix_credential_cbfunc_t <man5-pmix_credential_cbfunc_t>` invoked with
   the final status, the returned credential, and any accompanying information once
   the request completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -74,7 +74,7 @@ The blocking form returns results directly:
 The non-blocking form takes two additional parameters in place of ``results``
 and ``nresults``:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` to be executed once
   the group has been constructed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Group_destruct.3.rst
+++ b/docs/man/man3/PMIx_Group_destruct.3.rst
@@ -49,7 +49,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be executed once all
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be executed once all
   members of the group have called destruct.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Group_invite.3.rst
+++ b/docs/man/man3/PMIx_Group_invite.3.rst
@@ -70,7 +70,7 @@ The blocking form returns results directly:
 The non-blocking form takes two additional parameters in place of ``results``
 and ``nresult``:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` to be executed once
   the group has been fully assembled.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Group_join.3.rst
+++ b/docs/man/man3/PMIx_Group_join.3.rst
@@ -73,7 +73,7 @@ The blocking form returns results directly:
 The non-blocking form takes two additional parameters in place of ``results``
 and ``nresult``:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` to be executed once
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` to be executed once
   the group has been completely constructed or its construction has failed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Group_leave.3.rst
+++ b/docs/man/man3/PMIx_Group_leave.3.rst
@@ -49,7 +49,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be executed once the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be executed once the
   departure event has been locally generated.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_IOF_deregister.3.rst
+++ b/docs/man/man3/PMIx_IOF_deregister.3.rst
@@ -47,7 +47,7 @@ INPUT PARAMETERS
   disposition of any data currently in the I/O buffer for the affected
   processes. A ``NULL`` value is supported when no directives are desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when
   deregistration has completed. A ``NULL`` value makes the call blocking
   (see `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_IOF_pull.3.rst
+++ b/docs/man/man3/PMIx_IOF_pull.3.rst
@@ -60,13 +60,13 @@ INPUT PARAMETERS
   ``PMIX_FWD_STDOUT_CHANNEL`` and/or ``PMIX_FWD_STDERR_CHANNEL``).
   ``PMIX_FWD_STDIN_CHANNEL`` is **not** supported on this path and results in
   an error.
-* ``cbfunc``: Function of type ``pmix_iof_cbfunc_t`` to be called when
+* ``cbfunc``: Function of type :ref:`pmix_iof_cbfunc_t <man5-pmix_iof_cbfunc_t>` to be called when
   forwarded output is received (see `CALLBACK FUNCTION`_). A ``NULL`` value
   directs that output for the indicated channels be written to this process's
   own ``stdout``/``stderr`` file descriptors instead of being delivered to a
   callback.
 * ``regcbfunc``: Registration-completion callback of type
-  ``pmix_hdlr_reg_cbfunc_t``. Because registration is asynchronous, this
+  :ref:`pmix_hdlr_reg_cbfunc_t <man5-pmix_hdlr_reg_cbfunc_t>`. Because registration is asynchronous, this
   function is invoked once registration completes, delivering the final
   status and the reference identifier assigned to the request. A ``NULL``
   value makes the call blocking (see `DESCRIPTION`_).

--- a/docs/man/man3/PMIx_IOF_push.3.rst
+++ b/docs/man/man3/PMIx_IOF_push.3.rst
@@ -55,7 +55,7 @@ INPUT PARAMETERS
   behavior of the request (see `DIRECTIVES`_). A ``NULL`` value is supported
   when no directives are desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   operation has completed. A ``NULL`` value makes the call blocking (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -68,7 +68,7 @@ The blocking form returns any results directly:
 
 The non-blocking form replaces ``results`` and ``nresults`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` invoked with the
   final status and any returned data once the request has been processed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Log.3.rst
+++ b/docs/man/man3/PMIx_Log.3.rst
@@ -52,7 +52,7 @@ INPUT PARAMETERS
 
 The non-blocking form takes two additional parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be executed once the operation is
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be executed once the operation is
   complete.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Lookup.3.rst
+++ b/docs/man/man3/PMIx_Lookup.3.rst
@@ -76,7 +76,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``data`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_lookup_cbfunc_t`` invoked with an
+* ``cbfunc``: Callback function of type :ref:`pmix_lookup_cbfunc_t <man5-pmix_lookup_cbfunc_t>` invoked with an
   array of ``pmix_pdata_t`` structures for the found keys once the lookup
   completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_Notify_event.3.rst
+++ b/docs/man/man3/PMIx_Notify_event.3.rst
@@ -62,7 +62,7 @@ INPUT PARAMETERS
 
 The blocking behavior is selected by the callback parameters:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` to be invoked upon
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` to be invoked upon
   completion of the notification's local actions. If ``cbfunc`` is ``NULL``, the
   call is treated as **blocking** and the result of the operation is returned in
   the function's status code.

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -77,7 +77,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``results``/``nresults`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` invoked with the
   final status and any returned data once the request has been processed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Publish.3.rst
+++ b/docs/man/man3/PMIx_Publish.3.rst
@@ -51,7 +51,7 @@ INPUT PARAMETERS
 
 The non-blocking form adds a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked once the
   datastore confirms that the data has been posted.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -62,7 +62,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``results``/``nresults`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` invoked with the
   status and result array once the query completes.
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Register_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Register_event_handler.3.rst
@@ -55,9 +55,9 @@ INPUT PARAMETERS
   structures conveying directives that qualify the registration (see
   `DIRECTIVES`_). A ``NULL`` value is supported when no directives are desired.
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``evhdlr``: The event-handler function, of type ``pmix_notification_fn_t``,
+* ``evhdlr``: The event-handler function, of type :ref:`pmix_notification_fn_t <man5-pmix_notification_fn_t>`,
   to be called when a matching event is delivered (see `DESCRIPTION`_).
-* ``cbfunc``: Callback function of type ``pmix_hdlr_reg_cbfunc_t`` invoked when
+* ``cbfunc``: Callback function of type :ref:`pmix_hdlr_reg_cbfunc_t <man5-pmix_hdlr_reg_cbfunc_t>` invoked when
   the registration completes, delivering the final status and the reference
   identifier assigned to the handler. A ``NULL`` value makes the call blocking
   (see `DESCRIPTION`_).

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -48,7 +48,7 @@ INPUT PARAMETERS
 
 The non-blocking form adds a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked with the
   final status once the operation has been processed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -47,7 +47,7 @@ INPUT PARAMETERS
   action(s) to be taken. A ``NULL`` value is supported when no directives are
   desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t``. If ``NULL``, the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>`. If ``NULL``, the
   call is treated as a blocking operation; otherwise it is non-blocking and the
   callback is invoked once the request has been processed.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -75,7 +75,7 @@ INPUT PARAMETERS
 
 The non-blocking form replaces the ``nspace`` output parameter with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_spawn_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_spawn_cbfunc_t <man5-pmix_spawn_cbfunc_t>` invoked when the
   applications have been launched (or the launch has failed).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Unpublish.3.rst
+++ b/docs/man/man3/PMIx_Unpublish.3.rst
@@ -54,7 +54,7 @@ INPUT PARAMETERS
 
 The non-blocking form adds a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked once the
   server confirms removal of the specified data.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_Validate_credential.3.rst
+++ b/docs/man/man3/PMIx_Validate_credential.3.rst
@@ -69,7 +69,7 @@ OUTPUT PARAMETERS
 
 The non-blocking form replaces ``results`` and ``nresults`` with a callback:
 
-* ``cbfunc``: Callback function of type ``pmix_validation_cbfunc_t`` invoked with
+* ``cbfunc``: Callback function of type :ref:`pmix_validation_cbfunc_t <man5-pmix_validation_cbfunc_t>` invoked with
   the final status and any accompanying information once the request completes.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_server_IOF_deliver.3.rst
+++ b/docs/man/man3/PMIx_server_IOF_deliver.3.rst
@@ -54,7 +54,7 @@ INPUT PARAMETERS
   ``NULL`` value (with ``ninfo`` of zero) is supported when no metadata is
   provided.
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked once the
   library no longer requires access to the provided data. A ``NULL`` value makes
   the call blocking (see `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_collect_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_collect_inventory.3.rst
@@ -43,7 +43,7 @@ INPUT PARAMETERS
   `DIRECTIVES`_). A ``NULL`` value (with ``ndirs`` of zero) is supported when no
   directives are desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
-* ``cbfunc``: Callback function of type ``pmix_info_cbfunc_t`` invoked with the
+* ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>` invoked with the
   collected inventory once the operation completes (see `CALLBACK FUNCTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 

--- a/docs/man/man3/PMIx_server_deliver_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_deliver_inventory.3.rst
@@ -50,7 +50,7 @@ INPUT PARAMETERS
   `DIRECTIVES`_). A ``NULL`` value (with ``ndirs`` of zero) is supported when no
   directives are desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked once the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked once the
   library no longer requires access to the provided data. A ``NULL`` value makes
   the call blocking (see `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_deregister_client.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_client.3.rst
@@ -37,7 +37,7 @@ INPUT PARAMETERS
 
 * ``proc``: Pointer to a :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structure
   identifying the client by namespace and rank.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   deregistration completes. A ``NULL`` value makes the call *blocking* (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_deregister_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_nspace.3.rst
@@ -37,7 +37,7 @@ INPUT PARAMETERS
 
 * ``nspace``: The namespace (a character array of maximum length
   ``PMIX_MAX_NSLEN``) to deregister.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   deregistration completes. A ``NULL`` value makes the call *blocking* (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -44,7 +44,7 @@ INPUT PARAMETERS
   is used to select what to remove; the associated values are ignored except where
   they serve as qualifiers (see `DIRECTIVES`_).
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   operation completes. A ``NULL`` value makes the call **blocking** (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_dmodex_request.3.rst
+++ b/docs/man/man3/PMIx_server_dmodex_request.3.rst
@@ -43,7 +43,7 @@ INPUT PARAMETERS
   the process whose posted data is being requested. A rank of
   ``PMIX_RANK_WILDCARD`` requests the job-level information for the namespace
   rather than the data posted by a specific process. Must not be ``NULL``.
-* ``cbfunc``: Callback function of type ``pmix_dmodex_response_fn_t`` that is
+* ``cbfunc``: Callback function of type :ref:`pmix_dmodex_response_fn_t <man5-pmix_dmodex_response_fn_t>` that is
   invoked with the requested data once it becomes available. Must not be
   ``NULL``.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_register_client.3.rst
+++ b/docs/man/man3/PMIx_server_register_client.3.rst
@@ -46,7 +46,7 @@ INPUT PARAMETERS
   server-module function is invoked in relation to this specific process,
   letting the host access its tracking object without a namespace/rank lookup.
   May be ``NULL``.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   registration completes. A ``NULL`` value makes the call *blocking* (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_register_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_register_nspace.3.rst
@@ -54,7 +54,7 @@ INPUT PARAMETERS
   value is supported when no data is to be registered (for example, when using
   the ``PMIX_REGISTER_NODATA`` directive).
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   registration completes. A ``NULL`` value makes the call *blocking* (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_register_resources.3.rst
+++ b/docs/man/man3/PMIx_server_register_resources.3.rst
@@ -43,7 +43,7 @@ INPUT PARAMETERS
 * ``info``: Array of :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures carrying
   the information to be registered (see `DIRECTIVES`_).
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   operation completes. A ``NULL`` value makes the call **blocking** (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.

--- a/docs/man/man3/PMIx_server_setup_application.3.rst
+++ b/docs/man/man3/PMIx_server_setup_application.3.rst
@@ -51,7 +51,7 @@ INPUT PARAMETERS
   The array **must** include a description of the job via the ``PMIX_NODE_MAP`` and
   ``PMIX_PROC_MAP`` attributes.
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_setup_application_cbfunc_t`` invoked
+* ``cbfunc``: Callback function of type :ref:`pmix_setup_application_cbfunc_t <man5-pmix_setup_application_cbfunc_t>` invoked
   when the setup data is ready (see `CALLBACK FUNCTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.
 
@@ -153,7 +153,7 @@ application, and ``provided_cbdata`` |mdash| the ``cbdata`` originally passed to
 ``PMIx_server_setup_application``.
 
 The returned ``info`` array is **owned by the PMIx server library** and remains
-valid only until the recipient calls the ``cbfunc`` (of type ``pmix_op_cbfunc_t``)
+valid only until the recipient calls the ``cbfunc`` (of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>`)
 that is passed along with it; the library frees the array at that point.
 Accordingly, the host must copy any data it needs to retain and then invoke that
 completion function so the library can release its memory. If no data is returned,

--- a/docs/man/man3/PMIx_server_setup_local_support.3.rst
+++ b/docs/man/man3/PMIx_server_setup_local_support.3.rst
@@ -45,7 +45,7 @@ INPUT PARAMETERS
   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`
   call and distributed to this node. May be ``NULL`` with ``ninfo`` of zero.
 * ``ninfo``: Number of elements in the ``info`` array.
-* ``cbfunc``: Callback function of type ``pmix_op_cbfunc_t`` invoked when the
+* ``cbfunc``: Callback function of type :ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>` invoked when the
   operation completes. A ``NULL`` value makes the call **blocking** (see
   `DESCRIPTION`_).
 * ``cbdata``: Opaque pointer passed, unmodified, to ``cbfunc``.

--- a/docs/man/man5/index.rst
+++ b/docs/man/man5/index.rst
@@ -58,3 +58,4 @@ Config file manual pages (section 5)
    pmix_storage_persistence_t.5.rst
    pmix_regex2_t.5.rst
    pmix_server_module_t.5.rst
+   pmix_callback_functions.5.rst

--- a/docs/man/man5/pmix_callback_functions.5.rst
+++ b/docs/man/man5/pmix_callback_functions.5.rst
@@ -1,0 +1,457 @@
+.. _man5-pmix_callback_functions:
+
+PMIx Callback Functions
+=======================
+
+.. include_body
+
+The PMIx callback function signatures |mdash| the function-pointer types
+through which PMIx returns the results of non-blocking operations and
+delivers events.
+
+
+DESCRIPTION
+-----------
+
+Most PMIx operations are available in a non-blocking form. A non-blocking
+API accepts a callback function of one of the types documented here, together
+with an opaque ``void *cbdata`` pointer. The API returns immediately once the
+request has been accepted; the library later invokes the supplied callback on
+its internal progress thread when the operation completes, passing the
+``cbdata`` pointer back unmodified so the caller can correlate the response
+with its originating request. A leading ``pmix_status_t status`` argument (when
+present) reports the outcome: a value of ``PMIX_SUCCESS`` indicates the
+operation succeeded, while any other value is an error constant describing the
+failure. See :ref:`pmix_status_t(5) <man5-pmix_status_t>`.
+
+**Shared ownership contract.** Data passed *to* a callback is owned by the
+PMIx library. Unless otherwise stated, that data is valid only for the
+duration of the call and is released by the library as soon as the callback
+returns; a callee that needs to retain any of it must copy it before
+returning. Some callbacks additionally receive a
+:ref:`pmix_release_cbfunc_t <man5-pmix_release_cbfunc_t>` ``release_fn`` and a
+matching ``release_cbdata``. In that case the callee is permitted to retain
+the provided data (without copying) and must invoke ``release_fn(release_cbdata)``
+when it is finished with it, so the library can free the underlying storage.
+If ``release_fn`` is ``NULL``, no such retention is offered and the callee must
+copy anything it needs before returning.
+
+Callbacks run on the PMIx progress thread. They should therefore complete
+quickly and must not block waiting on other PMIx operations. The ``cbdata``
+object and any other input parameters supplied to the originating call must
+remain valid until the callback fires.
+
+
+CALLBACK FUNCTIONS
+------------------
+
+.. _man5-pmix_release_cbfunc_t:
+
+pmix_release_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_release_cbfunc_t)(void *cbdata);
+
+The fundamental "done with the data" callback. It carries no status and only
+the opaque ``cbdata`` that was provided alongside it. Data-returning callbacks
+that transfer ownership temporarily (for example
+:ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>`,
+:ref:`pmix_modex_cbfunc_t <man5-pmix_modex_cbfunc_t>`, and
+:ref:`pmix_device_dist_cbfunc_t <man5-pmix_device_dist_cbfunc_t>`) also pass a
+``release_fn`` of this type together with a ``release_cbdata``; the recipient
+calls it once it has finished using the retained data so the library can
+release it.
+
+
+.. _man5-pmix_op_cbfunc_t:
+
+pmix_op_cbfunc_t
+^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_op_cbfunc_t)(pmix_status_t status, void *cbdata);
+
+The generic callback for operations that simply return a completion status.
+``status`` reports success or failure and ``cbdata`` is the caller's opaque
+pointer. This is the most widely used callback in PMIx; examples include the
+non-blocking forms of Fence, Connect, Disconnect, Put/Commit, and event
+notification, as well as many server-side APIs.
+
+
+.. _man5-pmix_info_cbfunc_t:
+
+pmix_info_cbfunc_t
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_info_cbfunc_t)(pmix_status_t status,
+                                      pmix_info_t *info, size_t ninfo,
+                                      void *cbdata,
+                                      pmix_release_cbfunc_t release_fn,
+                                      void *release_cbdata);
+
+Returns an array of ``ninfo`` :ref:`pmix_info_t(5) <man5-pmix_info_t>`
+key/value pairs in ``info``. Used to deliver the results of queries such as
+:ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`. The ``info`` array is owned
+by the library; if ``release_fn`` is non-``NULL`` the recipient may retain the
+array and must call ``release_fn(release_cbdata)`` when done, otherwise it must
+copy any values it needs before returning.
+
+
+.. _man5-pmix_modex_cbfunc_t:
+
+pmix_modex_cbfunc_t
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_modex_cbfunc_t)(pmix_status_t status,
+                                       const char *data, size_t ndata,
+                                       void *cbdata,
+                                       pmix_release_cbfunc_t release_fn,
+                                       void *release_cbdata);
+
+A server-side callback used to return modex ("modular exchange") data
+collected in response to fence and remote "get" operations. ``data`` points to
+an opaque blob of ``ndata`` bytes aggregated from the participating servers.
+The blob is owned by the host server, so a non-``NULL`` ``release_fn`` is
+provided to notify the owner via ``release_fn(release_cbdata)`` once the
+recipient is finished with the data.
+
+
+.. _man5-pmix_value_cbfunc_t:
+
+pmix_value_cbfunc_t
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_value_cbfunc_t)(pmix_status_t status,
+                                       pmix_value_t *kv, void *cbdata);
+
+Returns a single retrieved value. Used by :ref:`PMIx_Get(3) <man3-PMIx_Get>`
+in its non-blocking form. ``status`` indicates whether the requested key was
+found; ``kv`` points to the :ref:`pmix_value_t(5) <man5-pmix_value_t>`
+containing the data, or is ``NULL`` if the data was not found. The value is
+released by the library on return, so the recipient must copy it if it needs to
+be retained.
+
+
+.. _man5-pmix_lookup_cbfunc_t:
+
+pmix_lookup_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_lookup_cbfunc_t)(pmix_status_t status,
+                                        pmix_pdata_t data[], size_t ndata,
+                                        void *cbdata);
+
+Returns the results of a non-blocking data lookup such as
+:ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>` (the companion of
+:ref:`PMIx_Publish(3) <man3-PMIx_Publish>`). Retrieved key/value pairs are
+returned as an array of ``ndata`` :ref:`pmix_pdata_t(5) <man5-pmix_pdata_t>`
+structures, each also identifying the namespace/rank of the process that
+published the item. The structures are released on return from the callback, so
+the recipient must copy anything it needs to retain.
+
+
+.. _man5-pmix_spawn_cbfunc_t:
+
+pmix_spawn_cbfunc_t
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_spawn_cbfunc_t)(pmix_status_t status,
+                                       pmix_nspace_t nspace, void *cbdata);
+
+Reports completion of a non-blocking :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`
+request. ``status`` indicates whether the spawn succeeded, and ``nspace``
+carries the namespace assigned to the newly spawned job. The returned
+``nspace`` value is released by the library upon return from the callback, so
+the recipient must copy it if it needs to be retained.
+
+
+.. _man5-pmix_credential_cbfunc_t:
+
+pmix_credential_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_credential_cbfunc_t)(pmix_status_t status,
+                                            pmix_byte_object_t *credential,
+                                            pmix_info_t info[], size_t ninfo,
+                                            void *cbdata);
+
+Returns a requested security credential obtained via
+:ref:`PMIx_Get_credential(3) <man3-PMIx_Get_credential>`. On success,
+``credential`` points to an allocated ``pmix_byte_object_t`` holding the opaque
+credential blob; ownership of the credential is transferred to the recipient,
+which is responsible for releasing that memory. The ``info`` array (``ninfo``
+elements) conveys any additional system-provided metadata about the credential,
+such as the identity of the issuing agent; that array is owned by the library
+and must not be altered or released by the recipient.
+
+
+.. _man5-pmix_validation_cbfunc_t:
+
+pmix_validation_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_validation_cbfunc_t)(pmix_status_t status,
+                                            pmix_info_t info[], size_t ninfo,
+                                            void *cbdata);
+
+Reports the result of validating a credential via
+:ref:`PMIx_Validate_credential(3) <man3-PMIx_Validate_credential>`. ``status``
+is ``PMIX_SUCCESS`` if the credential is valid, or an error code describing why
+it was rejected. The ``info`` array (``ninfo`` elements) carries any associated
+authorization information |mdash| commonly including the effective
+``PMIX_USERID`` and ``PMIX_GROUPID`` of the credential's holder. The array is
+owned by the library and must not be altered or released by the recipient.
+
+
+.. _man5-pmix_device_dist_cbfunc_t:
+
+pmix_device_dist_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_device_dist_cbfunc_t)(pmix_status_t status,
+                                             pmix_device_distance_t *dist,
+                                             size_t ndist,
+                                             void *cbdata,
+                                             pmix_release_cbfunc_t release_fn,
+                                             void *release_cbdata);
+
+Returns computed device distance arrays from
+:ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`. ``dist`` points
+to an array of ``ndist`` ``pmix_device_distance_t`` structures describing the
+relative locality of the calling process to each fabric or other device. The
+array is owned by the library; if ``release_fn`` is non-``NULL`` the recipient
+may retain it and must call ``release_fn(release_cbdata)`` when finished,
+otherwise it must copy the data before returning.
+
+
+.. _man5-pmix_hdlr_reg_cbfunc_t:
+
+pmix_hdlr_reg_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_hdlr_reg_cbfunc_t)(pmix_status_t status,
+                                          size_t refid,
+                                          void *cbdata);
+
+Reports completion of a handler registration request, such as registering an
+event handler or an IOF handler. ``status`` is ``PMIX_SUCCESS`` or an error
+constant, and ``refid`` is the reference identifier assigned to the handler by
+PMIx |mdash| it must be retained in order to later deregister the handler.
+
+
+.. _man5-pmix_evhdlr_reg_cbfunc_t:
+
+pmix_evhdlr_reg_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_evhdlr_reg_cbfunc_t)(pmix_status_t status,
+                                            size_t refid,
+                                            void *cbdata);
+
+The deprecated, event-handler-specific form of
+:ref:`pmix_hdlr_reg_cbfunc_t <man5-pmix_hdlr_reg_cbfunc_t>`, retained for
+backward compatibility. It has an identical signature and reports the
+registration ``status`` and assigned reference identifier ``refid`` for a call
+to :ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`.
+New code should use ``pmix_hdlr_reg_cbfunc_t``.
+
+
+.. _man5-pmix_notification_fn_t:
+
+pmix_notification_fn_t
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_notification_fn_t)(size_t evhdlr_registration_id,
+                                          pmix_status_t status,
+                                          const pmix_proc_t *source,
+                                          pmix_info_t info[], size_t ninfo,
+                                          pmix_info_t *results, size_t nresults,
+                                          pmix_event_notification_cbfunc_fn_t cbfunc,
+                                          void *cbdata);
+
+The user-supplied event handler. PMIx invokes it when an event is delivered to
+a handler registered via
+:ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`
+(events are generated with
+:ref:`PMIx_Notify_event(3) <man3-PMIx_Notify_event>`). Arguments are the
+handler's ``evhdlr_registration_id``; the ``status`` event code that occurred;
+the ``source`` process that generated it (an empty namespace with rank
+``PMIX_RANK_UNDEF`` denotes the resource manager); an ``info`` array of
+``ninfo`` event details; a ``results`` array of ``nresults`` outputs from any
+handlers already run for this event; and a completion ``cbfunc`` (of type
+:ref:`pmix_event_notification_cbfunc_fn_t <man5-pmix_event_notification_cbfunc_fn_t>`)
+with its ``cbdata``. The handler is **required** to invoke ``cbfunc`` when done
+so the library can continue the event chain. The ``info`` and ``results``
+arrays are owned by the library and are valid only for the duration of the
+call.
+
+
+.. _man5-pmix_event_notification_cbfunc_fn_t:
+
+pmix_event_notification_cbfunc_fn_t
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_event_notification_cbfunc_fn_t)(pmix_status_t status,
+                                                       pmix_info_t *results, size_t nresults,
+                                                       pmix_op_cbfunc_t cbfunc, void *thiscbdata,
+                                                       void *notification_cbdata);
+
+The completion callback that an event handler
+(:ref:`pmix_notification_fn_t <man5-pmix_notification_fn_t>`) must call to tell
+the library it has finished responding to a notification. The handler passes
+back a ``status`` |mdash| ``PMIX_SUCCESS`` if no further action is required
+|mdash| along with an optional ``results`` array of ``nresults``
+:ref:`pmix_info_t(5) <man5-pmix_info_t>` structures that are appended to the
+results seen by subsequent handlers in the chain. ``cbfunc``/``thiscbdata``
+allow the library to signal the handler once it has consumed the results (so a
+non-``NULL`` ``cbfunc`` lets the handler release its ``results`` array), and
+``notification_cbdata`` is the library's internal chaining context, passed back
+unmodified.
+
+
+.. _man5-pmix_setup_application_cbfunc_t:
+
+pmix_setup_application_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
+                                                   pmix_info_t info[], size_t ninfo,
+                                                   void *provided_cbdata,
+                                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+A server-side callback used to return the results of
+:ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`.
+The ``info`` array (``ninfo`` elements) contains application-specific
+environment variables, resource assignments, and other data (for example
+network security credentials) to be distributed with the application at launch.
+``provided_cbdata`` is the opaque pointer supplied to the setup call. The
+``info`` array is owned by the PMIx server library and remains valid until the
+recipient invokes the provided ``cbfunc`` (a
+:ref:`pmix_op_cbfunc_t <man5-pmix_op_cbfunc_t>`) with ``cbdata``, which
+releases it.
+
+
+.. _man5-pmix_connection_cbfunc_t:
+
+pmix_connection_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_connection_cbfunc_t)(int incoming_sd, void *cbdata);
+
+Used by a host server that operates its own connection-listener thread to hand
+an accepted local-client connection to the PMIx server library. After calling
+``accept`` on an incoming connection request, the host passes the resulting
+socket descriptor ``incoming_sd`` to this callback for further processing,
+along with its opaque ``cbdata``.
+
+
+.. _man5-pmix_tool_connection_cbfunc_t:
+
+pmix_tool_connection_cbfunc_t
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_tool_connection_cbfunc_t)(pmix_status_t status,
+                                                 pmix_proc_t *proc, void *cbdata);
+
+Used when a host environment registers a newly connected tool with the PMIx
+server library and must assign it an identity. The host returns the assigned
+namespace/rank in ``proc`` (rank 0 is the normal assignment), with ``status``
+indicating success or failure and ``cbdata`` the opaque pointer. This is the
+server-side counterpart to a tool's use of
+:ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`.
+
+
+.. _man5-pmix_dmodex_response_fn_t:
+
+pmix_dmodex_response_fn_t
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_dmodex_response_fn_t)(pmix_status_t status,
+                                             char *data, size_t sz,
+                                             void *cbdata);
+
+Returns the data blob produced by a direct-modex request made through
+:ref:`PMIx_server_dmodex_request(3) <man3-PMIx_server_dmodex_request>`.
+``data`` points to a blob of ``sz`` bytes that the host server should send back
+to the original remote requestor; ``status`` reports success or failure and
+``cbdata`` is the opaque pointer. The PMIx server frees the ``data`` blob upon
+return from this response function, so the recipient must copy or transmit it
+before returning.
+
+
+.. _man5-pmix_iof_cbfunc_t:
+
+pmix_iof_cbfunc_t
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+   typedef void (*pmix_iof_cbfunc_t)(size_t iofhdlr, pmix_iof_channel_t channel,
+                                     pmix_proc_t *source, pmix_byte_object_t *payload,
+                                     pmix_info_t info[], size_t ninfo);
+
+Delivers forwarded I/O (stdout/stderr) to a handler registered via
+:ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`. ``iofhdlr`` is the registration
+number of the handler being invoked (needed to deregister it); ``channel`` is a
+bitmask identifying the I/O channel the data arrived on; ``source`` is the
+namespace/rank that generated the output; and ``payload`` points to a
+``pmix_byte_object_t`` containing the data (which may hold multiple strings and
+is **not** guaranteed to be NUL-terminated). The optional ``info`` array
+(``ninfo`` elements) carries metadata about the payload, such as
+``PMIX_IOF_COMPLETE``. Note this callback receives no ``cbdata`` and no
+``status`` argument.
+
+
+.. seealso::
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
+   :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,
+   :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,
+   :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`,
+   :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`,
+   :ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`,
+   :ref:`PMIx_Notify_event(3) <man3-PMIx_Notify_event>`,
+   :ref:`PMIx_Get_credential(3) <man3-PMIx_Get_credential>`,
+   :ref:`PMIx_Validate_credential(3) <man3-PMIx_Validate_credential>`,
+   :ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`,
+   :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,
+   :ref:`PMIx_server_dmodex_request(3) <man3-PMIx_server_dmodex_request>`,
+   :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,
+   :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :ref:`pmix_pdata_t(5) <man5-pmix_pdata_t>`


### PR DESCRIPTION
Document the 19 public callback-function typedefs through which PMIx
returns the results of its non-blocking operations and delivers events.
These types appear throughout the API signatures -- `pmix_op_cbfunc_t`
alone is named by more than two dozen functions -- but their signatures
and semantics were not defined anywhere in the manual.

## Contents

- A single section-5 page, `pmix_callback_functions`, that first
  describes the asynchronous callback model and the shared data-ownership
  contract (data passed to a callback is owned by the library and valid
  only until the callback returns, unless a `pmix_release_cbfunc_t`
  release function is also supplied), then documents each callback in its
  own subsection:
  - fundamentals (`pmix_release_cbfunc_t`, `pmix_op_cbfunc_t`)
  - data-returning callbacks (`info`, `modex`, `value`, `lookup`,
    `spawn`, `credential`, `validation`, `device_dist`)
  - handler-registration callbacks (`hdlr_reg`, `evhdlr_reg`)
  - event-delivery types (`pmix_notification_fn_t` -- the user's event
    handler -- and its completion callback)
  - server/tool-specific callbacks (`setup_application`, `connection`,
    `tool_connection`, `dmodex_response`, `iof`)
- Each callback carries its own cross-reference anchor. The plain-text
  callback mentions across 44 API man pages are upgraded to resolvable
  links to the corresponding definition.
- Each callback name is installed as a section-5 alias of the
  consolidated page (via the `PMIX_MAN5_ALIASES` mechanism), so that
  `man pmix_op_cbfunc_t`, `man pmix_notification_fn_t`, etc. resolve to
  their definition.

## Verification

Signatures were copied verbatim from the public headers and the behavior
checked against the implementation (edge cases noted: `pmix_iof_cbfunc_t`
takes neither a status nor cbdata; `pmix_evhdlr_reg_cbfunc_t` is the
deprecated twin of `pmix_hdlr_reg_cbfunc_t`). Clean Sphinx build with
zero warnings; every `:ref:` resolves; the 19 alias symlinks were
verified with a staged install.