### PR TITLE
Implement pcompress get_decompressed_size/get_decompressed_strlen

### DIFF
--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +16,8 @@
  */
 
 #include "pmix_config.h"
+
+#include <string.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/base/pmix_base.h"
@@ -69,11 +71,43 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     return false;
 }
 
+/* These read the uncompressed length from the leading 4 bytes of a
+ * compressed blob (see the shared blob format); they need no compression
+ * library, so the base default implements them too. This keeps the
+ * PMIX_COMPRESSED_* size paths in bfrops safe on a host that built no
+ * compression component but still receives a compressed blob from a
+ * peer that did. */
+static size_t get_decompressed_size(const pmix_byte_object_t *bo)
+{
+    uint32_t len = 0;
+
+    if (NULL == bo || NULL == bo->bytes || bo->size < sizeof(uint32_t)) {
+        return 0;
+    }
+    /* the first 4 bytes contain the uncompressed size */
+    memcpy(&len, bo->bytes, sizeof(uint32_t));
+    return (size_t) len;
+}
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo)
+{
+    size_t len;
+
+    /* add one for the NUL terminator, matching PMIX_STRING accounting */
+    len = get_decompressed_size(bo);
+    if (0 == len) {
+        return 0;
+    }
+    return len + 1;
+}
+
 pmix_compress_base_module_t pmix_compress = {
     .compress = compress_block,
     .decompress = decompress_block,
+    .get_decompressed_size = get_decompressed_size,
     .compress_string = compress_string,
-    .decompress_string = decompress_string
+    .decompress_string = decompress_string,
+    .get_decompressed_strlen = get_decompressed_strlen
 };
 
 pmix_compress_base_t pmix_compress_base = {

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -48,11 +48,17 @@ static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes);
 
 static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len);
 
+static size_t get_decompressed_size(const pmix_byte_object_t *bo);
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo);
+
 pmix_compress_base_module_t pmix_pcompress_zlib_module = {
     .compress = zlib_compress,
     .decompress = zlib_decompress,
+    .get_decompressed_size = get_decompressed_size,
     .compress_string = compress_string,
     .decompress_string = decompress_string,
+    .get_decompressed_strlen = get_decompressed_strlen,
 };
 
 static bool zlib_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen)
@@ -232,4 +238,36 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     /* set the default error answer */
     *outstring = NULL;
     return false;
+}
+
+/* A blob produced by zlib_compress / compress_string carries the
+ * uncompressed length in its leading 4 bytes (see the shared blob
+ * format). These helpers return that length by reading the prefix,
+ * without inflating the payload, so callers computing the in-memory
+ * footprint of a PMIX_COMPRESSED_BYTE_OBJECT / PMIX_COMPRESSED_STRING
+ * need not decompress it first. */
+static size_t get_decompressed_size(const pmix_byte_object_t *bo)
+{
+    uint32_t len = 0;
+
+    if (NULL == bo || NULL == bo->bytes || bo->size < sizeof(uint32_t)) {
+        return 0;
+    }
+    /* the first 4 bytes contain the uncompressed size */
+    memcpy(&len, bo->bytes, sizeof(uint32_t));
+    return (size_t) len;
+}
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo)
+{
+    size_t len;
+
+    /* a compressed string stores its strlen (without the NUL) in the
+     * prefix; add one for the terminator so the reported size matches
+     * the uncompressed PMIX_STRING accounting */
+    len = get_decompressed_size(bo);
+    if (0 == len) {
+        return 0;
+    }
+    return len + 1;
 }

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -48,11 +48,17 @@ static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes);
 
 static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len);
 
+static size_t get_decompressed_size(const pmix_byte_object_t *bo);
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo);
+
 pmix_compress_base_module_t pmix_pcompress_zlibng_module = {
     .compress = zlibng_compress,
     .decompress = zlibng_decompress,
+    .get_decompressed_size = get_decompressed_size,
     .compress_string = compress_string,
     .decompress_string = decompress_string,
+    .get_decompressed_strlen = get_decompressed_strlen,
 };
 
 static bool zlibng_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen)
@@ -233,4 +239,36 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     /* set the default error answer */
     *outstring = NULL;
     return false;
+}
+
+/* A blob produced by zlibng_compress / compress_string carries the
+ * uncompressed length in its leading 4 bytes (see the shared blob
+ * format). These helpers return that length by reading the prefix,
+ * without inflating the payload, so callers computing the in-memory
+ * footprint of a PMIX_COMPRESSED_BYTE_OBJECT / PMIX_COMPRESSED_STRING
+ * need not decompress it first. */
+static size_t get_decompressed_size(const pmix_byte_object_t *bo)
+{
+    uint32_t len = 0;
+
+    if (NULL == bo || NULL == bo->bytes || bo->size < sizeof(uint32_t)) {
+        return 0;
+    }
+    /* the first 4 bytes contain the uncompressed size */
+    memcpy(&len, bo->bytes, sizeof(uint32_t));
+    return (size_t) len;
+}
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo)
+{
+    size_t len;
+
+    /* a compressed string stores its strlen (without the NUL) in the
+     * prefix; add one for the terminator so the reported size matches
+     * the uncompressed PMIX_STRING accounting */
+    len = get_decompressed_size(bo);
+    if (0 == len) {
+        return 0;
+    }
+    return len + 1;
 }


### PR DESCRIPTION
The bfrops size computation — `PMIx_Value_get_size` and the data-array
size path in `bfrop_base_fns.c` — calls
`pmix_compress.get_decompressed_strlen` and
`pmix_compress.get_decompressed_size` for `PMIX_COMPRESSED_STRING` and
`PMIX_COMPRESSED_BYTE_OBJECT` values without guarding the pointers. No
`pcompress` module ever set those function pointers, so any code sizing a
compressed value dereferenced NULL.

Implement both entry points in the zlib and zlibng components. Each reads
the uncompressed length that the compressor folds into the leading four
bytes of the blob and returns it without inflating the payload:
`get_decompressed_size` returns the raw byte count, and
`get_decompressed_strlen` adds one for the NUL terminator to match the
`PMIX_STRING` sizing convention. Both return zero for a NULL or too-short
blob rather than reading past it.

Implement them in the base default module as well. A process built
without a compression library cannot produce a compressed blob itself,
but it can still be handed one by a peer that had a compressor, and the
size query must not crash in that case either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
