### PR TITLE
Fix memory leak in the dmodex example

### DIFF
--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -231,6 +231,9 @@ int main(int argc, char **argv)
 
 done:
     /* finalize us */
+    if (NULL != locals) {
+        free(locals);
+    }
 
     /* call fence so everyone waits before leaving */
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, NULL, 0))) {


### PR DESCRIPTION
When a job spans more than one node, dmodex allocates a "locals" array
to record which peer ranks are local but never frees it. The leak only
appears in a multi-node run - in a single-node job every rank is local
so the array is never allocated - which is why it was not caught by the
single-node example checks.

Free the array before finalizing. It is initialized to NULL and only
assigned in the non-local branch, so the guarded free is safe on every
path.

Verified under valgrind in the multi-node dockerswarm harness
(prterun --host node1:2,node2:2 -np 4 --map-by node): every rank now
reports no leaks and no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)