### PR TITLE
Add pctrl man page and reconcile tool man pages with their help files

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -94,6 +94,7 @@ PMIX_MAN1 = \
         pmix_info.1 \
         palloc.1 \
         pattrs.1 \
+        pctrl.1 \
         pevent.1 \
         plookup.1 \
         pmixcc.1 \

--- a/docs/man/man1/index.rst
+++ b/docs/man/man1/index.rst
@@ -7,6 +7,7 @@ Commands (section 1)
    pmix_info.1.rst
    palloc.1.rst
    pattrs.1.rst
+   pctrl.1.rst
    pevent.1.rst
    plookup.1.rst
    pmixcc.1.rst

--- a/docs/man/man1/palloc.1.rst
+++ b/docs/man/man1/palloc.1.rst
@@ -42,6 +42,8 @@ OPTIONS
 
 * ``-V`` | ``--version``: Print version and exit.
 
+* ``--pmixmca <arg0> <arg1>``: Set MCA parameter value
+
 * ``--uri <arg0>``: Specify the URI of the server to which we are to connect, or
   the name of the file (specified as ``file:filename``) that contains that info
 
@@ -57,6 +59,8 @@ OPTIONS
 * ``--system-server-only``: Connect only to a system-level server
 
 * ``--system-controller``: Connect to the system controller
+
+* ``--scheduler``: Connect to the scheduler
 
 * ``--tmpdir <arg0>``: Set the root for the session directory tree
 

