### PR TITLE
Coverity fixes and revival of the pnet/tcp component

### DIFF
--- a/examples/monitor_multi.c
+++ b/examples/monitor_multi.c
@@ -61,11 +61,16 @@ static void update(size_t evhdlr_registration_id, pmix_status_t status,
                    pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     size_t n;
+    char *tmp;
     EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
 
-    fprintf(stderr, "[%s]UPDATE:\n", PMIx_Proc_string(&myproc));
+    tmp = PMIx_Proc_string(&myproc);
+    fprintf(stderr, "[%s]UPDATE:\n", tmp);
+    free(tmp);
     for (n=0; n < ninfo; n++) {
-        fprintf(stderr, "%s", PMIx_Info_string(&info[n]));
+        tmp = PMIx_Info_string(&info[n]);
+        fprintf(stderr, "%s", tmp);
+        free(tmp);
     }
     fprintf(stderr, "\n\n");
 
@@ -107,6 +112,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_data_array_t darray;
     char hostname[2048];
+    char *tmp;
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     gethostname(hostname, 2048);
@@ -214,7 +220,9 @@ int main(int argc, char **argv)
         } else {
             fprintf(stderr, "INITIAL PROC RESULTS:\n");
             for (n=0; n < nresults; n++) {
-                fprintf(stderr, "%s", PMIx_Info_string(&results[n]));
+                tmp = PMIx_Info_string(&results[n]);
+                fprintf(stderr, "%s", tmp);
+                free(tmp);
             }
             fprintf(stderr, "\n\n");
             n = 0;

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1047,7 +1047,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
     pmix_peer_events_info_t *pr;
     pmix_event_chain_t *chain;
     size_t n, nleft;
-    bool matched, holdcd;
+    bool matched, holdcd, cached;
     pmix_buffer_t *bfr;
     pmix_cmd_t cmd = PMIX_NOTIFY_CMD;
     pmix_status_t rc;
@@ -1077,6 +1077,11 @@ static void _notify_client_event(int sd, short args, void *cbdata)
             }
         }
     }
+    /* remember the caching decision: "holdcd" is reused further down to
+     * track whether the caddy is being held for an async upstream
+     * callback, so we cannot rely on it to tell us later whether this
+     * event was placed in the cache */
+    cached = holdcd;
     if (holdcd) {
         /* we cannot know if everyone who wants this notice has had a chance
          * to register for it - the notice may be coming too early. So cache
@@ -1306,14 +1311,14 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                         /* if the event was cached and this is the last one,
                          * then evict this event from the cache */
                         if (0 == cd->nleft) {
-                            if (holdcd) {
+                            if (cached) {
                                 /* remove it from the cache and release the
                                  * reference the cache was holding; our own
                                  * in-flight reference keeps cd alive through
                                  * the remainder of this routine */
                                 pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
                                 PMIX_RELEASE(cd);
-                                holdcd = false;
+                                cached = false;
                             }
                             break;
                         }
@@ -1479,6 +1484,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg)
     (void) fd;
     (void) flags;
     pmix_event_chain_t *ch = (pmix_event_chain_t *) arg;
+    pmix_status_t rc;
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(ch);
@@ -1491,9 +1497,16 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg)
     /* process this event thru the regular channels */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
-        pmix_server_notify_client_of_event(ch->status, &ch->source, ch->range,
-                                           ch->info, ch->ninfo,
-                                           ch->final_cbfunc, ch->final_cbdata);
+        /* on success, ch is released when the forwarded final_cbfunc
+         * (which carries ch as its cbdata) fires; on failure that
+         * callback will not run, so release the chain here */
+        rc = pmix_server_notify_client_of_event(ch->status, &ch->source, ch->range,
+                                                ch->info, ch->ninfo,
+                                                ch->final_cbfunc, ch->final_cbdata);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(ch);
+        }
     } else {
         pmix_invoke_local_event_hdlr(ch);
     }

--- a/src/mca/pnet/AGENTS.md
+++ b/src/mca/pnet/AGENTS.md
@@ -61,16 +61,20 @@ server code (e.g. `pmix_pnet.allocate`, `pmix_pnet.setup_fork`).
 
 Only **one** component, [`opa`](opa/AGENTS.md), is compiled in a default
 build, and it selects at runtime **only** when hwloc reports matching
