### PR TITLE
Deprecate PMIX_QUERY_PARTIAL_SUCCESS

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1678,9 +1678,6 @@ typedef int pmix_status_t;
 #define PMIX_DEBUGGER_RELEASE                       -3      // replaced deprecated PMIX_ERR_DEBUGGER_RELEASE
 #define PMIX_READY_FOR_DEBUG                        -58     // accompanied by PMIX_BREAKPOINT indicating where proc is waiting
 
-/* query errors */
-#define PMIX_QUERY_PARTIAL_SUCCESS                  -104
-
 /* job control */
 #define PMIX_JCTRL_CHECKPOINT                       -106    // monitored by client to trigger checkpoint operation
 #define PMIX_JCTRL_CHECKPOINT_COMPLETE              -107    // sent by client and monitored by server to notify that requested

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -135,6 +135,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 #define PMIX_ERR_LOST_CONNECTION_TO_SERVER          -101
 #define PMIX_ERR_LOST_PEER_CONNECTION               -102
 #define PMIX_ERR_LOST_CONNECTION_TO_CLIENT          -103
+#define PMIX_QUERY_PARTIAL_SUCCESS                  -104    // DEPRECATED - was never returned; use PMIX_ERR_PARTIAL_SUCCESS
 #define PMIX_NOTIFY_ALLOC_COMPLETE                  -105
 #define PMIX_ERR_INVALID_TERMINATION                -112
 #define PMIX_ERR_JOB_TERMINATED                     -145    // DEPRECATED NAME - non-error termination


### PR DESCRIPTION
`PMIX_QUERY_PARTIAL_SUCCESS` (-104) was defined as a query error status
but is never set, returned, or compared against anywhere in the library.
The query path returns the actively-used `PMIX_ERR_PARTIAL_SUCCESS` (-52)
instead, which is what `PMIx_Query_info` documents.

This moves the constant from `pmix_common.h.in` to the deprecated error
constants block in `pmix_deprecated.h`, preserving its numeric value so
that:

- any external consumer referencing the name still compiles (it remains
  visible via `pmix.h` -> `pmix_deprecated.h`), and
- the generated event-string table is unchanged in value (the generator
  scans both headers, so the constant is still registered at -104).

The now-empty `/* query errors */` comment is removed. Verified with a
full clean build (no warnings) and a value-uniqueness sweep across both
headers.