### PR TITLE
Wire up the pgpu framework and repair its stale components

### DIFF
--- a/src/mca/pgpu/amd/pgpu_amd.c
+++ b/src/mca/pgpu/amd/pgpu_amd.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +37,6 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"
-#include "src/util/alfg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
@@ -134,6 +134,9 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
                                (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
         kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+        /* the compressed copy now holds the payload - release the
+         * uncompressed buffer we unloaded above */
+        free(bo.bytes);
     } else {
         kv->value->data.bo.bytes = bo.bytes;
         kv->value->data.bo.size = bo.size;
@@ -206,6 +209,12 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
             /* we are done */
             break;
         }
+    }
+
+    /* the unpack loop terminates on the trailing empty read, which is
+     * the normal end of the blob - not an error to report to the base */
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        rc = PMIX_SUCCESS;
     }
 
     if (release) {

--- a/src/mca/pgpu/amd/pgpu_amd_component.c
+++ b/src/mca/pgpu/amd/pgpu_amd_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,14 +69,13 @@ PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, amd)
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &pmix_mca_pgpu_amd_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_amd_component.super;
 
     pmix_mca_pgpu_amd_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_amd_component.incparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_amd_component.incparms);
     if (NULL != pmix_mca_pgpu_amd_component.incparms) {
         pmix_mca_pgpu_amd_component.include = PMIx_Argv_split(pmix_mca_pgpu_amd_component.incparms, ',');
     }
@@ -85,8 +84,7 @@ static pmix_status_t component_register(void)
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_amd_component.excparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_amd_component.excparms);
     if (NULL != pmix_mca_pgpu_amd_component.excparms) {
         pmix_mca_pgpu_amd_component.exclude = PMIx_Argv_split(pmix_mca_pgpu_amd_component.excparms, ',');
     }

--- a/src/mca/pgpu/intel/pgpu_intel.c
+++ b/src/mca/pgpu/intel/pgpu_intel.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +37,6 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"
-#include "src/util/alfg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
@@ -134,6 +134,9 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
                                (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
         kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+        /* the compressed copy now holds the payload - release the
+         * uncompressed buffer we unloaded above */
+        free(bo.bytes);
     } else {
         kv->value->data.bo.bytes = bo.bytes;
         kv->value->data.bo.size = bo.size;
@@ -206,6 +209,12 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
             /* we are done */
             break;
         }
+    }
+
+    /* the unpack loop terminates on the trailing empty read, which is
+     * the normal end of the blob - not an error to report to the base */
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        rc = PMIX_SUCCESS;
     }
 
     if (release) {

--- a/src/mca/pgpu/intel/pgpu_intel_component.c
+++ b/src/mca/pgpu/intel/pgpu_intel_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,14 +69,13 @@ PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, intel)
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &pmix_mca_pgpu_intel_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_intel_component.super;
 
     pmix_mca_pgpu_intel_component.incparms = NULL;
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_intel_component.incparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_intel_component.incparms);
     if (NULL != pmix_mca_pgpu_intel_component.incparms) {
         pmix_mca_pgpu_intel_component.include = PMIx_Argv_split(pmix_mca_pgpu_intel_component.incparms, ',');
     }
@@ -85,8 +84,7 @@ static pmix_status_t component_register(void)
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_intel_component.excparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_intel_component.excparms);
     if (NULL != pmix_mca_pgpu_intel_component.excparms) {
         pmix_mca_pgpu_intel_component.exclude = PMIx_Argv_split(pmix_mca_pgpu_intel_component.excparms, ',');
     }

--- a/src/mca/pgpu/nvd/pgpu_nvd.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +37,6 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pcompress/pcompress.h"
 #include "src/mca/preg/preg.h"
