### PR TITLE
Document IOF, setup-app, and debugger attributes on PMIx_Spawn and PMIx_IOF_pull

### DIFF
--- a/docs/man/man3/PMIx_IOF_pull.3.rst
+++ b/docs/man/man3/PMIx_IOF_pull.3.rst
@@ -123,6 +123,15 @@ The following attributes are optional:
   identity (namespace/rank) and channel from which it originated.
 * ``PMIX_IOF_TIMESTAMP_OUTPUT`` (bool) |mdash| timestamp the output.
 * ``PMIX_IOF_XML_OUTPUT`` (bool) |mdash| format the output in XML.
+* ``PMIX_IOF_COPY`` (bool) |mdash| request that the host environment deliver a
+  *copy* of the specified output stream(s) to the requesting tool while the
+  stream(s) continue to be delivered to their current final destination. This
+  lets the tool tap into the output without redirecting it.
+* ``PMIX_IOF_REDIRECT`` (bool) |mdash| request that the host environment
+  *intercept* the specified output stream(s) and deliver them to the requesting
+  tool instead of their current final destination |mdash| for example, to keep
+  debugger-related output out of the application's result files. The original
+  destination is restored when the tool terminates.
 
 
 CALLBACK FUNCTION

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -196,6 +196,38 @@ Behavior, restart, and tool support:
   as a disconnected job.
 * ``PMIX_SPAWN_TOOL`` (bool) |mdash| the job being spawned is a tool.
 
+Debugger support:
+
+These attributes support co-launching an application under debugger control and
+spawning debugger daemons alongside it.
+
+* ``PMIX_DEBUG_STOP_ON_EXEC`` (varies) |mdash| stop the specified rank(s) upon
+  ``exec`` and notify that they are ready to be debugged. The value may be a
+  ``bool`` (``true`` for all ranks, ``false`` for none), a ``pmix_rank_t`` (a
+  single rank, or ``PMIX_RANK_WILDCARD`` for all), or a ``pmix_data_array_t`` of
+  individual processes.
+* ``PMIX_DEBUG_STOP_IN_INIT`` (varies) |mdash| stop the specified rank(s) inside
+  ``PMIx_Init`` and notify that they are ready to be debugged. Same value forms
+  as ``PMIX_DEBUG_STOP_ON_EXEC``.
+* ``PMIX_DEBUG_STOP_IN_APP`` (varies) |mdash| direct the specified rank(s) to
+  stop at an application-defined point and notify that they are ready to be
+  debugged. Same value forms as ``PMIX_DEBUG_STOP_ON_EXEC``.
+* ``PMIX_DEBUG_TARGET`` (pmix_proc_t\*) |mdash| identifier of the process(es) to
+  be debugged. A launcher spawning debugger daemons places this in the daemons'
+  job-level information so the daemons can self-determine their specific targets.
+* ``PMIX_DEBUG_DAEMONS_PER_PROC`` (uint16_t) |mdash| number of debugger daemons
+  to spawn per application process.
+* ``PMIX_DEBUG_DAEMONS_PER_NODE`` (uint16_t) |mdash| number of debugger daemons
+  to spawn on each node where the target job is executing.
+
+When a process stopped by one of the ``PMIX_DEBUG_STOP_*`` directives is ready to
+be debugged, it generates a ``PMIX_READY_FOR_DEBUG`` event accompanied by the
+following OUT attribute (delivered to the debugger's event handler, not passed to
+``PMIx_Spawn``):
+
+* ``PMIX_BREAKPOINT`` (char\*) |mdash| string identifier of the breakpoint at
+  which the process(es) are waiting.
+
 Timeouts:
 
 * ``PMIX_TIMEOUT`` (int) |mdash| time, in seconds, before the operation should be

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -206,15 +206,49 @@ Completion and termination notification:
 * ``PMIX_NOTIFY_PROC_TERMINATION`` (bool) |mdash| request that the launcher
   generate an event when any process in the spawned job terminates.
 
