### PR TITLE
Add --enable-test-build and revive pnet/simptest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,35 @@ working on by running `make install` **inside that component's
 directory** (e.g. `src/mca/pnet/tcp/`), instead of rebuilding the entire
 tree.
 
+### Compile-checking the environment-specific components (`--enable-test-build`)
+
+Many components only build when a piece of hardware, a fabric, or an
+optional third-party library is present — the GPU vendor components
+(`pgpu/{amd,intel,nvd}`), some transports (`pnet/nvd`, and the opt-in
+`pnet/tcp`), the test components (`pgpu/test`), and the library wrappers
+(`pcompress/{zlib,zlibng}`, `plog/smtp`, `psec/munge`). On a machine that
+lacks those dependencies, that code is silently left out of the build and
+never gets compiler coverage. (The one deliberate exception is
+`pnet/simptest`, which is stale and does not compile against the current
+interface; it stays behind `--with-simptest` until it is ported.)
+
+Configuring with `--enable-test-build` force-builds **all** of those
+components so they can be compile-checked (this is what CI uses to keep
+them warning-free). It defines the `PMIX_TESTBUILD` macro to `1`.
+Components that need a third-party header that may be absent are written
+to include a non-functional **shim** header under `#if PMIX_TESTBUILD`
+instead of the real one (see, e.g.,
+[`src/mca/pcompress/zlib/testbuild_zlib.h`](src/mca/pcompress/zlib/testbuild_zlib.h)
+or the in-source stub block in
+[`src/mca/psec/munge/psec_munge.c`](src/mca/psec/munge/psec_munge.c)),
+so they still compile. **The resulting library is only good for verifying
+that the code compiles — the shimmed components are non-functional — so
+never install a test-build for real use.** When you add a new
+environment-specific component that wraps an optional library, follow the
+same pattern: gate its `configure.m4` with `|| test "$pmix_testbuild" =
+"1"`, and guard its third-party include with `#if PMIX_TESTBUILD` against
+a shim header you ship in the component's `EXTRA_DIST`.
+
 ## Modifying the configure / build system
 
 Editing the build system means regenerating it — `make` alone can't,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,13 +357,11 @@ tree.
 
 Many components only build when a piece of hardware, a fabric, or an
 optional third-party library is present — the GPU vendor components
