### PR TITLE
Fix defects found reviewing src/client; add orientation guide

### DIFF
--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1,0 +1,253 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PMIx Client Library
+
+This document orients AI agents and human contributors working in
+`src/client`, the client-role implementation of the PMIx APIs. It assumes
+you have already read the top-level [`AGENTS.md`](../../AGENTS.md) — the
+golden rules (prefix conventions, `pmix_config.h`-first include order,
+constant-on-the-left comparisons, brace-everything, warning-free under
+`--enable-devel-check`), the **thread-safety / progress-thread model and
+the caddy pattern**, the backward-compatibility and wire-format rules,
+and the copyright-header requirement all apply here and are not repeated.
+This file covers what is specific to `src/client`: which public API each
+file implements, the two recurring control-flow shapes (the blocking↔`_nb`
+wrapper and the PTL send/recv round-trip), the client's global state, and
+the invariants that are easy to break.
+
+Like `src/class`, **`src/client` is not an MCA framework.** There is no
+framework header, no components, no selection logic — just a set of `.c`
+files compiled straight into `libpmix` (see [Building](#building)). It
+does, however, lean heavily on nearly every framework: `ptl` for
+transport, `bfrops` for pack/unpack, `gds` for the local datastore,
+`psec` for the connection handshake, `pmdl`/`pnet` for spawn/fabric
+support, and `preg` for regex proc expansion.
+
+## What this directory is
+
+`src/client` is the code that runs inside an application process (a
+"client") that called `PMIx_Init`. It owns:
+
+- the **connection lifecycle** to the local PMIx server (`pmix_client.c`);
+- the **client half of every public `PMIx_*` operation** — get, fence,
+  publish/lookup, spawn, connect/disconnect, group, resolve, fabric,
+  topology — each of which either satisfies the request locally or packs
+  a command and round-trips to the server;
+- the client's **global state** (`pmix_client_ops.h`:
+  `pmix_client_globals`).
+
+A parallel `src/server` tree implements the server role and `src/tool`
+the tool role; the three share `src/common`, `src/include/pmix_globals.*`,
+and the frameworks. Many APIs in this directory contain role branches
+(`PMIX_PEER_IS_SERVER`, `PMIX_PEER_IS_SCHEDULER`, `PMIX_PEER_IS_TOOL`)
+because a server or tool process also links this same client code and may
+enter these entry points.
+
+## The two control-flow shapes
+
+Almost every function in this directory is an instance of one of two
+patterns. Learn to recognize them before editing.
+
+### 1. The blocking ↔ non-blocking wrapper
+
+The public API is offered in two forms: a blocking `PMIx_Foo` and a
+non-blocking `PMIx_Foo_nb` that takes a user callback. The blocking form
+is almost always a **thin wrapper** over the `_nb` form:
+
+```c
+PMIx_Foo(...) {
+    pmix_cb_t cb;                        // or PMIX_NEW(pmix_cb_t)
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    rc = PMIx_Foo_nb(..., internal_cbfunc, &cb);  // pass an internal cb
+    if (PMIX_SUCCESS != rc) { ...; return rc; }
+    PMIX_WAIT_THREAD(&cb.lock);          // block until the cb fires
+    rc = cb.status;
+    PMIX_DESTRUCT(&cb);
+    return rc;
+}
+```
+
+The internal callback (commonly `op_cbfunc` / `mycbfunc` / `wait_cbfunc`)
+records the result into the `pmix_cb_t` and calls `PMIX_WAKEUP_THREAD`.
+When `cbfunc == NULL` is passed down, the `_nb` code recognizes the
+blocking case: the caddy pointer it receives *is* the caller's stack `cb`,
+so it must **not** `PMIX_NEW` its own and must **not** `PMIX_RELEASE` it.
+Every `_nb` branch keys off `NULL != cbfunc` to decide whether to allocate
+a caddy or reuse the passed-in one — getting that test wrong frees (or
+double-frees) a stack object.
+
+> **This wrapper is *not* the "don't call thread-shifting public APIs
+> internally" hazard.** The `_nb` variants here do their work and then
+> `PMIX_PTL_SEND_RECV` (or compute locally); they do not thread-shift, so
+> a blocking wrapper calling its own `_nb` sibling is safe and is the
+> sanctioned pattern. The hazard the top-level guide warns about is
+> calling a *different* public API that posts a caddy to the progress
+> thread — e.g. calling `PMIx_Notify_event`/`PMIx_Register_event_handler`
+> and then `PMIX_WAIT_THREAD` from code that is *already on* the progress
+> thread. `pmix_client_group.c` does exactly that on the caller thread
+> during invite/join and would deadlock if driven from a handler (see its
+> own header comments).
+
+### 2. The PTL send/recv round-trip
+
+When the request cannot be answered locally, the `_nb` code:
+
+1. builds a `pmix_buffer_t` and `PMIX_BFROPS_PACK`s a command
+   (`PMIX_*_CMD`) plus the operation's arguments;
+2. allocates or reuses a `pmix_cb_t` holding the caller's callback and a
+   pointer to any output object (a `pmix_fabric_t`, a `pmix_pdata_t[]`,
+   etc. — **by pointer, not copied**, per the no-copy caddy rule);
+3. calls `PMIX_PTL_SEND_RECV(rc, myserver, msg, recv_cbfunc, cb)` — this
+   **takes ownership of `msg`** and registers `recv_cbfunc` to fire on the
+   progress thread when the server replies.
+
+`recv_cbfunc` runs on the progress thread. It first checks
+`PMIX_BUFFER_IS_EMPTY(buf)` — a **zero-byte buffer means the connection
+was lost** and the recv is being completed synthetically — then unpacks a
+`PMIX_STATUS`, then any payload, stores payload via the GDS as needed, and
+finally either invokes the user callback and `PMIX_RELEASE`s the caddy
+(non-blocking) or `PMIX_WAKEUP_THREAD`s the waiter (blocking).
+
+Getting the release/wakeup discipline right on **every** exit path
+(including the pack-failure and send-failure early returns) is where most
+of the bugs in this directory live. When a `PMIX_PTL_SEND_RECV` returns an
+error, the caddy's recv callback will *not* fire, so the send site must
+clean up the caddy itself — and then **return**, not fall through into the
+blocking wait.
+
+## The files
+
+| File | Public API | Notes |
+|------|-----------|-------|
+| `pmix_client.c` | `PMIx_Init`, `PMIx_Finalize`, `PMIx_Initialized`, `PMIx_Get_version`, `PMIx_Abort`, `PMIx_Put`, `PMIx_Commit` | Connection lifecycle; the big one. |
+| `pmix_client_get.c` | `PMIx_Get`, `PMIx_Get_nb` | Local-query parser, realm resolution, pending-request coalescing. |
+| `pmix_client_fence.c` | `PMIx_Fence`, `PMIx_Fence_nb` | Collective barrier + modex. |
+| `pmix_client_pub.c` | `PMIx_Publish[_nb]`, `PMIx_Lookup[_nb]`, `PMIx_Unpublish[_nb]` | Publish/lookup data store. |
+| `pmix_client_spawn.c` | `PMIx_Spawn`, `PMIx_Spawn_nb` | Harvests envars, deep-copies the apps array, dispatches to host/pfexec/server. |
+| `pmix_client_connect.c` | `PMIx_Connect[_nb]`, `PMIx_Disconnect[_nb]` | Collective connect; round-trips job data for all participating nspaces. |
+| `pmix_client_group.c` | `PMIx_Group_construct/destruct/invite/join/leave[_nb]` | Largest file; invite/accept handshake via events; leader-failure watches. |
+| `pmix_client_fabric.c` | `PMIx_Fabric_construct/register/update/deregister[_nb]` | Results written directly into the caller's `pmix_fabric_t`. |
+| `pmix_client_topology.c` | `PMIx_Load_topology`, `PMIx_Parse_cpuset_string`, `PMIx_Get_cpuset`, `PMIx_Get_relative_locality`, `PMIx_Compute_distances[_nb]` | Mostly synchronous hwloc pass-throughs. |
+| `pmix_client_resolve.c` | `PMIx_Resolve_peers`, `PMIx_Resolve_nodes` | Host-query → local-compute → server round-trip, with local fallback. |
+| `pmix_client_convert.c` | `pmix_client_convert_group_procs`, `pmix_client_proc_is_included` | Internal helpers: expand PMIx-group nspaces into real members. |
+| `pmix_client_ops.h` | — | Declares `pmix_client_globals` and the few cross-file helpers. |
+
+## Client global state (`pmix_client_ops.h`)
+
+`pmix_client_globals` (defined in `pmix_client.c`, declared in the header)
+is the client's singleton state, initialized with `*_STATIC_INIT` macros
+and torn down in `PMIx_Finalize`. The load-bearing fields:
+
+- **`myserver`** (`pmix_peer_t *`) — the peer object for the local server;
+  the target of every `PMIX_PTL_SEND_RECV`, `PMIX_BFROPS_PACK`, and
+  server-side `PMIX_GDS_*` call. Its `sd < 0` on the singleton path.
+- **`singleton`** and **`local_iof`** — **two independent booleans that
+  must not be conflated.** `singleton` means "no server to talk to";
+  `local_iof` means "this process constructed the server-side IOF lists."
+  Finalize must tear the IOF lists down based on `local_iof`, never on
+  `singleton`, or it will double-free or leak. See the comment blocks in
+  `PMIx_Init`/`PMIx_Finalize`. (A prior latent crash traced to exactly
+  this conflation.)
+- **`pending_requests`** (`pmix_list_t` of `pmix_cb_t`) — outstanding
+  `PMIx_Get` requests awaiting a server reply. Multiple gets for the same
+  `nspace:rank` are **coalesced**: only the first sends; the rest are
+  appended and satisfied together when the reply arrives (see
+  `pmix_client_get.c`).
+- **`groups`** (`pmix_list_t` of `pmix_group_t`) — PMIx groups this client
+  currently belongs to; consulted by `pmix_client_convert_group_procs` to
+  expand group references in collective calls.
+- **`peers`** (`pmix_pointer_array_t`) — cached peer objects for data ops.
+- **`iof_stdout` / `iof_stderr`** — the two static IOF sinks for forwarded
+  output.
+- the many `*_output` / `*_verbose` pairs — per-subsystem
+  `pmix_output_verbose` channels, so debug output for get/connect/fence/
+  pub/spawn/event/iof/group/base can be enabled independently.
+
+Cross-file helpers declared here: `pmix_parse_localquery`,
+`pmix_client_convert_group_procs`, `pmix_client_proc_is_included`, and
+`pmix_client_group_cleanup` (drains leader-watch trackers still active at
+finalize, after the progress thread has stopped).
+
+## Invariants and gotchas
+
+- **`PMIx_Init` returns `PMIX_ERR_UNREACH`, not `PMIX_SUCCESS`, on the
+  singleton path.** A process with no server still initializes; callers
+  must treat `PMIX_ERR_UNREACH` from init as "up but unconnected," not as
+  failure.
+- **A zero-byte recv buffer means the connection was lost.** Every PTL
+  recv callback must check `PMIX_BUFFER_IS_EMPTY(buf)` before unpacking.
+  Note `PMIX_BUFFER_IS_EMPTY` dereferences its argument — a NULL `buf`
+  must be guarded separately (some callbacks do, some do not — be
+  consistent when you touch one).
+- **Realm directives change where data comes from.** In `PMIx_Get`, the
+  `PMIX_NODE_INFO` / `PMIX_APP_INFO` / `PMIX_SESSION_INFO` directives and
+  the hostname/nodeid/appnum/sessionid qualifiers redirect the lookup to a
+  different realm; the parser in `process_request`/`get_data` augments the
+  info array (setting `cb->infocopy = true` so the *new* array is freed,
+  never the caller's). A **NULL key is legal** ("all data for this proc"),
+  so realm code must not assume `cb->key` is non-NULL.
+- **Local GDS fetches on the progress thread must set `PMIX_OPTIONAL`.**
+  Otherwise the GDS may try to up-call the server, which deadlocks the
+  progress thread. `pmix_client_resolve.c` relies on this.
+- **`cb->infocopy` governs info-array ownership**; `fcd->copied` governs
+  the spawn caddy's info/apps ownership; the group tracker's fields and
+  the fabric `cb->fabric` are pointer-shared with the caller. When you add
+  an allocation to a caddy, make sure the matching destructor frees it and
+  the ownership flag is actually set.
+- **`PMIX_RELEASE(x)` nulls `x`.** After releasing a caddy you cannot
+  touch it (or dereference it in a later fall-through). The blocking paths
+  in particular must `return` immediately after releasing on an error, not
+  fall into a `PMIX_WAIT_THREAD`.
+- **Some entry points run on the caller's thread by design**, doing their
+  pre-send work (validation, group expansion, GDS reads) before handing
+  off to the PTL/progress thread. Group invite/join issue events from the
+  caller thread precisely because the blocking event APIs would deadlock
+  on the progress thread. The client's `groups` list is also mutated from
+  the caller thread in some paths and the progress thread in others; treat
+  concurrent multithreaded use of these APIs with suspicion.
+- **Wire compatibility.** These files pack/unpack command messages;
+  the order and content of packed fields is ABI across versions. Append
+  only at the end, tolerate `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` on
+  trailing reads (older peers), and never reorder — see the top-level
+  "Version Interoperability" rules.
+
+## Building
+
+`src/client` compiles straight into `libpmix` via `Makefile.include`
+(which appends to the top-level `sources`/`headers` lists — there is no
+`Makefile.am` here). Nothing is conditionally compiled, so a change takes
+effect with a plain top-level `make` from an already-configured tree — see
+the top-level guide's "Test-building your changes." You do **not** need
+`autogen.pl`/`configure` unless you add or remove a source file (adding
+one to `Makefile.include` then needs a `make`, which regenerates the
+top-level `Makefile`). After a build, smoke-test with `make check` in
+`test/` and `./simptest` in `test/simple/`. Do not diagnose functional
+failures against an `--enable-test-build` tree — its shimmed
+`pcompress`/`psec` components are non-functional (see the top-level guide).
+
+## When modifying code here
+
+- **Match the surrounding pattern exactly.** Pick the nearest sibling
+  function that already does what you need (a blocking wrapper, a recv
+  callback, a role-branched `_nb`) and mirror its caddy allocation,
+  ownership flags, error-path cleanup, and release/wakeup discipline. The
+  files are internally consistent; divergence is usually a bug.
+- **Walk every early-return path.** For each `return`/`goto` in a `_nb`
+  function or recv callback, confirm the caddy and any packed buffer are
+  released exactly once and that the correct completion (callback for
+  non-blocking, wakeup for blocking) happens on that path — including the
+  `PMIX_PTL_SEND_RECV`-failed path.
+- **Prefer a new attribute to a new API**, and if you must add an API,
+  give it the `pmix_info_t info[], size_t ninfo` pair (top-level "Role of
+  Attributes"). Deprecate, never alter, an existing signature.
+- **Keep it warning-free and portable** under `--enable-devel-check`; use
+  the `__pmix_attribute_*__` / `PMIX_HIDE_UNUSED_PARAMS` wrappers rather
+  than bare GCC attributes.

--- a/src/client/CLAUDE.md
+++ b/src/client/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -828,7 +828,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
      * have passed down a directive for this purpose. If they did, then
      * use it. Otherwise, we want the "hash" module */
     found = false;
-    if (info != NULL) {
+    if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_GDS_MODULE)) {
                 PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, info[n].value.data.string, PMIX_STRING);
@@ -994,8 +994,6 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                         PMIx_Data_type_string(kv->value->type));
             return PMIX_ERR_BAD_PARAM;
         }