-#include "src/util/alfg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
@@ -134,6 +134,9 @@ static pmix_status_t allocate(pmix_namespace_t *nptr,
     if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
                                (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
         kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+        /* the compressed copy now holds the payload - release the
+         * uncompressed buffer we unloaded above */
+        free(bo.bytes);
     } else {
         kv->value->data.bo.bytes = bo.bytes;
         kv->value->data.bo.size = bo.size;
@@ -206,6 +209,12 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
             /* we are done */
             break;
         }
+    }
+
+    /* the unpack loop terminates on the trailing empty read, which is
+     * the normal end of the blob - not an error to report to the base */
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        rc = PMIX_SUCCESS;
     }
 
     if (release) {

--- a/src/mca/pgpu/nvd/pgpu_nvd_component.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd_component.c
@@ -69,14 +69,13 @@ PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, nvd)
 
 static pmix_status_t component_register(void)
 {
-    pmix_mca_base_component_t *component = &pmix_mca_pgpu_nvd_component.super.base;
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_nvd_component.super;
 
     pmix_mca_pgpu_nvd_component.incparms = "CUDA_*,NCCL_*";
     (void) pmix_mca_base_component_var_register(
         component, "include_envars",
         "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_nvd_component.incparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_nvd_component.incparms);
     if (NULL != pmix_mca_pgpu_nvd_component.incparms) {
         pmix_mca_pgpu_nvd_component.include = PMIx_Argv_split(pmix_mca_pgpu_nvd_component.incparms, ',');
     }
@@ -85,8 +84,7 @@ static pmix_status_t component_register(void)
     (void) pmix_mca_base_component_var_register(
         component, "exclude_envars",
         "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
-        PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, PMIX_INFO_LVL_2, PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
-        &pmix_mca_pgpu_nvd_component.excparms);
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_nvd_component.excparms);
     if (NULL != pmix_mca_pgpu_nvd_component.excparms) {
         pmix_mca_pgpu_nvd_component.exclude = PMIx_Argv_split(pmix_mca_pgpu_nvd_component.excparms, ',');
     }

--- a/src/mca/pgpu/nvd/pgpu_nvd_component.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,7 +65,7 @@ pmix_pgpu_nvd_component_t pmix_mca_pgpu_nvd_component = {
     .include = NULL,
     .exclude = NULL
 };
-PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, nvidia)
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, nvd)
 
 static pmix_status_t component_register(void)
 {

--- a/src/mca/pgpu/test/Makefile.am
+++ b/src/mca/pgpu/test/Makefile.am
@@ -1,0 +1,56 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = pgpu_test.h
+sources = \
+        pgpu_test_component.c \
+        pgpu_test.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pgpu_test_DSO
+lib =
+lib_sources =
+component = pmix_mca_pgpu_test.la
+component_sources = $(headers) $(sources)
+else
+lib = libpmix_mca_pgpu_test.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+pmix_mca_pgpu_test_la_SOURCES = $(component_sources)
+pmix_mca_pgpu_test_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+pmix_mca_pgpu_test_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libpmix_mca_pgpu_test_la_SOURCES = $(lib_sources)
+libpmix_mca_pgpu_test_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pgpu/test/configure.m4
+++ b/src/mca/pgpu/test/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_pgpu_test_CONFIG([action-if-can-compile],
+#                           [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pgpu_test_CONFIG], [
+    AC_CONFIG_FILES([src/mca/pgpu/test/Makefile])
+
+    AC_ARG_WITH([pgpu-test],
+                [AS_HELP_STRING([--with-pgpu-test],
+                                [Build the pgpu test component used to exercise the GPU setup path (default: no)])],
+                [pmix_want_pgpu_test=yes], [pmix_want_pgpu_test=no])
+
+    AS_IF([test "$pmix_want_pgpu_test" = "yes"],
+          [$1],
+          [$2])
+
+    PMIX_SUMMARY_ADD([GPUs], [Test], [], [$pmix_want_pgpu_test])
+])dnl

