### PR TITLE
Document fabric, storage, and descriptive-value attributes

### DIFF
--- a/docs/man/man3/PMIx_Fabric_register.3.rst
+++ b/docs/man/man3/PMIx_Fabric_register.3.rst
@@ -109,6 +109,81 @@ aid callers in identifying the fabric whose data is being sought:
   Mellanox, HPE, Intel) whose fabric is to be accessed.
 
 
+FABRIC INFORMATION ATTRIBUTES
+-----------------------------
+
+Once registration is complete, the fabric information is retrieved using
+:ref:`PMIx_Get(3) <man3-PMIx_Get>` or
+:ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`. The following keys identify the
+available fabric-level and per-device information. These are returned values
+rather than registration directives, though several also serve as request
+modifiers as noted. The ``PMIX_FABRIC_PLANE``, ``PMIX_FABRIC_IDENTIFIER``, and
+``PMIX_FABRIC_VENDOR`` directives above likewise double as retrieval modifiers;
+unless a specific plane is named, information is returned for all planes in the
+system.
+
+Fabric-level information:
+
+* ``PMIX_FABRIC_COST_MATRIX`` (pointer) |mdash| pointer to a two-dimensional array
+  of point-to-point relative communication costs, expressed as ``uint16_t``
+  values.
+* ``PMIX_FABRIC_NUM_DEVICES`` (size_t) |mdash| total number of fabric devices in
+  the system, corresponding to the number of rows or columns in the cost matrix.
+* ``PMIX_FABRIC_INDEX`` (size_t) |mdash| the index of the fabric as returned in the
+  ``pmix_fabric_t`` structure.
+* ``PMIX_FABRIC_GROUPS`` (char\*) |mdash| the fabric group membership of the nodes,
+  as a string of ``group:node,node,...`` entries delimited by semicolons.
+* ``PMIX_FABRIC_COORDINATES`` (pmix_data_array_t\*) |mdash| an array of
+  ``pmix_geometry_t`` fabric coordinates for the devices on a node, covering all
+  supported coordinate views. Defaults to the local node when none is specified.
+* ``PMIX_FABRIC_DIMS`` (uint32_t) |mdash| the number of dimensions in the specified
+  fabric plane/view.
+* ``PMIX_FABRIC_SHAPE`` (pmix_data_array_t\*) |mdash| the size of each dimension in
+  the specified fabric plane/view, as an array of ``uint32_t`` values.
+* ``PMIX_FABRIC_SHAPE_STRING`` (char\*) |mdash| the fabric shape expressed as a
+  string (e.g., ``"10x12x2"``).
+* ``PMIX_FABRIC_SWITCH`` (char\*) |mdash| the ID of a fabric switch. As a modifier,
+  selects the switch whose information is returned; as a direct key, returns the
+  identifiers of all switches in the system.
+* ``PMIX_FABRIC_ENDPT`` (pmix_data_array_t\*) |mdash| the fabric endpoints for a
+  specified process, returned as an array of ``pmix_endpoint_t`` elements.
+
+Per-device information (carried within each ``PMIX_FABRIC_DEVICE`` array):
+
+* ``PMIX_FABRIC_DEVICE`` (pmix_data_array_t\*) |mdash| an array of ``pmix_info_t``
+  describing a single fabric device; the first element is the device identifier.
+* ``PMIX_FABRIC_DEVICES`` (pmix_data_array_t\*) |mdash| an array containing a
+  ``PMIX_FABRIC_DEVICE`` entry for every device on the specified node.
+* ``PMIX_FABRIC_DEVICE_NAME`` (char\*) |mdash| the OS name of the device (e.g.,
+  ``eth0``) or an absolute filename.
+* ``PMIX_FABRIC_DEVICE_INDEX`` (uint32_t) |mdash| index of the device within the
+  associated cost matrix.
+* ``PMIX_FABRIC_DEVICE_VENDOR`` (char\*) |mdash| name of the device's vendor.
+* ``PMIX_FABRIC_DEVICE_VENDORID`` (char\*) |mdash| vendor-provided identifier for
+  the device or product.
+* ``PMIX_FABRIC_DEVICE_BUS_TYPE`` (char\*) |mdash| type of bus to which the device
+  is attached (e.g., ``"PCI"``, ``"GEN-Z"``).
+* ``PMIX_FABRIC_DEVICE_DRIVER`` (char\*) |mdash| name of the driver associated with
+  the device.
+* ``PMIX_FABRIC_DEVICE_FIRMWARE`` (char\*) |mdash| the device's firmware version.
+* ``PMIX_FABRIC_DEVICE_ADDRESS`` (char\*) |mdash| the primary link-level address of
+  the device (e.g., a MAC address).
+* ``PMIX_FABRIC_DEVICE_COORDINATES`` (pmix_geometry_t) |mdash| the fabric
+  coordinates for the device across all supported coordinate views.
+* ``PMIX_FABRIC_DEVICE_MTU`` (size_t) |mdash| the maximum transfer unit of
+  link-level frames, in bytes.
+* ``PMIX_FABRIC_DEVICE_SPEED`` (size_t) |mdash| the active link data rate, in bits
+  per second.
+* ``PMIX_FABRIC_DEVICE_STATE`` (pmix_link_state_t) |mdash| the last available
+  physical port state (``PMIX_LINK_STATE_UNKNOWN``, ``PMIX_LINK_DOWN``, or
+  ``PMIX_LINK_UP``).
+* ``PMIX_FABRIC_DEVICE_TYPE`` (char\*) |mdash| the type of fabric interface active
+  on the device (e.g., Ethernet, InfiniBand).
+* ``PMIX_FABRIC_DEVICE_PCI_DEVID`` (char\*) |mdash| a node-level unique PCI device
+  identifier, as a colon-delimited ``domain:bus:device:function`` tuple in
+  hexadecimal.
+
+
 RETURN VALUE
 ------------
 

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -223,6 +223,47 @@ Resource usage, devices, and storage:
 * ``PMIX_QUERY_STORAGE_LIST`` (char*) |mdash| return a comma-delimited list of
   identifiers for all available storage systems.
 
+Storage system information. ``PMIX_QUERY_STORAGE_LIST`` returns the available
+storage-system identifiers; the following keys return the properties of a
+particular system, selected with a ``PMIX_STORAGE_ID`` qualifier:
+
+* ``PMIX_STORAGE_PATH`` (char*) |mdash| the mount point corresponding to the
+  specified storage ID.
+* ``PMIX_STORAGE_VERSION`` (char*) |mdash| the version string for the storage
+  system.
+* ``PMIX_STORAGE_MEDIUM`` (pmix_storage_medium_t) |mdash| the storage medium(s) the
+  system uses (e.g., SSD, HDD, tape). See
+  :ref:`pmix_storage_medium_t(5) <man5-pmix_storage_medium_t>`.
+* ``PMIX_STORAGE_ACCESSIBILITY`` (pmix_storage_accessibility_t) |mdash| the
+  accessibility level of the storage system (e.g., node, session). See
+  :ref:`pmix_storage_accessibility_t(5) <man5-pmix_storage_accessibility_t>`.
+* ``PMIX_STORAGE_PERSISTENCE`` (pmix_storage_persistence_t) |mdash| the persistence
+  level of the storage system (e.g., scratch, archive). See
+  :ref:`pmix_storage_persistence_t(5) <man5-pmix_storage_persistence_t>`.
+* ``PMIX_STORAGE_CAPACITY_LIMIT`` (uint64_t) |mdash| the overall capacity of the
+  storage system, in base-2 megabytes.
+* ``PMIX_STORAGE_CAPACITY_USED`` (double) |mdash| the overall used capacity of the
+  storage system, in bytes.
+* ``PMIX_STORAGE_OBJECT_LIMIT`` (uint64_t) |mdash| the overall limit on the number
+  of objects (e.g., inodes) in the storage system.
+* ``PMIX_STORAGE_OBJECTS_USED`` (uint64_t) |mdash| the number of objects currently
+  in use in the storage system.
+* ``PMIX_STORAGE_BW_CUR`` (double) |mdash| the recently observed bandwidth of the
+  storage system, in bytes/sec.
+* ``PMIX_STORAGE_BW_MAX`` (double) |mdash| the maximum (theoretical or observed)
+  bandwidth of the storage system, in bytes/sec.
+* ``PMIX_STORAGE_IOPS_CUR`` (double) |mdash| the recently observed I/O operations
+  per second for the storage system.
+* ``PMIX_STORAGE_IOPS_MAX`` (double) |mdash| the maximum (theoretical or observed)
+  I/O operations per second for the storage system.
+* ``PMIX_STORAGE_MINIMAL_XFER_SIZE`` (double) |mdash| the storage system's atomic
+  unit of transfer (e.g., block size), in bytes.
+* ``PMIX_STORAGE_SUGGESTED_XFER_SIZE`` (double) |mdash| the suggested transfer size
+  for the storage system, in bytes.
+
+The bandwidth, IOPS, and suggested-transfer-size keys may be further qualified by
+``PMIX_STORAGE_ACCESS_TYPE`` to select read, write, or read/write access.
+
 The following two keys appear only in returned results and **cannot** be used as
 input to ``PMIx_Query_info`` or ``PMIx_Get``:
 
@@ -259,6 +300,14 @@ Commonly used **qualifiers**:
 * ``PMIX_QUERY_SUPPORTED_QUALIFIERS`` (bool) |mdash| return a comma-delimited list of
   the qualifiers supported for the provided key, instead of performing the query on
   that key.
+* ``PMIX_STORAGE_ID`` (char*) |mdash| identify the storage system whose information
+  is being requested (used with the storage keys above).
+* ``PMIX_STORAGE_TYPE`` (char*) |mdash| restrict a storage query to systems of the
+  given type (e.g., ``lustre``, ``gpfs``, ``fabric-attached``).
+* ``PMIX_STORAGE_ACCESS_TYPE`` (pmix_storage_access_type_t) |mdash| for the storage
+  bandwidth, IOPS, and suggested-transfer-size keys, select which access type
+  (read, write, or read/write) to report. See
+  :ref:`pmix_storage_access_type_t(5) <man5-pmix_storage_access_type_t>`.
 
 Qualifiers that are not applicable to a given key are ignored.
 

--- a/docs/man/man5/pmix_regattr_t.5.rst
+++ b/docs/man/man5/pmix_regattr_t.5.rst
@@ -57,6 +57,23 @@ Although not strictly required, both PMIx library implementers and host
 environments are strongly encouraged to provide both human-readable and
 machine-parsable descriptions of supported attributes when registering them.
 
+DESCRIPTIVE VALUE ATTRIBUTES
+----------------------------
+
+Beyond the free-form ``description`` field, the following keys provide a
+standardized, machine-parsable vocabulary for describing the range of values an
+attribute accepts:
+
+* ``PMIX_MAX_VALUE`` (varies) |mdash| the maximum valid value for the associated
+  attribute. The value carries the attribute's own declared data type.
+* ``PMIX_MIN_VALUE`` (varies) |mdash| the minimum valid value for the associated
+  attribute. The value carries the attribute's own declared data type.
+* ``PMIX_ENUM_VALUE`` (char*) |mdash| the accepted values for the associated
+  attribute. Numerical values shall be presented in a form convertible to the
+  attribute's declared data type; named values (i.e., those defined by constant
+  names via a typical C-language ``enum`` declaration) must be provided as their
+  numerical equivalent.
+
 STATIC INITIALIZER
 ------------------
 


### PR DESCRIPTION
Fills three separate gaps between the attribute definitions in
`include/pmix_common.h.in` and the man pages. One man page per commit:

- **PMIx_Fabric_register** — add a "FABRIC INFORMATION ATTRIBUTES" section
  covering the ~26 `PMIX_FABRIC_*` fabric-level and per-device keys (cost
  matrix, coordinates, dimensions, shape, switch, endpoint, groups, and
  the full device descriptor set) that are retrieved via `PMIx_Get` /
  `PMIx_Query_info` once registration completes. Framed as returned
  values rather than registration directives. The struct helpers
  (`STATIC_INIT`, `CONSTRUCT`) remain on `pmix_fabric_t(5)`.
- **pmix_regattr_t** — document the descriptive value attributes
  `PMIX_MAX_VALUE`, `PMIX_MIN_VALUE`, and `PMIX_ENUM_VALUE`, the
  standardized vocabulary for describing an attribute's valid-value range.
- **PMIx_Query_info** — add a "Storage system information" key group for
  the `PMIX_STORAGE_*` properties (path, version, medium, accessibility,
  persistence, capacity/object limits and usage, bandwidth, IOPS,
  transfer sizes), selected per system with `PMIX_STORAGE_ID`, plus the
  storage qualifiers (`PMIX_STORAGE_ID`, `PMIX_STORAGE_TYPE`,
  `PMIX_STORAGE_ACCESS_TYPE`).

Documentation-only; man pages build cleanly with no new Sphinx warnings.