### PR TITLE
Fix local peers array leak in the client example

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -422,6 +422,9 @@ int main(int argc, char **argv)
     }
 
 done:
+    if (NULL != locals) {
+        free(locals);
+    }
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {


### PR DESCRIPTION
The `client` example allocates a `locals` array (the ranks of its local
peers, when not all processes are local) but never frees it, leaking it
at exit. Free it at the `done` label, matching the fix already applied
to the `dmodex` example.

Verified with valgrind in the dockerswarm harness (4 ranks across 2
nodes): the example now reports zero definitely-lost bytes with no
`client.c` frame on any rank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