-        PMIX_RELEASE(kv); // done with this value
-
         pmix_output_verbose(2, pmix_client_globals.base_output,
                             "[%s:%d] RECEIVED %s FOR RANK %s (%s)",
                             pmix_globals.myid.nspace,
@@ -1003,6 +1001,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                             PMIx_Get_attribute_name(kv->key),
                             PMIX_RANK_PRINT(rank),
                             PMIx_Data_type_string(kv->value->type));
+        PMIX_RELEASE(kv); // done with this value
 
         /* if the value was found and we are involved, then we need to wait
          * for debugger attach here */
@@ -1219,15 +1218,21 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         /* send to the server */
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);
         if (PMIX_SUCCESS != rc) {
+            /* the recv callback will not fire, so cancel the timer and
+             * tear down the lock before we return */
+            pmix_event_del(&tev.ev);
+            PMIX_DESTRUCT_LOCK(&tev.lock);
             return rc;
         }
 
         /* wait for the ack to return */
         PMIX_WAIT_THREAD(&tev.lock);
+        /* cancel the protection timer. If the server answered, the timer
+         * is still pending and must be removed from the event base before
+         * this stack frame (which holds tev) goes away; if the timer fired
+         * instead, deleting an inactive event is a harmless no-op */
+        pmix_event_del(&tev.ev);
         PMIX_DESTRUCT_LOCK(&tev.lock);
