### PR TITLE
Runtime layer: developer guide, bug fixes, and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,8 @@ test/unit/client_cycle
 test/unit/tool_cycle
 test/unit/event_chain
 test/unit/hwloc_datatype
+test/unit/progress_threads
+test/unit/info_support
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -1,0 +1,302 @@
+# AGENTS.md: The PMIx Runtime / Bootstrap Layer
+
+This document orients AI agents and human contributors working in
+`src/runtime`, the code that brings `libpmix` up and tears it back down.
+It assumes you have already read the top-level
+[`AGENTS.md`](../../AGENTS.md) — the golden rules (prefix conventions,
+`pmix_config.h`-first include order, constant-on-the-left comparisons,
+brace-everything, `#define`-logical-macros-to-0/1, warning-free under
+`--enable-devel-check`), the **thread-safety / progress-thread model and
+the caddy pattern**, the "prefer an MCA parameter over a hard-coded
+constant" rule, the `show_help` regeneration rule, and the
+copyright-header requirement all apply here and are not repeated. This
+file covers what is specific to `src/runtime`: the init/finalize
+ordering contract, the global-state object it owns, the MCA-parameter
+registry, the progress-thread engine, and the `pmix_info` support
+library.
+
+Like `src/client` and `src/event`, **`src/runtime` is not an MCA
+framework.** There is no component structure — just five `.c` files and
+four headers compiled straight into `libpmix` via `Makefile.include`
+(which appends to the top-level `sources`/`headers` lists; there is no
+`Makefile.am` here). A change takes effect with a plain top-level
+`make` from an already-configured tree; you need
+`autogen.pl`/`configure` only if you add or remove a source file. The
+code is *role-shared*: `pmix_rte_init` runs inside clients, servers,
+tools, and launchers, differentiated only by the `type` argument and a
+handful of incoming directives.
+
+## What this directory is
+
+This is the layer every PMIx process passes through exactly once on the
+way in and once on the way out. It owns:
+
+- **Library bring-up / tear-down** (`pmix_init.c` / `pmix_finalize.c`)
+  — `pmix_rte_init` and `pmix_rte_finalize`, plus the "util" sub-layer
+  (`pmix_init_util` / `pmix_finalize_util`) used by the standalone
+  tools that need MCA/params but not a full client. Also defines and
+  statically initializes the process-wide `pmix_globals` object.
+- **MCA parameter registration** (`pmix_params.c`) —
+  `pmix_register_params` / `pmix_deregister_params`: every
+  `pmix`-project MCA var that is not owned by a specific framework
+  (client/server verbosity, IOF options, event caching, hostname
+  handling, progress-thread binding, `pmix_info` colors, …).
+- **The progress-thread engine** (`pmix_progress_threads.c`) — the
+  libevent event-base + dedicated-thread machinery that *is* the PMIx
+  progress thread, reference-counted and addressable by name. Backs the
+  public `PMIx_Progress` and `PMIx_Progress_thread_stop` APIs.
+- **The `pmix_info` support library** (`pmix_info_support.c`) — all the
+  formatting/enumeration logic behind the `pmix_info` executable
+  (`src/tools/pmix_info/`) and, in part, the other CLI tools: MCA-var
+  dumping, component/version display, install-path display, config
+  dump, and the pretty/parsable output formatter.
+
+Almost all the *state* this directory manipulates lives in
+`pmix_globals` (`src/include/pmix_globals.h`) and
+`pmix_client_globals`/`pmix_server_globals`, not in file-scope
+variables here. The MCA-param C globals (e.g. `pmix_keep_fqdn_hostnames`,
+`pmix_maxfd`, `pmix_progress_thread_cpus`) are declared `extern` in
+[`pmix_rte.h`](pmix_rte.h) and defined in `pmix_params.c`.
+
+## The init / finalize ordering contract
+
+`pmix_rte_init(type, info, ninfo, cbfunc)` is called once from each
+role's own init: `pmix_client.c`, `pmix_server.c`, `pmix_tool.c`. The
+order of operations is load-bearing — later subsystems depend on
+earlier ones being open, and `pmix_rte_finalize` must unwind in a
+compatible order. The spine is:
+
+1. **`pmix_init_util`** (idempotent, latched on
+   `pmix_globals.util_initialized`): registers the calling thread as
+   "main" (`pmix_thread_set_main` — required so TSD keys get cleaned up;
+   see the comment at the call site), then output → pinstalldirs →
+   show_help → keyval parser → `mca_base_var` → `mca_base_open` →
+   `pmix_net_init` → `pif`. Standalone tools call this directly instead
+   of `pmix_rte_init`.
+2. **`pmix_register_params`** — must come before anything reads an MCA
+   value.
+3. **Directive scan** — walk the incoming `info[]` for the small set of
+   bootstrap directives (`PMIX_HOSTNAME`, `PMIX_NODEID`,
+   `PMIX_NODE_INFO_ARRAY`, `PMIX_EXTERNAL_PROGRESS`,
+   `PMIX_EXTERNAL_AUX_EVENT_BASE`, `PMIX_HOSTNAME_KEEP_FQDN`,
+   `PMIX_BIND_PROGRESS_THREAD`, `PMIX_BIND_REQUIRED`); everything else
+   is handed to `pmix_iof_check_flags`.
+4. **Progress thread + event base** (`pmix_progress_thread_init(NULL)`)
+   — creates `pmix_globals.evbase`. If no external aux event base was
+   supplied, `evauxbase` is aliased to `evbase`.
+5. **Globals construction** — ids, `mypeer` (a `pmix_peer_t` stamped
+   with our version), the events/notifications/nspaces/keyindex
+   structures, client-globals lists, verbosity output channels, uid/gid,
+   `PMIX_DEBUG` channel, hostname/aliases.
+6. **Framework open+select, in dependency order**: bfrops → pcompress →
+   ptl → psec → gds → preg (preg **must** follow pcompress) → plog.
+   `pmix_init_registered_attrs()` then builds the attribute registry.
+7. **`pmix_progress_thread_start(NULL)`** — actually spins the thread
+   (skipped when `external_progress` is set; the host drives progress).
+
+`pmix_rte_finalize` (guarded by `pmix_init_called`) unwinds:
+`progress_thread_pause` (stop the loop **without** freeing the base, so
+components can still finalize cleanly) → release attrs → close plog,
+preg, ptl, psec, bfrops, pcompress, gds → `pmix_net_finalize` →
+deregister/finalize params → keyval → pinstalldirs, pif, `mca_base_close`
+→ show_help → output → destruct the `pmix_globals` members → hwloc
+finalize → TSD key destruct → `pmix_name_fns_finalize` →
+`pmix_finalize_util` → **`pmix_progress_thread_stop(NULL)`** (this is
+what finally frees the event base) → NULL out `evbase`/`evauxbase`.
+
+**Re-entrancy is a first-class requirement here.** A process may call
+`PMIx_Init`/`PMIx_Finalize` (or the tool/server equivalents) more than
+once in its lifetime, and recent history in this directory is almost
+entirely about making the *second* init start from a clean slate (see
+`git log` — "Cleanup init/finalize cycle", "fix a problem after second
+pmix init", "Do not shutdown libevent during finalize", "runtime: leave
+no residue or dangling state after finalize"). Consequences you must
+preserve when editing:
+
+- **Do not destroy libevent's global thread state on finalize.** The
+  loop is paused and the base is freed, but the library is left able to
+  come back up. Freeing more aggressively re-introduces the
+  second-init crashes these commits fixed.
+- **Every pointer cached across the gap must be NULLed on finalize** so
+  the next init does not dereference freed memory —
+  `evbase`/`evauxbase` here, `shared_thread_tracker` in
+  `pmix_progress_threads.c`, the print-buffer TSD latch cleared by
+  `pmix_name_fns_finalize`. If you cache a new pointer at init, clear it
+  at finalize.
+- **`evauxbase` ownership is conditional.** It either aliases `evbase`
+  (we own it) or was supplied by the caller via
+  `PMIX_EXTERNAL_AUX_EVENT_BASE` (they own it). Finalize only drops the
+  reference; it must never `free` it. Consumers use it for
+  signal/SIGCHLD events (`src/common/pmix_pfexec.c`,
+  `src/common/pmix_iof.c`, `src/tool/pmix_tool.c`).
+
+## `pmix_globals`: the process-wide state object
+
+`pmix_init.c` defines `pmix_globals` with a large designated-initializer
+(the `*_STATIC_INIT` macros). This object is `PMIX_EXPORT`ed because
+**every plugin links against it** — it is the shared spine of the whole
+library. Rules:
+
+- The static initializer, the runtime construction in `pmix_rte_init`
+  (steps 5–6 above), and the teardown in `pmix_rte_finalize` are **three
+  views of the same field list** and must stay in agreement. If you add
+  a field to `pmix_globals_t`, initialize it statically, construct it in
+  init if it needs it, and destruct/free/NULL it in finalize. A field
+  constructed but not destructed leaks on every finalize; one destructed
+  but not re-constructed crashes on second init.
+- The finalize path deliberately drains the notification hotel
+  room-by-room and the `iof_requests` pointer array item-by-item before
+  destructing the containers — mirror that discipline for any new
+  container-of-refcounted-objects you add.
+
+## MCA parameters (`pmix_params.c`)
+
+`pmix_register_params` is latched by the file-scope `pmix_register_done`
+and registers all the non-framework `pmix`-project vars. Patterns to
+follow:
+
+- Set the C global to its default **before** the
+  `pmix_mca_base_var_register` call (the register call overwrites it
+  from the environment/file/CLI if the user set it). Add new params next
+  to their thematic neighbors (client verbosity, server verbosity, IOF,
+  event, hostname, …).
+- Verbosity params write directly into `pmix_client_globals.*_verbose` /
+  `pmix_server_globals.*_verbose`; `pmix_rte_init` later opens an output
+  channel for each nonzero one. If you add a verbosity var, add the
+  matching `pmix_output_open` block in `pmix_init.c`.
+- `pmix_deregister_params` intentionally does **not** free the
+  registered vars (the `mca_base_var` system frees them in
+  `pmix_mca_base_var_finalize`); it only resets the latch so a second
+  init re-registers cleanly. The one thing that *is* hand-freed is
+  `pmix_var_dump_color[]`, released in `pmix_rte_finalize`.
+- The `var_dump_color` machinery (`parse_color_string`) turns a
+  `key=ansi_code` list into ready-to-emit `\033[..m` escape strings used
+  by `pmix_info`. It reports malformed tokens via `help-pmix-runtime.txt`
+  and, on any allocation failure, frees the whole partial result.
+
+Help text for this directory lives in
+[`help-pmix-runtime.txt`](help-pmix-runtime.txt). Per the top-level
+rule, after editing any `show_help` content you must
+`rm src/util/pmix_show_help_content.* && make` so the compiled-in copy
+is regenerated.
+
+## The progress-thread engine (`pmix_progress_threads.c`)
+
+A `pmix_progress_tracker_t` wraps one libevent base + one OS thread,
+kept on a file-scope `tracking` list and identified by name. `NULL`
+means the shared **"PMIX-wide async progress thread"** — the one
+`pmix_rte_init` creates and that `pmix_globals.evbase` points at.
+Frameworks that need their own thread pass a name
+(`pstat` → `"PSTAT"`, `psensor` → `"PSENSOR"`).
+
+Lifecycle primitives, and how they differ (this is the easy-to-confuse
+part):
+
+| Function | Refcount | Event base | Thread |
+|----------|----------|------------|--------|
+| `pmix_progress_thread_init` | +1 (creates if absent) | creates | — |
+| `pmix_progress_thread_start` | — | — | spins the engine |
+| `pmix_progress_thread_pause` | — | kept | stops the loop, keeps base |
+| `pmix_progress_thread_resume` | — | kept | re-spins (errors if active) |
+| `pmix_progress_thread_stop` | −1; frees at 0 | freed at 0 | joined at 0 |
+
+Key facts:
+
+- **The base always carries a persistent "block" timer** (`dummy_timeout_cb`,
+  1-hour re-arm) so `pmix_event_loop(..., ONCE)` never returns just
+  because the base went empty.
+- Each base keeps something to block on via that timer; the engine loop
+  runs while `trk->ev_active` is set and exits after
+  `pmix_event_base_loopexit`.
+- `stop_progress_engine` sets/clears `pmix_globals.progress_thread_stopped`
+  for the *shared* thread only. That flag gates whether PMIx APIs may
+  still thread-shift work in — code that posts to the progress thread
+  checks it to avoid enqueuing onto a dead loop.
+- The public **`PMIx_Progress_thread_stop`** (2-arg, in `pmix.h`) is
+  *not* the same as internal `pmix_progress_thread_stop` (1-arg name).
+  The public one parses `PMIX_PROGRESS_THREAD_NAME` /
+  `PMIX_PROGRESS_THREAD_FLUSH` directives, optionally drains the base
+  with a marker event, and stops the engine **without** touching the
+  refcount or the tracking list. `PMIx_Progress` runs a single
+  non-blocking loop pass on the shared base (used by hosts that drive
+  progress themselves).
+- The shared-thread teardown in `pmix_rte_finalize` uses
+  `pause` (early) then `stop` (last).
+
+## The `pmix_info` support library (`pmix_info_support.c`)
+
+This is the largest file and is almost entirely presentation logic for
+the `pmix_info` tool and its siblings (`src/tools/*`). It has its own
+lightweight init/finalize (`pmix_info_init` / `pmix_info_finalize`)
+distinct from `pmix_rte_init` — a tool wants MCA params and framework
+registration but not a running progress thread or a connected peer.
+Notable pieces:
+
+- **`pmix_info_out`** is the shared formatter. It supports a
+  center-aligned "pretty" mode (with terminal-width wrapping and
+  ANSI-color-aware line-length accounting) and a `key:value` "parsable"
+  mode (which quote-escapes values containing `:` or `"`). Almost every
+  other function funnels through it.
+- **`pmix_info_register_framework_params`** /
+  **`pmix_info_close_components`** are refcounted
+  (`pmix_info_registered`) so multiple tools can share the registration.
+- Enumeration walks `pmix_frameworks[]` (generated by autogen, from
+  `src/include/pmix_frameworks.h`) and the `component_map` built by
+  `pmix_info_register_project_frameworks`.
+- Because these run in a short-lived CLI process, several functions
+  `exit()` directly on user error rather than returning, and cleanup is
+  deliberately minimal. Do not copy that style into library code.
+
+## Threading notes specific to this directory
+
+- `pmix_init_util` guards itself with an **atomic** bool
+  (`pmix_atomic_check_bool`/`set_bool`) because tools can race into it;
+  the rest of init assumes single-threaded bring-up (the progress
+  thread does not exist yet for most of it, and is paused first thing in
+  finalize).
+- Everything after `pmix_progress_thread_start` and before
+  `pmix_progress_thread_pause` is the normal PMIx world where the
+  progress-thread / caddy rules from the top-level guide apply. Init and
+  finalize themselves run on the main thread.
+
+## Building and testing
+
+Plain top-level `make` picks up edits here (no `configure` needed unless
+you add/remove a file). There is **no dedicated unit test** for
+`src/runtime` — every `make check` test and every `./simptest` run
+exercises init/finalize implicitly, and the re-entrancy fixes were
+validated with init→finalize→init cycles. If you change the
+init/finalize contract, an explicit double-cycle smoke test is the
+right thing to add under `test/unit`. Do not diagnose functional
+failures against an `--enable-test-build` tree (see the top-level
+guide).
+
+## Known rough spots
+
+Structural quirks worth knowing before you touch the relevant code:
+
+- **Init failure aborts rather than unwinds.** On any error after the
+  early stages, `pmix_rte_init` jumps to `return_error`, emits a
+  `show_help` diagnostic, frees the transient IOF-flag strings, and
+  returns — it deliberately does **not** tear down the frameworks,
+  globals, or event base it already brought up, because a failed
+  `PMIx_Init` aborts the process. Do not mistake this for a leak to
+  "fix" on the error path; if you add a new failure point, follow the
+  same pattern (set `error` to a short label and `goto return_error`).
+
+## When modifying code here
+
+- **Keep the three views of `pmix_globals` in sync** (static init,
+  `pmix_rte_init` construction, `pmix_rte_finalize` teardown). This is
+  the single most common way to break this directory.
+- **Preserve re-entrancy.** After your change, a
+  init→finalize→init→finalize cycle must run clean (no leak, no crash,
+  no use of a freed base). NULL every pointer you cache across finalize.
+- **Respect the framework open/select order** in `pmix_rte_init` and the
+  reverse-ish close order in `pmix_rte_finalize`; the preg-after-pcompress
+  dependency is real.
+- **Default an MCA param before registering it**, and add the matching
+  output-channel open if it is a verbosity var.
+- **Regenerate `show_help`** after touching `help-pmix-runtime.txt`.
+- Library code must not adopt the `pmix_info` tool's `exit()`-on-error /
+  minimal-cleanup style.

--- a/src/runtime/CLAUDE.md
+++ b/src/runtime/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -1312,7 +1312,19 @@ char *pmix_info_make_version_str(const char *scope, int major, int minor, int re
     char *str = NULL, *tmp;
     char temp[BUFSIZ];
 
+    /* Start with an empty string so that an unrecognized scope (or a
+     * scope whose branch leaves str NULL) falls through to a harmless
+     * empty result rather than the strdup(temp) below reading
+     * uninitialized stack. */
+    temp[0] = '\0';
     temp[BUFSIZ - 1] = '\0';
+
+    /* Be tolerant of misuse: a NULL scope yields an empty string
+     * rather than crashing in strcmp. */
+    if (NULL == scope) {
+        return strdup("");
+    }
+
     if (0 == strcmp(scope, pmix_info_ver_full) || 0 == strcmp(scope, pmix_info_ver_all)) {
         snprintf(temp, BUFSIZ - 1, "%d.%d.%d", major, minor, release);
         str = strdup(temp);
@@ -1328,9 +1340,10 @@ char *pmix_info_make_version_str(const char *scope, int major, int minor, int re
     } else if (0 == strcmp(scope, pmix_info_ver_release)) {
         snprintf(temp, BUFSIZ - 1, "%d", release);
     } else if (0 == strcmp(scope, pmix_info_ver_greek)) {
-        str = strdup(greek);
+        /* greek/repo may legitimately be absent; do not strdup(NULL) */
+        str = strdup(NULL != greek ? greek : "");
     } else if (0 == strcmp(scope, pmix_info_ver_repo)) {
-        str = strdup(repo);
+        str = strdup(NULL != repo ? repo : "");
     }
 
     if (NULL == str) {

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -558,7 +558,7 @@ void pmix_info_do_params(const char *project, bool want_all_in, bool want_intern
     pmix_cli_item_t *opt;
     char *type, *component, *str;
     bool found;
-    int i;
+    int i, j;
     bool want_all = false;
 
     opt = pmix_cmd_line_get_param(pmix_info_cmd_line, PMIX_CLI_INFO_PARAM);
@@ -610,8 +610,8 @@ void pmix_info_do_params(const char *project, bool want_all_in, bool want_intern
             }
             component = opt->values[i];
 
-            for (found = false, i = 0; i < mca_types->size; ++i) {
-                if (NULL == (str = (char *) pmix_pointer_array_get_item(mca_types, i))) {
+            for (found = false, j = 0; j < mca_types->size; ++j) {
+                if (NULL == (str = (char *) pmix_pointer_array_get_item(mca_types, j))) {
                     continue;
                 }
                 if (0 == strcmp(str, type)) {
@@ -698,7 +698,6 @@ void pmix_info_do_type(pmix_cli_result_t *pmix_info_cmd_line)
                 for (j = 0; strings[j]; ++j) {
                     if (0 == j && pmix_info_pretty) {
                         pmix_asprintf(&message, "MCA %s", group->group_framework);
-                        pmix_output(0, "STRINGS: %s", strings[j]);
                         pmix_info_out(message, message, strings[j]);
                         free(message);
                     } else {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -275,10 +275,15 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
                 ret = PMIx_Value_get_number(&info[n].value, &pmix_globals.nodeid, PMIX_UINT32);
                 if (PMIX_SUCCESS != ret) {
+                    error = "nodeid";
                     goto return_error;
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_INFO_ARRAY)) {
                 /* contains info about our node */
+                if (NULL == info[n].value.data.darray ||
+                    NULL == info[n].value.data.darray->array) {
+                    continue;
+                }
                 iptr = (pmix_info_t *) info[n].value.data.darray->array;
                 minfo = info[n].value.data.darray->size;
                 for (m = 0; m < minfo; m++) {
@@ -290,6 +295,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                     } else if (PMIX_CHECK_KEY(&iptr[m], PMIX_NODEID)) {
                         ret = PMIx_Value_get_number(&iptr[m].value, &pmix_globals.nodeid, PMIX_UINT32);
                         if (PMIX_SUCCESS != ret) {
+                            error = "nodeid";
                             goto return_error;
                         }
                     }
@@ -431,6 +437,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     /* create our peer object */
     pmix_globals.mypeer = PMIX_NEW(pmix_peer_t);
     if (NULL == pmix_globals.mypeer) {
+        error = "peer object";
         ret = PMIX_ERR_NOMEM;
         goto return_error;
     }
@@ -444,6 +451,7 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_globals.mypeer->nptr) {
         PMIX_RELEASE(pmix_globals.mypeer);
+        error = "namespace object";
         ret = PMIX_ERR_NOMEM;
         goto return_error;
     }

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -410,44 +410,6 @@ pmix_status_t pmix_progress_thread_stop(const char *name)
     return PMIX_ERR_NOT_FOUND;
 }
 
-pmix_status_t pmix_progress_thread_finalize(const char *name)
-{
-    pmix_progress_tracker_t *trk;
-
-    if (!inited) {
-        /* nothing we can do */
-        return PMIX_ERR_NOT_FOUND;
-    }
-
-    if (NULL == name) {
-        if (pmix_globals.external_progress) {
-            return PMIX_SUCCESS;
-        }
-        name = shared_thread_name;
-        // mark progress thread as stopped
-        pmix_atomic_set_bool(&pmix_globals.progress_thread_stopped);
-    }
-
-    /* find the specified engine */
-    PMIX_LIST_FOREACH (trk, &tracking, pmix_progress_tracker_t) {
-        if (0 == strcmp(name, trk->name)) {
-            /* If the refcount is still above 0, we're done here */
-            if (trk->refcount > 0) {
-                return PMIX_SUCCESS;
-            }
-
-            pmix_list_remove_item(&tracking, &trk->super);
-            if (trk == shared_thread_tracker) {
-                shared_thread_tracker = NULL;
-            }
-            PMIX_RELEASE(trk);
-            return PMIX_SUCCESS;
-        }
-    }
-
-    return PMIX_ERR_NOT_FOUND;
-}
-
 /*
  * Stop the progress thread, but don't delete the tracker (or event base)
  */

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -227,15 +227,20 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
         CPU_ZERO(&cpuset);
         // comma-delimited list of cpu ranges
         ranges = PMIx_Argv_split(pmix_progress_thread_cpus, ',');
-        for (n=0; NULL != ranges[n]; n++) {
-            // look for '-'
+        for (n=0; NULL != ranges && NULL != ranges[n]; n++) {
+            // a range is "start-end"; a bare entry is a single cpu. Note
+            // that strtoul sets 'dash' to the character where parsing
+            // stopped - which is never NULL - so we must test what it
+            // points at, not whether the pointer itself is NULL.
             start = strtoul(ranges[n], &dash, 10);
-            if (NULL == dash) {
+            if ('-' != *dash) {
+                // single cpu
                 CPU_SET(start, &cpuset);
             } else {
                 ++dash;  // skip over the '-'
                 end = strtoul(dash, NULL, 10);
-                for (k=start; k < end; k++) {
+                // the range is inclusive of both endpoints
+                for (k=start; k <= end; k++) {
                     CPU_SET(k, &cpuset);
                 }
             }
@@ -244,6 +249,10 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
         if (0 != rc && pmix_bind_progress_thread_reqd) {
             pmix_output(0, "Failed to bind progress thread %s", trk->name);
             rc = PMIX_ERR_NOT_SUPPORTED;
+            /* the engine thread is already running - stop it before we
+             * report failure so the caller can safely tear down the
+             * tracker without freeing a live event base */
+            stop_progress_engine(trk);
         } else {
             rc = PMIX_SUCCESS;
         }
@@ -338,6 +347,14 @@ pmix_status_t pmix_progress_thread_start(const char *name)
             }
             if (PMIX_SUCCESS != (rc = start_progress_engine(trk))) {
                 PMIX_ERROR_LOG(rc);
+                /* the engine failed to start (start_progress_engine has
+                 * already stopped it if it had begun running); drop the
+                 * tracker from the list and clear the shared cache so
+                 * nothing later dereferences the freed tracker */
+                pmix_list_remove_item(&tracking, &trk->super);
+                if (trk == shared_thread_tracker) {
+                    shared_thread_tracker = NULL;
+                }
                 PMIX_RELEASE(trk);
             }
             return rc;

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -51,18 +51,6 @@ PMIX_EXPORT pmix_status_t pmix_progress_thread_start(const char *name);
 PMIX_EXPORT pmix_status_t pmix_progress_thread_stop(const char *name);
 
 /**
- * Finalize a progress thread name (reference counted).
- *
- * Once this function is invoked after pmix_progress_thread_stop() has been called
- * as many times as pmix_progress_thread_init() was invoked on this name (or NULL),
- * the event base associated with it is destroyed.
- *
- * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
- * exist; PMIX_SUCCESS otherwise.
- */
-PMIX_EXPORT pmix_status_t pmix_progress_thread_finalize(const char *name);
-
-/**
  * Temporarily pause the progress thread associated with this name.
  *
  * This function does not destroy the event base associated with this

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpme
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
 compress_SOURCES =  \
         compress.c
@@ -98,5 +98,17 @@ hwloc_datatype_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hwloc_datatype_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+progress_threads_SOURCES = \
+        progress_threads.c
+progress_threads_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+progress_threads_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+info_support_SOURCES = \
+        info_support.c
+info_support_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+info_support_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support

--- a/test/unit/info_support.c
+++ b/test/unit/info_support.c
@@ -82,6 +82,13 @@ static void test_version_str(void)
     check_version("version:release", "release", 5, 1, 2, "", "", "2");
     check_version("version:greek", "greek", 5, 1, 2, "rc3", "", "rc3");
     check_version("version:repo", "repo", 5, 1, 2, "", "deadbeef", "deadbeef");
+
+    /* misuse hardening: none of these should crash or leak uninitialized
+     * memory - they all resolve to an empty string */
+    check_version("version:unknown-scope", "bogus", 5, 1, 2, "x", "y", "");
+    check_version("version:null-scope", NULL, 5, 1, 2, "x", "y", "");
+    check_version("version:greek-null", "greek", 5, 1, 2, NULL, "", "");
+    check_version("version:repo-null", "repo", 5, 1, 2, "", NULL, "");
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/unit/info_support.c
+++ b/test/unit/info_support.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pmix_info support-library formatting helpers in
+ * src/runtime/pmix_info_support.c.
+ *
+ * These functions are pure presentation logic and require no PMIx
+ * initialization: pmix_info_make_version_str simply builds a string,
+ * and pmix_info_out / pmix_info_out_int format a key/value pair to
+ * stdout.  The parsable (non-pretty) output path is deterministic, so
+ * we drive pmix_info_pretty=false and capture stdout to verify it
+ * exactly - this also exercises the internal quote/colon escaping.
+ *
+ * Test cases:
+ *   version-str: full/all include greek; major/minor/release/greek/repo
+ *                select the right field.
+ *   info-out:    plain "key:value"; values containing ':' are wrapped in
+ *                quotes; embedded '"' is backslash-escaped; a NULL/empty
+ *                plain message prints the bare value; out_int formats the
+ *                integer.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/runtime/pmix_info_support.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_info_make_version_str                                          */
+/* ------------------------------------------------------------------ */
+
+static void check_version(const char *name, const char *scope, int maj, int min,
+                          int rel, const char *greek, const char *repo,
+                          const char *expect)
+{
+    char *got = pmix_info_make_version_str(scope, maj, min, rel, greek, repo);
+    int ok = (NULL != got && 0 == strcmp(got, expect));
+    if (!ok) {
+        fprintf(stdout, "    (scope=%s) expected \"%s\", got \"%s\"\n", scope,
+                expect, NULL == got ? "(null)" : got);
+    }
+    report(name, ok);
+    if (NULL != got) {
+        free(got);
+    }
+}
+
+static void test_version_str(void)
+{
+    /* "full" and "all" render major.minor.release with the greek suffix
+     * appended verbatim (an empty greek appends nothing) */
+    check_version("version:full", "full", 5, 1, 2, "rc3", "sha", "5.1.2rc3");
+    check_version("version:full-nogreek", "full", 5, 1, 2, "", "sha", "5.1.2");
+    check_version("version:all", "all", 6, 0, 11, "a1", "sha", "6.0.11a1");
+
+    /* single-field scopes */
+    check_version("version:major", "major", 5, 1, 2, "", "", "5");
+    check_version("version:minor", "minor", 5, 1, 2, "", "", "1");
+    check_version("version:release", "release", 5, 1, 2, "", "", "2");
+    check_version("version:greek", "greek", 5, 1, 2, "rc3", "", "rc3");
+    check_version("version:repo", "repo", 5, 1, 2, "", "deadbeef", "deadbeef");
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_info_out - capture stdout and compare                          */
+/* ------------------------------------------------------------------ */
+
+static char capbuf[8192];
+
+/* Run one pmix_info_out call with stdout redirected to a temp file,
+ * then load what it printed into capbuf. */
+static void capture_out(const char *pretty, const char *plain, const char *value)
+{
+    int saved;
+    size_t n;
+    FILE *tmp;
+
+    capbuf[0] = '\0';
+    fflush(stdout);
+    saved = dup(fileno(stdout));
+    tmp = tmpfile();
+    if (NULL == tmp || 0 > saved) {
+        return;
+    }
+    dup2(fileno(tmp), fileno(stdout));
+
+    pmix_info_out(pretty, plain, value);
+
+    fflush(stdout);
+    dup2(saved, fileno(stdout));
+    close(saved);
+
+    rewind(tmp);
+    n = fread(capbuf, 1, sizeof(capbuf) - 1, tmp);
+    capbuf[n] = '\0';
+    fclose(tmp);
+}
+
+static void check_out(const char *name, const char *pretty, const char *plain,
+                      const char *value, const char *expect)
+{
+    capture_out(pretty, plain, value);
+    int ok = (0 == strcmp(capbuf, expect));
+    if (!ok) {
+        fprintf(stdout, "    expected \"%s\", got \"%s\"\n", expect, capbuf);
+    }
+    report(name, ok);
+}
+
+static void test_info_out_parsable(void)
+{
+    bool saved_pretty = pmix_info_pretty;
+    pmix_info_pretty = false;
+
+    /* plain key:value */
+    check_out("out:plain", NULL, "key", "value", "key:value\n");
+
+    /* a value containing a colon is wrapped in double quotes so the
+     * key/value split stays unambiguous */
+    check_out("out:colon", NULL, "key", "a:b", "key:\"a:b\"\n");
+
+    /* embedded double quotes are backslash-escaped (no colon -> no wrap) */
+    check_out("out:quote", NULL, "path", "a\"b", "path:a\\\"b\n");
+
+    /* both: escaped quote AND colon-wrapping */
+    check_out("out:quote-colon", NULL, "k", "a:\"b", "k:\"a:\\\"b\"\n");
+
+    /* an empty/NULL plain message prints just the bare value */
+    check_out("out:no-plain", NULL, NULL, "bare", "bare\n");
+    check_out("out:empty-plain", NULL, "", "bare", "bare\n");
+
+    /* NULL value is treated as empty string */
+    check_out("out:null-value", NULL, "key", NULL, "key:\n");
+
+    pmix_info_pretty = saved_pretty;
+}
+
+static void test_info_out_int(void)
+{
+    bool saved_pretty = pmix_info_pretty;
+    pmix_info_pretty = false;
+
+    int saved;
+    size_t n;
+    FILE *tmp;
+
+    capbuf[0] = '\0';
+    fflush(stdout);
+    saved = dup(fileno(stdout));
+    tmp = tmpfile();
+    if (NULL != tmp && 0 <= saved) {
+        dup2(fileno(tmp), fileno(stdout));
+        pmix_info_out_int(NULL, "count", 42);
+        fflush(stdout);
+        dup2(saved, fileno(stdout));
+        close(saved);
+        rewind(tmp);
+        n = fread(capbuf, 1, sizeof(capbuf) - 1, tmp);
+        capbuf[n] = '\0';
+        fclose(tmp);
+    }
+
+    int ok = (0 == strcmp(capbuf, "count:42\n"));
+    if (!ok) {
+        fprintf(stdout, "    expected \"count:42\\n\", got \"%s\"\n", capbuf);
+    }
+    report("out_int:value", ok);
+
+    pmix_info_pretty = saved_pretty;
+}
+
+int main(void)
+{
+    fprintf(stdout, "\n=== pmix_info support-library unit tests ===\n\n");
+
+    test_version_str();
+    test_info_out_parsable();
+    test_info_out_int();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/progress_threads.c
+++ b/test/unit/progress_threads.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the name-addressed progress-thread engine in
+ * src/runtime/pmix_progress_threads.c.
+ *
+ * The process is initialized as a PMIx server, which brings up libevent
+ * thread support and the shared "PMIX-wide" progress thread.  All of the
+ * tests here operate on *named* progress threads so they never disturb
+ * the library's shared thread; each test balances its own init/stop
+ * calls so nothing is left running.
+ *
+ * What is covered:
+ *   - init returns a usable base and is reference-counted per name
+ *     (a second init of the same name returns the same base);
+ *   - distinct names get distinct bases;
+ *   - a started engine actually progresses events posted to its base;
+ *   - resume on an active engine reports PMIX_ERR_RESOURCE_BUSY;
+ *   - pause followed by resume restores progress;
+ *   - stop is reference counted and removes the tracker at zero, after
+ *     which start/stop of that name report PMIX_ERR_NOT_FOUND;
+ *   - operations on an unknown name report PMIX_ERR_NOT_FOUND.
+ *
+ * Not covered: CPU-affinity binding (start_progress_engine's
+ * pthread_setaffinity_np path) is not observable through any public
+ * interface - the bound thread handle is internal - so it cannot be
+ * asserted from a unit test.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/include/pmix_types.h"
+#include "src/runtime/pmix_progress_threads.h"
+#include "src/threads/pmix_threads.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper: prove a base is being progressed by its engine thread.      */
+/*                                                                     */
+/* We post a manually-activated event onto the base; if the engine is  */
+/* looping it will fire our callback, which wakes the lock we block    */
+/* on.  This mirrors the marker-event pattern the library itself uses  */
+/* in PMIx_Progress_thread_stop.  It only returns once the event has   */
+/* run, so reaching the end means the base is live.                    */
+/* ------------------------------------------------------------------ */
+
+static void wake_cb(int fd, short args, void *cbdata)
+{
+    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(fd, args);
+    PMIX_WAKEUP_THREAD(lock);
+}
+
+static void drive_one_event(pmix_event_base_t *base)
+{
+    pmix_lock_t lock;
+    pmix_event_t ev;
+
+    PMIX_CONSTRUCT_LOCK(&lock);
+    pmix_event_assign(&ev, base, -1, EV_WRITE, wake_cb, &lock);
+    PMIX_POST_OBJECT(&lock);
+    pmix_event_active(&ev, EV_WRITE, 1);
+    PMIX_WAIT_THREAD(&lock);
+    PMIX_DESTRUCT_LOCK(&lock);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_refcount_identity(void)
+{
+    const char *nm = "UT-refcount";
+    pmix_event_base_t *b1, *b2;
+    pmix_status_t rc;
+
+    b1 = pmix_progress_thread_init(nm);
+    report("refcount:init-returns-base", NULL != b1);
+
+    /* second init of the same name returns the same base and ups the
+     * refcount rather than creating a new thread */
+    b2 = pmix_progress_thread_init(nm);
+    report("refcount:reinit-same-base", NULL != b2 && b2 == b1);
+
+    /* refcount is 2; the first stop must leave it alive */
+    rc = pmix_progress_thread_stop(nm);
+    report("refcount:first-stop-ok", PMIX_SUCCESS == rc);
+    rc = pmix_progress_thread_start(nm);
+    report("refcount:still-present-after-first-stop", PMIX_SUCCESS == rc);
+
+    /* engine got started above; a second stop drops the refcount to 0,
+     * stops the engine, and removes the tracker */
+    rc = pmix_progress_thread_stop(nm);
+    report("refcount:second-stop-ok", PMIX_SUCCESS == rc);
+
+    /* now it is gone: both start and stop should not find it */
+    rc = pmix_progress_thread_start(nm);
+    report("refcount:start-after-removal-notfound", PMIX_ERR_NOT_FOUND == rc);
+    rc = pmix_progress_thread_stop(nm);
+    report("refcount:stop-after-removal-notfound", PMIX_ERR_NOT_FOUND == rc);
+}
+
+static void test_distinct_names(void)
+{
+    pmix_event_base_t *ba, *bb;
+
+    ba = pmix_progress_thread_init("UT-A");
+    bb = pmix_progress_thread_init("UT-B");
+    report("distinct:two-names-two-bases",
+           NULL != ba && NULL != bb && ba != bb);
+
+    (void) pmix_progress_thread_stop("UT-A");
+    (void) pmix_progress_thread_stop("UT-B");
+}
+
+static void test_start_progresses(void)
+{
+    const char *nm = "UT-run";
+    pmix_event_base_t *base;
+    pmix_status_t rc;
+
+    base = pmix_progress_thread_init(nm);
+    if (NULL == base) {
+        report("start:init", 0);
+        return;
+    }
+
+    rc = pmix_progress_thread_start(nm);
+    report("start:start-ok", PMIX_SUCCESS == rc);
+
+    if (PMIX_SUCCESS == rc) {
+        /* if this returns, the engine thread progressed our event */
+        drive_one_event(base);
+        report("start:event-progressed", 1);
+
+        /* resume on an already-running engine is refused */
+        rc = pmix_progress_thread_resume(nm);
+        report("start:resume-busy", PMIX_ERR_RESOURCE_BUSY == rc);
+    }
+
+    (void) pmix_progress_thread_stop(nm);
+}
+
+static void test_pause_resume(void)
+{
+    const char *nm = "UT-pause";
+    pmix_event_base_t *base;
+    pmix_status_t rc;
+
+    base = pmix_progress_thread_init(nm);
+    if (NULL == base) {
+        report("pause:init", 0);
+        return;
+    }
+    rc = pmix_progress_thread_start(nm);
+    report("pause:start-ok", PMIX_SUCCESS == rc);
+
+    rc = pmix_progress_thread_pause(nm);
+    report("pause:pause-ok", PMIX_SUCCESS == rc);
+
+    /* resume must restart the engine (start_progress_engine path) */
+    rc = pmix_progress_thread_resume(nm);
+    report("pause:resume-ok", PMIX_SUCCESS == rc);
+
+    if (PMIX_SUCCESS == rc) {
+        /* progress works again after the resume */
+        drive_one_event(base);
+        report("pause:progress-after-resume", 1);
+    }
+
+    (void) pmix_progress_thread_stop(nm);
+}
+
+static void test_unknown_name(void)
+{
+    const char *nm = "UT-does-not-exist";
+
+    report("unknown:start", PMIX_ERR_NOT_FOUND == pmix_progress_thread_start(nm));
+    report("unknown:stop", PMIX_ERR_NOT_FOUND == pmix_progress_thread_stop(nm));
+    report("unknown:pause", PMIX_ERR_NOT_FOUND == pmix_progress_thread_pause(nm));
+    report("unknown:resume", PMIX_ERR_NOT_FOUND == pmix_progress_thread_resume(nm));
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== progress-thread engine unit tests ===\n\n");
+
+    test_refcount_identity();
+    test_distinct_names();
+    test_start_progresses();
+    test_pause_resume();
+    test_unknown_name();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
This branch is the result of a review of `src/runtime`. It adds a
developer orientation guide, fixes the concrete defects found during
that review, removes a dead API, and lands unit tests for the parts
that are feasibly testable.

## Documentation
- **Add `src/runtime/AGENTS.md`** (with the customary `CLAUDE.md`
  symlink) orienting contributors to the runtime/bootstrap layer: the
  init/finalize ordering contract and its re-entrancy requirements, the
  process-wide `pmix_globals` object, the non-framework MCA parameter
  registry, the reference-counted progress-thread engine, and the
  `pmix_info` support library. Follows the format of the AGENTS.md files
  already present in sibling `src/` subdirectories.

## Bug fixes
- **Progress-thread CPU-affinity binding.** The range parser tested
  `strtoul`'s end pointer against NULL (it never is), so a bare CPU
  number fell into the range branch, advanced past the string's
  terminator (an out-of-bounds read) and never set the CPU, while an
  explicit range like `3-5` excluded its final endpoint. Test the
  referenced character instead and make the range inclusive. Also tear
  down cleanly on a required-bind failure: the engine thread is already
  running when `pthread_setaffinity_np` fails, so stop it before
  returning the error and have the caller unlink the tracker before
  releasing it (previously it freed a live event base and left a
  dangling list entry).
- **`pmix_info` param/type display.** `pmix_info_do_params` reused its
  outer loop index for the inner `mca_types` search, so more than one
  `type component` pair to `--param` walked off the option array; give
  the inner search its own index. Also drop a leftover debug `printf`
  in `pmix_info_do_type`.
- **`pmix_rte_init` error paths.** Give the `PMIX_NODEID` and
  peer/namespace allocation failures a short label so the startup
  `show_help()` diagnostic names the failing step instead of formatting
  a NULL, and guard the `PMIX_NODE_INFO_ARRAY` handler against a NULL
  `darray`.
- **Harden `pmix_info_make_version_str`** against misuse: a NULL or
  unrecognized scope no longer crashes or reads uninitialized stack, and
  the `greek`/`repo` scopes no longer `strdup(NULL)`.

## Cleanup
- **Remove `pmix_progress_thread_finalize`** — it had no callers, and
  since `pmix_progress_thread_stop` already removes and releases the
  tracker at refcount zero it could never find a live tracker to act on.

## Tests
- **`test/unit/progress_threads`** exercises the name-addressed
  progress-thread engine (reference-counted init/stop, distinct bases
  per name, real event progression, pause/resume, resume-while-active,
  tracker removal at refcount zero, unknown-name handling), using named
  threads so it never disturbs the library's shared progress thread.
- **`test/unit/info_support`** covers `pmix_info_make_version_str` for
  every scope (including the new misuse-hardening paths) and the
  parsable `pmix_info_out`/`pmix_info_out_int` formatting via captured
  stdout.

Both are wired into `make check`. The whole series builds warning-free
under the default `--enable-devel-check`/`-Werror` flags, and each
commit compiles independently.