### PR TITLE
Fix launcher example hanging on a failed spawn

### DIFF
--- a/examples/launcher.c
+++ b/examples/launcher.c
@@ -151,11 +151,21 @@ int main(int argc, char **argv)
     /* can also provide environmental params in the app.env field */
 
     /* spawn the application */
-    PMIx_Spawn(NULL, 0, app, napps, appspace);
+    rc = PMIx_Spawn(NULL, 0, app, napps, appspace);
     /* cleanup */
     PMIX_APP_FREE(app, napps);
 
-    DEBUG_WAIT_THREAD(&myrel.lock);
+    /* If the launch itself failed, the library reports it via the
+     * return code rather than a job-termination event - so no event
+     * will ever arrive to wake us, and we must not wait for one.
+     * Only block on the completion event when the job actually
+     * started. */
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Spawn failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+    } else {
+        DEBUG_WAIT_THREAD(&myrel.lock);
+    }
     DEBUG_DESTRUCT_MYREL(&myrel);
 
 done:


### PR DESCRIPTION
The `launcher` example ignored the return code from `PMIx_Spawn` and then
unconditionally blocked on the job-completion event.

When PMIx itself performs the launch — as an unconnected launcher doing a
local fork/exec does — a failure to *start* the job (executable not found,
bad working directory, `execve` failure) is reported **synchronously**
through the `PMIx_Spawn` return code, and no job-termination event is ever
generated. The example therefore waited forever for an event that would
never arrive.

This honors the return code: report the error and skip the wait when the
launch failed, blocking on the completion event only when the job actually
started. The registered event handler still covers post-launch failures and
normal termination, so the connected-launcher path is unaffected.

Verified against a normal (non-test-build) local build:

- **executable not found** → prints `Spawn failed: PMIX_ERR_JOB_EXE_NOT_FOUND`
  and exits cleanly (previously hung);
- **`execve` failure** (`ENOEXEC`) and **bad working directory** → error is
  rendered and the example exits;
- **successful spawn** → job runs to completion, the example wakes on the
  termination event and exits 0 (unchanged).