### PR TITLE
Fix memory leaks across a batch of examples

### DIFF
--- a/examples/alloc.c
+++ b/examples/alloc.c
@@ -94,6 +94,7 @@ static void release_fn(size_t evhdlr_registration_id, pmix_status_t status,
 {
     myrel_t *lock;
     size_t n;
+    char *tmp;
     pmix_status_t rc, pstatus = PMIX_ERROR;
     EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
 
@@ -105,8 +106,10 @@ static void release_fn(size_t evhdlr_registration_id, pmix_status_t status,
         } else if (PMIx_Check_key(info[n].key, PMIX_ALLOC_STATUS)) {
             rc = PMIx_Value_get_number(&info[n].value, (void*)&pstatus, PMIX_STATUS);
             if (PMIX_SUCCESS != rc) {
+                tmp = PMIx_Proc_string(&myproc);
                 fprintf(stderr, "Client %s: Error in notification status returned: %s\n",
-                        PMIx_Proc_string(&myproc), PMIx_Error_string(rc));
+                        tmp, PMIx_Error_string(rc));
+                free(tmp);
             }
         }
     }
@@ -159,7 +162,7 @@ int main(int argc, char **argv)
     uint64_t nnodes = 12;
     myquery_data_t mydata;
     pmix_query_t *query;
-    char *myallocation = "MYALLOCATION";
+    char *myallocation = "MYALLOCATION", *tmp;
     mylock_t mylock;
     pmix_status_t code;
     myrel_t myrel;
@@ -209,6 +212,7 @@ int main(int argc, char **argv)
         PMIX_INFO_CREATE(info, 1);
         PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_STATUS, &rc, PMIX_STATUS);
         PMIx_Notify_event(PMIX_NOTIFY_ALLOC_COMPLETE, &myproc, PMIX_RANGE_GLOBAL, info, 1, NULL, NULL);
+        PMIX_INFO_FREE(info, 1);
 
     } else if (1 == myproc.rank) {
         /* demonstrate a notification based approach - register a handler
@@ -244,7 +248,9 @@ int main(int argc, char **argv)
         query[0].nqual = 1;
         PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_ALLOC_ID, myallocation, PMIX_STRING);
 
-        fprintf(stderr, "Client %s querying allocation\n", PMIx_Proc_string(&myproc));
+        tmp = PMIx_Proc_string(&myproc);
+        fprintf(stderr, "Client %s querying allocation\n", tmp);
+        free(tmp);
         if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, 1, infocbfunc, (void *) &mydata))) {
             fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
             goto done;

--- a/examples/group.c
+++ b/examples/group.c
@@ -198,6 +198,9 @@ int main(int argc, char **argv)
         }
 
         rc = PMIx_Group_construct("ourgroup", procs, nprocs, info, psize, &results, &nresults);
+        for (n = 0; n < psize; n++) {
+            PMIX_INFO_DESTRUCT(&info[n]);
+        }
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));

--- a/examples/group_dmodex.c
+++ b/examples/group_dmodex.c
@@ -164,6 +164,7 @@ int main(int argc, char **argv)
                 break;
             }
         }
+        PMIX_INFO_FREE(results, nresults);
     } else {
         fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
         goto done;

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv)
         /* execute the query */
         if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(&query, 1, cbfunc, (void *) &mylock))) {
             fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
+            PMIX_QUERY_DESTRUCT(&query);
             goto done;
         }
         DEBUG_WAIT_THREAD(&mylock);
@@ -145,6 +146,7 @@ int main(int argc, char **argv)
             rc = mylock.status;
         }
         DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_QUERY_DESTRUCT(&query);
 
 #endif
     }

--- a/examples/jctrl.c
+++ b/examples/jctrl.c
@@ -150,6 +150,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[0], PMIX_JOB_CTRL_PREEMPTIBLE, (void *) &flag, PMIX_BOOL);
     /* can't use "load" to load a pmix_data_array_t */
     (void) strncpy(info[1].key, PMIX_JOB_CTRL_CHECKPOINT_METHOD, PMIX_MAX_KEYLEN);
+    info[1].value.type = PMIX_DATA_ARRAY;
     PMIX_DATA_ARRAY_CREATE(info[1].value.data.darray, 2, PMIX_INFO);
     dptr = info[1].value.data.darray;
     rc = SIGUSR2;

