### PR TITLE
Deep review of src/util: bug fixes, developer guide, and unit tests

### DIFF
--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1,0 +1,300 @@
+# AGENTS.md: `src/util` — the PMIx low-level utility layer
+
+This document orients AI agents and human contributors working in
+`src/util`. It assumes you have already read the top-level
+[`AGENTS.md`](../../AGENTS.md) — the golden rules (prefix conventions,
+`pmix_config.h`-first include order, constant-on-the-left comparisons,
+brace-everything, `#define` logical macros to 0/1, warning-free under
+`--enable-devel-check`), the thread-safety / progress-thread / caddy
+model, and the copyright-header and contribution rules all apply here and
+are not repeated. This file covers what is specific to `src/util`.
+
+## What this directory is
+
+`src/util` is the **grab-bag of low-level, mostly self-contained helper
+code** that the rest of PMIx builds on: argv/string/environment munging,
+path and filesystem helpers, the output/verbose subsystem, the
+`show_help` machinery, the command-line parser, network/interface
+utilities, the TMA-aware hash datastore helper, a flex-based keyval
+parser, shared-memory/virtual-memory helpers, an RNG, and profiling.
+
+Unlike `src/mca/*`, **this is not an MCA framework** — there are no
+components, no selection logic, no `configure.m4`. Everything here
+compiles into the convenience library `libpmix_util.la` (plus the
+`keyval/` sub-library `libpmixutilkeyval.la`), which is absorbed into
+`libpmix`. A change here therefore takes effect with a plain top-level
+`make` from an already-configured tree; you only need
+`autogen.pl`/`configure` if you add or remove a source file (adding a
+file only needs `make`, which regenerates the `Makefile`).
+
+Most functions here are **pure-ish leaf utilities** that do not touch
+shared library state and do not thread-shift, so they are safe to call
+from anywhere (including inside the library). The notable stateful
+exceptions — which keep process-global state and rely on the caller
+serializing (in practice, the progress thread) — are `pmix_output`,
+`pmix_show_help`, `pmix_keyval_parse`, and `pmix_if` (the discovered
+interface list).
+
+## File map
+
+| File | Purpose | Testable? |
+|------|---------|-----------|
+| `pmix_argv.{c,h}` | argv-array helpers *not* in the public `PMIx_Argv_*` set (append-unique, join-range, delete, insert, copy-strip). The core `PMIx_Argv_*` primitives live in `src/mca/bfrops/base`. | pure |
+| `pmix_environ.{c,h}` | environ-array merge/get/unset, `$TMPDIR`/`$HOME` resolution, envar harvesting | pure (some touch `environ`/`getpwuid`) |
+| `pmix_string_copy.{c,h}` / `pmix_strnlen.h` | always-NUL-terminating bounded copy; `pmix_getline`; `PMIX_STRNLEN` | pure |
+| `pmix_basename.{c,h}` | OS-independent `basename`/`dirname` (fresh allocations) | pure |
+| `pmix_parse_options.{c,h}` | numeric range-string expansion (`"1,3-5"` → argv) | pure |
+| `pmix_keyval_parse.{c,h}` + `keyval/keyval_lex.l` | flex parser for `key = value` / `-mca` / `-x` config files | needs a temp file + callback |
+| `pmix_cmd_line.{c,h}` | the `getopt_long`-based CLI parser used by `src/tools` | partial (see `util_cmd_line`) |
+| `pmix_output.{c,h}` | the generalized output/verbose stream subsystem (≤64 streams) | partial |
+| `pmix_show_help.{c,h}` + `pmix_show_help_content.c` + `convert-help.py` | help-message lookup/aggregation; content compiled from `help-*.txt` | partial |
+| `pmix_printf.{c,h}` | portable `asprintf`/`snprintf` wrappers | pure |
+| `pmix_error.{c,h}` | `PMIx_Error_string` / `PMIx_Error_code` over the event-strings table | pure |
+| `pmix_name_fns.{c,h}` | `[nspace,rank]` printing (rotating TSD buffers); proc compare | pure |
+| `pmix_net.{c,h}` | IP address parsing/classification, CIDR→netmask | pure |
+| `pmix_if.{c,h}` | discovered-interface list + lookups; the `a.b.c.d/mask` tuple parser | tuple parser is pure; list lookups need fixtures |
+| `pmix_hash.{c,h}` | TMA-aware key/value datastore used by `gds` (store/fetch/remove, keyindex, qualifiers) | needs `PMIx_server_init` |
+| `pmix_path.{c,h}` / `pmix_os_path.{c,h}` / `pmix_os_dirpath.{c,h}` / `pmix_getcwd.{c,h}` | path search/resolution, path assembly, dir-tree create/destroy, cwd | `os_path` pure; rest need a tmpdir |
+| `pmix_fd.{c,h}` | fd read/write, cloexec, type predicates, peer name, mass-close | needs pipes/sockets |
+| `pmix_few.{c,h}` | fork/exec/waitpid a child | needs a child |
+| `pmix_getid.{c,h}` | peer uid/gid over a socket (`SO_PEERCRED`/`getpeereid`) | needs a socketpair |
+| `pmix_shmem.{c,h}` / `pmix_vmem.{c,h}` | mmap-backed shared-memory segment; `/proc/self/maps` hole finder (Linux) | `pad_to_page`/`parse_map_line` pure; rest need mmap |
+| `pmix_pty.{c,h}` / `pmix_tty.{c,h}` | pty open/forkpty; termios/winsize helpers | need real pty/tty |
+| `pmix_alfg.{c,h}` | additive lagged-Fibonacci RNG (from Open MPI's `opal_rand`) | pure/deterministic |
+| `pmix_timings.{c,h}` | optional profiling (`--enable-timing`, off by default) | needs `--enable-timing` |
+| `pmix_context_fns.{c,h}` | process-launch cwd/exe resolution helpers | needs a fixture |
+
+## Subsystems that deserve a closer look
+
+### `pmix_output` — the verbose/output engine
+
+A fixed array of up to `PMIX_OUTPUT_MAX_STREAMS` (64) stream descriptors,
+each able to fan a message out to stdout/stderr/syslog/a file. The
+`pmix_output_verbose(level, id, ...)` macro is the hot entry point;
+guard expensive verbose output behind it. `make_string` (static) is where
+a formatted line gets its prefix/suffix and trailing newline assembled —
+subtle indexing, so read it before touching. This subsystem is
+process-global and assumes single-threaded (progress-thread) use.
+
+### `pmix_show_help` — help text is compiled *into the library*
+
+Help content does **not** come from the `help-*.txt` files at runtime.
+`convert-help.py` scans every `help-*.txt` in the tree and generates
+`pmix_show_help_content.c` (a big static table) which is compiled into
+`libpmix`. So after **any** add/delete/modify of `show_help` content you
+must regenerate the pair, exactly as the top-level guide says:
+
+```sh
+rm src/util/pmix_show_help_content.* && make
+```
+
+A plain `make` will *not* pick up changed help text. `pmix_show_help`
+also aggregates duplicate notices (fired from a libevent timer) and can
+thread-shift delivery through the log path; the global `abd_tuples` list
+is manipulated without locking and assumes progress-thread-only callers.
+
+### `pmix_cmd_line` — the CLI parser
+
+A `getopt_long` wrapper that copies argv (getopt reorders in place),
+walks options, and stashes results in a `pmix_cli_result_t` (a list of
+`pmix_cli_item_t` plus a `tail` of positionals). It is intricate and
+carries several special cases (`-v` repeat counting, `--` separator,
+MCA-param option pairs, the `-np` shortcut, optional `-h` argument). Two
+parser quirks that bit `src/tools` and are worth remembering: a bare
+invocation (`argc == 1`) returns early with `tail == NULL` (it must *not*
+fall through the `done:` copy, which would leave the program name in the
+tail), and a positional placed *before* an option is dropped by getopt's
+reordering — put options first.
+
+### `pmix_hash` — the TMA-aware datastore helper
+
+Backs the `gds` framework. Stores `pmix_dstor_t` values per rank in a
+`pmix_hash_table_t`, keyed by an integer *keyindex* (`pmix_hash_lookup_key`
+auto-registers unknown string keys). Values can carry **qualifiers**
+(a `pmix_qual_t[]` in a side pointer-array). All allocation goes through
+the table's **TMA** (`pmix_tma_*` off `pmix_obj_get_tma`) so the same code
+serves both the normal-heap and shared-memory (`gds/shmem2`) cases —
+never call raw libc `malloc`/`free` on data that lives in a hash table.
+When constructing the qualifier array, remember the count of *actual*
+qualifiers (`PMIX_INFO_IS_QUALIFIER`) can be smaller than `nquals`: index
+the destination array by the compacted counter, not the loop variable
+(this was the bug fixed in July 2026 — see below).
+
+### `pmix_net` / `pmix_if` — network helpers
+
+`pmix_net` is pure address math (CIDR→netmask in *network* order,
+localhost/link-local/public classification, `isaddr`). `pmix_if` owns the
+discovered-interface list (populated by the `src/mca/pif/*` components —
+this file only *consumes* it) and the `a.b.c.d[/mask]` tuple parser
+`pmix_iftupletoaddr`, which returns masks in **host** order. Mind that
+byte-order difference if you ever mix the two.
+
+### `keyval/` — the flex lexer
+
+`keyval_lex.l` is the flex source; `keyval_lex.c` is a **generated build
+product** — never hand-edit it, edit the `.l` and let the build
+regenerate. `pmix_keyval_parse` drives it over a real `FILE*` under
+`keyval_mutex` with process-global scratch buffers.
+
+## Build wiring
+
+- `Makefile.am` builds `noinst` `libpmix_util.la` from the `headers` +
+  `sources` lists and pulls in `keyval/libpmixutilkeyval.la` via
+  `LIBADD`. Adding a source means adding it to `sources` (and `headers`
+  if it ships a public internal header, which are installed into
+  `$(pmixincludedir)/src/util`).
+- `pmix_show_help_content.c` is generated by the `convert-help.py` rule
+  and is a `clean-local` / `distclean` / `MAINTAINERCLEAN` target — it is
+  in `.gitignore`, never commit it.
+- Editing only `Makefile.am` needs just `make`; adding/removing a source
+  file also only needs `make` (it regenerates the `Makefile`). You only
+  need the full `autogen.pl && configure` if you touch `configure.ac` /
+  `config/*.m4`.
+
+## Testing
+
+Unit tests live in [`test/unit/util`](../../test/unit/util) and are wired
+into `make check`. Each is a standalone `main()` that links
+`libpmix.la`, runs a set of `report(name, passed)` assertions, prints a
+pass/fail tally, and returns non-zero on any failure. To add one:
+
+1. Write `util_<thing>.c` following the existing pattern (copyright
+   header, `report()` helper, `PMIX_HIDE_UNUSED_PARAMS(argc, argv)`).
+2. Add it to `check_PROGRAMS`, `TESTS`, a `*_SOURCES/_LDFLAGS/_LDADD`
+   block, and the `clean-local` list in `test/unit/util/Makefile.am`.
+3. Add the binary name to `test/unit/util/.gitignore`.
+4. `make check` from `test/unit/util`.
+
+**Prefer testing the pure leaf functions** — they need no server. A few
+helpers (`pmix_hash`) need `PMIx_server_init` because they copy values
+through the `bfrops` MCA framework (`util_hash.c` shows the pattern).
+Things that need real OS resources (pty, tty, shmem, `getid`, `few`) are
+integration-style; only the arithmetic/parsing parts (`pad_to_page`,
+`parse_map_line`, `pmix_alfg` determinism) are unit-friendly.
+
+Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
+`context_fns`, `environ`, `error`, `hash` (incl. a mixed-qualifier
+regression), `if` (the tuple parser), `name_fns` (incl. special-rank
+compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
+(incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
+`string_copy`, `timings`.
+
+## Fixed defects (July 2026 review)
+
+A deep review of this directory fixed the following, each landed as its
+own commit. Recorded so they are not re-introduced by a future edit.
+
+- **`pmix_hash.c` qualifier array — heap overflow + wrong index.** When
+  the info array mixes non-qualifier and qualifier entries, the store
+  loop wrote `qarray[n].index` (loop var, indexing all infos) instead of
+  `qarray[m].index` (compacted qualifier counter) — an out-of-bounds
+  write past the `m`-element array, leaving the real slot's index
+  uninitialized so qualified fetches silently failed to match. Also
+  `calloc` the array so an error-path `erase_qualifiers()` never releases
+  an uninitialized `value` pointer. Regression test: `util_hash.c`.
+- **`pmix_if.c` tuple parsing.** `pmix_iftupletoaddr` swallowed a
+  malformed dotted netmask (the error rc was overwritten by the network
+  parse — now returns immediately); rejected valid `/0` and `/32`
+  prefixes and did a shift-by-32 (UB) — now accepts `0..32` with a
+  guarded shift; `parse_ipv4_dots` accepted octets that wrap a `uint32_t`
+  — now range-checks before truncating; `isalpha()` was called on a
+  possibly-negative `char` — now cast to `unsigned char`; `pmix_ifindextomask`
+  did an unclamped `memcpy(length)` — now `MIN`-clamped like its siblings.
+  Regression test: `util_if.c`.
+- **`pmix_fd.c`.** `pmix_fd_get_peer_name` used a bare `struct sockaddr`
+  (16 bytes) for an IPv6 peer → truncated address + out-of-bounds stack
+  read; now uses `struct sockaddr_storage`. `pmix_close_open_file_descriptors`
+  tested `__OSX__` (never defined) instead of `__APPLE__`, so macOS
+  always took the slow O(fdmax) close path.
+- **`pmix_path.c`.** `pmix_find_absolute_path` `free()`d the caller's
+  `app_name` when `realpath` failed on an already-absolute input (the
+  success path guards this; the failure path did not).
+- **`pmix_name_fns.c`.** `pmix_util_compare_proc` returned
+  `a->rank - b->rank` on `uint32_t` ranks — the mod-2³² result has the
+  wrong sign when ranks differ by more than `INT_MAX`, mis-ordering sorts
+  that mix normal ranks with the special top-of-range ranks
+  (`PMIX_RANK_WILDCARD`, `…UNDEF`). Now an explicit three-way compare.
+  Regression test: `util_name_fns.c`.
+- **`pmix_environ.c`.** `pmix_home_directory` dereferenced a NULL
+  `getpwuid()` result (reachable in a container whose passwd lacks the
+  UID, with `HOME` unset); now NULL-checked. `pmix_util_harvest_envars`
+  indexed `var[len-1]` without guarding an empty include/exclude var
+  (`size_t` underflow → OOB read); both loops now guard `0 < len`.
+- **`pmix_parse_options.c`.** `pmix_util_parse_range_options` dereferenced
+  a NULL `r2[0]` on a bare `"-"` token (`PMIx_Argv_split("-", '-')`
+  returns NULL); reachable from user port-range strings. Now guarded.
+  Regression test: `util_parse_options.c`.
+- **`pmix_show_help.c`.** `pmix_show_accumulated_duplicates` leaked the
+  two `pmix_asprintf`'d `tmp` buffers on every duplicate-help flush
+  (`local_delivery` copies the message, it does not take ownership).
+- **`pmix_output.c`.** `make_string` indexed `[len-1]` on an empty
+  formatted string (`SIZE_MAX` read); now guards `0 == len`.
+  `pmix_output_init` returned `PMIX_ERR_NOMEM` (truthy) from a `bool`
+  function on `asprintf` failure — reported success; now `false`.
+- **`pmix_timings.c`.** Both output paths did
+  `snprintf(buf, PMIX_TIMING_STR_LEN, "%s%s", buf, line)` — aliasing
+  `buf` as both source and destination (UB) and capping the buffer at
+  1024 rather than the size it was allocated for. Now appends at the
+  current end with the real remaining capacity. (`--enable-timing` only.)
+- **`pmix_pty.c`.** The `PMIX_ENABLE_PTY_SUPPORT == 0` stubs had a missing
+  semicolon and signatures that disagreed with the header (`pmix_ptymopen`
+  dropped `maxlen`; `pmix_forkpty` had extra/concrete params), and the
+  hand-rolled `pmix_openpty` fallback called `pmix_ptymopen(line)` without
+  `maxlen` and used `pmix_string_copy` without including its header —
+  compile failures in those (CI-unexercised) build configs.
+- **`pmix_keyval_parse.c`.** `isspace()` on a possibly-negative `char`
+  (project portability rule) → cast to `unsigned char`; `trim_name`'s
+  suffix back-scan could step before the buffer on an all-whitespace
+  value → now bounded at `buffer`.
+- **`pmix_shmem.c`.** `pmix_shmem_segment_create` sized the backing store
+  as `pad_to_page(size + sizeof(header))`, but the data region starts a
+  full page in (`data_addr_from_base` rounds the header up to a page), so
+  for any non-page-multiple `size` the tail of the requested range fell
+  past the end of the mapping. Now `pad_to_page(header) + pad_to_page(size)`.
+  Masked today only because the sole caller pre-pads to a page multiple.
+
+## Known / latent issues not yet fixed
+
+These were surfaced by the same review but left as-is (latent,
+config-gated, or by-design). Fix opportunistically, as separate commits.
+
+- **`pmix_show_help.c` `get_content` `#include` parser (latent).** The
+  first branch (the `project == NULL` path) mis-parses an
+  `#include#FILE#TOPIC` content line — `strrchr` re-finds the same `#`,
+  and it never NUL-terminates, so `file` == `topic`. It is unreachable
+  today because no `help-*.txt` uses `#include`, but it will silently
+  break the moment one does. The second branch is the correct reference.
+- **`pmix_path.c`.** `pmix_path_df` casts a 64-bit `f_bavail` to `int`
+  for its sign test → can report 0 bytes free on very large filesystems.
+  `pmix_path_nfs` sets/leaks `*fstype` even when returning `false` and
+  never NULL-checks `strdup`/`fstype`.
+- **`pmix_output.c`.** `open_file` does an unbounded `strcat` chain into a
+  `PMIX_PATH_MAX` buffer (pathological `TMPDIR`); `pmix_output_reopen_all`
+  uses `gethostname` without guaranteeing NUL termination (the init path
+  guards it).
+- **`pmix_environ.c`.** A non-wildcard include like `"PATH"` prefix-matches
+  `"PATHFINDER=…"` (`strncmp` over the key length); the exclusion loop
+  reads `data.envar` without checking `type == PMIX_ENVAR`.
+- **OOM robustness / doc drift.** Several helpers (`pmix_os_path`,
+  `pmix_os_dirpath_create`, `pmix_path_findv`, `pmix_name_fns` TSD alloc)
+  don't NULL-check `malloc`/`calloc`/`strdup`; `pmix_getcwd` and
+  `pmix_os_dirpath_*` return codes disagree with their header docs.
+- **`pmix_alfg.c`.** `pmix_srand` unconditionally clobbers the file-static
+  global `alfg_buffer` even when seeding a caller-supplied buffer, and
+  `pmix_random()` (unused today) is never auto-seeded.
+- **`pmix_printf.c`.** The `!HAVE_VASPRINTF` fallback `guess_strlen` reads
+  `double`/`long` args via `va_arg(ap, int)` (UB) — dead on any modern
+  platform, but wrong.
+- **`pmix_tty.c`.** `pmix_settermios` verifies via a full-struct `memcmp`
+  of `struct termios`, which can spuriously fail across libc/kernel
+  combos (padding / canonicalized fields).
+
+## When in doubt
+
+- These are leaf utilities — match the surrounding function's style and
+  keep them free of hidden global state and thread-shifts.
+- Prefer a `make check`-able pure unit test over a manual check; the
+  `test/unit/util` harness makes it cheap.
+- Regenerate `pmix_show_help_content.*` after touching any help text.
+- Don't hand-edit generated files (`pmix_show_help_content.c`,
+  `keyval/keyval_lex.c`).

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -253,41 +253,58 @@ own commit. Recorded so they are not re-introduced by a future edit.
   past the end of the mapping. Now `pad_to_page(header) + pad_to_page(size)`.
   Masked today only because the sole caller pre-pads to a page multiple.
 
-## Known / latent issues not yet fixed
+A second pass then cleared the remaining latent/robustness items:
 
-These were surfaced by the same review but left as-is (latent,
-config-gated, or by-design). Fix opportunistically, as separate commits.
+- **`pmix_show_help.c` `get_content` `#include` parser.** The
+  `project == NULL` first branch mis-parsed an `#include#FILE#TOPIC` line
+  (`strrchr` re-found the same `#`, never NUL-terminated, so `file == topic`).
+  Now strdups the line and parses each `#`-delimited field like the second
+  (correct) branch, defaulting the project to `pmix`. Unreachable today (no
+  `help-*.txt` uses `#include`) but now correct if one does.
+- **`pmix_path.c`.** `pmix_path_df` checked the sign of `f_bavail` after
+  truncating it to `int` (could report 0 free on a large filesystem) — now
+  uses an `int64_t` sign test. `pmix_path_nfs` set `*fstype` on false
+  returns (a leak, against its "valid only if true" contract) and never
+  NULL-checked the pointer — now sets it only on the true path, guarded.
+  `pmix_path_findv` leaked the partial `dirv` on a `strdup` OOM — now frees it.
+- **`pmix_output.c`.** `open_file` assembled the filename with an unbounded
+  `strcat` chain into a `PMIX_PATH_MAX` buffer — now a single bounded
+  `snprintf`. `pmix_output_reopen_all` called `gethostname` without
+  guaranteeing NUL termination — now matches the init path.
+- **`pmix_environ.c`.** The include/exclude matcher treated a trailing `*`
+  as a wildcard but matched every entry as a prefix regardless, so `"PATH"`
+  also matched `"PATHFINDER"`. Now a bare name is an exact match (bounded at
+  the `=`/NUL) and only a trailing `*` prefix-matches — matching the
+  documented `"OMPI_*,OPAL_*"` convention. The exclusion loop also now skips
+  non-`PMIX_ENVAR` kvals before reading `data.envar`.
+- **OOM robustness / doc drift.** `pmix_os_path`, `pmix_os_dirpath_create`,
+  `pmix_path_findv`, and the `pmix_name_fns` TSD allocator now NULL-check
+  their allocations (the last unwinds partially-allocated buffers).
+  `pmix_getcwd` also NULL-checks `pmix_basename` before copying; its header
+  referenced a nonexistent `PMIX_ERR_TEMP_OUT_OF_RESOURCE` — the doc was
+  corrected to the real `PMIX_ERR_OUT_OF_RESOURCE`. `pmix_os_dirpath_destroy`
+  now returns `PMIX_ERR_NOT_FOUND` (not `PMIX_ERROR`) for a missing
+  directory, per its header.
+- **`pmix_printf.c`.** The `!HAVE_VASPRINTF` fallback `guess_strlen` read
+  `double`/`long` varargs via `va_arg(ap, int)` — now uses the correct
+  `double`/`long` types. Dead on modern platforms, but no longer UB.
+- **`pmix_tty.c`.** `pmix_settermios` verified a set via a full-struct
+  `memcmp` of `struct termios` (padding / canonicalized fields → spurious
+  failures) — now compares the individual POSIX fields (`c_iflag`,
+  `c_oflag`, `c_cflag`, `c_lflag`, `c_cc`).
 
-- **`pmix_show_help.c` `get_content` `#include` parser (latent).** The
-  first branch (the `project == NULL` path) mis-parses an
-  `#include#FILE#TOPIC` content line — `strrchr` re-finds the same `#`,
-  and it never NUL-terminates, so `file` == `topic`. It is unreachable
-  today because no `help-*.txt` uses `#include`, but it will silently
-  break the moment one does. The second branch is the correct reference.
-- **`pmix_path.c`.** `pmix_path_df` casts a 64-bit `f_bavail` to `int`
-  for its sign test → can report 0 bytes free on very large filesystems.
-  `pmix_path_nfs` sets/leaks `*fstype` even when returning `false` and
-  never NULL-checks `strdup`/`fstype`.
-- **`pmix_output.c`.** `open_file` does an unbounded `strcat` chain into a
-  `PMIX_PATH_MAX` buffer (pathological `TMPDIR`); `pmix_output_reopen_all`
-  uses `gethostname` without guaranteeing NUL termination (the init path
-  guards it).
-- **`pmix_environ.c`.** A non-wildcard include like `"PATH"` prefix-matches
-  `"PATHFINDER=…"` (`strncmp` over the key length); the exclusion loop
-  reads `data.envar` without checking `type == PMIX_ENVAR`.
-- **OOM robustness / doc drift.** Several helpers (`pmix_os_path`,
-  `pmix_os_dirpath_create`, `pmix_path_findv`, `pmix_name_fns` TSD alloc)
-  don't NULL-check `malloc`/`calloc`/`strdup`; `pmix_getcwd` and
-  `pmix_os_dirpath_*` return codes disagree with their header docs.
-- **`pmix_alfg.c`.** `pmix_srand` unconditionally clobbers the file-static
-  global `alfg_buffer` even when seeding a caller-supplied buffer, and
-  `pmix_random()` (unused today) is never auto-seeded.
-- **`pmix_printf.c`.** The `!HAVE_VASPRINTF` fallback `guess_strlen` reads
-  `double`/`long` args via `va_arg(ap, int)` (UB) — dead on any modern
-  platform, but wrong.
-- **`pmix_tty.c`.** `pmix_settermios` verifies via a full-struct `memcmp`
-  of `struct termios`, which can spuriously fail across libc/kernel
-  combos (padding / canonicalized fields).
+## Known issue left as-is (by design)
+
+- **`pmix_alfg.c`.** `pmix_srand(buff, seed)` also copies the seeded state
+  into the file-static `alfg_buffer` that `pmix_random()` reads. This looks
+  like a footgun (two callers seeding their own buffers stomp the shared
+  global), but it is the *only* way to seed `pmix_random`'s global — and
+  `util_alfg.c` deliberately tests that `pmix_srand` + `pmix_random` is
+  deterministic. It is left unchanged: `pmix_random` is unused in-tree and
+  the two real `pmix_srand` callers (`pnet/tcp`, `pnet/opa`) use their own
+  buffers and never call `pmix_random`, so the "last writer wins" hazard
+  is not actually reachable. Do not "fix" it by dropping the global copy
+  without also giving `pmix_random` another way to be seeded.
 
 ## When in doubt
 

--- a/src/util/CLAUDE.md
+++ b/src/util/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -242,7 +242,12 @@ const char *pmix_home_directory(uid_t uid)
     }
     if (NULL == home) {
         struct passwd *pw = getpwuid(uid);
-        home = pw->pw_dir;
+        /* getpwuid returns NULL when there is no passwd entry for uid
+         * (e.g. inside a container whose /etc/passwd lacks the running
+         * UID) - avoid dereferencing it */
+        if (NULL != pw) {
+            home = pw->pw_dir;
+        }
     }
 
     return home;
@@ -259,7 +264,8 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
     /* harvest envars to pass along */
     for (j = 0; NULL != incvars[j]; j++) {
         len = strlen(incvars[j]);
-        if ('*' == incvars[j][len - 1]) {
+        /* guard the len-1 index against an empty include var ("") */
+        if (0 < len && '*' == incvars[j][len - 1]) {
             --len;
         }
         for (i = 0; NULL != environ[i]; ++i) {
@@ -315,7 +321,8 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
     if (NULL != excvars) {
         for (j = 0; NULL != excvars[j]; j++) {
             len = strlen(excvars[j]);
-            if ('*' == excvars[j][len - 1]) {
+            /* guard the len-1 index against an empty exclude var ("") */
+            if (0 < len && '*' == excvars[j][len - 1]) {
                 --len;
             }
             PMIX_LIST_FOREACH_SAFE (kv, next, ilist, pmix_kval_t) {

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -263,13 +263,21 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
 
     /* harvest envars to pass along */
     for (j = 0; NULL != incvars[j]; j++) {
+        bool inc_wild = false;
         len = strlen(incvars[j]);
-        /* guard the len-1 index against an empty include var ("") */
+        /* a trailing '*' makes this a prefix (wildcard) match; without it
+         * the entry is an exact environment-variable name. Guard the len-1
+         * index against an empty include var (""). */
         if (0 < len && '*' == incvars[j][len - 1]) {
             --len;
+            inc_wild = true;
         }
         for (i = 0; NULL != environ[i]; ++i) {
-            if (0 == strncmp(environ[i], incvars[j], len)) {
+            /* environ entries are "NAME=value"; for an exact (non-wildcard)
+             * name the character just past the match must be the '='
+             * boundary, so "PATH" does not also match "PATHFINDER=..." */
+            if (0 == strncmp(environ[i], incvars[j], len) &&
+                (inc_wild || '=' == environ[i][len])) {
                 cs_env = strdup(environ[i]);
                 string_key = strchr(cs_env, '=');
                 if (NULL == string_key) {
@@ -320,13 +328,23 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
     /* now check the exclusions and remove any that match */
     if (NULL != excvars) {
         for (j = 0; NULL != excvars[j]; j++) {
+            bool exc_wild = false;
             len = strlen(excvars[j]);
-            /* guard the len-1 index against an empty exclude var ("") */
+            /* trailing '*' -> prefix match, else exact name. Guard the
+             * len-1 index against an empty exclude var (""). */
             if (0 < len && '*' == excvars[j][len - 1]) {
                 --len;
+                exc_wild = true;
             }
             PMIX_LIST_FOREACH_SAFE (kv, next, ilist, pmix_kval_t) {
-                if (0 == strncmp(kv->value->data.envar.envar, excvars[j], len)) {
+                /* the list is caller-supplied; only consider envar kvals */
+                if (PMIX_ENVAR != kv->value->type) {
+                    continue;
+                }
+                /* .envar is the bare name, so an exact match ends at the
+                 * name's terminating NUL */
+                if (0 == strncmp(kv->value->data.envar.envar, excvars[j], len) &&
+                    (exc_wild || '\0' == kv->value->data.envar.envar[len])) {
                     pmix_list_remove_item(ilist, &kv->super);
                     PMIX_RELEASE(kv);
                 }

--- a/src/util/pmix_fd.c
+++ b/src/util/pmix_fd.c
@@ -179,26 +179,30 @@ static char str[INET_ADDRSTRLEN];
 const char *pmix_fd_get_peer_name(int fd)
 {
     const char *ret = NULL;
-    struct sockaddr sa;
+    /* use sockaddr_storage, not sockaddr: a bare struct sockaddr is only
+     * 16 bytes and cannot hold an IPv6 (sockaddr_in6, 28 bytes) address,
+     * so getpeername() of an IPv6 peer would truncate the address and the
+     * subsequent inet_ntop() would read past the end of the struct */
+    struct sockaddr_storage sa;
     socklen_t slt = (socklen_t) sizeof(sa);
     int rc;
 
     memset(str, 0, sizeof(str));
 
-    rc = getpeername(fd, &sa, &slt);
+    rc = getpeername(fd, (struct sockaddr *) &sa, &slt);
     if (0 != rc) {
         pmix_string_copy(str, "Unknown", sizeof(str) - 1);
         ret = str;
         return ret;
     }
 
-    if (sa.sa_family == AF_INET) {
+    if (sa.ss_family == AF_INET) {
         struct sockaddr_in *si;
         si = (struct sockaddr_in *) &sa;
         ret = inet_ntop(AF_INET, &(si->sin_addr), str, INET_ADDRSTRLEN);
     }
 #if PMIX_ENABLE_IPV6
-    else if (sa.sa_family == AF_INET6) {
+    else if (sa.ss_family == AF_INET6) {
         struct sockaddr_in6 *si6;
         si6 = (struct sockaddr_in6 *) &sa;
         ret = inet_ntop(AF_INET6, &(si6->sin6_addr), str, INET6_ADDRSTRLEN);
@@ -220,11 +224,11 @@ static int fdmax = -1;
  and the pipe up to the parent. */
 void pmix_close_open_file_descriptors(int protected_fd)
 {
-#if defined(__OSX__)
+#if defined(__APPLE__)
     DIR *dir = opendir("/dev/fd");
 #else  /* Linux */
     DIR *dir = opendir("/proc/self/fd");
-#endif  /* defined(__OSX__) */
+#endif  /* defined(__APPLE__) */
     struct dirent *files;
     int dir_scan_fd = -1;
 

--- a/src/util/pmix_getcwd.c
+++ b/src/util/pmix_getcwd.c
@@ -65,6 +65,11 @@ int pmix_getcwd(char *buf, size_t size)
          * of the basename as possible
          */
         shortened = pmix_basename(pwd);
+        if (NULL == shortened) {
+            /* pmix_basename failed to allocate - report it rather than
+             * passing a NULL src to pmix_string_copy */
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
         pmix_string_copy(buf, shortened, size);
         free(shortened);
         /* indicate that it isn't the full path */

--- a/src/util/pmix_getcwd.h
+++ b/src/util/pmix_getcwd.h
@@ -36,9 +36,9 @@ BEGIN_C_DECLS
  * @param buf Caller-allocated buffer to put the result
  * @param size Length of the buf array
  *
- * @retval PMIX_ERR_OUT_OF_RESOURCE If internal malloc() fails.
- * @retval PMIX_ERR_TEMP_OUT_OF_RESOURCE If the supplied buf buffer
- * was not long enough to handle the result.
+ * @retval PMIX_ERR_OUT_OF_RESOURCE If an internal malloc() fails, or if
+ * the supplied buf buffer was not long enough to hold the full result
+ * (in which case as much of the basename as fits is copied in).
  * @retval PMIX_ERR_BAD_PARAM If buf is NULL or size>INT_MAX
  * @retval PMIX_ERR_IN_ERRNO If an other error occurred
  * @retval PMIX_SUCCESS If all went well and a valid value was placed

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -224,7 +224,9 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
         }
         if (0 < m) {
             darray = (pmix_data_array_t*)pmix_tma_malloc(tma, sizeof(pmix_data_array_t));
-            darray->array = (pmix_qual_t*)pmix_tma_malloc(tma, m * sizeof(pmix_qual_t));
+            /* zero-initialize so a partially-filled array can be safely
+             * released by erase_qualifiers() on an error path below */
+            darray->array = (pmix_qual_t*)pmix_tma_calloc(tma, m, sizeof(pmix_qual_t));
             darray->size = m;
             hv->qualindex = pmix_pointer_array_add(proc_data->quals, darray);
             qarray = (pmix_qual_t*)darray->array;
@@ -241,7 +243,7 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
                         pmix_dstor_release_tma(hv, tma);
                         return PMIX_ERR_BAD_PARAM;
                     }
-                    qarray[n].index = p->index;
+                    qarray[m].index = p->index;
                     rc = pmix_bfrops_base_tma_copy_value(&qarray[m].value, &qualifiers[n].value, PMIX_VALUE, tma);
                     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                         PMIX_ERROR_LOG(rc);

--- a/src/util/pmix_if.c
+++ b/src/util/pmix_if.c
@@ -372,7 +372,10 @@ int pmix_ifindextomask(int if_index, uint32_t *if_mask, int length)
          intf != (pmix_pif_t *) pmix_list_get_end(&pmix_if_list);
          intf = (pmix_pif_t *) pmix_list_get_next(intf)) {
         if (intf->if_index == if_index) {
-            memcpy(if_mask, &intf->if_mask, length);
+            /* clamp to the size of if_mask so an over-large caller-supplied
+             * length cannot read past the field / overflow the caller's
+             * buffer (mirrors the other getters) */
+            memcpy(if_mask, &intf->if_mask, MIN((size_t) length, sizeof(intf->if_mask)));
             return PMIX_SUCCESS;
         }
     }
@@ -502,7 +505,7 @@ static int parse_ipv4_dots(const char *addr, uint32_t *net, int *dots)
 
     /* now assemble the address */
     for (i = 0; i < 4; i++) {
-        n[i] = strtoul(start, (char **) &end, 10);
+        unsigned long val = strtoul(start, (char **) &end, 10);
         if (end == start) {
             /* this is not an error, but indicates that
              * we were given a partial address - e.g.,
@@ -511,10 +514,14 @@ static int parse_ipv4_dots(const char *addr, uint32_t *net, int *dots)
              */
             break;
         }
-        /* did we read something sensible? */
-        if (n[i] > 255) {
+        /* did we read something sensible? Check the full parsed value
+         * before truncating into the uint32_t so an out-of-range octet
+         * that would wrap (e.g. 4294967296) is rejected rather than
+         * silently accepted as 0. */
+        if (val > 255) {
             return PMIX_ERR_FABRIC_NOT_PARSEABLE;
         }
+        n[i] = (uint32_t) val;
         /* skip all the . */
         for (start = end; '\0' != *start; start++)
             if ('.' != *start)
@@ -540,18 +547,30 @@ int pmix_iftupletoaddr(const char *inaddr, uint32_t *net, uint32_t *mask)
             ptr = ptr + 1; /* skip the / */
             /* is the mask a tuple? */
             if (NULL != strchr(ptr, '.')) {
-                /* yes - extract mask from it */
-                rc = parse_ipv4_dots(ptr, mask, &dots);
+                /* yes - extract mask from it. Must return on error here:
+                 * otherwise the rc is silently overwritten by the network
+                 * parse below and a bogus mask (e.g. from 256.0.0.0) is
+                 * accepted. */
+                if (PMIX_SUCCESS != (rc = parse_ipv4_dots(ptr, mask, &dots))) {
+                    return rc;
+                }
             } else {
                 /* no - must be an int telling us how much of the addr to use: e.g., /16
                  * For more information please read http://en.wikipedia.org/wiki/Subnetwork.
                  */
                 pval = strtol(ptr, NULL, 10);
-                if ((pval > 31) || (pval < 1)) {
+                /* a prefix length of 0..32 is valid CIDR: /0 matches
+                 * everything, /32 is an exact host match */
+                if ((pval > 32) || (pval < 0)) {
                     pmix_output(0, "pmix_iftupletoaddr: unknown mask");
                     return PMIX_ERR_FABRIC_NOT_PARSEABLE;
                 }
-                *mask = 0xFFFFFFFF << (32 - pval);
+                /* guard against a 32-bit shift-by-32 (undefined behavior) */
+                if (0 == pval) {
+                    *mask = 0;
+                } else {
+                    *mask = 0xFFFFFFFF << (32 - pval);
+                }
             }
         } else {
             /* use the number of dots to determine it */
@@ -634,7 +653,9 @@ int pmix_ifmatches(int kidx, char **nets)
          */
         named_if = false;
         for (j = 0; j < strlen(nets[i]); j++) {
-            if (isalpha(nets[i][j]) && '.' != nets[i][j]) {
+            /* cast to unsigned char: passing a plain (possibly negative)
+             * char to isalpha() is undefined behavior */
+            if (isalpha((unsigned char) nets[i][j]) && '.' != nets[i][j]) {
                 named_if = true;
                 break;
             }

--- a/src/util/pmix_keyval_parse.c
+++ b/src/util/pmix_keyval_parse.c
@@ -200,14 +200,15 @@ static void trim_name(char *buffer, const char *prefix, const char *suffix)
         }
     }
 
-    /* trim spaces at the beginning */
-    while (isspace(*pchr)) {
+    /* trim spaces at the beginning (cast to unsigned char: passing a
+     * possibly-negative char to isspace() is undefined behavior) */
+    while (isspace((unsigned char) *pchr)) {
         pchr++;
     }
 
     /* trim spaces at the end */
     echr = buffer + buffer_len;
-    while (echr > buffer && isspace(*(echr - 1))) {
+    while (echr > buffer && isspace((unsigned char) *(echr - 1))) {
         echr--;
     }
     echr[0] = '\0';
@@ -218,9 +219,11 @@ static void trim_name(char *buffer, const char *prefix, const char *suffix)
         echr -= suffix_len;
 
         if (0 == strncmp(echr, suffix, strlen(suffix))) {
+            /* bound the back-scan at buffer[0] so a value that is all
+             * whitespace up to the suffix cannot step before the buffer */
             do {
                 echr--;
-            } while (isspace(*echr));
+            } while (echr > buffer && isspace((unsigned char) *echr));
             echr[1] = '\0';
         }
     }

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -214,5 +214,16 @@ int pmix_util_compare_proc(const void *a, const void *b)
     if (nspace_dif != 0)
         return nspace_dif;
 
-    return proc_a->rank - proc_b->rank;
+    /* pmix_rank_t is uint32_t, and the special ranks (PMIX_RANK_WILDCARD,
+     * PMIX_RANK_UNDEF, ...) live at the top of the range. A plain
+     * subtraction would reduce mod 2^32 and can yield the wrong sign when
+     * the ranks differ by more than INT_MAX, mis-ordering a sort/search.
+     * Use an explicit three-way compare. */
+    if (proc_a->rank < proc_b->rank) {
+        return -1;
+    }
+    if (proc_a->rank > proc_b->rank) {
+        return 1;
+    }
+    return 0;
 }

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -108,11 +108,29 @@ static pmix_print_args_buffers_t *get_print_name_buffer(void)
 
     if (NULL == ptr) {
         ptr = (pmix_print_args_buffers_t *) malloc(sizeof(pmix_print_args_buffers_t));
+        if (NULL == ptr) {
+            return NULL;
+        }
         for (i = 0; i < PMIX_PRINT_NAME_ARG_NUM_BUFS; i++) {
             ptr->buffers[i] = (char *) calloc((PMIX_PRINT_NAME_ARGS_MAX_SIZE + 1), sizeof(char));
+            if (NULL == ptr->buffers[i]) {
+                /* unwind rather than hand back a struct with NULL buffers */
+                while (i-- > 0) {
+                    free(ptr->buffers[i]);
+                }
+                free(ptr);
+                return NULL;
+            }
         }
         ptr->cntr = 0;
         ret = pmix_tsd_setspecific(print_args_tsd_key, (void *) ptr);
+        if (PMIX_SUCCESS != ret) {
+            for (i = 0; i < PMIX_PRINT_NAME_ARG_NUM_BUFS; i++) {
+                free(ptr->buffers[i]);
+            }
+            free(ptr);
+            return NULL;
+        }
     }
 
     return (pmix_print_args_buffers_t *) ptr;

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -99,6 +99,10 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
        incoming path + 1 (for \0) */
 
     tmp = (char *) calloc((strlen(path) + 1), sizeof(char));
+    if (NULL == tmp) {
+        PMIx_Argv_free(parts);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     tmp[0] = '\0';
 
     /* Iterate through all the subdirectory names in the path,
@@ -169,7 +173,9 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
     /* Open up the directory */
     dp = opendir(path);
     if (NULL == dp) {
-        return PMIX_ERROR;
+        /* per the documented contract, a directory that does not exist is
+         * reported as NOT_FOUND; any other open failure is a generic error */
+        return (ENOENT == errno) ? PMIX_ERR_NOT_FOUND : PMIX_ERROR;
     }
 
     while (NULL != (ep = readdir(dp))) {

--- a/src/util/pmix_os_path.c
+++ b/src/util/pmix_os_path.c
@@ -57,6 +57,9 @@ char *pmix_os_path(int relative, ...)
 
     if (0 == num_elements) { /* must be looking for a simple answer */
         path = (char *) malloc(3);
+        if (NULL == path) {
+            return (NULL);
+        }
         path[0] = '\0';
         if (relative) {
             strcpy(path, ".");

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -234,7 +234,8 @@ void pmix_output_reopen_all(void)
         default_stderr_fd = -1;
     }
 
-    gethostname(hostname, sizeof(hostname));
+    gethostname(hostname, sizeof(hostname) - 1);
+    hostname[sizeof(hostname) - 1] = '\0';
     if (NULL != verbose.lds_prefix) {
         free(verbose.lds_prefix);
         verbose.lds_prefix = NULL;
@@ -638,17 +639,19 @@ static int open_file(int i)
         if (NULL == filename) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
-        pmix_strncpy(filename, output_dir, PMIX_PATH_MAX - 1);
-        strcat(filename, "/");
-        if (NULL != output_prefix) {
-            strcat(filename, output_prefix);
-        }
+        /* assemble dir/prefix+suffix with a single bounded write - the
+         * previous strncpy + unbounded strcat chain could overflow the
+         * PMIX_PATH_MAX buffer for a pathological output_dir/prefix */
+        const char *file_prefix = (NULL != output_prefix) ? output_prefix : "";
+        const char *file_suffix;
         if (pmix_output_info[i].ldi_file_suffix != NULL) {
-            strcat(filename, pmix_output_info[i].ldi_file_suffix);
+            file_suffix = pmix_output_info[i].ldi_file_suffix;
         } else {
             pmix_output_info[i].ldi_file_suffix = NULL;
-            strcat(filename, "output.txt");
+            file_suffix = "output.txt";
         }
+        snprintf(filename, PMIX_PATH_MAX, "%s/%s%s", output_dir, file_prefix,
+                 file_suffix);
         flags = O_CREAT | O_RDWR;
         if (!pmix_output_info[i].ldi_file_want_append) {
             flags |= O_TRUNC;

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -153,7 +153,7 @@ bool pmix_output_init(void)
     gethostname(hostname, sizeof(hostname) - 1);
     hostname[sizeof(hostname) - 1] = '\0';
     if (0 > asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
-        return PMIX_ERR_NOMEM;
+        return false;
     }
 
     for (i = 0; i < PMIX_OUTPUT_MAX_STREAMS; ++i) {
@@ -728,7 +728,9 @@ static int make_string(char **out, char **no_newline_string, pmix_output_desc_t 
         return PMIX_ERR_NOMEM;
     }
     total_len = len = strlen(*no_newline_string);
-    if ('\n' != (*no_newline_string)[len - 1]) {
+    /* guard the len-1 index: an empty formatted string has no last
+     * character, and should simply get a trailing newline */
+    if (0 == len || '\n' != (*no_newline_string)[len - 1]) {
         want_newline = true;
         ++total_len;
     } else if (NULL != ldi->ldi_suffix) {

--- a/src/util/pmix_parse_options.c
+++ b/src/util/pmix_parse_options.c
@@ -85,6 +85,13 @@ void pmix_util_parse_range_options(char *inp, char ***output)
                 PMIx_Argv_free(r2);
                 goto cleanup;
             }
+            /* a token like "-" (or "--") splits to all-empty tokens, so
+             * PMIx_Argv_split returns NULL - guard against dereferencing
+             * r2[0] in that case rather than crashing */
+            if (0 == PMIx_Argv_count(r2)) {
+                PMIx_Argv_free(r2);
+                continue;
+            }
             start = strtol(r2[0], NULL, 10);
             end = start;
         }

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -197,6 +197,9 @@ char *pmix_path_findv(char *fname, int mode, char **envv, char *wrkdir)
                 free(dirv[i]);
                 dirv[i] = strdup(wrkdir);
                 if (NULL == dirv[i]) {
+                    /* free the partially-built path vector rather than
+                     * leaking it on this OOM path */
+                    PMIx_Argv_free(dirv);
                     return NULL;
                 }
             }
@@ -453,13 +456,18 @@ bool pmix_path_nfs(char *fname, char **fstype)
         }
 
         if (s.st_dev == dev) {
-            *fstype = strdup(mnt.mnt_type);
             close(fd);
             endmntent(fp);
             // check if this is a file system of concern
             for (n=0; NULL != fs_types[n]; n++) {
                 if (0 == strcmp(fs_types[n], mnt.mnt_type)) {
-                    // yep, this is a shared file system
+                    // yep, this is a shared file system. Per the contract,
+                    // *fstype is only valid (and owned by the caller) on a
+                    // true return - so only set it here, and not on any of
+                    // the false paths where it would leak.
+                    if (NULL != fstype) {
+                        *fstype = strdup(mnt.mnt_type);
+                    }
                     return true;
                 }
             }
@@ -477,7 +485,6 @@ bool pmix_path_nfs(char *fname, char **fstype)
 #else
     // cannot do anything
     PMIX_HIDE_UNUSED_PARAMS(fname, fstype);
-    *fstype = strdup("unknown");
     return false;
 #endif
 }
@@ -516,8 +523,11 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     }
 
     /* now set the amount of free space available on path */
-    /* sometimes buf.f_bavail is negative */
-    *out_avail = buf.f_bsize * ((int) buf.f_bavail < 0 ? 0 : buf.f_bavail);
+    /* f_bavail is signed on some platforms and can be negative; check the
+     * sign in a full-width signed type rather than truncating to int,
+     * which on a large filesystem would misread a valid 64-bit count as
+     * negative and report zero free space */
+    *out_avail = buf.f_bsize * (((int64_t) buf.f_bavail < 0) ? 0 : buf.f_bavail);
 
     pmix_output_verbose(10, 2,
                          "pmix_path_df: stat(v)fs states "

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -363,7 +363,11 @@ char *pmix_find_absolute_path(char *app_name)
         char *resolved_path = (char *) malloc(PMIX_PATH_MAX);
         if (NULL == realpath(abs_app_name, resolved_path)) {
             free(resolved_path);
-            free(abs_app_name);
+            /* only free abs_app_name if we allocated it - in the
+             * already-absolute case it aliases the caller's app_name */
+            if (abs_app_name != app_name) {
+                free(abs_app_name);
+            }
             return NULL;
         }
         if (abs_app_name != app_name) {

--- a/src/util/pmix_printf.c
+++ b/src/util/pmix_printf.c
@@ -112,7 +112,9 @@ static int guess_strlen(const char *fmt, va_list ap)
                     break;
 
                 case 'f':
-                    farg = (float) va_arg(ap, int);
+                    /* a float argument is promoted to double through
+                     * varargs; read it as a double, not an int */
+                    farg = (float) va_arg(ap, double);
                     /* Alloc for minus sign */
                     if (farg < 0) {
                         ++len;
@@ -128,7 +130,7 @@ static int guess_strlen(const char *fmt, va_list ap)
                     break;
 
                 case 'g':
-                    darg = va_arg(ap, int);
+                    darg = va_arg(ap, double);
                     /* Alloc for minus sign */
                     if (darg < 0) {
                         ++len;
@@ -150,7 +152,7 @@ static int guess_strlen(const char *fmt, va_list ap)
                         switch (fmt[i]) {
                             case 'x':
                             case 'X':
-                                larg = va_arg(ap, int);
+                                larg = va_arg(ap, long);
                                 /* Now get the log16 */
                                 do {
                                     ++len;
@@ -159,7 +161,7 @@ static int guess_strlen(const char *fmt, va_list ap)
                                 break;
 
                             case 'f':
-                                darg = va_arg(ap, int);
+                                darg = va_arg(ap, double);
                                 /* Alloc for minus sign */
                                 if (darg < 0) {
                                     ++len;
@@ -176,7 +178,7 @@ static int guess_strlen(const char *fmt, va_list ap)
 
                             case 'd':
                             default:
-                                larg = va_arg(ap, int);
+                                larg = va_arg(ap, long);
                                 /* Now get the log10 */
                                 do {
                                     ++len;

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -98,14 +98,15 @@
 
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_pty.h"
+#include "src/util/pmix_string_copy.h"
 
 
 #if PMIX_ENABLE_PTY_SUPPORT == 0
 
-PMIX_EXPORT int pmix_ptymopen(char *pts_name)
+PMIX_EXPORT int pmix_ptymopen(char *pts_name, size_t maxlen)
 {
-    PMIX_HIDE_UNUSED_PARAMS(pts_name);
-    return -1
+    PMIX_HIDE_UNUSED_PARAMS(pts_name, maxlen);
+    return -1;
 }
 
 PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name)
@@ -285,7 +286,7 @@ int pmix_openpty(int *amaster, int *aslave, char *name,
                  struct termios *termp, struct winsize *winp)
 {
     char line[20];
-    *amaster = pmix_ptymopen(line);
+    *amaster = pmix_ptymopen(line, sizeof(line));
     if (*amaster < 0) {
         return -1;
     }
@@ -318,11 +319,10 @@ int pmix_openpty(int *amaster, int *aslave, char *name,
 
 #if PMIX_ENABLE_PTY_SUPPORT == 0
 
-pid_t pmix_forkpty(int *master, char *slave, size_t len,
-                   const struct termios *sterm,
-                   const struct winsize *sws)
+pid_t pmix_forkpty(int *master, char *slave,
+                   const void *sterm, const void *sws)
 {
-    PMIX_HIDE_UNUSED_PARAMS(master, slave, len, sterm, sws);
+    PMIX_HIDE_UNUSED_PARAMS(master, slave, sterm, sws);
     return -1;
 }
 

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -158,10 +158,15 @@ pmix_shmem_segment_create(
     const char *backing_path
 ) {
     int rc = PMIX_SUCCESS;
-    // Real size of the segment: add header plus extra to pad to page boundary.
-    const size_t real_size = pmix_shmem_utils_pad_to_page(
-        size + sizeof(pmix_shmem_header_t)
-    );
+    // Real size of the segment. The data region begins a full page in
+    // (data_addr_from_base() rounds the header up to a page boundary), so
+    // the segment must reserve that page-aligned header offset PLUS a
+    // page-rounded data region of the requested size. Rounding
+    // "size + sizeof(header)" as a single quantity would under-allocate the
+    // data region whenever size is not a page multiple, leaving the tail of
+    // the requested range past the end of the mapping.
+    const size_t real_size = pmix_shmem_utils_pad_to_page(sizeof(pmix_shmem_header_t))
+                             + pmix_shmem_utils_pad_to_page(size);
 
     const int fd = open(backing_path, O_CREAT | O_RDWR, 0600);
     if (fd == -1) {

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -257,11 +257,14 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
             pmix_asprintf(&buf, "%s-%s", tli->tli_filename, stamp);
             local_delivery(buf, tli->tli_topic, tmp);
             free(buf);
+            /* local_delivery copies the message, so we own tmp */
+            free(tmp);
             tli->tli_count_since_last_display = 0;
 
             if (first) {
                 pmix_asprintf(&tmp, "%s", "Set MCA parameter \"base_help_aggregate\" to 0 to see all help / error messages\n");
                 local_delivery(tli->tli_filename, tli->tli_topic, tmp);
+                free(tmp);
                 first = false;
             }
         }

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -452,15 +452,28 @@ static void get_content(char ***output,
                         // found a matching entry
                         for (m=0; NULL != ie->content[m]; m++) {
                             if (0 == strncmp(ie->content[m], "#include", strlen("#include"))) {
-                                // parse the project (if provided), file and topic being included
-                                p = strrchr(ie->content[m], '#');
+                                // parse the project (if provided), file and
+                                // topic being included. Work on a writable
+                                // copy so we can NUL-terminate each field -
+                                // ie->content[m] is a read-only string literal.
+                                line = strdup(ie->content[m]);
+                                p = strrchr(line, '#');
+                                *p = '\0';
                                 tp = p + 1;
-                                --p;
-                                p = strrchr(p, '#');
+                                p = strrchr(line, '#');
+                                *p = '\0';
                                 file = p + 1;
-                                --p;
-                                // project can only be "pmix"
-                                get_content(output, "pmix", file, tp);
+                                p = strrchr(line, '#');
+                                ++p;
+                                // if this isn't pointing at "include", then it
+                                // must be a project; otherwise default to pmix
+                                if (0 != strncmp(p, "include", strlen("include"))) {
+                                    pj = p;
+                                } else {
+                                    pj = "pmix";
+                                }
+                                get_content(output, pj, file, tp);
+                                free(line);
                             } else {
                                 PMIx_Argv_append_nosize(output, ie->content[m]);
                             }

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -397,7 +397,12 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
             buf[0] = '\0';
             buf_size = 0;
         }
-        snprintf(buf, PMIX_TIMING_STR_LEN, "%s%s", buf, line);
+        /* append at the current end using the real remaining capacity;
+         * the previous "snprintf(buf, STR_LEN, \"%s%s\", buf, line)" both
+         * aliased buf as source and destination (undefined behavior) and
+         * capped the whole buffer at PMIX_TIMING_STR_LEN (1024) rather than
+         * the OUTBUF_SIZE it was sized for, silently dropping output */
+        snprintf(buf + buf_size, (PMIX_TIMING_OUTBUF_SIZE + 1) - buf_size, "%s", line);
         buf_size += strlen(line);
         free(line);
     }
@@ -575,7 +580,10 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
                 goto err_exit;
             }
         }
-        snprintf(buf, PMIX_TIMING_STR_LEN, "%s%s", buf, line);
+        /* append at the current end using the real remaining capacity
+         * (see the matching fix in pmix_timing_report): the old form
+         * aliased buf as src+dst and ignored the grown buffer size */
+        snprintf(buf + buf_used, buf_size - buf_used, "%s", line);
         buf_used += line_size;
         free(line);
     }

--- a/src/util/pmix_tty.c
+++ b/src/util/pmix_tty.c
@@ -94,13 +94,20 @@ pmix_status_t pmix_settermios(int fd, struct termios *terms)
     } else {
 
         /* check that it was fully successful - tcsetattr returns
-         * success if ANY change succeeded */
+         * success if ANY change succeeded. Compare the individual POSIX
+         * termios fields rather than memcmp'ing the whole struct: the
+         * struct carries padding and (on some platforms) speed fields the
+         * kernel canonicalizes, so a byte-exact compare gives spurious
+         * failures even when every requested setting was applied. */
         rc = pmix_gettermios(fd, &check);
         if (0 != rc) {
             return PMIX_ERROR;
         }
-        rc = memcmp(terms, &check, sizeof(struct termios));
-        if (0 != rc) {
+        if (terms->c_iflag != check.c_iflag ||
+            terms->c_oflag != check.c_oflag ||
+            terms->c_cflag != check.c_cflag ||
+            terms->c_lflag != check.c_lflag ||
+            0 != memcmp(terms->c_cc, check.c_cc, sizeof(terms->c_cc))) {
             errno = EINVAL;
             return PMIX_ERROR;
         }

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -15,3 +15,6 @@ util_alfg
 util_printf
 util_os_dirpath
 util_net
+util_if
+util_parse_options
+util_os_path

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -12,14 +12,14 @@ check_PROGRAMS = util_hash util_name_fns \
     util_show_help util_timings util_context_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
-    util_net
+    util_net util_if util_parse_options util_os_path
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
     util_show_help util_timings util_context_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
-    util_net
+    util_net util_if util_parse_options util_os_path
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -106,10 +106,25 @@ util_net_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_net_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+util_if_SOURCES = util_if.c
+util_if_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_if_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+util_parse_options_SOURCES = util_parse_options.c
+util_parse_options_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_parse_options_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+util_os_path_SOURCES = util_os_path.c
+util_os_path_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_os_path_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f util_hash util_name_fns \
 	    util_output util_error util_cmd_line \
 	    util_show_help util_timings util_context_fns \
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
-	    util_net
+	    util_net util_if util_parse_options util_os_path

--- a/test/unit/util/util_hash.c
+++ b/test/unit/util/util_hash.c
@@ -263,6 +263,67 @@ static void test_multiple_ranks(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Qualified store/fetch                                                */
+/* ------------------------------------------------------------------ */
+
+/* Regression for the pmix_hash_store qualifier-array construction bug:
+ * when the info array mixes non-qualifier and qualifier entries, the
+ * qualifier's index was written to the wrong (out-of-bounds) slot, so the
+ * stored qualifier index was left uninitialized and a later qualified
+ * fetch failed to match (and the OOB write corrupted the heap). Store a
+ * value qualified by a marked qualifier that is preceded by a
+ * non-qualifier info, then confirm a matching qualified fetch finds it. */
+static void test_store_fetch_qualified(void)
+{
+    pmix_hash_table_t *t = new_table();
+    pmix_kval_t *kv = make_kval_str("unit.qkey", "qvalue");
+    pmix_info_t quals[2];
+    pmix_info_t fq[1];
+    pmix_list_t kvals;
+    pmix_status_t rc;
+    uint32_t plain = 7, qval = 42;
+
+    /* quals[0] is an ordinary (non-qualifier) info; quals[1] is the
+     * actual qualifier - this ordering is what triggered the bug. */
+    PMIX_INFO_LOAD(&quals[0], "unit.plain.directive", &plain, PMIX_UINT32);
+    PMIX_INFO_LOAD(&quals[1], "unit.qualifier", &qval, PMIX_UINT32);
+    PMIX_INFO_SET_QUALIFIER(&quals[1]);
+
+    rc = pmix_hash_store(t, 0, kv, quals, 2, NULL);
+    PMIX_RELEASE(kv);
+    report("store_qualified: store returns SUCCESS", PMIX_SUCCESS == rc);
+
+    /* fetch qualified by the same key/value must match */
+    PMIX_INFO_LOAD(&fq[0], "unit.qualifier", &qval, PMIX_UINT32);
+    PMIX_INFO_SET_QUALIFIER(&fq[0]);
+
+    PMIX_CONSTRUCT(&kvals, pmix_list_t);
+    rc = pmix_hash_fetch(t, 0, "unit.qkey", fq, 1, &kvals, NULL);
+    report("store_qualified: qualified fetch matches",
+           PMIX_SUCCESS == rc && !pmix_list_is_empty(&kvals));
+    drain_list(&kvals);
+    PMIX_DESTRUCT(&kvals);
+
+    /* fetch qualified by a different value must NOT match */
+    qval = 99;
+    PMIX_INFO_DESTRUCT(&fq[0]);
+    PMIX_INFO_LOAD(&fq[0], "unit.qualifier", &qval, PMIX_UINT32);
+    PMIX_INFO_SET_QUALIFIER(&fq[0]);
+    PMIX_CONSTRUCT(&kvals, pmix_list_t);
+    rc = pmix_hash_fetch(t, 0, "unit.qkey", fq, 1, &kvals, NULL);
+    report("store_qualified: mismatched qualifier not found",
+           PMIX_ERR_NOT_FOUND == rc);
+    drain_list(&kvals);
+    PMIX_DESTRUCT(&kvals);
+
+    PMIX_INFO_DESTRUCT(&quals[0]);
+    PMIX_INFO_DESTRUCT(&quals[1]);
+    PMIX_INFO_DESTRUCT(&fq[0]);
+    pmix_hash_remove_data(t, 0, NULL, NULL);
+    PMIX_RELEASE(t);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -286,6 +347,7 @@ int main(int argc, char **argv)
     test_store_overwrite();
     test_remove_then_fetch();
     test_multiple_ranks();
+    test_store_fetch_qualified();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/util/util_if.c
+++ b/test/unit/util/util_if.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pure address/mask parser in src/util/pmix_if.c
+ * (pmix_iftupletoaddr).  These need no populated interface list, so they
+ * run without any server/tool initialization.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/util/pmix_if.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Expected network values are assembled in host byte order, matching
+ * pmix_iftupletoaddr's output. */
+#define ADDR(a, b, c, d) \
+    ((uint32_t)(((a) << 24) | ((b) << 16) | ((c) << 8) | (d)))
+
+static void check_ok(const char *label, const char *input,
+                     uint32_t exp_net, uint32_t exp_mask)
+{
+    uint32_t net = 0, mask = 0;
+    int rc = pmix_iftupletoaddr(input, &net, &mask);
+    report(label, PMIX_SUCCESS == rc && net == exp_net && mask == exp_mask);
+}
+
+static void check_err(const char *label, const char *input)
+{
+    uint32_t net = 0, mask = 0;
+    int rc = pmix_iftupletoaddr(input, &net, &mask);
+    report(label, PMIX_SUCCESS != rc);
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_iftupletoaddr unit tests ===\n\n");
+
+    /* integer CIDR prefixes */
+    check_ok("cidr /24", "192.168.1.0/24", ADDR(192, 168, 1, 0), 0xFFFFFF00);
+    check_ok("cidr /16", "10.20.0.0/16", ADDR(10, 20, 0, 0), 0xFFFF0000);
+    /* /32 is a valid single-host match (regression: used to be rejected) */
+    check_ok("cidr /32 host route", "10.1.2.3/32", ADDR(10, 1, 2, 3), 0xFFFFFFFF);
+    /* /0 matches everything (regression: used to be rejected, and the
+     * shift-by-32 was undefined behavior) */
+    check_ok("cidr /0 match-all", "0.0.0.0/0", ADDR(0, 0, 0, 0), 0x00000000);
+
+    /* dotted-quad netmask */
+    check_ok("dotted mask", "192.168.1.0/255.255.255.0",
+             ADDR(192, 168, 1, 0), 0xFFFFFF00);
+
+    /* mask inferred from number of dots when no '/' is present */
+    check_ok("implicit /16 from dots", "192.168",
+             ADDR(192, 168, 0, 0), 0xFFFF0000);
+
+    /* a malformed dotted mask must be reported, not silently swallowed
+     * (regression: the error rc was overwritten by the net parse) */
+    check_err("malformed dotted mask rejected", "192.168.1.0/256.0.0.0");
+
+    /* an out-of-range prefix length is rejected */
+    check_err("prefix > 32 rejected", "10.0.0.0/33");
+
+    /* an octet that would wrap a uint32_t must be rejected, not accepted
+     * as its truncated value (regression) */
+    check_err("wrapping octet rejected", "4294967296.0.0.0");
+
+    /* out-of-range octet */
+    check_err("octet > 255 rejected", "192.168.1.300/24");
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_name_fns.c
+++ b/test/unit/util/util_name_fns.c
@@ -177,6 +177,35 @@ static void test_compare_proc_rank_order(void)
 
 /* ------------------------------------------------------------------ */
 
+/* Regression: pmix_rank_t is uint32_t and the special ranks live at the
+ * top of the range. A plain "a->rank - b->rank" comparator reduces mod
+ * 2^32 and returns the wrong sign when the ranks differ by more than
+ * INT_MAX, mis-ordering a sort. A normal rank must always compare less
+ * than PMIX_RANK_WILDCARD / PMIX_RANK_UNDEF. */
+static void test_compare_proc_special_ranks(void)
+{
+    pmix_proc_t normal, wildcard, undef;
+
+    memset(&normal, 0, sizeof(normal));
+    memset(&wildcard, 0, sizeof(wildcard));
+    memset(&undef, 0, sizeof(undef));
+    pmix_strncpy(normal.nspace, "ns", PMIX_MAX_NSLEN);
+    pmix_strncpy(wildcard.nspace, "ns", PMIX_MAX_NSLEN);
+    pmix_strncpy(undef.nspace, "ns", PMIX_MAX_NSLEN);
+    normal.rank = 0;
+    wildcard.rank = PMIX_RANK_WILDCARD; /* 0xFFFFFFFE */
+    undef.rank = PMIX_RANK_UNDEF;       /* 0xFFFFFFFF */
+
+    report("compare_proc_special: 0 < WILDCARD",
+           pmix_util_compare_proc(&normal, &wildcard) < 0);
+    report("compare_proc_special: WILDCARD > 0",
+           pmix_util_compare_proc(&wildcard, &normal) > 0);
+    report("compare_proc_special: WILDCARD < UNDEF",
+           pmix_util_compare_proc(&wildcard, &undef) < 0);
+    report("compare_proc_special: identical special ranks equal",
+           0 == pmix_util_compare_proc(&undef, &undef));
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -200,6 +229,7 @@ int main(int argc, char **argv)
     test_compare_proc_equal();
     test_compare_proc_nspace_diff();
     test_compare_proc_rank_order();
+    test_compare_proc_special_ranks();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/util/util_os_path.c
+++ b/test/unit/util/util_os_path.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for src/util/pmix_os_path.c (pmix_os_path).
+ *
+ * Pure string assembly - no server/tool init required. Assumes a POSIX
+ * '/' path separator (PMIX_PATH_SEP), which holds on every platform the
+ * test suite runs on.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/util/pmix_os_path.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+static void check(const char *label, char *got, const char *expected)
+{
+    report(label, NULL != got && 0 == strcmp(got, expected));
+    if (NULL != got) {
+        free(got);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_os_path unit tests ===\n\n");
+
+    check("absolute multi-element", pmix_os_path(false, "a", "b", "c", NULL), "/a/b/c");
+    check("relative multi-element", pmix_os_path(true, "a", "b", NULL), "./a/b");
+    check("absolute, no elements", pmix_os_path(false, NULL), "/");
+    check("relative, no elements", pmix_os_path(true, NULL), "./");
+
+    /* an element that already begins with the separator must not produce a
+     * doubled slash */
+    check("leading-separator element", pmix_os_path(false, "/a", "b", NULL), "/a/b");
+    check("single element", pmix_os_path(false, "usr", NULL), "/usr");
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_parse_options.c
+++ b/test/unit/util/util_parse_options.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for src/util/pmix_parse_options.c
+ *   pmix_util_parse_range_options, pmix_util_get_ranges
+ *
+ * These are pure argv transformers - no server/tool init required.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix.h"
+
+#include "src/util/pmix_parse_options.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Compare an argv against an expected NULL-terminated list. */
+static int argv_equals(char **got, const char *const *exp)
+{
+    int i;
+    int gcount = PMIx_Argv_count(got);
+    int ecount = 0;
+    while (NULL != exp[ecount]) {
+        ecount++;
+    }
+    if (gcount != ecount) {
+        return 0;
+    }
+    for (i = 0; i < gcount; i++) {
+        if (0 != strcmp(got[i], exp[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void check_range(const char *label, char *input,
+                        const char *const *expected)
+{
+    char **out = NULL;
+    pmix_util_parse_range_options(input, &out);
+    report(label, argv_equals(out, expected));
+    PMIx_Argv_free(out);
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_parse_options unit tests ===\n\n");
+
+    {
+        const char *const exp[] = {"3", NULL};
+        char in[] = "3";
+        check_range("single value", in, exp);
+    }
+    {
+        const char *const exp[] = {"3", "4", "5", NULL};
+        char in[] = "3-5";
+        check_range("range 3-5", in, exp);
+    }
+    {
+        const char *const exp[] = {"1", "2", "3", "4", "7", NULL};
+        char in[] = "1,2-4,7";
+        check_range("mixed list and range", in, exp);
+    }
+    {
+        const char *const exp[] = {"7", "BANG", NULL};
+        char in[] = "7!";
+        check_range("bang operator", in, exp);
+    }
+    {
+        const char *const exp[] = {"-1", NULL};
+        char in[] = "-1";
+        check_range("wildcard -1", in, exp);
+    }
+    {
+        /* reversed range yields nothing (documented behavior) */
+        const char *const exp[] = {NULL};
+        char in[] = "5-3";
+        check_range("reversed range is empty", in, exp);
+    }
+    {
+        /* Regression: a bare "-" token used to dereference a NULL argv
+         * and crash. It must now be skipped without producing output. */
+        const char *const exp[] = {NULL};
+        char in[] = "-";
+        check_range("bare dash does not crash", in, exp);
+    }
+    {
+        /* Regression: an embedded bare "-" is skipped, neighbors kept. */
+        const char *const exp[] = {"1", "3", NULL};
+        char in[] = "1,-,3";
+        check_range("embedded bare dash skipped", in, exp);
+    }
+
+    /* NULL input is a documented no-op */
+    {
+        char **out = NULL;
+        pmix_util_parse_range_options(NULL, &out);
+        report("NULL input leaves output NULL", NULL == out);
+        PMIx_Argv_free(out);
+    }
+
+    /* pmix_util_get_ranges: parallel start/end arrays */
+    {
+        char **starts = NULL, **ends = NULL;
+        const char *const exp_s[] = {"3", "7", NULL};
+        const char *const exp_e[] = {"5", "7", NULL};
+        char in[] = "3-5,7";
+        pmix_util_get_ranges(in, &starts, &ends);
+        report("get_ranges: start points", argv_equals(starts, exp_s));
+        report("get_ranges: end points", argv_equals(ends, exp_e));
+        PMIx_Argv_free(starts);
+        PMIx_Argv_free(ends);
+    }
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
This is a deep review of `src/util`, the low-level utility layer compiled
into `libpmix`. It lands as focused, independently-reviewable commits: one
logical fix each, a developer guide, and unit tests. The whole tree builds
warning-free under the default `--enable-devel-check`, and `test/unit/util`
passes 20/20.

## Bug fixes (correctness / robustness — none are hot-path)

- **`pmix_hash`**: qualifier-array construction wrote the qualifier index
  to the wrong (out-of-bounds) slot when the info array mixes non-qualifier
  and qualifier entries — a heap overflow that also left the real slot's
  index uninitialized, so qualified fetches silently missed. Array now
  `calloc`'d and indexed by the compacted counter.
- **`pmix_if`**: swallowed a malformed dotted netmask; rejected valid `/0`
  and `/32` (and did a shift-by-32 UB); accepted wrapping octets; `isalpha`
  on a signed `char`; unclamped `memcpy` in `pmix_ifindextomask`.
- **`pmix_fd`**: `pmix_fd_get_peer_name` used a bare `struct sockaddr` for
  IPv6 (truncation + OOB read) — now `sockaddr_storage`; `__OSX__` →
  `__APPLE__` so macOS uses the fast fd-close path.
- **`pmix_path`**: `pmix_find_absolute_path` freed the caller's string on a
  `realpath` failure; `path_df` truncated 64-bit free space to `int`;
  `path_nfs` leaked `*fstype` on false returns; `path_findv` OOM leak.
- **`pmix_name_fns`**: `pmix_util_compare_proc` used `uint32_t` subtraction
  (wrong sign for special ranks like `PMIX_RANK_WILDCARD`) — now three-way.
- **`pmix_environ`**: `getpwuid()` NULL-deref; empty-var `[len-1]`
  underflow; include/exclude now honor exact-vs-wildcard names (`"PATH"` no
  longer matches `"PATHFINDER"`); exclusion loop skips non-envar kvals.
- **`pmix_parse_options`**: bare-`"-"` range token NULL-deref (reachable
  from user port-range strings).
- **`pmix_show_help`**: leaked the aggregated-duplicate messages; fixed the
  latent `#include` content parser.
- **`pmix_output`**: `make_string` `[len-1]` on an empty string; `bool`
  return of `PMIX_ERR_NOMEM`; unbounded `strcat` filename build; NUL-unsafe
  `gethostname`.
- **`pmix_timings`**: self-aliasing/mis-bounded `snprintf` append
  (`--enable-timing` only).
- **`pmix_pty`**: compile errors in the non-default (no-pty / no-`openpty`)
  build configs.
- **`pmix_keyval_parse`**: `isspace` on a signed `char`; unbounded
  `trim_name` back-scan.
- **`pmix_shmem`**: segment under-sized for non-page-multiple sizes.
- **`pmix_printf`**: fallback `guess_strlen` read `double`/`long` varargs as
  `int` (UB).
- **`pmix_tty`**: `settermios` verified via a fragile whole-struct `memcmp`
  — now field-wise.
- Assorted OOM NULL-checks and return-code/doc alignment (`pmix_os_path`,
  `pmix_os_dirpath`, `pmix_getcwd`).

One issue was **intentionally left as-is**: `pmix_alfg`'s `pmix_srand`
seeding the shared global. It looks like a footgun but is the only way to
seed `pmix_random`, and `util_alfg` tests that contract; it is unreachable
in practice. Documented as by-design.

## Developer guide

`src/util/AGENTS.md` (+ `CLAUDE.md` symlink): what the layer is, a file map,
deeper notes on the stateful subsystems, build wiring, the test harness, and
a record of the fixes above.

## Tests

New pure-function tests wired into `make check` — `util_if`,
`util_parse_options`, `util_os_path` — plus regressions added to
`util_hash` (mixed qualifiers) and `util_name_fns` (special-rank compare).
Each bug-fix regression was verified by reverting the fix and confirming the
test fails.