-fabric hardware. [`nvd`](nvd/AGENTS.md) and [`tcp`](tcp/AGENTS.md) are
-hardwired **off** in their `configure.m4` (see [Building](#building)), and
-[`simptest`](simptest/AGENTS.md) builds only with `--with-simptest`.
-Moreover, `tcp` and `simptest` are **stale**: their module functions no
-longer match the current `pmix_pnet_module_t` interface and they reference
-base symbols that no longer exist, so they would not compile against
-today's tree (this is invisible in CI precisely because they are not
-built). Treat the shipped components as a mix of one live example (`opa`),
-one current-but-disabled example (`nvd`), and two stale examples
-(`tcp`, `simptest`). See each component's `AGENTS.md` for specifics, and
+fabric hardware. [`tcp`](tcp/AGENTS.md) also compiles against the current
+interface but is **opt-in** — its `configure.m4` is guarded by
+`--with-tcp`, so it is off by default; when built it has no hardware gate
+and is selected on **every** server (its entry points then self-gate on
+role / blob key). [`nvd`](nvd/AGENTS.md) is hardwired **off** in its
+`configure.m4` (see [Building](#building)), and
+[`simptest`](simptest/AGENTS.md) builds only with `--with-simptest` and is
+**stale** — its module functions no longer match the current
+`pmix_pnet_module_t` interface and it references base symbols that no
+longer exist, so it would not compile against today's tree (this is
+invisible in CI precisely because it is not built). Treat the shipped
+components as two current examples (`opa` built by default, `tcp` opt-in
+via `--with-tcp`), one current-but-disabled example (`nvd`), and one stale
+example (`simptest`). See each component's `AGENTS.md` for specifics, and
 do not assume any of them reflects a supported, exercised code path.
 
 ## Single-select vs. multi-select
@@ -227,13 +231,16 @@ Default priorities and runtime gates (from each component's
 | `nvd` | 10 | **No** (hardwired off) | hwloc reports a Mellanox `0x15b3` / NVIDIA `0x10de` device of class `0x207` |
 | `opa` | 10 | **Yes** | hwloc reports an Intel `0x8086` device of class `0x208` |
 | `simptest` | 0 | Only with `--with-simptest` | server role **and** `pnet=simptest` MCA selection **and** a config file given |
-| `tcp` | 5 | **No** (hardwired off) | always returns a module (its gating is inside the module, on `PMIX_PEER_IS_GATEWAY`) |
+| `tcp` | 5 | **No** (`--with-tcp`) | always returns a module (no hardware gate); its entry points self-gate on `PMIX_PEER_IS_GATEWAY` / their own blob key, but `collect_inventory` runs on every server |
 
 Because `nvd`/`opa` gate selection on a hwloc hardware probe in
-`component_open`, on a typical server **no** `pnet` component ends up in
-`actives`, and the base functions quietly do nothing. That is the normal,
-intended behavior — `pnet` is opt-in on the presence of real fabric
-hardware or an explicit test configuration.
+`component_open`, they only end up in `actives` on hosts with the matching
+fabric hardware. On a default build with no matching hardware, **no**
+`pnet` component ends up in `actives` and the base functions quietly do
+nothing. If `tcp` is built (`--with-tcp`) it has no such gate, so it then
+lands in `actives` on every server; its entry points self-gate, so the
+only work done on a non-gateway server without a matching blob is
+`collect_inventory` reporting the local TCP interfaces.
 
 ## MCA parameters
 
@@ -261,9 +268,9 @@ src/mca/pnet/
 │   ├── pnet_base_select.c  multi-select: build the priority-ordered actives list
 │   └── pnet_base_fns.c     the pmix_pnet_base_* fan-out functions
 ├── nvd/                    Mellanox/NVIDIA example (current interface, disabled in build)
-├── opa/                    Omni-Path example (the only default-built component)
+├── opa/                    Omni-Path example (default-built; hwloc-gated at runtime)
 ├── simptest/               static-endpoint test example (stale; --with-simptest only)
-└── tcp/                    static TCP/UDP port example (stale; disabled in build)
+└── tcp/                    static TCP/UDP port example (--with-tcp; no hardware gate)
 ```
 
 ## Threading
@@ -291,10 +298,12 @@ are unusually blunt about it:
   It is the only component listed in the generated
   `base/static-components.h` in a default configure. (Whether it then
   *selects* still depends on the hwloc probe at runtime.)
+- **`tcp`** — guarded by `--with-tcp` (same `AC_ARG_WITH` pattern as
+  `simptest`): **not built by default**. When the flag is given it
+  compiles and, having no runtime hardware gate, also always selects.
 - **`nvd`** — `AS_IF([test "yes" = "no"], …)`, i.e. the "can-compile"
   branch is never taken: **never built**. Its `Makefile` is still
   generated, but the source is not compiled into the library.
-- **`tcp`** — same hardwired-off pattern as `nvd`: **never built**.
 - **`simptest`** — built only when `--with-simptest` is passed to
   `configure`.
 
@@ -311,24 +320,28 @@ Per the top-level build rules: editing a `Makefile.am` needs only a plain
 `make`; **adding or removing a component directory, or changing a
 `configure.m4`, changes the build wiring and requires
 `./autogen.pl && ./configure … && make`** (this is exactly the mechanism
-that keeps `nvd`/`tcp` out of the library today).
+that keeps `nvd` out of the library today).
 
 ## When working in this framework
 
-- **Do not assume any component is a working reference.** `opa` compiles
-  and is the closest thing to a live example, but it only runs on
-  Omni-Path hardware. `nvd` matches the current interface but is not
-  built. `tcp` and `simptest` are stale (see below) and are not built by
-  default. Read `opa` first if you need a template.
-- **Know why `tcp`/`simptest` don't compile against HEAD.** Their module
+- **`opa` and `tcp` are the current references.** Both compile against
+  today's interface. `opa` is built by default but only *runs* on
+  Omni-Path hardware; `tcp` is opt-in (`--with-tcp`) and, once built, has
+  no hardware gate so it always selects. `nvd` matches the current
+  interface but is not built. `simptest` is stale (see below) and builds
+  only with `--with-simptest`. Read `opa` or `tcp` first if you need a
+  template.
+- **Know why `simptest` doesn't compile against HEAD.** Its module
   functions use signatures from an older `pmix_pnet_module_t` (e.g. a
   `setup_fork` module slot that no longer exists, inventory functions that
   still take `pmix_inventory_cbfunc_t`/`pmix_op_cbfunc_t` callbacks, a
-  `setup_local_network` taking `pmix_namespace_t *`), and `tcp` references
-  base symbols (`pmix_pnet_globals.nodes`, `pmix_pnet_node_t`,
-  `pmix_pnet_resource_t`) that no longer exist. If you resurrect either,
-  you must port it to the current interface — do not "fix" the framework
-  header to match the stale component.
+  `setup_local_network` taking `pmix_namespace_t *`). `tcp` used to share
+  these problems and additionally referenced base symbols
+  (`pmix_pnet_globals.nodes`, `pmix_pnet_node_t`, `pmix_pnet_resource_t`)
+  that no longer exist; it has since been ported to the current interface
+  (its inventory archive now lives in a component-local tree). If you
+  resurrect `simptest`, port it the same way — do not "fix" the framework
+  header to match a stale component.
 - **`setup_fork` is base-only.** If a component needs an envar in the
   child's environment, it must add it to the namespace's envar cache
   during `setup_local_network` (append a `pmix_envar_list_item_t` to

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -76,7 +76,13 @@ pmix_pnet_module_t pmix_opa_module = {
 static inline void transports_use_rand(uint64_t *unique_key)
 {
     pmix_rng_buff_t rng;
-    pmix_srand(&rng, (unsigned int) time(NULL));
+    /* pmix_srand() wants a 32-bit seed, so fold the full width of the
+     * time_t into 32 bits rather than silently truncating it - this
+     * lets every bit of the clock contribute to the seed and remains
+     * well-defined whether time_t is 32 or 64 bits wide */
+    uint64_t now = (uint64_t) time(NULL);
+    uint32_t seed = (uint32_t) now ^ (uint32_t) (now >> 32);
+    pmix_srand(&rng, seed);
     unique_key[0] = pmix_rand(&rng);
     unique_key[1] = pmix_rand(&rng);
 }

--- a/src/mca/pnet/tcp/AGENTS.md
+++ b/src/mca/pnet/tcp/AGENTS.md
@@ -16,12 +16,17 @@ each job a slice of a pre-configured port pool, and each daemon caches the
 assignment as job-level info. Read the framework [`AGENTS.md`](../AGENTS.md)
 first; this file covers only what is specific to `tcp`.
 
-**Status warning:** `tcp` is **not built** (hardwired off in
-`configure.m4`) *and* is **stale** — its module functions no longer match
-the current `pmix_pnet_module_t`, and it references base symbols that no
-longer exist. It would not compile against today's tree. Read it as a
-historical example of the intended port-allocation design, not as working
-code.
+**Status:** `tcp` compiles against the current `pmix_pnet_module_t`, but
+it is **opt-in** — its `configure.m4` is guarded by `--with-tcp`, so it is
+**not built by default** (like `simptest`). When you *do* build it, note
+that unlike `nvd`/`opa` it has **no hardware gate** — `component_open`
+always succeeds and `component_query` always returns the module at
+priority **5** — so it is then **selected into `actives` on every
+server**. Its entry points self-gate: `allocate`/`tcp_init`/
+`deregister_nspace` act only for the gateway role, and
+`setup_local_network`/`deliver_inventory` act only on their own blob key.
+`collect_inventory`, however, runs on every server and reports the local
+TCP interfaces.
 
 ## Files
 
@@ -29,28 +34,29 @@ code.
 |------|----------|
 | `pnet_tcp.h` | Component struct type (`static_ports`, `default_request`, `costmatrix`, …). |
 | `pnet_tcp_component.c` | Component struct, `component_register` (MCA params), `component_query` (priority **5**). |
-| `pnet_tcp.c` | The module: init/finalize, allocate, setup_local_network, setup_fork, finalize hooks, collect/deliver inventory, and the `process_request` port assigner. |
-| `configure.m4` | Hardwired **off** (`test "yes" = "no"`); adds the `TCP` summary line. |
+| `pnet_tcp.c` | The module: init/finalize, allocate, setup_local_network, finalize hooks, collect/deliver inventory, and the `process_request` port assigner. |
+| `configure.m4` | Guarded by `--with-tcp` (off by default); adds the `TCP` summary line. |
 
-## Why it does not compile against HEAD
+## Interface notes for maintainers
 
-The module struct it fills in uses an **older** interface:
+The module was ported to the current framework interface; when editing,
+keep it aligned with `pmix_pnet_module_t`:
 
-- It sets a `.setup_fork` slot — but `pmix_pnet_module_t` has **no
-  `setup_fork` field** any more (fork-time envar injection is base-only).
-- `collect_inventory` is declared `(directives, ndirs,
-  pmix_inventory_cbfunc_t cbfunc, void *cbdata)` and `deliver_inventory`
-  `(info, ninfo, directives, ndirs, pmix_op_cbfunc_t cbfunc, void *cbdata)`
-  — the current typedefs take a plain `pmix_list_t *inventory` and no
-  callbacks, respectively.
-- `setup_local_network` takes `pmix_namespace_t *` rather than the
-  current `pmix_nspace_env_cache_t *`.
-- `deliver_inventory` references `pmix_pnet_globals.nodes`,
-  `pmix_pnet_node_t`, and `pmix_pnet_resource_t`, none of which exist in
-  the current `base/base.h`.
-
-Any resurrection must port all of the above to the current framework
-header — do not change the header to match this file.
+- There is **no `.setup_fork` slot** — fork-time envar injection is
+  base-only, so a component that needs an envar in the child appends a
+  `pmix_envar_list_item_t` to the namespace's `ns->envars` cache during
+  `setup_local_network`.
+- `collect_inventory` takes a plain `pmix_list_t *inventory` (append
+  `pmix_kval_t`s to it) and `deliver_inventory` takes
+  `(info, ninfo, directives, ndirs)` — neither uses a callback.
+- `setup_local_network` takes a `pmix_nspace_env_cache_t *` (use
+  `ns->ns` for the underlying `pmix_namespace_t *`).
+- The framework's old global inventory store (`pmix_pnet_globals.nodes`
+  and the `pmix_pnet_node_t` / `pmix_pnet_resource_t` types) was removed.
+  `deliver_inventory` therefore archives into a **component-local** node
+  tree (`tcp_node_t` → `tcp_resource_t` → `tcp_available_ports_t`), held
+  on the static `nodes` list and dumped at verbosity >5. Nothing else
+  queries that tree today; it exists to keep the archiving example intact.
 
 ## The intended design (what the code shows)
 
@@ -80,19 +86,19 @@ header — do not change the header to match this file.
 - **`collect_inventory`** enumerates non-loopback, non-virtual IPv4/IPv6
   interfaces via the `pmix_if*` API and packs `(device, tcp[46]://addr)`
   pairs into an inventory blob keyed `PMIX_TCP_INVENTORY_KEY`;
-  **`deliver_inventory`** unpacks such blobs into the (now-removed)
-  per-node resource lists.
+  **`deliver_inventory`** unpacks such blobs into the component-local
+  `nodes` tree (see the interface notes above).
 
 ## Gotchas
 
-- **Do not treat this as a template.** Prefer [`opa`](../opa/AGENTS.md) or
-  [`nvd`](../nvd/AGENTS.md), which match the current interface. This file
-  is an archaeology reference for the port-allocation idea only.
-- **The port-recycling lives in the tracker destructor.** If you ever port
-  this forward, keep the invariant that releasing a `tcp_port_tracker_t`
-  returns its ports to its `src` pool — that is what makes ports reusable
-  across successive jobs.
-- **MCA params still register.** `component_register` is on the built
-  code path only if the component is built; today it is not, so
+- **It is an example, not production code.** `tcp` illustrates the
+  static-port-allocation design; `opa` and `nvd` are the other current
+  references. The port-allocation path only does real work on the gateway
+  with `static_ports` configured.
+- **The port-recycling lives in the tracker destructor.** Keep the
+  invariant that releasing a `tcp_port_tracker_t` returns its ports to its
+  `src` pool — that is what makes ports reusable across successive jobs.
+- **MCA params register at runtime when built.** With `--with-tcp`,
   `static_ports` / `default_network_allocation` / `include_envars` /
-  `exclude_envars` are not actually available at runtime.
+  `exclude_envars` are available (visible via `pmix_info --all` under
+  `MCA pnet tcp`). Without it, the component is absent entirely.

--- a/src/mca/pnet/tcp/configure.m4
+++ b/src/mca/pnet/tcp/configure.m4
@@ -16,12 +16,13 @@
 AC_DEFUN([MCA_pmix_pnet_tcp_CONFIG], [
     AC_CONFIG_FILES([src/mca/pnet/tcp/Makefile])
 
-    AS_IF([test "yes" = "no"],
-          [$1
-           pmix_pnet_tcp_happy=yes],
-          [$2
-           pmix_pnet_tcp_happy=no])
+    AC_ARG_WITH([tcp], [AS_HELP_STRING([--with-tcp], [Include TCP/UDP static-port fabric support])],
+                [pmix_want_tcp=yes], [pmix_want_tcp=no])
 
-    PMIX_SUMMARY_ADD([Transports], [TCP], [], [$pmix_pnet_tcp_happy])
+    AS_IF([test "$pmix_want_tcp" = "yes"],
+          [$1],
+          [$2])
+
+    PMIX_SUMMARY_ADD([Transports], [TCP], [], [$pmix_want_tcp])
 
 ])dnl

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,10 +34,11 @@
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_socket_errno.h"
 #include "src/mca/preg/preg.h"
-#include "src/util/apmix_lfg.h"
+#include "src/util/pmix_alfg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_parse_options.h"
 #include "src/util/pmix_if.h"
 #include "src/util/pmix_environ.h"
@@ -52,22 +53,21 @@ static pmix_status_t tcp_init(void);
 static void tcp_finalize(void);
 static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo,
                               pmix_list_t *ilist);
-static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo);
-static pmix_status_t setup_fork(pmix_namespace_t *nptr, const pmix_proc_t *peer, char ***env);
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr, pmix_info_t info[],
+                                         size_t ninfo);
 static void child_finalized(pmix_proc_t *peer);
 static void local_app_finalized(pmix_namespace_t *nptr);
 static void deregister_nspace(pmix_namespace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
-                                       pmix_inventory_cbfunc_t cbfunc, void *cbdata);
+                                       pmix_list_t *inventory);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo, pmix_info_t directives[],
-                                       size_t ndirs, pmix_op_cbfunc_t cbfunc, void *cbdata);
+                                       size_t ndirs);
 
 pmix_pnet_module_t pmix_tcp_module = {.name = "tcp",
                                       .init = tcp_init,
                                       .finalize = tcp_finalize,
                                       .allocate = allocate,
                                       .setup_local_network = setup_local_network,
-                                      .setup_fork = setup_fork,
                                       .child_finalized = child_finalized,
                                       .local_app_finalized = local_app_finalized,
                                       .deregister_nspace = deregister_nspace,
@@ -97,7 +97,24 @@ typedef struct {
     tcp_available_ports_t *src; // source of the allocated ports
 } tcp_port_tracker_t;
 
-static pmix_list_t allocations, available;
+/* the framework used to archive delivered inventory in a global
+ * node/resource tree (pmix_pnet_globals.nodes). That store was
+ * removed, so this component keeps its own equivalent tree for the
+ * inventory it is handed - a node holds a list of per-type resources,
+ * each of which holds the reported ports/devices for that type */
+typedef struct {
+    pmix_list_item_t super;
+    char *name;
+    pmix_list_t resources;
+} tcp_resource_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    char *name;
+    pmix_list_t resources;
+} tcp_node_t;
+
+static pmix_list_t allocations, available, nodes;
 static pmix_status_t process_request(pmix_namespace_t *nptr, char *idkey, int ports_per_node,
                                      tcp_port_tracker_t *trk, pmix_list_t *ilist);
 
