### PR TITLE
Document previously-uncited PMIx attributes on their man pages

### DIFF
--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -292,6 +292,12 @@ whose host environment provides an allocation entry point that can forward the
 request. A process hosted directly by the scheduler cannot issue an allocation
 request against itself and will receive ``PMIX_ERR_NOT_SUPPORTED``.
 
+Upon completion of an allocation request, the host environment may generate an
+event to notify processes other than the requestor |mdash| for example, the
+members of a job affected by the change |mdash| of the result. The result is
+conveyed in that event through the ``PMIX_ALLOC_STATUS`` (pmix_status_t)
+attribute, which carries the completion status of the allocation request.
+
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -154,6 +154,11 @@ support the following attributes:
 The following attributes are optional for host environments that support this
 operation.
 
+* ``PMIX_REQUESTOR`` (pmix_proc_t\*) |mdash| identifier of the process on whose
+  behalf the request is being made, used when one process relays the operation
+  to the PMIx library on behalf of another (the API itself takes no requestor
+  parameter).
+
 Identifying an existing allocation (for the ``PMIX_ALLOC_EXTEND``,
 ``PMIX_ALLOC_RELEASE``, ``PMIX_ALLOC_REAQUIRE``, and ``PMIX_ALLOC_REQ_CANCEL``
 directives):

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -299,6 +299,12 @@ key with :ref:`PMIx_Put(3) <man3-PMIx_Put>`, committed it with
 typically via a :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` |mdash| unless the
 ``PMIX_OPTIONAL`` or ``PMIX_IMMEDIATE`` directives are used to bound the search.
 
+**Qualified values.** When a key was posted together with qualifiers (using the
+``PMIX_QUALIFIED_VALUE`` key to :ref:`PMIx_Put(3) <man3-PMIx_Put>`), supply the
+desired qualifiers in the ``info`` array to select among the values stored under
+that key. ``PMIx_Get`` returns the primary value of the matching entry; the
+qualifiers themselves are used only for matching and are not returned.
+
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -137,6 +137,120 @@ for host environments.
   exposes the requested data.
 
 
+RESERVED KEYS
+-------------
+
+In addition to keys posted by applications via
+:ref:`PMIx_Put(3) <man3-PMIx_Put>`, the host environment provides a range of
+reserved keys (those beginning with ``"pmix"``) that describe the process,
+its job, and the resources it occupies. These are passed as the ``key``
+parameter and, unless otherwise noted, are retrieved for the process
+identified in ``proc``. A rank of ``PMIX_RANK_WILDCARD`` retrieves the
+job-level value for the process's namespace. The following are commonly
+available:
+
+**Process identity and rank**
+
+* ``PMIX_NSPACE`` (char*) |mdash| namespace of the process's job.
+* ``PMIX_JOBID`` (char*) |mdash| job identifier assigned by the scheduler.
+* ``PMIX_PROCID`` (pmix_proc_t\*) |mdash| process identifier (namespace and
+  rank).
+* ``PMIX_RANK`` (pmix_rank_t) |mdash| rank of the process within its job.
+* ``PMIX_GLOBAL_RANK`` (pmix_rank_t) |mdash| rank of the process spanning across
+  all jobs in this session.
+* ``PMIX_APP_RANK`` (pmix_rank_t) |mdash| rank of the process within its
+  application.
+* ``PMIX_LOCAL_RANK`` (uint16_t) |mdash| rank of the process on its node within
+  its job.
+* ``PMIX_NODE_RANK`` (uint16_t) |mdash| rank of the process on its node spanning
+  all jobs.
+* ``PMIX_PACKAGE_RANK`` (uint16_t) |mdash| rank of the process within its job on
+  the package where it resides.
+* ``PMIX_NPROC_OFFSET`` (pmix_rank_t) |mdash| starting global rank of this job.
+* ``PMIX_LOCALLDR`` (pmix_rank_t) |mdash| lowest rank on this node within this
+  job.
+* ``PMIX_APPLDR`` (pmix_rank_t) |mdash| lowest rank in this application within
+  this job.
+* ``PMIX_APPNUM`` (uint32_t) |mdash| application number within the job in which
+  the process is included.
+* ``PMIX_SESSION_ID`` (uint32_t) |mdash| session identifier.
+* ``PMIX_PROC_PID`` (pid_t) |mdash| operating-system process identifier (pid) of
+  the specified process.
+
+**Node and host information**
+
+* ``PMIX_HOSTNAME`` (char*) |mdash| name of the host on which the specified
+  process is located.
+* ``PMIX_HOSTNAME_ALIASES`` (char*) |mdash| comma-delimited list of names by
+  which the node is known.
+* ``PMIX_HOSTNAME_KEEP_FQDN`` (bool) |mdash| indicates that fully-qualified
+  domain-name hostnames are being retained.
+* ``PMIX_NODEID`` (uint32_t) |mdash| node identifier where the specified process
+  is located.
+* ``PMIX_CLUSTER_ID`` (char*) |mdash| string name of the cluster on which the
+  process is executing.
+* ``PMIX_NODE_LIST`` (char*) |mdash| comma-delimited list of nodes running
+  processes for the specified namespace.
+* ``PMIX_ALLOCATED_NODELIST`` (char*) |mdash| comma-delimited list of all nodes
+  in this allocation, regardless of whether or not they currently host
+  processes.
+* ``PMIX_LOCAL_PEERS`` (char*) |mdash| comma-delimited string of ranks on this
+  node within the specified namespace.
+* ``PMIX_LOCAL_PROCS`` (pmix_data_array_t\*) |mdash| array of
+  :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` structures identifying the processes
+  on the specified node.
+* ``PMIX_LOCAL_CPUSETS`` (char*) |mdash| colon-delimited cpusets of the local
+  peers within the specified namespace.
+
+**Sizes and counts**
+
+* ``PMIX_UNIV_SIZE`` (uint32_t) |mdash| number of slots in this session.
+* ``PMIX_JOB_SIZE`` (uint32_t) |mdash| number of processes in this job.
+* ``PMIX_JOB_NUM_APPS`` (uint32_t) |mdash| number of applications in this job.
+* ``PMIX_APP_SIZE`` (uint32_t) |mdash| number of processes in the application.
+* ``PMIX_LOCAL_SIZE`` (uint32_t) |mdash| number of processes in this job on the
+  local node.
+* ``PMIX_NODE_SIZE`` (uint32_t) |mdash| number of processes across all jobs on
+  this node.
+* ``PMIX_MAX_PROCS`` (uint32_t) |mdash| maximum number of processes for this
+  job.
+* ``PMIX_NUM_SLOTS`` (uint32_t) |mdash| number of slots allocated.
+* ``PMIX_NUM_NODES`` (uint32_t) |mdash| number of nodes currently hosting
+  processes in the specified realm.
+* ``PMIX_NUM_ALLOCATED_NODES`` (uint32_t) |mdash| number of nodes in the
+  specified realm, regardless of whether or not they currently host processes.
+
+**Scratch directories**
+
+* ``PMIX_TMPDIR`` (char*) |mdash| top-level temporary directory assigned to the
+  session.
+* ``PMIX_NSDIR`` (char*) |mdash| sub-directory of the session temporary
+  directory assigned to the namespace.
+* ``PMIX_PROCDIR`` (char*) |mdash| sub-directory of the namespace directory
+  assigned to the process.
+* ``PMIX_TDIR_RMCLEAN`` (bool) |mdash| the resource manager will clean up the
+  session directories, so the application need not do so.
+
+**Process state and launch**
+
+* ``PMIX_SPAWNED`` (bool) |mdash| true if this process resulted from a call to
+  :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`.
+* ``PMIX_PARENT_ID`` (pmix_proc_t\*) |mdash| identifier of the process that
+  called :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>` to launch this process's
+  application.
+* ``PMIX_EXIT_CODE`` (int) |mdash| exit code returned when the specified process
+  terminated.
+* ``PMIX_REINCARNATION`` (uint32_t) |mdash| number of times this process has
+  been instantiated |mdash| i.e., a count of the number of times it has been
+  restarted.
+* ``PMIX_NODE_OVERSUBSCRIBED`` (bool) |mdash| true if the number of processes
+  from this job on this node exceeds the number of slots allocated to it.
+* ``PMIX_CPUSET_BITMAP`` (pmix_cpuset_t\*) |mdash| bitmap applied to the process
+  at launch.
+* ``PMIX_CREDENTIAL`` (char*) |mdash| security credential assigned to the
+  process.
+
+
 RETURN VALUE
 ------------
 

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -255,6 +255,15 @@ available:
 * ``PMIX_PSET_NAMES`` (pmix_data_array_t\*) |mdash| array of the string names of
   the process sets in which the specified process is a member.
 
