### PR TITLE
Fix several memory leaks in the PMIx server library

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1306,8 +1306,15 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                         /* if the event was cached and this is the last one,
                          * then evict this event from the cache */
                         if (0 == cd->nleft) {
-                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
-                            holdcd = false;
+                            if (holdcd) {
+                                /* remove it from the cache and release the
+                                 * reference the cache was holding; our own
+                                 * in-flight reference keeps cd alive through
+                                 * the remainder of this routine */
+                                pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
+                                PMIX_RELEASE(cd);
+                                holdcd = false;
+                            }
                             break;
                         }
                     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -633,6 +633,7 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
     pmix_query_t *query;
+    char *key;
 } pmix_server_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
 

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -453,6 +453,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
     size_t niptr = 0;
     pmix_peer_t *peer = (pmix_peer_t *) pr;
     bool optional = false;
+    bool cmdline_loaded = false;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:base: connecting to server");
@@ -672,6 +673,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
         kv->info = &mycmdlineinfo;
         pmix_list_append(&ilist, &kv->super);
         free(p);
+        cmdline_loaded = true;
     }
 
     /* if we need to pass anything, setup an array */
@@ -914,6 +916,13 @@ cleanup:
     }
     if (NULL != iptr) {
         PMIX_INFO_FREE(iptr, niptr);
+    }
+    if (NULL != order) {
+        PMIx_Argv_free(order);
+    }
+    /* the command line was xfer'd into iptr, so release our local copy */
+    if (cmdline_loaded) {
+        PMIX_INFO_DESTRUCT(&mycmdlineinfo);
     }
     if (NULL != rendfile) {
         free(rendfile);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -228,6 +228,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     if (PMIX_SUCCESS == rc) {
         keyprovided = true;
     }
+    /* the caddy takes ownership of the key string so that it is
+     * released no matter which of the many exit paths below is
+     * taken - cddes will free it when the caddy is released */
+    cd->key = key;
 
     /* search for directives we can deal with here */
     for (n = 0; n < cd->ninfo; n++) {
@@ -466,6 +470,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         if (NULL != key) {
             free(key);
             key = NULL;
+            cd->key = NULL;
         }
         goto request;
     }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -678,9 +678,9 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, char 
     }
     if (NULL != lcd) {
         /* we already have a request, so just track that someone
-         * else wants data from the same target */
+         * else wants data from the same target - the new request
+         * created below takes its own reference on the tracker */
         rc = PMIX_SUCCESS; // indicates we found an existing request
-        PMIX_RETAIN(lcd);
         goto complete;
     }
     /* we do not have an existing request, so let's create
@@ -715,12 +715,9 @@ complete:
     req->lcd = lcd;
     req->cbfunc = cbfunc;
     pmix_list_append(&lcd->loc_reqs, &req->super);
-    /* if provided, the cbdata is always a pmix_server_caddy_t. Since
-     * it will be released by every req when it completes, we have to
-     * up the refcount on it to avoid multiple free's of its contents */
-    if (NULL != cbdata && 1 < pmix_list_get_size(&lcd->loc_reqs)) {
-        PMIX_RETAIN(cbdata);
-    }
+    /* the cbdata is a pmix_server_caddy_t that is unique to this
+     * request (each GET creates its own), so this request owns the
+     * single reference on it and no additional retain is required */
     req->cbdata = cbdata;
     *ld = lcd;
     *rq = req;

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -177,6 +177,14 @@ static void gtdes(grp_trk_t *t)
     if (NULL != t->blk) {
         PMIX_RELEASE(t->blk);
     }
+    /* the tracker owns its copy of the participant array and the
+     * info array handed to it by get_tracker */
+    if (NULL != t->pcs) {
+        PMIX_PROC_FREE(t->pcs, t->npcs);
+    }
+    if (NULL != t->info) {
+        PMIX_INFO_FREE(t->info, t->ninfo);
+    }
     PMIX_LIST_DESTRUCT(&t->local_cbs);
 }
 static PMIX_CLASS_INSTANCE(grp_trk_t,
@@ -1101,6 +1109,13 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     }
     // grpid has been copied into the tracker
     free(grpid);
