### PR TITLE
Fix memory leaks in the PMIx_Get value-return path

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -709,7 +709,12 @@ done:
                 cb->value = val;
                 gcbfn(0, 0, cb);
             } else {
-                cb->cbfunc.valuefn(rc, val, cb->cbdata);
+                /* hand the value to the cb so the blocking caller
+                 * collects it directly.  Passing it as cb->value lets
+                 * _value_cbfunc() take ownership rather than copying it
+                 * onto a separate pointer that would then be leaked */
+                cb->value = val;
+                cb->cbfunc.valuefn(rc, cb->value, cb->cbdata);
             }
         }
     }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -477,7 +477,11 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cb);
     cb = (pmix_cb_t *) cbdata;
     cb->status = status;
-    if (PMIX_SUCCESS == status) {
+    /* the local get_data path invokes us with the value it already
+     * stashed in cb->value - in that case it is ours to keep, so copying
+     * it onto itself would simply orphan (leak) the original.  Only make
+     * a copy when we are handed a value we do not already own. */
+    if (PMIX_SUCCESS == status && kv != cb->value) {
         PMIX_BFROPS_COPY(rc, pmix_client_globals.myserver, (void **)&cb->value, kv, PMIX_VALUE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -731,13 +731,21 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     if (NULL != cb->key && 1 == pmix_list_get_size(kvs)) {
         kv = (pmix_kval_t *) pmix_list_get_first(kvs);
         if (PMIX_CHECK_KEY(kv, PMIX_QUALIFIED_VALUE)) {
-            // extract the actual value
+            // the actual value is embedded in the qualified-value array,
+            // which the kv still owns.  Hand back a standalone copy so the
+            // caller can release it, and leave the kv (with its array) to
+            // be released normally when the cb is destructed.
             iptr = (pmix_info_t*)kv->value->data.darray->array;
-            cb->value = &iptr[0].value;
+            PMIX_VALUE_CREATE(cb->value, 1);
+            if (NULL == cb->value) {
+                return PMIX_ERR_NOMEM;
+            }
+            PMIx_Value_xfer(cb->value, &iptr[0].value);
         } else {
+            // take ownership of the value away from the kv
             cb->value = kv->value;
+            kv->value = NULL;
         }
-        kv->value = NULL; // protect the value
         return PMIX_SUCCESS;
     }
     /* we will return the data as an array of pmix_info_t

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -431,9 +431,16 @@ static void lgcon(pmix_get_logic_t *p)
     p->appdirective = false;
     p->appnum = UINT32_MAX;
 }
+static void lgdes(pmix_get_logic_t *p)
+{
+    if (NULL != p->hostname) {
+        free(p->hostname);
+        p->hostname = NULL;
+    }
+}
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_get_logic_t,
                                 pmix_object_t,
-                                lgcon, NULL);
+                                lgcon, lgdes);
 
 static void cbcon(pmix_cb_t *p)
 {


### PR DESCRIPTION
Three related leaks in the client-side PMIx_Get path, found while
running the client examples under valgrind (prterun -n 2,
--leak-check=full).

**1. pmix_get_logic_t had no destructor.** The class used to track a
PMIx_Get request was declared with a NULL destructor, but its
"hostname" field is populated with a strdup'd string while resolving
node-level requests. Releasing the logic object leaked that string. Add
an lgdes() destructor that frees it.

**2. The blocking PMIx_Get orphaned a locally-satisfied value.** When a
blocking get was satisfied from local data, get_data() stored the value
in cb->value and then invoked _value_cbfunc(cb->status, cb->value, cb).
_value_cbfunc() unconditionally copied the value it was handed into
cb->value - but it was handed cb->value itself, so the copy overwrote
(and leaked) the value process_values() had already taken ownership of,
along with everything it referenced. Only copy when the incoming value
is not already cb->value.

**3. The blocking PMIx_Get leaked a server-satisfied value.** When the
data had to be fetched from the server, _getnb_cbfunc() extracted the
value into a local "val" and passed it to _value_cbfunc(), which (cb->value
being NULL there) copied it and left the original val unreleased. Store
the value in cb->value before dispatching, mirroring the non-blocking
branch, so fix #2 lets _value_cbfunc() take ownership instead of copying.

Verified: with all three fixes the per-Get value leaks are gone across
the client examples (client2/client3/client4 are completely leak-free),
the returned values remain correct, and no new valgrind errors appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)