### PR TITLE
Clean up src/threads and fix TSD key lifecycle bugs

### DIFF
--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -67,12 +67,12 @@ earlier ones being open, and `pmix_rte_finalize` must unwind in a
 compatible order. The spine is:
 
 1. **`pmix_init_util`** (idempotent, latched on
-   `pmix_globals.util_initialized`): registers the calling thread as
-   "main" (`pmix_thread_set_main` — required so TSD keys get cleaned up;
-   see the comment at the call site), then output → pinstalldirs →
+   `pmix_globals.util_initialized`): output → pinstalldirs →
    show_help → keyval parser → `mca_base_var` → `mca_base_open` →
    `pmix_net_init` → `pif`. Standalone tools call this directly instead
-   of `pmix_rte_init`.
+   of `pmix_rte_init`. (TSD keys created later, e.g. in `pmix_net_init`,
+   register themselves for finalize-time cleanup regardless of which
+   thread creates them — see `src/threads/thread.c`.)
 2. **`pmix_register_params`** — must come before anything reads an MCA
    value.
 3. **Directive scan** — walk the incoming `info[]` for the small set of

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -160,14 +160,6 @@ int pmix_init_util(pmix_info_t info[], size_t ninfo, char *libdir)
         return PMIX_SUCCESS;
     }
 