+**Fabric locality**
+
+* ``PMIX_SWITCH_PEERS`` (pmix_data_array_t\*) |mdash| the peer ranks that share a
+  switch with the specified process. Returns an array of ``pmix_info_t``, one per
+  local fabric device; each element is itself a ``PMIX_SWITCH_PEERS`` entry
+  holding a three-element array that gives the device's
+  ``PMIX_FABRIC_DEVICE_ID``, the ``PMIX_FABRIC_SWITCH`` to which it is connected,
+  and a comma-delimited string of the peer ranks sharing that switch.
+
 
 RETURN VALUE
 ------------

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -250,6 +250,11 @@ available:
 * ``PMIX_CREDENTIAL`` (char*) |mdash| security credential assigned to the
   process.
 
+**Process set membership**
+
+* ``PMIX_PSET_NAMES`` (pmix_data_array_t\*) |mdash| array of the string names of
+  the process sets in which the specified process is a member.
+
 
 RETURN VALUE
 ------------

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -167,6 +167,10 @@ OpenMP runtime co-located in the same process can discover one another via a
   ``"core"``, etc.
 * ``PMIX_MODEL_AFFINITY_POLICY`` (char\*) |mdash| thread affinity policy, e.g.
   ``"master"``, ``"close"``, or ``"spread"``.
