### PR TITLE
Restore and harden the psensor process-monitor dispatch path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ test/simple/stability
 test/simple/gwclient
 test/simple/gwtest
 test/simple/simpjctrl
+test/simple/simpmonitor
 test/simple/simpio
 test/simple/data-*
 test/simple/simpcoord
@@ -262,6 +263,7 @@ test/unit/run_grpmemberfail.pl
 test/unit/run_grpleader.pl
 test/unit/run_grpcabort.pl
 test/unit/run_grpctimeout.pl
+test/unit/run_monitor.pl
 test/unit/util_argv
 test/unit/util_basename
 test/unit/util_path

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1017,6 +1017,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpleader.pl], [chmod +x test/unit/run_grpleader.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpcabort.pl], [chmod +x test/unit/run_grpcabort.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpctimeout.pl], [chmod +x test/unit/run_grpctimeout.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_monitor.pl], [chmod +x test/unit/run_monitor.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
 #    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
     if test "$WANT_PYTHON_BINDINGS" = "1"; then

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -23,6 +23,7 @@
 #include "include/pmix_server.h"
 
 #include "src/mca/bfrops/bfrops.h"
+#include "src/mca/psensor/psensor.h"
 #include "src/mca/pstat/pstat.h"
 #include "src/mca/ptl/ptl.h"
 #include "src/threads/pmix_threads.h"
@@ -189,6 +190,36 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
     local = false;
     remote = false;
     error = cb->status;
+
+    // Liveness monitoring (heartbeat/file) is serviced by the psensor
+    // framework rather than by pstat's resource-usage sampling, and it
+    // watches the requesting process itself, so it has no local/remote
+    // target to resolve. Offer the request to psensor first: it claims a
+    // liveness monitor and returns the start status, or returns
+    // PMIX_ERR_NOT_SUPPORTED when the monitor is none of its keys - in
+    // which case we fall through to the resource-usage path below. The
+    // sensors track the requesting peer, which must be one of our local
+    // clients (recovered here from the requestor's procid).
+    ptr = pmix_get_peer_object(&cb->proc[0]);
+    if (NULL != ptr) {
+        rc = pmix_psensor.start(ptr, error, cb->info, cb->directives, cb->ndirs);
+        if (PMIX_ERR_NOT_SUPPORTED != rc) {
+            // psensor claimed the request (started it, or failed trying).
+            // A start returns only a status - there are no info results.
+            cb->status = rc;
+            if (NULL != cb->proc) {
+                PMIX_PROC_FREE(cb->proc, 1);
+            }
+            if (cb->infocopy) {
+                PMIX_INFO_FREE(cb->info, cb->ninfo);
+                cb->info = NULL;
+                cb->ninfo = 0;
+                cb->infocopy = false;
+            }
+            goto complete;
+        }
+        // not a liveness monitor - fall through to the pstat path
+    }
 
     // see if the requested targets involve our node, or processes on
     // our local node

--- a/src/mca/psensor/base/psensor_base_stubs.c
+++ b/src/mca/psensor/base/psensor_base_stubs.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,27 +24,35 @@ pmix_status_t pmix_psensor_base_start(pmix_peer_t *requestor, pmix_status_t erro
 {
     pmix_psensor_active_module_t *mod;
     pmix_status_t rc;
-    bool didit = false;
+    bool serviced = false;
 
     pmix_output_verbose(5, pmix_psensor_base_framework.framework_output,
                         "%s:%d sensor:base: starting sensors", pmix_globals.myid.nspace,
                         pmix_globals.myid.rank);
 
-    /* call the start function of all modules in priority order */
+    /* offer the request to the start function of all modules in
+     * priority order. A module that recognizes the monitor claims it by
+     * returning PMIX_SUCCESS; one that does not declines with
+     * PMIX_ERR_TAKE_NEXT_OPTION so the next module gets a chance. */
     PMIX_LIST_FOREACH (mod, &pmix_psensor_base.actives, pmix_psensor_active_module_t) {
-        if (NULL != mod->module->start) {
-            rc = mod->module->start(requestor, error, monitor, directives, ndirs);
-            if (PMIX_SUCCESS != rc && PMIX_ERR_TAKE_NEXT_OPTION != rc) {
-                return rc;
-            }
-            didit = true;
+        if (NULL == mod->module->start) {
+            continue;
+        }
+        rc = mod->module->start(requestor, error, monitor, directives, ndirs);
+        if (PMIX_SUCCESS == rc) {
+            /* a module claimed and started the request */
+            serviced = true;
+        } else if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+            /* the module claimed the request but hit a hard error */
+            return rc;
         }
     }
 
-    /* if none of the components could do it, then report
-     * not supported upwards so the server knows to ask
-     * the host to try */
-    if (!didit) {
+    /* if no module could service the request, report not supported
+     * upwards so the server knows to ask the host to try. This matches
+     * the convention pstat uses (its unsupported module returns
+     * PMIX_ERR_NOT_SUPPORTED) when nothing can meet the request. */
+    if (!serviced) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -9,7 +9,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,6 +82,7 @@ typedef struct {
     uint32_t nmisses;
     pmix_status_t error;
     pmix_data_range_t range;
+    pmix_proc_t source;
     pmix_info_t *info;
     size_t ninfo;
 } file_tracker_t;
@@ -103,6 +104,7 @@ static void ft_constructor(file_tracker_t *ft)
     ft->nmisses = 0;
     ft->error = PMIX_SUCCESS;
     ft->range = PMIX_RANGE_NAMESPACE;
+    PMIX_PROC_CONSTRUCT(&ft->source);
     ft->info = NULL;
     ft->ninfo = 0;
 }
@@ -283,7 +285,6 @@ static void file_sample(int sd, short args, void *cbdata)
     file_tracker_t *ft = (file_tracker_t *) cbdata;
     struct stat buf;
     pmix_status_t rc;
-    pmix_proc_t source;
 
     PMIX_ACQUIRE_OBJECT(ft);
 
@@ -344,10 +345,12 @@ static void file_sample(int sd, short args, void *cbdata)
         }
         /* stop monitoring this client */
         pmix_list_remove_item(&pmix_mca_psensor_file_component.trackers, &ft->super);
-        /* generate an event */
-        pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
-        source.rank = ft->requestor->info->pname.rank;
-        rc = PMIx_Notify_event(PMIX_MONITOR_FILE_ALERT, &source, ft->range, ft->info, ft->ninfo,
+        /* generate an event - the source proc lives in the tracker (not
+         * on the stack) because PMIx_Notify_event borrows the pointer and
+         * processes the event asynchronously, after we return */
+        pmix_strncpy(ft->source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
+        ft->source.rank = ft->requestor->info->pname.rank;
+        rc = PMIx_Notify_event(PMIX_MONITOR_FILE_ALERT, &ft->source, ft->range, ft->info, ft->ninfo,
                                opcbfunc, ft);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -4,7 +4,7 @@
  *                         reserved.
  *
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +62,7 @@ typedef struct {
     uint32_t nmissed;
     pmix_status_t error;
     pmix_data_range_t range;
+    pmix_proc_t source;
     pmix_info_t *info;
     size_t ninfo;
     bool stopped;
@@ -79,6 +80,7 @@ static void ft_constructor(pmix_heartbeat_trkr_t *ft)
     ft->nmissed = 0;
     ft->error = PMIX_SUCCESS;
     ft->range = PMIX_RANGE_NAMESPACE;
+    PMIX_PROC_CONSTRUCT(&ft->source);
     ft->info = NULL;
     ft->ninfo = 0;
     ft->stopped = false;
@@ -276,7 +278,6 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
 {
     pmix_heartbeat_trkr_t *ft = (pmix_heartbeat_trkr_t *) cbdata;
     pmix_status_t rc;
-    pmix_proc_t source;
 
     PMIX_ACQUIRE_OBJECT(ft);
     PMIX_HIDE_UNUSED_PARAMS(fd, dummy);
@@ -293,15 +294,17 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
                              "[%s:%d] sensor:check_heartbeat failed for proc %s:%d",
                              pmix_globals.myid.nspace, pmix_globals.myid.rank,
                              ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank);
-        /* generate an event */
-        pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
-        source.rank = ft->requestor->info->pname.rank;
+        /* generate an event - the source proc lives in the tracker (not
+         * on the stack) because PMIx_Notify_event borrows the pointer and
+         * processes the event asynchronously, after we return */
+        pmix_strncpy(ft->source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
+        ft->source.rank = ft->requestor->info->pname.rank;
         /* ensure the tracker remains throughout the process */
         PMIX_RETAIN(ft);
         /* mark that the process appears stopped so we don't
          * continue to report it */
         ft->stopped = true;
-        rc = PMIx_Notify_event(PMIX_MONITOR_HEARTBEAT_ALERT, &source, ft->range, ft->info,
+        rc = PMIx_Notify_event(PMIX_MONITOR_HEARTBEAT_ALERT, &ft->source, ft->range, ft->info,
                                ft->ninfo, opcbfunc, ft);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/mca/pstat/plinux/pstat_plinux_module.c
+++ b/src/mca/pstat/plinux/pstat_plinux_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1518,7 +1518,11 @@ processprocs:
         return PMIX_SUCCESS;
     }
 
-    return PMIX_SUCCESS;
+    // the monitor key matched none of the statistics we collect - say so
+    // rather than reporting a spurious success, so the caller can fall
+    // back to the host (or another framework)
+    PMIX_RELEASE(op);
+    return PMIX_ERR_NOT_SUPPORTED;
 }
 
 static char *local_getline(FILE *fp)

--- a/src/mca/pstat/pmacos/pstat_pmacos_module.c
+++ b/src/mca/pstat/pmacos/pstat_pmacos_module.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2025      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2025-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1204,5 +1204,9 @@ processprocs:
         return PMIX_SUCCESS;
     }
 
-    return PMIX_SUCCESS;
+    // the monitor key matched none of the statistics we collect - say so
+    // rather than reporting a spurious success, so the caller can fall
+    // back to the host (or another framework)
+    PMIX_RELEASE(op);
+    return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/pstat/test/pstat_test.c
+++ b/src/mca/pstat/test/pstat_test.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  *
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1039,5 +1039,9 @@ processprocs:
         return PMIX_SUCCESS;
     }
 
-    return PMIX_SUCCESS;
+    // the monitor key matched none of the statistics we collect - say so
+    // rather than reporting a spurious success, so the caller can fall
+    // back to the host (or another framework)
+    PMIX_RELEASE(op);
+    return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -30,7 +30,7 @@ noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
                   simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
                   hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader \
-                  simpgrpcabort simpgrpctimeout simpgrpddie
+                  simpgrpcabort simpgrpctimeout simpgrpddie simpmonitor
 
 simptest_SOURCES = $(headers) \
         simptest.c
@@ -120,6 +120,12 @@ simpjctrl_SOURCES = $(headers) \
         simpjctrl.c
 simpjctrl_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpjctrl_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpmonitor_SOURCES = $(headers) \
+        simpmonitor.c
+simpmonitor_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpmonitor_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 simpio_SOURCES = $(headers) \

--- a/test/simple/simpmonitor.c
+++ b/test/simple/simpmonitor.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * Regression test for heartbeat monitoring via PMIx_Process_monitor.
+ *
+ * This client asks its server to watch it for heartbeats, then
+ * deliberately never sends one. The server's psensor/heartbeat monitor
+ * must therefore observe an empty window and raise
+ * PMIX_MONITOR_HEARTBEAT_ALERT back to us. We register a handler for that
+ * code and wait a bounded time for it to fire.
+ *
+ * The subtlety this guards against: PMIx_Process_monitor_nb returns
+ * success for a heartbeat request whether or not a monitor was actually
+ * started (an unhandled monitor key used to fall through to a spurious
+ * success). So a passing "start" says nothing on its own - only the
+ * arrival of the alert proves the sensor was really armed. If the
+ * monitor path is not wired to psensor, no alert is ever generated and
+ * this test fails on the timeout.
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "include/pmix.h"
+#include "simptest.h"
+
+static pmix_proc_t myproc;
+static mylock_t alertlock;
+
+static void hide_unused_params(int x, ...)
+{
+    va_list ap;
+    (void) x;
+    va_start(ap, x);
+    va_end(ap);
+}
+
+/* handler for PMIX_MONITOR_HEARTBEAT_ALERT - fired by the server when it
+ * detects that we have stopped sending heartbeats */
+static void alert_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                          const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                          pmix_info_t results[], size_t nresults,
+                          pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    int rc = 0;
+    hide_unused_params(rc, evhdlr_registration_id, source, info, ninfo, results, nresults);
+
+    fprintf(stderr, "Client %s:%d MONITOR ALERT RECEIVED (%s)\n", myproc.nspace, myproc.rank,
+            PMIx_Error_string(status));
+
+    /* let the notification system know we are done with the event */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    /* wake the main thread */
+    alertlock.status = status;
+    DEBUG_WAKEUP_THREAD(&alertlock);
+}
+
+static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lk = (mylock_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                myproc.nspace, myproc.rank, status, (unsigned long) evhandler_ref);
+    }
+    lk->status = status;
+    DEBUG_WAKEUP_THREAD(lk);
+}
+
+static void infocbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                       pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    mylock_t *lk = (mylock_t *) cbdata;
+    int rc = 0;
+    hide_unused_params(rc, info, ninfo);
+
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    lk->status = status;
+    DEBUG_WAKEUP_THREAD(lk);
+}
+
+/* bounded wait on a lock; returns 0 if the lock was signalled,
+ * -1 if we timed out first */
+static int wait_for_alert(mylock_t *lk, int seconds)
+{
+    struct timespec ts;
+    int rc = 0;
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += seconds;
+
+    pthread_mutex_lock(&lk->mutex);
+    while (lk->active) {
+        rc = pthread_cond_timedwait(&lk->cond, &lk->mutex, &ts);
+        if (ETIMEDOUT == rc) {
+            break;
+        }
+    }
+    rc = lk->active ? -1 : 0;
+    pthread_mutex_unlock(&lk->mutex);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc = 0;
+    pmix_info_t *monitor, *info;
+    pmix_status_t code = PMIX_MONITOR_HEARTBEAT_ALERT;
+    mylock_t mylock;
+    uint32_t n;
+    hide_unused_params(rc, argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* register a handler specifically for the heartbeat alert */
+    DEBUG_CONSTRUCT_LOCK(&alertlock);
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, alert_handler, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "Client ns %s rank %d: alert handler registration failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        rc = 1;
+        goto done;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    /* ask to be monitored via heartbeats, with a short (1 second) window
+     * so the alert fires quickly once we go silent */
+    PMIX_INFO_CREATE(monitor, 1);
+    PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_HEARTBEAT, NULL, PMIX_POINTER);
+
+    PMIX_INFO_CREATE(info, 3);
+    PMIX_INFO_LOAD(&info[0], PMIX_MONITOR_ID, "SIMPMONITOR", PMIX_STRING);
+    n = 1; /* require a heartbeat every second */
+    PMIX_INFO_LOAD(&info[1], PMIX_MONITOR_HEARTBEAT_TIME, &n, PMIX_UINT32);
+    n = 1; /* tolerate a single missed beat */
+    PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_HEARTBEAT_DROPS, &n, PMIX_UINT32);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    rc = PMIx_Process_monitor_nb(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, info, 3, infocbfunc,
+                                 (void *) &mylock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_INFO_FREE(monitor, 1);
+        PMIX_INFO_FREE(info, 3);
+        rc = 1;
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&mylock);
+    PMIX_INFO_FREE(monitor, 1);
+    PMIX_INFO_FREE(info, 3);
+    if (PMIX_SUCCESS != mylock.status && PMIX_OPERATION_SUCCEEDED != mylock.status) {
+        fprintf(stderr, "Client ns %s rank %d: heartbeat monitor request rejected: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        rc = 1;
+        goto done;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    fprintf(stderr, "Client ns %s rank %d: heartbeat monitor request accepted\n", myproc.nspace,
+            myproc.rank);
+
+    /* deliberately send NO heartbeats and wait for the server to notice
+     * and alert us. The window is 1s; allow generous slack. */
+    if (0 == wait_for_alert(&alertlock, 30)) {
+        fprintf(stderr, "Client ns %s rank %d: MONITOR TEST PASSED\n", myproc.nspace, myproc.rank);
+        rc = 0;
+    } else {
+        fprintf(stderr, "Client ns %s rank %d: MONITOR TEST FAILED - no heartbeat alert\n",
+                myproc.nspace, myproc.rank);
+        rc = 1;
+    }
+
+done:
+    DEBUG_DESTRUCT_LOCK(&alertlock);
+    if (PMIX_SUCCESS != PMIx_Finalize(NULL, 0)) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Finalize failed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return rc;
+}

--- a/test/simple/simpmonitor.c
+++ b/test/simple/simpmonitor.c
@@ -25,19 +25,28 @@
 /*
  * Regression test for heartbeat monitoring via PMIx_Process_monitor.
  *
- * This client asks its server to watch it for heartbeats, then
- * deliberately never sends one. The server's psensor/heartbeat monitor
- * must therefore observe an empty window and raise
- * PMIX_MONITOR_HEARTBEAT_ALERT back to us. We register a handler for that
- * code and wait a bounded time for it to fire.
+ * Run as two ranks in one namespace (simptest -n 2):
  *
- * The subtlety this guards against: PMIx_Process_monitor_nb returns
- * success for a heartbeat request whether or not a monitor was actually
- * started (an unhandled monitor key used to fall through to a spurious
- * success). So a passing "start" says nothing on its own - only the
- * arrival of the alert proves the sensor was really armed. If the
- * monitor path is not wired to psensor, no alert is ever generated and
- * this test fails on the timeout.
+ *   - rank 0 (the monitored proc) asks its server to watch it for
+ *     heartbeats, then deliberately never sends one. It stays connected
+ *     until rank 1 has had its say.
+ *   - rank 1 (the observer) registers for PMIX_MONITOR_HEARTBEAT_ALERT
+ *     and waits for it.
+ *
+ * When rank 0 goes silent the server's psensor/heartbeat monitor observes
+ * an empty window and raises PMIX_MONITOR_HEARTBEAT_ALERT with rank 0 as
+ * the source, scoped to the namespace. The source proc is deliberately
+ * NOT notified of its own event (it is presumed dead), which is why the
+ * observer is a *different* rank. rank 1 receives the alert and checks
+ * that its source is really rank 0, then prints "MONITOR TEST PASSED".
+ *
+ * This guards two things at once:
+ *   1. that the monitor API is wired to psensor at all - otherwise no
+ *      alert is ever generated and rank 1 times out; and
+ *   2. that the alert carries the correct source - the source proc is
+ *      passed to an asynchronous notify, so it must outlive the call that
+ *      raised it. A stack-allocated source produces a garbage rank/nspace
+ *      here.
  */
 
 #include <errno.h>
@@ -52,8 +61,12 @@
 #include "include/pmix.h"
 #include "simptest.h"
 
+#define MONITORED_RANK 0
+#define OBSERVER_RANK  1
+
 static pmix_proc_t myproc;
 static mylock_t alertlock;
+static volatile int alert_source_ok = 0;
 
 static void hide_unused_params(int x, ...)
 {
@@ -63,25 +76,27 @@ static void hide_unused_params(int x, ...)
     va_end(ap);
 }
 
-/* handler for PMIX_MONITOR_HEARTBEAT_ALERT - fired by the server when it
- * detects that we have stopped sending heartbeats */
+/* observer handler for PMIX_MONITOR_HEARTBEAT_ALERT */
 static void alert_handler(size_t evhdlr_registration_id, pmix_status_t status,
                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
                           pmix_info_t results[], size_t nresults,
                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     int rc = 0;
-    hide_unused_params(rc, evhdlr_registration_id, source, info, ninfo, results, nresults);
+    hide_unused_params(rc, evhdlr_registration_id, info, ninfo, results, nresults);
 
-    fprintf(stderr, "Client %s:%d MONITOR ALERT RECEIVED (%s)\n", myproc.nspace, myproc.rank,
-            PMIx_Error_string(status));
+    /* the alert must name the monitored proc as its source */
+    if (NULL != source && PMIX_CHECK_NSPACE(source->nspace, myproc.nspace)
+        && MONITORED_RANK == (int) source->rank) {
+        alert_source_ok = 1;
+    }
+    fprintf(stderr, "Observer %s:%d ALERT RECEIVED (%s) source=%s:%d source_ok=%d\n", myproc.nspace,
+            myproc.rank, PMIx_Error_string(status), (NULL == source) ? "NULL" : source->nspace,
+            (NULL == source) ? -1 : (int) source->rank, alert_source_ok);
 
-    /* let the notification system know we are done with the event */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
-
-    /* wake the main thread */
     alertlock.status = status;
     DEBUG_WAKEUP_THREAD(&alertlock);
 }
@@ -112,8 +127,7 @@ static void infocbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, vo
     DEBUG_WAKEUP_THREAD(lk);
 }
 
