### PR TITLE
Review and fix src/tools; make pps functional

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -390,6 +390,9 @@ static void scon(pmix_shift_caddy_t *p)
 static void scdes(pmix_shift_caddy_t *p)
 {
     PMIX_DESTRUCT_LOCK(&p->lock);
+    if (NULL != p->key) {
+        free((char *) p->key);
+    }
     if (NULL != p->peer) {
         PMIX_RELEASE(p->peer);
     }

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -1,0 +1,294 @@
+# AGENTS.md: `src/tools` — the user-facing PMIx command-line executables
+
+This document orients AI agents and human contributors working in
+`src/tools`. It assumes you have already read the top-level
+[`AGENTS.md`](../../AGENTS.md) — the golden rules (prefix conventions,
+`pmix_config.h`-first include order, constant-on-the-left comparisons,
+brace-everything, warning-free under `--enable-devel-check`), the
+thread-safety / progress-thread / caddy model, and the
+copyright-header and contribution rules all apply here and are not
+repeated. This file covers what is specific to `src/tools`.
+
+## What this directory is
+
+`src/tools` holds the **installed, user-facing executables** that ship
+with PMIx. Each subdirectory builds exactly one `bin_PROGRAM`. They are
+thin front-ends: nearly all real work is done by `libpmix` (the client,
+tool, and common layers). A tool's job is to (1) bootstrap just enough of
+the library to parse a command line, (2) translate CLI options into a
+`pmix_info_t` array or a query/request, (3) call one public `PMIx_*` API,
+and (4) print the result.
+
+**Do not confuse `src/tools` with `src/tool` (singular).** `src/tool` is
+the *tool-role library code* (`PMIx_tool_init` and friends) that lives
+inside `libpmix`; `src/tools` (plural) is the collection of standalone
+*programs* that link against that library. Most tools here call
+`PMIx_tool_init`, but `pmix_info` and `pmixcc` do not connect to anything.
+
+| Tool | One-liner | Connects to a server? |
+|------|-----------|-----------------------|
+| `pmix_info` | Report build config, version, MCA params, and component versions (the PMIx analogue of `ompi_info`) | No |
+| `wrapper` (`pmixcc`) | Compiler wrapper — injects PMIx's CPPFLAGS/LDFLAGS/LIBS and execs the real compiler | No |
+| `pattrs` | List the attributes/functions supported by the client, server, tool, or host | Only for `--host` (else `PMIX_TOOL_DO_NOT_CONNECT`) |
+| `pquery` | Run `PMIx_Query_info_nb` for one or more keys (with optional qualifiers) | Yes |
+| `pevent` | Generate/notify a PMIx event (`PMIx_Notify_event`) | Optional |
+| `plookup` | `PMIx_Lookup` of published keys | Yes |
+| `palloc` | Request/extend/shrink an allocation via `PMIx_Allocation_request_nb` | Yes (scheduler/controller) |
+| `pctrl` | Job control (`PMIx_Job_control_nb`): pause/resume/kill/signal/checkpoint/… | Yes |
+| `pps` | "PMIx ps" — intended to list namespaces/nodes/procs. **Skeleton only** (see below) | Yes |
+
+## The shared skeleton every tool follows
+
+The connecting tools (everything except `pmix_info` and `pmixcc`) are
+copy-paste siblings. Reading one teaches you all of them; the flip side
+is that **a bug fixed in one is usually present in the others** — grep the
+siblings before assuming a fix is local. The common spine:
+
+1. `signal(SIGPIPE, SIG_IGN)` — tolerate a consumer closing a pipe early.
+2. Set `pmix_tool_basename` (used by `pmix_show_help` for the program name).
+3. **Bootstrap the library enough to parse.** Two idioms exist:
+   - The **long form** (`pmix_info`, `pps`, `pevent`, `plookup`, `pattrs`):
+     `pmix_output_init()` → open+init `pinstalldirs` → `pmix_show_help_init()`
+     → `pmix_util_keyval_parse_init()` → `pmix_mca_base_var_init()`.
+   - The **short form** (`pquery`, `palloc`, `pctrl`, `pmixcc`):
+     a single `pmix_init_util(NULL, 0, NULL)` that does the equivalent.
+     Prefer `pmix_init_util` for new tools — it is the maintained wrapper.
+4. `pmix_cmd_line_parse(argv, shorts, options, NULL, &results, "help-<tool>.txt")`.
+5. Walk `results.instances` for `PMIX_CLI_PMIXMCA` and feed each value to
+   `pmix_expose_param()` so `--pmixmca foo bar` works.
+6. `pmix_register_params()` (long form) — the short form did it already.
+7. Build a `pmix_info_t` array describing **how to connect** (see the
+   connection ladder below), then `PMIx_tool_init(&myproc, info, ninfo)`.
+8. Register a default event handler (all of them install a no-op
+   `notification_fn` plus an `evhandler_reg_callbk` that wakes a lock).
+9. Do the one operation, print, `PMIx_tool_finalize()`, return `rc`.
+
+### The connection-selection ladder
+
+The connecting tools share a near-identical if/else chain that inspects
+the CLI and loads **one** connection directive into `info[0]`, in this
+priority order: `--pid <int|file:PATH>` → `--namespace`/`--nspace` →
+`--uri` → `--system-server-first` → `--system-server[-only]` →
+(`palloc` only) `--connection-order`, `--system-controller`,
+`--scheduler` → a tool-specific default. The `--pid file:PATH` branch
+`fscanf`s a single `%lu` out of a rendezvous file. When you add a
+connection option to one tool, decide deliberately whether the siblings
+need it too.
+
+### Command-line option tables
+
+Options are declared as a `static struct option[]` built from
+`PMIX_OPTION_DEFINE` / `PMIX_OPTION_SHORT_DEFINE` macros, terminated by
+`PMIX_OPTION_END`, paired with a short-option string (e.g. `"h::vV"`).
+Reusable option *names* come from `src/util/pmix_cmd_line.h`
+(`PMIX_CLI_HELP`, `PMIX_CLI_PID`, `PMIX_CLI_URI`, …). Tool-specific
+options are `#define`d locally at the top of the `.c` (e.g. `pevent`'s
+`PMIX_CLI_RANGE`, `pattrs`'s `PMIX_CLI_CLIENT`). Keep the short-option
+string and the table in sync: a short letter in the string with no
+matching `PMIX_OPTION_SHORT_DEFINE` (or vice-versa) is a latent parse bug.
+
+> **Positional arguments come back in `results.tail`.** After a parse,
+> `results.tail` is the `NULL`-terminated vector of arguments the parser
+> did not consume as options — the tool's positional operands (keys,
+> event names, …), or `NULL` if there were none. Two parser quirks are
+> worth knowing:
+> - A **bare invocation** (just the program name) used to leave the
+>   program name itself as `tail[0]`, defeating every tool's
+>   "you-gave-me-no-arguments" guard. That was fixed in
+>   `pmix_cmd_line_parse` (the `argc == 1` early-out now returns with
+>   `tail == NULL` instead of falling through the `done:` copy); a bare
+>   `pevent`/`plookup`/`pquery` now correctly prints its usage/guard.
+> - A **positional placed before an option** (`pquery key --uri x`) is
+>   still dropped by the parser's option/positional reordering — put
+>   options first (`pquery --uri x key`). This is a `pmix_cmd_line`
+>   limitation, not a per-tool bug.
+>
+> `pmix_info` additionally compares `join(results.tail)` against `argv[0]`
+> as belt-and-suspenders; new tools need only null-check `results.tail`.
+
+## `pmix_info` — the odd one out (no connection)
+
+`pmix_info` never calls `PMIx_tool_init`. It drives the
+`src/runtime/pmix_info_support.*` helpers directly: it builds an
+`mca_types` pointer-array and a `pmix_component_map`, registers all
+framework params, then dispatches on the flags (`--all`, `--config`,
+`--param`, `--path`, `--arch`, `--hostname`, `--type`, `--version`).
+With no arguments it prints a default digest. Its cleanup is meticulous
+(it destructs the arrays and releases every `pmix_info_component_map_t`)
+because it is the reference for "a tool that shuts the library down
+cleanly." If you touch the info-dumping logic, the substance lives in
+`src/runtime/pmix_info_support.c`, not here.
+
+## `pmixcc` (the wrapper) — how it actually works
+
+`pmixcc` is a self-contained compiler wrapper descended from Open MPI's
+`opal_wrapper`. It does **not** use `PMIx_tool_init`. Flow:
+
+- `data_init()` reads the installed **`pmixcc-wrapper-data.txt`** (built
+  from [`wrapper/pmixcc-wrapper-data.txt.in`](wrapper/pmixcc-wrapper-data.txt.in)
+  by `configure`, which substitutes `@WRAPPER_CC@`,
+  `@PMIX_WRAPPER_CPPFLAGS@`, `@PMIX_WRAPPER_LIBS@`, …). The file is a
+  keyval file parsed by `pmix_util_keyval_parse` into one or more
+  `options_data_t` blocks. The wrapper flags themselves are decided in
+  `config/pmix_setup_wrappers.m4` — **that** is where you change what
+  `pmixcc` injects, not this `.c`.
+- Environment overrides: `PMIX_CC`, `PMIX_CPPFLAGS`, `PMIX_CFLAGS`,
+  `PMIX_LDFLAGS`, `PMIX_LIBS` (via `load_env_data*`).
+- `-showme`, `-showme:compile`, `-showme:link`, `-showme:libs`,
+  `-showme:incdirs`, `-showme:version`, `-showme:help`, … either print a
+  slice of the assembled command line and exit, or (the first few) set a
+  `COMP_WANT_*` bitmask and still build the full line.
+- The final command line is assembled in a fixed order (compiler →
+  prefix flags → user args → preproc → compile → link → libs) and run
+  via `pmix_few()`. `-showme` alone is a dry run (`COMP_DRY_RUN`).
+
+`pmixcc` is the most self-testable tool: every `-showme:*` path runs
+without a server and exits 0. Use it in smoke tests (see below).
+
+## `pps` — process/node status
+
+[`pps/pps.c`](pps/pps.c) connects to a server (honoring the standard
+connection ladder: `--pid`, `--namespace`, `--uri`, `--system-server`,
+else system-first), queries `PMIX_QUERY_NAMESPACES` for the active
+namespaces, and then, for each namespace, runs a `PMIX_QUERY_PROC_TABLE`
+query (qualified by `PMIX_NSPACE`) and prints the returned
+`pmix_proc_info_t` array. Two presentations:
+
+- default — a per-process table (rank, pid, node, state, executable);
+- `--nodes` — a per-node roll-up (how many of the job's processes run on
+  each node).
+
+The proc-table result is a `pmix_data_array_t*` of `pmix_proc_info_t`;
+`get_proc_array()` defends against a server that returns something else
+(e.g. a stub `query_fn`) by type-checking and degrading to "no process
+information available" rather than dereferencing. The data-array
+consumption mirrors [`examples/debugger.c`](../../examples/debugger.c).
+
+Historical note: `pps` used to be a skeleton — everything below `main()`
+was fenced out under `#if 0` and referenced Open-MPI/ORTE types
+(`pmix_ps_mpirun_info_t`, `pmix_job_t`, `pmix_node_t`, …) that no longer
+exist. That dead block has been removed; do not resurrect it. A real
+proc-table needs a proc-table-capable server (e.g. PRRTE's `prted`); the
+`test/simple/simptest` stub `query_fn` returns a string for every key, so
+`pps` against it exercises only the graceful-degradation path.
+
+## Help text and `show_help`
+
+Each tool ships a `help-<tool>.txt`. These are **not** installed as data
+files by the tool `Makefile.am` (the `EXTRA_DIST` line only puts them in
+the tarball). Their content is compiled *into `libpmix`* through the
+generated `src/util/pmix_show_help_content.c` — so a runtime
+`pmix_show_help("help-foo.txt", "topic", …)` call resolves against that
+compiled table regardless of which tool emits it. Consequences:
+
+- **After editing any `help-*.txt`, regenerate the content pair** exactly
+  as the top-level guide says:
+  `rm src/util/pmix_show_help_content.* && make`. A plain `make` will
+  *not* pick up the new text otherwise.
+- Because all help content lives in one table, `pevent` and `pctrl`
+  currently source their `--pid` error messages from **`help-pquery.txt`**
+  (topics `bad-option-input`, `file-open-error`, `bad-file`) rather than
+  their own files. It works, but it is a coupling smell: those topics must
+  never be deleted from `help-pquery.txt`. Prefer adding the topics to a
+  tool's own help file when you touch this.
+
+## Build wiring
+
+- Every tool is registered in [`Makefile.include`](Makefile.include)
+  (`SUBDIRS` + `DIST_SUBDIRS`), which is `include`d by `src/Makefile.am`.
+  **Adding a new tool means adding it in both lists** and creating a
+  `Makefile.am` modeled on an existing one.
+- Each tool `Makefile.am` guards its `bin_PROGRAMS` with
+  `if PMIX_INSTALL_BINARIES` so a library-only install builds nothing
+  here. `*_LDADD = $(top_builddir)/src/libpmix.la`.
+- `pmix_info` and `pmixcc` carry the extra `AM_CFLAGS` block of
+  `-DPMIX_BUILD_*` / `-DPMIX_CONFIGURE_*` defines (they print build
+  provenance); the others do not need it.
+- Editing only a `Makefile.am` needs just `make`. Adding a tool
+  directory, or anything touched by `configure` (like the wrapper data
+  file), requires the full `./autogen.pl && ./configure` regeneration —
+  see the top-level guide.
+- `.gitignore`: each tool dir ignores its built binary. A new tool needs
+  the same (see `wrapper/.gitignore`).
+
+## Testing
+
+These are `main()` programs whose interesting helpers (`convert_signal`,
+`convert_procs` in `pctrl`; the flag assembly in `pmixcc`) are `static`,
+so classic unit tests can't link them without refactoring. The
+regression coverage that *is* possible drives the **no-connect** paths of
+the built binaries and asserts they parse, execute, and finalize without
+crashing:
+
+- [`test/unit/run_tools.pl`](../../test/unit/run_tools.pl) (wired into
+  `make check`) exercises `pmix_info --version`, several `pmixcc
+  -showme:*` variants, and `pattrs --client-fns/--server-fns/--tool-fns`.
+  It deliberately avoids every server-connecting path because a
+  developer's machine may have live PMIx servers (stale `pmix.*`
+  rendezvous files in `$TMPDIR`) that make those paths non-deterministic.
+
+When adding a tool, add its no-connect invocation to that script. Testing
+the connecting tools (`pquery`, `palloc`, `pctrl`, `plookup`, `pevent`)
+end-to-end needs a server; model that on `test/simple/simptest` +
+`test/unit/run_*.pl` and keep it out of the default `make check` unless it
+is fully self-contained.
+
+## Fixed defects (July 2026 review)
+
+A deep review of this directory surfaced the following defects, all now
+**fixed** on `topic/tool-review`. Recorded here so the same problems are
+not re-introduced by a future copy-paste.
+
+- **`palloc` / `pctrl` double-free on the synchronous-completion path.**
+  When `PMIx_Allocation_request_nb` / `PMIx_Job_control_nb` returned
+  `PMIX_OPERATION_SUCCEEDED`, the code did `PMIX_RELEASE(req)` and then
+  `goto done`, where `if (NULL != req) PMIX_RELEASE(req)` released the
+  same caddy again. Fixed by nulling `req` after the inline release.
+- **`palloc --signal` targeted the wrong attribute** (`PMIX_ALLOC_NODE_LIST`,
+  copy-paste from `--nodelist`). Now parses `<signal>[@seconds]`, converts
+  the signal name/number via a local `convert_signal()`, and loads
+  `PMIX_SESSION_SIGNAL` (int).
+- **`palloc` printed `req->key`, which was never set.** Now prints the
+  returned `req->sessionid` (captured by `cbfunc`) when available.
+- **`pctrl` leaked `req->key`, and neither tool freed the converted info
+  array.** `scdes` (in `src/include/pmix_globals.c`) now frees
+  `pmix_shift_caddy_t.key` — verified safe: the only setters of that field
+  are `pctrl` (owned `strdup`) and `palloc` (never set); the `key`
+  assignments in `src/server/pmix_server_get.c` are on *different* caddy
+  types. Both tools now set `req->infocopy = true` so the destructor frees
+  the `PMIx_Info_list_convert` array.
+- **`pctrl convert_procs` NULL-derefed a target with no `:`** — now
+  reports a "malformed target" error (and frees the split argv, which it
+  also used to leak).
+- **`pattrs` read an uninitialized `mq`.** Now static-initialized like
+  `pquery`, plus a `ninfo == 0` guard before dereferencing `mq.info[0]`.
+- **`pquery` freed only `info[0]` of a 3-element array** (`PMIX_INFO_FREE(info, 1)`
+  → `info, n`) and **called `pmix_init_util()` twice** (the second call
+  removed).
+- **`pmixcc` filter typo** `"-L/usr/lb"` → `"-L/usr/lib"`.
+- **`plookup` did not include `pmix_config.h`** (now the first include,
+  replacing the manual `#define _GNU_SOURCE`) and **ignored `--pid`**
+  (now honored via the standard int/`file:PATH` branch).
+- **Bare-invocation guards were defeated** by the parser leaving the
+  program name in `results.tail`; fixed at the `pmix_cmd_line_parse`
+  source (see the callout above).
+- **`pps` was a `#if 0` skeleton** — now a working tool (see the `pps`
+  section).
+
+**Note the false alarm we ruled out:** `pmix_attributes_print_headers()`
+returns immediately for a `*_FUNCTIONS` level, so `pattrs`'s
+`--host-fns` branch was *not* leaking headers — that call is a harmless
+no-op, left as-is.
+
+None of these were hot-path; they are correctness/robustness and hygiene
+issues. When you touch one tool, check the copy-paste siblings for the
+same shape, and land each logical fix as its own commit.
+
+## When in doubt
+
+- Match the surrounding tool's structure — they are intentionally uniform.
+- The real behavior lives in `libpmix`; a tool should stay a thin
+  translator of CLI → `pmix_info_t[]` → one `PMIx_*` call → print.
+- Never add a bare `PMIx_*` public call that thread-shifts from inside a
+  callback; the tools only call public APIs from `main()`, which is the
+  safe place to do so.

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -30,8 +30,10 @@
 #include "include/pmix_server.h"
 
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -46,6 +48,10 @@
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
+
+/* translate a signal name (e.g. "SIGTERM") or number to its integer
+ * value; returns 0 for an unrecognized name */
+static int convert_signal(const char *val);
 
 static struct option pallocptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
@@ -425,7 +431,24 @@ int main(int argc, char **argv)
     }
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_SIGNAL))) {
-        PMIX_INFO_LIST_ADD(rc, options, PMIX_ALLOC_NODE_LIST, opt->values[0], PMIX_STRING);
+        /* the value has the form "<signal>[@seconds]" - split off any
+         * trailing "@seconds" (the pre-end warning time) and convert the
+         * signal name or number to its integer value */
+        char *at, *sigstr;
+        int sigval;
+        sigstr = strdup(opt->values[0]);
+        if (NULL != (at = strchr(sigstr, '@'))) {
+            *at = '\0';
+        }
+        sigval = convert_signal(sigstr);
+        free(sigstr);
+        if (0 == sigval) {
+            fprintf(stderr, "Unrecognized signal: %s\n", opt->values[0]);
+            PMIX_INFO_LIST_RELEASE(options);
+            rc = PMIX_ERR_BAD_PARAM;
+            goto done;
+        }
+        PMIX_INFO_LIST_ADD(rc, options, PMIX_SESSION_SIGNAL, &sigval, PMIX_INT);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "PMIx info list add failed: %s\n", PMIx_Error_string(rc));
             PMIX_INFO_LIST_RELEASE(options);
