### PR TITLE
Fix two libpmix leaks on the directed-Get and group leader-watch paths

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1245,6 +1245,9 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
+    /* reclaim any group leader-watch trackers whose construct event never
+     * arrived to tear them down (safe now that the progress thread is stopped) */
+    pmix_client_group_cleanup();
     for (i = 0; i < pmix_client_globals.peers.size; i++) {
         peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_client_globals.peers, i);
         if (NULL != peer) {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -532,6 +532,14 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
             PMIX_INFO_XFER(&immediate[n], &cb->info[n]);
         }
         PMIX_INFO_LOAD(&immediate[n], PMIX_IMMEDIATE, NULL, PMIX_BOOL);
+        /* if cb->info was already a library-allocated copy (e.g., the
+         * directive array built for a node/app/session-level get), release
+         * it now that its contents have been transferred - otherwise it is
+         * orphaned by the reassignment and leaks. A caller-provided array
+         * (infocopy == false) must be left untouched. */
+        if (cb->infocopy) {
+            PMIX_INFO_FREE(cb->info, cb->ninfo);
+        }
         cb->info = immediate;
         cb->ninfo = nimm;
         cb->infocopy = true;

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -62,7 +62,7 @@
 
 /* define a tracking object for group operations */
 typedef struct {
-    pmix_object_t super;
+    pmix_list_item_t super;
     pmix_lock_t lock;
     pmix_status_t status;
     size_t ref;
@@ -149,7 +149,23 @@ static void gtdes(pmix_group_tracker_t *p)
         p->grpid = NULL;
     }
 }
-PMIX_CLASS_INSTANCE(pmix_group_tracker_t, pmix_object_t, gtcon, gtdes);
+PMIX_CLASS_INSTANCE(pmix_group_tracker_t, pmix_list_item_t, gtcon, gtdes);
+
+/* Registry of active leader-watch trackers. Each acceptor of a group
+ * invitation registers a persistent event handler (see setup_leader_watch)
+ * that must live until the group construct completes. The construct-complete
+ * (or construct-abort) event that would trigger teardown is not guaranteed to
+ * reach the acceptor before it finalizes - in practice, for the common
+ * single-server case, it often does not. Rather than leak the tracker (and its
+ * registered handler) in that case, we record each active watch here and
+ * release any survivors at finalize. Access is confined to the progress thread
+ * (watches are added in watch_regcb and removed in watch_teardown, both of
+ * which run there) and to finalize after the progress thread has stopped, so
+ * no lock is required - the same discipline used for pending_requests. The
+ * list is constructed lazily on first use (a static initializer alone does not
+ * wire up the sentinel for appends) and drained at finalize. */
+static pmix_list_t pmix_group_leader_watches = PMIX_LIST_STATIC_INIT;
+static bool pmix_group_leader_watches_active = false;
 
 /* callback for wait completion */
 static void construct_cbfunc(struct pmix_peer_t *pr,
@@ -1257,6 +1273,10 @@ static void watch_teardown(int sd, short args, void *cbdata)
     pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    /* this watch is being torn down on its own terms, so drop it from the
+     * finalize-time registry before releasing it */
+    pmix_list_remove_item(&pmix_group_leader_watches, &cb->super);
+
     if (SIZE_MAX != cb->ref) {
         PMIx_Deregister_event_handler(cb->ref, watch_deregcb, cb);
         cb->ref = SIZE_MAX;
@@ -1337,6 +1357,13 @@ static void watch_regcb(pmix_status_t status, size_t refid, void *cbdata)
         return;
     }
     cb->ref = refid;
+    /* the watch is now live - record it so a survivor can be reclaimed at
+     * finalize should its construct-complete event never arrive */
+    if (!pmix_group_leader_watches_active) {
+        PMIX_CONSTRUCT(&pmix_group_leader_watches, pmix_list_t);
+        pmix_group_leader_watches_active = true;
+    }
+    pmix_list_append(&pmix_group_leader_watches, &cb->super);
     PMIX_POST_OBJECT(cb);
 }
 