-        if (tev.active) {
-            pmix_event_del(&tev.ev);
-        }
 
         pmix_output_verbose(2, pmix_client_globals.base_output,
                             "%s:%d pmix:client finalize sync received", pmix_globals.myid.nspace,

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -340,6 +340,10 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 PMIX_INFO_DESTRUCT(&xfer);
                 PMIx_Info_list_release(ilist);
             }
+            /* release the job-info fetch results (the error paths above
+             * destruct cb2 before jumping to moveon, so this only runs on
+             * the normal path) */
+            PMIX_DESTRUCT(&cb2);
         }
     }
 

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -115,6 +115,9 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
         goto complete;
     }
     if (PMIX_SUCCESS != cb->status) {
+        /* propagate the server's error to the completion below so a
+         * non-blocking caller's callback is not told the op succeeded */
+        rc = cb->status;
         goto complete;
     }
 
@@ -300,7 +303,13 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update(pmix_fabric_t *fabric)
      * the non-blocking operation is complete */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.fabric = fabric;
-    if (PMIX_SUCCESS != (rc = PMIx_Fabric_update_nb(fabric, NULL, &cb))) {
+    rc = PMIx_Fabric_update_nb(fabric, NULL, &cb);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        /* the operation completed synchronously (e.g., we are the
+         * scheduler and handled it ourselves); no callback will fire */
+        PMIX_DESTRUCT(&cb);
+        return PMIX_SUCCESS;
+    } else if (PMIX_SUCCESS != rc) {
         PMIX_DESTRUCT(&cb);
         return rc;
     }