--- a/examples/monitor.c
+++ b/examples/monitor.c
@@ -61,11 +61,16 @@ static void update(size_t evhdlr_registration_id, pmix_status_t status,
                    pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     size_t n;
+    char *tmp;
     EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
 
-    fprintf(stderr, "[%s]UPDATE:\n", PMIx_Proc_string(&myproc));
+    tmp = PMIx_Proc_string(&myproc);
+    fprintf(stderr, "[%s]UPDATE:\n", tmp);
+    free(tmp);
     for (n=0; n < ninfo; n++) {
-        fprintf(stderr, "%s", PMIx_Info_string(&info[n]));
+        tmp = PMIx_Info_string(&info[n]);
+        fprintf(stderr, "%s", tmp);
+        free(tmp);
     }
     fprintf(stderr, "\n\n");
 
@@ -104,6 +109,7 @@ int main(int argc, char **argv)
     pmix_info_t monitor, *results=NULL, directives[2];
     size_t nresults;
     bool flag;
+    char *tmp;
     mylock_t mylock;
     pmix_data_array_t darray;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
@@ -185,7 +191,9 @@ int main(int argc, char **argv)
         } else {
             fprintf(stderr, "INITIAL PROC RESULTS:\n");
             for (n=0; n < nresults; n++) {
-                fprintf(stderr, "%s", PMIx_Info_string(&results[n]));
+                tmp = PMIx_Info_string(&results[n]);
+                fprintf(stderr, "%s", tmp);
+                free(tmp);
             }
             fprintf(stderr, "\n\n");
             n = 0;
@@ -197,6 +205,13 @@ int main(int argc, char **argv)
             }
         }
 
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
+        }
+
         // cancel the monitor
         PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_CANCEL, "mymonitor", PMIX_STRING);
         rc = PMIx_Process_monitor(&monitor, PMIX_MONITOR_RESUSAGE_UPDATE,
@@ -205,6 +220,13 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: cancel monitor failed: %s\n", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
             goto done;
+        }
+
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
         }
 
         /* ask to monitor node resource usage */
@@ -227,7 +249,9 @@ int main(int argc, char **argv)
         } else {
             fprintf(stderr, "INITIAL NODE RESULTS:\n");
             for (n=0; n < nresults; n++) {
-                fprintf(stderr, "%s", PMIx_Info_string(&results[n]));
+                tmp = PMIx_Info_string(&results[n]);
+                fprintf(stderr, "%s", tmp);
+                free(tmp);
             }
             fprintf(stderr, "\n\n");
             n = 0;
@@ -239,6 +263,13 @@ int main(int argc, char **argv)
             }
         }
 
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
+        }
+
         PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_CANCEL, "nodemon", PMIX_STRING);
         rc = PMIx_Process_monitor(&monitor, PMIX_MONITOR_RESUSAGE_UPDATE,
                                   NULL, 0, &results, &nresults);
@@ -246,6 +277,13 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: cancel monitor failed: %s\n", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
             goto done;
+        }
+
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
         }
 
         /* ask to monitor disk resource usage */
@@ -268,7 +306,9 @@ int main(int argc, char **argv)
         } else {
             fprintf(stderr, "INITIAL DISK RESULTS:\n");
             for (n=0; n < nresults; n++) {
-                fprintf(stderr, "%s", PMIx_Info_string(&results[n]));
+                tmp = PMIx_Info_string(&results[n]);
+                fprintf(stderr, "%s", tmp);
+                free(tmp);
             }
             fprintf(stderr, "\n\n");
             n = 0;
@@ -280,6 +320,13 @@ int main(int argc, char **argv)
             }
         }
 
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
+        }
+
         PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_CANCEL, "dkmon", PMIX_STRING);
         rc = PMIx_Process_monitor(&monitor, PMIX_MONITOR_RESUSAGE_UPDATE,
                                   NULL, 0, &results, &nresults);
@@ -287,6 +334,13 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: cancel monitor failed: %s\n", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
             goto done;
+        }
+
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
         }
 
         /* ask to monitor network resource usage */
@@ -309,7 +363,9 @@ int main(int argc, char **argv)
         } else {
             fprintf(stderr, "INITIAL NETWORK RESULTS:\n");
             for (n=0; n < nresults; n++) {
-                fprintf(stderr, "%s", PMIx_Info_string(&results[n]));
+                tmp = PMIx_Info_string(&results[n]);
+                fprintf(stderr, "%s", tmp);
+                free(tmp);
             }
             fprintf(stderr, "\n\n");
             n = 0;
@@ -321,6 +377,13 @@ int main(int argc, char **argv)
             }
         }
 
+        PMIX_INFO_DESTRUCT(&monitor);
+        PMIX_INFO_DESTRUCT(&directives[0]);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
+        }
+
         PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_CANCEL, "netmon", PMIX_STRING);
         rc = PMIx_Process_monitor(&monitor, PMIX_MONITOR_RESUSAGE_UPDATE,
                                   NULL, 0, &results, &nresults);
@@ -328,6 +391,11 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: cancel monitor failed: %s\n", myproc.nspace,
                     myproc.rank, PMIx_Error_string(rc));
             goto done;
+        }
+        PMIX_INFO_DESTRUCT(&monitor);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+            results = NULL;
         }
 
     }

