### PR TITLE
Tool multi-server switch: finalize/ptl fixes and regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ test/simple/simpgrpleader
 test/simple/simpgrpcabort
 test/simple/simpgrpctimeout
 test/simple/simptoolcycle
+test/simple/tool_server_switch
 test/simple/simpfabric
 test/simple/get_put_example
 test/simple/simpvni
@@ -261,6 +262,7 @@ test/unit/info_support
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl
+test/unit/run_toolswitch.pl
 test/unit/run_grpmember.pl
 test/unit/run_grpinvite.pl
 test/unit/run_grptimeout.pl

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1008,6 +1008,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolswitch.pl], [chmod +x test/unit/run_toolswitch.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -408,9 +408,11 @@ static pmix_status_t pmix_ptl_close(void)
             }
         }
         free(pmix_ptl_base.rendezvous_filename);
+        pmix_ptl_base.rendezvous_filename = NULL;
     }
     if (NULL != pmix_ptl_base.uri) {
         free(pmix_ptl_base.uri);
+        pmix_ptl_base.uri = NULL;
     }
     if (NULL != pmix_ptl_base.urifile) {
         if (pmix_ptl_base.created_urifile) {

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -316,16 +316,22 @@ as intended behavior.
    - `disc` released only the clients-array reference when disconnecting
      the primary, never the outgoing `myserver` reference.
 
-   Now every `myserver = X` reassignment is paired with `PMIX_RETAIN(X)`
-   and a `PMIX_RELEASE` of the outgoing `myserver` across all three
-   functions (in `disc` the departing primary drops both its `myserver`
-   and clients-array references, via a separate handle since
-   `PMIX_RELEASE` NULLs its argument). Smoke-tested with `simptest`,
-   `test/unit/tool_cycle` (1200 init/finalize cycles), and
-   `test/simple/simptoolcycle` (connect+finalize cycles). The **actual
-   multi-server switch path** (attach-as-primary → finalize) has no
-   dedicated automated test yet; when touching this code, add one or
-   validate under valgrind against a tool/debugger attach→finalize flow.
+   The fix has three parts: (a) every `myserver = X` reassignment in
+   `pmix_tool_retry_attach` / `pmix_tool_retry_set` / `disc` is now paired
+   with `PMIX_RETAIN(X)` and a `PMIX_RELEASE` of the outgoing `myserver`
+   (in `disc` the departing primary drops both its `myserver` and
+   clients-array references, via a separate handle since `PMIX_RELEASE`
+   NULLs its argument); (b) `PMIx_tool_finalize` no longer releases
+   `myserver` separately when it aliases `mypeer` (the disconnected-to-self
+   state), which would otherwise free `mypeer` a third time after
+   `pmix_rte_finalize` and the `mypeer` release; and (c) a companion
+   re-init bug where `pmix_ptl_base.uri` was freed but not NULLed on close
+   (`ptl_base_frame.c`), which failed the *next* init's reconnect after an
+   attach-by-URI. The **multi-server switch path is now covered** by
+   `test/simple/tool_server_switch` (make check via
+   `test/unit/run_toolswitch.pl`): two independent servers, a tool child
+   looping attach-as-primary → set_server(self/A/B) → disconnect →
+   finalize. It reproduced the double-free abort before the fix.
 
 ## Building
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1514,6 +1514,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     pmix_peer_t *peer;
     pmix_pfexec_child_t *child, *nxt;
     pmix_lock_t lock;
+    bool myserver_is_mypeer;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -1655,11 +1656,20 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         pmix_server_globals.system_tmpdir = NULL;
     }
 
+    /* Capture whether our active server currently aliases our own peer
+     * BEFORE rte_finalize releases (and may NULL) mypeer. The switch paths
+     * (disc, pmix_tool_retry_set) point myserver back at pmix_globals.mypeer
+     * when we disconnect our primary, taking a reference on it. rte_finalize
+     * plus the mypeer release below already drop mypeer's references, so
+     * releasing myserver separately in that case would free mypeer a third
+     * time. */
+    myserver_is_mypeer = (pmix_client_globals.myserver == pmix_globals.mypeer);
+
     pmix_rte_finalize();
     if (NULL != pmix_globals.mypeer) {
         PMIX_RELEASE(pmix_globals.mypeer);
     }
-    if (NULL != pmix_client_globals.myserver) {
+    if (!myserver_is_mypeer && NULL != pmix_client_globals.myserver) {
         PMIX_RELEASE(pmix_client_globals.myserver);
     }
 

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -28,7 +28,7 @@ headers = simptest.h
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
-                  simpcoord simpcycle simptoolcycle doubleget simpfabric get_put_example simpvni \
+                  simpcoord simpcycle simptoolcycle tool_server_switch doubleget simpfabric get_put_example simpvni \
                   hybrid simpqual simpdist legacy refresh simpgrpmember simpgrpdie simpgrpleader \
                   simpgrpcabort simpgrpctimeout simpgrpddie simpmonitor
 
@@ -192,6 +192,12 @@ simptoolcycle_SOURCES = $(headers) \
         simptoolcycle.c
 simptoolcycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptoolcycle_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tool_server_switch_SOURCES = $(headers) \
+        tool_server_switch.c
+tool_server_switch_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_server_switch_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 doubleget_SOURCES = $(headers) \

--- a/test/simple/tool_server_switch.c
+++ b/test/simple/tool_server_switch.c
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for the tool multi-server "switch" path: the code that
+ * moves pmix_client_globals.myserver between the servers a tool is
+ * connected to. That path lives in pmix_tool_retry_attach (attach a new
+ * server as primary), pmix_tool_retry_set (switch the primary to an
+ * already-known server, or back to ourselves), and disc (disconnect a
+ * server). Each of those repoints "myserver", and each must keep the peer
+ * reference counts balanced against PMIx_tool_finalize, which releases a
+ * server peer once for its clients-array entry AND once for the myserver
+ * global. A missing PMIX_RETAIN/PMIX_RELEASE around a switch shows up as a
+ * double-free/use-after-free at finalize (or a slow peer leak), so this
+ * test drives the whole switch API in a loop and finalizes every cycle.
+ *
+ * Because a tool addresses its servers by {nspace,rank}, two connections
+ * to the *same* server process are indistinguishable to set_server /
+ * disconnect - so a faithful test needs two DISTINCT servers. This one
+ * binary plays three roles, dispatched by argv:
+ *
+ *   (default)      - orchestrator / "server A": inits a PMIx server
+ *                    (scheduler + tool support), fork+execs a second
+ *                    independent server ("server B"), then fork+execs a
+ *                    tool child seeded with A's rendezvous (via setup_fork)
+ *                    and B's URI. Waits for the child, tears B down, and
+ *                    reports PASS/FAIL.
+ *   --server-b F   - a second, independent PMIx server. Writes its own
+ *                    connection URI to file F, then idles until F.done
+ *                    appears, then finalizes.
+ *   --tool-child N - the tool. Loops N times: init (-> A), attach B as
+ *                    primary, query the server list, switch the primary
+ *                    among B / A / self, disconnect both, finalize.
+ *
+ * A crash (the double-free), a failed API call, a wrong server count, or a
+ * hang all surface as a non-zero child exit or a timeout from the harness.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix_server.h"
+#include "include/pmix_tool.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/base/base.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "src/util/pmix_argv.h"
+
+#define DEFAULT_CYCLES 30
+
+/* ------------------------------------------------------------------ */
+/* shared helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+/* hand every connecting tool a fresh identity so repeated attaches across
+ * cycles never collide on the server side */
+static int idcounter = 0;
+static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
+                            pmix_tool_connection_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_proc_t proc;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    snprintf(proc.nspace, PMIX_MAX_NSLEN, "TOOL%d", idcounter++);
+    proc.rank = 0;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, &proc, cbdata);
+    }
+}
+
+static pmix_server_module_t mymodule = {
+    .tool_connected = tool_connect_fn
+};
+
+/* ------------------------------------------------------------------ */
+/* role: server B (a second, independent PMIx server)                 */
+/* ------------------------------------------------------------------ */
+
+static int run_server_b(const char *urifile)
+{
+    pmix_status_t rc;
+    pmix_info_t info[1];
+    char donefile[4096];
+    char tmpfile[4096];
+    char bdir[4096];
+    FILE *fp;
+    struct timespec ts = {0, 50 * 1000 * 1000}; /* 50ms */
+    struct stat sb;
+
+    /* server B must not share a rendezvous directory with server A, or the
+     * two collide - give it its own tmpdir. B is reached only by explicit
+     * URI (never as the scheduler/system server), so tool support alone is
+     * enough and it does not fight A for the system rendezvous. */
+    snprintf(bdir, sizeof(bdir), "%s.d", urifile);
+    (void) mkdir(bdir, 0700);
+    setenv("PMIX_SERVER_TMPDIR", bdir, 1);
+
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
+    rc = PMIx_server_init(&mymodule, info, 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "server-b: PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    if (NULL == pmix_ptl_base.listener.uri) {
+        fprintf(stderr, "server-b: no listener URI available\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* publish our URI atomically: write to a temp file then rename, so the
+     * parent never reads a half-written path */
+    snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", urifile);
+    fp = fopen(tmpfile, "w");
+    if (NULL == fp) {
+        fprintf(stderr, "server-b: cannot write %s: %s\n", tmpfile, strerror(errno));
+        PMIx_server_finalize();
+        return 1;
+    }
+    fprintf(fp, "%s\n", pmix_ptl_base.listener.uri);
+    fclose(fp);
+    if (0 != rename(tmpfile, urifile)) {
+        fprintf(stderr, "server-b: cannot rename %s: %s\n", urifile, strerror(errno));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* idle until the parent signals us to shut down */
+    snprintf(donefile, sizeof(donefile), "%s.done", urifile);
+    while (0 != stat(donefile, &sb)) {
+        nanosleep(&ts, NULL);
+    }
+
+    PMIx_server_finalize();
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* role: the tool child - drive the whole switch API in a loop         */
+/* ------------------------------------------------------------------ */
+
+static int find_other(pmix_proc_t *servers, size_t n, const pmix_proc_t *known,
+                      pmix_proc_t *out)
+{
+    size_t i;
+    for (i = 0; i < n; i++) {
+        if (!PMIX_CHECK_PROCID(&servers[i], known)) {
+            PMIX_LOAD_PROCID(out, servers[i].nspace, servers[i].rank);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int tool_one_cycle(long cyc, const char *burl)
+{
+    pmix_proc_t myproc, srvrA, srvrB, tmpproc;
+    pmix_proc_t *servers = NULL;
+    size_t nservers = 0;
+    pmix_status_t rc;
+    pmix_info_t info[3];
+    int itmo = 2;
+
+    /* come up with a server-assigned nspace/rank each cycle: clear any
+     * identity vars a previous init/attach left in our environment, or a
+     * later init sees a namespace without a rank (or vice versa) and fails
+     * PMIX_ERR_BAD_PARAM */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+
+    /* connect to server A as the scheduler; a scheduler-connected tool
+     * skips its job-info request, so A need not register a job for us */
+    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, info, 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: PMIx_tool_init failed: %s\n", cyc, PMIx_Error_string(rc));
+        return 1;
+    }
+    if (!PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: not connected after init\n", cyc);
+        goto err;
+    }
+
+    /* only server A is known so far - capture its identity */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_SUCCESS != rc || 1 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers after init: rc=%s n=%zu (want 1)\n",
+                cyc, PMIx_Error_string(rc), nservers);
+        goto err;
+    }
+    PMIX_LOAD_PROCID(&srvrA, servers[0].nspace, servers[0].rank);
+    PMIX_PROC_FREE(servers, nservers);
+    servers = NULL;
+
+    /* attach to server B as the new primary: this is the
+     * pmix_tool_retry_attach switch path (the one that double-freed) */
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, burl, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_PRIMARY_SERVER, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[2], PMIX_TIMEOUT, &itmo, PMIX_INT);
+    rc = PMIx_tool_attach_to_server(&myproc, &srvrB, info, 3);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: attach_to_server(B) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    if (!PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: not connected after attach\n", cyc);
+        goto err;
+    }
+
+    /* both A and B must now be known, with distinct identities */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_SUCCESS != rc || 2 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers after attach: rc=%s n=%zu (want 2)\n",
+                cyc, PMIx_Error_string(rc), nservers);
+        goto err;
+    }
+    /* sanity: the "other" server (not B) must be A */
+    if (0 != find_other(servers, nservers, &srvrB, &tmpproc) ||
+        !PMIX_CHECK_PROCID(&tmpproc, &srvrA)) {
+        fprintf(stderr, "cycle %ld: server list does not hold both A and B\n", cyc);
+        goto err;
+    }
+    PMIX_PROC_FREE(servers, nservers);
+    servers = NULL;
+
+    /* switch the primary back to ourselves: pmix_tool_retry_set
+     * "switch back to me" branch (points myserver at our own peer) */
+    rc = PMIx_tool_set_server(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(self) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+
+    /* switch to A, then to B: pmix_tool_retry_set main (known-server) path */
+    rc = PMIx_tool_set_server(&srvrA, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(A) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+    rc = PMIx_tool_set_server(&srvrB, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(B) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+
+    /* disconnect A while B is primary: disc non-primary branch */
+    rc = PMIx_tool_disconnect(&srvrA);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: disconnect(A) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+    /* disconnect B, the primary: disc primary branch (myserver -> self) */
+    rc = PMIx_tool_disconnect(&srvrB);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: disconnect(B) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+
+    /* teardown: the finalize path a switch-refcount bug double-frees, now
+     * that myserver has been pointed back at our own peer by the last
+     * disconnect */
+    rc = PMIx_tool_finalize();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: PMIx_tool_finalize failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        return 1;
+    }
+    return 0;
+
+err:
+    if (NULL != servers) {
+        PMIX_PROC_FREE(servers, nservers);
+    }
+    PMIx_tool_finalize();
+    return 1;
+}
+
+static int run_tool_child(long ncycles, const char *burl)
+{
+    long i;
+
+    for (i = 0; i < ncycles; i++) {
+        if (0 != tool_one_cycle(i, burl)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* role: orchestrator / server A                                       */
+/* ------------------------------------------------------------------ */
+
+static char *read_uri(const char *urifile)
+{
+    FILE *fp;
+    static char buf[4096];
+    char *p;
+
+    fp = fopen(urifile, "r");
+    if (NULL == fp) {
+        return NULL;
+    }
+    p = fgets(buf, sizeof(buf), fp);
+    fclose(fp);
+    if (NULL == p) {
+        return NULL;
+    }
+    /* strip trailing newline */
+    p = strchr(buf, '\n');
+    if (NULL != p) {
+        *p = '\0';
+    }
+    if (0 == strlen(buf)) {
+        return NULL;
+    }
+    return buf;
+}
+
+static pid_t spawn_server_b(const char *self, const char *urifile)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        return -1;
+    }
+    if (0 == pid) {
+        char *argv[4];
+        argv[0] = (char *) self;
+        argv[1] = (char *) "--server-b";
+        argv[2] = (char *) urifile;
+        argv[3] = NULL;
+        execv(self, argv);
+        fprintf(stderr, "server-b execv failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    return pid;
+}
+
+static pid_t spawn_tool(const char *self, long ncycles, const char *burl, char **base_env)
+{
+    pmix_status_t rc;
+    pmix_proc_t proc;
+    char **child_env = NULL;
+    char **child_argv = NULL;
+    char cycles_str[32];
+    char burl_env[4200];
+    pid_t pid;
+    int n;
+
+    for (n = 0; NULL != base_env[n]; n++) {
+        PMIx_Argv_append_nosize(&child_env, base_env[n]);
+    }
+    /* seed the child with server A's rendezvous */
+    PMIX_LOAD_PROCID(&proc, "foobar", 0);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, &child_env))) {
+        fprintf(stderr, "setup_fork failed: %s\n", PMIx_Error_string(rc));
+        PMIx_Argv_free(child_env);
+        return -1;
+    }
+    /* and with server B's URI */
+    snprintf(burl_env, sizeof(burl_env), "PMIX_TEST_SERVERB_URI=%s", burl);
+    PMIx_Argv_append_nosize(&child_env, burl_env);
+
+    snprintf(cycles_str, sizeof(cycles_str), "%ld", ncycles);
+    PMIx_Argv_append_nosize(&child_argv, (char *) self);
+    PMIx_Argv_append_nosize(&child_argv, (char *) "--tool-child");
+    PMIx_Argv_append_nosize(&child_argv, cycles_str);
+
+    pid = fork();
+    if (pid < 0) {
+        PMIx_Argv_free(child_env);
+        PMIx_Argv_free(child_argv);
+        return -1;
+    }
+    if (0 == pid) {
+        execve(self, child_argv, child_env);
+        fprintf(stderr, "tool execve failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    PMIx_Argv_free(child_env);
+    PMIx_Argv_free(child_argv);
+    return pid;
+}
+
+static int run_orchestrator(char *self, long ncycles)
+{
+    pmix_status_t rc;
+    pmix_info_t info[2];
+    pid_t bpid, tpid;
+    char urifile[256];
+    char donefile[512];
+    char *burl;
+    int wstatus, i, toolrc;
+    struct timespec ts = {0, 50 * 1000 * 1000}; /* 50ms */
+    FILE *fp;
+    extern char **environ;
+
+    fprintf(stdout, "\n=== tool multi-server switch test (%ld cycles) ===\n\n", ncycles);
+
+    snprintf(urifile, sizeof(urifile), "/tmp/pmix-toolswitch-b-%lu.uri",
+             (unsigned long) getpid());
+    snprintf(donefile, sizeof(donefile), "%s.done", urifile);
+    unlink(urifile);
+    unlink(donefile);
+
+    /* start server B first so its URI is ready before the tool runs */
+    bpid = spawn_server_b(self, urifile);
+    if (bpid < 0) {
+        fprintf(stderr, "failed to spawn server B: %s\n", strerror(errno));
+        return 1;
+    }
+
+    /* bring up server A (scheduler + tool support) */
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
+    rc = PMIx_server_init(&mymodule, info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "server A PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        kill(bpid, SIGKILL);
+        waitpid(bpid, &wstatus, 0);
+        return 1;
+    }
+
+    /* wait (bounded) for server B to publish its URI */
+    burl = NULL;
+    for (i = 0; i < 400; i++) { /* up to ~20s */
+        burl = read_uri(urifile);
+        if (NULL != burl) {
+            break;
+        }
+        nanosleep(&ts, NULL);
+    }
+    if (NULL == burl) {
+        fprintf(stderr, "server B never published a URI\n");
+        kill(bpid, SIGKILL);
+        waitpid(bpid, &wstatus, 0);
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* run the tool child */
+    tpid = spawn_tool(self, ncycles, burl, environ);
+    if (tpid < 0) {
+        fprintf(stderr, "failed to spawn tool child\n");
+        kill(bpid, SIGKILL);
+        waitpid(bpid, &wstatus, 0);
+        PMIx_server_finalize();
+        return 1;
+    }
+    toolrc = 1;
+    if (tpid == waitpid(tpid, &wstatus, 0)) {
+        if (WIFEXITED(wstatus) && 0 == WEXITSTATUS(wstatus)) {
+            toolrc = 0;
+        } else {
+            fprintf(stderr, "tool child exited abnormally (status %d)\n", wstatus);
+        }
+    }
+
+    /* tell server B to shut down, then reap it */
+    fp = fopen(donefile, "w");
+    if (NULL != fp) {
+        fclose(fp);
+    }
+    for (i = 0; i < 200; i++) {
+        if (bpid == waitpid(bpid, &wstatus, WNOHANG)) {
+            break;
+        }
+        nanosleep(&ts, NULL);
+    }
+    if (0 == i) {
+        /* already reaped above */
+    } else if (200 == i) {
+        kill(bpid, SIGKILL);
+        waitpid(bpid, &wstatus, 0);
+    }
+
+    unlink(urifile);
+    unlink(donefile);
+
+    PMIx_server_finalize();
+
+    if (0 == toolrc) {
+        fprintf(stdout, "\ntool multi-server switch: PASS\n\n");
+    } else {
+        fprintf(stdout, "\ntool multi-server switch: FAIL\n\n");
+    }
+    return toolrc;
+}
+
+int main(int argc, char **argv)
+{
+    long ncycles = DEFAULT_CYCLES;
+
+    if (2 < argc && 0 == strcmp(argv[1], "--tool-child")) {
+        char *burl = getenv("PMIX_TEST_SERVERB_URI");
+        ncycles = strtol(argv[2], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+        if (NULL == burl) {
+            fprintf(stderr, "tool child: PMIX_TEST_SERVERB_URI not set\n");
+            return 1;
+        }
+        return run_tool_child(ncycles, burl);
+    }
+
+    if (2 < argc && 0 == strcmp(argv[1], "--server-b")) {
+        return run_server_b(argv[2]);
+    }
+
+    if (1 < argc) {
+        ncycles = strtol(argv[1], NULL, 10);
+        if (0 >= ncycles) {
+            ncycles = DEFAULT_CYCLES;
+        }
+    }
+    return run_orchestrator(argv[0], ncycles);
+}

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,13 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_toolswitch.pl.in
+++ b/test/unit/run_toolswitch.pl.in
@@ -1,0 +1,114 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise the tool multi-server "switch" path - the code that moves
+# pmix_client_globals.myserver between the servers a tool is connected to
+# (pmix_tool_retry_attach, pmix_tool_retry_set, and disc). tool_server_switch
+# forks into two independent PMIx servers (A and B) plus a tool child that
+# loops: init (-> A), attach B as primary, query the server list, switch the
+# primary among B / A / self, disconnect both, finalize. A reference-count
+# slip around any of those switches double-frees a peer at finalize (or leaks
+# one), which surfaces as a crash, a failed API call, or a hang. See the
+# src/tool switch-path fixes and docs/how-things-work/init-finalize.rst.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen
+# hands us every possible component directory in
+# PMIX_COMPONENT_LIBRARY_PATHS; turn each into an absolute path to the
+# built component so the MCA base can find them without a prior install.
+# tool_server_switch re-execs itself as the server-B and tool children and
+# seeds their environment from its own, so this search path reaches them too.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# tool_server_switch re-execs itself by argv[0], so run from its directory.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
+# arm a Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./tool_server_switch");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run in a child we control, merging stderr into stdout, and slurp it.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec tool_server_switch: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: tool_server_switch exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The harness must exit 0: a crash (the double-free), a failed switch API
+# call, a wrong server count, or a hang drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: tool_server_switch did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the switch loop actually ran and passed, so a vacuous pass (e.g.
+# server B never came up) cannot slip through.
+my $passed = ($output =~ /tool multi-server switch: PASS/);
+if (!$passed) {
+    print "FAIL: tool_server_switch did not report a clean switch cycle\n";
+    exit(1);
+}
+print "PASS: tool switched cleanly among multiple servers across all cycles\n";
+exit(0);


### PR DESCRIPTION
Follow-up to #4018 (merged). While adding a regression test for the tool
multi-server switch path, two further defects surfaced that the merged
reference-counting fix did not cover. This PR fixes both and adds the
test that exercises the whole switch API.

## Fixes

**1. `ptl` re-init dangling pointers.** `pmix_ptl_close()` freed
`pmix_ptl_base.uri` and `pmix_ptl_base.rendezvous_filename` but left them
pointing at freed memory (unlike the adjacent `urifile`, which is
NULLed). When a tool attaches to a server by explicit `PMIX_SERVER_URI`,
`connect_to_peer` caches that string in `pmix_ptl_base.uri`; the next
`PMIx_tool_init` in the same process then sees the stale non-NULL pointer
and fails the reconnect with `PMIX_ERR_BAD_PARAM`. Now both are NULLed on
close.

**2. Tool finalize double-free when disconnected to self.** The switch
paths point `myserver` back at `pmix_globals.mypeer` (taking a reference)
when a tool disconnects its primary. In that state `PMIx_tool_finalize`
released the same object three times — in `pmix_rte_finalize()`, as
`mypeer`, and again as `myserver` — but `mypeer` carries only two
references there, so the third release hit freed memory (an abort in a
debug build, heap corruption otherwise). Finalize now detects the
`myserver == mypeer` alias before `rte_finalize` and skips the redundant
`myserver` release. Behavior is unchanged when `myserver` is a distinct
server peer.

## Test

Adds `test/simple/tool_server_switch`, wired into `make check` via
`test/unit/run_toolswitch.pl`. A tool addresses its servers by
`{nspace,rank}`, so two connections to one server are indistinguishable —
the test therefore stands up two independent PMIx servers (the binary
forks server B and a tool child) and loops: init (→ A), attach B as
primary, query the server list, switch the primary among B / A / self,
disconnect both, finalize. It reproduced the finalize abort before fix #2
and passes after. This exercises `pmix_tool_retry_attach`,
`pmix_tool_retry_set` (both branches), `disc` (both branches),
`PMIx_tool_get_servers`, `PMIx_tool_is_connected`, and the finalize
teardown.

## Testing

Clean warning-free build under `--enable-devel-check`. Full `make check`
passes (0 failures), including the new `run_toolswitch.pl`, the existing
`run_toolcycle.pl` / `tool_cycle` / `run_simpcycle.pl`, and the rest of
the suite.