-(`pgpu/{amd,intel,nvd}`), some transports (`pnet/nvd`, and the opt-in
-`pnet/tcp`), the test components (`pgpu/test`), and the library wrappers
-(`pcompress/{zlib,zlibng}`, `plog/smtp`, `psec/munge`). On a machine that
-lacks those dependencies, that code is silently left out of the build and
-never gets compiler coverage. (The one deliberate exception is
-`pnet/simptest`, which is stale and does not compile against the current
-interface; it stays behind `--with-simptest` until it is ported.)
+(`pgpu/{amd,intel,nvd}`), some transports (`pnet/nvd` and the opt-in
+`pnet/{simptest,tcp}`), the test components (`pgpu/test`), and the library
+wrappers (`pcompress/{zlib,zlibng}`, `plog/smtp`, `psec/munge`). On a
+machine that lacks those dependencies, that code is silently left out of
+the build and never gets compiler coverage.
 
 Configuring with `--enable-test-build` force-builds **all** of those
 components so they can be compile-checked (this is what CI uses to keep

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1444,6 +1444,42 @@ fi
 AM_CONDITIONAL(MCA_BUILD_PSEC_DUMMY_HANDSHAKE, test "$DISABLE_psec_dummy_handshake" = "0")
 
 #
+# Do we want to force-build all the test and environment-specific
+# components so they can be compile-checked?
+#
+# Normally, environment-specific components (e.g., the GPU vendor
+# components, or the transports that require a particular fabric) and
+# the components that wrap an optional third-party library (e.g.,
+# zlib/zlib-ng, libesmtp, MUNGE) only build when their supporting
+# hardware, headers, or libraries are detected. That leaves those code
+# paths silently out of the build - and therefore untested by CI - on
+# machines that lack the dependency. Setting --enable-test-build forces
+# every such component into the build. Components that need a
+# third-party header that may be absent supply a non-functional
+# "testbuild" shim header (see, e.g., src/mca/pcompress/zlib) so they
+# still compile. The resulting library is only good for verifying that
+# the code compiles - the shimmed components are not functional - so
+# this option is intended for developers and CI, not production.
+#
+AC_MSG_CHECKING([if want to test-build all components])
+AC_ARG_ENABLE([test-build],
+    [AS_HELP_STRING([--enable-test-build],
+        [Force-build all test and environment-specific components (including those that wrap an optional third-party library, using non-functional shim headers where needed) so they can be compile-checked. The resulting components are not functional; intended for developers and CI (default: disabled)])])
+if test "$enable_test_build" = "yes"; then
+    AC_MSG_RESULT([yes])
+    pmix_testbuild=1
+    pmix_testbuild_msg=yes
+else
+    AC_MSG_RESULT([no])
+    pmix_testbuild=0
+    pmix_testbuild_msg=no
+fi
+AC_DEFINE_UNQUOTED([PMIX_TESTBUILD], [$pmix_testbuild],
+                   [Force-build all test and environment-specific components using shim headers where needed])
+
+PMIX_SUMMARY_ADD([Miscellaneous], [Test build all components], [], [$pmix_testbuild_msg])
+
+#
 # Do we want to enable IPv6 support?
 #
 AC_MSG_CHECKING([if want IPv6 support])

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,16 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Added the --enable-test-build configure option. It force-builds the
+   test and environment-specific components - the GPU vendor components,
+   the NVIDIA and TCP transports, the pgpu test component, and the
+   optional-library wrappers (zlib, zlib-ng, libesmtp, MUNGE) - so they
+   can be compile-checked on a machine that lacks the supporting hardware
+   or libraries. Components that need a third-party header supply a
+   non-functional shim header used under the resulting PMIX_TESTBUILD
+   macro. The option is intended for developers and CI: the shimmed
+   components are not functional, so a test-build must not be installed
+   for real use
  - PMIx_Load_topology no longer leaks the source string. When the caller
    does not request a specific source, the returned topology's source
    field now points to a read-only, statically allocated string instead

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -9,7 +9,7 @@ series, in reverse chronological order.
 Detailed changes since v6.1.0:
  - Added the --enable-test-build configure option. It force-builds the
    test and environment-specific components - the GPU vendor components,
-   the NVIDIA and TCP transports, the pgpu test component, and the
+   the NVIDIA/simptest/TCP transports, the pgpu test component, and the
    optional-library wrappers (zlib, zlib-ng, libesmtp, MUNGE) - so they
    can be compile-checked on a machine that lacks the supporting hardware
    or libraries. Components that need a third-party header supply a
@@ -17,6 +17,13 @@ Detailed changes since v6.1.0:
    macro. The option is intended for developers and CI: the shimmed
    components are not functional, so a test-build must not be installed
    for real use
+ - Revived the pnet/simptest test fabric component. It had grown stale
+   (its module signatures and internal node struct no longer matched the
+   pnet interface) and no longer compiled; it has been ported to the
+   current interface and once again drives the static endpoint/coordinate
+   assignment path end-to-end. Fabric endpoints are delivered as per-proc
+   data and fabric coordinates as per-node info, matching how PMIx_Get
+   resolves each
  - PMIx_Load_topology no longer leaks the source string. When the caller
    does not request a specific source, the returned topology's source
    field now points to a read-only, statically allocated string instead

--- a/src/mca/pcompress/zlib/Makefile.am
+++ b/src/mca/pcompress/zlib/Makefile.am
@@ -14,6 +14,9 @@
 
 AM_CPPFLAGS = $(pcompress_zlib_CPPFLAGS)
 
+# Non-functional shim used only under --enable-test-build; always shipped
+EXTRA_DIST = testbuild_zlib.h
+
 sources = \
         compress_zlib.h \
         compress_zlib_component.c \

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -25,7 +25,11 @@
 #if HAVE_UNISTD_H
 #    include <unistd.h>
 #endif /* HAVE_UNISTD_H */
-#include <zlib.h>
+#if PMIX_TESTBUILD
+#    include "testbuild_zlib.h"
+#else
+#    include <zlib.h>
+#endif
 
 #include "src/include/pmix_stdint.h"
 #include "src/util/pmix_argv.h"

--- a/src/mca/pcompress/zlib/configure.m4
+++ b/src/mca/pcompress/zlib/configure.m4
@@ -41,8 +41,11 @@ AC_DEFUN([MCA_pmix_pcompress_zlib_CONFIG],[
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi
 
+    # --enable-test-build force-builds this component (against the
+    # non-functional testbuild_zlib.h shim if the real headers are
+    # absent) so it can be compile-checked.
     AC_MSG_CHECKING([will zlib support be built])
-    AS_IF([test "$pmix_zlib_support" = "1"],
+    AS_IF([test "$pmix_zlib_support" = "1" || test "$pmix_testbuild" = "1"],
           [$1
            AC_MSG_RESULT([yes])],
           [$2

--- a/src/mca/pcompress/zlib/testbuild_zlib.h
+++ b/src/mca/pcompress/zlib/testbuild_zlib.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Non-functional "test build" shim for the subset of the zlib API used
+ * by this component. It is included in place of the real <zlib.h> only
+ * when the library is configured with --enable-test-build (PMIX_TESTBUILD)
+ * so that the component can be compile-checked on a machine that lacks
+ * the zlib development headers. The stubs return placeholder values and
+ * do NOT perform any compression - a component built against this shim is
+ * not functional.
+ */
+
+#ifndef PMIX_PCOMPRESS_ZLIB_TESTBUILD_H
+#define PMIX_PCOMPRESS_ZLIB_TESTBUILD_H
+
+#include "pmix_config.h"
+
+#include <stdint.h>
+
+#define Z_OK         0
+#define Z_STREAM_END 1
+#define Z_FINISH     4
+
+typedef struct {
+    uint8_t *next_in;
+    unsigned int avail_in;
+    uint8_t *next_out;
+    unsigned int avail_out;
+} z_stream;
+
+static inline int deflateInit(z_stream *strm, int level)
+{
+    (void) strm;
+    (void) level;
+    return Z_OK;
+}
+
+static inline unsigned long deflateBound(z_stream *strm, unsigned long sourceLen)
+{
+    (void) strm;
+    return sourceLen;
+}
+
+static inline int deflate(z_stream *strm, int flush)
+{
+    (void) strm;
+    (void) flush;
+    return Z_STREAM_END;
+}
+
+static inline int deflateEnd(z_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+static inline int inflateInit(z_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+static inline int inflate(z_stream *strm, int flush)
+{
+    (void) strm;
+    (void) flush;
+    return Z_STREAM_END;
+}
+
+static inline int inflateEnd(z_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+#endif /* PMIX_PCOMPRESS_ZLIB_TESTBUILD_H */

--- a/src/mca/pcompress/zlibng/Makefile.am
+++ b/src/mca/pcompress/zlibng/Makefile.am
@@ -14,6 +14,9 @@
 
 AM_CPPFLAGS = $(pcompress_zlibng_CPPFLAGS)
 
+# Non-functional shim used only under --enable-test-build; always shipped
+EXTRA_DIST = testbuild_zlibng.h
+
 sources = \
         compress_zlibng.h \
         compress_zlibng_component.c \

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -25,7 +25,11 @@
 #if HAVE_UNISTD_H
 #    include <unistd.h>
 #endif /* HAVE_UNISTD_H */
-#include <zlib-ng.h>
+#if PMIX_TESTBUILD
+#    include "testbuild_zlibng.h"
+#else
+#    include <zlib-ng.h>
+#endif
 
 #include "src/include/pmix_stdint.h"
 #include "src/util/pmix_argv.h"

--- a/src/mca/pcompress/zlibng/configure.m4
+++ b/src/mca/pcompress/zlibng/configure.m4
@@ -41,8 +41,11 @@ AC_DEFUN([MCA_pmix_pcompress_zlibng_CONFIG],[
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi
 
+    # --enable-test-build force-builds this component (against the
+    # non-functional testbuild_zlibng.h shim if the real headers are
+    # absent) so it can be compile-checked.
     AC_MSG_CHECKING([will zlib-ng support be built])
-    AS_IF([test "$pmix_zlibng_support" = "1"],
+    AS_IF([test "$pmix_zlibng_support" = "1" || test "$pmix_testbuild" = "1"],
           [$1
            AC_MSG_RESULT([yes])],
           [$2

--- a/src/mca/pcompress/zlibng/testbuild_zlibng.h
+++ b/src/mca/pcompress/zlibng/testbuild_zlibng.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Non-functional "test build" shim for the subset of the zlib-ng API
+ * used by this component. It is included in place of the real
+ * <zlib-ng.h> only when the library is configured with
+ * --enable-test-build (PMIX_TESTBUILD) so that the component can be
+ * compile-checked on a machine that lacks the zlib-ng development
+ * headers. The stubs return placeholder values and do NOT perform any
+ * compression - a component built against this shim is not functional.
+ */
+
+#ifndef PMIX_PCOMPRESS_ZLIBNG_TESTBUILD_H
+#define PMIX_PCOMPRESS_ZLIBNG_TESTBUILD_H
+
+#include "pmix_config.h"
+
+#include <stdint.h>
+
+#define Z_OK         0
+#define Z_STREAM_END 1
+#define Z_FINISH     4
+
+typedef struct {
+    uint8_t *next_in;
+    unsigned int avail_in;
+    uint8_t *next_out;
+    unsigned int avail_out;
+} zng_stream;
+
+static inline int zng_deflateInit(zng_stream *strm, int level)
+{
+    (void) strm;
+    (void) level;
+    return Z_OK;
+}
+
+static inline unsigned long zng_deflateBound(zng_stream *strm, unsigned long sourceLen)
+{
+    (void) strm;
+    return sourceLen;
+}
+
+static inline int zng_deflate(zng_stream *strm, int flush)
+{
+    (void) strm;
+    (void) flush;
+    return Z_STREAM_END;
+}
+
+static inline int zng_deflateEnd(zng_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+static inline int zng_inflateInit(zng_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+static inline int zng_inflate(zng_stream *strm, int flush)
+{
+    (void) strm;
+    (void) flush;
+    return Z_STREAM_END;
+}
+
+static inline int zng_inflateEnd(zng_stream *strm)
+{
+    (void) strm;
+    return Z_OK;
+}
+
+#endif /* PMIX_PCOMPRESS_ZLIBNG_TESTBUILD_H */

--- a/src/mca/pgpu/amd/configure.m4
+++ b/src/mca/pgpu/amd/configure.m4
@@ -22,12 +22,14 @@
 AC_DEFUN([MCA_pmix_pgpu_amd_CONFIG],[
     AC_CONFIG_FILES([src/mca/pgpu/amd/Makefile])
 
-    AS_IF([test "yes" = "no"],
+    # No real AMD/ROCm-runtime detection exists yet, so this component
+    # only builds under --enable-test-build for compile coverage.
+    AS_IF([test "$pmix_testbuild" = "1"],
           [$1
            pmix_pgpu_amd_happy=yes],
           [$2
            pmix_pgpu_amd_happy=no])
 
-    PMIX_SUMMARY_ADD([GPUs], [AMD], [],[$pmix_pgpu_amd_happy])])])
+    PMIX_SUMMARY_ADD([GPUs], [AMD], [],[$pmix_pgpu_amd_happy])
 ])
 

--- a/src/mca/pgpu/intel/configure.m4
+++ b/src/mca/pgpu/intel/configure.m4
@@ -26,7 +26,9 @@ AC_DEFUN([MCA_pmix_pgpu_intel_CONFIG],[
 
 # eventually need to check for L0 library
 
-    AS_IF([test "yes" = "no"],
+    # No real Intel L0-runtime detection exists yet, so this component
+    # only builds under --enable-test-build for compile coverage.
+    AS_IF([test "$pmix_testbuild" = "1"],
           [$1
           pmix_pgpu_intel_happy=yes],
           [$2

--- a/src/mca/pgpu/nvd/configure.m4
+++ b/src/mca/pgpu/nvd/configure.m4
@@ -22,12 +22,14 @@
 AC_DEFUN([MCA_pmix_pgpu_nvd_CONFIG],[
     AC_CONFIG_FILES([src/mca/pgpu/nvd/Makefile])
 
-    AS_IF([test "yes" = "no"],
+    # No real NVIDIA-runtime detection exists yet, so this component
+    # only builds under --enable-test-build for compile coverage.
+    AS_IF([test "$pmix_testbuild" = "1"],
           [$1
            pmix_pgpu_nvd_happy=yes],
           [$2
            pmix_pgpu_nvd_happy=no])
 
-    PMIX_SUMMARY_ADD([GPUs], [NVIDIA], [], [$pmix_pgpu_nvd_happy])])])
+    PMIX_SUMMARY_ADD([GPUs], [NVIDIA], [], [$pmix_pgpu_nvd_happy])
 ])
 

--- a/src/mca/pgpu/test/configure.m4
+++ b/src/mca/pgpu/test/configure.m4
@@ -23,7 +23,8 @@ AC_DEFUN([MCA_pmix_pgpu_test_CONFIG], [
                                 [Build the pgpu test component used to exercise the GPU setup path (default: no)])],
                 [pmix_want_pgpu_test=yes], [pmix_want_pgpu_test=no])
 
-    AS_IF([test "$pmix_want_pgpu_test" = "yes"],
+    # --enable-test-build force-builds this component for compile coverage
+    AS_IF([test "$pmix_want_pgpu_test" = "yes" || test "$pmix_testbuild" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/plog/smtp/Makefile.am
+++ b/src/mca/plog/smtp/Makefile.am
@@ -22,6 +22,9 @@
 
 AM_CPPFLAGS = $(plog_smtp_CPPFLAGS)
 
+# Non-functional shim used only under --enable-test-build; always shipped
+EXTRA_DIST = testbuild_libesmtp.h
+
 sources = \
         plog_smtp.h \
         plog_smtp.c \

--- a/src/mca/plog/smtp/configure.m4
+++ b/src/mca/plog/smtp/configure.m4
@@ -47,8 +47,11 @@ AC_DEFUN([MCA_pmix_plog_smtp_CONFIG], [
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi
 
+    # --enable-test-build force-builds this component (against the
+    # non-functional testbuild_libesmtp.h shim if the real headers are
+    # absent) so it can be compile-checked.
     AC_MSG_CHECKING([will smtp support be built])
-    AS_IF([test "$pmix_smtp_support" = "1"],
+    AS_IF([test "$pmix_smtp_support" = "1" || test "$pmix_testbuild" = "1"],
           [$1
            AC_MSG_RESULT([yes])],
           [$2

--- a/src/mca/plog/smtp/plog_smtp.h
+++ b/src/mca/plog/smtp/plog_smtp.h
@@ -27,7 +27,11 @@
 
 #include <netdb.h>
 
-#include "libesmtp.h"
+#if PMIX_TESTBUILD
+#    include "testbuild_libesmtp.h"
+#else
+#    include "libesmtp.h"
+#endif
 
 #include "src/mca/plog/plog.h"
 

--- a/src/mca/plog/smtp/testbuild_libesmtp.h
+++ b/src/mca/plog/smtp/testbuild_libesmtp.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Non-functional "test build" shim for the subset of the libesmtp API
+ * used by this component. It is included in place of the real
+ * <libesmtp.h> only when the library is configured with
+ * --enable-test-build (PMIX_TESTBUILD) so that the component can be
+ * compile-checked on a machine that lacks the libesmtp development
+ * headers. The stubs return placeholder values and do NOT send any
+ * email - a component built against this shim is not functional.
+ */
+
+#ifndef PMIX_PLOG_SMTP_TESTBUILD_H
+#define PMIX_PLOG_SMTP_TESTBUILD_H
+
+#include "pmix_config.h"
+
+#include <stdlib.h>
+
+typedef struct pmix_testbuild_smtp_session *smtp_session_t;
+typedef struct pmix_testbuild_smtp_message *smtp_message_t;
+typedef struct pmix_testbuild_smtp_recipient *smtp_recipient_t;
+
+typedef const char *(*smtp_messagecb_t)(void **buf, int *len, void *arg);
+
+static inline smtp_session_t smtp_create_session(void)
+{
+    return NULL;
+}
+
+static inline smtp_message_t smtp_add_message(smtp_session_t session)
+{
+    (void) session;
+    return NULL;
+}
+
+static inline int smtp_set_server(smtp_session_t session, const char *hostport)
+{
+    (void) session;
+    (void) hostport;
+    return 1;
+}
+
+static inline int smtp_set_reverse_path(smtp_message_t message, const char *mailbox)
+{
+    (void) message;
+    (void) mailbox;
+    return 1;
+}
+
+static inline int smtp_set_header(smtp_message_t message, const char *header, ...)
+{
+    (void) message;
+    (void) header;
+    return 1;
+}
+
+static inline smtp_recipient_t smtp_add_recipient(smtp_message_t message, const char *mailbox)
+{
+    (void) message;
+    (void) mailbox;
+    return NULL;
+}
+
+static inline int smtp_set_messagecb(smtp_message_t message, smtp_messagecb_t cb, void *arg)
+{
+    (void) message;
+    (void) cb;
+    (void) arg;
+    return 1;
+}
+
+static inline int smtp_start_session(smtp_session_t session)
+{
+    (void) session;
+    return 1;
+}
+
+static inline void smtp_destroy_session(smtp_session_t session)
+{
+    (void) session;
+}
+
+static inline int smtp_errno(void)
+{
+    return 0;
+}
+
+static inline char *smtp_strerror(int e, char *buf, size_t buflen)
+{
+    (void) e;
+    (void) buflen;
+    return buf;
+}
+
+static inline int smtp_version(void *buf, size_t len, int what)
+{
+    (void) what;
+    if (NULL != buf && 0 < len) {
+        ((char *) buf)[0] = '\0';
+    }
+    return 0;
+}
+
+#endif /* PMIX_PLOG_SMTP_TESTBUILD_H */

--- a/src/mca/pnet/AGENTS.md
+++ b/src/mca/pnet/AGENTS.md
@@ -67,14 +67,13 @@ interface but is **opt-in** — its `configure.m4` is guarded by
 and is selected on **every** server (its entry points then self-gate on
 role / blob key). [`nvd`](nvd/AGENTS.md) is hardwired **off** in its
 `configure.m4` (see [Building](#building)), and
-[`simptest`](simptest/AGENTS.md) builds only with `--with-simptest` and is
-**stale** — its module functions no longer match the current
-`pmix_pnet_module_t` interface and it references base symbols that no
-longer exist, so it would not compile against today's tree (this is
-invisible in CI precisely because it is not built). Treat the shipped
-components as two current examples (`opa` built by default, `tcp` opt-in
-via `--with-tcp`), one current-but-disabled example (`nvd`), and one stale
-example (`simptest`). See each component's `AGENTS.md` for specifics, and
+[`simptest`](simptest/AGENTS.md) is a working test fabric that builds with
+`--with-simptest` or `--enable-test-build`; it compiles against the
+current interface and drives the assign → cache → `PMIx_Get` path
+end-to-end (exercised by `test/simple/simpcoord.c`). Treat the shipped
+components as three current examples (`opa` built by default, `tcp` and
+`simptest` opt-in) and one current-but-disabled example (`nvd`). See each
+component's `AGENTS.md` for specifics, and
 do not assume any of them reflects a supported, exercised code path.
 
 ## Single-select vs. multi-select
@@ -269,7 +268,7 @@ src/mca/pnet/
 │   └── pnet_base_fns.c     the pmix_pnet_base_* fan-out functions
 ├── nvd/                    Mellanox/NVIDIA example (current interface, disabled in build)
 ├── opa/                    Omni-Path example (default-built; hwloc-gated at runtime)
-├── simptest/               static-endpoint test example (stale; --with-simptest only)
+├── simptest/               static-endpoint test example (working; --with-simptest / --enable-test-build)
 └── tcp/                    static TCP/UDP port example (--with-tcp; no hardware gate)
 ```
 
@@ -304,8 +303,8 @@ are unusually blunt about it:
 - **`nvd`** — `AS_IF([test "yes" = "no"], …)`, i.e. the "can-compile"
   branch is never taken: **never built**. Its `Makefile` is still
   generated, but the source is not compiled into the library.
-- **`simptest`** — built only when `--with-simptest` is passed to
-  `configure`.
+- **`simptest`** — built when `--with-simptest` is passed to `configure`,
+  or force-built for compile coverage by `--enable-test-build`.
 
 Each component reports its state through `PMIX_SUMMARY_ADD([Transports],
 …)`, so `configure`'s summary shows `NVIDIA`, `OmniPath`, `Simptest`,
@@ -324,24 +323,23 @@ that keeps `nvd` out of the library today).
 
 ## When working in this framework
 
-- **`opa` and `tcp` are the current references.** Both compile against
-  today's interface. `opa` is built by default but only *runs* on
+- **`opa`, `tcp`, and `simptest` are the current references.** All compile
+  against today's interface. `opa` is built by default but only *runs* on
   Omni-Path hardware; `tcp` is opt-in (`--with-tcp`) and, once built, has
-  no hardware gate so it always selects. `nvd` matches the current
-  interface but is not built. `simptest` is stale (see below) and builds
-  only with `--with-simptest`. Read `opa` or `tcp` first if you need a
-  template.
-- **Know why `simptest` doesn't compile against HEAD.** Its module
-  functions use signatures from an older `pmix_pnet_module_t` (e.g. a
-  `setup_fork` module slot that no longer exists, inventory functions that
-  still take `pmix_inventory_cbfunc_t`/`pmix_op_cbfunc_t` callbacks, a
-  `setup_local_network` taking `pmix_namespace_t *`). `tcp` used to share
-  these problems and additionally referenced base symbols
-  (`pmix_pnet_globals.nodes`, `pmix_pnet_node_t`, `pmix_pnet_resource_t`)
-  that no longer exist; it has since been ported to the current interface
-  (its inventory archive now lives in a component-local tree). If you
-  resurrect `simptest`, port it the same way — do not "fix" the framework
-  header to match a stale component.
+  no hardware gate so it always selects; `simptest` is opt-in
+  (`--with-simptest` / `--enable-test-build`) and drives the
+  endpoint/coordinate assignment path without real hardware. `nvd` matches
+  the current interface but is not built. Read `opa` or `tcp` first if you
+  need a template, or `simptest` for the static assign → cache → `Get`
+  flow.
+- **`simptest` shows the per-proc vs. per-node split.** Fabric endpoints
+  (`PMIX_FABRIC_ENDPT`) are per-process data, fetched by rank, so they go
+  in a `PMIX_PROC_DATA` array; fabric coordinates
+  (`PMIX_FABRIC_COORDINATES`) are per-node, fetched at the node level
+  (rank `PMIX_RANK_UNDEF`), so they must be delivered in a
+  `PMIX_NODE_INFO_ARRAY` rather than proc data or the client's `PMIx_Get`
+  will not find them. This mirrors how a real fabric component must split
+  the two.
 - **`setup_fork` is base-only.** If a component needs an envar in the
   child's environment, it must add it to the namespace's envar cache
   during `setup_local_network` (append a `pmix_envar_list_item_t` to

--- a/src/mca/pnet/nvd/configure.m4
+++ b/src/mca/pnet/nvd/configure.m4
@@ -24,7 +24,9 @@ AC_DEFUN([MCA_pmix_pnet_nvd_CONFIG],[
 
     AC_CONFIG_FILES([src/mca/pnet/nvd/Makefile])
 
-    AS_IF([test "yes" = "no"],
+    # No real NVIDIA-transport detection exists yet, so this component
+    # only builds under --enable-test-build for compile coverage.
+    AS_IF([test "$pmix_testbuild" = "1"],
           [$1
            pmix_nvd_happy=yes],
           [$2

--- a/src/mca/pnet/simptest/AGENTS.md
+++ b/src/mca/pnet/simptest/AGENTS.md
@@ -127,7 +127,21 @@ is a recognizable placeholder.
   e.g. `PMIX_MCA_pnet=simptest
   PMIX_MCA_pnet_simptest_config_file=topo.txt ./simptest -n 2 -e
   ./simpcoord`, where `topo.txt` lists one `nodename coord...` line per
-  node (the node name must match the launcher's node map).
+  node.
+- **The config-file node names must match the launcher's node map.**
+  `allocate` looks up each node from the `PMIX_NODE_MAP` in `mynodes` by
+  exact name (`strcmp`), so a name in the topology file that does not
+  appear in the job's node map is silently skipped and its procs get no
+  fabric data. This is intrinsic to a topology-description file - it names
+  the real nodes the RM placed the job on - not a bug to fix. Note the
+  node map may carry the **short** host name (e.g. `node01`) while the OS
+  reports an FQDN; use whatever name the launcher's node map uses. (The
+  per-node coordinate is tagged with that same config name as its
+  `PMIX_HOSTNAME`; the backend GDS reconciles short-name/FQDN/alias
+  differences when it matches the node-info to the local node, so the
+  coordinate still resolves on the compute node.) With
+  `test/simple/simptest` the map is generated from the local host, so the
+  topology file needs a single line for this node.
 - **Editing the help text** (`help-pnet-simptest.txt`) requires the
   regenerate-help golden rule: `rm src/util/pmix_show_help_content.* &&
   make`.

--- a/src/mca/pnet/simptest/AGENTS.md
+++ b/src/mca/pnet/simptest/AGENTS.md
@@ -17,13 +17,14 @@ can be exercised without real fabric hardware. Read the framework
 [`AGENTS.md`](../AGENTS.md) first; this file covers only what is specific
 to `simptest`.
 
-**Status warning:** `simptest` builds only with `--with-simptest`, and in
-its current form it is **stale** — its `setup_local_network` signature
-does not match the current `pmix_pnet_module_t`, and its module body
-references struct fields (`nd->coord`, `nd->endpt`) that its own
-`pnet_node_t` definition does not contain. As written it would not compile
-even with `--with-simptest`. Treat it as an illustrative sketch of the
-static-endpoint assignment flow, not as working test infrastructure.
+**Status:** `simptest` builds with either `--with-simptest` or
+`--enable-test-build`, and it is **working** — it compiles against the
+current `pmix_pnet_module_t` interface and drives the full
+assign → pack → cache → `PMIx_Get` path end-to-end (exercised by the
+[`test/simple/simpcoord.c`](../../../../test/simple/simpcoord.c) client,
+which retrieves the assigned endpoints and coordinates). It was
+previously stale (signature drift plus an internal `pnet_node_t`
+field mismatch) and has been ported back to the live interface.
 
 ## Files
 
@@ -60,45 +61,73 @@ pmix_pnet_module_t pmix_simptest_module = {
 };
 ```
 
-Note `setup_local_network` here is written as
-`(pmix_namespace_t *nptr, …)`, which does **not** match the current
-typedef's `pmix_nspace_env_cache_t *` — one of the reasons the file is
-stale.
+`setup_local_network` takes the current typedef's
+`pmix_nspace_env_cache_t *nptr`; the underlying `pmix_namespace_t *` is
+reached as `nptr->ns` when caching.
 
-## What the code is trying to do
+## The `pnet_node_t` topology cache
+
+Each line of the config file becomes one `pnet_node_t`:
+
+```c
+typedef struct {
+    pmix_list_item_t super;
+    char *name;             // node name (first token on the line)
+    pmix_coord_t coord;     // fabric coordinate (remaining integer tokens)
+    pmix_byte_object_t endpt;  // synthesized endpoint string
+} pnet_node_t;
+```
+
+`simptest_init` fills `coord` from the parsed integer vector (as
+`uint32_t` values, logical view) and synthesizes `endpt` as the string
+`"simptest.endpt.<name>"` — simptest has no real fabric, so the endpoint
+is a recognizable placeholder.
+
+## What the code does
 
 - **`simptest_init`** reads the `config_file` line by line (skipping
-  `#` comments), building a `mynodes` list of `pnet_node_t` — one per
-  node, each with a name and an integer coordinate vector parsed from the
-  rest of the line. Missing file → `show_help("help-pnet-simptest.txt",
-  "missing-file", …)`.
+  `#` comments), building the `mynodes` list. Missing file →
+  `show_help("help-pnet-simptest.txt", "missing-file", …)`.
 - **`allocate`** (scheduler only) parses `PMIX_PROC_MAP` and
   `PMIX_NODE_MAP` via `pmix_preg.parse_procs` / `parse_nodes`, then for
-  each node assigns every local rank a `PMIX_PROC_DATA` array holding its
-  rank, a `PMIX_FABRIC_COORDINATE`, and a `PMIX_FABRIC_ENDPT`. The kvals
-  are packed under `PMIX_ALLOC_FABRIC_ENDPTS` into a
-  `"pmix-pnet-simptest-blob"` byte object appended to `ilist`. It returns
-  `PMIX_ERR_TAKE_NEXT_OPTION` when no proc/node map is present.
-- **`setup_local_network`** finds `"pmix-pnet-simptest-blob"`, unpacks the
-  kvals, and for `PMIX_ALLOC_FABRIC_ENDPTS` caches the per-rank endpoint /
-  coordinate arrays as job info via `PMIX_GDS_CACHE_JOB_INFO`.
+  each node emits **two** kinds of data into the blob:
+  - a `PMIX_ALLOC_FABRIC_ENDPTS` kval whose value is a `PMIX_PROC_DATA`
+    array — one entry per local rank holding the rank and its
+    `PMIX_FABRIC_ENDPT` (a data array of byte objects). The endpoint is
+    **per-process** data, fetched by rank.
+  - a `PMIX_NODE_INFO_ARRAY` kval tagging this node (`PMIX_HOSTNAME`)
+    with its `PMIX_FABRIC_COORDINATES` (a data array of `pmix_coord_t`).
+    The coordinate is a **per-node** attribute — `PMIX_FABRIC_COORDINATES`
+    is fetched at the node level (rank `PMIX_RANK_UNDEF`), not by rank, so
+    it must be delivered as node info rather than proc data.
 
-The `pnet_node_t` destructor frees `pmix_geometry_t` devices,
-`pmix_endpoint_t` endpts, and `pmix_device_distance_t` distances — but the
-`allocate`/`init` code instead reads/writes `nd->coord` and `nd->endpt`,
-fields the struct does not declare. That mismatch is the concrete bug that
-prevents compilation.
+  All kvals are packed under a `"pmix-pnet-simptest-blob"` byte object
+  appended to `ilist`. It returns `PMIX_ERR_TAKE_NEXT_OPTION` when no
+  proc/node map is present.
+- **`setup_local_network`** finds `"pmix-pnet-simptest-blob"`, unpacks the
+  kvals, and caches each via `PMIX_GDS_CACHE_JOB_INFO`: the
+  `PMIX_ALLOC_FABRIC_ENDPTS` proc-data becomes per-rank job info, and each
+  `PMIX_NODE_INFO_ARRAY` becomes node-level info that the GDS matches to
+  the local node. A client on that node then resolves both
+  `PMIx_Get(rank, PMIX_FABRIC_ENDPT)` and
+  `PMIx_Get(PMIX_FABRIC_COORDINATES)`.
 
 ## Gotchas
 
-- **It does not compile as-is.** Before using `simptest` for anything you
-  must reconcile the `pnet_node_t` fields (`coord`/`endpt` vs.
-  `devices`/`endpts`/`distances`) and update `setup_local_network` to the
-  current `pmix_nspace_env_cache_t *` signature.
+- **Endpoint is per-proc; coordinate is per-node.** This split is not
+  cosmetic — `PMIX_FABRIC_ENDPT` is fetched by rank while
+  `PMIX_FABRIC_COORDINATES` is fetched at the node level. Delivering the
+  coordinate as proc data (as an earlier version did) caches it under a
+  rank the client never queries, so `PMIx_Get` returns
+  `PMIX_ERR_NOT_FOUND`. Keep the coordinate in a `PMIX_NODE_INFO_ARRAY`.
 - **It is the canonical `PMIX_ALLOC_FABRIC_ENDPTS` producer.** The blob it
-  builds (rank + `PMIX_FABRIC_COORDINATE` + `PMIX_FABRIC_ENDPT` per proc)
-  is the shape a real fabric component's `allocate` should emit, so it is
-  useful as a design reference even while broken.
+  builds is the shape a real fabric component's `allocate` should emit, so
+  it is a working design reference.
+- **Running it:** select the component and point it at a topology file,
+  e.g. `PMIX_MCA_pnet=simptest
+  PMIX_MCA_pnet_simptest_config_file=topo.txt ./simptest -n 2 -e
+  ./simpcoord`, where `topo.txt` lists one `nodename coord...` line per
+  node (the node name must match the launcher's node map).
 - **Editing the help text** (`help-pnet-simptest.txt`) requires the
   regenerate-help golden rule: `rm src/util/pmix_show_help_content.* &&
   make`.

--- a/src/mca/pnet/simptest/configure.m4
+++ b/src/mca/pnet/simptest/configure.m4
@@ -20,6 +20,11 @@ AC_DEFUN([MCA_pmix_pnet_simptest_CONFIG], [
     AC_ARG_WITH([simptest], [AS_HELP_STRING([--with-simptest], [Include simptest fabric support])],
                 [pmix_want_simptest=yes], [pmix_want_simptest=no])
 
+    # NOTE: simptest is deliberately NOT wired to --enable-test-build. It
+    # is stale (its module signatures and internal struct no longer match
+    # the current pnet interface) and does not compile against HEAD;
+    # force-building it would break the test-build. It stays opt-in via
+    # --with-simptest until it is ported to the current interface.
     AS_IF([test "$pmix_want_simptest" = "yes"],
           [$1],
           [$2])

--- a/src/mca/pnet/simptest/configure.m4
+++ b/src/mca/pnet/simptest/configure.m4
@@ -20,12 +20,8 @@ AC_DEFUN([MCA_pmix_pnet_simptest_CONFIG], [
     AC_ARG_WITH([simptest], [AS_HELP_STRING([--with-simptest], [Include simptest fabric support])],
                 [pmix_want_simptest=yes], [pmix_want_simptest=no])
 
-    # NOTE: simptest is deliberately NOT wired to --enable-test-build. It
-    # is stale (its module signatures and internal struct no longer match
-    # the current pnet interface) and does not compile against HEAD;
-    # force-building it would break the test-build. It stays opt-in via
-    # --with-simptest until it is ported to the current interface.
-    AS_IF([test "$pmix_want_simptest" = "yes"],
+    # --enable-test-build force-builds this component for compile coverage
+    AS_IF([test "$pmix_want_simptest" = "yes" || test "$pmix_testbuild" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/pnet/simptest/pnet_simptest.c
+++ b/src/mca/pnet/simptest/pnet_simptest.c
@@ -41,6 +41,7 @@
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "pnet_simptest.h"
@@ -51,7 +52,8 @@ static pmix_status_t simptest_init(void);
 static void simptest_finalize(void);
 static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo,
                               pmix_list_t *ilist);
-static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo);
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr, pmix_info_t info[],
+                                         size_t ninfo);
 
 pmix_pnet_module_t pmix_simptest_module = {
     .name = "simptest",
@@ -60,38 +62,32 @@ pmix_pnet_module_t pmix_simptest_module = {
     .allocate = allocate,
     .setup_local_network = setup_local_network};
 
-/* internal tracking structures */
+/* internal tracking structures - each node in the config file is
+ * assigned a fabric coordinate (parsed from the file) and a synthetic
+ * endpoint, which are then handed out to the procs running on it */
 typedef struct {
     pmix_list_item_t super;
     char *name;
-    pmix_geometry_t *devices;
-    size_t ndevices;
-    pmix_endpoint_t *endpts;
-    size_t nendpts;
-    pmix_device_distance_t *distances;
-    size_t ndists;
+    pmix_coord_t coord;
+    pmix_byte_object_t endpt;
 } pnet_node_t;
 static void ndcon(pnet_node_t *p)
 {
     p->name = NULL;
-    p->devices = NULL;
-    p->endpts = NULL;
-    p->distances = NULL;
+    p->coord.view = PMIX_COORD_VIEW_UNDEF;
+    p->coord.coord = NULL;
+    p->coord.dims = 0;
+    PMIX_BYTE_OBJECT_CONSTRUCT(&p->endpt);
 }
 static void nddes(pnet_node_t *p)
 {
     if (NULL != p->name) {
         free(p->name);
     }
-    if (NULL != p->devices) {
-        PMIX_GEOMETRY_FREE(p->devices, p->ndevices);
+    if (NULL != p->coord.coord) {
+        free(p->coord.coord);
     }
-    if (NULL != p->endpts) {
-        PMIX_ENDPOINT_FREE(p->endpts, p->nendpts);
-    }
-    if (NULL != p->distances) {
-        PMIX_DEVICE_DIST_FREE(p->distances, p->ndists);
-    }
+    PMIX_BYTE_OBJECT_DESTRUCT(&p->endpt);
 }
 static PMIX_CLASS_INSTANCE(pnet_node_t, pmix_list_item_t, ndcon, nddes);
 
@@ -127,7 +123,7 @@ static pmix_status_t simptest_init(void)
     FILE *fp = NULL;
     char *line, **tmp;
     pnet_node_t *nd;
-    int n, cache[1024];
+    int i, n, cache[1024];
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output, "pnet: simptest init");
 
@@ -163,9 +159,19 @@ static pmix_status_t simptest_init(void)
             ++n;
         }
 
+        /* the remainder of the line is this node's fabric coordinate */
+        nd->coord.view = PMIX_COORD_LOGICAL_VIEW;
         nd->coord.dims = n;
-        nd->coord.coord = (int *) malloc(nd->coord.dims * sizeof(int));
-        memcpy(nd->coord.coord, cache, nd->coord.dims * sizeof(int));
+        if (0 < n) {
+            nd->coord.coord = (uint32_t *) malloc(n * sizeof(uint32_t));
+            for (i = 0; i < n; i++) {
+                nd->coord.coord[i] = (uint32_t) cache[i];
+            }
+        }
+        /* synthesize a fabric endpoint for this node - simptest has no
+         * real fabric, so we just fabricate a recognizable string */
+        pmix_asprintf((char **) &nd->endpt.bytes, "simptest.endpt.%s", nd->name);
+        nd->endpt.size = strlen(nd->endpt.bytes) + 1;
         free(line);
         PMIx_Argv_free(tmp);
     }
@@ -196,12 +202,13 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
     pmix_list_t mylist;
     char **locals;
     pnet_node_t *nd, *nd2;
-    pmix_kval_t *kv;
+    pmix_kval_t *kv, *kvc;
     pmix_info_t *iptr, *ip2;
-    pmix_data_array_t *darray, *d2, *d3;
+    pmix_data_array_t *darray, *d2, *d3, *dcoord, *dnode;
     pmix_rank_t rank;
     pmix_buffer_t buf;
     pmix_byte_object_t *bptr;
+    pmix_coord_t *cptr;
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:simptest:allocate for nspace %s", nptr->nspace);
@@ -291,10 +298,12 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
         kv->value->data.darray = darray;
         iptr = (pmix_info_t *) darray->array;
         for (m = 0; NULL != locals[m]; m++) {
-            /* each proc has one endpoint and one coord corresponding to the
-             * node they upon which they are executing */
+            /* each proc is assigned a fabric endpoint corresponding to
+             * the node upon which it is executing. The endpoint is
+             * per-process data (PMIX_FABRIC_ENDPT is fetched by rank),
+             * so it lives in this proc's PMIX_PROC_DATA array */
             PMIX_LOAD_KEY(iptr[m].key, PMIX_PROC_DATA);
-            PMIX_DATA_ARRAY_CREATE(d2, 3, PMIX_INFO);
+            PMIX_DATA_ARRAY_CREATE(d2, 2, PMIX_INFO);
             iptr[m].value.type = PMIX_DATA_ARRAY;
             iptr[m].value.data.darray = d2;
             ip2 = (pmix_info_t *) d2->array;
@@ -304,13 +313,11 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
                                 "pnet:simptest:allocate assigning %d endpoints for rank %u",
                                 (int) q, rank);
             PMIX_INFO_LOAD(&ip2[0], PMIX_RANK, &rank, PMIX_PROC_RANK);
-            /* the second element in this array is the coord */
-            PMIX_INFO_LOAD(&ip2[1], PMIX_FABRIC_COORDINATE, &nd->coord, PMIX_COORD);
-            /* third element is the endpt */
+            /* the second element is the endpt - a data array of byte objects */
             PMIX_DATA_ARRAY_CREATE(d3, 1, PMIX_BYTE_OBJECT);
-            PMIX_LOAD_KEY(ip2[2].key, PMIX_FABRIC_ENDPT);
-            ip2[2].value.type = PMIX_DATA_ARRAY;
-            ip2[2].value.data.darray = d3;
+            PMIX_LOAD_KEY(ip2[1].key, PMIX_FABRIC_ENDPT);
+            ip2[1].value.type = PMIX_DATA_ARRAY;
+            ip2[1].value.data.darray = d3;
             bptr = (pmix_byte_object_t *) d3->array;
             bptr[0].bytes = strdup(nd->endpt.bytes);
             bptr[0].size = nd->endpt.size;
@@ -318,6 +325,41 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
         PMIx_Argv_free(locals);
         locals = NULL;
         pmix_list_append(&mylist, &kv->super);
+
+        /* the fabric coordinate is a per-NODE attribute
+         * (PMIX_FABRIC_COORDINATES is fetched at the node level, not by
+         * rank), so deliver it inside a PMIX_NODE_INFO_ARRAY tagged with
+         * this node's name. The backend GDS will match it to the local
+         * node and hand it to every proc running there */
+        kvc = PMIX_NEW(pmix_kval_t);
+        if (NULL == kvc) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        kvc->key = strdup(PMIX_NODE_INFO_ARRAY);
+        kvc->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        if (NULL == kvc->value) {
+            PMIX_RELEASE(kvc);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        kvc->value->type = PMIX_DATA_ARRAY;
+        PMIX_DATA_ARRAY_CREATE(dnode, 2, PMIX_INFO);
+        kvc->value->data.darray = dnode;
+        ip2 = (pmix_info_t *) dnode->array;
+        PMIX_INFO_LOAD(&ip2[0], PMIX_HOSTNAME, nd->name, PMIX_STRING);
+        PMIX_DATA_ARRAY_CREATE(dcoord, 1, PMIX_COORD);
+        PMIX_LOAD_KEY(ip2[1].key, PMIX_FABRIC_COORDINATES);
+        ip2[1].value.type = PMIX_DATA_ARRAY;
+        ip2[1].value.data.darray = dcoord;
+        cptr = (pmix_coord_t *) dcoord->array;
+        cptr[0].view = nd->coord.view;
+        cptr[0].dims = nd->coord.dims;
+        if (0 < nd->coord.dims) {
+            cptr[0].coord = (uint32_t *) malloc(nd->coord.dims * sizeof(uint32_t));
+            memcpy(cptr[0].coord, nd->coord.coord, nd->coord.dims * sizeof(uint32_t));
+        }
+        pmix_list_append(&mylist, &kvc->super);
     }
 
     /* pack all our results into a buffer for xmission to the backend */
@@ -362,7 +404,8 @@ cleanup:
     return rc;
 }
 
-static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t info[], size_t ninfo)
+static pmix_status_t setup_local_network(pmix_nspace_env_cache_t *nptr, pmix_info_t info[],
+                                         size_t ninfo)
 {
     size_t n, nvals;
     pmix_buffer_t bkt;
@@ -370,9 +413,15 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
     pmix_kval_t *kv;
     pmix_status_t rc;
     pmix_info_t *iptr;
+    pmix_info_t nodeinfo;
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:simptest:setup_local_network with %lu info", (unsigned long) ninfo);
+
+    /* the value field is filled in per node-info kval below; the GDS
+     * copies the data, so a borrowed shallow value is sufficient */
+    PMIX_INFO_CONSTRUCT(&nodeinfo);
+    PMIX_LOAD_KEY(nodeinfo.key, PMIX_NODE_INFO_ARRAY);
 
     if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
@@ -402,7 +451,20 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr, pmix_info_t inf
                         pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                                             "pnet:simptest:setup_local_network caching %d endpts",
                                             (int) nvals);
-                        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, iptr, nvals);
+                        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr->ns, iptr, nvals);
+                        if (PMIX_SUCCESS != rc) {
+                            PMIX_RELEASE(kv);
+                            return rc;
+                        }
+                    } else if (PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY)) {
+                        /* per-node fabric coordinate - hand the entire
+                         * node-info array to the GDS, which will store it
+                         * as node-level info and match it to the local
+                         * node so PMIX_FABRIC_COORDINATES resolves there */
+                        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                            "pnet:simptest:setup_local_network caching node info");
+                        nodeinfo.value = *kv->value;
+                        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr->ns, &nodeinfo, 1);
                         if (PMIX_SUCCESS != rc) {
                             PMIX_RELEASE(kv);
                             return rc;

--- a/src/mca/pnet/tcp/configure.m4
+++ b/src/mca/pnet/tcp/configure.m4
@@ -19,7 +19,8 @@ AC_DEFUN([MCA_pmix_pnet_tcp_CONFIG], [
     AC_ARG_WITH([tcp], [AS_HELP_STRING([--with-tcp], [Include TCP/UDP static-port fabric support])],
                 [pmix_want_tcp=yes], [pmix_want_tcp=no])
 
-    AS_IF([test "$pmix_want_tcp" = "yes"],
+    # --enable-test-build force-builds this component for compile coverage
+    AS_IF([test "$pmix_want_tcp" = "yes" || test "$pmix_testbuild" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/psec/AGENTS.md
+++ b/src/mca/psec/AGENTS.md
@@ -342,8 +342,9 @@ are conditional:
   `OAC_CHECK_PACKAGE` for `munge.h` / `libmunge`. It is built only if
   MUNGE is present (or errors out if `--with-munge` was requested and not
   found). Its source can be *compile-tested* without the real library via
-  the `#if 0` stub block at the top of `psec_munge.c` — that block is not
-  used in real builds.
+  the `#if PMIX_TESTBUILD` stub block at the top of `psec_munge.c`
+  (activated by `--enable-test-build`) — that block is not used in real
+  builds.
 - **`dummy_handshake`** has no `configure.m4`; it is gated by the
   Automake conditional `MCA_BUILD_PSEC_DUMMY_HANDSHAKE`, set by
   `--enable-dummy-handshake` (default: disabled) in `config/pmix.m4`.

--- a/src/mca/psec/munge/AGENTS.md
+++ b/src/mca/psec/munge/AGENTS.md
@@ -98,6 +98,11 @@ each active module's `finalize`, so `mycred` is reclaimed at teardown.
   (`#include <munge.h>`). The `PMIX_TESTBUILD` macro is 0 by default and
   is set to 1 only by `--enable-test-build` (see the top-level AGENTS.md),
   so the stub is never active in a normal build. Do not hard-code the
-  guard to `#if 1` in committed code.
+  guard to `#if 1` in committed code. The stubbed `munge_encode`
+  deliberately returns a **failure** (never `EMUNGE_SUCCESS`) so that
+  `munge_init`'s liveness probe fails and the psec framework de-selects
+  MUNGE at runtime: a `--enable-test-build` library therefore falls back
+  to `native` rather than selecting a non-functional MUNGE module and
+  crashing in `create_cred` on the credential it never produced.
 - **libmunge is LGPL** (noted in the source header). Keep MUNGE behind its
   `configure.m4` gate so the dependency stays optional.

--- a/src/mca/psec/munge/AGENTS.md
+++ b/src/mca/psec/munge/AGENTS.md
@@ -91,10 +91,13 @@ each active module's `finalize`, so `mycred` is reclaimed at teardown.
 - **`munge_init` is a real dependency probe, not a formality.** It talks
   to `munged`. Returning success from it when the daemon is down would put
   a dead module in the actives list and break connections that select it.
-- **The `#if 0` stub block at the top of `psec_munge.c` is compile-test
-  scaffolding only.** It provides fake `munge_encode`/`munge_decode`/
-  `munge_strerror` so the file can be syntax-checked without libmunge; the
-  real build takes the `#else` branch (`#include <munge.h>`). Never flip
-  it to `#if 1` in committed code.
+- **The `#if PMIX_TESTBUILD` stub block at the top of `psec_munge.c` is
+  compile-test scaffolding only.** It provides fake `munge_encode`/
+  `munge_decode`/`munge_strerror` so the file can be syntax-checked
+  without libmunge; the real build takes the `#else` branch
+  (`#include <munge.h>`). The `PMIX_TESTBUILD` macro is 0 by default and
+  is set to 1 only by `--enable-test-build` (see the top-level AGENTS.md),
+  so the stub is never active in a normal build. Do not hard-code the
+  guard to `#if 1` in committed code.
 - **libmunge is LGPL** (noted in the source header). Keep MUNGE behind its
   `configure.m4` gate so the dependency stays optional.

--- a/src/mca/psec/munge/configure.m4
+++ b/src/mca/psec/munge/configure.m4
@@ -38,9 +38,12 @@ AC_DEFUN([MCA_pmix_psec_munge_CONFIG],[
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi
 
-    AS_IF([test "$psec_munge_support" != "1"],
-          [$2],
-          [$1])
+    # --enable-test-build force-builds this component (against the
+    # non-functional in-source shim in psec_munge.c if libmunge is
+    # absent) so it can be compile-checked.
+    AS_IF([test "$psec_munge_support" = "1" || test "$pmix_testbuild" = "1"],
+          [$1],
+          [$2])
 
     PMIX_SUMMARY_ADD([External Packages], [munge], [], [${psec_munge_SUMMARY}])
 

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -25,8 +25,9 @@
 #    include <sys/types.h>
 #endif
 
-// define abstractions to test compile this component
-#if 0
+// Non-functional shim so this component can be compile-checked without
+// libmunge when the library is configured with --enable-test-build.
+#if PMIX_TESTBUILD
 typedef int32_t munge_err_t;
 
 typedef struct {

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -27,6 +27,12 @@
 
 // Non-functional shim so this component can be compile-checked without
 // libmunge when the library is configured with --enable-test-build.
+// The encode/decode stubs deliberately return a failure code (never
+// EMUNGE_SUCCESS): munge_init treats a failed encode as "the munge
+// daemon is unreachable" and returns PMIX_ERR_SERVER_NOT_AVAIL, so the
+// psec framework de-selects this component at runtime. That keeps a
+// test-build library from selecting a non-functional MUNGE module and
+// crashing when it later tries to use the (never-produced) credential.
 #if PMIX_TESTBUILD
 typedef int32_t munge_err_t;
 
@@ -35,25 +41,26 @@ typedef struct {
 } munge_ctx_t;
 
 #define EMUNGE_SUCCESS 0
+#define EMUNGE_SNAFU   1
 
 static inline munge_err_t munge_encode (char **cred, munge_ctx_t *ctx,
                                         const void *buf, int len)
 {
     PMIX_HIDE_UNUSED_PARAMS(cred, ctx, buf, len);
-    return EMUNGE_SUCCESS;
+    return EMUNGE_SNAFU;
 }
 
 static inline  munge_err_t munge_decode (const char *cred, munge_ctx_t *ctx,
                                          void **buf, int *len, uid_t *uid, gid_t *gid)
 {
     PMIX_HIDE_UNUSED_PARAMS(cred, ctx, buf, len, uid, gid);
-    return EMUNGE_SUCCESS;
+    return EMUNGE_SNAFU;
 }
 
 static inline  const char * munge_strerror (munge_err_t e)
 {
     PMIX_HIDE_UNUSED_PARAMS(e);
-    return "FOO";
+    return "munge testbuild shim - not functional";
 }
 
 #else


### PR DESCRIPTION
## Summary

Adds a new `--enable-test-build` configure option that force-builds every
optional / environment-specific MCA component purely for compile coverage,
and revives the stale `pnet/simptest` test-fabric component so it compiles
and works against the current interface.

### `--enable-test-build`

Many components only build when their supporting hardware, fabric, or
optional third-party library is detected at configure time — the GPU
vendor components (`pgpu/{amd,intel,nvd}`), the NVIDIA/simptest/TCP
transports, `pgpu/test`, and the optional-library wrappers
(`pcompress/{zlib,zlibng}`, `plog/smtp`, `psec/munge`). On a machine that
lacks those dependencies the code is silently omitted from the build and
never gets compiler coverage, so bit-rot is invisible to CI.

`--enable-test-build` defines the `PMIX_TESTBUILD` macro and gates each
such component's `configure.m4` to also build when it is set. Components
that need a third-party header that may be absent include a non-functional
shim header under `#if PMIX_TESTBUILD` instead of the real one (new
`testbuild_zlib.h` / `testbuild_zlibng.h` / `testbuild_libesmtp.h`, shipped
via `EXTRA_DIST`; `psec/munge` already carried an in-source stub block, now
keyed off `PMIX_TESTBUILD` rather than a hard-coded `#if 0`). The resulting
library only verifies compilation — the shimmed components are not
functional — so it must not be installed for real use.

The `psec/munge` shim's probe deliberately returns failure so `munge_init`
de-selects the module at runtime (fallback to `native`) rather than
selecting a non-functional module and crashing.

### pnet/simptest revival

`pnet/simptest` had grown stale: its `setup_local_network` used the old
`pmix_namespace_t*` signature, and its module body read/wrote
`pnet_node_t` fields (`coord`, `endpt`) that its own struct no longer
declared, so it did not compile against HEAD. Ported it back to the live
interface:

- `pnet_node_t` now holds the `pmix_coord_t` coordinate and synthesized
  `pmix_byte_object_t` endpoint the code actually uses.
- Fabric endpoints are delivered as **per-process** data (`PMIX_FABRIC_ENDPT`
  is fetched by rank) and fabric coordinates as **per-node** info in a
  `PMIX_NODE_INFO_ARRAY` (`PMIX_FABRIC_COORDINATES` is fetched at the node
  level) — matching how `PMIx_Get` resolves each. The earlier form cached
  the coordinate under a rank the client never queries.

## Testing

- Clean warning-free build under `--enable-devel-check` with both
  `--enable-test-build` and a normal configuration.
- End-to-end verified with `test/simple/simpcoord.c`: both ranks receive
  their assigned endpoint and coordinate.
- A `--enable-test-build` install now runs without crashing (munge
  de-selects, native takes over).