--- a/examples/nodeinfo.c
+++ b/examples/nodeinfo.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     pmix_value_t *val;
     pmix_proc_t proc;
     uint32_t nprocs;
-    char *nodelist, **nodes, *hostname;
+    char *nodelist = NULL, **nodes = NULL, *hostname = NULL, *tmp;
     pmix_info_t info[2];
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
@@ -112,8 +112,10 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates for rank %u failed: %s\n",
                     myproc.nspace, myproc.rank, proc.rank, PMIx_Error_string(rc));
         } else {
+            tmp = PMIx_Value_string(val);
             fprintf(stderr, "Client ns %s rank %d: Rank %u has coordinates\n    %s\n",
-                    myproc.nspace, myproc.rank, proc.rank, PMIx_Value_string(val));
+                    myproc.nspace, myproc.rank, proc.rank, tmp);
+            free(tmp);
             PMIX_VALUE_RELEASE(val);
         }
 
@@ -121,17 +123,28 @@ int main(int argc, char **argv)
         proc.rank = PMIX_RANK_WILDCARD;
         PMIX_INFO_LOAD(&info[0], PMIX_NODE_INFO, NULL, PMIX_BOOL);
         PMIX_INFO_LOAD(&info[1], PMIX_HOSTNAME, hostname, PMIX_STRING);
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val))) {
+        rc = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, info, 2, &val);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get coordinates with directive for host %s failed: %s\n",
                     myproc.nspace, myproc.rank, hostname, PMIx_Error_string(rc));
             goto done;
         }
+        tmp = PMIx_Value_string(val);
         fprintf(stderr, "Client ns %s rank %d: Host %s has coordinates\n    %s\n",
-                myproc.nspace, myproc.rank, hostname, PMIx_Value_string(val));
+                myproc.nspace, myproc.rank, hostname, tmp);
+        free(tmp);
         PMIX_VALUE_RELEASE(val);
     }
 
 done:
+    if (NULL != nodes) {
+        PMIX_ARGV_FREE(nodes);
+    }
+    if (NULL != hostname) {
+        free(hostname);
+    }
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {

--- a/examples/pubstress.c
+++ b/examples/pubstress.c
@@ -284,6 +284,8 @@ int main(int argc, char **argv)
                     myproc.rank, rc);
             goto done;
         }
+        free(keys[0]);
+        free(keys[1]);
         // purge the rest
         if (PMIX_SUCCESS != (rc = PMIx_Unpublish(NULL, NULL, 0))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish purge failed: %d\n", myproc.nspace,
@@ -366,6 +368,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish of app persistence succeeded\n", myproc.nspace,
                     myproc.rank);
         }
+        free(keys[0]);
 
         // verify the app persistence keys are gone
         PMIX_PDATA_CONSTRUCT(&pdata);


### PR DESCRIPTION
This sweep fixes memory leaks in a batch of PMIx example programs,
found by running each example under valgrind (`--leak-check=full
--show-leak-kinds=definite,indirect`) across multiple nodes in the
`contrib/dockerswarm` harness. Multi-node runs were used deliberately:
several leaks only surface when a `PMIx_Get`/lookup has to be satisfied
remotely rather than locally.

Each commit is one example. The fixes are all in `examples/` and touch
example code only:

- **group_dmodex** – free the `results` array returned by
  `PMIx_Group_construct`.
- **nodeinfo** – free the `PMIx_Value_string` result, the split node
  argv, and the cached hostname; destruct the directed-get info array.
- **hello** – destruct the stack `pmix_query_t` (its keys/qualifiers)
  once the query has been issued.
- **group** – destruct the info entries (including the
  final-membership data array) consumed by `PMIx_Group_construct`.
- **alloc** – free the notification info array after
  `PMIx_Notify_event`, and free both `PMIx_Proc_string` results.
- **jctrl** – set `info[1].value.type = PMIX_DATA_ARRAY` so the
  hand-built checkpoint-method array is both serialized and released
  correctly.
- **pubstress** – free the `asprintf`'d key strings passed to
  `PMIx_Unpublish`.
- **monitor** – free every `PMIx_Info_string`/`PMIx_Proc_string`
  result (including in the repeatedly-fired update handler), free each
  `PMIx_Process_monitor` results array, and destruct the reused
  monitor/directive info structs between resource types.

After each fix the example reports zero definitely-lost bytes with no
example frame in any remaining valgrind record on every rank.

Note: a handful of examples still show residual leaks that are rooted
in the **library**, not the examples (e.g. `PMIx_Lookup` not freeing
its keys argv on the success path; `pmix_parse_localquery` not
destructing its unresolved-query list; `PMIx_Group_join_nb` /
`setup_leader_watch`; `PMIx_Log`; and the directive-get info array in
`get_data`). Those are being tracked separately and will be addressed
in their own library-scoped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