+    // get_tracker copied the participant array into the tracker, so
+    // release our unpacked copy - the tracker's trk->pcs is used from
+    // here on
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
     // mark as a construct op
     blk->grpop = op;
     // track ctx id request
@@ -1116,7 +1131,7 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
          * so we cannot aggregate info from this proc. We therefore pass
          * everything up separately and rely on the host to properly
          * deal with it */
-        rc = pmix_host_server.group(PMIX_GROUP_CONSTRUCT, blk->id, procs, nprocs,
+        rc = pmix_host_server.group(PMIX_GROUP_CONSTRUCT, blk->id, trk->pcs, trk->npcs,
                                     trk->info, trk->ninfo, grpcbfunc, blk);
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             // the host will not be calling back

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3120,6 +3120,7 @@ static void cdcon(pmix_server_caddy_t *cd)
     cd->info = NULL;
     cd->ninfo = 0;
     cd->query = NULL;
+    cd->key = NULL;
 }
 static void cddes(pmix_server_caddy_t *cd)
 {
@@ -3137,6 +3138,9 @@ static void cddes(pmix_server_caddy_t *cd)
     }
     if (NULL != cd->query) {
         PMIX_QUERY_FREE(cd->query, 1);
+    }
+    if (NULL != cd->key) {
+        free(cd->key);
     }
 }
 PMIX_CLASS_INSTANCE(pmix_server_caddy_t,

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1520,6 +1520,8 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
     }
     cnt = cd->ninfo;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    /* the caddy owns this array and must release it when done */
+    cd->infocopy = true;
     /* unpack the data */
     if (0 < cnt) {
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
@@ -1550,6 +1552,8 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_INFO_CREATE(cd->directives, cd->ndirs);
         PMIX_INFO_LOAD(&cd->directives[cnt], PMIX_LOG_SOURCE, &proc, PMIX_PROC);
     }
+    /* the caddy owns this array and must release it when done */
+    cd->dircopy = true;
 
     /* unpack the directives */
     if (0 < cnt) {


### PR DESCRIPTION
These are memory leaks in the PMIx **server** library itself (as
embedded in a host such as prterun/prted), found by running the
examples under a host launcher wrapped in valgrind so that only the
server library - not the client applications - is leak-checked. Each
was confirmed lost-at-exit with an allocation frame entirely inside
libpmix (no host/PRRTE frame in the ownership chain).

- **GET handler key.** `pmix_server_get()` unpacks the optional key
  string from a client request but only freed it on the refresh-cache
  path, leaking it on every other exit (wildcard, deferred, pset-names,
  satisfied, remote, not-found). Ownership is now handed to the
  request server caddy, which is always released and whose destructor
  already frees the request info/query.

- **Log handler arrays.** `pmix_server_log()` allocated the info and
  directives arrays into a shift caddy but never set the caddy
  infocopy/dircopy flags, so the destructor never freed them.

- **Group tracker arrays.** The group collective tracker owns a copy of
  the participant array and the info array, but the tracker destructor
  released neither. The unpacked participant array in
  `pmix_server_group()` was also only freed on the error path.

- **Cached notification reference.** A targeted server notification
  cached in the notifications hotel takes an extra reference the hotel
  owns; the "all targets notified" checkout removed it from the hotel
  without releasing that reference, leaking the notify caddy on every
  completed targeted event.

- **Tool connection order/cmdline.** The tool/server connect path built
  a connection-order argv and a local command-line info object that
  were never released on the normal or error paths.

Verified with a warning-free (-Werror) build, `make check` 15/15, and
re-running each affected example under valgrind (target leaks gone, no
new errors).