--- a/docs/man/man1/pctrl.1.rst
+++ b/docs/man/man1/pctrl.1.rst
@@ -1,0 +1,133 @@
+.. _man1-pctrl:
+
+pctrl
+=====
+
+.. include_body
+
+pctrl |mdash| Request job control operations on running processes
+
+SYNOPSIS
+--------
+
+``pctrl [options]``
+
+
+DESCRIPTION
+-----------
+
+``pctrl`` is the PMIx job control tool. It allows a user to request
+job control operations |mdash| such as pausing, resuming, signaling,
+terminating, checkpointing, or restarting |mdash| against a specified
+set of running processes. The tool connects to a PMIx server and relays
+the request to the host environment for processing, returning a status
+indicating whether or not the requested operation succeeded.
+
+The processes to be acted upon are identified with the ``--targets``
+option. The specific control operation is selected by the corresponding
+option (e.g., ``--pause``, ``--kill``, ``--checkpoint``).
+
+
+OPTIONS
+-------
+
+``pctrl`` accepts the following options:
+
+* ``-h`` | ``--help <arg0>``: Show help message. If the optional
+  argument is not provided, then a generalized help message similar
+  to the information provided here is returned. If an argument is
+  provided, then a more detailed help message for that specific
+  command line option is returned.
+
+* ``-v`` | ``--verbose``: Enable debug output.
+
+* ``-V`` | ``--version``: Print version and exit.
+
+* ``--pmixmca <arg0> <arg1>``: Set the value of a PMIx MCA parameter,
+  where ``<arg0>`` is the parameter name (key) and ``<arg1>`` is its
+  value.
+
+* ``--uri <arg0>``: Specify the URI of the server to which we are to connect, or
+  the name of the file (specified as ``file:filename``) that contains that info
+
+* ``--namespace <arg0>``: Namespace of the daemon to which we should connect
+
+* ``--nspace <arg0>``: Synonym for ``namespace``
+
+* ``--pid <arg0>``: PID of the daemon to which we should connect (``int`` => ``PID``
+  or ``file:<file>`` for file containing the PID
+
+* ``--system-server-first``: First look for a system server and connect to it if found
+
+* ``--system-server-only``: Connect only to a system-level server
+
+* ``--tmpdir <arg0>``: Set the root for the session directory tree
+
+* ``--wait-to-connect <arg0>``: Delay specified number of seconds before trying to connect
+
+* ``--num-connect-retries <arg0>``: Max number of times to try to connect
+
+* ``--request-id <arg0>``: String identifier for this job control request. The
+  request ID can be used for subsequent query of request status and/or
+  cancellation of the request, and must be unique among currently active
+  requests.
+
+* ``--pause``: Pause the specified processes (typically by applying ``SIGSTOP``).
+
+* ``--resume``: "Un-pause" the specified processes, resuming execution
+  (typically by applying ``SIGCONT``).
+
+* ``--cancel <arg0>``: Cancel the specified request ID (``all`` => cancel all
+  requests from this requestor).
+
+* ``--kill``: Force terminate the specified processes. Typically delivers the
+  sequence ``SIGCONT``, ``SIGTERM``, ``SIGKILL``.
+
+* ``--terminate``: Politely terminate the specified processes. Typically delivers
+  the sequence ``SIGCONT``, ``SIGTERM``.
+
+* ``--signal <arg0>``: Deliver the given signal to the specified processes. The
+  signal is provided by name (e.g., ``SIGTERM``, ``SIGKILL``) or as an integer
+  value (e.g., ``-9``).
+
+* ``--restart <arg0>``: Restart the specified processes using the given
+  checkpoint ID.
+
+* ``--checkpoint <arg0>``: Checkpoint the specified processes and assign the
+  given ID to it. The checkpoint is conducted according to the method specified
+  when the processes were originally spawned.
+
+* ``--pset <arg0>``: Define a new process set (with the given name) whose
+  membership is comprised of the specified processes.
+
+* ``--targets <arg0>``: Comma-delimited list of target processes for the
+  requested job-control operation. Each process is identified as ``nspace:rank``;
+  a wildcard rank (to apply the request to all processes in the namespace) can be
+  indicated with an asterisk (``*``).
+
+
+EXIT STATUS
+-----------
+
+Returns 0 for success, non-zero error code if a problem occurred. Note that
+success does not necessarily translate to success of the requested operation,
+depending upon the provided options, but may instead mean that the request has
+been accepted for processing. ``pctrl`` returns a status indicating whether or
+not the requested job-control operation succeeded.
+
+
+EXAMPLES
+--------
+
+Pause every process in the namespace ``myjob``::
+
+   pctrl --targets myjob:* --pause
+
+Forcibly terminate ranks 0 and 3 of ``myjob``::
+
+   pctrl --targets myjob:0,myjob:3 --kill
+
+
+.. seealso::
+   :ref:`PMIx_Job_control(3) <man3-PMIx_Job_control>`,
+   :ref:`openpmix(5) <man5-openpmix>`

--- a/docs/man/man1/pevent.1.rst
+++ b/docs/man/man1/pevent.1.rst
@@ -37,7 +37,20 @@ OPTIONS
 
 * ``--pmixmca <arg0> <arg1>``: Set MCA parameter value
 
+* ``--uri <arg0>``: Specify the URI of the server to which we are to connect, or
+  the name of the file (specified as ``file:filename``) that contains that info
+
+* ``--namespace <arg0>``: Namespace of the daemon to which we should connect
+
+* ``--system-server-first``: First look for a system server and connect to it if found
+
+* ``--system-server``: Connect to a system server if a local server isn't found
+
 * ``--pid <arg0>``: PID of the daemon to which we should connect (int => PID or file:<file> for file containing the PID
+
+* ``--wait-to-connect <arg0>``: Delay specified number of seconds before trying to connect
+
+* ``--num-connect-retries <arg0>``: Max number of times to try to connect
 
 * ``--tmpdir <arg0>``: Set the root for the session directory tree
 

--- a/docs/man/man1/pmix_info.1.rst
+++ b/docs/man/man1/pmix_info.1.rst
@@ -43,6 +43,9 @@ OPTIONS
 
 * ``-V`` | ``--version``: Print version and exit.
 
+* ``--pmixmca <key> <value>``: Pass a PMIx MCA parameter, where ``key`` is the
+  parameter name and ``value`` is the parameter value.
+
 * ``-a`` | ``--all``: Show all configuration options and MCA
   parameters.
 
@@ -60,6 +63,18 @@ OPTIONS
   parameter is the framework (or the keyword "all"); the second parameter
   is a comma-delimited list of specific component names (if only <arg0>
   is given, then all components will be reported).
+
+* ``--params <arg0>:<arg1>,<arg2>``: Synonym for ``--param``.
+
+* ``--type <arg0>``: Show MCA parameters of the type specified in the argument.
+  Accepts: ``unsigned_int``, ``unsigned_long``, ``unsigned_long_long``,
+  ``size_t``, ``string``, ``version_string``, ``bool``, and ``double``.
+
+* ``--show-version <arg0>:<arg1>``: Show the version of PMIx or a component. The
+  first parameter can be the keywords ``pmix`` or ``all``, a framework name (all
+  components in a framework), or a ``framework:component`` string. The second
+  parameter can be one of: ``full``, ``major``, ``minor``, ``release``,
+  ``greek``, ``repo``.
 
 * ``--path <type>``: Show paths that PMIx was configured
   with. Accepts the following parameters: ``all``, ``prefix``, ``bindir``,

--- a/src/tools/pctrl/help-pctrl.txt
+++ b/src/tools/pctrl/help-pctrl.txt
@@ -175,8 +175,10 @@ provided via their name (e.g., SIGTERM, SIGKILL) or an integer value
 (e.g., -9).
 #
 [restart]
-"Un-pause" the specified processes - usually implemented by applying a
-SIGCONT signal to the processes.
+Restart the specified processes using the given checkpoint ID. The restart
+operation will be conducted according to the method specified when the processes
+were originally spawned. Support for this operation therefore depends both on the
+capabilities of the runtime environment _and_ the application being restarted.
 #
 [checkpoint]
 Checkpoint the specified processes and assign the given ID to it. The checkpoint

--- a/src/tools/pmix_info/help-pmix_info.txt
+++ b/src/tools/pmix_info/help-pmix_info.txt
@@ -55,7 +55,7 @@ PMIx Library Information
                                      specific component names (if only <arg0> is given, then all
                                      components will be reported).
    --params <arg0>:<arg1>,<arg2>     Synonym for "param"
-   --path <type>                     Show paths with which PRRTE was configured. Accepts the following
+   --path <type>                     Show paths with which PMIx was configured. Accepts the following
                                      parameters: "prefix", "bindir", "libdir", "incdir", "mandir",
                                      "pkglibdir", "sysconfdir".
    --show-version <arg0>:<arg1>      Show version of PMIx or a component.  The first parameter can be the


### PR DESCRIPTION
## Summary

Fills a gap in the command-line tool documentation and brings the tool
man pages into agreement with the option tables in each tool's
`help-*.txt` file.

## Changes

- **Add a man page for `pctrl`** (`docs/man/man1/pctrl.1.rst`) — the only
  PMIx tool that lacked one. Its options are drawn from the option table in
  `src/tools/pctrl/help-pctrl.txt`. Wired into the man1 index and the
  `PMIX_MAN1` install list.

- **Sync tool man page options with their help files.** An audit of every
  tool man page against its help `[usage]` table found three pages missing
  options the tool actually accepts:
  - `pevent`: `--uri`, `--namespace`, `--system-server-first`,
    `--system-server`, `--wait-to-connect`, `--num-connect-retries`
  - `palloc`: `--pmixmca`, `--scheduler`
  - `pmix_info`: `--pmixmca`, `--params`, `--show-version`, `--type`

  The other tools (`pattrs`, `pctrl`, `plookup`, `pps`, `pquery`, `pmixcc`)
  already matched.

## Incidental help-text fixes (standalone commits)

- **`pctrl --restart`**: the detailed help section was a copy-paste of the
  `--resume` text ("un-pause … SIGCONT"), contradicting the option's own
  summary. Corrected to describe restarting from the given checkpoint ID.
- **`pmix_info --path`**: described showing paths "with which PRRTE was
  configured", a leftover from the tool's `prte_info` ancestry; corrected to
  PMIx.

Both help-text fixes regenerate the compiled `pmix_show_help_content.*`
per the project's show_help workflow (the generated files are not
committed).

## Testing

Docs build warning-free (Sphinx, warnings-as-errors). Full library builds
cleanly after regenerating the show_help content. A re-run of the
option-consistency audit reports all nine tools in agreement with their
help files.