@@ -175,6 +192,34 @@ static void ttdes(tcp_port_tracker_t *p)
 }
 static PMIX_CLASS_INSTANCE(tcp_port_tracker_t, pmix_list_item_t, ttcon, ttdes);
 
+static void rescon(tcp_resource_t *p)
+{
+    p->name = NULL;
+    PMIX_CONSTRUCT(&p->resources, pmix_list_t);
+}
+static void resdes(tcp_resource_t *p)
+{
+    if (NULL != p->name) {
+        free(p->name);
+    }
+    PMIX_LIST_DESTRUCT(&p->resources);
+}
+static PMIX_CLASS_INSTANCE(tcp_resource_t, pmix_list_item_t, rescon, resdes);
+
+static void ndcon(tcp_node_t *p)
+{
+    p->name = NULL;
+    PMIX_CONSTRUCT(&p->resources, pmix_list_t);
+}
+static void nddes(tcp_node_t *p)
+{
+    if (NULL != p->name) {
+        free(p->name);
+    }
+    PMIX_LIST_DESTRUCT(&p->resources);
+}
+static PMIX_CLASS_INSTANCE(tcp_node_t, pmix_list_item_t, ndcon, nddes);
+
 static pmix_status_t tcp_init(void)
 {
     tcp_available_ports_t *trk;
@@ -182,6 +227,10 @@ static pmix_status_t tcp_init(void)
     size_t n;
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet: tcp init");
+
+    /* the inventory cache is used regardless of role, so set it up
+     * before we check whether we are the gateway */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
 
     /* if we are not the "gateway", then there is nothing
      * for us to do */
@@ -245,6 +294,7 @@ static void tcp_finalize(void)
         PMIX_LIST_DESTRUCT(&allocations);
         PMIX_LIST_DESTRUCT(&available);
     }
