### PR TITLE
Document missing attributes on several API man pages

### DIFF
--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -146,24 +146,114 @@ support the following attributes:
   this allocation request, which can later be used to query its status.
 * ``PMIX_ALLOC_NUM_NODES`` (uint64_t) |mdash| number of nodes being requested.
 * ``PMIX_ALLOC_NUM_CPUS`` (uint64_t) |mdash| number of CPUs being requested.
-* ``PMIX_ALLOC_TIME`` (uint32_t) |mdash| time (in seconds) for which the
-  resources are being requested.
+* ``PMIX_ALLOC_TIME`` (char*) |mdash| time for which the resources are being
+  requested, specified in the usual ``months:days:hours:minutes:seconds``
+  format, scanned from right to left (i.e., a value of ``"2"`` equates to two
+  seconds).
 
 The following attributes are optional for host environments that support this
-operation:
+operation.
+
+Identifying an existing allocation (for the ``PMIX_ALLOC_EXTEND``,
+``PMIX_ALLOC_RELEASE``, ``PMIX_ALLOC_REAQUIRE``, and ``PMIX_ALLOC_REQ_CANCEL``
+directives):
+
+* ``PMIX_ALLOC_ID`` (char*) |mdash| the host-provided string identifier of the
+  allocation to be operated upon (used both as a qualifier on input and, for a
+  new-resource request, returned on output |mdash| see below).
+
+Describing the resources being requested:
 
 * ``PMIX_ALLOC_NODE_LIST`` (char*) |mdash| regular expression of the specific
   nodes being requested.
+* ``PMIX_ALLOC_EXCLUDE`` (char*) |mdash| regular expression of nodes to exclude
+  from scheduling consideration.
 * ``PMIX_ALLOC_NUM_CPU_LIST`` (char*) |mdash| regular expression of the number
   of CPUs being requested on each node.
 * ``PMIX_ALLOC_CPU_LIST`` (char*) |mdash| regular expression of the specific
   CPUs being requested on each node.