+* ``PMIX_MODEL_PHASE_NAME`` (char\*) |mdash| user-assigned name for a phase in the
+  application's execution (e.g., ``"cfd reduction"``).
+* ``PMIX_MODEL_PHASE_TYPE`` (char\*) |mdash| type of phase being executed (e.g.,
+  ``"matrix multiply"``).
 
 
 INITIALIZATION EVENTS

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -142,6 +142,13 @@ Runtime attributes
 * ``PMIX_EXTERNAL_PROGRESS`` (bool) |mdash| the host will progress the PMIx
   library as needed via calls to ``PMIx_Progress`` (see PMIx_Progress(3)),
   rather than PMIx spawning its own internal progress thread.
+* ``PMIX_BIND_PROGRESS_THREAD`` (char\*) |mdash| comma-delimited ranges of CPUs to
+  which the internal PMIx progress thread is to be bound.
+* ``PMIX_BIND_REQUIRED`` (bool) |mdash| return an error if the internal PMIx
+  progress thread cannot be bound as requested.
+* ``PMIX_EXTERNAL_AUX_EVENT_BASE`` (void\*) |mdash| pointer to an ``event_base``
+  the library is to use for auxiliary functions (e.g., capturing signals) that
+  would otherwise interfere with the host.
 
 Programming-model attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -167,6 +167,10 @@ Optional for supporting host environments:
   to the target processes.
 * ``PMIX_JOB_CTRL_SEP`` (bool) |mdash| separate the specified namespace from its
   parent |mdash| i.e., allow the two to terminate independently.
+* ``PMIX_REQUESTOR`` (pmix_proc_t\*) |mdash| identifier of the process on whose
+  behalf the request is being made, used when one process relays the operation
+  to the PMIx library on behalf of another (the API itself takes no requestor
+  parameter).
 
 
 RETURN VALUE

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -117,6 +117,14 @@ processes until they are committed with :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`
 and, typically, a subsequent synchronization such as
 :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` has completed.
 
+**Qualified values.** A value may be posted together with one or more qualifiers
+that scope its later retrieval by using the reserved key
+``PMIX_QUALIFIED_VALUE``. In that case ``val`` must be a ``pmix_value_t`` of type
+``PMIX_DATA_ARRAY`` whose first element is the primary key-value pair and whose
+remaining elements are the qualifier key-value pairs. The stored value is later
+obtained with :ref:`PMIx_Get(3) <man3-PMIx_Get>` by supplying the matching
+qualifiers, allowing several distinct values to be posted under the same key.
+
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -138,7 +138,9 @@ Commonly used **keys**:
   :ref:`PMIx_Get(3) <man3-PMIx_Get>` to retrieve the same information for a single
   process.
 * ``PMIX_QUERY_AVAIL_SERVERS`` |mdash| scan the local node for PMIx servers the
-  caller could connect to.
+  caller could connect to. The result is an array of ``pmix_info_t``, each a
+  ``PMIX_SERVER_INFO_ARRAY`` (pmix_data_array_t*) holding the available data for
+  one connectable server (beginning with its namespace).
 * ``PMIX_QUERY_STABLE_ABI_VERSION`` / ``PMIX_QUERY_PROVISIONAL_ABI_VERSION``
   |mdash| return the stable or provisional Standard ABI version supported by the
   library. These are resolved locally and may be queried before initialization.
@@ -192,6 +194,10 @@ Scheduler, queues, and allocations:
 * ``PMIX_QUERY_AVAILABLE_SLOTS`` (uint32_t) |mdash| return the number of slots
   currently available in the session (a point-in-time snapshot). Accepts an optional
   ``PMIX_SESSION_ID`` qualifier.
+* ``PMIX_TIME_REMAINING`` (uint32_t) |mdash| return the number of seconds
+  remaining in the allocation for the specified namespace, defaulting to the
+  allocation containing the caller. Accepts an optional ``PMIX_NSPACE``
+  qualifier.
 
 Process sets and groups:
 
@@ -217,6 +223,10 @@ Resource usage, devices, and storage:
 * ``PMIX_QUERY_NODE_RESOURCE_USAGE`` (char*) |mdash| return the resource-usage
   statistics for the specified node(s). Accepts ``PMIX_SESSION_ID``, ``PMIX_NSPACE``,
   or ``PMIX_JOBID`` qualifiers.
+* ``PMIX_DAEMON_MEMORY`` (float) |mdash| return the amount of memory, in
+  megabytes, currently in use by the PMIx server daemon.
+* ``PMIX_CLIENT_AVG_MEMORY`` (float) |mdash| return the average amount of
+  memory, in megabytes, in use by the client processes on the node.
 * ``PMIX_QUERY_DEVICES`` (pmix_data_array_t*) |mdash| return an array of
   ``pmix_device_t`` for the devices in the current topology that meet the query
   qualifications, e.g., a ``PMIX_DEVICE_TYPE`` qualifier.
