### PR TITLE
Release stranded fetched values in the client get callback

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -721,6 +721,14 @@ done:
                     }
                 }
             }
+            /* release any fetched values we are not going to deliver -
+             * the failed-fetch and multiple-value paths above leave
+             * entries stranded in the cb's kvs list, and the cb is
+             * delivered (and may be reused for a coalesced request)
+             * without that list otherwise being drained */
+            while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(&cb->kvs))) {
+                PMIX_RELEASE(kv);
+            }
             if (cb->checked) {
                 cb->status = rc;
                 cb->value = val;


### PR DESCRIPTION
When a server get-response is processed in `_getnb_cbfunc`, each matching
pending request has its data fetched into the request's `kvs` list. The code
only consumed that list on the single-value success path. When the fetch
produced **zero or multiple** values — e.g. a `PMIX_GLOBAL` key stored in
both the local and remote hash tables and therefore returned twice — or when
the fetch ultimately failed, the fetched kvals were left stranded in the list
and leaked.

This explicitly releases any values remaining in the list after the delivery
value has been extracted. On the normal single-value path the list is already
empty, so it is a no-op there; the delivered value is a separate object and is
unaffected.

### How it was found / verified

Surfaced by valgrinding the `dynamic` and `multi_nspace_group` examples across
a multi-node PRRTE DVM — kvals allocated in the hash fetch (`make_copy` →
`pmix_bfrop_tma_kval_new`) were reported definitely lost with an allocation
frame rooted entirely in the progress thread (`_getnb_cbfunc` →
`pmix_gds_hash_fetch`). With this change the `dynamic` example is fully
valgrind-clean (0 definite/0 indirect on every rank).