### PR TITLE
Free interface-discovery allocations in pif components

### DIFF
--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,6 +109,7 @@ static int if_bsdx_open(void)
     /* create the linked list of ifaddrs structs */
     if (getifaddrs(ifadd_list) < 0) {
         pmix_output(0, "pmix_ifinit: getifaddrs() failed with error=%d\n", errno);
+        free(ifadd_list);
         return PMIX_ERROR;
     }
 
@@ -137,6 +138,8 @@ static int if_bsdx_open(void)
         intf = PMIX_NEW(pmix_pif_t);
         if (NULL == intf) {
             pmix_output(0, "pmix_ifinit: unable to allocate %d bytes\n", (int) sizeof(pmix_pif_t));
+            freeifaddrs(*ifadd_list);
+            free(ifadd_list);
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
         intf->af_family = AF_INET;
@@ -157,6 +160,9 @@ static int if_bsdx_open(void)
 
         pmix_list_append(&pmix_if_list, &(intf->super));
     } /*  of for loop over ifaddrs list */
+
+    freeifaddrs(*ifadd_list);
+    free(ifadd_list);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -163,6 +163,7 @@ static int if_bsdx_ipv6_open(void)
         intf = PMIX_NEW(pmix_pif_t);
         if (NULL == intf) {
             pmix_output(0, "pmix_ifinit: unable to allocate %lu bytes\n", sizeof(pmix_pif_t));
+            freeifaddrs(*ifadd_list);
             free(ifadd_list);
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
@@ -190,6 +191,7 @@ static int if_bsdx_ipv6_open(void)
         pmix_list_append(&pmix_if_list, &(intf->super));
     } /*  of for loop over ifaddrs list */
 
+    freeifaddrs(*ifadd_list);
     free(ifadd_list);
 
     return PMIX_SUCCESS;

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -5,7 +5,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -296,6 +296,7 @@ static int if_posix_open(void)
         /* get the MAC address */
         if (ioctl(sd, SIOCGIFHWADDR, ifr) < 0) {
             pmix_output(0, "pmix_ifinit: ioctl(SIOCGIFHWADDR) failed with errno=%d", errno);
+            PMIX_RELEASE(intf);
             break;
         }
         memcpy(intf->if_mac, ifr->ifr_hwaddr.sa_data, 6);
@@ -305,6 +306,7 @@ static int if_posix_open(void)
         /* get the MTU */
         if (ioctl(sd, SIOCGIFMTU, ifr) < 0) {
             pmix_output(0, "pmix_ifinit: ioctl(SIOCGIFMTU) failed with errno=%d", errno);
+            PMIX_RELEASE(intf);
             break;
         }
         intf->ifmtu = ifr->ifr_mtu;


### PR DESCRIPTION
The `pif` interface-discovery components leaked memory during their
one-time startup scan of the local node's network interfaces:

- **`bsdx_ipv4`** never released the `getifaddrs(3)` result at all: it
  neither called `freeifaddrs()` on the returned list nor freed the
  outer `ifadd_list` pointer, on any exit path (success, `getifaddrs`
  failure, or interface-object allocation failure).
- **`bsdx_ipv6`** freed the outer `ifadd_list` pointer but never called
  `freeifaddrs()` on the list content, so the interface list the kernel
  handed back was leaked.
- **`posix_ipv4`** leaked a freshly-allocated `pmix_pif_t` when the
  `SIOCGIFHWADDR` or `SIOCGIFMTU` ioctl failed: both paths break out of
  the discovery loop before the object is appended to `pmix_if_list`,
  without releasing it (unlike the neighboring `SIOCGIFADDR` path, which
  already releases before breaking).

Add the missing `freeifaddrs()`/`free()` calls and `PMIX_RELEASE()` so
each path cleans up what it allocated. These are bounded one-time leaks
(discovery runs once at library init), but real ones that show up under
valgrind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
