### PR TITLE
Fix memory leaks, double-frees, and correctness bugs in src/server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,9 @@ test/unit/bfrops_alloc_inherit
 test/unit/gds_fallback
 test/unit/pmix_log
 test/unit/collective_status
+test/unit/collect_job_info
+test/unit/trk_complete
+test/unit/tracker_match
 test/unit/client_cycle
 test/unit/tool_cycle
 test/unit/event_chain

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -669,6 +669,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* assign our internal bfrops module */
     pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
     if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
+        /* rc still holds SUCCESS from pmix_rte_init - report a real error */
+        rc = PMIX_ERR_INIT;
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -688,6 +690,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     evar = getenv("PMIX_SECURITY_MODE");
     pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(evar);
     if (NULL == pmix_globals.mypeer->nptr->compat.psec) {
+        /* rc still holds SUCCESS - report a real error */
+        rc = PMIX_ERR_INIT;
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -696,7 +700,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, "hash", PMIX_STRING);
     pmix_globals.mypeer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
     if (NULL == pmix_globals.mypeer->nptr->compat.gds) {
+        /* rc still holds SUCCESS - report a real error */
+        rc = PMIX_ERR_INIT;
         PMIX_ERROR_LOG(rc);
+        PMIX_INFO_DESTRUCT(&ginfo);
         return rc;
     }
     PMIX_INFO_DESTRUCT(&ginfo);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4253,17 +4253,16 @@ static void _cnct(int sd, short args, void *cbdata)
                         PMIX_ERROR_LOG(rc);
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&pbkt);
-                        PMIX_DESTRUCT(&cb);
                         goto error;
                     }
                 } else {
                     PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
                     PMIX_BFROPS_PACK(rc, cd->peer, reply, &bo, 1, PMIX_BYTE_OBJECT);
+                    PMIX_BYTE_OBJECT_DESTRUCT(&bo); // data has been copied
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&pbkt);
-                        PMIX_DESTRUCT(&cb);
                         goto error;
                     }
                 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3620,7 +3620,10 @@ static void _resopcbfunc(int sd, short args, void *cbdata)
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
-    return;
+    /* the PTL owns the reply on a successful send - fall through to
+     * release the caddies (previously this path returned early, leaking
+     * cd, scd, scd->nspace, and scdwrapper on every successful reply) */
+    reply = NULL;
 
     /* cleanup */
 cleanup:

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -123,7 +123,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
-        return rc;
+        goto cleanup;
     }
     ninfo = ninf + 2;
     PMIX_INFO_CREATE(info, ninfo);
@@ -229,6 +229,9 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     }
 
 cleanup:
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+    }
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }
@@ -405,11 +408,28 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * notified when we are done */
     pmix_list_append(&trk->local_cbs, &cd->super);
 
