### PR TITLE
Invoke the psec module finalize, not the component finalize

### DIFF
--- a/src/mca/psec/base/psec_base_frame.c
+++ b/src/mca/psec/base/psec_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +64,8 @@ static pmix_status_t pmix_psec_close(void)
     PMIX_LIST_FOREACH_SAFE (active, prev, &pmix_psec_globals.actives,
                             pmix_psec_base_active_module_t) {
         pmix_list_remove_item(&pmix_psec_globals.actives, &active->super);
-        if (NULL != active->component->finalize) {
-            active->component->finalize();
+        if (NULL != active->module->finalize) {
+            active->module->finalize();
         }
         PMIX_RELEASE(active);
     }


### PR DESCRIPTION
`pmix_psec_close` walked the active-module list and called
`active->component->finalize()` for each entry. But no `psec` component
sets a component-level finalize hook: all four (native, none, munge,
dummy_handshake) populate the finalize slot of their *module* struct
(`pmix_psec_module_t`) instead. The component-level finalize is always
`NULL`, so the guarded call never fired and the module finalize
functions were dead code.

Dereference `active->module->finalize` so the module teardown hooks
actually run at framework close. This matters for munge, whose
`munge_finalize` frees the credential cached by `munge_init`; previously
that credential was leaked at shutdown. The other modules' finalize
routines only emit verbose output, so invoking them is harmless. The
call remains guarded, and `munge_finalize` is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