@@ -511,6 +534,8 @@ int main(int argc, char **argv)
     } else {
         req->info = (pmix_info_t *) darray.array;
         req->ninfo = darray.size;
+        /* the caddy now owns this array - tell its destructor to free it */
+        req->infocopy = true;
     }
     PMIX_INFO_LIST_RELEASE(options);
 
@@ -529,8 +554,12 @@ int main(int argc, char **argv)
                                     cbfunc, req);
     if (PMIX_SUCCESS != rc) {
         if (PMIX_OPERATION_SUCCEEDED == rc) {
-            fprintf(stderr, "Allocation %s granted\n", req->key);
+            /* the request completed synchronously, so no callback fired
+             * and no session ID was returned to us */
+            fprintf(stderr, "Allocation granted\n");
             PMIX_RELEASE(req);
+            /* avoid a second release of the same caddy at "done:" */
+            req = NULL;
             rc = PMIX_SUCCESS;
             goto done;
         }
@@ -545,7 +574,12 @@ int main(int argc, char **argv)
 
     PMIX_WAIT_THREAD(&req->lock);
     if (PMIX_SUCCESS == req->status) {
-        fprintf(stderr, "Allocation %s granted\n", req->key);
+        /* cbfunc records the returned session ID (if any) in req->sessionid */
+        if (UINT32_MAX == req->sessionid) {
+            fprintf(stderr, "Allocation granted\n");
+        } else {
+            fprintf(stderr, "Allocation granted: session %u\n", req->sessionid);
+        }
     } else {
         fprintf(stderr, "Allocation request failed: %s\n", PMIx_Error_string(req->status));
     }
@@ -557,4 +591,81 @@ done:
     PMIx_tool_finalize();
 
     return (rc);
+}
+
+typedef struct {
+    char *name;
+    int value;
+} pmix_signal_t;
+
+static pmix_signal_t sigs[] = {
+#ifdef SIGHUP
+    {"SIGHUP", SIGHUP},
+#endif
+#ifdef SIGABRT
+    {"SIGABRT", SIGABRT},
+#endif
+#ifdef SIGALRM
+    {"SIGALRM", SIGALRM},
+#endif
+#ifdef SIGKILL
+    {"SIGKILL", SIGKILL},
+#endif
+#ifdef SIGPIPE
+    {"SIGPIPE", SIGPIPE},
+#endif
+#ifdef SIGTERM
+    {"SIGTERM", SIGTERM},
+#endif
+#ifdef SIGSTOP
+    {"SIGSTOP", SIGSTOP},
+#endif
+#ifdef SIGTSTP
+    {"SIGTSTP", SIGTSTP},
+#endif
+#ifdef SIGCONT
+    {"SIGCONT", SIGCONT},
+#endif
+#ifdef SIGCHLD
+    {"SIGCHLD", SIGCHLD},
+#endif
+#ifdef SIGINFO
+    {"SIGINFO", SIGINFO},
+#endif
+#ifdef SIGUSR1
+    {"SIGUSR1", SIGUSR1},
+#endif
+#ifdef SIGUSR2
+    {"SIGUSR2", SIGUSR2},
+#endif
+#ifdef SIGINT
+    {"SIGINT", SIGINT},
+#endif
+#ifdef SIGTRAP
+    {"SIGTRAP", SIGTRAP},
+#endif
+    {NULL, 0}
+};
+
+static int convert_signal(const char *val)
+{
+    int n;
+    char *endp;
+    long sigval;
+
+    /* accept a raw signal number */
+    sigval = strtol(val, &endp, 10);
+    if (NULL != endp && '\0' == endp[0] && val != endp) {
+        return (int) sigval;
+    }
+
+    /* otherwise look up the signal by name */
+    n = 0;
+    while (NULL != sigs[n].name) {
+        if (0 == strcasecmp(val, sigs[n].name)) {
+            return sigs[n].value;
+        }
+        ++n;
+    }
+    return 0;
 }