-    /* record the initializing thread as "main" so that thread-specific
-     * data keys it creates (e.g., in pmix_net_init) are registered for
-     * cleanup. Without this the registry stays empty and every key -
-     * and its pthread slot - leaks across an init/finalize cycle,
-     * eventually exhausting PTHREAD_KEYS_MAX. init and finalize run on
-     * this same thread, so it is also where pmix_tsd_keys_destruct runs. */
-    pmix_thread_set_main();
-
     /* initialize the output system */
     if (!pmix_output_init()) {
         return PMIX_ERROR;

--- a/src/threads/AGENTS.md
+++ b/src/threads/AGENTS.md
@@ -1,0 +1,236 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: PMIx Threading Primitives
+
+This document orients AI agents and human contributors working in
+`src/threads`, the small set of low-level threading primitives on which
+PMIx's concurrency model is built. It assumes you have already read the
+top-level [`AGENTS.md`](../../AGENTS.md) — the golden rules (prefix
+conventions, `pmix_config.h`-first include order, constant-on-the-left
+comparisons, brace-everything, `#define`-logical-macros-to-0/1,
+warning-free under `--enable-devel-check`), the copyright-header
+requirement, and **especially the "Thread Safety and the Progress
+Thread" section** all apply here and are not repeated. That section
+describes the *policy* (thread-shift before touching shared state, caddy
+lifetimes, blocking vs. non-blocking API paths); this directory provides
+the *mechanism* those policies are built from.
+
+Like `src/class`, **`src/threads` is not an MCA framework** — no
+framework header, no components, no selection logic, no `configure.m4`.
+It is a handful of headers and two `.c` files compiled directly into
+`libpmix` (see [Building](#building)). Its wire-up lives in
+`Makefile.include`, which is *included* from the top-level
+`src/Makefile.am` (note: not a standalone `Makefile.am`, and it builds no
+separate convenience library).
+
+## Why this code matters more than its size suggests
+
+Under 900 lines total, but load-bearing. The `pmix_lock_t` construct and
+its `PMIX_CONSTRUCT_LOCK` / `PMIX_ACQUIRE_THREAD` / `PMIX_WAIT_THREAD` /
+`PMIX_WAKEUP_THREAD` / `PMIX_RELEASE_THREAD` macros defined in
+`pmix_threads.h` are the exact machinery every blocking public API uses
+to hand a request to the progress thread and block until it completes —
+they appear in **~300 sites** across the tree. The memory-barrier macros
+`PMIX_POST_OBJECT` / `PMIX_ACQUIRE_OBJECT` are the only thing making
+cross-thread object hand-off safe. A subtle change to any of these is not
+a local change; it is a tree-wide concurrency change that can manifest as
+a rare deadlock or a use-after-free that only shows up under load on one
+platform. Treat this directory as semantics-frozen unless you have a
+specific, measured reason and team consensus, and match the existing
+patterns exactly.
+
+## The files
+
+```
+src/threads/
+├── pmix_mutex.h          public mutex API (prototypes); pulls in the unix impl
+├── pmix_mutex_unix.h     pthread-backed mutex struct, inlines, static-init macro
+├── mutex.c               pmix_mutex_t class constructor/destructor
+├── pmix_threads.h        pmix_lock_t, the ACQUIRE/WAIT/WAKEUP/RELEASE macros,
+│                         condition wrappers, memory barriers, thread API protos
+├── thread.c              pmix_thread_t lifecycle + TSD key registry/cleanup
+├── pmix_tsd.h            thread-specific-data (pthread key) wrappers
+└── Makefile.include      included from src/Makefile.am (adds headers + sources)
+```
+
+Most of the behavior lives in the headers as `static inline` functions
+and macros — `mutex.c` and `thread.c` together are barely 200 lines. Read
+the `.h` files first; for the lock/barrier machinery the header *is* the
+implementation.
+
+## The mutex (`pmix_mutex.h`, `pmix_mutex_unix.h`, `mutex.c`)
+
+`pmix_mutex_t` is a `pmix_object_t` subclass wrapping a
+`pthread_mutex_t`. It is a full class (`PMIX_CONSTRUCT`/`PMIX_NEW`-able)
+and also has a `PMIX_MUTEX_STATIC_INIT` for file-scope statics.
+
+- **Debug builds harden the mutex.** Under `PMIX_ENABLE_DEBUG` the plain
+  mutex is created `ERRORCHECK` (via `PMIX_HAVE_PTHREAD_MUTEX_ERRORCHECK`
+  / `..._NP`, whichever `configure` found), so a self-deadlock or a
+  double-unlock aborts loudly with a `perror` instead of hanging
+  silently. The `pmix_mutex_trylock`/`lock`/`unlock` inlines check for
+  `EDEADLK`/`EPERM` and `abort()` in debug; in release they are a thin
+  pass-through to the pthread call with zero overhead.
+- **The `atomic_` variants are aliases.** `pmix_mutex_atomic_lock` and
+  friends simply call the non-atomic versions — the historical
+  distinction (lock-free vs. pthread) collapsed to "always pthread" in
+  PMIx. Do not read significance into the `atomic_` name.
+
+## The lock (`pmix_threads.h`) — the piece you will actually touch
+
+`pmix_lock_t` bundles a `pmix_mutex_t`, a `pmix_condition_t` (a raw
+`pthread_cond_t` with `pmix_condition_wait/signal/broadcast` wrappers), a
+`bool active`, and a `pmix_status_t status`. It is the standard
+handshake between a caller thread and the progress thread. Every access
+to `active` happens under the mutex (with the barrier macros below), so
+it is a plain `bool` — do not add `volatile` back to it. The lifecycle
+macros:
+
+| Macro | Runs on | Effect |
+|-------|---------|--------|
+| `PMIX_CONSTRUCT_LOCK(l)` | caller | init mutex+cond, set `active = true` |
+| `PMIX_DESTRUCT_LOCK(l)` | caller | tear down mutex+cond |
+| `PMIX_ACQUIRE_THREAD(l)` | caller | block until `active == false`, **then re-arm** `active = true` |
+| `PMIX_WAIT_THREAD(l)` | caller | block until `active == false`, leave it false |
+| `PMIX_RELEASE_THREAD(l)` | holder | set `active = false`, signal, **unlock** (assumes lock already held) |
+| `PMIX_WAKEUP_THREAD(l)` | handler | lock, set `active = false`, signal, unlock |
+
+The two easy-to-confuse pairs:
+
+- **`ACQUIRE` vs. `WAIT`.** Both block on the condition. `ACQUIRE_THREAD`
+  re-arms `active = true` before returning (it is a *gate* you pass
+  through repeatedly — acquire/release cycles), and returns holding the
+  mutex is *not* implied — read the macro. `WAIT_THREAD` is a one-shot:
+  it waits, then unlocks and returns, leaving `active` false. Blocking
+  public APIs use the `CONSTRUCT_LOCK` … `THREADSHIFT` … `WAIT_THREAD`
+  pattern (see the top-level thread-safety section and
+  `src/server/pmix_server.c`).
+- **`RELEASE` vs. `WAKEUP`.** `RELEASE_THREAD` assumes the caller already
+  holds the mutex (it pairs with `ACQUIRE_THREAD`); it does not lock,
+  only unlocks. `WAKEUP_THREAD` takes the lock itself — it is what a
+  progress-thread handler calls to wake a blocked API caller that is
+  sitting in `WAIT_THREAD`. **Every blocking path needs a matching
+  `WAKEUP` (or `RELEASE`)** or the caller hangs forever — this is the
+  single most common threading bug in the code base.
+
+All four blocking/waking macros loop on `while ((lck)->active)` to absorb
+spurious condition-variable wakeups — do not "simplify" that to an `if`.
+
+`PMIX_LOCK_STATIC_INIT` exists for file-scope locks; note it initializes
+`active = false`, whereas `PMIX_CONSTRUCT_LOCK` sets `active = true` — a
+statically-initialized lock is "already released," a constructed one is
+"armed." Pick the initializer that matches how the first
+acquire/wait will read `active`.
+
+### Memory barriers and cross-thread object hand-off
+
+`PMIX_POST_OBJECT(o)` (a write memory barrier, `pmix_atomic_wmb`) and
+`PMIX_ACQUIRE_OBJECT(o)` (a read barrier, `pmix_atomic_rmb`) bracket the
+publication of an object from one thread and its consumption by another.
+The lock macros already embed them (`ACQUIRE`/`WAIT` do an
+`ACQUIRE_OBJECT`, `RELEASE`/`WAKEUP` do a `POST_OBJECT`), so within the
+lock handshake you get the barrier for free. If you ever hand an object
+between threads *outside* a lock, you are responsible for the barrier
+pair yourself. The object argument is currently ignored — the macros are
+whole-thread fences — but pass the real object anyway; the header notes
+the model may be revamped and the argument made meaningful.
+
+## Threads (`thread.c`)
+
+`pmix_thread_t` wraps a `pthread_t` plus a run function and argument.
+`pmix_thread_start` / `pmix_thread_join` are the only two entry points,
+and their only live caller is the progress-thread engine in
+`src/runtime/pmix_progress_threads.c`. `PMIX_THREAD_CANCELLED` is the
+sentinel a cancellable thread body returns. The "not started" / "joined"
+state of a `pmix_thread_t` is tracked with a `(pthread_t) -1` sentinel in
+`t_handle`, compared with plain `==`/`!=`; this is a sentinel test, not a
+comparison of two real thread identities (which would use
+`pthread_equal`), and is left as-is deliberately.
+
+## Thread-specific data (`pmix_tsd.h`, `thread.c`)
+
+Thin wrappers over `pthread_key_*`, plus a small **key registry** in
+`thread.c` that exists to plug a real leak:
+
+- `pmix_tsd_key_create()` creates a pthread key and appends the
+  key+destructor to a global registry (`pmix_tsd_key_values`),
+  **regardless of which thread it runs on**. Callers create their keys
+  lazily on first use, which may land on any thread (commonly the
+  progress thread), so the registry mutation is serialized by a private
+  `pmix_tsd_key_values_lock`. The `realloc` return is checked; on OOM the
+  key stays valid and usable, it just is not registered for auto-cleanup.
+- `pmix_tsd_keys_destruct()` (called from `pmix_finalize.c`, on the main
+  thread) walks the registry under the same lock, invokes each destructor
+  on the finalizing thread's value, and **deletes the pthread key** so
+  its slot is reclaimed. This is necessary because pthread destructors
+  never fire for the main thread (there is no `pthread_join(main)`), so
+  without it every key — and its `PTHREAD_KEYS_MAX`-limited slot — would
+  leak across an init/finalize cycle.
+
+The only live callers of the TSD API are `src/util/pmix_net.c`
+(`hostname_tsd_key`) and `src/util/pmix_name_fns.c`
+(`print_args_tsd_key`); both create their key lazily on first use and
+clear a static `*_init` latch in their `_finalize` so a subsequent
+`PMIx_Init` recreates it. Because registration no longer depends on the
+creating thread, that lazy-first-use pattern is safe — the key is tracked
+and cleaned up no matter which thread touched it first.
+
+## Design notes worth knowing
+
+- **Direct `active` writes bypass the macros in a few init paths.** A
+  handful of sites (`src/server/pmix_server.c`,
+  `src/mca/pmdl/base/pmdl_base_frame.c`) set `lock.active = false`
+  directly on a freshly constructed caddy/lock. That is a plain
+  single-threaded initialization write on the owning thread *before* the
+  mutex/cond handshake begins, which is why `active` needs no `volatile`;
+  do not assume those writes provide any cross-thread ordering.
+- **`ACQUIRE_THREAD` and `WAIT_THREAD` emit distinct debug strings**
+  (`"Acquiring thread"` / `"Thread acquired"` vs. `"Waiting for thread"` /
+  `"Thread obtained"`) so the two are distinguishable in a
+  `pmix_debug_threads` log.
+
+## Building
+
+`src/threads` has no `configure.m4` and nothing conditionally compiled,
+so a change to any of these files takes effect with a plain top-level
+`make` from an already-configured tree (see the top-level guide's
+"Test-building your changes"). You only need the
+`autogen.pl` + `configure` cycle if you *add or remove* a source file,
+because the file list lives in `Makefile.include` — and even then, since
+`Makefile.include` is `include`d by `src/Makefile.am`, editing it is a
+`Makefile.am` change: a plain `make` regenerates the `Makefile` and
+rebuilds. (Full `autogen.pl`/`configure` is only mandatory for
+`configure.ac`/`config/*.m4` changes, which this directory has none of.)
+The four headers are listed in `Makefile.include`'s `headers` and are
+installed under `$(pmixincludedir)/src/threads`, so they are part of the
+consumable internal surface — keep them warning-free and portable.
+
+## When changing code here
+
+- **Preserve the lock handshake exactly.** If you add a blocking API,
+  copy the `CONSTRUCT_LOCK` / `THREADSHIFT` / `WAIT_THREAD` /
+  `DESTRUCT_LOCK` pattern from `src/server/pmix_server.c` and make sure
+  the progress-thread handler calls `WAKEUP_THREAD` (or `RELEASE_THREAD`)
+  on every exit path, including error paths. A missing wake is a hang.
+- **Keep the spurious-wakeup `while` loops.** Never collapse them to
+  `if`.
+- **Do not add locking "for safety" to the mutex/lock primitives
+  themselves**, and do not reorder or resize `struct pmix_mutex_t` /
+  `pmix_lock_t` casually — they are embedded by value in hundreds of
+  structs and initialized by static-init macros that mirror their layout.
+- **Build the whole tree and run `make check` plus
+  `test/simple/simptest`** after any change here, and prefer valgrind:
+  concurrency bugs in this directory are rarely caught by a compile, and
+  the debug `ERRORCHECK` mutex + clean-shutdown paths exist precisely to
+  make deadlocks and leaks observable.
+- **Keep it warning-free and portable.** This code compiles on every
+  platform PMIx supports, under `-Werror` in CI. Use the
+  `__pmix_attribute_*__` wrappers rather than bare GCC attributes.

--- a/src/threads/CLAUDE.md
+++ b/src/threads/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/threads/mutex.c
+++ b/src/threads/mutex.c
@@ -42,10 +42,6 @@ static void pmix_mutex_construct(pmix_mutex_t *m)
 
     pthread_mutex_init(&m->m_lock_pthread, &attr);
     pthread_mutexattr_destroy(&attr);
-
-    m->m_lock_debug = 0;
-    m->m_lock_file = NULL;
-    m->m_lock_line = 0;
 #else
 
     /* Without debugging, choose the fastest available mutexes */
@@ -60,23 +56,3 @@ static void pmix_mutex_destruct(pmix_mutex_t *m)
 }
 
 PMIX_CLASS_INSTANCE(pmix_mutex_t, pmix_object_t, pmix_mutex_construct, pmix_mutex_destruct);
-
-static void pmix_recursive_mutex_construct(pmix_recursive_mutex_t *m)
-{
-    pthread_mutexattr_t attr;
-    pthread_mutexattr_init(&attr);
-
-#if PMIX_ENABLE_DEBUG
-    m->m_lock_debug = 0;
-    m->m_lock_file = NULL;
-    m->m_lock_line = 0;
-#endif
-
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-
-    pthread_mutex_init(&m->m_lock_pthread, &attr);
-    pthread_mutexattr_destroy(&attr);
-}
-
-PMIX_CLASS_INSTANCE(pmix_recursive_mutex_t, pmix_object_t, pmix_recursive_mutex_construct,
-                    pmix_mutex_destruct);

--- a/src/threads/pmix_mutex.h
+++ b/src/threads/pmix_mutex.h
@@ -44,7 +44,6 @@ BEGIN_C_DECLS
  * Opaque mutex object
  */
 typedef struct pmix_mutex_t pmix_mutex_t;
-typedef struct pmix_mutex_t pmix_recursive_mutex_t;
 
 /**
  * Try to acquire a mutex.

--- a/src/threads/pmix_mutex_unix.h
+++ b/src/threads/pmix_mutex_unix.h
@@ -51,55 +51,14 @@ struct pmix_mutex_t {
     pmix_object_t super;
 
     pthread_mutex_t m_lock_pthread;
-
-#if PMIX_ENABLE_DEBUG
-    int m_lock_debug;
-    const char *m_lock_file;
-    int m_lock_line;
-#endif
 };
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mutex_t);
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_recursive_mutex_t);
 
-#if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
-#    define PMIX_PTHREAD_RECURSIVE_MUTEX_INITIALIZER PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
-#elif defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
-#    define PMIX_PTHREAD_RECURSIVE_MUTEX_INITIALIZER PTHREAD_RECURSIVE_MUTEX_INITIALIZER
-#endif
-
-#if PMIX_ENABLE_DEBUG
-#    define PMIX_MUTEX_STATIC_INIT                                                               \
-        {                                                                                        \
-            .super = PMIX_OBJ_STATIC_INIT(pmix_mutex_t),                                         \
-            .m_lock_pthread = PTHREAD_MUTEX_INITIALIZER, .m_lock_debug = 0, .m_lock_file = NULL, \
-            .m_lock_line = 0,                                                                    \
-        }
-#else
-#    define PMIX_MUTEX_STATIC_INIT                                                               \
-        {                                                                                        \
-            .super = PMIX_OBJ_STATIC_INIT(pmix_mutex_t),                                         \
-            .m_lock_pthread = PTHREAD_MUTEX_INITIALIZER,                                         \
-        }
-#endif
-
-#if defined(PMIX_PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
-
-#    if PMIX_ENABLE_DEBUG
-#        define PMIX_RECURSIVE_MUTEX_STATIC_INIT                                               \
-            {                                                                                  \
-                .super = PMIX_OBJ_STATIC_INIT(pmix_mutex_t),                                   \
-                .m_lock_pthread = PMIX_PTHREAD_RECURSIVE_MUTEX_INITIALIZER, .m_lock_debug = 0, \
-                .m_lock_file = NULL, .m_lock_line = 0,                                         \
-            }
-#    else
-#        define PMIX_RECURSIVE_MUTEX_STATIC_INIT                            \
-            {                                                               \
-                .super = PMIX_OBJ_STATIC_INIT(pmix_mutex_t),                \
-                .m_lock_pthread = PMIX_PTHREAD_RECURSIVE_MUTEX_INITIALIZER, \
-            }
-#    endif
-
-#endif
+#define PMIX_MUTEX_STATIC_INIT                          \
+    {                                                   \
+        .super = PMIX_OBJ_STATIC_INIT(pmix_mutex_t),    \
+        .m_lock_pthread = PTHREAD_MUTEX_INITIALIZER,    \
+    }
 
 /************************************************************************
  *

--- a/src/threads/pmix_threads.h
+++ b/src/threads/pmix_threads.h
@@ -28,7 +28,6 @@
 #include "src/include/pmix_config.h"
 
 #include <pthread.h>
-#include <signal.h>
 
 #include "src/class/pmix_object.h"
 #include "src/include/pmix_atomic.h"
@@ -42,7 +41,7 @@ BEGIN_C_DECLS
 
 typedef void *(*pmix_thread_fn_t)(pmix_object_t *);
 
-#define PMIX_THREAD_CANCELLED ((void *) 1);
+#define PMIX_THREAD_CANCELLED ((void *) 1)
 
 struct pmix_thread_t {
     pmix_object_t super;
@@ -69,7 +68,7 @@ typedef struct {
     pmix_status_t status;
     pmix_mutex_t mutex;
     pmix_condition_t cond;
-    volatile bool active;
+    bool active;
 } pmix_lock_t;
 
 #define PMIX_LOCK_STATIC_INIT               \
@@ -101,13 +100,13 @@ typedef struct {
         do {                                                                    \
             pmix_mutex_lock(&(lck)->mutex);                                     \
             if (pmix_debug_threads) {                                           \
-                pmix_output(0, "Waiting for thread %s:%d", __FILE__, __LINE__); \
+                pmix_output(0, "Acquiring thread %s:%d", __FILE__, __LINE__);   \
             }                                                                   \
             while ((lck)->active) {                                             \
                 pmix_condition_wait(&(lck)->cond, &(lck)->mutex);               \
             }                                                                   \
             if (pmix_debug_threads) {                                           \
-                pmix_output(0, "Thread obtained %s:%d", __FILE__, __LINE__);    \
+                pmix_output(0, "Thread acquired %s:%d", __FILE__, __LINE__);    \
             }                                                                   \
             PMIX_ACQUIRE_OBJECT(lck);                                           \
             (lck)->active = true;                                               \
@@ -196,10 +195,6 @@ typedef struct {
 
 PMIX_EXPORT int pmix_thread_start(pmix_thread_t *);
 PMIX_EXPORT int pmix_thread_join(pmix_thread_t *, void **thread_return);
-PMIX_EXPORT bool pmix_thread_self_compare(pmix_thread_t *);
-PMIX_EXPORT pmix_thread_t *pmix_thread_get_self(void);
-PMIX_EXPORT void pmix_thread_kill(pmix_thread_t *, int sig);
-PMIX_EXPORT void pmix_thread_set_main(void);
 
 END_C_DECLS
 

--- a/src/threads/pmix_tsd.h
+++ b/src/threads/pmix_tsd.h
@@ -100,4 +100,4 @@ PMIX_EXPORT int pmix_tsd_keys_destruct(void);
 
 END_C_DECLS
 
-#endif /* PMIX_MTHREADS_TSD_H */
+#endif /* PMIX_THREADS_TSD_H */

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -31,8 +31,6 @@ bool pmix_debug_threads = false;
 
 static void pmix_thread_construct(pmix_thread_t *t);
 
-static pthread_t pmix_main_thread;
-
 struct pmix_tsd_key_value {
     pmix_tsd_key_t key;
     pmix_tsd_destructor_t destructor;
@@ -40,6 +38,10 @@ struct pmix_tsd_key_value {
 
 static struct pmix_tsd_key_value *pmix_tsd_key_values = NULL;
 static int pmix_tsd_key_values_count = 0;
+/* protects the key registry above: pmix_tsd_key_create can run on any
+ * thread (its callers create their key lazily on first use), so the
+ * registry it mutates must be serialized */
+static pthread_mutex_t pmix_tsd_key_values_lock = PTHREAD_MUTEX_INITIALIZER;
 
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_thread_t, pmix_object_t, pmix_thread_construct, NULL);
 
@@ -74,35 +76,41 @@ int pmix_thread_join(pmix_thread_t *t, void **thr_return)
     return (rc == 0) ? PMIX_SUCCESS : PMIX_ERROR;
 }
 
-bool pmix_thread_self_compare(pmix_thread_t *t)
-{
-    return t->t_handle == pthread_self();
-}
-
-pmix_thread_t *pmix_thread_get_self(void)
-{
-    pmix_thread_t *t = PMIX_NEW(pmix_thread_t);
-    t->t_handle = pthread_self();
-    return t;
-}
-
-void pmix_thread_kill(pmix_thread_t *t, int sig)
-{
-    pthread_kill(t->t_handle, sig);
-}
-
 int pmix_tsd_key_create(pmix_tsd_key_t *key, pmix_tsd_destructor_t destructor)
 {
     int rc;
+    struct pmix_tsd_key_value *tmp;
+
     rc = pthread_key_create(key, destructor);
-    if ((0 == rc) && (pthread_self() == pmix_main_thread)) {
-        pmix_tsd_key_values = (struct pmix_tsd_key_value *)
-            realloc(pmix_tsd_key_values,
-                    (pmix_tsd_key_values_count + 1) * sizeof(struct pmix_tsd_key_value));
-        pmix_tsd_key_values[pmix_tsd_key_values_count].key = *key;
-        pmix_tsd_key_values[pmix_tsd_key_values_count].destructor = destructor;
-        pmix_tsd_key_values_count++;
+    if (0 != rc) {
+        return rc;
     }
+
+    /* Register the key so its slot can be reclaimed - and its
+     * destructor invoked for the finalizing thread's value - by
+     * pmix_tsd_keys_destruct at finalize. pthread never runs
+     * destructors for the main thread (there is no pthread_join of
+     * main), so without this the key and its PTHREAD_KEYS_MAX-limited
+     * slot would leak across every init/finalize cycle. Callers create
+     * their keys lazily on first use, which may land on any thread, so
+     * we register regardless of which thread we are on and serialize the
+     * registry with its own lock. */
+    pthread_mutex_lock(&pmix_tsd_key_values_lock);
+    tmp = (struct pmix_tsd_key_value *)
+        realloc(pmix_tsd_key_values,
+                (pmix_tsd_key_values_count + 1) * sizeof(struct pmix_tsd_key_value));
+    if (NULL == tmp) {
+        /* leave the existing registry intact; the key is still valid and
+         * usable, it simply will not be auto-cleaned at finalize */
+        pthread_mutex_unlock(&pmix_tsd_key_values_lock);
+        return rc;
+    }
+    pmix_tsd_key_values = tmp;
+    pmix_tsd_key_values[pmix_tsd_key_values_count].key = *key;
+    pmix_tsd_key_values[pmix_tsd_key_values_count].destructor = destructor;
+    pmix_tsd_key_values_count++;
+    pthread_mutex_unlock(&pmix_tsd_key_values_lock);
+
     return rc;
 }
 
@@ -110,6 +118,8 @@ int pmix_tsd_keys_destruct(void)
 {
     int i;
     void *ptr;
+
+    pthread_mutex_lock(&pmix_tsd_key_values_lock);
     for (i = 0; i < pmix_tsd_key_values_count; i++) {
         if (PMIX_SUCCESS == pmix_tsd_getspecific(pmix_tsd_key_values[i].key, &ptr)) {
             if (NULL != pmix_tsd_key_values[i].destructor) {
@@ -129,10 +139,7 @@ int pmix_tsd_keys_destruct(void)
         pmix_tsd_key_values = NULL;
         pmix_tsd_key_values_count = 0;
     }
-    return PMIX_SUCCESS;
-}
+    pthread_mutex_unlock(&pmix_tsd_key_values_lock);
 
-void pmix_thread_set_main(void)
-{
-    pmix_main_thread = pthread_self();
+    return PMIX_SUCCESS;
 }

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -42,7 +42,14 @@
 #define PMIX_SCHEMA_INVALID_CHAR    '$'
 #define PMIX_SCHEMA_INVALID_STRING  "$"
 
-static bool fns_init = false;
+/* one-time creation of print_args_tsd_key is guarded by
+ * print_args_init_lock so that two threads racing the first call to
+ * get_print_name_buffer cannot both create the key (which would leak one
+ * of them). fns_init is atomic so the fast path can skip the lock once
+ * the key exists, while still ordering the key's publication against a
+ * concurrent reader. */
+static pmix_atomic_bool_t fns_init = false;
+static pthread_mutex_t print_args_init_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static pmix_tsd_key_t print_args_tsd_key;
 char *pmix_print_args_null = "NULL";
@@ -71,7 +78,7 @@ void pmix_name_fns_finalize(void)
      * by pmix_tsd_keys_destruct during finalize; clear our latch here so
      * that a subsequent PMIx_Init recreates and re-registers the key
      * rather than reusing one that no longer exists. */
-    fns_init = false;
+    pmix_atomic_unset_bool(&fns_init);
 }
 
 static pmix_print_args_buffers_t *get_print_name_buffer(void)
@@ -79,13 +86,20 @@ static pmix_print_args_buffers_t *get_print_name_buffer(void)
     pmix_print_args_buffers_t *ptr;
     int ret, i;
 
-    if (!fns_init) {
-        /* setup the print_args function */
-        if (PMIX_SUCCESS != (ret = pmix_tsd_key_create(&print_args_tsd_key, buffer_cleanup))) {
-            PMIX_ERROR_LOG(ret);
-            return NULL;
+    if (!pmix_atomic_check_bool(&fns_init)) {
+        /* setup the print_args function - serialize so only one thread
+         * creates the key, and re-check under the lock in case another
+         * thread won the race while we were blocked */
+        pthread_mutex_lock(&print_args_init_lock);
+        if (!pmix_atomic_check_bool(&fns_init)) {
+            if (PMIX_SUCCESS != (ret = pmix_tsd_key_create(&print_args_tsd_key, buffer_cleanup))) {
+                pthread_mutex_unlock(&print_args_init_lock);
+                PMIX_ERROR_LOG(ret);
+                return NULL;
+            }
+            pmix_atomic_set_bool(&fns_init);
         }
-        fns_init = true;
+        pthread_mutex_unlock(&print_args_init_lock);
     }
 
     ret = pmix_tsd_getspecific(print_args_tsd_key, (void **) &ptr);


### PR DESCRIPTION
This is a review-driven cleanup of `src/threads` (the low-level mutex,
lock, thread, and thread-specific-data primitives), plus a related
race fix in the one lazy TSD user. It also adds an `AGENTS.md`
orientation guide for the directory.

## Behavioral fixes

- **TSD key leak across init/finalize.** `pmix_tsd_key_create` only
  registered keys for finalize-time cleanup when it ran on the "main"
  thread. Its real users create their key lazily on first use, which
  frequently lands on the progress thread, so the key was never
  registered and leaked (along with its per-thread buffers) on every
  init/finalize cycle. Keys are now registered regardless of creating
  thread, serialized by their own lock, and the previously unchecked
  `realloc` return is now handled. The now-unneeded main-thread
  machinery (`pmix_thread_set_main`, `pmix_main_thread`) and its call
  site in `pmix_init_util` are removed.

- **Race in `pmix_name_fns.c` lazy key creation.** `get_print_name_buffer`
  guarded its one-time `pmix_tsd_key_create` with a plain non-atomic
  bool; two threads racing the first call could both create the key and
  leak one. Now uses double-checked locking with a static mutex and an
  atomic latch.

## Cleanups

- Remove dead code with no callers anywhere in the tree: the
  recursive-mutex machinery (`pmix_recursive_mutex_t`, its
  constructor/class instance, and the recursive static-init macros), and
  `pmix_thread_get_self` / `pmix_thread_self_compare` / `pmix_thread_kill`.
- Drop the `m_lock_debug` / `m_lock_file` / `m_lock_line` members of
  `pmix_mutex_t` — written by the constructors but read nowhere (a
  leftover of a debug-locking wrapper that no longer exists).
- Remove the stray trailing semicolon in the `PMIX_THREAD_CANCELLED`
  value macro, drop the redundant `volatile` on `pmix_lock_t::active`
  (every access is already under the mutex), give `PMIX_ACQUIRE_THREAD`
  its own debug strings so it is distinguishable from `PMIX_WAIT_THREAD`,
  and fix a stray `M` in the `pmix_tsd.h` header-guard comment.

## Docs

- Add `src/threads/AGENTS.md` (with `CLAUDE.md` symlink) documenting the
  mutex/lock handshake, memory-barrier object hand-off, thread
  lifecycle, and TSD registry, matching the convention used in sibling
  directories. Updates the one cross-reference in `src/runtime/AGENTS.md`.

## Testing

Clean warning-free build under the default `--enable-devel-check`
(debug) configuration; `make check` passes; `test/simple/simptest`
passes.