-* ``PMIX_ALLOC_MEM_SIZE`` (float) |mdash| amount of memory being requested.
-* ``PMIX_ALLOC_FABRIC``, ``PMIX_ALLOC_FABRIC_ID``, ``PMIX_ALLOC_BANDWIDTH``,
-  ``PMIX_ALLOC_FABRIC_QOS``, ``PMIX_ALLOC_FABRIC_TYPE``,
-  ``PMIX_ALLOC_FABRIC_PLANE``, ``PMIX_ALLOC_FABRIC_ENDPTS``,
-  ``PMIX_ALLOC_FABRIC_ENDPTS_NODE``, ``PMIX_ALLOC_FABRIC_SEC_KEY`` |mdash|
-  attributes describing fabric resources being requested.
+* ``PMIX_ALLOC_MEM_SIZE`` (float) |mdash| amount of memory being requested, in
+  Mbytes.
+* ``PMIX_ALLOC_RES_BLOCK`` (char*) |mdash| name of a previously-defined
+  resource block to be allocated.
+* ``PMIX_ALLOC_NUM_BLOCKS`` (uint64_t) |mdash| number of the specified resource
+  blocks to allocate.
+* ``PMIX_ALLOC_MAU`` (pmix_data_array_t*) |mdash| minimum allocatable unit for
+  the system, expressed as an array of ``pmix_resource_unit_t`` structures.
+* ``PMIX_ALLOC_IMAGE`` (char*) |mdash| name of the image that the requested
+  nodes are to have on them.
+* ``PMIX_MEM_ALLOC_KIND`` (char*) |mdash| comma-delimited list of memory kinds
+  being allocated (e.g., ``system,mpi,rocm:device``).
+* ``PMIX_GPU_SUPPORT`` (bool) |mdash| direct the application to enable (true)
+  or disable (false) its internal library's GPU support.
+
+Describing fabric resources being requested:
+
+* ``PMIX_ALLOC_FABRIC`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures describing a fabric
+  resource request. It must include at least ``PMIX_ALLOC_FABRIC_ID``,
+  ``PMIX_ALLOC_FABRIC_TYPE``, and ``PMIX_ALLOC_FABRIC_ENDPTS``, plus any other
+  desired descriptors.
+* ``PMIX_ALLOC_FABRIC_ID`` (char*) |mdash| key to be used when accessing this
+  requested fabric allocation.
+* ``PMIX_ALLOC_FABRIC_TYPE`` (char*) |mdash| type of desired transport (e.g.,
+  ``tcp``, ``udp``).
+* ``PMIX_ALLOC_FABRIC_PLANE`` (char*) |mdash| identifier string for the NIC
+  (fabric plane) to be used for this allocation.
+* ``PMIX_ALLOC_FABRIC_ENDPTS`` (size_t) |mdash| number of endpoints to allocate
+  per process.
+* ``PMIX_ALLOC_FABRIC_ENDPTS_NODE`` (size_t) |mdash| number of endpoints to
+  allocate per node.
+* ``PMIX_ALLOC_FABRIC_QOS`` (char*) |mdash| quality-of-service level being
+  requested.
+* ``PMIX_ALLOC_BANDWIDTH`` (float) |mdash| bandwidth being requested, in
+  Mbits/sec.
+* ``PMIX_ALLOC_FABRIC_SEC_KEY`` (pmix_byte_object_t) |mdash| fabric security
+  key.
+
+Controlling scheduling, timing, and lifecycle:
+
+* ``PMIX_ALLOC_QUEUE`` (char*) |mdash| name of the queue being referenced.
+* ``PMIX_ALLOC_PREEMPTIBLE`` (bool) |mdash| whether the jobs in the resulting
+  allocation are to be considered preemptible (overridable at the per-job
+  level).
+* ``PMIX_ALLOC_BEGIN`` (char*) |mdash| direct the scheduler to defer the
+  allocation until the specified time (see the attribute definition in
+  ``pmix_common.h`` for the accepted time formats).
+* ``PMIX_ALLOC_DEPENDENCY`` (char*) |mdash| defer the start of the allocation
+  until the specified dependencies have successfully completed.
+* ``PMIX_ALLOC_WAIT_ALL_NODES`` (bool) |mdash| whether to wait for all nodes to
+  be scheduled before beginning to initialize and release nodes for use.
+* ``PMIX_ALLOC_WARN_TIMEOUT`` (uint32_t) |mdash| request that the scheduler
+  provide advance warning of the impending expiration of the allocation. The
+  value is the number of seconds prior to expiration at which the warning is to
+  be delivered via a ``PMIX_ALLOC_TIMEOUT_WARNING`` event.
+* ``PMIX_ALLOC_LEND`` (char*) |mdash| estimated time before the lent resources
+  shall be available for return, in the same time format as ``PMIX_ALLOC_TIME``
+  (used with the ``PMIX_ALLOC_RELEASE`` directive).
+* ``PMIX_ALLOC_RELEASABLE`` (bool) |mdash| true if the entire allocation may be
+  released.
+* ``PMIX_ALLOC_NOSHELL`` (bool) |mdash| immediately exit after allocating
+  resources, without running a command.
+* ``PMIX_ALLOC_NOT_WAITING`` (bool) |mdash| the requestor is not waiting for
+  the allocation to be issued; it will discover the allocation by monitoring
+  for the "allocated" event or by querying the system.
+* ``PMIX_ALLOC_PROPERTY`` (char*) |mdash| name of an allocation property.
+
+Controlling ownership, sharing, and inheritance:
+
+* ``PMIX_ALLOC_TARGET`` (char*) |mdash| namespace to which the allocated
+  resources are to be assigned; the host reserves the resources to members of
+  that namespace.
+* ``PMIX_ALLOC_SHARE`` (bool) |mdash| if true, make the allocated resources
+  generally available within the requestor's session rather than reserving them
+  solely for the requestor's namespace (false by default).
+* ``PMIX_ALLOC_CHILD_SEP`` (bool) |mdash| treat the resulting allocation as
+  independent from its parent |mdash| i.e., do not terminate the allocation
+  upon termination of the parent.
+* ``PMIX_ALLOC_INHERITANCE`` (pmix_alloc_inheritance_t) |mdash| inheritance
+  rules to be applied to the allocated resources. If not provided, defaults to
+  ``PMIX_ALLOC_INHERIT_DEFAULT``.
 
 On successful completion of a request for additional resources, the returned
 data includes ``PMIX_ALLOC_ID`` (char*), a host-provided string identifier for

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -229,6 +229,10 @@ The following attributes are relevant to this operation:
   across all members of the group during construction. When the array is passed
   to the host, its first element must be the process ID (marked by
   ``PMIX_PROCID``) of the process that provided it.
+* ``PMIX_GROUP_LOCAL_CID`` (size_t) |mdash| the local context ID for the
+  providing process as a member of this group. It is supplied as an entry within
+  the process's ``PMIX_GROUP_INFO`` array so that it is shared with the other
+  group members during construction.
 * ``PMIX_GROUP_LOCAL_ONLY`` (bool) |mdash| the group operation involves only
   processes that are local to this node, allowing the library to complete it
   without engaging the host environment.

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -190,6 +190,9 @@ DIRECTIVES
 
 The following attributes are relevant to this operation:
 
+* ``PMIX_GROUP_ID`` (char*) |mdash| the user-provided group identifier. This is
+  normally passed as the ``grp`` argument; the attribute form is accepted as an
+  equivalent means of conveying the identifier.
 * ``PMIX_GROUP_LEADER`` (bool) |mdash| declare this process to be the leader of
   the construction procedure. If a process provides this attribute, failure
   notification for any participating process goes only to that process. In the
@@ -221,9 +224,32 @@ The following attributes are relevant to this operation:
   the surviving members when a required member is lost, delivering a
   ``PMIX_GROUP_MEMBER_FAILED`` event for each loss, instead of aborting the
   operation (default: ``false``).
+* ``PMIX_GROUP_INFO`` (pmix_data_array_t\*) |mdash| an array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` containing data that is to be shared
+  across all members of the group during construction. When the array is passed
+  to the host, its first element must be the process ID (marked by
+  ``PMIX_PROCID``) of the process that provided it.
+* ``PMIX_GROUP_LOCAL_ONLY`` (bool) |mdash| the group operation involves only
+  processes that are local to this node, allowing the library to complete it
+  without engaging the host environment.
+* ``PMIX_GROUP_FINAL_MEMBERSHIP_ORDER`` (pmix_data_array_t\*) |mdash| an array of
+  ``pmix_proc_t`` specifying the desired order of the processes in the final
+  group membership. The order may be given by individual process or by namespace
+  (with a wildcard rank). If more than one participant supplies this attribute,
+  the provided orderings must be identical.
 * ``PMIX_TIMEOUT`` (int) |mdash| return an error if the group does not assemble
   within the specified number of seconds. This targets the scenario where a
   process fails to participate due to hanging.
