### PR TITLE
Fix two more PMIx server library memory leaks

### DIFF
--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -802,12 +802,16 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
         PMIX_LIST_FOREACH (blob, &rank_blobs, rank_blob_t) {
             /* extract the blob */
             PMIX_UNLOAD_BUFFER(blob->buf, bo.bytes, bo.size);
+            /* the payload now belongs to bo, so release the emptied
+             * buffer object - the list destructor skips it once cleared */
+            PMIX_RELEASE(blob->buf);
             blob->buf = NULL;
             /* pack the returned blob */
             PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket, &bo, 1, PMIX_BYTE_OBJECT);
             PMIX_BYTE_OBJECT_DESTRUCT(&bo); // releases the data
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&rank_blobs);
                 goto cleanup;
             }
         }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -174,9 +174,11 @@ static void gtcon(grp_trk_t *t)
 static void gtdes(grp_trk_t *t)
 {
     PMIX_DESTRUCT_LOCK(&t->lock);
-    if (NULL != t->blk) {
-        PMIX_RELEASE(t->blk);
-    }
+    /* t->blk is a non-owning back-reference: the block owns its trackers
+     * (they live on blk->mbrs and are freed by this destructor when the
+     * block is released), so the tracker must NOT hold a reference on the
+     * block - doing so forms a refcount cycle that leaks the entire block,
+     * its trackers, and their queued participant caddies. */
     /* the tracker owns its copy of the participant array and the
      * info array handed to it by get_tracker */
     if (NULL != t->pcs) {
@@ -348,7 +350,7 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
             *block = blk;
             // new signature, so create a tracker for it
             trk = PMIX_NEW(grp_trk_t);
-            PMIX_RETAIN(blk);
+            // non-owning back-reference - see gtdes
             trk->blk = blk;
             trk->npcs = nprocs;
             PMIX_PROC_CREATE(trk->pcs, trk->npcs);
@@ -370,7 +372,7 @@ newblock:
     *block = blk;
     // setup a tracker for it
     trk = PMIX_NEW(grp_trk_t);
-    PMIX_RETAIN(blk);
+    // non-owning back-reference - see gtdes
     trk->npcs = nprocs;
     if (NULL != procs) {
         PMIX_PROC_CREATE(trk->pcs, trk->npcs);
@@ -472,7 +474,7 @@ static void notify_local_members_of_loss(grp_block_t *blk)
 static void _grpcbfunc(int sd, short args, void *cbdata)
 {
     grp_shifter_t *scd = (grp_shifter_t *) cbdata;
-    grp_block_t *blk = scd->blk, *bk;
+    grp_block_t *blk = scd->blk, *bk, *nxt_bk;
     char *id;
     pmix_group_operation_t op;
     grp_trk_t *trk;
@@ -579,8 +581,10 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
     }
 
     // because bootstrap will have added multiple blocks to the collectives
-    // for each bootstrap operation, cycle across the list to find them all
-    PMIX_LIST_FOREACH(bk, &pmix_server_globals.grp_collectives, grp_block_t) {
+    // for each bootstrap operation, cycle across the list to find them all.
+    // Use the SAFE variant: matching blocks are removed and released below,
+    // so we must cache the next pointer before freeing the current block.
+    PMIX_LIST_FOREACH_SAFE(bk, nxt_bk, &pmix_server_globals.grp_collectives, grp_block_t) {
         if (0 != strcmp(id, bk->id)) {
             continue;
         }
@@ -700,7 +704,10 @@ static void grpcbfunc(pmix_status_t status,
     grp_shifter_t *scd;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(blk);
+        /* we are shutting down and cannot thread-shift. The block is still
+         * on the collectives list (it is removed only in _grpcbfunc), so
+         * leave it there for finalize to reclaim via PMIX_LIST_DESTRUCT
+         * rather than releasing the list's reference out from under it. */
         return;
     }
 


### PR DESCRIPTION
Follow-on to #3988, found by valgrinding an embedded PMIx server (the
one inside prterun/prted) across a multi-node group-exchange example.
Both leaks are in libpmix, not in the host, and both leak on normal,
successful completion.

**Fence data collection — emptied rank buffer.** When a data-collecting
fence assembles its modex, `pmix_server_collect_data` builds one
`pmix_buffer_t` per contributing rank, then unloads each buffer's byte
array into the outgoing bucket. The unload leaves the `pmix_buffer_t`
object itself allocated, but the loop nulled `blob->buf` before
destructing the blob list, so the list destructor skipped it and the
emptied buffer object leaked - one per rank per fence. Release the
emptied object before clearing the pointer, and destruct the blob list
on the packing error path as well.

**Group block/tracker reference-count cycle.** Each group operation's
`grp_block_t` owns its participant trackers on `blk->mbrs`, and every
`grp_trk_t` took a `PMIX_RETAIN` on the block for a `trk->blk`
back-pointer that is never dereferenced. Block-owns-tracker plus
tracker-owns-block is a cycle: when the operation completed, the single
list reference was released but the trackers' references kept the block
(and its trackers and their queued participant caddies) alive forever -
roughly ten kilobytes leaked per group operation on a node hosting
several participants. Make `trk->blk` a non-owning back-reference by
dropping the retain and its matching release in the tracker destructor.

That change means the block is now genuinely freed on completion, which
exposed two latent issues that are fixed here as well: `_grpcbfunc`
removes and releases matching blocks while walking the collectives list,
so it now iterates with the SAFE variant; and the
progress-thread-stopped guard in `grpcbfunc` no longer releases the
block (it is still on the collectives list, so finalize reclaims it).

Verified on a two-node group_dmodex run under valgrind: the group
block/tracker/caddy tree and the fence rank-buffer leaks are gone, with
no invalid frees, and `make check` passes (21/21 and 15/15).