@@ -324,11 +333,27 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FABRIC_UPDATE_CMD;
 
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
     /* if I am a scheduler server, then I should be able
      * to support this myself */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
+        /* update_fabric is synchronous and takes no callback, so we must
+         * bridge its result to the (non)blocking completion contract */
         rc = pmix_pnet.update_fabric(fabric);
-        return rc;
+        if (PMIX_SUCCESS != rc) {
+            /* error: no callback fires, caller sees the error return */
+            return rc;
+        }
+        if (NULL != cbfunc) {
+            /* async caller: deliver completion via the callback */
+            cbfunc(PMIX_SUCCESS, cbdata);
+            return PMIX_SUCCESS;
+        }
+        /* blocking caller: signal that we completed synchronously */
+        return PMIX_OPERATION_SUCCEEDED;
     }
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -202,6 +202,9 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
+        /* the recv callback will not fire; do not fall through into the
+         * blocking wait, which would dereference the just-released cb */
+        return rc;
     }
 
     if (NULL == cbfunc) {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -164,7 +164,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             lg->appinfo = true;
             lg->nodeinfo = false;
             lg->sessioninfo = false;
-        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_INFO)) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_INFO)) {
             /* regardless of the default setting, they want us
              * to get it from the session realm */
             lg->sessiondirective = true;
@@ -281,7 +281,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     /* if they passed a group in the nspace of proc,
      * replace it with the translated proc. */
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
-        proc != NULL && 0 != strlen(proc->nspace)) {
+        NULL != proc && 0 != strlen(proc->nspace)) {
         rc = pmix_client_convert_group_procs(proc, 1, &procs, &nprocs);
         if (PMIX_SUCCESS != rc) {
             return rc;
@@ -584,6 +584,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     int32_t cnt;
     pmix_kval_t *kv;
     pmix_get_logic_t *lg;
+    pmix_proc_t rproc;
     pmix_info_t *iptr;
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
@@ -637,8 +638,16 @@ done:
      * don't support calls to "get" for a NULL key */
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix: get_nb looking for requested key");
+    /* snapshot the reference proc. The cb this recv was in response to is
+     * itself in the pending list and its "lg" is the one we hold here;
+     * once we start delivering results below, that cb (and its lg) will
+     * be released, so we must not dereference lg during the loop */
+    PMIX_LOAD_PROCID(&rproc, lg->p.nspace, lg->p.rank);
     PMIX_LIST_FOREACH_SAFE (cb, cb2, &pmix_client_globals.pending_requests, pmix_cb_t) {
-        if (PMIX_CHECK_NSPACE(lg->p.nspace, cb->pname.nspace) && cb->pname.rank == lg->p.rank) {
+        if (PMIX_CHECK_NSPACE(rproc.nspace, cb->pname.nspace) && cb->pname.rank == rproc.rank) {
+            /* reset per iteration so a failed fetch for this request can
+             * never deliver a value already handed to a previous one */
+            val = NULL;
             pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
             if (PMIX_SUCCESS != ret) {
                 if (cb->checked) {
@@ -650,7 +659,7 @@ done:
                 continue;
             }
             /* we have the data for this proc - see if we can find the key */
-            cb->proc = &lg->p;
+            cb->proc = &rproc;
             cb->scope = PMIX_SCOPE_UNDEF;
             pmix_output_verbose(2, pmix_client_globals.get_output,
                                 "pmix: get_nb searching for key %s for rank %s", cb->key,
@@ -952,7 +961,7 @@ static void get_data(int sd, short args, void *cbdata)
             if (NULL != lg->hostname) {
                 PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_HOSTNAME, lg->hostname, PMIX_STRING);
             } else {
-                PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_HOSTNAME, &lg->nodeid, PMIX_UINT32);
+                PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_NODEID, &lg->nodeid, PMIX_UINT32);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo+2], PMIX_OPTIONAL, NULL, PMIX_BOOL);
             cb->infocopy = true;
@@ -1007,7 +1016,7 @@ static void get_data(int sd, short args, void *cbdata)
         }
         /* we get here with a valid appnum - if that is what they were
          * asking for, then we are done */
-        if (0 == strcmp(cb->key, PMIX_APPNUM)) {
+        if (NULL != cb->key && 0 == strcmp(cb->key, PMIX_APPNUM)) {
             cb->status = PMIX_SUCCESS;
             PMIX_VALUE_CREATE(cb->value, 1);
             PMIX_VALUE_LOAD(cb->value, &lg->appnum, PMIX_UINT32);
@@ -1074,7 +1083,7 @@ static void get_data(int sd, short args, void *cbdata)
             }
         }
         /* if they were asking for sessionid, then we are done */
-        if (0 == strcmp(cb->key, PMIX_SESSION_ID)) {
+        if (NULL != cb->key && 0 == strcmp(cb->key, PMIX_SESSION_ID)) {
             cb->status = PMIX_SUCCESS;
             PMIX_VALUE_CREATE(cb->value, 1);
             PMIX_VALUE_LOAD(cb->value, &lg->sessionid, PMIX_UINT32);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -143,8 +143,10 @@ static void gtdes(pmix_group_tracker_t *p)
     if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
-    if (NULL != p->grpid)
-    {
+    if (NULL != p->results) {
+        PMIX_INFO_FREE(p->results, p->nresults);
+    }
+    if (NULL != p->grpid) {
         free(p->grpid);
         p->grpid = NULL;
     }
@@ -336,6 +338,7 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, icopy, sz, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_INFO_FREE(icopy, sz);
             return rc;
         }
         PMIX_INFO_FREE(icopy, sz);

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -612,6 +612,7 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_pdata_t *tgt = (pmix_pdata_t *) cb->cbdata;
+    pmix_status_t rc;
     size_t i, j;
 
     PMIX_ACQUIRE_OBJECT(cb);
@@ -624,9 +625,15 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
                 if (0 == strcmp(pdata[i].key, tgt[j].key)) {
                     /* transfer the publishing proc id */
                     memcpy(&tgt[j].proc, &pdata[i].proc, sizeof(pmix_proc_t));
-                    /* transfer the value to the pmix_info_t */
-                    PMIX_BFROPS_VALUE_XFER(cb->status, pmix_client_globals.myserver,
+                    /* transfer the value to the pmix_info_t. Do not fold
+                     * the xfer result into cb->status - that would mask a
+                     * PMIX_ERR_PARTIAL_SUCCESS return; only surface an
+                     * actual transfer failure */
+                    PMIX_BFROPS_VALUE_XFER(rc, pmix_client_globals.myserver,
                                            &tgt[j].value, &pdata[i].value);
+                    if (PMIX_SUCCESS != rc) {
+                        cb->status = rc;
+                    }
                     break;
                 }
             }

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -342,6 +342,7 @@ done:
     }
     PMIX_DESTRUCT(&cb);
     cd->status = rc;
+    PMIX_POST_OBJECT(cd);
     PMIX_WAKEUP_THREAD(&cd->lock);
 }
 
@@ -364,8 +365,8 @@ static void respeer(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
-    PMIX_WAKEUP_THREAD(&cb->lock);
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_nspace_t nspace,
@@ -422,24 +423,27 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
             if (PMIX_SUCCESS == rc) {
                 // wait for the response
                 PMIX_WAIT_THREAD(&cb.lock);
-                PMIX_QUERY_DESTRUCT(&query);
                 rc = cb.status;
-                if (PMIX_SUCCESS == rc) {
-                    // string return should be in first info
-                    if (0 < cb.ninfo) {
-                        val = &cb.info[0].value;
-                        if (PMIX_DATA_ARRAY != val->type ||
-                            PMIX_PROC != val->data.darray->type) {
-                            PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
-                        } else {
-                            *procs = (pmix_proc_t*)val->data.darray->array;
-                            *nprocs = val->data.darray->size;
-                            // protect the returned data
-                            cb.info = NULL;
-                            cb.ninfo = 0;
-                            PMIX_DESTRUCT(&cb);
-                            return rc;
-                        }
+            }
+            // done with the query inputs regardless of outcome - the host
+            // is finished with them once the callback fired (success) or
+            // the call failed synchronously (no callback)
+            PMIX_QUERY_DESTRUCT(&query);
+            if (PMIX_SUCCESS == rc) {
+                // string return should be in first info
+                if (0 < cb.ninfo) {
+                    val = &cb.info[0].value;
+                    if (PMIX_DATA_ARRAY != val->type ||
+                        PMIX_PROC != val->data.darray->type) {
+                        PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
+                    } else {
+                        *procs = (pmix_proc_t*)val->data.darray->array;
+                        *nprocs = val->data.darray->size;
+                        // protect the returned data
+                        cb.info = NULL;
+                        cb.ninfo = 0;
+                        PMIX_DESTRUCT(&cb);
+                        return rc;
                     }
                 }
             }
@@ -667,8 +671,8 @@ done:
     cb.info = NULL;
     cb.ninfo = 0;
     PMIX_DESTRUCT(&cb);
-    PMIX_WAKEUP_THREAD(&cd->lock);
     PMIX_POST_OBJECT(cd);
+    PMIX_WAKEUP_THREAD(&cd->lock);
 }
 
 static void resnode(pmix_status_t status, pmix_info_t info[], size_t ninfo, void *cbdata,
@@ -690,8 +694,8 @@ static void resnode(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
-    PMIX_WAKEUP_THREAD(&cb->lock);
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **nodelist)
@@ -735,22 +739,25 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
             if (PMIX_SUCCESS == rc) {
                 // wait for the response
                 PMIX_WAIT_THREAD(&cb.lock);
-                // protect the qualifier
-                query.qualifiers = NULL;
-                query.nqual = 0;
-                PMIX_QUERY_DESTRUCT(&query);
                 rc = cb.status;
-                if (PMIX_SUCCESS == rc) {
-                    // string return should be in first info
-                    if (0 < cb.ninfo) {
-                        val = &cb.info[0].value;
-                        if (PMIX_STRING != val->type) {
-                            PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
-                        } else {
-                            *nodelist = strdup(val->data.string);
-                            PMIX_DESTRUCT(&cb);
-                            return rc;
-                        }
+            }
+            // done with the query inputs regardless of outcome. The
+            // qualifier is a stack object, so detach it before destructing
+            // the query, then free its contents separately
+            query.qualifiers = NULL;
+            query.nqual = 0;
+            PMIX_QUERY_DESTRUCT(&query);
+            PMIX_INFO_DESTRUCT(&info);
+            if (PMIX_SUCCESS == rc) {
+                // string return should be in first info
+                if (0 < cb.ninfo) {
+                    val = &cb.info[0].value;
+                    if (PMIX_STRING != val->type) {
+                        PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
+                    } else {
+                        *nodelist = strdup(val->data.string);
+                        PMIX_DESTRUCT(&cb);
+                        return rc;
                     }
                 }
             }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -244,12 +244,18 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         }
         fcd->info = darray.array;
         fcd->ninfo = darray.size;
+        /* convert copies into darray; the list is ours to release */
+        PMIx_Info_list_release(xlist);
     }
 
     /* sadly, we have to copy the apps array since we are
      * going to modify the individual app structs */
     fcd->napps = napps;
     PMIX_APP_CREATE(fcd->apps, fcd->napps);
+    /* we now own the info and apps arrays we filled into the caddy, so
+     * mark it copied - this is what tells the destructor (scaddes) to
+     * free them, on both the completion path and every error path below */
+    fcd->copied = true;
     for (n = 0; n < napps; n++) {
         aptr = (pmix_app_t *) &apps[n];
         /* protect against bozo case */

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -193,6 +193,11 @@ bool pmix_bfrops_base_tma_check_key(const char *key,
 {
     PMIX_HIDE_UNUSED_PARAMS(tma);
 
+    /* a NULL key (e.g., an unset attribute) cannot match a specific
+     * target string, so report "no match" rather than dereferencing it */
+    if (NULL == key || NULL == str) {
+        return false;
+    }
     if (0 == strncmp(key, str, PMIX_MAX_KEYLEN)) {
         return true;
     }


### PR DESCRIPTION
A deep review of `src/client` turned up a number of memory-safety,
memory-leak, and correctness defects. This PR fixes them, hardens the
shared `PMIx_Check_key` helper against a NULL key, and adds a developer
orientation guide for the directory. Each fix is a separate, signed-off
commit.

## Memory safety / crashes
- **Get** (`_getnb_cbfunc`): reset the result value per iteration over
  `pending_requests` (a failed fetch could re-deliver a prior request's
  value → double free), and snapshot the reference proc so the loop no
  longer dereferences a `lg` that is released mid-iteration (UAF).
- **client core**: move `PMIX_RELEASE(kv)` after the verbose message
  that reads it in the debugger-stop-in-init path (UAF/NULL deref); and
  actually cancel the finalize protection timer, which was left
  registered against a stack object because its delete was dead code.
- **Fence**: `return` after releasing on a failed send so a blocking
  fence does not fall through into a wait on the freed callback object.
- **Check_key**: `PMIx_Check_key`/`PMIX_CHECK_KEY` now return `false`
  for a NULL key instead of dereferencing it. A NULL key cannot match a
  specific target string, and callers legitimately pass an unset key
  (e.g. a whole-proc `PMIx_Get`). Hardens ~525 call sites at one point.

## Memory leaks
- **Spawn**: set the caddy `copied` flag so the destructor frees the
  copied info and apps arrays, and release the info list on the success
  path after conversion.
- **Group**: free the tracker `results` array in the destructor, and
  free `icopy` on the info-pack-failure path in `construct_msg`.
- **Connect**: destruct the job-info fetch caddy on the normal
  multi-namespace contribution path.
- **Resolve**: clean up the query object (and the stack qualifier) on
  all paths, not just when the host query succeeds.

## Correctness
- **Get**: load the nodeid fallback under `PMIX_NODEID` (was
  `PMIX_HOSTNAME`); honor `PMIX_SESSION_INFO` at any array index (was
  only element 0).
- **Fabric**: propagate the server's error status to a non-blocking
  callback; make blocking/non-blocking `PMIx_Fabric_update` work on a
  scheduler (the synchronous `update_fabric` was treated as async,
  hanging the blocking form and never firing the callback); add the
  missing `initialized` guard to `PMIx_Fabric_update_nb`.
- **Lookup**: stop masking `PMIX_ERR_PARTIAL_SUCCESS` with the transfer
  status of a matched value.
- Minor: normalize a few post-object/wakeup orderings and constant-on-
  left comparisons.

## Docs
- Add `src/client/AGENTS.md` (with the customary `CLAUDE.md` symlink)
  describing the client role, its files, the blocking/non-blocking and
  PTL send/recv control-flow shapes, the client global state, and the
  invariants most easily gotten wrong.

Builds warning-free under `--enable-devel-check`; `test/simple/simptest`
passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)