@@ -1383,6 +1410,26 @@ static void setup_leader_watch(const char *grp, const pmix_proc_t *leader)
     PMIX_INFO_LOAD(&cb->info[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
     PMIx_Register_event_handler(codes, ncodes, cb->info, cb->ninfo,
                                 leader_watch_handler, watch_regcb, cb);
+}
+
+/* Release any leader-watch trackers still active at finalize. The construct
+ * event that would normally tear a watch down is not guaranteed to reach the
+ * acceptor before it finalizes, so reclaim the survivors here. This runs after
+ * the progress thread has stopped, so no handler can be firing and the list is
+ * ours to drain; the registered event handlers are torn down with the rest of
+ * the event base. */
+void pmix_client_group_cleanup(void)
+{
+    pmix_group_tracker_t *cb;
+
+    if (!pmix_group_leader_watches_active) {
+        return;
+    }
+    while (NULL != (cb = (pmix_group_tracker_t *) pmix_list_remove_first(&pmix_group_leader_watches))) {
+        PMIX_RELEASE(cb);
+    }
+    PMIX_DESTRUCT(&pmix_group_leader_watches);
+    pmix_group_leader_watches_active = false;
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *leader,

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -70,6 +70,10 @@ PMIX_EXPORT pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inp
 
 PMIX_EXPORT bool pmix_client_proc_is_included(const pmix_proc_t *procs, size_t nprocs);
 
+/* Reclaim any leader-watch trackers still active at finalize. Called from
+ * PMIx_Finalize after the progress thread has stopped. */
+PMIX_EXPORT void pmix_client_group_cleanup(void);
+
 END_C_DECLS
 
 #endif /* PMIX_CLIENT_OPS_H */


### PR DESCRIPTION
Two library-level memory leaks surfaced while valgrind-leak-checking the
PMIx examples across nodes in the dockerswarm harness. Both are in
`libpmix` (internal, non-`main` allocation frames), so they are fixed
here rather than in the examples.

## 1. Directed `PMIx_Get`: leaked directive array when adding the immediate flag

For a node/app/session-level key, `get_data` builds a library-owned
directive array (`iptr`), points `cb->info` at it, and sets
`cb->infocopy = true` so the caddy destructor frees it. When that key is
reserved but not found locally, `_pack_get` then rebuilds `cb->info` as a
new `immediate` array (adding `PMIX_IMMEDIATE`) and overwrote the pointer
without freeing the prior library-allocated copy, orphaning it. The fix
releases the previous array when `infocopy` is already set; a
caller-provided array (`infocopy == false`) is still left untouched.
(surfaced by the `nodeinfo` example)

## 2. Group leader-watch tracker leaked at finalize

A process that accepts a group invitation via `PMIx_Group_join_nb`
registers a persistent event handler (`setup_leader_watch`) to catch loss
of the group leader before the construct completes. The tracker is only
torn down when a `PMIX_GROUP_CONSTRUCT_COMPLETE`/`_ABORT` or a
leader-termination event reaches the acceptor's `leader_watch_handler`.
That construct-resolution event is not guaranteed to reach the acceptor
before it finalizes -- in the common single-server case it typically does
not, because the one-shot event is dispatched before the acceptor's
handler registration becomes active -- so the tracker and its handler
leaked (~700 bytes per acceptor).

The fix records each live watch on a progress-thread-only registry as its
registration completes, drops it on normal teardown, and releases any
survivors from `PMIx_Finalize` after the progress thread has stopped.
(surfaced by `asyncgroup` and `group_invite`)

## Verification

- `asyncgroup` and `group_invite` run across two nodes under
  `valgrind --leak-check=full`: 0 definitely/indirectly lost and 0 errors
  on all four ranks (previously ~700 bytes lost per acceptor).
- `nodeinfo` directed-Get path: 0 leaks.
- `make check`: 15/15 pass.
- Full build warning-free under `--enable-devel-check` (`-Werror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)