--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -186,7 +186,12 @@ int main(int argc, char **argv)
     pmix_cli_item_t *opt;
     char **fns = NULL, *ptr;
     size_t n, m;
-    myquery_data_t mq;
+    myquery_data_t mq = {
+        .lock = PMIX_LOCK_STATIC_INIT,
+        .status = 0,
+        .info = NULL,
+        .ninfo = 0
+    };
     pmix_query_t query;
     pmix_regattr_t *reg;
     char **ans = NULL;
@@ -440,6 +445,9 @@ int main(int argc, char **argv)
     if (PMIX_SUCCESS != mq.status) {
         fprintf(stderr, "PMIx_Query_info returned: %s\n", PMIx_Error_string(mq.status));
         rc = mq.status;
+    } else if (0 == mq.ninfo || NULL == mq.info) {
+        fprintf(stderr, "PMIx_Query_info returned no results\n");
+        rc = PMIX_ERR_NOT_FOUND;
     } else if (!PMIX_CHECK_KEY(&mq.info[0], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
         fprintf(stderr, "PMIx_Query_info returned incorrect key: %s\n", mq.info[0].key);
         rc = PMIX_ERR_BAD_PARAM;

--- a/src/tools/pctrl/pctrl.c
+++ b/src/tools/pctrl/pctrl.c
@@ -442,6 +442,8 @@ int main(int argc, char **argv)
     } else {
         req->info = (pmix_info_t *) darray.array;
         req->ninfo = darray.size;
+        /* the caddy now owns this array - tell its destructor to free it */
+        req->infocopy = true;
     }
     PMIx_Info_list_release(options);
 
@@ -452,6 +454,8 @@ int main(int argc, char **argv)
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             fprintf(stderr, "Job control request %s granted\n", req->key);
             PMIX_RELEASE(req);
+            /* avoid a second release of the same caddy at "done:" */
+            req = NULL;
             rc = PMIX_SUCCESS;
             goto done;
         }
@@ -496,6 +500,14 @@ static pmix_status_t convert_procs(const char *vals,
     for (n=0; NULL != p[n]; n++) {
         // find the nspace/rank delimiting ':'
         r = strrchr(p[n], ':');
+        if (NULL == r) {
+            // no rank was provided - this is a malformed target
+            fprintf(stderr, "%s: malformed target \"%s\" - expected <nspace>:<rank>\n",
+                    pmix_tool_basename, p[n]);
+            PMIx_Argv_free(p);
+            PMIx_Data_array_destruct(array);
+            return PMIX_ERR_BAD_PARAM;
+        }
         *r = '\0';
         ++r;  // step over the colon
         PMIX_LOAD_NSPACE(procs[n].nspace, p[n]);
@@ -505,6 +517,7 @@ static pmix_status_t convert_procs(const char *vals,
             procs[n].rank = strtoul(r, NULL, 10);
         }
     }
+    PMIx_Argv_free(p);
     return PMIX_SUCCESS;
 
 }

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -24,10 +24,12 @@
  *
  */
 
-#define _GNU_SOURCE
+#include "pmix_config.h"
+
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -208,12 +210,60 @@ int main(int argc, char **argv)
     }
     ndata = count;
 
