### PR TITLE
Close hwloc shmem fd after adopting the topology

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -289,6 +289,9 @@ pmix_status_t pmix_hwloc_setup_topology(pmix_info_t *info, size_t ninfo)
     free(file);
     rc = hwloc_shmem_topology_adopt((hwloc_topology_t *) &pmix_globals.topology.topology, fd, 0,
                                     (void *) addr, size, 0);
+    /* the topology has been mmap'd, so the fd is no longer
+     * needed regardless of whether the adopt succeeded */
+    close(fd);
     if (0 == rc) {
         pmix_output_verbose(2, pmix_hwloc_output, "%s:%s shmem adopted",
                             __FILE__, __func__);


### PR DESCRIPTION
pmix_hwloc_setup_topology() opened the shared-memory topology file
and passed the descriptor to hwloc_shmem_topology_adopt(), but never
closed it. hwloc mmaps the region during adopt, so the descriptor is no
longer needed once the call returns - on either the success or failure
path.

Leaving it open leaked one file descriptor for the lifetime of every
client process.

Found with a valgrind `--track-fds` run of a simple PMIx_Init /
PMIx_Finalize client under prterun: the `/tmp/.../hwloc.sm` descriptor
was still open at exit. With this `close()` the client exits with only
the three standard descriptors open, and valgrind reports no memory
leaks and no errors.