+Output forwarding:
+
+These attributes control how the spawned job's ``stdout``/``stderr`` streams are
+tagged, formatted, and directed as they are forwarded. They supersede the older,
+now-deprecated non-``IOF`` output attributes (see the note below).
+
+* ``PMIX_IOF_TAG_OUTPUT`` (bool) |mdash| tag each line of output with the
+  ``[local jobid,rank]`` of its source and the channel it came from.
+* ``PMIX_IOF_TAG_DETAILED_OUTPUT`` (bool) |mdash| tag output with the
+  ``[local jobid,rank][hostname:pid]`` and channel of its source.
+* ``PMIX_IOF_TAG_FULLNAME_OUTPUT`` (bool) |mdash| tag output with the
+  ``[nspace,rank]`` and channel of its source.
+* ``PMIX_IOF_RANK_OUTPUT`` (bool) |mdash| tag output with the rank it came from.
+* ``PMIX_IOF_TIMESTAMP_OUTPUT`` (bool) |mdash| timestamp each line of output.
+* ``PMIX_IOF_MERGE_STDERR_STDOUT`` (bool) |mdash| merge the ``stderr`` stream
+  into the ``stdout`` stream of the application processes.
+* ``PMIX_IOF_XML_OUTPUT`` (bool) |mdash| format the forwarded output in XML.
+* ``PMIX_IOF_OUTPUT_RAW`` (bool) |mdash| do not buffer output into complete
+  lines; emit characters as the stream delivers them.
+* ``PMIX_IOF_LOCAL_OUTPUT`` (bool) |mdash| write the output streams to the local
+  ``stdout``/``stderr``.
+* ``PMIX_IOF_OUTPUT_TO_FILE`` (char\*) |mdash| direct application output into
+  files of the form ``<filename>.rank``, with both ``stdout`` and ``stderr``
+  redirected into it.
+* ``PMIX_IOF_OUTPUT_TO_DIRECTORY`` (char\*) |mdash| direct application output
+  into files of the form ``<directory>/<jobid>/rank.<rank>/stdout[err]``.
+* ``PMIX_IOF_FILE_PATTERN`` (bool) |mdash| treat the ``PMIX_IOF_OUTPUT_TO_FILE``
+  value as a pattern, suppressing the automatic annotation by nspace, rank, or
+  other parameters.
+* ``PMIX_IOF_FILE_ONLY`` (bool) |mdash| output only into the designated files; do
+  not also emit a copy to ``stdout``/``stderr``.
+
 .. note::
    Several attributes historically used with ``PMIx_Spawn`` to control output
    forwarding |mdash| ``PMIX_TAG_OUTPUT``, ``PMIX_TIMESTAMP_OUTPUT``,
-   ``PMIX_MERGE_STDERR_STDOUT``, and ``PMIX_OUTPUT_TO_FILE`` |mdash| as well as
+   ``PMIX_MERGE_STDERR_STDOUT``, ``PMIX_OUTPUT_TO_FILE``, and
+   ``PMIX_OUTPUT_TO_DIRECTORY`` |mdash| are now deprecated in favor of the
+   ``PMIX_IOF_*`` equivalents listed above under **Output forwarding**, as is
    ``PMIX_NON_PMI`` (indicating that the spawned processes will not call
-   ``PMIx_Init``) are now deprecated and should not be used in new code. Tools
-   requesting that the spawned job's output be forwarded to them may use
-   ``PMIX_FWD_STDOUT`` / ``PMIX_FWD_STDERR`` (bool), and may forward their own
-   stdin to the spawned processes with ``PMIX_FWD_STDIN`` (bool).
+   ``PMIx_Init``); none of these should be used in new code. Tools requesting
+   that the spawned job's output be forwarded to them may use ``PMIX_FWD_STDOUT``
+   / ``PMIX_FWD_STDERR`` (bool), and may forward their own stdin to the spawned
+   processes with ``PMIX_FWD_STDIN`` (bool).
 
 
 RETURN VALUE

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -179,6 +179,12 @@ Environment control:
   an environment variable in the spawned processes' environment.
 * ``PMIX_ENVARS_HARVESTED`` (bool) |mdash| indicates that the requestor has already
   harvested and included the relevant environment variables.
+* ``PMIX_SETUP_APP_ENVARS`` (bool) |mdash| direct the spawn library to harvest the
+  environment variables relevant to the application's programming model and include
+  them with the request. May be placed in the ``job_info`` array or in an individual
+  application's ``info`` array. The full set of application-setup-data attributes is
+  described under
+  :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`.
 
 Behavior, restart, and tool support:
 


### PR DESCRIPTION
Fills gaps between the attribute definitions in `include/pmix_common.h.in`
and the spawn/IOF man pages. One man page change per commit:

- **PMIx_Spawn** — added an "Output forwarding" subsection covering the
  `PMIX_IOF_*` output-control attributes (tagging, timestamp, merge, XML,
  raw, local output, file/directory redirection), and updated the
  deprecation note to point the old non-IOF output attributes at their
  `PMIX_IOF_*` replacements.
- **PMIx_IOF_pull** — documented `PMIX_IOF_COPY` and `PMIX_IOF_REDIRECT`
  (tool stream tap vs. redirect).
- **PMIx_Spawn** — documented `PMIX_SETUP_APP_ENVARS` in Environment
  control, with a cross-reference to `PMIx_server_setup_application` for
  the full application-setup-data set.
- **PMIx_Spawn** — added a "Debugger support" subsection covering the
  `PMIX_DEBUG_*` co-launch directives, plus `PMIX_BREAKPOINT` documented
  as the OUT attribute carried by the `PMIX_READY_FOR_DEBUG` event.

Documentation-only; man pages build cleanly with no new Sphinx warnings.