### PR TITLE
Document that --enable-test-build is non-functional, and make compression tests honest under it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,22 @@ same pattern: gate its `configure.m4` with `|| test "$pmix_testbuild" =
 "1"`, and guard its third-party include with `#if PMIX_TESTBUILD` against
 a shim header you ship in the component's `EXTRA_DIST`.
 
+**Do not expect correct runtime behavior from a `--enable-test-build`
+tree, and do not run `make check` / the functional test suite against
+one.** The shims return placeholder values rather than doing real work, so
+any test that exercises a shimmed component *will* misbehave — and it is
+**expected**, not a bug to chase. A concrete example that has burned us
+before: with the `pcompress/{zlib,zlibng}` shims in place, `deflate`
+becomes a no-op, so compression produces an empty payload and a
+compression round-trip yields an empty string. That makes
+`test/unit/preg` fail its "large list" case and the `test/unit/compress`
+smoke test print `NODES ERROR` — neither indicates a real defect, only
+that a functional test was pointed at a non-functional library. Before
+investigating a failing functional test, confirm the tree was **not**
+configured with `--enable-test-build` (check `./config.status --config`
+or `grep PMIX_TESTBUILD src/include/pmix_config.h`); reproduce functional
+failures only in an ordinary build.
+
 ## Modifying the configure / build system
 
 Editing the build system means regenerating it — `make` alone can't,

--- a/test/unit/compress.c
+++ b/test/unit/compress.c
@@ -49,7 +49,8 @@
 #include "src/util/pmix_printf.h"
 
 
-static pmix_server_module_t mymodule = {
+/* Unused when PMIX_TESTBUILD short-circuits main() before server init. */
+static pmix_server_module_t mymodule __pmix_attribute_unused__ = {
     .client_connected = NULL,
     .client_finalized = NULL,
     .abort = NULL,
@@ -76,13 +77,23 @@ static pmix_server_module_t mymodule = {
 
 int main(int argc, char **argv)
 {
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+#if PMIX_TESTBUILD
+    /* This test drives real (de)compression end-to-end, but the pcompress
+     * components are non-functional shims in a --enable-test-build (see the
+     * top-level AGENTS.md): deflate/inflate are no-ops, so the round-trips
+     * cannot reproduce their input. Report the automake "skip" status (77)
+     * rather than a spurious failure. */
+    fprintf(stdout, "SKIP: compression is stubbed in --enable-test-build\n");
+    return 77;
+#else
     char **nodes = NULL, **nodesout;
     char **procs = NULL, **procsout;
     char *tmp, *regex, *ppn, *t1;
     int n, rk;
+    int errors = 0;
     pmix_status_t rc;
-    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
-
 
     /* setup the server library */
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
@@ -108,6 +119,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "NODES MATCH\n");
     } else {
         fprintf(stderr, "NODES ERROR\n");
+        errors++;
     }
     free(tmp);
     free(t1);
@@ -132,6 +144,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "PROCS MATCH\n");
     } else {
         fprintf(stderr, "PROCS ERROR\n");
+        errors++;
     }
     free(tmp);
     free(t1);
@@ -141,5 +154,6 @@ int main(int argc, char **argv)
         fprintf(stderr, "Finalize failed with error %d\n", rc);
     }
 
-    return 0;
+    return errors;
+#endif
 }

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -53,6 +53,7 @@ static pmix_server_module_t mymodule = {
 
 static int npass = 0;
 static int nfail = 0;
+static int nskip = 0;
 
 /* Report a single test result and update counters */
 static void report(const char *name, int passed)
@@ -65,6 +66,16 @@ static void report(const char *name, int passed)
         nfail++;
     }
 }
+
+#if PMIX_TESTBUILD
+/* Note a test case that cannot run in this configuration. Only needed in a
+ * --enable-test-build, where the compression-dependent case is skipped. */
+static void skipped(const char *name, const char *reason)
+{
+    fprintf(stdout, "  SKIP: %s (%s)\n", name, reason);
+    nskip++;
+}
+#endif
 
 /*
  * Round-trip helper: generate a regex from input, then parse it back and
@@ -176,7 +187,16 @@ static void test_large_list(void)
     input = PMIx_Argv_join(nodes, ',');
     PMIx_Argv_free(nodes);
 
+#if PMIX_TESTBUILD
+    /* A large, highly-compressible list is encoded via the pcompress
+     * "blob" path, but the pcompress components are non-functional shims
+     * in a --enable-test-build (see the top-level AGENTS.md): deflate is a
+     * no-op, so the round-trip cannot reproduce the input. Skip rather
+     * than report a spurious failure. */
+    skipped("large list (10000 nodes)", "compression stubbed in --enable-test-build");
+#else
     report("large list (10000 nodes)", roundtrip(input));
+#endif
     free(input);
 }
 
@@ -273,7 +293,7 @@ int main(int argc, char **argv)
     /* Structural checks */
     test_type_field_set();
 
-    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    fprintf(stdout, "\nResults: %d passed, %d failed, %d skipped\n\n", npass, nfail, nskip);
 
     PMIx_server_finalize();
 


### PR DESCRIPTION
`--enable-test-build` compiles the environment-specific components against
non-functional shim headers so they can be compile-checked where the real
dependency is absent. The shims make those components no-ops at runtime,
which is easy to forget: it sent a review down a rabbit hole chasing a
"compression bug" that was really just the `pcompress` zlib/zlibng shim's
`deflate` doing nothing.

## Documentation
- Extend the `--enable-test-build` section of the top-level `AGENTS.md`:
  do not expect correct runtime behavior from such a tree and do not run
  `make check` against one; a shimmed compressor yields an empty
  round-trip, which makes `test/unit/preg` fail its large-list case and
  `test/unit/compress` print `NODES ERROR` — expected, not a defect.
  Check `PMIX_TESTBUILD` before investigating a functional-test failure.

## Tests
- Make the compression functional tests honest under `PMIX_TESTBUILD`:
  `test/unit/compress` now returns non-zero on a real mismatch (it
  previously always returned 0, hiding regressions) and reports the
  automake skip status (77) in a test build; `test/unit/preg` skips only
  its compression-dependent large-list case and reports a skip count.
  Both stay warning-free in an ordinary build.

Verified `make check` is green in an `--enable-test-build` tree
(`compress` = SKIP, `preg` = PASS). The ordinary-build `#else` paths
should be confirmed by a normal-config CI run.