@@ -293,6 +303,12 @@ Commonly used **qualifiers**:
   ``PMIX_HOST_ATTRIBUTES`` / ``PMIX_TOOL_ATTRIBUTES`` (bool) |mdash| when used with
   ``PMIX_QUERY_ATTRIBUTE_SUPPORT``, select the level(s) of attribute support to
   report. Omitting all levels is equivalent to requesting every level.
+* ``PMIX_CLIENT_FUNCTIONS`` / ``PMIX_SERVER_FUNCTIONS`` /
+  ``PMIX_TOOL_FUNCTIONS`` / ``PMIX_HOST_FUNCTIONS`` (bool) |mdash| when used with
+  ``PMIX_QUERY_ATTRIBUTE_SUPPORT``, return a comma-delimited list of the PMIx
+  functions supported at the client, server, tool, or host level, respectively
+  (in place of the per-function attribute listing produced by the
+  corresponding ``PMIX_*_ATTRIBUTES`` qualifier).
 * ``PMIX_QUERY_LOCAL_ONLY`` (bool) |mdash| constrain the query to locally available
   information only, rather than forwarding it to the host environment.
 * ``PMIX_QUERY_REPORT_AVG`` (bool) |mdash| report average values.

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -140,7 +140,9 @@ Commonly used **keys**:
 * ``PMIX_QUERY_AVAIL_SERVERS`` |mdash| scan the local node for PMIx servers the
   caller could connect to. The result is an array of ``pmix_info_t``, each a
   ``PMIX_SERVER_INFO_ARRAY`` (pmix_data_array_t*) holding the available data for
-  one connectable server (beginning with its namespace).
+  one connectable server (beginning with its namespace). That per-server data
+  includes the server's ``PMIX_SERVER_START_TIME`` (char*), the ctime-format time
+  at which it created its rendezvous file.
 * ``PMIX_QUERY_STABLE_ABI_VERSION`` / ``PMIX_QUERY_PROVISIONAL_ABI_VERSION``
   |mdash| return the stable or provisional Standard ABI version supported by the
   library. These are resolved locally and may be queried before initialization.

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -89,6 +89,11 @@ The ``directive`` argument is a value of type
 Values at or above ``PMIX_RESOURCE_BLOCK_EXTERNAL`` are reserved for
 implementer-defined directives.
 
+The ``info`` array may additionally carry the following attribute:
+
+* ``PMIX_RESOURCE_BLOCK_NAME`` (char\*) |mdash| name of the resource block that
+  the operation concerns.
+
 
 RETURN VALUE
 ------------

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -90,6 +90,10 @@ Identifying the request:
 
 * ``PMIX_SESSION_CTRL_ID`` (char*) |mdash| a string identifier for this request,
   allowing its status to later be queried or the operation to be cancelled.
+* ``PMIX_REQUESTOR`` (pmix_proc_t\*) |mdash| identifier of the process on whose
+  behalf the request is being made, used when one process relays the operation
+  to the PMIx library on behalf of another (the API itself takes no requestor
+  parameter).
 
 Instantiating a session (typically issued by a scheduler):
 

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -220,6 +220,10 @@ Environment control:
 * ``PMIX_SET_ENVAR`` / ``PMIX_ADD_ENVAR`` / ``PMIX_PREPEND_ENVAR`` /
   ``PMIX_APPEND_ENVAR`` (pmix_envar_t\*) |mdash| set, add, prepend to, or append to
   an environment variable in the spawned processes' environment.
+* ``PMIX_FIRST_ENVAR`` (pmix_envar_t\*) |mdash| ensure the given value appears
+  first in the specified environment variable, using the provided separator.
+* ``PMIX_UNSET_ENVAR`` (char\*) |mdash| unset the named environment variable in
+  the spawned processes' environment, if present.
 * ``PMIX_ENVARS_HARVESTED`` (bool) |mdash| indicates that the requestor has already
   harvested and included the relevant environment variables.
 * ``PMIX_FWD_ENVIRONMENT`` (bool) |mdash| forward the local environment to each

--- a/docs/man/man3/PMIx_server_init.3.rst
+++ b/docs/man/man3/PMIx_server_init.3.rst
@@ -159,6 +159,13 @@ Topology and behavior attributes
   singleton process; the value is the ``nspace.rank`` string of that singleton.
 * ``PMIX_IOF_LOCAL_OUTPUT`` (bool) |mdash| write output streams to the server's
   own stdout/stderr.
+* ``PMIX_BIND_PROGRESS_THREAD`` (char\*) |mdash| comma-delimited ranges of CPUs to
+  which the internal PMIx progress thread is to be bound.
+* ``PMIX_BIND_REQUIRED`` (bool) |mdash| return an error if the internal PMIx
+  progress thread cannot be bound as requested.
+* ``PMIX_EXTERNAL_AUX_EVENT_BASE`` (void\*) |mdash| pointer to an ``event_base``
+  the library is to use for auxiliary functions (e.g., capturing signals) that
+  would otherwise interfere with the host.
 
 
 RETURN VALUE