-    /* if we were given the pid of a starter, then direct that
-     * we connect to it */
-
-    /* otherwise, use the system connection first, if available */
     PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_PID))) {
+        /* if we were given the pid of a starter, then direct that
+         * we connect to it - the value may be an integer pid or a
+         * "file:PATH" pointing at a rendezvous file holding the pid */
+        char *leftover, *param;
+        pid_t pid;
+        leftover = NULL;
+        pid = strtol(opt->values[0], &leftover, 10);
+        if (NULL == leftover || 0 == strlen(leftover)) {
+            /* it is an integer */
+            PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
+        } else if (0 == strncasecmp(opt->values[0], "file", 4)) {
+            FILE *fp;
+            /* step over the file: prefix */
+            param = strchr(opt->values[0], ':');
+            if (NULL == param) {
+                /* malformed input */
+                pmix_show_help("help-pquery.txt", "bad-option-input", true, pmix_tool_basename,
+                               "--pid", opt->values[0], "file:path");
+                PMIX_INFO_FREE(info, 1);
+                exit(PMIX_ERR_BAD_PARAM);
+            }
+            ++param;
+            fp = fopen(param, "r");
+            if (NULL == fp) {
+                pmix_show_help("help-pquery.txt", "file-open-error", true, pmix_tool_basename,
+                               "--pid", opt->values[0], param);
+                PMIX_INFO_FREE(info, 1);
+                exit(PMIX_ERR_BAD_PARAM);
+            }
+            rc = fscanf(fp, "%lu", (unsigned long *) &pid);
+            if (1 != rc) {
+                /* if we were unable to obtain the single conversion we
+                 * require, then error out */
+                pmix_show_help("help-pquery.txt", "bad-file", true, pmix_tool_basename,
+                               "--pid", opt->values[0], param);
+                fclose(fp);
+                PMIX_INFO_FREE(info, 1);
+                exit(PMIX_ERR_BAD_PARAM);
+            }
+            fclose(fp);
+            PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
+        } else { /* a string that's neither an integer nor starts with 'file:' */
+            pmix_show_help("help-pquery.txt", "bad-option-input", true,
+                           pmix_tool_basename, "--pid",
+                           opt->values[0], "file:path");
+            PMIX_INFO_FREE(info, 1);
+            exit(PMIX_ERR_BAD_PARAM);
+        }
+    } else {
+        /* otherwise, use the system connection first, if available */
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    }
     /* init as a tool */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
         fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);

--- a/src/tools/pps/help-pps.txt
+++ b/src/tools/pps/help-pps.txt
@@ -39,6 +39,7 @@ PMIx Job and Process Status Tool
 -h|--help <arg0>                     Help for the specified option
 -v|--verbose                         Enable typical debug options
 -V|--version                         Print version and exit
+   --pmixmca <arg0> <arg1>           Set MCA parameter value
 
    --uri <arg0>                      Specify the URI of the server to which we are to connect, or
                                      the name of the file (specified as file:filename) that contains that info
@@ -53,6 +54,14 @@ PMIx Job and Process Status Tool
    --nodes                           Display Node Information
 
 Report bugs to %s
+#
+[pmixmca]
+
+Pass a PMIx MCA parameter
+
+Syntax: "pmixmca <key> <value>", where "key" is the parameter name
+and "value" is the parameter value.
+
 #
 [uri]
 Specify the URI of the PMIx server we are to contact, or the name of the file (specified as

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -27,9 +27,14 @@
  */
 
 /**
- * @fie
+ * @file
  * PMIX PS command
  *
+ * Report the processes running under the PMIx server(s) we can reach.
+ * With no options it connects to the local/system server, queries the
+ * set of active namespaces, and prints a process table for each. With
+ * "--nodes" it instead reports, per namespace, the set of nodes the
+ * job occupies and how many of its processes live on each.
  */
 
 #include "pmix_config.h"
@@ -41,34 +46,21 @@
 #    include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 #include <stdlib.h>
-#ifdef HAVE_SYS_STAT_H
-#    include <sys/stat.h>
-#endif /* HAVE_SYS_STAT_H */
-#ifdef HAVE_SYS_TYPES_H
-#    include <sys/types.h>
-#endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_SYS_WAIT_H
-#    include <sys/wait.h>
-#endif /* HAVE_SYS_WAIT_H */
 #include <string.h>
-#ifdef HAVE_DIRENT_H
-#    include <dirent.h>
-#endif /* HAVE_DIRENT_H */
 
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/pinstalldirs/base/base.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/threads/pmix_threads.h"
-#include "src/util/pmix_basename.h"
+#include "src/util/pmix_argv.h"
 #include "src/util/pmix_cmd_line.h"
 #include "src/util/pmix_keyval_parse.h"
 #include "src/util/pmix_output.h"
-#include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "include/pmix.h"
 #include "include/pmix_tool.h"
-#include "src/include/pmix_globals.h"
 
 typedef struct {
     pmix_lock_t lock;
@@ -79,31 +71,12 @@ typedef struct {
  * info from a query */
 typedef struct {
     mylock_t lock;
+    pmix_status_t status;
     pmix_info_t *info;
     size_t ninfo;
 } myquery_data_t;
 
 static pmix_proc_t myproc;
-
-/******************
- * Local Functions
- ******************/
-#if 0
-static int gather_information(pmix_ps_mpirun_info_t *hnpinfo);
-static int gather_active_jobs(pmix_ps_mpirun_info_t *hnpinfo);
-static int gather_nodes(pmix_ps_mpirun_info_t *hnpinfo);
-static int gather_vpid_info(pmix_ps_mpirun_info_t *hnpinfo);
-
-static int pretty_print(pmix_ps_mpirun_info_t *hnpinfo);
-static int pretty_print_nodes(pmix_node_t **nodes, pmix_std_cntr_t num_nodes);
-static int pretty_print_jobs(pmix_job_t **jobs, pmix_std_cntr_t num_jobs);
-static int pretty_print_vpids(pmix_job_t *job);
-static void pretty_print_dashed_line(int len);
-
-static char *pretty_node_state(pmix_node_state_t state);
-
-static int parseable_print(pmix_ps_mpirun_info_t *hnpinfo);
-#endif
 
 #define PMIX_CLI_NODES  "nodes"
 
@@ -111,6 +84,7 @@ static struct option ppsoptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERSION, PMIX_ARG_NONE, 'V'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
 
     PMIX_OPTION_DEFINE(PMIX_CLI_SYS_SERVER_FIRST, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PMIX_CLI_SYSTEM_SERVER, PMIX_ARG_NONE),
@@ -143,8 +117,8 @@ static void querycbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
 {
     myquery_data_t *mq = (myquery_data_t *) cbdata;
     size_t n;
-    PMIX_HIDE_UNUSED_PARAMS(status);
 
+    mq->status = status;
     /* save the returned info - the PMIx library "owns" it
      * and will release it and perform other cleanup actions
      * when release_fn is called */
@@ -202,15 +176,186 @@ static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, voi
     PMIX_WAKEUP_THREAD(&lock->lock);
 }
 
+/* run a single PMIX_QUERY_PROC_TABLE query for the given namespace,
+ * returning the array of pmix_proc_info_t (owned by the caller, who
+ * must PMIX_INFO_FREE mq->info) via the mq structure */
+static pmix_status_t query_proctable(const char *nspace, myquery_data_t *mq)
+{
+    pmix_query_t query;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_PROC_TABLE);
+    PMIX_QUERY_QUALIFIERS_CREATE(&query, 1);
+    PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_NSPACE, nspace, PMIX_STRING);
+
+    PMIX_CONSTRUCT_LOCK(&mq->lock.lock);
+    mq->status = PMIX_SUCCESS;
+    mq->info = NULL;
+    mq->ninfo = 0;
+    rc = PMIx_Query_info_nb(&query, 1, querycbfunc, (void *) mq);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&mq->lock.lock);
+    }
+    PMIX_DESTRUCT_LOCK(&mq->lock.lock);
+    PMIX_QUERY_DESTRUCT(&query);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    return mq->status;
+}
+
+/* extract the pmix_proc_info_t array (if any) from a returned
+ * proc-table query result */
+static pmix_proc_info_t *get_proc_array(myquery_data_t *mq, size_t *np)
+{
+    *np = 0;
+    if (0 == mq->ninfo || NULL == mq->info) {
+        return NULL;
+    }
+    if (PMIX_DATA_ARRAY != mq->info[0].value.type ||
+        NULL == mq->info[0].value.data.darray ||
+        NULL == mq->info[0].value.data.darray->array) {
+        return NULL;
+    }
+    *np = mq->info[0].value.data.darray->size;
+    return (pmix_proc_info_t *) mq->info[0].value.data.darray->array;
+}
+
+static void print_proctable(const char *nspace, pmix_proc_info_t *pi, size_t np)
+{
+    size_t n;
+
+    printf("\nNamespace %s (%lu process%s)\n", nspace,
+           (unsigned long) np, (1 == np) ? "" : "es");
+    printf("    %8s  %8s  %-20s  %-14s  %s\n",
+           "Rank", "PID", "Node", "State", "Executable");
+    for (n = 0; n < np; n++) {
+        printf("    %8u  %8lu  %-20s  %-14s  %s\n",
+               (unsigned) pi[n].proc.rank,
+               (unsigned long) pi[n].pid,
+               (NULL == pi[n].hostname) ? "unknown" : pi[n].hostname,
+               PMIx_Proc_state_string(pi[n].state),
+               (NULL == pi[n].executable_name) ? "unknown" : pi[n].executable_name);
+    }
+}
+
+static void print_nodes(const char *nspace, pmix_proc_info_t *pi, size_t np)
+{
+    size_t n, m;
+    char **nodes = NULL;
+    int *counts = NULL;
+    int nnodes = 0;
+    const char *host;
+
+    /* aggregate the process count per unique node */
+    for (n = 0; n < np; n++) {
+        host = (NULL == pi[n].hostname) ? "unknown" : pi[n].hostname;
+        for (m = 0; (int) m < nnodes; m++) {
+            if (0 == strcmp(nodes[m], host)) {
+                counts[m]++;
+                break;
+            }
+        }
+        if ((int) m == nnodes) {
+            PMIx_Argv_append_nosize(&nodes, host);
+            counts = (int *) realloc(counts, (nnodes + 1) * sizeof(int));
+            counts[nnodes] = 1;
+            nnodes++;
+        }
+    }
+
+    printf("\nNamespace %s (%d node%s)\n", nspace, nnodes, (1 == nnodes) ? "" : "s");
+    printf("    %-20s  %s\n", "Node", "Processes");
+    for (m = 0; (int) m < nnodes; m++) {
+        printf("    %-20s  %d\n", nodes[m], counts[m]);
+    }
+    PMIx_Argv_free(nodes);
+    if (NULL != counts) {
+        free(counts);
+    }
+}
+
+/* build the connection directive(s) requested on the command line;
+ * returns a freshly-created info array (caller frees) and its size */
+static pmix_status_t set_connection(pmix_cli_result_t *results,
+                                    pmix_info_t **infoptr, size_t *ninfo)
+{
+    pmix_cli_item_t *opt;
+    pmix_info_t *info;
+
+    PMIX_INFO_CREATE(info, 1);
+    *infoptr = info;
+    *ninfo = 1;
+
+    if (NULL != (opt = pmix_cmd_line_get_param(results, PMIX_CLI_PID))) {
+        /* the value may be an integer pid or a "file:PATH" pointing at a
+         * rendezvous file holding the pid */
+        char *leftover, *param;
+        pid_t pid;
+        leftover = NULL;
+        pid = strtol(opt->values[0], &leftover, 10);
+        if (NULL == leftover || 0 == strlen(leftover)) {
+            PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
+        } else if (0 == strncasecmp(opt->values[0], "file", 4)) {
+            FILE *fp;
+            param = strchr(opt->values[0], ':');
+            if (NULL == param) {
+                pmix_show_help("help-pquery.txt", "bad-option-input", true, "pps",
+                               "--pid", opt->values[0], "file:path");
+                PMIX_INFO_FREE(info, 1);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            ++param;
+            fp = fopen(param, "r");
+            if (NULL == fp) {
+                pmix_show_help("help-pquery.txt", "file-open-error", true, "pps",
+                               "--pid", opt->values[0], param);
+                PMIX_INFO_FREE(info, 1);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            if (1 != fscanf(fp, "%lu", (unsigned long *) &pid)) {
+                pmix_show_help("help-pquery.txt", "bad-file", true, "pps",
+                               "--pid", opt->values[0], param);
+                fclose(fp);
+                PMIX_INFO_FREE(info, 1);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            fclose(fp);
+            PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
+        } else {
+            pmix_show_help("help-pquery.txt", "bad-option-input", true,
+                           "pps", "--pid", opt->values[0], "file:path");
+            PMIX_INFO_FREE(info, 1);
+            return PMIX_ERR_BAD_PARAM;
+        }
+    } else if (NULL != (opt = pmix_cmd_line_get_param(results, PMIX_CLI_NAMESPACE))) {
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_NSPACE, opt->values[0], PMIX_STRING);
+    } else if (NULL != (opt = pmix_cmd_line_get_param(results, PMIX_CLI_URI))) {
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, opt->values[0], PMIX_STRING);
+    } else if (pmix_cmd_line_is_taken(results, PMIX_CLI_SYSTEM_SERVER)) {
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
+    } else {
+        /* default: use the system connection first, if available */
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    }
+    return PMIX_SUCCESS;
+}
+
 int main(int argc, char *argv[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_info_t *info;
+    size_t ninfo, n;
     pmix_query_t *query;
-    size_t nq;
     myquery_data_t myquery_data;
     mylock_t mylock;
     pmix_cli_result_t results;
+    pmix_cli_item_t *opt;
+    bool nodes;
+    char **nspaces = NULL;
+    pmix_proc_info_t *pi;
+    size_t np;
     PMIX_HIDE_UNUSED_PARAMS(argc);
 
     /* protect against problems if someone passes us thru a pipe
@@ -258,12 +403,6 @@ int main(int argc, char *argv[])
         return PMIX_ERROR;
     }
 
-    /* register params for pmix */
-    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
-        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
-        return PMIX_ERROR;
-    }
-
     /* Parse the command line options */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = pmix_cmd_line_parse(argv, ppsshorts, ppsoptions,
@@ -279,18 +418,36 @@ int main(int argc, char *argv[])
         exit(rc);
     }
 
-    /* if we were given the pid of a starter, then direct that
-     * we connect to it */
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PMIX_CLI_PMIXMCA)) {
+            for (n = 0; NULL != opt->values[n]; n++) {
+                pmix_expose_param(opt->values[n]);
+            }
+        }
+    }
 