+
+The following values may be returned in the ``results`` array (or the
+non-blocking callback):
+
+* ``PMIX_GROUP_CONTEXT_ID`` (size_t) |mdash| the numerical context ID assigned to
+  the group by the resource manager, returned when ``PMIX_GROUP_ASSIGN_CONTEXT_ID``
+  was requested.
+* ``PMIX_GROUP_MEMBERSHIP`` (pmix_data_array_t\*) |mdash| an array of
+  ``pmix_proc_t`` giving the final membership of the constructed group. This is
+  also carried by the ``PMIX_GROUP_MEMBERSHIP_UPDATE`` event.
 
 
 RETURN VALUE

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -163,6 +163,10 @@ Optional for supporting host environments:
   be provisioned.
 * ``PMIX_JOB_CTRL_PREEMPTIBLE`` (bool) |mdash| register the job as available for
   preemption.
+* ``PMIX_JOB_CTRL_DEFINE_PSET`` (char*) |mdash| process set name to be assigned
+  to the target processes.
+* ``PMIX_JOB_CTRL_SEP`` (bool) |mdash| separate the specified namespace from its
+  parent |mdash| i.e., allow the two to terminate independently.
 
 
 RETURN VALUE

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -187,6 +187,123 @@ When a monitoring request involves other nodes, the library adds the
 passes to its host environment.
 
 
