### PR TITLE
Return a static source string from PMIx_Load_topology

### DIFF
--- a/docs/man/man3/PMIx_Load_topology.3.rst
+++ b/docs/man/man3/PMIx_Load_topology.3.rst
@@ -55,7 +55,22 @@ indicate that the implementation is not available by returning
 
 The returned description should be treated as a read-only object; attempts to
 modify it may result in errors. The PMIx library is responsible for performing
-any required cleanup when the client library finalizes.
+any required cleanup of the returned topology when the client library finalizes.
+
+Ownership of the ``source`` field depends on who set it:
+
+* If the caller set the ``source`` field before the call to request a
+  particular implementation, that string belongs to the caller, and the caller
+  remains responsible for releasing it.
+* If the caller did *not* set the ``source`` field, the library fills it in on
+  return with a read-only, statically allocated string identifying the source
+  of the returned topology. The caller must **not** modify or release this
+  string; the library manages its lifetime.
+
+In neither case should the caller destruct or free the returned topology
+itself (for example with ``PMIx_Topology_destruct()``): the topology object is
+shared, library-managed state, and releasing it would corrupt the library's
+internal copy. The library performs the necessary cleanup at finalize.
 
 
 RETURN VALUE

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,13 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - PMIx_Load_topology no longer leaks the source string. When the caller
+   does not request a specific source, the returned topology's source
+   field now points to a read-only, statically allocated string instead
+   of a heap copy the caller had no safe way to release (the returned
+   topology is shared, library-managed state that must not be destructed
+   by the caller). A source the caller did supply remains theirs to free.
+   The PMIx_Load_topology man page documents this ownership split
  - Group construct fault handling. When a member is lost before
    contributing to a PMIx_Group_construct, the server now consults the
    PMIX_GROUP_FT_COLLECTIVE directive (previously ignored): by default

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -611,6 +611,15 @@ pmix_status_t pmix_hwloc_load_topology(pmix_topology_t *topo)
     pmix_proc_t wildcard;
     pmix_status_t rc;
     pmix_topology_t *t;
+    /* Source string reported for a caller-provided topology when the caller
+     * did not request a specific source. It has static storage duration, so
+     * the caller must treat it as read-only and must NOT free it - consistent
+     * with the returned topology being a library-managed, read-only object.
+     * A source the caller DID provide remains theirs to free. We never assign
+     * this to our own cached topology, whose source is heap-allocated and
+     * released when the library finalizes. */
+    static const char hwloc_source[] = "hwloc:" HWLOC_VERSION;
+    bool source_given = (NULL != topo->source);
 
     pmix_output_verbose(2, pmix_hwloc_output, "%s:%s", __FILE__, __func__);
 
@@ -642,7 +651,8 @@ pmix_status_t pmix_hwloc_load_topology(pmix_topology_t *topo)
             pmix_output_verbose(2, pmix_hwloc_output,
                                 "%s:%s no source stipulated - returning current version", __FILE__,
                                 __func__);
-            topo->source = strdup(pmix_globals.topology.source);
+            /* read-only static source - caller must not free it */
+            topo->source = (char *) hwloc_source;
             topo->topology = pmix_globals.topology.topology;
             return PMIX_SUCCESS;
         }
@@ -664,8 +674,15 @@ pmix_status_t pmix_hwloc_load_topology(pmix_topology_t *topo)
         if (NULL != t) {
             pmix_output_verbose(2, pmix_hwloc_output,
                                 "%s:%s found in storage", __FILE__, __func__);
-            topo->source = strdup(t->source);
-            topo->topology = t->topology;
+            /* populate the caller's topology (unless it IS our cache). A
+             * caller-provided source stays theirs; otherwise report the
+             * read-only static source they must not free. */
+            if (topo != &pmix_globals.topology) {
+                if (!source_given) {
+                    topo->source = (char *) hwloc_source;
+                }
+                topo->topology = t->topology;
+            }
             pmix_globals.topology.source = strdup(t->source);
             pmix_globals.topology.topology = t->topology;
             return PMIX_SUCCESS;
@@ -676,8 +693,12 @@ pmix_status_t pmix_hwloc_load_topology(pmix_topology_t *topo)
     pmix_output_verbose(2, pmix_hwloc_output,
                         "%s:%s nothing found - calling setup", __FILE__, __func__);
     rc = pmix_hwloc_setup_topology(NULL, 0);
-    if (PMIX_SUCCESS == rc) {
-        topo->source = strdup(pmix_globals.topology.source);
+    if (PMIX_SUCCESS == rc && topo != &pmix_globals.topology) {
+        /* setup populated our cache; hand the caller the shared topology
+         * plus a read-only static source (unless they provided their own) */
+        if (!source_given) {
+            topo->source = (char *) hwloc_source;
+        }
         topo->topology = pmix_globals.topology.topology;
     }
     return rc;


### PR DESCRIPTION
`PMIx_Load_topology` returns a topology whose `topology` field is the
library's own shared handle - the returned object is library-managed and
must **not** be destructed by the caller (doing so would
`hwloc_topology_destroy` the shared handle and corrupt the library's
copy, and is what the man page's "read-only object" language warns
against).

When the caller did not request a specific source, however, the library
also `strdup`'d a `source` string into the caller's struct. Since the
caller must not destruct the topology, that heap string had no safe
owner and leaked on every call (surfaced by the `client` example's
`PMIx_Load_topology` call under valgrind).

**Fix:** when the caller did not provide a `source`, point the returned
`source` at a read-only, statically allocated string (`"hwloc:" HWLOC_VERSION`)
so there is nothing for the caller to free. A `source` the caller *did*
provide (to request a particular implementation) is left untouched and
remains theirs to release. The library's own cached topology continues
to hold a heap-allocated `source` that is released at finalize, so the
static string is never assigned to it (the internal
`&pmix_globals.topology` call path is guarded).

The `PMIx_Load_topology` man page now documents this ownership split, and
a news entry is added.

**Verification** (dockerswarm, 4 ranks / 2 nodes, valgrind): the
`client` example's topology `source` leak is gone; `make check` passes
15/15; the changed file rebuilds warning-free under `-Wall -Wextra -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