+    /* if a timeout was specified, arm it once - guard against re-arming for
+     * each contributor. Do not retain the tracker: its collectives-list
+     * reference persists until completion, and completion deletes the timer
+     * before releasing (mirroring the fence family). */
+    if (0 < tv.tv_sec && !trk->event_active) {
+        PMIX_THREADSHIFT_DELAY(trk, connect_timeout, tv.tv_sec);
+        trk->event_active = true;
+    }
+
     /* if all local contributions have been received,
      * let the local host's server know that we are at the
      * "fence" point - they will callback once the [dis]connect
      * across all participants has been completed */
     if (pmix_server_trk_complete(trk)) {
+        /* delete the local-phase timer before handing the tracker to the
+         * host, so a late internal timeout cannot race the host completion
+         * (which could return the tracker after we released it). Once handed
+         * up, the host owns any further timeout. */
+        if (trk->event_active) {
+            pmix_event_del(&trk->ev);
+            trk->event_active = false;
+        }
         /* if all the participants are local, then we don't need the host */
         if (trk->local) {
             /* the operation is being atomically completed and the host will
@@ -463,12 +483,6 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
         }
     } else {
         rc = PMIX_SUCCESS;
-    }
-    /* if a timeout was specified, set it */
-    if (PMIX_SUCCESS == rc && 0 < tv.tv_sec) {
-        PMIX_RETAIN(trk);
-        PMIX_THREADSHIFT_DELAY(trk, connect_timeout, tv.tv_sec);
-        trk->event_active = true;
     }
 
 cleanup:

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -183,7 +183,16 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
             /* ensure that the switchyard doesn't release the caddy */
             rc = PMIX_SUCCESS;
         } else if (NULL == pmix_host_server.disconnect) {
-            PMIX_RELEASE(trk);
+            /* the host cannot execute this operation. Detach this caddy so
+             * the switchyard can send the error to this caller, and drive the
+             * op completion function to notify all other participants and tear
+             * down the tracker (unlink from collectives + release, exactly
+             * once). Releasing the still-linked tracker directly here would
+             * leave a dangling collectives entry and double-free this caddy. */
+            pmix_list_remove_item(&trk->local_cbs, &cd->super);
+            cd->trk = NULL;
+            trk->host_called = false;
+            cbfunc(PMIX_ERR_NOT_SUPPORTED, trk);
             rc = PMIX_ERR_NOT_SUPPORTED;
             goto cleanup;
         } else {
@@ -412,7 +421,16 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
             /* ensure that the switchyard doesn't release the caddy */
             rc = PMIX_SUCCESS;
         } else if (NULL == pmix_host_server.connect) {
-            PMIX_RELEASE(trk);
+            /* the host cannot execute this operation. Detach this caddy so
+             * the switchyard can send the error to this caller, and drive the
+             * op completion function to notify all other participants and tear
+             * down the tracker (unlink from collectives + release, exactly
+             * once). Releasing the still-linked tracker directly here would
+             * leave a dangling collectives entry and double-free this caddy. */
+            pmix_list_remove_item(&trk->local_cbs, &cd->super);
+            cd->trk = NULL;
+            trk->host_called = false;
+            cbfunc(PMIX_ERR_NOT_SUPPORTED, trk);
             rc = PMIX_ERR_NOT_SUPPORTED;
             goto cleanup;
         } else {

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -331,7 +331,10 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
         /* check for a timeout */
         for (n = 0; n < ninf; n++) {
             if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-                tv.tv_sec = info[n].value.data.uint32;
+                /* use the type-tolerant accessor rather than a raw union
+                 * read so any integer type for the timeout is accepted,
+                 * matching the fence family */
+                PMIx_Value_get_number(&info[n].value, &tv.tv_sec, PMIX_UINT32);
                 break;
             }
         }

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -586,7 +586,7 @@ static void _collect_job_info(int sd, short args, void *cbdata)
     bool found;
     pmix_proc_t proc;
     pmix_cb_t cb;
-    pmix_status_t ret;
+    pmix_status_t ret = PMIX_SUCCESS;
     pmix_buffer_t pbkt;
     pmix_kval_t *kptr;
     pmix_byte_object_t pbo;
@@ -684,7 +684,11 @@ static void _collect_job_info(int sd, short args, void *cbdata)
 
 
         PMIX_UNLOAD_BUFFER(&pbkt, pbo.bytes, pbo.size);
-        PMIX_BFROPS_PACK(ret, pmix_globals.mypeer, &cb.data, &pbo, 1, PMIX_BYTE_OBJECT);
+        /* accumulate into the caller's caddy (cbin), not the local cb that
+         * was just destructed above and re-created each iteration - the
+         * caller reads cbin->data, so packing into cb.data returned an empty
+         * job-info buffer to every consumer of PMIx_server_collect_job_info */
+        PMIX_BFROPS_PACK(ret, pmix_globals.mypeer, &cbin->data, &pbo, 1, PMIX_BYTE_OBJECT);
         PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
@@ -697,8 +701,9 @@ static void _collect_job_info(int sd, short args, void *cbdata)
 
 done:
     PMIx_Argv_free(nspaces);
+    cbin->status = ret;
+    PMIX_POST_OBJECT(cbin);
     PMIX_WAKEUP_THREAD(&cbin->lock);
-    PMIX_POST_OBJECT(cb);
 }
 
 pmix_status_t PMIx_server_collect_job_info(pmix_proc_t *procs, size_t nprocs,

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -138,6 +138,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
         PMIX_BFROPS_UNPACK(rc, peer, buf, &b2, &cnt, PMIX_BUFFER);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&b2);
             return rc;
         }
         /* unpack the buffer and store the values - we store them
@@ -934,7 +935,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
-        return rc;
+        goto cleanup;
     }
     ninfo = ninf + 2;
     PMIX_INFO_CREATE(info, ninfo);

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -775,7 +775,7 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                 /* pack the returned kval's */
                 PMIX_LIST_FOREACH (kv, &cb.kvs, pmix_kval_t) {
                     PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, pbkt, kv, 1, PMIX_KVAL);
-                    if (rc != PMIX_SUCCESS) {
+                    if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&cb);
                         PMIX_LIST_DESTRUCT(&rank_blobs);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -309,6 +309,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
             /* pack it for transmission */
             PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
             PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
+            PMIX_BYTE_OBJECT_DESTRUCT(&bo); // data has been copied
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT(&pbkt);
@@ -831,6 +832,7 @@ static pmix_status_t get_job_data(char *nspace,
         PMIX_DESTRUCT(&pkt);
         /* pack it for transmission */
         PMIX_BFROPS_PACK(rc, cd->peer, pbkt, &bo, 1, PMIX_BYTE_OBJECT);
+        PMIX_BYTE_OBJECT_DESTRUCT(&bo); // data has been copied
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&cb);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -743,9 +743,9 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
         }
 
         /*  If they asked for job level data, then the data was just registered */