+RESOURCE USAGE ATTRIBUTES
+-------------------------
+
+The following attributes describe the individual resource-usage statistics
+associated with the ``PMIX_MONITOR_PROC_RESOURCE_USAGE``,
+``PMIX_MONITOR_NODE_RESOURCE_USAGE``, ``PMIX_MONITOR_DISK_RESOURCE_USAGE``, and
+``PMIX_MONITOR_NET_RESOURCE_USAGE`` actions. They serve a dual purpose: placed
+(as keys, with their values ignored) in the array accompanying a
+``*_RESOURCE_USAGE`` action, they select which specific statistics are to be
+reported; they then label the corresponding values in the returned data. If the
+accompanying array is ``NULL``, all available statistics are reported. The
+availability of any given statistic varies across implementations and operating
+systems. Each per-sample container places its subject identifier in the first
+element of the array; the ordering of the remaining elements is arbitrary.
+
+Process resource usage:
+
+* ``PMIX_PROC_RESOURCE_USAGE`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` describing the resource usage of a
+  process, with the process ID (marked by ``PMIX_PROCID``) as the first element.
+* ``PMIX_PROC_OS_STATE`` (char*) |mdash| the state of the process as reported by
+  the OS (on Linux, a single character).
+* ``PMIX_PROC_TIME`` (struct timeval) |mdash| cumulative CPU time.
+* ``PMIX_PROC_PERCENT_CPU`` (float) |mdash| percent CPU utilization by the
+  process (typically the CPU-time / real-time ratio, as a percentage).
+* ``PMIX_PROC_PRIORITY`` (int32_t) |mdash| priority of the process (higher
+  numbers mean higher priority).
+* ``PMIX_PROC_NUM_THREADS`` (uint16_t) |mdash| number of threads operating in
+  the process.
+* ``PMIX_PROC_PSS`` (float) |mdash| proportional share size |mdash| the
+  non-swapped physical memory, with shared memory proportionally accounted to
+  all tasks mapping it (MBytes).
+* ``PMIX_PROC_VSIZE`` (float) |mdash| virtual memory size of the process
+  (MBytes).
+* ``PMIX_PROC_RSS`` (float) |mdash| resident set size |mdash| the non-swapped
+  physical memory the task has used (MBytes).
+* ``PMIX_PROC_PEAK_VSIZE`` (float) |mdash| peak virtual memory size of the
+  process (MBytes).
+* ``PMIX_PROC_CPU`` (uint16_t) |mdash| the processor on which the process last
+  executed.
+* ``PMIX_PROC_SAMPLE_TIME`` (time_t) |mdash| time when the sample was taken.
+  Always included in returned process-usage data.
+
+Disk resource usage:
+
+* ``PMIX_DISK_RESOURCE_USAGE`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` describing the resource usage of a
+  disk, with the disk name (marked by ``PMIX_DISK_ID``) as the first element.
+* ``PMIX_DISK_ID`` (char*) |mdash| string identifier of a disk.
+* ``PMIX_DISK_READ_COMPLETED`` (uint64_t) |mdash| number of completed read
+  operations.
+* ``PMIX_DISK_READ_MERGED`` (uint64_t) |mdash| number of merged reads.
+* ``PMIX_DISK_READ_SECTORS`` (uint64_t) |mdash| number of sectors read.
+* ``PMIX_DISK_READ_MILLISEC`` (uint64_t) |mdash| milliseconds spent reading the
+  disk.
+* ``PMIX_DISK_WRITE_COMPLETED`` (uint64_t) |mdash| number of completed write
+  operations.
+* ``PMIX_DISK_WRITE_MERGED`` (uint64_t) |mdash| number of merged writes.
+* ``PMIX_DISK_WRITE_SECTORS`` (uint64_t) |mdash| number of sectors written.
+* ``PMIX_DISK_WRITE_MILLISEC`` (uint64_t) |mdash| milliseconds spent writing to
+  the disk.
+* ``PMIX_DISK_IO_IN_PROGRESS`` (uint64_t) |mdash| number of disk I/O operations
+  in progress.
+* ``PMIX_DISK_IO_MILLISEC`` (uint64_t) |mdash| milliseconds spent in I/O
+  operations.
+* ``PMIX_DISK_IO_WEIGHTED`` (uint64_t) |mdash| number of I/Os in progress times
+  the milliseconds spent doing I/O since the last update |mdash| an indicator of
+  accumulating backlog.
+* ``PMIX_DISK_SAMPLE_TIME`` (time_t) |mdash| time when the sample was taken.
+  Always included in returned disk-usage data.
+
+Network resource usage:
+
+* ``PMIX_NETWORK_RESOURCE_USAGE`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` describing the resource usage of a
+  network interface, with the interface name (marked by ``PMIX_NETWORK_ID``) as
+  the first element.
+* ``PMIX_NETWORK_ID`` (char*) |mdash| string identifier of a network interface.
+* ``PMIX_NET_RECVD_BYTES`` (uint64_t) |mdash| number of bytes received.
+* ``PMIX_NET_RECVD_PCKTS`` (uint64_t) |mdash| number of packets received.
+* ``PMIX_NET_RECVD_ERRS`` (uint64_t) |mdash| number of receive errors.
+* ``PMIX_NET_SENT_BYTES`` (uint64_t) |mdash| number of bytes sent.
+* ``PMIX_NET_SENT_PCKTS`` (uint64_t) |mdash| number of packets sent.
+* ``PMIX_NET_SENT_ERRS`` (uint64_t) |mdash| number of send errors.
+* ``PMIX_NET_SAMPLE_TIME`` (time_t) |mdash| time when the sample was taken.
+  Always included in returned network-usage data.
+
+Node resource usage:
+
+* ``PMIX_NODE_RESOURCE_USAGE`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` describing the resource usage of a
+  node, with the node ID (marked by ``PMIX_HOSTNAME`` or ``PMIX_NODEID``) as the
+  first element.
+* ``PMIX_NODE_LOAD_AVG`` (float) |mdash| load average over the last minute.
+* ``PMIX_NODE_LOAD_AVG5`` (float) |mdash| load average over the last five
+  minutes.
+* ``PMIX_NODE_LOAD_AVG15`` (float) |mdash| load average over the last fifteen
+  minutes.
+* ``PMIX_NODE_MEM_TOTAL`` (float) |mdash| total usable RAM |mdash| physical RAM
+  minus reserved bits and kernel binary code (MBytes).
+* ``PMIX_NODE_MEM_FREE`` (float) |mdash| total free RAM (MBytes).
+* ``PMIX_NODE_MEM_BUFFERS`` (float) |mdash| temporary storage for raw disk
+  blocks (MBytes).
+* ``PMIX_NODE_MEM_CACHED`` (float) |mdash| in-memory cache for files read from
+  disk, plus tmpfs and shmem (excluding ``PMIX_NODE_MEM_SWAP_CACHED``) (MBytes).
+* ``PMIX_NODE_MEM_SWAP_CACHED`` (float) |mdash| memory that was swapped out and
+  swapped back in but is still also present in the swapfile (MBytes).
+* ``PMIX_NODE_SWAP_TOTAL`` (float) |mdash| total amount of swap space available
+  (MBytes).
+* ``PMIX_NODE_MEM_SWAP_FREE`` (float) |mdash| memory evicted from RAM and
+  temporarily on disk (MBytes).
+* ``PMIX_NODE_MEM_MAPPED`` (float) |mdash| files that have been mmapped, such as
+  libraries (MBytes).
+* ``PMIX_NODE_SAMPLE_TIME`` (time_t) |mdash| time when the sample was taken.
+  Always included in returned node-usage data.
+
+
 RETURN VALUE
 ------------
 

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -129,6 +129,12 @@ Commonly used **keys**:
   user-level API names (e.g., ``"PMIx_Get"``) whose support is being queried.
 * ``PMIX_QUERY_NUM_PSETS`` / ``PMIX_QUERY_PSET_NAMES`` |mdash| return the number,
   or the names, of the defined process sets.