--- a/docs/man/man3/PMIx_server_init.3.rst
+++ b/docs/man/man3/PMIx_server_init.3.rst
@@ -131,6 +131,13 @@ Role and support attributes
   system controller.
 * ``PMIX_SERVER_REMOTE_CONNECTIONS`` (bool) |mdash| allow (or disable)
   connections from remote tools.
+* ``PMIX_SERVER_ALLOW_FOREIGN_TOOLS`` (bool) |mdash| mark the tool rendezvous
+  files as readable by all users and allow tools running under user IDs other
+  than that of the server to connect. The host retains ultimate authority over
+  such connections and may restrict what foreign tools are permitted to do
+  (for example, limiting them to queries) as dictated by host policy.
+* ``PMIX_ALLOW_CLIENT_CLONES`` (bool) |mdash| allow connections from clones
+  (forks) of a registered client process.
 
 Topology and behavior attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/man/man3/PMIx_server_register_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_register_nspace.3.rst
@@ -146,6 +146,18 @@ Job-realm information
   nodes hosting the job (see ``PMIx_generate_regex2``).
 * ``PMIX_PROC_MAP`` (char\*) |mdash| regular-expression representation of the
   process-to-node mapping.
+* ``PMIX_NODE_MAP_RAW`` (char\*) |mdash| comma-delimited list of the nodes
+  containing processes for this job, provided as an alternative to the
+  regular-expression form in ``PMIX_NODE_MAP``.
+* ``PMIX_PROC_MAP_RAW`` (char\*) |mdash| semicolon-delimited list of strings,
+  each a comma-delimited list of the ranks on the corresponding node, provided
+  as an alternative to the regular-expression form in ``PMIX_PROC_MAP``.
+* ``PMIX_ANL_MAP`` (char\*) |mdash| process mapping in ANL notation, as used by
+  PMI-1 and PMI-2.
+* ``PMIX_APP_MAP_TYPE`` (char\*) |mdash| type of mapping used to lay out the
+  application (e.g., ``cyclic``).
+* ``PMIX_APP_MAP_REGEX`` (char\*) |mdash| regular expression describing the
+  result of the mapping.
 * ``PMIX_JOB_NUM_APPS`` (uint32_t) |mdash| number of applications in the job;
   required when the job contains more than one application.
 * ``PMIX_SERVER_NSPACE`` (char\*) |mdash| namespace of the PMIx server itself.

--- a/docs/man/man3/PMIx_tool_init.3.rst
+++ b/docs/man/man3/PMIx_tool_init.3.rst
@@ -194,6 +194,13 @@ Behavioral attributes
 * ``PMIX_SYSTEM_TMPDIR`` (char\*) |mdash| temporary directory used for the
   system-level server rendezvous point. Defaults to the ``PMIX_SYSTEM_TMPDIR``
   environment variable, if set.
+* ``PMIX_BIND_PROGRESS_THREAD`` (char\*) |mdash| comma-delimited ranges of CPUs to
+  which the internal PMIx progress thread is to be bound.
+* ``PMIX_BIND_REQUIRED`` (bool) |mdash| return an error if the internal PMIx
+  progress thread cannot be bound as requested.
+* ``PMIX_EXTERNAL_AUX_EVENT_BASE`` (void\*) |mdash| pointer to an ``event_base``
+  the library is to use for auxiliary functions (e.g., capturing signals) that
+  would otherwise interfere with the host.
 
 
 RETURN VALUE

--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -204,6 +204,9 @@ contact the remote server hosting a given process and retrieve that process's
 modex blob on demand (used when a :ref:`PMIx_Get(3) <man3-PMIx_Get>` cannot be
 satisfied from local data). The blob is returned through a
 ``pmix_modex_cbfunc_t``. A timeout directive may be supplied to bound the wait.
+The request may carry a ``PMIX_REQUIRED_KEY`` (char*) naming the specific key the
+requester is waiting on, allowing the host to defer its response until that key
+has been posted by the target process.
 
 publish
 ^^^^^^^