-        if(cd->proc.rank == PMIX_RANK_WILDCARD){
+        if (PMIX_RANK_WILDCARD == cd->proc.rank) {
             found = true;
-        }else{
+        } else {
             PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
                 if (info->pname.rank == cd->proc.rank) {
                     found = true; // we will satisy this request upon commit from new proc

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -1123,10 +1123,13 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
      * stored (e.g., via a register_nspace call in response to a request
      * for job-level data). For now, we will retrieve it so it can
      * be stored for each peer */
+    /* construct this unconditionally so that every error path jumping to
+     * the 'complete' label releases it (and its retained namespace
+     * references) in one place */
+    PMIX_CONSTRUCT(&nspaces, pmix_list_t);
     if (PMIX_SUCCESS == caddy->status) {
         /* cycle across all outstanding local requests and collect their
          * unique nspaces so we can store this for each one */
-        PMIX_CONSTRUCT(&nspaces, pmix_list_t);
         PMIX_LIST_FOREACH (dm, &caddy->lcd->loc_reqs, pmix_dmdx_request_t) {
             /* this is a local proc that has requested this data - search
              * the list of nspace's and see if we already have it */
@@ -1220,6 +1223,9 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         caddy->status = rc;
+                        PMIX_RELEASE(kv);
+                        pbkt.base_ptr = NULL; // do not free the caller's data
+                        PMIX_DESTRUCT(&pbkt);
                         goto complete;
                     }
                     PMIX_RELEASE(kv);
@@ -1237,10 +1243,10 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                 }
             }
         }
-        PMIX_LIST_DESTRUCT(&nspaces);
     }
 
 complete:
+    PMIX_LIST_DESTRUCT(&nspaces);
     /* always execute the callback to avoid having the client hang */
     pmix_pending_resolve(nptr, caddy->lcd->proc.rank,
                          caddy->status, PMIX_REMOTE, caddy->lcd);

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -689,6 +689,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
     }
 
     /* we are done */
+    PMIX_LIST_DESTRUCT(&grpinfo);
     free(id);
     if (NULL != scd->relfn) {
         scd->relfn(scd->cbdata);

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -1223,6 +1223,11 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
             return PMIX_SUCCESS;
         }
+        /* detach this caddy from the tracker before releasing the block:
+         * releasing the block destructs trk->local_cbs, which would release
+         * this caddy, and the switchyard also releases it on our non-SUCCESS
+         * return -- a double free. The sibling error paths above do the same. */
+        pmix_list_remove_item(&trk->local_cbs, &cd->super);
         /* remove the tracker from the list */
         pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
         PMIX_RELEASE(blk);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1239,7 +1239,15 @@ void pmix_server_deregister_events(pmix_peer_t *peer, pmix_buffer_t *buf)
                 /* if all of the peers for this code are now gone, then remove it */
                 if (0 == pmix_list_get_size(&reginfo->peers)) {
                     pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
-                    /* if this was registered with the host, then deregister it */
+                    /* NOTE: we intentionally do NOT call the host's
+                     * deregister_events here. The server does not
+                     * reference-count enviro/system event registrations against
+                     * the host, so it never tells the host to stop forwarding a
+                     * code - an event that continues to arrive with no matching
+                     * local handler is simply received and ignored by the
+                     * notification fan-out. Implementing the full
+                     * activate-on-first / deregister-on-last handshake with the
+                     * host is deferred - see openpmix/openpmix#4014. */
                     PMIX_RELEASE(reginfo);
                 }
             }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1876,10 +1876,13 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                     }
                 }
                 if (!duplicate) {
-                    /* append it to the end of the list */
+                    /* append a copy to the end of the list - cf itself is a
+                     * member of the local ignorefiles list (destructed below),
+                     * so appending &cf->super would put one item on two lists
+                     * and leave a dangling entry when ignorefiles is freed */
                     cfptr = PMIX_NEW(pmix_cleanup_file_t);
                     cfptr->path = strdup(cf->path);
-                    pmix_list_append(&epicd->epi->ignores, &cf->super);
+                    pmix_list_append(&epicd->epi->ignores, &cfptr->super);
                 }
             }
         }
@@ -1938,9 +1941,9 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                     /* check for conflict with ignore */
                     PMIX_LIST_FOREACH (cf2, &epicd->epi->ignores, pmix_cleanup_file_t) {
                         if (0 == strcmp(cf->path, cf2->path)) {
-                            /* return an error */
+                            /* return an error - cachedirs was already
+                             * destructed above, so only cachefiles remains */
                             rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
-                            PMIX_LIST_DESTRUCT(&cachedirs);
                             PMIX_LIST_DESTRUCT(&cachefiles);
                             goto exit;
                         }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2360,6 +2360,10 @@ pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf,
     }
 
 exit:
+    /* mirror pmix_server_iofreg: on an async SUCCESS the host owns cd and
+     * releases it via the callback; on any error path here it was never
+     * handed off, so release it (previously it leaked on every error). */
+    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -2472,9 +2476,15 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
     if (PMIX_SUCCESS
         != (rc = pmix_host_server.push_stdin(&source, cd->procs, cd->nprocs, cd->info, cd->ninfo,
                                              cd->bo, stdcbfunc, cd))) {
-        if (PMIX_OPERATION_SUCCEEDED != rc) {
-            goto error;
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* the host completed atomically and will not call back - invoke
+             * the callback ourselves (it sends the reply and releases cd)
+             * and tell the switchyard we are done. Previously this path
+             * leaked cd (its procs, info, and byte object). */
+            stdcbfunc(PMIX_SUCCESS, cd);
+            return PMIX_SUCCESS;
         }
+        goto error;
     }
     return rc;
 
@@ -2671,6 +2681,10 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
     return PMIX_SUCCESS;
 
 exit:
+    /* every path reaching here failed before handing qcd to an async
+     * callback, so release it (and its retained server caddy) here.
+     * The sibling pmix_server_fabric_register does the same. */
+    PMIX_RELEASE(qcd);
     return rc;
 }
 
@@ -2839,6 +2853,9 @@ pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
         PMIX_RELEASE(pbkt);
     }
 
+    /* we queued the reply ourselves and return SUCCESS, so the switchyard
+     * will not release the caddy - we must do so here */
+    PMIX_RELEASE(cd);
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2538,7 +2538,7 @@ pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd, pmix_buffer_t
     }
     /* unpack the directives */
     if (0 < qcd->ninfo) {
-        PMIX_INFO_CREATE(cd->info, qcd->ninfo);
+        PMIX_INFO_CREATE(qcd->info, qcd->ninfo);
         cnt = qcd->ninfo;
         PMIX_BFROPS_UNPACK(rc, cd->peer, buf, qcd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -2862,7 +2862,7 @@ pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
     }
 
     scd = PMIX_NEW(pmix_setup_caddy_t);
-    if (NULL == cd) {
+    if (NULL == scd) {
         return PMIX_ERR_NOMEM;
     }
     scd->cbdata = cd;
@@ -2958,7 +2958,7 @@ pmix_status_t pmix_server_session_ctrl(pmix_server_caddy_t *cd,
     }
 
     scd = PMIX_NEW(pmix_shift_caddy_t);
-    if (NULL == cd) {
+    if (NULL == scd) {
         return PMIX_ERR_NOMEM;
     }
     scd->cbdata = cd;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -821,35 +821,35 @@ static void _check_cached_events(int sd, short args, void *cbdata)
             /* nothing we can do */
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             ret = PMIX_ERR_NOMEM;
+            if (found) {
+                /* this event was checked out of the hotel above */
+                PMIX_RELEASE(cd);
+            }
             break;
         }
         /* pack the info data stored in the event */
         PMIX_BFROPS_PACK(ret, scd->peer, relay, &cmd, 1, PMIX_COMMAND);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            break;
+        if (PMIX_SUCCESS == ret) {
+            PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->status, 1, PMIX_STATUS);
         }
-        PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->status, 1, PMIX_STATUS);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            break;
+        if (PMIX_SUCCESS == ret) {
+            PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->source, 1, PMIX_PROC);
         }
-        PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->source, 1, PMIX_PROC);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            break;
+        if (PMIX_SUCCESS == ret) {
+            PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->ninfo, 1, PMIX_SIZE);
         }
-        PMIX_BFROPS_PACK(ret, scd->peer, relay, &cd->ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            break;
-        }
-        if (0 < cd->ninfo) {
+        if (PMIX_SUCCESS == ret && 0 < cd->ninfo) {
             PMIX_BFROPS_PACK(ret, scd->peer, relay, cd->info, cd->ninfo, PMIX_INFO);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_ERROR_LOG(ret);
-                break;
+        }
+        if (PMIX_SUCCESS != ret) {
+            /* release the relay we could not fill, and the event if it was
+             * checked out of the hotel, before abandoning the loop */
+            PMIX_ERROR_LOG(ret);
+            PMIX_RELEASE(relay);
+            if (found) {
+                PMIX_RELEASE(cd);
             }
+            break;
         }
         PMIX_SERVER_QUEUE_REPLY(ret, scd->peer, 0, relay);
         if (PMIX_SUCCESS != ret) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1118,7 +1118,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
                 2, pmix_server_globals.event_output,
                 "server register events: host server processing event registration");
             if (NULL != affected) {
-                free(affected);
+                PMIX_PROC_FREE(affected, naffected);
             }
             return rc;
         } else if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -477,7 +477,7 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
     pmix_cb_t cb;
     pmix_status_t rc, ret = PMIX_SUCCESS;