+* ``PMIX_GROUP_NAMES`` (pmix_data_array_t*) |mdash| return an array of the string
+  names of the process groups in which the given process is a member. The target
+  process is identified with the usual ``PMIX_PROCID`` (or ``PMIX_NSPACE`` /
+  ``PMIX_RANK``) qualifier. This key may also be passed directly to
+  :ref:`PMIx_Get(3) <man3-PMIx_Get>` to retrieve the same information for a single
+  process.
 * ``PMIX_QUERY_AVAIL_SERVERS`` |mdash| scan the local node for PMIx servers the
   caller could connect to.
 * ``PMIX_QUERY_STABLE_ABI_VERSION`` / ``PMIX_QUERY_PROVISIONAL_ABI_VERSION``

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -44,8 +44,8 @@ INPUT PARAMETERS
   applies to all sessions under the caller's control.
 * ``directives``: Pointer to an array of
   :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures describing the control
-  action(s) to be taken. A ``NULL`` value is supported when no directives are
-  desired.
+  action(s) to be taken (see `DIRECTIVES`_). A ``NULL`` value is supported when
+  no directives are desired.
 * ``ndirs``: Number of elements in the ``directives`` array.
 * ``cbfunc``: Callback function of type :ref:`pmix_info_cbfunc_t <man5-pmix_info_cbfunc_t>`. If ``NULL``, the
   call is treated as a blocking operation; otherwise it is non-blocking and the