-    /* otherwise, use the system connection first, if available */
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
-    /* init as a tool */
-    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
-        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    nodes = pmix_cmd_line_is_taken(&results, PMIX_CLI_NODES);
+
+    /* build the connection directive from the command line */
+    rc = set_connection(&results, &info, &ninfo);
+    if (PMIX_SUCCESS != rc) {
         exit(rc);
     }
-    PMIX_INFO_FREE(info, 1);
+
+    /* init as a tool */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
+        fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_FREE(info, ninfo);
+        exit(rc);
+    }
+    PMIX_INFO_FREE(info, ninfo);
 
     /* register a default event handler */
     PMIX_CONSTRUCT_LOCK(&mylock.lock);
@@ -299,531 +456,71 @@ int main(int argc, char *argv[])
     PMIX_WAIT_THREAD(&mylock.lock);
     PMIX_DESTRUCT_LOCK(&mylock.lock);
 
-    /* if we were given a specific nspace to ask about, then do so */
-
-    /* if we were asked to provide the status of the nodes, then do that */
-
-    /* otherwise, query the active nspaces */
-    nq = 1;
-    PMIX_QUERY_CREATE(query, nq);
+    /* query the active namespaces */
+    PMIX_QUERY_CREATE(query, 1);
     PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
-    /* setup the caddy to retrieve the data */
     PMIX_CONSTRUCT_LOCK(&myquery_data.lock.lock);
+    myquery_data.status = PMIX_SUCCESS;
     myquery_data.info = NULL;
     myquery_data.ninfo = 0;
-    /* execute the query */
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, querycbfunc, (void *) &myquery_data))) {
-        fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
+    rc = PMIx_Query_info_nb(query, 1, querycbfunc, (void *) &myquery_data);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&myquery_data.lock.lock);
+    }
+    PMIX_DESTRUCT_LOCK(&myquery_data.lock.lock);
+    PMIX_QUERY_FREE(query, 1);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Query_info failed: %s\n", PMIx_Error_string(rc));
         goto done;
     }
-    PMIX_WAIT_THREAD(&myquery_data.lock.lock);
-    PMIX_DESTRUCT_LOCK(&myquery_data.lock.lock);
+    if (PMIX_SUCCESS != myquery_data.status) {
+        fprintf(stderr, "PMIx_Query_info returned: %s\n", PMIx_Error_string(myquery_data.status));
+        rc = myquery_data.status;
+        goto done;
+    }
 
     /* we should have received back one info struct containing
      * a comma-delimited list of nspaces */
-    if (1 != myquery_data.ninfo) {
-        /* this is an error */
-        fprintf(stderr, "PMIx Query returned an incorrect number of results: %lu\n",
-                myquery_data.ninfo);
+    if (1 != myquery_data.ninfo || NULL == myquery_data.info ||
+        PMIX_STRING != myquery_data.info[0].value.type ||
+        NULL == myquery_data.info[0].value.data.string) {
+        fprintf(stderr, "No active namespaces were found\n");
         PMIX_INFO_FREE(myquery_data.info, myquery_data.ninfo);
         goto done;
     }
 
-    fprintf(stderr, "Active nspaces: %s\n", myquery_data.info[0].value.data.string);
+    nspaces = PMIx_Argv_split(myquery_data.info[0].value.data.string, ',');
+    PMIX_INFO_FREE(myquery_data.info, myquery_data.ninfo);
+
+    /* for each active namespace, query and print its process table */
+    for (n = 0; NULL != nspaces[n]; n++) {
+        myquery_data_t mq;
+        rc = query_proctable(nspaces[n], &mq);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Namespace %s: query failed: %s\n",
+                    nspaces[n], PMIx_Error_string(rc));
+            /* the callback may still have handed us partial results */
+            PMIX_INFO_FREE(mq.info, mq.ninfo);
+            continue;
+        }
+        pi = get_proc_array(&mq, &np);
+        if (NULL == pi) {
+            printf("\nNamespace %s (no process information available)\n", nspaces[n]);
+        } else if (nodes) {
+            print_nodes(nspaces[n], pi, np);
+        } else {
+            print_proctable(nspaces[n], pi, np);
+        }
+        PMIX_INFO_FREE(mq.info, mq.ninfo);
+    }
+    PMIx_Argv_free(nspaces);
 
     /***************
      * Cleanup
      ***************/
 done:
+    PMIX_DESTRUCT(&results);
     PMIx_tool_finalize();
 
     return rc;
 }
-
-#if 0
-static int pretty_print(pmix_ps_mpirun_info_t *hnpinfo) {
-    char *header;
-    int len_hdr;
-
-    /*
-     * Print header and remember header length
-     */
-    len_hdr = asprintf(&header, "Information from mpirun %s", PMIX_JOBID_PRINT(hnpinfo->hnp->name.jobid));
-
-    printf("\n\n%s\n", header);
-    free(header);
-    pretty_print_dashed_line(len_hdr);
-
-    /*
-     * Print Node Information
-     */
-    if( pmix_ps_globals.nodes )
-        pretty_print_nodes(hnpinfo->nodes, hnpinfo->num_nodes);
-
-    /*
-     * Print Job Information
-     */
-    pretty_print_jobs(hnpinfo->jobs, hnpinfo->num_jobs);
-
-    return PMIX_SUCCESS;
-}
-
-static int pretty_print_nodes(pmix_node_t **nodes, pmix_std_cntr_t num_nodes) {
-    int line_len;
-    int len_name    = 0,
-        len_state   = 0,
-        len_slots   = 0,
-        len_slots_i = 0,
-        len_slots_m = 0;
-    pmix_node_t *node;
-    pmix_std_cntr_t i;
-
-    /*
-     * Calculate segment lengths
-     */
-    len_name    = (int) strlen("Node Name");
-    len_state   = (int) strlen("State");
-    len_slots   = (int) strlen("Slots");
-    len_slots_i = (int) strlen("Slots In Use");
-    len_slots_m = (int) strlen("Slots Max");
-
-    for(i=0; i < num_nodes; i++) {
-        node = nodes[i];
-
-        if( NULL != node->name &&
-            (int)strlen(node->name) > len_name)
-            len_name = (int) strlen(node->name);
-
-        if( (int)strlen(pretty_node_state(node->state)) > len_state )
-            len_state = (int)strlen(pretty_node_state(node->state));
-    }
-
-    line_len = (len_name    + 3 +
-                len_state   + 3 +
-                len_slots   + 3 +
-                len_slots_i + 3 +
-                len_slots_m) + 2;
-
-    /*
-     * Print the header
-     */
-    printf("%*s | ", len_name,    "Node Name");
-    printf("%*s | ", len_state,   "State");
-    printf("%*s | ", len_slots,   "Slots");
-    printf("%*s | ", len_slots_m, "Slots Max");
-    printf("%*s | ", len_slots_i, "Slots In Use");
-    printf("\n");
-
-    pretty_print_dashed_line(line_len);
-
-    /*
-     * Print Info
-     */
-    for(i=0; i < num_nodes; i++) {
-        node = nodes[i];
-
-        printf("%*s | ", len_name,    node->name);
-        printf("%*s | ", len_state,   pretty_node_state(node->state));
-        printf("%*d | ", len_slots,   (uint)node->slots);
-        printf("%*d | ", len_slots_m, (uint)node->slots_max);
-        printf("%*d | ", len_slots_i, (uint)node->slots_inuse);
-        printf("\n");
-
-    }
-
-    return PMIX_SUCCESS;
-}
-
-static int pretty_print_jobs(pmix_job_t **jobs, pmix_std_cntr_t num_jobs) {
-    int len_jobid = 0,
-        len_state = 0,
-        len_slots = 0,
-        len_vpid_r = 0,
-        len_ckpt_s = 0,
-        len_ckpt_r = 0,
-        len_ckpt_l = 0;
-    int line_len;
-    pmix_job_t *job;
-    pmix_std_cntr_t i;
-    char *jobstr;
-    pmix_jobid_t mask=0x0000ffff;
-
-    for(i=0; i < num_jobs; i++) {
-        job = jobs[i];
-
-        /* check the jobid to see if this is the daemons' job */
-        if ((0 == (mask & job->jobid)) && !pmix_ps_globals.daemons) {
-            continue;
-        }
-
-        /* setup the printed name - do -not- free this! */
-        jobstr = PMIX_JOBID_PRINT(job->jobid);
-
-        /*
-         * Calculate segment lengths
-         */
-        len_jobid  = strlen(jobstr);;
-        len_state  = (int) (strlen(pmix_job_state_to_str(job->state)) < strlen("State") ?
-                            strlen("State") :
-                            strlen(pmix_job_state_to_str(job->state)));
-        len_slots  = 6;
-        len_vpid_r = (int) strlen("Num Procs");
-        len_ckpt_s = -3;
-        len_ckpt_r = -3;
-        len_ckpt_l = -3;
-
-        line_len = (len_jobid  + 3 +
-                    len_state  + 3 +
-                    len_slots  + 3 +
-                    len_vpid_r + 3 +
-                    len_ckpt_s + 3 +
-                    len_ckpt_r + 3 +
-                    len_ckpt_l)
-                    + 2;
-
-        /*
-         * Print Header
-         */
-        printf("\n");
-        printf("%*s | ", len_jobid  , "JobID");
-        printf("%*s | ", len_state  , "State");
-        printf("%*s | ", len_slots  , "Slots");
-        printf("%*s | ", len_vpid_r , "Num Procs");
-        printf("\n");
-
-        pretty_print_dashed_line(line_len);
-
-        /*
-         * Print Info
-         */
-        printf("%*s | ",  len_jobid ,  PMIX_JOBID_PRINT(job->jobid));
-        printf("%*s | ",  len_state ,  pmix_job_state_to_str(job->state));
-        printf("%*d | ",  len_slots ,  (uint)job->total_slots_alloc);
-        printf("%*d | ",  len_vpid_r,  job->num_procs);
-        printf("\n");
-
-
-        pretty_print_vpids(job);
-        printf("\n\n"); /* give a little room between job outputs */
-    }
-
-    return PMIX_SUCCESS;
-}
-
-static int pretty_print_vpids(pmix_job_t *job) {
-    int len_o_proc_name = 0,
-        len_proc_name   = 0,
-        len_rank        = 0,
-        len_pid         = 0,
-        len_state       = 0,
-        len_node        = 0,
-        len_ckpt_s      = 0,
-        len_ckpt_r      = 0,
-        len_ckpt_l      = 0;
-    int i, line_len;
-    pmix_vpid_t v;
-    pmix_proc_t *vpid;
-    pmix_app_context_t *app;
-    char *o_proc_name;
-    char **nodename = NULL;
-
-    if (0 == job->num_procs) {
-        return PMIX_SUCCESS;
-    }
-
-    /*
-     * Calculate segment lengths
-     */
-    len_o_proc_name = (int)strlen("PMIX Name");
-    len_proc_name   = (int)strlen("Process Name");
-    len_rank        = (int)strlen("Local Rank");
-    len_pid         = 6;
-    len_state       = 0;
-    len_node        = 0;
-    len_ckpt_s      = -3;
-    len_ckpt_r      = -3;
-    len_ckpt_l      = -3;
-
-    nodename = (char **) calloc(job->num_procs, sizeof(char *));
-    for(v=0; v < job->num_procs; v++) {
-        char *rankstr;
-        vpid = (pmix_proc_t*)job->procs->addr[v];
-
-        /*
-         * Find my app context
-         */
-        if( 0 >= (int)job->num_apps ) {
-            if( 0 == vpid->name.vpid ) {
-                if( (int)strlen("pmixrun") > len_proc_name)
-                    len_proc_name = strlen("pmixrun");
-            }
-            else {
-                if( (int)strlen("pmixd") > len_proc_name)
-                    len_proc_name = strlen("pmixd");
-            }
-        }
-        for( i = 0; i < (int)job->num_apps; ++i) {
-            app = (pmix_app_context_t*)job->apps->addr[i];
-            if( app->idx == vpid->app_idx ) {
-                if( (int)strlen(app->app) > len_proc_name)
-                    len_proc_name = strlen(app->app);
-                break;
-            }
-        }
-
-        o_proc_name = pmix_util_print_name_args(&vpid->name);
-        if ((int)strlen(o_proc_name) > len_o_proc_name)
-            len_o_proc_name = strlen(o_proc_name);
-
-        asprintf(&rankstr, "%u", (uint)vpid->local_rank);
-        if ((int)strlen(rankstr) > len_rank)
-            len_rank = strlen(rankstr);
-        free(rankstr);
-
-        nodename[v] = NULL;
-        if( pmix_get_attribute(&vpid->attributes, PMIX_PROC_NODENAME, (void**)&nodename[v], PMIX_STRING) &&
-            (int)strlen(nodename[v]) > len_node) {
-            len_node = strlen(nodename[v]);
-        } else if ((int)strlen("Unknown") > len_node) {
-            len_node = strlen("Unknown");
-        }
-
-        if( (int)strlen(pmix_proc_state_to_str(vpid->state)) > len_state)
-            len_state = strlen(pmix_proc_state_to_str(vpid->state));
-
-    }
-
-    line_len = (len_o_proc_name + 3 +
-                len_proc_name   + 3 +
-                len_rank        + 3 +
-                len_pid         + 3 +
-                len_state       + 3 +
-                len_node        + 3 +
-                len_ckpt_s      + 3 +
-                len_ckpt_r      + 3 +
-                len_ckpt_l)
-                + 2;
-
-    /*
-     * Print Header
-     */
-    printf("\t");
-    printf("%*s | ", len_proc_name   , "Process Name");
-    printf("%*s | ", len_o_proc_name , "PMIX Name");
-    printf("%*s | ", len_rank        , "Local Rank");
-    printf("%*s | ", len_pid         , "PID");
-    printf("%*s | ", len_node        , "Node");
-    printf("%*s | ", len_state       , "State");
-    printf("\n");
-
-    printf("\t");
-    pretty_print_dashed_line(line_len);
-
-    /*
-     * Print Info
-     */
-    for(v=0; v < job->num_procs; v++) {
-        vpid = (pmix_proc_t*)job->procs->addr[v];
-
-        printf("\t");
-
-        if( 0 >= (int)job->num_apps ) {
-            if( 0 == vpid->name.vpid ) {
-                printf("%*s | ", len_proc_name, "pmixrun");
-            } else {
-                printf("%*s | ", len_proc_name, "pmixd");
-            }
-        }
-        for( i = 0; i < (int)job->num_apps; ++i) {
-            app = (pmix_app_context_t*)job->apps->addr[i];
-            if( app->idx == vpid->app_idx ) {
-                printf("%*s | ", len_proc_name, app->app);
-                break;
-            }
-        }
-
-        o_proc_name = pmix_util_print_name_args(&vpid->name);
-
-        printf("%*s | ",  len_o_proc_name, o_proc_name);
-        printf("%*u | ",  len_rank       , (uint)vpid->local_rank);
-        printf("%*d | ",  len_pid        , vpid->pid);
-        printf("%*s | ",  len_node       , (NULL == nodename[v]) ? "Unknown" : nodename[v]);
-        printf("%*s | ",  len_state      , pmix_proc_state_to_str(vpid->state));
-
-        if (NULL != nodename[v]) {
-            free(nodename[v]);
-        }
-        printf("\n");
-
-    }
-    if (NULL != nodename) {
-        free(nodename);
-    }
-    return PMIX_SUCCESS;
-}
-
-static void pretty_print_dashed_line(int len) {
-    static const char dashes[9] = "--------";
-
-    while (len >= 8) {
-        printf("%8.8s", dashes);
-        len -= 8;
-    }
-    printf("%*.*s\n", len, len, dashes);
-}
-
-static int gather_information(pmix_ps_mpirun_info_t *hnpinfo) {
-    int ret;
-
-    if( PMIX_SUCCESS != (ret = gather_active_jobs(hnpinfo) )) {
-        goto cleanup;
-    }
-
-    if( PMIX_SUCCESS != (ret = gather_nodes(hnpinfo) )) {
-        goto cleanup;
-    }
-
-    if( PMIX_SUCCESS != (ret = gather_vpid_info(hnpinfo) )) {
-        goto cleanup;
-    }
-
- cleanup:
-    return ret;
-}
-
-static int gather_active_jobs(pmix_ps_mpirun_info_t *hnpinfo) {
-    int ret;
-
-    if (PMIX_SUCCESS != (ret = pmix_util_comm_query_job_info(&(hnpinfo->hnp->name), pmix_ps_globals.jobid,
-                                                             &hnpinfo->num_jobs, &hnpinfo->jobs))) {
-        PMIX_ERROR_LOG(ret);
-    }
-
-    return ret;
-}
-
-static int gather_nodes(pmix_ps_mpirun_info_t *hnpinfo) {
-    int ret;
-
-    if (PMIX_SUCCESS != (ret = pmix_util_comm_query_node_info(&(hnpinfo->hnp->name), NULL,
-                                                             &hnpinfo->num_nodes, &hnpinfo->nodes))) {
-        PMIX_ERROR_LOG(ret);
-    }
-    pmix_output(0, "RECEIVED %d NODES", hnpinfo->num_nodes);
-    return ret;
-}
-
-static int gather_vpid_info(pmix_ps_mpirun_info_t *hnpinfo) {
-    int ret;
-    pmix_std_cntr_t i;
-    int cnt;
-    pmix_job_t *job;
-    pmix_proc_t **procs;
-
-    /*
-     * For each Job in the HNP
-     */
-    for(i=0; i < hnpinfo->num_jobs; i++) {
-        job = hnpinfo->jobs[i];
-
-        /*
-         * Skip getting the vpid's for the HNP, unless asked to do so
-         * The HNP is always the first in the array
-         */
-        if( 0 == i && !pmix_ps_globals.daemons) {
-            continue;
-        }
-
-        /* query the HNP for info on the procs in this job */
-        if (PMIX_SUCCESS != (ret = pmix_util_comm_query_proc_info(&(hnpinfo->hnp->name),
-                                                                  job->jobid,
-                                                                  PMIX_VPID_WILDCARD,
-                                                                  &cnt,
-                                                                  &procs))) {
-            PMIX_ERROR_LOG(ret);
-        }
-        job->procs->addr = (void**)procs;
-        job->procs->size = cnt;
-        job->num_procs = cnt;
-    }
-
-    return PMIX_SUCCESS;
-}
-
-static char *pretty_node_state(pmix_node_state_t state) {
-    switch(state) {
-    case PMIX_NODE_STATE_DOWN:
-        return strdup("Down");
-        break;
-    case PMIX_NODE_STATE_UP:
-        return strdup("Up");
-        break;
-    case PMIX_NODE_STATE_REBOOT:
-        return strdup("Reboot");
-        break;
-    case PMIX_NODE_STATE_UNKNOWN:
-    default:
-        return strdup("Unknown");
-        break;
-    }
-}
-
-static int parseable_print(pmix_ps_mpirun_info_t *hnpinfo)
-{
-    pmix_job_t **jobs;
-    pmix_node_t **nodes;
-    pmix_proc_t *proc;
-    pmix_app_context_t *app;
-    char *appname;
-    int i, j;
-    char *nodename;
-
-    /* don't include the daemon job in the number of jobs reppmixd */
-    printf("mpirun:%lu:num nodes:%d:num jobs:%d\n",
-           (unsigned long)hnpinfo->hnp->pid, hnpinfo->num_nodes, hnpinfo->num_jobs-1);
-
-    if (pmix_ps_globals.nodes) {
-        nodes = hnpinfo->nodes;
-        for (i=0; i < hnpinfo->num_nodes; i++) {
-            printf("node:%s:state:%s:slots:%d:in use:%d\n",
-                   nodes[i]->name, pretty_node_state(nodes[i]->state),
-                   nodes[i]->slots, nodes[i]->slots_inuse);
-        }
-    }
-
-    jobs = hnpinfo->jobs;
-    /* skip job=0 as that's the daemon job */
-    for (i=1; i < hnpinfo->num_jobs; i++) {
-        printf("jobid:%d:state:%s:slots:%d:num procs:%d\n",
-               PMIX_LOCAL_JOBID(jobs[i]->jobid),
-               pmix_job_state_to_str(jobs[i]->state),
-               jobs[i]->total_slots_alloc,
-               jobs[i]->num_procs);
-        /* print the proc info */
-        for (j=0; j < jobs[i]->procs->size; j++) {
-            if (NULL == (proc = (pmix_proc_t*)pmix_pointer_array_get_item(jobs[i]->procs, j))) {
-                continue;
-            }
-            app = (pmix_app_context_t*)pmix_pointer_array_get_item(jobs[i]->apps, proc->app_idx);
-            if (NULL == app) {
-                appname = strdup("NULL");
-            } else {
-                appname = pmix_basename(app->app);
-            }
-            nodename = NULL;
-            pmix_get_attribute(&proc->attributes, PMIX_PROC_NODENAME, (void**)&nodename, PMIX_STRING);
-            printf("process:%s:rank:%s:pid:%lu:node:%s:state:%s\n",
-                   appname, PMIX_VPID_PRINT(proc->name.vpid),
-                   (unsigned long)proc->pid,
-                   (NULL == nodename) ? "unknown" : nodename,
-                   pmix_proc_state_to_str(proc->state));
-            free(appname);
-            if (NULL != nodename) {
-                free(nodename);
-            }
-        }
-    }
-
-    return PMIX_SUCCESS;
-}
-#endif