-    pmix_nspace_t nspace;
+    char *nspace;
     pmix_info_t info;
     pmix_proc_t proc;
     pmix_kval_t *kv;
@@ -487,6 +487,9 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
     size_t n;
     pmix_buffer_t *reply;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    // the first qualifier in the query has the nspace in it
+    nspace = cd->query->qualifiers[0].value.data.string;
 
     // restrict our search to already available info
     PMIX_INFO_LOAD(&info, PMIX_OPTIONAL, NULL, PMIX_BOOL);
@@ -503,7 +506,7 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
-            PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb);
+            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS != rc) {
                 continue;
             }
@@ -546,7 +549,7 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
 
     // looking for a specific nspace
     PMIX_LOAD_NSPACE(proc.nspace, nspace);
-    PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb);
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_DESTRUCT(&cb);
         ret = rc;

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,9 +27,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpme
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
 compress_SOURCES =  \
         compress.c
@@ -73,6 +73,24 @@ collective_status_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 collective_status_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+collect_job_info_SOURCES = \
+        collect_job_info.c
+collect_job_info_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+collect_job_info_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+trk_complete_SOURCES = \
+        trk_complete.c
+trk_complete_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+trk_complete_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tracker_match_SOURCES = \
+        tracker_match.c
+tracker_match_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tracker_match_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 client_cycle_SOURCES = \
         client_cycle.c
 client_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -111,4 +129,4 @@ info_support_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support