@@ -75,6 +75,67 @@ through a single entry point, selected by the ``cbfunc`` argument:
 
 As with all non-blocking PMIx APIs, when a ``cbfunc`` is supplied the caller
 **must** keep the ``directives`` array valid until ``cbfunc`` is invoked.
+
+
+DIRECTIVES
+----------
+
+The requested action is expressed entirely through the ``directives`` array.
+The PMIx library is not required to interpret these directives itself |mdash|
+it passes them to the host environment (typically the scheduler) for
+processing. Actual support for any given directive depends on the host
+environment.
+
+Identifying the request:
+
+* ``PMIX_SESSION_CTRL_ID`` (char*) |mdash| a string identifier for this request,
+  allowing its status to later be queried or the operation to be cancelled.
+
+Instantiating a session (typically issued by a scheduler):
+
+* ``PMIX_SESSION_INSTANTIATE`` (bool) |mdash| instantiate the specified session.
+* ``PMIX_SESSION_RESOURCES`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures describing the resources
+  to be included in the session (e.g., a regular expression of node names, an
+  array of resource blocks, etc.).
+* ``PMIX_SESSION_APP`` (pmix_data_array_t*) |mdash| array of ``pmix_app_t``
+  structures to be executed in the assigned session upon instantiation.
+* ``PMIX_SESSION_JOB`` (pmix_data_array_t*) |mdash| array of
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures describing the job
+  information to be applied in conjunction with the specified
+  ``PMIX_SESSION_APP`` definitions. It is an error to provide this without a
+  ``PMIX_SESSION_APP`` description.
+* ``PMIX_SESSION_PROVISION_NODES`` (char*) |mdash| regular expression
+  identifying nodes that are to be provisioned.
+* ``PMIX_SESSION_PROVISION_IMAGE`` (char*) |mdash| name of the image that is to
+  be provisioned.
+
+Controlling a session's operation:
+
+* ``PMIX_SESSION_PAUSE`` (bool) |mdash| pause all jobs in the specified session.
+* ``PMIX_SESSION_RESUME`` (bool) |mdash| resume ("un-pause") all jobs in the
+  specified session.
+* ``PMIX_SESSION_PREEMPT`` (bool) |mdash| preempt the indicated jobs (named via
+  a ``PMIX_NSPACE`` attribute in the accompanying array) in the specified
+  session and recover all their resources. If no ``PMIX_NSPACE`` is given, all
+  jobs in the session are preempted.
+* ``PMIX_SESSION_RESTORE`` (bool) |mdash| restore the indicated jobs (named via
+  a ``PMIX_NSPACE`` attribute in the accompanying array) in the specified
+  session, including all their resources. If no ``PMIX_NSPACE`` is given, all
+  jobs in the session are restored.
+* ``PMIX_SESSION_SIGNAL`` (int) |mdash| send the given signal to all processes
+  of every job in the session.
+* ``PMIX_SESSION_EXTEND`` (bool) |mdash| extend the specified session, either in
+  time or in resources, based on additional provided attributes.
+* ``PMIX_SESSION_SEP`` (bool) |mdash| separate the specified session from its
+  parent |mdash| i.e., allow the two to terminate independently.
+* ``PMIX_SESSION_TERMINATE`` (bool) |mdash| terminate all jobs in the specified
+  session and recover all resources included in the session.
+* ``PMIX_SESSION_COMPLETE`` (bool) |mdash| indicate that the specified session
+  has completed and all of its resources have been recovered and are available
+  for scheduling. The accompanying array must include
+  :ref:`pmix_info_t(5) <man5-pmix_info_t>` structures reporting the returned
+  status of any jobs executed in the session.
 
 
 RETURN VALUE


### PR DESCRIPTION
Several man pages were missing many of the attributes defined for their
APIs in `pmix_common.h.in`. This branch fills those gaps, one man page
per commit:

- **PMIx_Allocation_request** — expanded the ATTRIBUTES section to cover
  the full `PMIX_ALLOC_*` set (resources, fabric, scheduling/lifecycle,
  ownership/inheritance), and corrected the type of `PMIX_ALLOC_TIME`
  (char*, not uint32_t).
- **PMIx_Job_control** — added the two missing `PMIX_JOB_CTRL_*`
  directives (`DEFINE_PSET`, `SEP`).
- **PMIx_Session_control** — added a DIRECTIVES section (the page had
  none) covering the request-identifier, instantiation, and operational
  `PMIX_SESSION_*` control attributes.
- **PMIx_Process_monitor** — added a RESOURCE USAGE ATTRIBUTES section
  covering the process/disk/network/node statistics (`PMIX_PROC_*`,
  `PMIX_DISK_*`, `PMIX_NETWORK_*`/`PMIX_NET_*`, `PMIX_NODE_*`).
- **PMIx_Group_construct** — added the remaining user-facing
  construction attributes (`PMIX_GROUP_ID`, `PMIX_GROUP_INFO`,
  `PMIX_GROUP_LOCAL_CID`, `PMIX_GROUP_LOCAL_ONLY`,
  `PMIX_GROUP_FINAL_MEMBERSHIP_ORDER`) plus the returned values
  (`PMIX_GROUP_CONTEXT_ID`, `PMIX_GROUP_MEMBERSHIP`).
- **PMIx_Query_info** — documented `PMIX_GROUP_NAMES`, noting it can also
  be passed to `PMIx_Get`.

Documentation-only; the man pages build cleanly with Sphinx and no new
warnings.