### PR TITLE
Plug memory leaks in the group/spawn examples

### DIFF
--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 {
     int rc;
     pmix_value_t *val = NULL, value;
-    pmix_proc_t proc, *parray;
+    pmix_proc_t proc, *parray = NULL;
     uint32_t nprocs;
     size_t nall, n, maxprocs = 2;
     char nsp2[PMIX_MAX_NSLEN + 1], *nsp;
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
                 goto done;
             }
             PMIX_APP_FREE(app, 1);
+            PMIX_INFO_DESTRUCT(&info);
 
             // share the child namespace
             value.type = PMIX_STRING;
@@ -171,6 +172,7 @@ int main(int argc, char **argv)
             for (n=0; n < maxprocs; n++) {
                 PMIX_LOAD_PROCID(&parray[n+nprocs], nsp, n);
             }
+            PMIX_VALUE_RELEASE(val);
         }
     } else {
         // we are the child job
@@ -227,6 +229,12 @@ int main(int argc, char **argv)
     }
 
 done:
+    if (NULL != parray) {
+        PMIX_PROC_FREE(parray, nall);
+    }
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
 

--- a/examples/group_bootstrap.c
+++ b/examples/group_bootstrap.c
@@ -150,6 +150,10 @@ int main(int argc, char **argv)
         PMIX_INFO_LOAD(&info[2], PMIX_GROUP_ADD_MEMBERS, &dry, PMIX_DATA_ARRAY);
         PMIX_DATA_ARRAY_DESTRUCT(&dry);
         rc = PMIx_Group_construct("ourgroup", &myproc, 1, info, 3, &results, &nresults);
+        /* the info array was copied by the library, so release our copy */
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        PMIX_INFO_DESTRUCT(&info[2]);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n",
                     myproc.nspace, myproc.rank, PMIx_Error_string(rc));
@@ -215,6 +219,11 @@ int main(int argc, char **argv)
     }
 
 done:
+    /* release the results handed back by PMIx_Group_construct */
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+        results = NULL;
+    }
     /* finalize us */
     DEBUG_CONSTRUCT_LOCK(&lock);
     PMIx_Deregister_event_handler(1, op_callbk, &lock);

--- a/examples/multi_nspace_group.c
+++ b/examples/multi_nspace_group.c
@@ -186,6 +186,8 @@ int main(int argc, char **argv)
                 goto done;
             }
             PMIX_APP_DESTRUCT(&app);
+            /* release the spawn directive before we reuse info[0] below */
+            PMIX_INFO_DESTRUCT(&info[0]);
 
             // circulate the child nspace with our peers
             value.type = PMIX_STRING;
@@ -251,6 +253,7 @@ int main(int argc, char **argv)
             // the spawned children
             PMIX_LOAD_PROCID(&parray[0], myproc.nspace, PMIX_RANK_WILDCARD);
             PMIX_LOAD_PROCID(&parray[1], val->data.string, PMIX_RANK_WILDCARD);
+            PMIX_VALUE_RELEASE(val);
 
             rc = PMIx_Group_construct("ourgroup", parray, 2, NULL, 0, &results, &nresults);
             if (PMIX_SUCCESS != rc) {
@@ -300,6 +303,7 @@ int main(int argc, char **argv)
 
         PMIX_LOAD_PROCID(&parray[0], val->data.string, PMIX_RANK_WILDCARD);
         PMIX_LOAD_PROCID(&parray[1], myproc.nspace, PMIX_RANK_WILDCARD);
+        PMIX_VALUE_RELEASE(val);
 
         // construct the group
         rc = PMIx_Group_construct("ourgroup", parray, 2, NULL, 0, &results, &nresults);
@@ -366,11 +370,17 @@ int main(int argc, char **argv)
                 } else {
                     fprintf(stderr, "Client ns %s rank %d: Get modex for proc %s:%u returned %lu\n",
                             myproc.nspace, myproc.rank, proc.nspace, proc.rank, (unsigned long)val->data.uint64);
+                    PMIX_VALUE_RELEASE(val);
                 }
             }
         }
     }
 done:
+    /* release the results handed back by PMIx_Group_construct */
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+        results = NULL;
+    }
     /* finalize us */
     DEBUG_CONSTRUCT_LOCK(&lock);
     PMIx_Deregister_event_handler(1, op_callbk, &lock);


### PR DESCRIPTION
The `group_bootstrap`, `multi_nspace_group`, and `dynamic` examples never
released several objects they owned, so each rank leaked on exit:

- the `results` array handed back by `PMIx_Group_construct` (all three);
- the `info` array built for the group-construct / spawn directives — in
  `multi_nspace_group` the same `info[0]` slot was reloaded for the group
  construct without releasing the spawn directive first;
- the proc array allocated for `PMIx_Connect` (`dynamic`);
- `pmix_value_t` results returned by `PMIx_Get` for the child nspace, the
  parent id, and the per-proc modex data (`multi_nspace_group`, `dynamic`).

Verified with valgrind across a multi-node PRRTE DVM: all three examples now
report **zero definite and zero indirect** bytes lost on every rank (they
previously leaked hundreds to thousands of bytes per rank).

These are the spawn-dependent examples the earlier example-leak sweep
(#3983) could not validate without a functional launcher.