@@ -237,7 +240,11 @@ spawn
 :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`. Launches the given array of applications.
 A failure to start any process causes the entire request to be terminated and an
 error returned. The namespace of the spawned job is returned through a
-``pmix_spawn_cbfunc_t``.
+``pmix_spawn_cbfunc_t``. The job-level information accompanying the request may
+include ``PMIX_REQUESTOR_IS_TOOL`` or ``PMIX_REQUESTOR_IS_CLIENT`` (bool),
+indicating whether the process that issued the spawn request is a tool or a
+client, respectively; a host may use this to apply different policies to
+tool-initiated launches.
 
 connect
 ^^^^^^^

--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -201,8 +201,10 @@ The ``info`` array may include ``PMIX_LOCAL_COLLECTIVE_STATUS``
 of the local portion of the collective |mdash| for example, an error detected
 among the local participants. A host that receives a failing status should
 propagate it into the collective result rather than proceeding with the data
-exchange. This attribute applies equally to the other collective module
-functions below (``connect``, ``disconnect``, and ``group``).
+exchange. The library may likewise supply ``PMIX_LOCAL_PARTICIPANTS``
+(pmix_data_array_t*), an array of ``pmix_proc_t`` identifying the local processes
+that contributed to the collective. These attributes apply equally to the other
+collective module functions below (``connect``, ``disconnect``, and ``group``).
 
 direct_modex
 ^^^^^^^^^^^^
@@ -262,8 +264,9 @@ connect
 "connected" so the host treats the failure of any of them as a reportable event.
 This is a client-side collective, so the callback fires once all participants
 have contributed; completion is reported through a ``pmix_op_cbfunc_t``. As with
-``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``
-reporting the status of the local portion of the collective.
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and
+``PMIX_LOCAL_PARTICIPANTS`` reporting the status and membership of the local
+portion of the collective.
 
 disconnect
 ^^^^^^^^^^
@@ -272,8 +275,9 @@ disconnect
 :ref:`PMIx_Disconnect(3) <man3-PMIx_Disconnect>`. Reverses a prior ``connect`` of
 the same set of processes; an error is returned if the set was not previously
 connected. Completion is reported through a ``pmix_op_cbfunc_t``. As with
-``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``
-reporting the status of the local portion of the collective.
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and
+``PMIX_LOCAL_PARTICIPANTS`` reporting the status and membership of the local
+portion of the collective.
 
 register_events
 ^^^^^^^^^^^^^^^
@@ -409,8 +413,8 @@ operations. The ``op`` argument (a ``pmix_group_operation_t``) selects construct
 destruct, or cancel of the named group across its member processes; directives
 may request, for example, assignment of a group context ID. Results are returned
 through a ``pmix_info_cbfunc_t``. As with ``fence_nb``, the ``info`` array may
-carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` reporting the status of the local portion
-of the collective.
+carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and ``PMIX_LOCAL_PARTICIPANTS`` reporting
+the status and membership of the local portion of the collective.
 
 fabric
 ^^^^^^

--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -196,6 +196,14 @@ aggregated result through a ``pmix_modex_cbfunc_t``. A NULL ``data`` means the
 local processes had nothing to contribute. Directives in the ``info`` array
 steer the collective and are optional unless the mandatory flag is set.
 
+The ``info`` array may include ``PMIX_LOCAL_COLLECTIVE_STATUS``
+(pmix_status_t), by which the PMIx server library reports to the host the status
+of the local portion of the collective |mdash| for example, an error detected
+among the local participants. A host that receives a failing status should
+propagate it into the collective result rather than proceeding with the data
+exchange. This attribute applies equally to the other collective module
+functions below (``connect``, ``disconnect``, and ``group``).
+
 direct_modex
 ^^^^^^^^^^^^
 
@@ -253,7 +261,9 @@ connect
 :ref:`PMIx_Connect(3) <man3-PMIx_Connect>`. Records the specified processes as
 "connected" so the host treats the failure of any of them as a reportable event.
 This is a client-side collective, so the callback fires once all participants
-have contributed; completion is reported through a ``pmix_op_cbfunc_t``.
+have contributed; completion is reported through a ``pmix_op_cbfunc_t``. As with
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``
+reporting the status of the local portion of the collective.
 
 disconnect
 ^^^^^^^^^^
@@ -261,7 +271,9 @@ disconnect
 ``disconnect`` (``pmix_server_disconnect_fn_t``) |mdash| Services
 :ref:`PMIx_Disconnect(3) <man3-PMIx_Disconnect>`. Reverses a prior ``connect`` of
 the same set of processes; an error is returned if the set was not previously
-connected. Completion is reported through a ``pmix_op_cbfunc_t``.
+connected. Completion is reported through a ``pmix_op_cbfunc_t``. As with
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``
+reporting the status of the local portion of the collective.
 
 register_events
 ^^^^^^^^^^^^^^^
@@ -396,7 +408,9 @@ group
 operations. The ``op`` argument (a ``pmix_group_operation_t``) selects construct,
 destruct, or cancel of the named group across its member processes; directives
 may request, for example, assignment of a group context ID. Results are returned
-through a ``pmix_info_cbfunc_t``.
+through a ``pmix_info_cbfunc_t``. As with ``fence_nb``, the ``info`` array may
+carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` reporting the status of the local portion
+of the collective.
 
 fabric
 ^^^^^^

--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -353,7 +353,9 @@ allocate
 :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`. The host acts
 on the requested allocation modification (identified by a
 ``pmix_alloc_directive_t``) and returns any results through a
-``pmix_info_cbfunc_t``.
+``pmix_info_cbfunc_t``. The directives may include ``PMIX_REQUESTOR``
+(pmix_proc_t*) identifying the process on whose behalf the request was made when
+it was relayed by another process.
 
 job_control
 ^^^^^^^^^^^