+    PMIX_LIST_DESTRUCT(&nodes);
 }
 
 /* some network users may want to encrypt their communications
@@ -264,7 +314,13 @@ static void tcp_finalize(void)
 static inline void generate_key(uint64_t *unique_key)
 {
     pmix_rng_buff_t rng;
-    pmix_srand(&rng, (unsigned int) time(NULL));
+    /* pmix_srand() wants a 32-bit seed, so fold the full width of the
+     * time_t into 32 bits rather than silently truncating it - this
+     * lets every bit of the clock contribute to the seed and remains
+     * well-defined whether time_t is 32 or 64 bits wide */
+    uint64_t now = (uint64_t) time(NULL);
+    uint32_t seed = (uint32_t) now ^ (uint32_t) (now >> 32);
+    pmix_srand(&rng, seed);
     unique_key[0] = pmix_rand(&rng);
     unique_key[1] = pmix_rand(&rng);
 }
@@ -711,7 +767,8 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
 /* upon receipt of the launch message, each daemon adds the
  * static address assignments to the job-level info cache
  * for that job */
-static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo)
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr, pmix_info_t info[],
+                                         size_t ninfo)
 {
     size_t n, m, nkvals;
     pmix_buffer_t bkt;
@@ -779,7 +836,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
                 }
 
                 /* cache the info on the job */
