### PR TITLE
Fix memory leaks in the libpmix lookup, query, and log paths

### DIFF
--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -238,6 +238,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata, const 
      * nothing more for us to do */
     rc = cb->status;
     PMIX_RELEASE(cb);
+    PMIx_Argv_free(keys);
     return rc;
 }
 

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -69,6 +69,8 @@ static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     if (NULL != cd->cbfunc.opcbfn) {
         cd->cbfunc.opcbfn(status, cd->cbdata);
     }
+    PMIX_PROC_FREE(cd->proc, 1);
+    cd->proc = NULL;
     PMIX_RELEASE(cd);
 }
 

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -421,6 +421,10 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
         }
         ++n;
     }
+    /* the unresolved queries have been copied into the caddy's
+     * query cache, so we are done with the list */
+    PMIX_LIST_DESTRUCT(&unresolved);
+
     /* ask for help */
     rc = request_help(cd);
     if (PMIX_SUCCESS != rc) {

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -518,9 +518,13 @@ static void qlcon(pmix_querylist_t *p)
 {
     PMIX_QUERY_CONSTRUCT(&p->query);
 }
+static void qldes(pmix_querylist_t *p)
+{
+    PMIX_QUERY_DESTRUCT(&p->query);
+}
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_querylist_t,
                                 pmix_list_item_t,
-                                qlcon, NULL);
+                                qlcon, qldes);
 
 static void qcon(pmix_query_caddy_t *p)
 {
@@ -547,6 +551,7 @@ static void qdes(pmix_query_caddy_t *p)
 {
     PMIX_DESTRUCT_LOCK(&p->lock);
     PMIX_BYTE_OBJECT_DESTRUCT(&p->bo);
+    PMIX_QUERY_FREE(p->queries, p->nqueries);
     PMIX_PROC_FREE(p->targets, p->ntargets);
     PMIX_INFO_FREE(p->info, p->ninfo);
     PMIX_LIST_DESTRUCT(&p->results);


### PR DESCRIPTION
This is the library-scoped follow-up to the example leak sweep (#3983).
While valgrinding the examples across multiple nodes in the
`contrib/dockerswarm` harness, several residual definite leaks turned
out to be rooted in **libpmix** itself rather than the examples. This PR
fixes the ones with a clear, self-contained cause.

**Fixes:**

- **`PMIx_Lookup`** built a `keys` argv and freed it only on the
  `PMIx_Lookup_nb` error path. `Lookup_nb` only packs the keys (no
  ownership transfer), so the argv leaked on every successful lookup.
  Free it once the operation completes. *(surfaced by pub, pubi,
  pubstress)*

- **Query processing path** (`pmix_parse_localquery`):
  - the temporary `unresolved` list of `pmix_querylist_t` was copied
    into the caddy's query cache but never destructed;
  - `pmix_querylist_t` had a constructor but no destructor, so its
    embedded query's keys/qualifiers leaked when such a list was
    released;
  - the query caddy destructor freed `targets`/`info`/`results` but
    never `queries`.

  `PMIx_Query_free` tolerates the `NULL` the server paths leave after
  their own explicit free, so freeing `queries` in the destructor does
  not double-free. *(surfaced by hello, alloc)*

- **`PMIx_Log`** allocated a source proc on the shift caddy; the local
  processing paths free it, but the client→server completion callback
  released the caddy without doing so (the caddy destructor leaves
  `proc` alone because it is borrowed elsewhere). Free it in the log
  completion callback. *(surfaced by log)*

**Verification** (dockerswarm, 4 ranks across 2 nodes, valgrind
`--leak-check=full`): pub, pubi, hello, log, pubstress, alloc all report
**zero** definitely-lost bytes after the fixes; client3, group_leave,
pub2 confirm no regressions. `make check` passes (15/15), and the four
changed files rebuild warning-free under `-Wall -Wextra -Werror`.

**Deferred:** two further leaks are genuinely rooted in library
lifecycle/event-delivery semantics rather than a missing free, and are
left for focused follow-up rather than a guessed fix in a critical path:
the directive-`PMIx_Get` info array (`get_data`), whose owning `pmix_cb_t`
outlives on the async-get/`pending_requests` path, and the group
leader-watch tracker (`setup_leader_watch`), which is only torn down when
a `PMIX_GROUP_CONSTRUCT_COMPLETE`/termination event reaches the acceptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