--- a/src/mca/pgpu/test/pgpu_test.c
+++ b/src/mca/pgpu/test/pgpu_test.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include "pmix_common.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/pcompress/pcompress.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_error.h"
+#include "src/util/pmix_output.h"
+
+#include "pgpu_test.h"
+#include "src/mca/pgpu/base/base.h"
+#include "src/mca/pgpu/pgpu.h"
+
+static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist);
+static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
+                                 pmix_info_t info[], size_t ninfo);
+
+pmix_pgpu_module_t pmix_pgpu_test_module = {
+    .name = "test",
+    .allocate = allocate,
+    .setup_local = setup_local
+};
+
+/* The scheduler/lead server calls "allocate" from within
+ * PMIx_server_setup_application. We harvest the configured envars from
+ * our own environment and pack them into a blob appended to ilist for
+ * transport to the compute-node daemons.
+ *
+ * NOTE: if there is any binary data to be transferred, then this
+ * function MUST pack it for transport as the host will not know how to
+ * do so. */
+static pmix_status_t allocate(pmix_namespace_t *nptr,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_list_t *ilist)
+{
+    pmix_buffer_t mydata;
+    pmix_kval_t *kv;
+    pmix_byte_object_t bo;
+    bool envars = false;
+    pmix_status_t rc;
+    pmix_list_t cache;
+    size_t n;
+
+    pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
+                        "pgpu:test:allocate for nspace %s", nptr->nspace);
+
+    if (NULL == info) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ENVARS)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SETUP_APP_ALL)) {
+            envars = PMIX_INFO_TRUE(&info[n]);
+        }
+    }
+    if (!envars) {
+        /* nothing for us to do */
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    /* setup a buffer - we will pack the info into it for transmission to
+     * the backend compute node daemons */
+    PMIX_CONSTRUCT(&mydata, pmix_buffer_t);
+
+    pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
+                        "pgpu: test harvesting envars %s excluding %s",
+                        (NULL == pmix_mca_pgpu_test_component.incparms)
+                            ? "NONE" : pmix_mca_pgpu_test_component.incparms,
+                        (NULL == pmix_mca_pgpu_test_component.excparms)
+                            ? "NONE" : pmix_mca_pgpu_test_component.excparms);
+
+    /* harvest envars to pass along */
+    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    if (NULL != pmix_mca_pgpu_test_component.include) {
+        rc = pmix_util_harvest_envars(pmix_mca_pgpu_test_component.include,
+                                      pmix_mca_pgpu_test_component.exclude, &cache);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_LIST_DESTRUCT(&cache);
+            PMIX_DESTRUCT(&mydata);
+            return rc;
+        }
+        /* pack anything that was found */
+        PMIX_LIST_FOREACH (kv, &cache, pmix_kval_t) {
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &mydata, &kv->value->data.envar, 1, PMIX_ENVAR);
+        }
+    }
+    PMIX_LIST_DESTRUCT(&cache);
+
+    /* load all our results into a buffer for xmission to the backend */
+    PMIX_KVAL_NEW(kv, PMIX_PGPU_TEST_BLOB);
+    if (NULL == kv || NULL == kv->value) {
+        PMIX_DESTRUCT(&mydata);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_BYTE_OBJECT;
+    PMIX_UNLOAD_BUFFER(&mydata, bo.bytes, bo.size);
+    /* to help scalability, compress this blob */
+    if (pmix_compress.compress((uint8_t *) bo.bytes, bo.size,
+                               (uint8_t **) &kv->value->data.bo.bytes, &kv->value->data.bo.size)) {
+        kv->value->type = PMIX_COMPRESSED_BYTE_OBJECT;
+        free(bo.bytes);
+    } else {
+        kv->value->data.bo.bytes = bo.bytes;
+        kv->value->data.bo.size = bo.size;
+    }
+    PMIX_DESTRUCT(&mydata);
+    pmix_list_append(ilist, &kv->super);
+    return PMIX_SUCCESS;
+}
+
+/* PMIx_server_setup_local_support calls the "setup_local" function on
+ * each compute node. We search the incoming info array for the blob our
+ * "allocate" produced, unpack the harvested envars, and cache them on
+ * the namespace's envar list so the base setup_fork injects them into
+ * each child. */
+static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
+                                 pmix_info_t info[], size_t ninfo)
+{
+    size_t n;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_status_t rc = PMIX_SUCCESS;
+    uint8_t *data;
+    size_t size;
+    bool release = false;
+    pmix_envar_list_item_t *ev;
+
+    pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
+                        "pgpu:test:setup_local with %lu info", (unsigned long) ninfo);
+
+    /* prep the unpack buffer */
+    PMIX_CONSTRUCT(&bkt, pmix_buffer_t);
+
+    for (n = 0; n < ninfo; n++) {
+        /* look for my key */
+        if (PMIX_CHECK_KEY(&info[n], PMIX_PGPU_TEST_BLOB)) {
+            pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
+                                "pgpu:test:setup_local found my blob");
+
+            /* if this is a compressed byte object, decompress it */
+            if (PMIX_COMPRESSED_BYTE_OBJECT == info[n].value.type) {
+                pmix_compress.decompress(&data, &size, (uint8_t *) info[n].value.data.bo.bytes,
+                                         info[n].value.data.bo.size);
+                release = true;
+            } else {
+                data = (uint8_t *) info[n].value.data.bo.bytes;
+                size = info[n].value.data.bo.size;
+            }
+            PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &bkt, data, size);
+
+            /* all we packed was envars, so just cycle thru */
+            ev = PMIX_NEW(pmix_envar_list_item_t);
+            cnt = 1;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            while (PMIX_SUCCESS == rc) {
+                pmix_list_append(&ns->envars, &ev->super);
+                /* get the next envar */
+                ev = PMIX_NEW(pmix_envar_list_item_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &ev->envar, &cnt, PMIX_ENVAR);
+            }
+            // we will have created one more envar than we want
+            PMIX_RELEASE(ev);
+
+            /* we are done */
+            break;
+        }
+    }
+
+    /* the unpack loop stops on the trailing empty read, which is normal */
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    /* NB: bkt was loaded NON_DESTRUCT - it only borrows the info blob's
+     * bytes, which remain owned by the caller's info array. We must NOT
+     * PMIX_DESTRUCT(&bkt) here or we would free that borrowed buffer and
+     * leave the caller with a double free. */
+    if (release) {
+        free(data);
+    }
+
+    return rc;
+}