-                PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, &stinfo, 1);
+                PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr->ns, &stinfo, 1);
                 PMIX_INFO_DESTRUCT(&stinfo);
             }
         }
@@ -790,17 +847,12 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_fork(pmix_namespace_t *nptr, const pmix_proc_t *peer, char ***env)
-{
-    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet:tcp:setup_fork");
-    return PMIX_SUCCESS;
-}
-
 /* when a local client finalizes, the server gives us a chance
  * to do any required local cleanup for that peer. We don't
  * have anything we need to do */
 static void child_finalized(pmix_proc_t *peer)
 {
+    PMIX_HIDE_UNUSED_PARAMS(peer);
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet:tcp child finalized");
 }
 
@@ -810,6 +862,7 @@ static void child_finalized(pmix_proc_t *peer)
  * We don't have anything we need to do */
 static void local_app_finalized(pmix_namespace_t *nptr)
 {
+    PMIX_HIDE_UNUSED_PARAMS(nptr);
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet:tcp app finalized");
 }
 
@@ -843,9 +896,8 @@ static void deregister_nspace(pmix_namespace_t *nptr)
 }
 
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
-                                       pmix_inventory_cbfunc_t cbfunc, void *cbdata)
+                                       pmix_list_t *inventory)
 {
-    pmix_inventory_rollup_t *cd = (pmix_inventory_rollup_t *) cbdata;
     char *prefix;
     char myconnhost[PMIX_MAXHOSTNAMELEN] = {0};
     char name[32], uri[2048];
@@ -857,6 +909,8 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
     bool found = false;
     pmix_byte_object_t pbo;
     pmix_kval_t *kv;
+
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs);
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet:tcp:collect_inventory");
 