--- a/test/unit/collect_job_info.c
+++ b/test/unit/collect_job_info.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for PMIx_server_collect_job_info().
+ *
+ * The internal handler behind this API accumulated each namespace's packed job
+ * info into a local, per-iteration pmix_cb_t rather than into the caller's
+ * caddy, so the API always returned an *empty* buffer to its consumers. This
+ * test registers a namespace carrying job-level data, calls the API, and
+ * asserts the returned data buffer is non-empty (and unpacks the leading
+ * namespace name to confirm real content). Before the fix the buffer is empty
+ * and this test fails; after the fix it carries the job info.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* Register a namespace with a minimal-but-valid job description: a
+ * PMIX_JOB_INFO_ARRAY carrying the node/proc maps and job sizes, one
+ * PMIX_NODE_INFO_ARRAY, and one PMIX_PROC_DATA entry per rank. This mirrors the
+ * shape a real host builds in PMIx_server_register_nspace. */
+static pmix_status_t register_job(const char *nspace, int nprocs)
+{
+    char *regex = NULL, *ppn = NULL, *rks, **agg = NULL;
+    char tmp[64];
+    pmix_info_t *info, *iptr, *pdata;
+    pmix_data_array_t *array;
+    size_t ninfo, n;
+    int m, k, nnodes = 1;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+
+    PMIx_generate_regex(pmix_globals.hostname, &regex);
+    for (m = 0; m < nprocs; m++) {
+        snprintf(tmp, sizeof(tmp), "%d", m);
+        PMIx_Argv_append_nosize(&agg, tmp);
+    }
+    rks = PMIx_Argv_join(agg, ',');
+    PMIx_Argv_free(agg);
+    PMIx_generate_ppn(rks, &ppn);
+    free(rks);
+
+    ninfo = 1 /* job-info array */ + (size_t) nnodes + (size_t) nprocs;
+    PMIX_INFO_CREATE(info, ninfo);
+
+    n = 0;
+    /* job-level info array */
+    pmix_strncpy(info[n].key, PMIX_JOB_INFO_ARRAY, PMIX_MAX_KEYLEN);
+    info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(info[n].value.data.darray, 8, PMIX_INFO);
+    iptr = (pmix_info_t *) info[n].value.data.darray->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NODE_MAP, regex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[3], PMIX_JOBID, "1234", PMIX_STRING);
+    PMIX_INFO_LOAD(&iptr[4], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[5], PMIX_MAX_PROCS, &nprocs, PMIX_UINT32);
+    m = 1;
+    PMIX_INFO_LOAD(&iptr[6], PMIX_JOB_NUM_APPS, &m, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[7], PMIX_NUM_NODES, &nnodes, PMIX_UINT32);
+    free(regex);
+    free(ppn);
+    ++n;
+
+    /* one node-info array */
+    pmix_strncpy(info[n].key, PMIX_NODE_INFO_ARRAY, PMIX_MAX_KEYLEN);
+    info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(info[n].value.data.darray, 3, PMIX_INFO);
+    iptr = (pmix_info_t *) info[n].value.data.darray->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+    m = 0;
+    PMIX_INFO_LOAD(&iptr[1], PMIX_NODEID, &m, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_NODE_SIZE, &nprocs, PMIX_UINT32);
+    ++n;
+
+    /* per-proc data */
+    for (m = 0; m < nprocs; m++) {
+        pmix_strncpy(info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        info[n].value.type = PMIX_DATA_ARRAY;
+        PMIX_DATA_ARRAY_CREATE(array, 3, PMIX_INFO);
+        info[n].value.data.darray = array;
+        pdata = (pmix_info_t *) array->array;
+        k = 0;
+        pmix_strncpy(pdata[k].key, PMIX_RANK, PMIX_MAX_KEYLEN);
+        pdata[k].value.type = PMIX_PROC_RANK;
+        pdata[k].value.data.rank = m;
+        ++k;
+        pmix_strncpy(pdata[k].key, PMIX_LOCAL_RANK, PMIX_MAX_KEYLEN);
+        pdata[k].value.type = PMIX_UINT16;
+        pdata[k].value.data.uint16 = m;
+        ++k;
+        pmix_strncpy(pdata[k].key, PMIX_NODEID, PMIX_MAX_KEYLEN);
+        pdata[k].value.type = PMIX_UINT32;
+        pdata[k].value.data.uint32 = 0;
+        ++n;
+    }
+
+    PMIX_LOAD_NSPACE(ns, nspace);
+    /* NULL cbfunc -> blocking registration */
+    rc = PMIx_server_register_nspace(ns, nprocs, info, ninfo, NULL, NULL);
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    const char *nspace = "collect-job-test";
+    pmix_proc_t procs[1];
+    pmix_data_buffer_t dbuf;
+    char *unpacked = NULL;
+    int32_t cnt;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIx_server_collect_job_info unit test ===\n\n");
+
+    rc = register_job(nspace, 2);
+    /* a blocking (NULL cbfunc) registration reports success as either
+     * PMIX_SUCCESS or PMIX_OPERATION_SUCCEEDED */
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "register_nspace failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    PMIX_LOAD_PROCID(&procs[0], nspace, PMIX_RANK_WILDCARD);
+    PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+
+    rc = PMIx_server_collect_job_info(procs, 1, &dbuf);
+    report("collect_job_info returns success", PMIX_SUCCESS == rc);
+
+    /* the core regression: the returned buffer must not be empty */
+    report("returned job-info buffer is non-empty",
+           PMIX_SUCCESS == rc && 0 < dbuf.bytes_used);
+
+    /* verify real content: each participating nspace is packed as one byte
+     * object whose payload is an inner buffer that begins with the nspace
+     * name. Unpack the byte object, load it, and read the leading name. */
+    if (PMIX_SUCCESS == rc && 0 < dbuf.bytes_used) {
+        pmix_byte_object_t bo;
+        pmix_data_buffer_t inner;
+
+        PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+        cnt = 1;
+        rc = PMIx_Data_unpack(NULL, &dbuf, &bo, &cnt, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS == rc && NULL != bo.bytes && 0 < bo.size) {
+            PMIX_DATA_BUFFER_CONSTRUCT(&inner);
+            PMIx_Data_load(&inner, &bo);
+            cnt = 1;
+            PMIx_Data_unpack(NULL, &inner, &unpacked, &cnt, PMIX_STRING);
+            report("per-nspace blob carries the namespace name",
+                   NULL != unpacked && 0 == strcmp(unpacked, nspace));
+            if (NULL != unpacked) {
+                free(unpacked);
+            }
+            PMIX_DATA_BUFFER_DESTRUCT(&inner);
+        } else {
+            report("per-nspace blob carries the namespace name", 0);
+        }
+    } else {
+        report("per-nspace blob carries the namespace name", 0);
+    }
+
+    PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/tracker_match.c
+++ b/test/unit/tracker_match.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for the collective-tracker identity machinery:
+ * pmix_server_new_tracker() and pmix_server_get_tracker().
+ *
+ * A collective tracker is uniquely identified either by a string id, or by the
+ * tuple {set of participating procs, collective type}. get_tracker() performs a
+ * brute-force search of pmix_server_globals.collectives and must:
+ *   - find a tracker by its id;
+ *   - find a tracker by an exact proc-set + type match (order-independent);
+ *   - NOT match when the type differs, the proc set differs, or the id is
+ *     unknown.
+ * This underpins how the fence/connect/disconnect families join contributors to
+ * the right in-flight collective, so a matching regression would silently split
+ * or merge collectives.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+static void release_tracker(pmix_server_trkr_t *trk)
+{
+    /* new_tracker appended it to the collectives list; detach before
+     * releasing so we do not leave a dangling entry */
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+    PMIX_RELEASE(trk);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    pmix_server_trkr_t *t1, *t2, *found;
+    pmix_proc_t procsA[1];
+    pmix_proc_t procsB[2];
+    pmix_proc_t procsB_rev[2];
+    pmix_proc_t procsC[1];
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== collective tracker matching unit tests ===\n\n");
+
+    PMIX_LOAD_PROCID(&procsA[0], "trk.ns.a", 0);
+
+    PMIX_LOAD_PROCID(&procsB[0], "trk.ns.b", 0);
+    PMIX_LOAD_PROCID(&procsB[1], "trk.ns.b", 1);
+    /* same set as procsB but in reversed order - matching must be
+     * order-independent */
+    PMIX_LOAD_PROCID(&procsB_rev[0], "trk.ns.b", 1);
+    PMIX_LOAD_PROCID(&procsB_rev[1], "trk.ns.b", 0);
+
+    PMIX_LOAD_PROCID(&procsC[0], "trk.ns.c", 0);
+
+    /* an id-identified tracker (as group collectives use) */
+    t1 = pmix_server_new_tracker("trk-collective-A", procsA, 1, PMIX_FENCENB_CMD);
+    report("new_tracker(id) returns a tracker", NULL != t1);
+
+    /* a proc-set/type-identified tracker (as fence/connect use) */
+    t2 = pmix_server_new_tracker(NULL, procsB, 2, PMIX_CONNECTNB_CMD);
+    report("new_tracker(procs) returns a tracker", NULL != t2);
+
+    /* found by id */
+    found = pmix_server_get_tracker("trk-collective-A", NULL, 0, PMIX_FENCENB_CMD);
+    report("get_tracker finds by id", found == t1);
+
+    /* found by exact proc set + type, regardless of proc order */
+    found = pmix_server_get_tracker(NULL, procsB_rev, 2, PMIX_CONNECTNB_CMD);
+    report("get_tracker finds by proc set (order-independent)", found == t2);
+
+    /* same proc set but a different collective type must NOT match */
+    found = pmix_server_get_tracker(NULL, procsB, 2, PMIX_DISCONNECTNB_CMD);
+    report("get_tracker rejects a type mismatch", NULL == found);
+
+    /* a proc set that no tracker holds must NOT match */
+    found = pmix_server_get_tracker(NULL, procsC, 1, PMIX_CONNECTNB_CMD);
+    report("get_tracker rejects an unknown proc set", NULL == found);
+
+    /* an unknown id must NOT match */
+    found = pmix_server_get_tracker("no-such-collective", NULL, 0, PMIX_FENCENB_CMD);
+    report("get_tracker rejects an unknown id", NULL == found);
+
+    release_tracker(t1);
+    release_tracker(t2);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/trk_complete.c
+++ b/test/unit/trk_complete.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for pmix_server_trk_complete().
+ *
+ * This is the single predicate the server uses to decide whether a
+ * collective's local phase is complete. It gates on two things: the tracker
+ * definition must be complete (def_complete - all participating nspaces are
+ * registered so nlocal is final), AND every expected local participant must be
+ * accounted for, either by contributing (an entry on local_cbs) or by departing
+ * before contributing (an entry on departed):
+ *
+ *     def_complete && (len(local_cbs) + len(departed)) >= nlocal
+ *
+ * The '>=' is deliberate: it tolerates any over-count from fork/exec'd clones
+ * without ever falsely reporting the collective incomplete. These tests pin
+ * both the def_complete gate and the counting/tolerance behavior, since the
+ * fence, connect, disconnect, and group teardown paths all rest on it.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* build a tracker with the given def_complete flag, nlocal count, and the
+ * requested number of entries on the local_cbs and departed lists */
+static pmix_server_trkr_t *make_trk(bool def_complete, uint32_t nlocal,
+                                    size_t ncontributed, size_t ndeparted)
+{
+    pmix_server_trkr_t *trk;
+    pmix_server_caddy_t *cd;
+    pmix_proclist_t *p;
+    size_t i;
+
+    trk = PMIX_NEW(pmix_server_trkr_t);
+    trk->def_complete = def_complete;
+    trk->nlocal = nlocal;
+    for (i = 0; i < ncontributed; i++) {
+        cd = PMIX_NEW(pmix_server_caddy_t);
+        pmix_list_append(&trk->local_cbs, &cd->super);
+    }
+    for (i = 0; i < ndeparted; i++) {
+        p = PMIX_NEW(pmix_proclist_t);
+        pmix_list_append(&trk->departed, &p->super);
+    }
+    return trk;
+}
+
+static void check(const char *name, bool def_complete, uint32_t nlocal,
+                  size_t ncontributed, size_t ndeparted, bool expected)
+{
+    pmix_server_trkr_t *trk;
+
+    trk = make_trk(def_complete, nlocal, ncontributed, ndeparted);
+    report(name, expected == pmix_server_trk_complete(trk));
+    PMIX_RELEASE(trk);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== pmix_server_trk_complete unit tests ===\n\n");
+
+    /* the def_complete gate: even a fully-accounted-for tracker is incomplete
+     * while its definition is still open */
+    check("incomplete definition is never complete", false, 2, 2, 0, false);
+
+    /* nobody heard from yet */
+    check("no participants accounted for", true, 2, 0, 0, false);
+
+    /* partial: one of two contributed */
+    check("partial contribution is incomplete", true, 2, 1, 0, false);
+
+    /* exactly complete by contribution */
+    check("all contributed is complete", true, 2, 2, 0, true);
+
+    /* completion by a mix of contributed and departed */
+    check("contributed + departed reaches nlocal", true, 2, 1, 1, true);
+
+    /* all expected participants departed before contributing */
+    check("all departed is complete", true, 2, 0, 2, true);
+
+    /* clone over-count: more contributors than nlocal must still be complete
+     * (the '>=' tolerance), never falsely incomplete */
+    check("clone over-count stays complete", true, 2, 3, 0, true);
+
+    /* degenerate all-remote collective: nlocal 0, nothing local */
+    check("nlocal zero is complete", true, 0, 0, 0, true);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
A deep review of `src/server` turned up a set of defects, almost all in
the same bug class the subsystem is prone to: success-path memory/caddy
leaks and error-path double-frees around the switchyard reply-ownership
contract and the collective-tracker lifecycle. Each fix is a separate,
signed-off commit so it can be reviewed and bisected on its own.

### Crashes / NULL-pointer / correctness
- `fabric_update`: unpacked directives into a `NULL` array (`cd->info`
  was allocated, `qcd->info` was written) — a crash on any
  fabric-register carrying directives.
- `resblk` / `session_ctrl`: OOM guard tested the wrong pointer
  (`if (NULL == cd)` instead of the freshly-`PMIX_NEW`'d `scd`).
- `resolve_node`: read an uninitialized `nspace` and fetched from
  `pmix_client_globals.myserver` instead of `pmix_globals.mypeer`.
- `PMIx_server_init`: returned `PMIX_SUCCESS` on bfrops/psec/gds module
  assignment failure (stale `rc`), leaving a half-initialized peer.
- `PMIx_server_collect_job_info`: accumulated into a per-iteration local
  caddy instead of the caller's, so it **always returned an empty
  buffer**.
- `job_control` `PMIX_CLEANUP_IGNORE`: appended the iterated list member
  instead of the freshly-created copy — list corruption, a leak, and a
  use-after-free when the epilog runs.

### Double-frees on collective host-error paths
- `group`, `connect`, and `disconnect` released the collective
  tracker/block while the requesting caddy was still on `local_cbs`
  (and, for connect/disconnect, while still linked in `collectives`),
  which the switchyard then freed a second time.

### Leaks
- Caddy/peer-retain leaks: `_resopcbfunc` (RESBLK) success path,
  `refresh_cache` success path, `fabric_update`/`iofdereg` `exit:`
  labels, `iofstdin` on `PMIX_OPERATION_SUCCEEDED`, disconnect `procs`,
  and the connect timeout retain/re-arm.
- Byte-object leaks after packing (`PMIX_UNLOAD_BUFFER` + pack copies):
  `get_job_data`, the PSET_NAMES GET path, and `_cnct`.
- Error-path list/array leaks: fence `procs`/`b2`, `_grpcbfunc`
  `grpinfo`, `_process_dmdx_reply` `nspaces`/`kv`, and
  `_check_cached_events` relay.

### Consistency
- `free()` → `PMIX_PROC_FREE`, type-tolerant timeout parse, and a couple
  of constant-on-left / brace-spacing nits.

### Deferred, tracked as an issue
- Corrected a misleading comment in `pmix_server_deregister_events`: the
  server does not reference-count enviro/system event registrations
  against the host — it never tells the host to stop, and unwanted
  events are received and ignored. Completing the full
  activate-on-first / deregister-on-last handshake is a real design
  change, tracked in #4014.

### Tests
Adds three white-box unit tests under `test/unit` (wired into
`make check`): `collect_job_info` (a regression guard for the
empty-buffer bug, verified to fail against the pre-fix code),
`trk_complete` (the collective-completion predicate), and
`tracker_match` (tracker identity/lookup).

Builds warning-free under `--enable-devel-check`; the full `test/unit`
suite passes (29 tests). The remaining fixes — the switchyard-handler
leaks and double-frees — are exercised for behavior by the existing
`make check` functional tests (`connect_die`, `group_die`,
`group_leave`, `group_destruct_die`, `group_invite*`) and are best
confirmed for leaks under valgrind.