@@ -361,7 +363,9 @@ job_control
 ``job_control`` (``pmix_server_job_control_fn_t``) |mdash| Services
 :ref:`PMIx_Job_control(3) <man3-PMIx_Job_control>`. The host executes the
 requested control action (e.g., pause, resume, signal, terminate) against the
-target processes and returns results through a ``pmix_info_cbfunc_t``.
+target processes and returns results through a ``pmix_info_cbfunc_t``. The
+directives may include ``PMIX_REQUESTOR`` (pmix_proc_t*) identifying the process
+on whose behalf the request was made when it was relayed by another process.
 
 monitor
 ^^^^^^^
@@ -463,7 +467,9 @@ session_control
 ``session_control`` (``pmix_server_session_control_fn_t``) |mdash| Services
 :ref:`PMIx_Session_control(3) <man3-PMIx_Session_control>`. The host executes the
 requested control operation against the identified session (``sessionID``) and
-returns results through a ``pmix_info_cbfunc_t``.
+returns results through a ``pmix_info_cbfunc_t``. The directives may include
+``PMIX_REQUESTOR`` (pmix_proc_t*) identifying the process on whose behalf the
+request was made when it was relayed by another process.
 
 resource_block
 ^^^^^^^^^^^^^^

--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -203,8 +203,11 @@ among the local participants. A host that receives a failing status should
 propagate it into the collective result rather than proceeding with the data
 exchange. The library may likewise supply ``PMIX_LOCAL_PARTICIPANTS``
 (pmix_data_array_t*), an array of ``pmix_proc_t`` identifying the local processes
-that contributed to the collective. These attributes apply equally to the other
-collective module functions below (``connect``, ``disconnect``, and ``group``).
+that contributed to the collective, and ``PMIX_SORTED_PROC_ARRAY`` (bool) to
+indicate that the array of participating processes has already been sorted into
+canonical order so the host need not sort it again. These attributes apply
+equally to the other collective module functions below (``connect``,
+``disconnect``, and ``group``).
 
 direct_modex
 ^^^^^^^^^^^^
@@ -264,8 +267,8 @@ connect
 "connected" so the host treats the failure of any of them as a reportable event.
 This is a client-side collective, so the callback fires once all participants
 have contributed; completion is reported through a ``pmix_op_cbfunc_t``. As with
-``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and
-``PMIX_LOCAL_PARTICIPANTS`` reporting the status and membership of the local
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``,
+``PMIX_LOCAL_PARTICIPANTS``, and ``PMIX_SORTED_PROC_ARRAY`` describing the local
 portion of the collective.
 
 disconnect
@@ -275,8 +278,8 @@ disconnect
 :ref:`PMIx_Disconnect(3) <man3-PMIx_Disconnect>`. Reverses a prior ``connect`` of
 the same set of processes; an error is returned if the set was not previously
 connected. Completion is reported through a ``pmix_op_cbfunc_t``. As with
-``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and
-``PMIX_LOCAL_PARTICIPANTS`` reporting the status and membership of the local
+``fence_nb``, the ``info`` array may carry ``PMIX_LOCAL_COLLECTIVE_STATUS``,
+``PMIX_LOCAL_PARTICIPANTS``, and ``PMIX_SORTED_PROC_ARRAY`` describing the local
 portion of the collective.
 
 register_events
@@ -413,8 +416,8 @@ operations. The ``op`` argument (a ``pmix_group_operation_t``) selects construct
 destruct, or cancel of the named group across its member processes; directives
 may request, for example, assignment of a group context ID. Results are returned
 through a ``pmix_info_cbfunc_t``. As with ``fence_nb``, the ``info`` array may
-carry ``PMIX_LOCAL_COLLECTIVE_STATUS`` and ``PMIX_LOCAL_PARTICIPANTS`` reporting
-the status and membership of the local portion of the collective.
+carry ``PMIX_LOCAL_COLLECTIVE_STATUS``, ``PMIX_LOCAL_PARTICIPANTS``, and
+``PMIX_SORTED_PROC_ARRAY`` describing the local portion of the collective.
 
 fabric
 ^^^^^^

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1280,7 +1280,6 @@ typedef uint32_t pmix_rank_t;
                                                                     // in environments where multiple authentication mechanisms
                                                                     // may be available. When returned in a callback function, a
                                                                     // string identifier of the credential type
-#define PMIX_CRYPTO_KEY                     "pmix.sec.key"          // (pmix_byte_object_t) blob containing crypto key
 
 
 /* IO Forwarding Attributes */

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1480,7 +1480,7 @@ typedef uint32_t pmix_rank_t;
                                                                    //         PMIX_FABRIC_PLANE followed by that plane's fabric shape string.
                                                                    //         Default is to provide the shape in logical view.
 