@@ -947,9 +1001,11 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
     kv = PMIX_NEW(pmix_kval_t);
     kv->key = strdup(PMIX_TCP_INVENTORY_KEY);
     PMIX_VALUE_CREATE(kv->value, 1);
-    pmix_value_load(kv->value, &pbo, PMIX_BYTE_OBJECT);
-    PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    pmix_list_append(&cd->payload, &kv->super);
+    kv->value->type = PMIX_BYTE_OBJECT;
+    /* transfer ownership of the unloaded blob into the value */
+    kv->value->data.bo.bytes = pbo.bytes;
+    kv->value->data.bo.size = pbo.size;
+    pmix_list_append(inventory, &kv->super);
 
     return PMIX_SUCCESS;
 }
@@ -962,6 +1018,8 @@ static pmix_status_t process_request(pmix_namespace_t *nptr, char *idkey, int po
     size_t m;
     int p, ppn;
     tcp_available_ports_t *avail = trk->src;
+
+    PMIX_HIDE_UNUSED_PARAMS(nptr);
 
     kv = PMIX_NEW(pmix_kval_t);
     if (NULL == kv) {
@@ -1040,18 +1098,20 @@ static pmix_status_t process_request(pmix_namespace_t *nptr, char *idkey, int po
 }
 
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo, pmix_info_t directives[],
-                                       size_t ndirs, pmix_op_cbfunc_t cbfunc, void *cbdata)
+                                       size_t ndirs)
 {
     pmix_buffer_t bkt, pbkt;
     size_t n;
     int32_t cnt;
     char *hostname, *device, *address;
     pmix_byte_object_t pbo;
-    pmix_pnet_node_t *nd, *ndptr;
-    pmix_pnet_resource_t *lt, *lst;
+    tcp_node_t *nd, *ndptr;
+    tcp_resource_t *lt, *lst;
     tcp_available_ports_t *prts;
     tcp_device_t *res;
     pmix_status_t rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(directives, ndirs);
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet:tcp deliver inventory");
 
@@ -1071,27 +1131,27 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo, pmix_in
             }
             /* do we already have this node? */
             nd = NULL;