-/* bounded wait on a lock; returns 0 if the lock was signalled,
- * -1 if we timed out first */
+/* bounded wait on a lock; returns 0 if signalled, -1 on timeout */
 static int wait_for_alert(mylock_t *lk, int seconds)
 {
     struct timespec ts;
@@ -134,39 +148,14 @@ static int wait_for_alert(mylock_t *lk, int seconds)
     return rc;
 }
 
-int main(int argc, char **argv)
+/* rank 0: ask to be monitored via heartbeats, then go silent */
+static int run_monitored(void)
 {
-    int rc = 0;
+    int rc;
     pmix_info_t *monitor, *info;
-    pmix_status_t code = PMIX_MONITOR_HEARTBEAT_ALERT;
     mylock_t mylock;
     uint32_t n;
-    hide_unused_params(rc, argc, argv);
 
-    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
-        exit(1);
-    }
-    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
-
-    /* register a handler specifically for the heartbeat alert */
-    DEBUG_CONSTRUCT_LOCK(&alertlock);
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, NULL, 0, alert_handler, evhandler_reg_callbk,
-                                (void *) &mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    if (PMIX_SUCCESS != mylock.status) {
-        fprintf(stderr, "Client ns %s rank %d: alert handler registration failed: %s\n",
-                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
-        DEBUG_DESTRUCT_LOCK(&mylock);
-        rc = 1;
-        goto done;
-    }
-    DEBUG_DESTRUCT_LOCK(&mylock);
-
-    /* ask to be monitored via heartbeats, with a short (1 second) window
-     * so the alert fires quickly once we go silent */
     PMIX_INFO_CREATE(monitor, 1);
     PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_HEARTBEAT, NULL, PMIX_POINTER);
 