--- a/src/tools/pquery/pquery.c
+++ b/src/tools/pquery/pquery.c
@@ -224,11 +224,6 @@ int main(int argc, char **argv)
         }
     }
 
-    // setup the base infrastructure
-    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
-        return PMIX_ERROR;
-    }
-
     /* get the argv array of keys they want us to query */
     qkeys = results.tail;
 
@@ -319,7 +314,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
         exit(rc);
     }
-    PMIX_INFO_FREE(info, 1);
+    PMIX_INFO_FREE(info, n);
 
     /* they might be querying the system about a client, server, or tool
      * attribute, so register those - this will allow us to compare the

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -64,7 +64,7 @@
 #define PMIX_LIBDIR_FLAG  "-L"
 
 static const char * filtered_args[] = { "-I/usr/include",
-                                        "-L/usr/lb",
+                                        "-L/usr/lib",
                                         "-L/usr/lib64",
                                         NULL };
 

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -117,8 +117,14 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
     optarg = NULL;
 
     if (1 == argc) {
-        // nothing to parse
-        goto done;
+        // nothing to parse - only the executable name is present, so
+        // there is no command "tail". Note we cannot "goto done" here:
+        // optind was just reset to 0, and the done: block would then
+        // copy argv[0] (the executable) into results->tail, leaving
+        // every caller to mistake the program name for a positional
+        // argument.
+        PMIx_Argv_free(argv);
+        return PMIX_SUCCESS;
     }
 
     // run the parser

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -23,13 +23,16 @@
 
 SUBDIRS = util class
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in
+# run_tools.pl is self-locating (it finds the build tree from its own
+# path) and needs no configure substitution, so it is committed directly
+# rather than generated from a .pl.in.
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl
 
 check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/run_tools.pl
+++ b/test/unit/run_tools.pl
@@ -1,0 +1,108 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Smoke-test the user-facing command-line tools in src/tools that do NOT
+# need to connect to a PMIx server. This guards the shared tool spine -
+# command-line parsing, the pinstalldirs/show_help bootstrap, and a clean
+# library shutdown - by running the built binaries and asserting they
+# parse, execute, and finalize with the expected exit status and output.
+#
+# We deliberately exercise only the no-connect paths:
+#   pmix_info --version / -c        (never calls PMIx_tool_init)
+#   pmixcc  -showme:*               (compiler wrapper; never connects)
+#   pattrs  --client/server/tool-fns (uses PMIX_TOOL_DO_NOT_CONNECT)
+# The server-connecting tools (pquery, palloc, pctrl, plookup, pevent) are
+# intentionally left out: a developer's machine may have live PMIx servers
+# or stale pmix.* rendezvous files in $TMPDIR that make those paths
+# non-deterministic. Connecting tools belong in a simptest-based harness.
+
+use strict;
+use warnings;
+
+# Locate the build tree from this script's own path: test/unit/ -> root.
+use File::Basename;
+use Cwd 'abs_path';
+my $here = dirname(abs_path($0));
+my $root = abs_path("$here/../..");
+my $tdir = "$root/src/tools";
+
+# The tools are static (non-DSO) in this build, so they need no MCA
+# component path to run from the build tree.
+
+# Bound every invocation so a wedged tool can never hang "make check".
+sub run {
+    my ($label, $argv, $want_exit, $want_re) = @_;
+    my $cmd = join(" ", @$argv) . " </dev/null 2>&1";
+    my $out = "";
+    my $status;
+    eval {
+        local $SIG{ALRM} = sub { die "alarm\n"; };
+        alarm(120);
+        $out = `$cmd`;
+        $status = $? >> 8;
+        alarm(0);
+    };
+    if ($@) {
+        print "FAIL [$label]: timed out\n";
+        return 1;
+    }
+    if (defined($want_exit) && $status != $want_exit) {
+        print "FAIL [$label]: exit $status (wanted $want_exit)\n$out\n";
+        return 1;
+    }
+    if (defined($want_re) && $out !~ $want_re) {
+        print "FAIL [$label]: output did not match $want_re\n$out\n";
+        return 1;
+    }
+    print "PASS [$label]\n";
+    return 0;
+}
+
+# Make sure the binaries were actually built before asserting on them.
+my %bin = (
+    pmix_info => "$tdir/pmix_info/pmix_info",
+    pmixcc    => "$tdir/wrapper/pmixcc",
+    pattrs    => "$tdir/pattrs/pattrs",
+);
+foreach my $name (sort keys %bin) {
+    unless (-x $bin{$name}) {
+        print "SKIP: $name not built at $bin{$name}\n";
+        exit(77);   # automake "skipped" status
+    }
+}
+
+my $fails = 0;
+
+# pmix_info: prints the version banner, exit 0.
+$fails += run("pmix_info --version", [$bin{pmix_info}, "--version"],
+              0, qr/\(PMIx\)/);
+# pmix_info -c: dumps configure line, exit 0.
+$fails += run("pmix_info -c", [$bin{pmix_info}, "-c"], 0, qr/Configured/);
+
+# pmixcc showme variants: each is a dry run, exit 0, non-empty where useful.
+$fails += run("pmixcc -showme:version", [$bin{pmixcc}, "-showme:version"],
+              0, qr/\(PMIx\)/);
+$fails += run("pmixcc -showme:compile", [$bin{pmixcc}, "-showme:compile"],
+              0, qr/\S/);
+$fails += run("pmixcc -showme:link", [$bin{pmixcc}, "-showme:link"],
+              0, qr/-lpmix/);
+$fails += run("pmixcc -showme:libs", [$bin{pmixcc}, "-showme:libs"], 0, undef);
+
+# pattrs function lists: use PMIX_TOOL_DO_NOT_CONNECT, exit 0.
+$fails += run("pattrs --client-fns", [$bin{pattrs}, "--client-fns"],
+              0, qr/CLIENT SUPPORTED FUNCTIONS/);
+$fails += run("pattrs --server-fns", [$bin{pattrs}, "--server-fns"],
+              0, qr/SERVER SUPPORTED FUNCTIONS/);
+$fails += run("pattrs --tool-fns", [$bin{pattrs}, "--tool-fns"],
+              0, qr/TOOL SUPPORTED FUNCTIONS/);
+
+if ($fails) {
+    print "\n$fails tool smoke-test(s) FAILED\n";
+    exit(1);
+}
+print "\nAll tool smoke-tests passed\n";
+exit(0);


### PR DESCRIPTION
This branch is a deep review of `src/tools` (the user-facing CLI
executables). It adds a developer guide plus a `make check` smoke test,
fixes a set of correctness/robustness defects found during the review,
and turns `pps` from a skeleton into a working tool. Each logical change
is a separate commit.

## Shared fixes
- **cmd-line parser**: `pmix_cmd_line_parse()` left the program name in
  `results.tail` on a bare invocation (it `goto done`'d with `optind`
  reset to 0, so `done:` copied `argv[0]`). This defeated every tool's
  "you gave me no arguments" guard (a bare `pevent` reported "could not
  identify status <path>"). Fixed to return with `tail == NULL`.
- **`pmix_shift_caddy_t` destructor** now frees `key` (verified safe:
  only `pctrl`/`palloc` use that field on this caddy type).

## Per-tool fixes
- **palloc**: double-free of the request caddy on the
  `PMIX_OPERATION_SUCCEEDED` path; `--signal` loaded `PMIX_ALLOC_NODE_LIST`
  instead of a signal attribute (now `PMIX_SESSION_SIGNAL`); printed a
  never-set `req->key` (now the returned session id); sets `infocopy`.
- **pctrl**: `convert_procs` NULL-deref crash on a target with no `:`;
  same caddy double-free; frees a leaked split argv; sets `infocopy`.
- **pquery**: freed only 1 of 3 `info` elements; dropped a duplicate
  `pmix_init_util()`.
- **pattrs**: uninitialized `mq` dereferenced on an empty query result.
- **pmixcc**: default library-path filter typo `-L/usr/lb`.
- **plookup**: missing `pmix_config.h` include; ignored `--pid`.

## pps
Rewritten against the current `PMIx_Query` API: honors the standard
connection ladder, queries the active namespaces, and prints a
per-process table (or a `--nodes` roll-up) built from
`PMIX_QUERY_PROC_TABLE`. The returned data array is type-checked so a
server without proc-table support degrades gracefully. The dead `#if 0`
ORTE block is removed.

## Docs / tests
- `src/tools/AGENTS.md` (+ `CLAUDE.md` symlink): orientation to the tools.
- `test/unit/run_tools.pl`, wired into `make check`, exercises the
  no-connect paths of `pmix_info`, `pmixcc`, and `pattrs`.

## Testing
Warning-free build under `--enable-devel-check`; the new smoke test
passes; the bare-invocation guards and the `pctrl` malformed-target path
were verified by hand. `pps`'s live proc-table rendering was **not**
exercised end-to-end -- it needs a proc-table-capable server (PRRTE),
which was not available in the test environment; the code mirrors
`examples/debugger.c` and the working `pquery`/`pattrs` query paths, and
the graceful-degradation path was verified.