--- a/src/mca/pgpu/test/pgpu_test.h
+++ b/src/mca/pgpu/test/pgpu_test.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PGPU_TEST_H
+#define PMIX_PGPU_TEST_H
+
+#include "src/include/pmix_config.h"
+
+#include "src/mca/pgpu/pgpu.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pgpu_base_component_t super;
+    char *incparms;
+    char *excparms;
+    char **include;
+    char **exclude;
+} pmix_pgpu_test_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pgpu_test_component_t pmix_mca_pgpu_test_component;
+extern pmix_pgpu_module_t pmix_pgpu_test_module;
+
+/* define a key for the blob we send in a launch msg */
+#define PMIX_PGPU_TEST_BLOB "pmix.pgpu.test.blob"
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pgpu/test/pgpu_test_component.c
+++ b/src/mca/pgpu/test/pgpu_test_component.c
@@ -1,0 +1,134 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "pmix_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "src/include/pmix_config.h"
+#include "pmix_common.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/pgpu/base/base.h"
+#include "src/util/pmix_argv.h"
+
+#include "pgpu_test.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_status_t component_register(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pgpu_test_component_t pmix_mca_pgpu_test_component = {
+    .super = {
+        PMIX_PGPU_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "test",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_register_component_params = component_register,
+        .pmix_mca_query_component = component_query,
+    },
+    .incparms = NULL,
+    .excparms = NULL,
+    .include = NULL,
+    .exclude = NULL
+};
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pgpu, test)
+
+static pmix_status_t component_register(void)
+{
+    pmix_mca_base_component_t *component = &pmix_mca_pgpu_test_component.super;
+
+    pmix_mca_pgpu_test_component.incparms = "PMIX_TEST_GPU_*";
+    (void) pmix_mca_base_component_var_register(
+        component, "include_envars",
+        "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_test_component.incparms);
+    if (NULL != pmix_mca_pgpu_test_component.incparms) {
+        pmix_mca_pgpu_test_component.include = PMIx_Argv_split(pmix_mca_pgpu_test_component.incparms, ',');
+    }
+
+    pmix_mca_pgpu_test_component.excparms = NULL;
+    (void) pmix_mca_base_component_var_register(
+        component, "exclude_envars",
+        "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
+        PMIX_MCA_BASE_VAR_TYPE_STRING, &pmix_mca_pgpu_test_component.excparms);
+    if (NULL != pmix_mca_pgpu_test_component.excparms) {
+        pmix_mca_pgpu_test_component.exclude = PMIx_Argv_split(pmix_mca_pgpu_test_component.excparms, ',');
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* This is a test-only component: it never probes for real GPU hardware.
+ * To avoid activating during ordinary runs, we select ourselves ONLY
+ * when the local peer is a server AND the user explicitly named "test"
+ * in the pgpu MCA selection string (e.g. PMIX_MCA_pgpu=test). That makes
+ * the GPU setup path deterministically exercisable on any machine. */
+static pmix_status_t component_open(void)
+{
+    int index;
+    const pmix_mca_base_var_storage_t *value = NULL;
+
+    if (!PMIX_PROC_IS_SERVER(&pmix_globals.mypeer->proc_type)) {
+        return PMIX_ERROR;
+    }
+
+    if (0 > (index = pmix_mca_base_var_find("pmix", "pgpu", NULL, NULL))) {
+        return PMIX_ERROR;
+    }
+    pmix_mca_base_var_get_value(index, &value, NULL, NULL);
+    if (NULL != value && NULL != value->stringval && '\0' != value->stringval[0]) {
+        if (NULL != strcasestr(value->stringval, "test")) {
+            return PMIX_SUCCESS;
+        }
+    }
+    return PMIX_ERROR;
+}
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 10;
+    *module = (pmix_mca_base_module_t *) &pmix_pgpu_test_module;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,7 +132,7 @@ static pmix_status_t pmix_pmdl_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&pmix_pmdl_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pmdl, "PMIx Network Operations", pmix_pmdl_register,
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pmdl, "PMIx Programming Model Operations", pmix_pmdl_register,
                                 pmix_pmdl_open, pmix_pmdl_close, pmix_mca_pmdl_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 

--- a/src/mca/pmdl/pmdl.h
+++ b/src/mca/pmdl/pmdl.h
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,9 +17,10 @@
 /**
  * @file
  *
- * This interface is for use by PMIx servers to obtain network-related info
- * such as security keys that need to be shared across applications, and to
- * setup network support for applications prior to launch
+ * This interface is for use by PMIx servers and tools to collect the
+ * environment variables and MCA parameters a programming model (e.g.,
+ * MPI, OpenMP, OpenSHMEM) requires, and to inject them into application
+ * processes prior to launch
  *
  * Available plugins may be defined at runtime via the typical MCA parameter
  * syntax.
@@ -90,14 +92,14 @@ typedef pmix_status_t (*pmix_pmdl_base_module_setup_fork_fn_t)(const pmix_proc_t
                                                                char ***priors);
 
 /**
- * Provide an opportunity for the fabric components to cleanup any
- * resources they may have created to track the nspace
+ * Provide an opportunity for the programming model components to cleanup
+ * any resources they may have created to track the nspace
  */
 typedef void (*pmix_pmdl_base_module_dregister_nspace_fn_t)(pmix_namespace_t *nptr);
 
 /**
  * Base structure for a PMDL module. Each component should malloc a
- * copy of the module structure for each fabric plane they support.
+ * copy of the module structure for each programming model they support.
  */
 typedef struct {
     char *name;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2847,6 +2847,11 @@ static void _setup_app(int sd, short args, void *cbdata)
         goto depart;
     }
 
+    /* pass to the GPU libraries */
+    if (PMIX_SUCCESS != (rc = pmix_pgpu.allocate(cd->nspace, cd->info, cd->ninfo, &ilist))) {
+        goto depart;
+    }
+
     /* pass to the programming model libraries */
     if (PMIX_SUCCESS != (rc = pmix_pmdl.harvest_envars(cd->nspace, cd->info, cd->ninfo, &ilist))) {
         goto depart;
@@ -2935,6 +2940,11 @@ static void _setup_local_support(int sd, short args, void *cbdata)
 
     /* pass to the network libraries */
     rc = pmix_pnet.setup_local_network(cd->nspace, cd->info, cd->ninfo);
+
+    /* pass to the GPU libraries */
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_pgpu.setup_local(cd->nspace, cd->info, cd->ninfo);
+    }
 
     /* pass the info back */
     if (NULL != cd->opcbfunc) {


### PR DESCRIPTION
This series brings the `pgpu` framework's launch-time path into service,
adds a way to test it, repairs the three stale vendor components, and
cleans up unrelated stale boilerplate in `pmdl`. Each concern is a
separate commit for reviewability/bisection.

### pgpu launch integration
- **Wire the pgpu framework into application and local setup.**
  `pmix_pgpu.allocate` and `pmix_pgpu.setup_local` were fully implemented
  and wired into the global `pmix_pgpu` module, but the server never
  called them — `_setup_app` drove `pmix_pnet.allocate` /
  `pmix_pmdl.harvest_envars` and `_setup_local_support` drove
  `pmix_pnet.setup_local_network`, both omitting pgpu. The GPU
  envar-harvest pipeline was therefore dead code. Added the two missing
  calls, mirroring the pnet wiring.
- **Add a build-on-request pgpu test component.** No default-built
  component exercises that path (nvd/amd/intel gate on real hardware and
  are hardwired off). Modeled on `pnet/simptest`: builds only with
  `--with-pgpu-test`, selects only when a server sets `PMIX_MCA_pgpu=test`,
  harvests `PMIX_TEST_GPU_*`, and round-trips the blob through
  `setup_application` → `setup_local` → `setup_fork`. Verified end-to-end
  through the `simptest` harness.

### Repair the stale vendor components
`nvd`, `amd`, and `intel` are hardwired off in their `configure.m4` and
had drifted out of compilability. Enabling each build gate locally
surfaced the same set of issues (fixed in all three; verified they
compile and link cleanly under `--enable-devel-check`):
- `component_register` took the address of a nonexistent `.super.base`;
  `pmix_pgpu_base_component_t` is a plain `pmix_mca_base_component_t`, so
  the handle is `&component.super`.
- Both `pmix_mca_base_component_var_register` calls used the long,
  pre-refactor argument list; the current signature is
  `(component, name, description, type, storage)`.
- Each module `#include`d `src/util/alfg.h`, renamed to
  `src/util/pmix_alfg.h` long ago and unused here — dropped.
- `allocate()` leaked the uncompressed buffer when `pcompress` succeeded.
- `setup_local()` returned `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` (the
  normal terminator of the envar unpack loop), which the base treats as a
  hard error — reset to `PMIX_SUCCESS`.
- (`nvd` only) `PMIX_MCA_BASE_COMPONENT_INIT` used `nvidia` instead of
  `nvd`, so it referenced an undefined component symbol.

The build gates are intentionally left disabled: real CUDA / ROCm /
Level-Zero detection is still needed before any of them can ship on by
default.

### pmdl cleanup
- **Re-skin pmdl's stale network boilerplate.** `pmdl` was cloned from
  `pnet` and never re-described: its framework description was
  `"PMIx Network Operations"` (identical to pnet's) and its header
  comments referred to "network support" and "fabric plane[s]". Corrected
  to describe programming-model env/param setup. Comment/description text
  only — no behavioral or ABI impact.

### Testing
Clean `./autogen.pl && ./configure --enable-devel-check && make` (zero
warnings) for the default configuration, and separately with each
component's gate flipped on to confirm they compile and link. The pgpu
test component's harvest→pack→setup_local→fork round trip was exercised
under `simptest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)