-            PMIX_LIST_FOREACH (ndptr, &pmix_pnet_globals.nodes, pmix_pnet_node_t) {
+            PMIX_LIST_FOREACH (ndptr, &nodes, tcp_node_t) {
                 if (0 == strcmp(hostname, ndptr->name)) {
                     nd = ndptr;
                     break;
                 }
             }
             if (NULL == nd) {
-                nd = PMIX_NEW(pmix_pnet_node_t);
+                nd = PMIX_NEW(tcp_node_t);
                 nd->name = strdup(hostname);
-                pmix_list_append(&pmix_pnet_globals.nodes, &nd->super);
+                pmix_list_append(&nodes, &nd->super);
             }
             /* does this node already have a TCP entry? */
             lst = NULL;
-            PMIX_LIST_FOREACH (lt, &nd->resources, pmix_pnet_resource_t) {
+            PMIX_LIST_FOREACH (lt, &nd->resources, tcp_resource_t) {
                 if (0 == strcmp(lt->name, "tcp")) {
                     lst = lt;
                     break;
                 }
             }
             if (NULL == lst) {
-                lst = PMIX_NEW(pmix_pnet_resource_t);
+                lst = PMIX_NEW(tcp_resource_t);
                 lst->name = strdup("tcp");
                 pmix_list_append(&nd->resources, &lst->super);
             }
@@ -1137,7 +1197,7 @@ static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo, pmix_in
             if (5 < pmix_output_get_verbosity(pmix_pnet_base_framework.framework_output)) {
                 /* dump the resulting node resources */
                 pmix_output(0, "TCP resources for node: %s", nd->name);
-                PMIX_LIST_FOREACH (lt, &nd->resources, pmix_pnet_resource_t) {
+                PMIX_LIST_FOREACH (lt, &nd->resources, tcp_resource_t) {
                     if (0 == strcmp(lt->name, "tcp")) {
                         PMIX_LIST_FOREACH (prts, &lt->resources, tcp_available_ports_t) {
                             device = NULL;


### PR DESCRIPTION
This branch collects three static-analysis (Coverity) fixes plus a
revival of the long-dormant `pnet/tcp` component. Each is a separate,
independently reviewable commit.

### Coverity fixes

- **Event notification (`src/event/pmix_event_notification.c`)** — two
  independent defects:
  - *DEADCODE*: in `_notify_client_event()` the `holdcd` variable was
    reused for two purposes and reset before the per-target loop, making
    the "evict a fully-delivered custom-range event from the cache"
    guard unreachable. Tracked the caching decision in a separate
    `cached` flag so the eviction runs as intended.
  - *CHECKED_RETURN / leak*: in `pmix_event_timeout_cb()` the return of
    `pmix_server_notify_client_of_event()` was ignored; on an error
    return the forwarded callback never fires and the chain leaks. Now
    checked and released on failure, matching the `pmix_tool.c` idiom.

- **`monitor_multi` example** — `PMIx_Proc_string()` /
  `PMIx_Info_string()` results were passed to `fprintf()` and dropped,
  leaking. Saved, printed, and freed each (matching `monitor.c`).

- **`pnet/opa` transport seed** — replaced the implicit
  `(unsigned int) time(NULL)` narrowing (Y2K38_SAFETY) with an explicit
  XOR-fold of the clock's high/low halves.

### Revive `pnet/tcp`

The `pnet/tcp` component no longer matched the current
`pmix_pnet_module_t` interface and referenced base symbols that were
removed, so it would not compile; it was hardwired off, which hid the
breakage. This ports it back to the current interface (module slots,
inventory signatures, `pmix_nspace_env_cache_t *`, component-local
inventory store in place of the removed framework node/resource tree)
and gates it behind a new `--with-tcp` flag using the same pattern as
`pnet/simptest`, so it is **not built by default** but stays compilable.
The `pnet` / `pnet/tcp` `AGENTS.md` docs are updated to match.

### Testing

- Full `--enable-devel-check` build is warning-free in both default
  (no `--with-tcp`) and `--with-tcp` configurations.
- `pnet/tcp` links into `libpmix`, loads under `pmix_info --all`, and
  registers its MCA params when `--with-tcp` is given.
- `test/simple/simptest` runs clean with the component active.

### Note for reviewers

`pnet/tcp` has no hwloc gate, so when built it selects on every server
(its entry points then self-gate on the gateway role / their own blob
key, but `collect_inventory` runs everywhere). Keeping it `--with-tcp`
opt-in avoids changing default runtime behavior; happy to adjust the
gating if a different default is preferred.