@@ -180,38 +169,98 @@ int main(int argc, char **argv)
     DEBUG_CONSTRUCT_LOCK(&mylock);
     rc = PMIx_Process_monitor_nb(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, info, 3, infocbfunc,
                                  (void *) &mylock);
-    if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
-        DEBUG_DESTRUCT_LOCK(&mylock);
-        PMIX_INFO_FREE(monitor, 1);
-        PMIX_INFO_FREE(info, 3);
-        rc = 1;
-        goto done;
-    }
-    DEBUG_WAIT_THREAD(&mylock);
-    PMIX_INFO_FREE(monitor, 1);
-    PMIX_INFO_FREE(info, 3);
-    if (PMIX_SUCCESS != mylock.status && PMIX_OPERATION_SUCCEEDED != mylock.status) {
-        fprintf(stderr, "Client ns %s rank %d: heartbeat monitor request rejected: %s\n",
-                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
-        DEBUG_DESTRUCT_LOCK(&mylock);
-        rc = 1;
-        goto done;
+    if (PMIX_SUCCESS == rc) {
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
     }
     DEBUG_DESTRUCT_LOCK(&mylock);
-    fprintf(stderr, "Client ns %s rank %d: heartbeat monitor request accepted\n", myproc.nspace,
+    PMIX_INFO_FREE(monitor, 1);
+    PMIX_INFO_FREE(info, 3);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Monitored %s:%d: heartbeat monitor request rejected: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, "Monitored %s:%d: monitoring started, going silent\n", myproc.nspace,
             myproc.rank);
+    /* deliberately send NO heartbeats; the second fence below keeps us
+     * connected until the observer has seen (or waited out) the alert */
+    return 0;
+}
 
-    /* deliberately send NO heartbeats and wait for the server to notice
-     * and alert us. The window is 1s; allow generous slack. */
-    if (0 == wait_for_alert(&alertlock, 30)) {
-        fprintf(stderr, "Client ns %s rank %d: MONITOR TEST PASSED\n", myproc.nspace, myproc.rank);
-        rc = 0;
-    } else {
-        fprintf(stderr, "Client ns %s rank %d: MONITOR TEST FAILED - no heartbeat alert\n",
-                myproc.nspace, myproc.rank);
-        rc = 1;
+/* rank 1: watch for the alert the server raises about rank 0 */
+static int run_observer(void)
+{
+    pmix_status_t code = PMIX_MONITOR_HEARTBEAT_ALERT;
+    mylock_t mylock;
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, alert_handler, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "Observer %s:%d: alert handler registration failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(mylock.status));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        return 1;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    int rc = 0, result = 0;
+    pmix_proc_t proc;
+    pmix_info_t fenceinfo;
+    bool flag;
+    hide_unused_params(rc, argc, argv);
+
+    DEBUG_CONSTRUCT_LOCK(&alertlock);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* the observer arms its handler before anyone synchronizes */
+    if (OBSERVER_RANK == (int) myproc.rank) {
+        result = run_observer();
+    }
+
+    /* barrier: everyone is set up before the monitored proc goes silent */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    flag = false;
+    PMIX_INFO_LOAD(&fenceinfo, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, &fenceinfo, 1))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence(1) failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        result = 1;
+        goto done;
+    }
+
+    if (MONITORED_RANK == (int) myproc.rank) {
+        result = run_monitored();
+    } else if (OBSERVER_RANK == (int) myproc.rank) {
+        if (0 == wait_for_alert(&alertlock, 30) && alert_source_ok) {
+            fprintf(stderr, "Observer %s:%d: MONITOR TEST PASSED\n", myproc.nspace, myproc.rank);
+            result = 0;
+        } else {
+            fprintf(stderr, "Observer %s:%d: MONITOR TEST FAILED - no valid heartbeat alert\n",
+                    myproc.nspace, myproc.rank);
+            result = 1;
+        }
+    }
+
+    /* second barrier: keeps the monitored proc connected until the
+     * observer is done, so it does not disconnect (and cancel its
+     * monitor) before the alert has fired and been seen */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, &fenceinfo, 1))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence(2) failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        result = 1;
     }
 
 done:
@@ -220,5 +269,5 @@ done:
         fprintf(stderr, "Client ns %s rank %d: PMIx_Finalize failed\n", myproc.nspace, myproc.rank);
     }
     fflush(stderr);
-    return rc;
+    return result;
 }

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl pmix_log collective_status client_cycle tool_cycle
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status client_cycle tool_cycle
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_monitor.pl.in
+++ b/test/unit/run_monitor.pl.in
@@ -62,7 +62,7 @@ foreach my $p (@paths) {
 
 # Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
 # arm a Perl alarm so a wedged run can never hang "make check" forever.
-my @cmd = ("./simptest", "-e", "./simpmonitor");
+my @cmd = ("./simptest", "-n", "2", "-e", "./simpmonitor");
 my $use_alarm = 0;
 if ("" ne $timeout_cmd) {
     unshift(@cmd, split(' ', $timeout_cmd));

--- a/test/unit/run_monitor.pl.in
+++ b/test/unit/run_monitor.pl.in
@@ -1,0 +1,124 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise heartbeat monitoring end-to-end through PMIx_Process_monitor.
+# A single persistent server (test/simple/simptest) forks one client
+# (test/simple/simpmonitor) that asks to be monitored via heartbeats and
+# then deliberately never sends one. The server's psensor/heartbeat
+# monitor must observe the empty window and raise
+# PMIX_MONITOR_HEARTBEAT_ALERT back to the client, which is waiting for
+# it. The client prints "MONITOR TEST PASSED" only after the alert
+# arrives.
+#
+# This guards the connection between the monitor API and the psensor
+# framework: a heartbeat request returns success whether or not a sensor
+# was actually armed, so only the arrival of the alert proves the monitor
+# is live. If the monitor path is not wired to psensor, no alert is ever
+# generated and the client times out waiting - failing this test.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its client from the current directory using a relative
+# path ("./simpmonitor"), so run from the directory that holds both binaries.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-e", "./simpmonitor");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and
+# slurp the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a crash anywhere in the monitor/psensor path
+# drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# The client explicitly reports failure if it never received the alert.
+if ($output =~ /MONITOR TEST FAILED/) {
+    print "FAIL: client did not receive the heartbeat alert\n";
+    exit(1);
+}
+
+# Confirm the alert actually fired rather than passing vacuously: the
+# client prints this line only from inside its heartbeat-alert handler.
+if ($output !~ /MONITOR TEST PASSED/) {
+    print "FAIL: client did not confirm heartbeat monitoring\n";
+    exit(1);
+}
+print "PASS: heartbeat monitor raised the expected alert\n";
+exit(0);


### PR DESCRIPTION
Restore and harden the `PMIx_Process_monitor` → `psensor` dispatch path,
which the stats revamp that introduced `src/common/pmix_monitor.c` had
silently disabled, and add regression coverage so it cannot break again.

**Route heartbeat/file monitoring back to the psensor framework** — the
monitor request was no longer reaching the psensor components; re-wire
`pmix_monitor.c` so heartbeat and file monitoring dispatch to psensor as
before.

**Return `NOT_SUPPORTED` for an unrecognized monitor key in pstat** —
each pstat component's query fell through to a trailing
`return PMIX_SUCCESS` for an unhandled key, reporting spurious success and
leaking the already-allocated `pmix_pstat_op_t`. Release the op and return
`PMIX_ERR_NOT_SUPPORTED` (matching pstat's own unsupported stub and the
psensor framework). Applied to plinux, pmacos, and the test component.

**Add a `make check` test for heartbeat monitoring** — `simpmonitor`
registers a `PMIX_MONITOR_HEARTBEAT_ALERT` handler, asks its server to
monitor it, sends no heartbeats, and waits (bounded) for the alert;
`run_monitor.pl` drives it under the existing harness. A heartbeat request
reports success whether or not a sensor was armed, so only the alert's
arrival proves the monitor is live. Verified it passes with the dispatch
in place and fails without it.

**Give the psensor alert its source proc a safe lifetime** — both psensor
monitors built the event's source proc on the stack and passed its address
to `PMIx_Notify_event`, which does not copy the source; the event is
processed asynchronously after the sampler returns, so the delivered event
carried a garbage source nspace/rank. Move the source into the tracker
object (retained across the notify), so `&ft->source` stays valid as long
as the event needs it. The heartbeat test now runs two ranks and asserts
the alert's source is really rank 0, guarding this fix too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
