### PR TITLE
Document the remaining event handler attributes

### DIFF
--- a/docs/man/man3/PMIx_Notify_event.3.rst
+++ b/docs/man/man3/PMIx_Notify_event.3.rst
@@ -139,6 +139,15 @@ will be passed, when relevant, to all invoked handlers:
   behalf of the original source.
 * ``PMIX_EVENT_TEXT_MESSAGE`` (char*) |mdash| a human-readable text message
   describing the event, suitable for reporting to the user.
+* ``PMIX_EVENT_TIMESTAMP`` (time_t) |mdash| the system time at which the associated
+  event occurred.
+* ``PMIX_EVENT_STAYS_LOCAL`` (bool) |mdash| the event is not to be passed up to the
+  host environment. Used together with a custom range to also indicate a range of
+  "local" and to prevent infinite notification loops with the host.
+* ``PMIX_EVENT_SILENT_TERMINATION`` (bool) |mdash| suppress the event that is
+  otherwise generated when a job terminates normally. This is typically supplied in
+  a job's launch-time information (e.g., to :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`)
+  rather than passed to ``PMIx_Notify_event`` directly.
 
 Host environments that implement support for PMIx event notification are required
 to provide the following attributes for all events they generate:

--- a/docs/man/man3/PMIx_Register_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Register_event_handler.3.rst
@@ -177,6 +177,8 @@ the registration.
 * ``PMIX_EVENT_RETURN_OBJECT`` (void*) |mdash| an object to be returned to this
   process whenever the registered handler is invoked. The object is returned
   only to the process that registered it.
+* ``PMIX_EVENT_ONESHOT`` (bool) |mdash| automatically deregister this handler
+  after it has been invoked once.
 
 Host environments that implement PMIx event notification are additionally
 required to support the following directives, which restrict the handler to


### PR DESCRIPTION
The event handler registration/notification block in
`include/pmix_common.h.in` (`PMIX_EVENT_HDLR_NAME` through
`PMIX_EVENT_STAYS_LOCAL`) had a few keys that were not documented on
either event man page. This adds them to the correct page by direction of
use:

- **PMIx_Register_event_handler:** `PMIX_EVENT_ONESHOT` — a registration
  directive that automatically deregisters the handler after its first
  invocation.
- **PMIx_Notify_event:** `PMIX_EVENT_TIMESTAMP` (system time the event
  occurred), `PMIX_EVENT_STAYS_LOCAL` (keep the event from being passed up
  to the host, used with a custom local range to avoid notification
  loops), and `PMIX_EVENT_SILENT_TERMINATION` (suppress the event normally
  generated on normal job termination).

`PMIX_EVENT_SILENT_TERMINATION` is also referenced on `PMIx_Spawn` (see
the companion spawn-attributes PR) since it is supplied in a job's
launch-time information; the two entries cross-reference each other.

Documentation-only; builds cleanly with no new Sphinx warnings.