-#define PMIX_SWITCH_PEERS                   "pmix.speers"          // (char*) Peer ranks that share the same switch as the process specified in
+#define PMIX_SWITCH_PEERS                   "pmix.speers"          // (pmix_data_array_t*) Peer ranks that share the same switch as the process specified in
                                                                    //         the call to PMIx_Get. Returns a pmix_data_array_t array of
                                                                    //         pmix_info_t results, each element containing the PMIX_SWITCH_PEERS
                                                                    //         key with a three-element pmix_data_array_t array of pmix_info_t

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -154,6 +154,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
 /* ATTRIBUTES */
 #define PMIX_EVENT_BASE                     "pmix.evbase"           // (struct event_base *) pointer to libevent event_base
                                                                     // to use in place of the internal progress thread ***** DEPRECATED *****
+#define PMIX_CRYPTO_KEY                     "pmix.sec.key"          // (pmix_byte_object_t) ***** DEPRECATED ***** blob containing crypto key
 #define PMIX_TOPOLOGY                       "pmix.topo"             // (hwloc_topology_t) ***** DEPRECATED ***** pointer to the PMIx client's internal
                                                                     //         topology object
 #define PMIX_DEBUG_JOB                      "pmix.dbg.job"          // (char*) ***** DEPRECATED ***** nspace of the job assigned to this debugger to be debugged. Note


### PR DESCRIPTION
## Summary

An audit of `include/pmix_common.h.in` against the `docs/man` man pages found
77 defined attributes that were not cited on any man page. This branch closes
the great majority of that gap: **69 of the 77** are now documented on the
correct page, with the attribute-to-API association taken from the PMIx
Standard and reconciled against actual library usage (library wins on
conflict).

Each commit is scoped to one logical change (generally one man page), so the
series can be reviewed and bisected commit by commit.

## What landed

- **`PMIx_Get`** — a new RESERVED KEYS section covering the reserved
  informational keys (process identity/rank, node/host info, sizes/counts,
  scratch directories, process state), plus `PMIX_PSET_NAMES` and
  `PMIX_SWITCH_PEERS`.
- **`PMIx_Query_info`** — the `*_FUNCTIONS` qualifiers, `PMIX_TIME_REMAINING`,
  the memory-usage keys, `PMIX_SERVER_INFO_ARRAY`, and `PMIX_SERVER_START_TIME`.
- **`PMIx_server_register_nspace`** — the raw/alternate process-map keys.
- **`PMIx_server_init` / `PMIx_Init` / `PMIx_tool_init`** — the foreign-tool and
  client-clone attributes, plus the progress-thread binding and auxiliary
  event-base attributes common to all three init entry points.
- **`PMIx_Spawn`** — `PMIX_FIRST_ENVAR` / `PMIX_UNSET_ENVAR`.
- **`PMIx_Init`** — the model-phase attributes.
- **`PMIx_Put` / `PMIx_Get`** — the `PMIX_QUALIFIED_VALUE` mechanism.
- **`PMIx_Resource_block`** — `PMIX_RESOURCE_BLOCK_NAME`.
- **`PMIx_Allocation_request`** — `PMIX_ALLOC_STATUS` (completion event) and
  `PMIX_REQUESTOR`.
- **`PMIx_Session_control` / `PMIx_Job_control`** — `PMIX_REQUESTOR`.
- **`pmix_server_module_t`** — requestor-identity and required-key attributes on
  the spawn/dmodex callbacks; `PMIX_LOCAL_COLLECTIVE_STATUS`,
  `PMIX_LOCAL_PARTICIPANTS`, and `PMIX_SORTED_PROC_ARRAY` on the fence/connect/
  disconnect/group collective callbacks; `PMIX_REQUESTOR` on the
  allocate/job_control/session_control callbacks.

## Incidental fixes (standalone commits)

- **Corrected the `PMIX_SWITCH_PEERS` type** from `(char*)` to
  `(pmix_data_array_t*)`. The marker contradicted the attribute's own
  description and drove `construct_dictionary.py` to record the wrong type
  (`PMIX_STRING`); it now regenerates as `PMIX_DATA_ARRAY`. No library code
  produces the value, so there is no wire-format impact.
- **Deprecated `PMIX_CRYPTO_KEY`** by moving it to `pmix_deprecated.h`. It is
  defined but consumed nowhere in the library; the string key and value are
  unchanged, so the symbol remains available and stays in the generated
  dictionary.

## Not included (deliberately)

Eight attributes remain uncited and are left for follow-up: the
`PMIX_ATTR_UNDEF` sentinel; `PMIX_VERSION_INFO` (internal connection
handshake); `PMIX_JOB_TERM_STATUS` / `PMIX_PROC_TERM_STATUS` (event payloads
with no API home); and the library-only `PMIX_REALUID`, `PMIX_REALGID`,
`PMIX_TOPOLOGY_INDEX`, and `PMIX_VERSION_NUMERIC` (not in the Standard; several
overlap the pending `pmix_attributes.c` refresh).

## Testing

Docs build warning-free (`make` under `docs/`, Sphinx with warnings-as-errors).
The full library also builds cleanly after the `PMIX_SWITCH_PEERS` type change
and the `PMIX_CRYPTO_KEY` move (dictionary regenerated, no redefinition).