### PR TITLE
Fix defects in the Python bindings, add unit tests and developer docs

### DIFF
--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -1,0 +1,316 @@
+# AGENTS.md: PMIx Python Bindings (`bindings/python/`)
+
+Orientation for AI and human contributors working on the PMIx Python
+bindings. This is a *map*, not the rulebook — the top-level
+[`CLAUDE.md`/`AGENTS.md`](../../CLAUDE.md) at the repo root and the docs under
+[`docs/`](../../docs/) are authoritative. When this file and those disagree,
+they win — and please fix this file.
+
+The bindings are a **Cython** extension named `pmix` that wraps `libpmix`. A
+Python program does `from pmix import *` and drives PMIx through four classes
+(`PMIxClient`, `PMIxServer`, `PMIxTool`, `PMIxScheduler`).
+
+---
+
+## 1. File map — what is source, what is generated
+
+**Never hand-edit a generated file.** Editing the wrong file means your
+change is silently discarded on the next build.
+
+| File | Role | Edit? |
+|------|------|-------|
+| `pmix.pyx` | **Source.** The four role classes and all module-level callback trampolines. The heart of the bindings. | ✅ |
+| `pmix.pxi` | **Source.** Cython `include`d by `pmix.pyx`. All the Python↔C conversion helpers (`pmix_load_*`, `pmix_unload_*`, `pmix_free_*`), the `myLock` class, and the `pmix_pyshift_t` caddy. | ✅ |
+| `construct.py` | **Source.** A code generator: harvests `#define`/enum/typedef constants and API/type names from the installed C headers and emits `pmix_constants.pxi` and `pmix_constants.pxd`. | ✅ |
+| `setup.py` | **Source.** setuptools/Cython build driver. Reads `PMIX_BINDINGS_TOP_{BUILDDIR,SRCDIR}` env vars to find `pmix.pyx` and the include dirs; derives the version from `include/pmix_version.h`. | ✅ |
+| `Makefile.am` | **Source.** Automake wiring: runs `construct.py`, then `setup.py`, and installs the egg. | ✅ |
+| `requirements.txt` | **Source.** `cython`, `setuptools`. | ✅ |
+| `pmix_constants.pxi` | **Generated** by `construct.py`. Runtime constant values (`PMIX_SUCCESS = 0`, …). Its first line, `from pmix_constants cimport *`, pulls in the `.pxd`. | ❌ |
+| `pmix_constants.pxd` | **Generated** by `construct.py`. `cdef extern` declarations of every C struct/type/function the bindings call. | ❌ |
+| `pmix.c` | **Generated** by Cython from `pmix.pyx`. ~7 MB. Never read or edit it to understand behavior — read the `.pyx`/`.pxi`. | ❌ |
+| `Makefile`, `Makefile.in` | **Generated** by Autotools. | ❌ |
+| `build/`, `pypmix.egg-info/` | **Generated** build products. | ❌ |
+
+`tests/` under this directory holds a small Cython round-trip smoke test
+(`tests/cython/`) and legacy copies of the connected test scripts
+(`tests/python/`). The *maintained* test scripts live in the top-level
+[`test/python/`](../../test/python/) directory (see §7).
+
+---
+
+## 2. The class hierarchy
+
+```
+PMIxClient
+    └── PMIxServer
+            └── PMIxTool
+                    └── PMIxScheduler
+```
+
+Each subclass *is a* superset of the one above: a `PMIxServer` can call every
+`PMIxClient` method, a `PMIxTool` adds tool-attach/IOF, and `PMIxScheduler`
+adds session/allocation direction. The classes are Cython `cdef class`es;
+their C-level state (`pmix_proc_t myproc`, `pmix_server_module_t myserver`,
+…) is declared with `cdef` at class scope and is not visible from Python.
+
+Method → C-API coverage (and the gaps) is tracked in
+[`MISSING_BINDINGS.md`](MISSING_BINDINGS.md). Consult it before adding a new
+method so you match the existing naming and don't duplicate work.
+
+---
+
+## 3. The data convention: dicts and lists, not structs
+
+The bindings never expose C structs to Python. Everything crosses the
+boundary as plain `dict`/`list` objects, converted by the helpers in
+`pmix.pxi`. Learn these shapes — every method uses them.
+
+**A value** is a dict with `value` and `val_type` (a `PMIX_*` type constant):
+
+```python
+{'value': 42, 'val_type': PMIX_INT32}
+{'value': 'hello', 'val_type': PMIX_STRING}
+{'value': {'nspace': 'myjob', 'rank': 0}, 'val_type': PMIX_PROC}
+```
+
+**An info/attribute** adds a `key` (and optional `flags`):
+
+```python
+{'key': PMIX_PROGRAMMING_MODEL, 'value': 'MPI', 'val_type': PMIX_STRING}
+```
+
+Methods that take attributes take a **list of info dicts** (`dicts:list`,
+`pyinfo:list`, `pydirs:list`, …). An empty list or `None` means "no
+attributes".
+
+**A proc** is `{'nspace': str, 'rank': int}`. Lists of procs are passed as
+`peers:list` / `pytargets:list`. When a proc list is empty/`None`, most
+methods default to *this proc's whole job* (`self.myproc.nspace`,
+`PMIX_RANK_WILDCARD`).
+
+**Return convention:** most methods return the integer `rc` (a `PMIX_*`
+status). Methods that also produce data return a **tuple**, e.g.
+`get()` → `(rc, value_dict)`, `spawn()` → `(rc, nspace)`,
+`init()` → `(rc, myname_dict)`. Check the first element against
+`PMIX_SUCCESS` (== 0) before trusting the second.
+
+### The conversion helpers (`pmix.pxi`)
+
+- `pmix_load_value` / `pmix_unload_value` — one value dict ↔ `pmix_value_t`.
+  A big `if/elif` over `val_type`, one arm per PMIx data type.
+- `pmix_load_info` / `pmix_unload_info` / `pmix_alloc_info` / `pmix_free_info`
+  — info dict lists ↔ `pmix_info_t[]`. `pmix_alloc_info` is the standard
+  "malloc + load" entry point used by nearly every method.
+- `pmix_load_darray` / `pmix_unload_darray` — nested `PMIX_DATA_ARRAY`.
+- `pmix_load_procs` / `pmix_unload_procs`, `pmix_load_pdata`, `pmix_load_apps`,
+  etc. — the remaining structured types.
+
+**Cython auto-converts C structs to dicts.** When a helper reads a struct
+value like `value[0].data.endpoint[0]`, Cython (having the struct's fields
+from the `.pxd`) silently produces a **Python dict** with those fields. That
+means `value[0].data.endpoint[0].size` is *attribute access on a dict*, not a
+C field read — it raises `AttributeError` at runtime, not compile time. Access
+converted-struct members with subscript (`['endpt']['bytes']`), and be aware
+that struct-member typos in the unload paths are **runtime** failures the
+compiler will not catch.
+
+---
+
+## 4. Threading and callbacks — the hardest part
+
+`libpmix` is asynchronous and runs its own progress thread; the bindings must
+bridge that to Python. Two distinct mechanisms are in play.
+
+### 4a. Blocking bridge: `myLock` + `active`
+
+Some server methods call an async C API and wait for its C callback before
+returning. They use the module-global `active = myLock()` (a
+`threading.Event` subclass) and the pattern:
+
+```python
+active.clear()
+rc = PMIx_server_setup_application(nspace, info, sz, setupapp_cbfunc, NULL)
+if PMIX_SUCCESS == rc:
+    active.wait()             # blocks until the C callback fires active.set()
+    active.fetch_info(dataout)
+```
+
+The C callback (`setupapp_cbfunc`, `dmodx_cbfunc`, `collectinventory_cbfunc`)
+caches its results into `active` and calls `active.set(status)`. Because
+`active` is a single global, these blocking calls are **not reentrant / not
+thread-safe** across concurrent operations — a known limitation.
+
+### 4b. Upcalls: C server-module and event/IOF handlers → Python
+
+When the process acts as a server, `libpmix` calls back *into* Python for
+every server operation (client connected, fence, publish, …). The chain:
+
+1. `setmodulefn(key, fn)` validates `key` against a fixed `permitted` list and
+   records the Python function in the module-global dict `pmixservermodule`.
+2. `server_module_init(kvkeys)` wires a C trampoline (`clientconnected`,
+   `fencenb`, `publish`, …) into the `pmix_server_module_t` struct for each
+   registered key.
+3. When `libpmix` invokes a trampoline, the `cdef` function runs `with gil`,
+   converts the C args to dicts/lists, looks the Python handler up in
+   `pmixservermodule`, and calls it.
+
+Event and IOF handlers work similarly through the module-global list
+`myhdlrs` (a list of `{'refid', 'hdlr'}` dicts). `pyeventhandler` /
+`pyiofhandler` find the matching handler by `refid`. If the handler isn't
+registered yet (a race with registration), they stash the event in a
+`pmix_pyshift_t` caddy wrapped in a `PyCapsule` and retry via a
+`threading.Timer(0.001, …)`.
+
+**Server-module keys** accepted by `setmodulefn` are the strings in its
+`permitted` list; the *wiring* names checked in `server_module_init` must
+match exactly (adding a key to one list without the other silently drops the
+callback — that class of mismatch bit the `notifyevent` key historically). A
+Python server registers them via `PMIxServer.init(info, module_map)` where
+`module_map` is `{'clientconnected': fn, 'fencenb': fn, ...}`.
+
+### Rules when touching callback code
+
+- Trampolines that call back into Python **must** be `cdef ... with gil`.
+- Trampolines that only touch C state and release into `libpmix` use
+  `with nogil` around the actual C callback invocation (see
+  `pypmix_op_cbfunc`).
+- Do not add work between allocating a `pmix_pyshift_t` caddy and wrapping it
+  in its capsule; the capsule owns the lifetime.
+- Match the existing free discipline: whoever allocs the `pmix_info_t[]` /
+  procs / caddy is responsible for freeing it after the C call returns or in
+  the release callback.
+
+---
+
+## 5. Constants: `construct.py`
+
+`pmix_constants.pxi` and `pmix_constants.pxd` are **generated** by
+`construct.py` from the *installed* C headers (`pmix_common.h`,
+`pmix_deprecated.h`, `pmix.h`, `pmix_server.h`, `pmix_tool.h`, …). To add a
+new constant, attribute, or C API to the bindings you generally do **not**
+hand-edit the `.pxi`/`.pxd` — you add it to the C header and re-run the
+generator (Automake does this during a normal build). If a constant is
+missing from Python, first confirm it exists in the header and that the build
+re-ran `construct.py`.
+
+`construct.py` classifies each harvested line as a string constant, numeric
+constant, error code, typedef, or API declaration, and emits the appropriate
+Cython. Its parsing is textual and line-oriented, so unusual formatting in a
+header (multi-line macros, unusual comments) can trip it — keep new header
+entries in the conventional one-line style.
+
+---
+
+## 6. Building
+
+The bindings build as part of the normal tree build when Python bindings are
+enabled (`configure` reports `WANT_PYTHON_BINDINGS`; requires a Python 3 with
+Cython and setuptools). From the repo root:
+
+```sh
+./autogen.pl && ./configure --enable-python-bindings ... && make -j
+```
+
+`make` in this directory runs `construct.py` then `setup.py build_ext`. The
+generated `pmix.c` and the compiled `pmix*.so` land under `build/`.
+
+**Quick standalone check that the current source cythonizes** (does not need a
+full build):
+
+```sh
+cd bindings/python
+PMIX_BINDINGS_TOP_BUILDDIR=<repo-root> PMIX_BINDINGS_TOP_SRCDIR=<repo-root> \
+    cython -3 -I. pmix.pyx -o /tmp/pmix_check.c
+```
+
+Exit 0 means the source is syntactically valid Cython. **Caution:** Cython
+type-checks C struct field access but, per §3, struct-to-dict auto-conversion
+means many logic bugs in the unload paths compile cleanly and only fail at
+runtime. A clean cythonize is necessary, not sufficient.
+
+The `.so` embeds an absolute path to `libpmix` (via the linker), so once built
+it imports without setting `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` — only
+`PYTHONPATH` to the `build/lib.*` directory is needed.
+
+---
+
+## 7. Testing
+
+Two flavors of test live in [`test/python/`](../../test/python/):
+
+- **Connected/integration:** `server.py` launches `client.py` under a real
+  PMIx server; `sched.py` exercises the scheduler role. Wired into
+  `make check` as `run_server.sh` / `run_sched.sh`. These need a working
+  server environment.
+- **Standalone unit tests:** `test_bindings.py` — a `unittest` suite covering
+  everything that needs **no** server: import, the class hierarchy, constant
+  definitions, and the stateless `*_string` converters. It self-locates the
+  built extension and exits 77 (automake SKIP) if `pmix` can't be imported, so
+  it is safe to run anywhere. Also wired into `make check`.
+
+Run the unit tests directly:
+
+```sh
+cd test/python
+PYTHONPATH=<repo>/bindings/python/build/lib.<platform> ./test_bindings.py
+# or just ./test_bindings.py from an in-tree build (it finds the .so)
+```
+
+**Where unit tests can and can't reach:** the `*_string` converters and
+constant/version accessors are pure and testable without a server. The
+conversion helpers (`pmix_load_value`, …) are `cdef` and **not importable from
+Python**, so they can't be unit-tested directly — the practical way to cover
+them is a round-trip through a connected client/server (put→get,
+publish→lookup), which belongs in the integration scripts. When adding a new
+stateless helper, prefer exposing enough of it to add a `test_bindings.py`
+case.
+
+---
+
+## 8. Defects found and fixed, and gotchas
+
+A deep review (2026-07) found ~22 real bugs in the conversion and method
+code; all but one (see below) were fixed in the same pass. The full catalogue
+— with file/line, severity, and what was wrong — is retained in
+[`MISSING_BINDINGS.md`](MISSING_BINDINGS.md) (§Defects) as history and as a
+map of the fragile spots. The patterns that caused them are worth
+internalizing so they are not reintroduced:
+
+- **A `cdef class` method needs an explicit `self`.** Several methods were
+  declared `def foo(arg):` and raised `TypeError` when called. Cython does not
+  add `self` for you — every instance method needs it.
+- **Struct-to-dict auto-conversion hides field typos** (see §3). The unload
+  paths had several `.size`/`.bytes`/`[index]` mistakes that compiled cleanly
+  and only failed (or silently returned garbage) at runtime. When you touch an
+  unload arm, exercise it on real data.
+- **`memset`/`malloc` counts must include `sizeof(T)`**, and NUL-terminated
+  `char**` arrays need one extra slot. Byte counts vs element counts were a
+  recurring source of overflow.
+- **Copy from the right key.** Loaders read from a value dict; getting the
+  wrong key (`envar` vs `value`, `val_type` vs `value`) silently corrupts data.
+- **`setmodulefn`'s `permitted` list and `server_module_init`'s wiring names
+  must stay in lockstep** (§4b).
+
+The one **not** fixed is a genuine unimplemented feature, not a bug:
+`PMIxScheduler.assign_session` and `PMIxServer.generate_cpuset_string` /
+`generate_locality_string` are honest stubs that return
+`PMIX_ERR_NOT_SUPPORTED` because the underlying capability isn't wired to a C
+entry point yet. They are tracked in [`MISSING_BINDINGS.md`](MISSING_BINDINGS.md).
+
+Do **not** work around a defect by weakening a test — fix the code (see the
+top-level guidance on never bending a test to a bug).
+
+### Style / conventions specific to these bindings
+
+- Match the top-level PMIx rules: constant-on-left comparisons
+  (`NULL == ptr`, `PMIX_SUCCESS != rc`), 4-space indent, brace every block.
+- Every new public method takes the attribute list parameter
+  (`dicts`/`pyinfo`) even if it ignores it today — attributes are how PMIx
+  APIs grow. See the top-level *Role of Attributes* section.
+- Strings cross to C as ASCII (`.encode('ascii')`); guard with
+  `isinstance(x, str)` since callers may pass `bytes`. Use `pmix_copy_nspace`
+  / `pmix_copy_key` for the fixed-size `nspace`/`key` arrays (they guarantee
+  NUL-termination and length clamping).
+- Accessors that return C strings decode to `str` (e.g. `get_version()` now
+  returns `str`). A few round-trip payloads (byte objects, IOF data) are
+  `bytes`; decode defensively when a value could be either.

--- a/bindings/python/CLAUDE.md
+++ b/bindings/python/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/bindings/python/MISSING_BINDINGS.md
+++ b/bindings/python/MISSING_BINDINGS.md
@@ -1,0 +1,174 @@
+# PMIx Python Bindings — Coverage Gaps and Defects
+
+Tracking document for the PMIx Python bindings (`bindings/python/`). It has
+two parts:
+
+1. **Missing bindings** — real operational C APIs that have no Python method
+   yet, to be implemented in a later pass.
+2. **Defects** — bugs found in the *existing* bindings during the 2026-07 deep
+   review, to be fixed in a later pass.
+
+Utility/struct-helper C APIs with no meaningful Python analogue are
+intentionally **out of scope** and are *not* listed as missing:
+`PMIx_Argv_*`, `PMIx_Setenv`, `PMIx_Info_*`, `PMIx_Value_*`, `PMIx_Data_*`
+(struct helpers), `PMIx_Load_*`, `PMIx_Coord_*`, `PMIx_Topology_*`,
+`PMIx_Cpuset_*`, `PMIx_Device_*`, `PMIx_Geometry_*`, `PMIx_Endpoint_*`,
+`PMIx_Envar_*`, `PMIx_Pdata_*`, `PMIx_Proc_*`, `PMIx_App_*`,
+`PMIx_Byte_object_*`, `PMIx_Regattr_*`, `PMIx_Resource_unit_*`,
+`PMIx_Node_pid_*`, and all `*_construct/_destruct/_create/_free/_release/`
+`_load/_xfer` macro families. In Python these are handled by the
+dict/list conversion layer in `pmix.pxi`.
+
+Headers surveyed: `include/pmix.h`, `include/pmix_server.h`,
+`include/pmix_tool.h`, `include/pmix_deprecated.h`. Bindings surveyed:
+`bindings/python/pmix.pyx`.
+
+---
+
+## Part 1 — Missing bindings
+
+### 1.1 Non-blocking (`_nb`) variants — none are bound
+
+Every operational client call is bound **only** in its blocking form. None of
+the callback-style non-blocking variants exist in Python. Adding these is the
+single largest coverage gap and would let Python programs drive PMIx
+asynchronously (they would need the callback-trampoline machinery already used
+for the server module — see AGENTS.md §4).
+
+- `PMIx_Fence_nb`
+- `PMIx_Get_nb`
+- `PMIx_Publish_nb`
+- `PMIx_Lookup_nb`
+- `PMIx_Unpublish_nb`
+- `PMIx_Spawn_nb`
+- `PMIx_Connect_nb`
+- `PMIx_Disconnect_nb`
+- `PMIx_Query_info_nb`
+- `PMIx_Log_nb`
+- `PMIx_Allocation_request_nb`
+- `PMIx_Job_control_nb`
+- `PMIx_Process_monitor_nb`
+- `PMIx_Get_credential_nb`
+- `PMIx_Validate_credential_nb`
+- `PMIx_Group_construct_nb`
+- `PMIx_Group_destruct_nb`
+- `PMIx_Group_invite_nb`
+- `PMIx_Group_join_nb`
+- `PMIx_Group_leave_nb`
+- `PMIx_Fabric_register_nb`
+- `PMIx_Fabric_update_nb`
+- `PMIx_Fabric_deregister_nb`
+- `PMIx_Compute_distances_nb`
+- `PMIx_Resource_block_nb`
+
+### 1.2 Client role (`PMIxClient`) — unique unbound APIs
+
+| C API | Description |
+|-------|-------------|
+| `PMIx_Heartbeat` | Send a heartbeat to the server to feed process health/monitoring. No args. |
+| `PMIx_Progress_thread_stop` | Stop the internal progress thread (accepts directives, e.g. `PMIX_PROGRESS_THREAD_FLUSH`). |
+| `PMIx_Resource_block` | Request/manipulate a block of resources per a `pmix_resource_block_directive_t`. Scheduler-facing. (`_nb` form also unbound — see §1.1.) |
+
+### 1.3 Server role (`PMIxServer`) — unbound APIs
+
+| C API | Description |
+|-------|-------------|
+| `PMIx_generate_regex2` | Current regex generator producing a `pmix_regex2_t`. Only the **deprecated** `PMIx_generate_regex` is bound (as `generate_regex`). |
+| `PMIx_parse_regex2` | Parse a `pmix_regex2_t` back into its node/host list. Counterpart to `generate_regex2`. |
+| `PMIx_server_generate_cpuset` | Build a `pmix_cpuset_t` from a cpuset string. Only the `_string` form is bound (and it is a stub — see Defects). |
+| `PMIx_server_collect_job_info` | Collect job-level info for a set of procs, for packaging/forwarding to a remote server. |
+
+### 1.4 Tool role (`PMIxTool`)
+
+| C API | Description |
+|-------|-------------|
+| `PMIx_tool_connect_to_server` | **Deprecated**; superseded by `PMIx_tool_attach_to_server` (bound). Safe to leave unbound. |
+
+### 1.5 Scheduler role (`PMIxScheduler`)
+
+The scheduler's core operation is `PMIx_Resource_block` /
+`PMIx_Resource_block_nb` (see §1.2) — unbound. `PMIx_Session_control` is
+bound, but on `PMIxServer`, not surfaced as a distinct scheduler method.
+
+### 1.6 Low-priority unbound string/utility converters
+
+Non-operational pretty-printers; add only if a caller needs them:
+`PMIx_Error_code`, `PMIx_Group_operation_string`,
+`PMIx_Value_comparison_string`, `PMIx_Resource_block_directive_string`,
+`PMIx_Alloc_inheritance_string`, `PMIx_Data_print`.
+
+### 1.7 Coverage summary
+
+- Operational client/server/tool APIs bound: **~75** (blocking forms + tool IOF).
+- Not bound: **25** `_nb` variants, **3** unique client APIs, **4** server
+  APIs, **1** deprecated tool API.
+
+---
+
+## Part 2 — Defects in existing bindings
+
+Found during the 2026-07 deep review. **Status: D1–D21 and D23 were fixed in
+the follow-up pass** (the source cythonizes warning-free, the standalone unit
+suite passes, and the connected server↔client round-trip below succeeds).
+**D22 remains** — it is an unimplemented feature (honest stub), not a bug.
+Line numbers are against the originally reviewed `pmix.pyx` / `pmix.pxi` and
+drift as the files are edited; they are kept for historical traceability and
+as a map of the fragile spots.
+
+**End-to-end verification.** After clearing a pre-existing environmental
+blocker (a stale `pmix.sched.<host>` rendezvous file that made the PMIx
+server's listener setup abort — unrelated to the bindings), the connected
+round-trip in `test/python/` (`server.py` launching `client.py`) runs clean:
+server `init`/`register_nspace`/`register_client`/`setup_fork` succeed, the
+client connects, and a `put`(INT32) → `commit` → `fence` → `get` returns the
+correct value (`{'value': 1, 'val_type': 9}`), with the event handler and the
+`clientconnected`/`clientfinalized`/`fencenb` server-module upcalls all firing.
+This exercises `pmix_load_value`/`pmix_unload_value` and the D18 `PMIx_Value_free`
+fix live. (Fixing the round-trip also required updating the **stale
+`test/python/server.py` harness**, whose server-module handlers used the old
+1-argument signature instead of the current `(request, cbfunc, cbdata)`
+convention — see `bindings/python/tests/python/server_upcalls.py` for the
+reference pattern.)
+
+### 2.1 High severity — method is unusable / crashes
+
+| # | Location | Defect |
+|---|----------|--------|
+| D1 | `pmix.pyx` — `register_resources`, `deregister_resources`, `register_attributes`, `collect_inventory`, `deliver_inventory`, `iof_deliver`, `define_process_set`, `delete_process_set`, `session_control` (PMIxServer); `disconnect` (PMIxTool); `assign_session` (PMIxScheduler) | **Missing `self` parameter.** Declared `def foo(arg):` inside a `cdef class`. Called as bound methods they shift arguments and raise `TypeError`. Confirmed at runtime. |
+| D2 | `pmix.pyx` `assign_session` (~3359) | **Truncated/incomplete.** The source file ends mid-method after `# convert the app list`; it never calls any C API and implicitly returns `None`. |
+| D3 | `pmix.pyx` `PMIxScheduler.init` (~3334) | Calls `self.server_module_init()` with **no argument**, but the method requires `kvkeys:list`. Scheduler init raises `TypeError`. |
+| D4 | `pmix.pyx` `PMIxServer.iof_deliver` (~2245-2251) | `source = NULL` then immediately `pmix_copy_nspace(source[0].nspace, …)` **dereferences NULL** → crash. Also `bo.size = sizeof(data)` uses `sizeof` (pointer size) instead of `len(data)`. |
+| D5 | `pmix.pyx` `PMIxTool.iof_deregister` (~3247) | `for h in myhdlrs and not found:` iterates over the **boolean** `not found`, not the list → `TypeError`; the local handler is never removed. |
+
+### 2.2 Medium severity — data corruption / wrong results
+
+| # | Location | Defect |
+|---|----------|--------|
+| D6 | `pmix.pxi` `pmix_convert_locality` (~139) | `pyloc.len()` — lists have no `.len()` method → `AttributeError`. Should be `len(pyloc)`. |
+| D7 | `pmix.pxi` `pmix_load_darray`, `PMIX_DOUBLE` arm (~322-324) | `n += 1` executed **twice** per element: writes every other slot and overruns the allocation. |
+| D8 | `pmix.pxi` `pmix_load_darray`, `PMIX_ENVAR` arm (~485-497) | The `value` field is loaded from `item['envar']` (never reads `item['value']`); the envar name is duplicated as its value. |
+| D9 | `pmix.pxi` `pmix_load_darray`, `PMIX_DATA_ARRAY` arm (~452-468) | Allocates only **one** element (`sizeof(pmix_data_array_t)`, not `mysize * …`) and `return`s inside the loop on the first item — only the first nested array is ever processed. |
+| D10 | `pmix.pxi` `pmix_load_value`, `PMIX_TIME` arm (~1086) | Assigns `val['val_type']` instead of `val['value']` to `data.time`. |
+| D11 | `pmix.pxi` `pmix_unload_value`, byte-object/coord/geometry/endpoint arms (~1588, 1643, 1670, 1694) | Reads a **single element at index `[size]`/`[dims]`** (out-of-bounds by one) instead of slicing `[:size]`. Returns one int, not the buffer. |
+| D12 | `pmix.pxi` `pmix_unload_value`, `PMIX_ENDPOINT` arm (~1691-1695) | Accesses `.size`/`.bytes` on the Cython-converted endpoint dict; the struct field is `endpt` (a byte object) → `AttributeError` at runtime. Correct: `['endpt']['bytes']`. |
+| D13 | `pmix.pxi` `pmix_load_value`, devdist osname (~1408-1411) and endpoint osname (~1440-1443) | Missing `else:` — the encoded ASCII value is unconditionally overwritten with the raw `str`, so a non-`bytes` object reaches `strdup`. (geometry/device arms do it correctly.) |
+| D14 | `pmix.pxi` `pmix_unload_queries` (~1897-1910) | `query = {}`, `keylist`, `qualist` are created **once outside** the loop and reused/accumulated; every appended entry aliases the same dict. Broken for more than one query. |
+| D15 | `pmix.pxi` `pmix_load_apps` (~2031, 2038, 2051) | `memset(argv, 0, m)` zeroes `m` **bytes**, but the array is `m * sizeof(char*)` bytes → tail pointers left uninitialized. |
+| D16 | `pmix.pxi` `pmix_unload_darray`, `PMIX_DATA_ARRAY` arm (~786-801) | Never builds/returns the result dict (falls through returning the `PMIX_SUCCESS` int from a `dict`-typed function). Nested-array unload is effectively broken. |
+| D17 | `pmix.pyx` server-module key mismatch | `setmodulefn`'s `permitted` list contains `'notify_event'` and `'listener'`, but `server_module_init` wires the key `'notifyevent'`. Registering `'notify_event'` passes validation but the callback is never installed. |
+| D23 | `pmix.pyx` `register_event_handler` | The `pycodes:list` / `pyinfo:list` argument annotations make Cython reject `None` at the call boundary, even though the body explicitly handles `None` (default handler / no directives). The natural, documented usage `register_event_handler(None, None, hdlr)` raised `TypeError`. Fixed by dropping the `:list` annotations. Found while validating the connected round-trip. |
+
+### 2.3 Low severity — leaks / API warts
+
+| # | Location | Defect |
+|---|----------|--------|
+| D18 | `pmix.pyx` `PMIxClient.get` (~726) | The value from `PMIx_Get` is allocated by `libpmix` (libc `malloc`) but freed via `pmix_free_value` → `PyMem_Free` — allocator mismatch (UB on some builds). |
+| D19 | `pmix.pyx` `pypmix_credential_cbfunc` (~205, 226) | `size` is initialized to 0 and never updated, so `if 0 < size: free(c_byteobject.bytes)` never runs → credential bytes leak. |
+| D20 | `pmix.pyx` `PMIxClient.unpublish` (~777) | On alloc failure `PMIX_ERR_NOMEM` is evaluated but **not returned** (missing `return`); the code proceeds to use a possibly-NULL `keys`. |
+| D21 | `pmix.pyx` `get_version` | Returns `bytes`, not `str`, unlike the other accessors — callers must decode. Minor API inconsistency. |
+| D22 | `pmix.pyx` `PMIxServer.generate_cpuset_string` / `generate_locality_string` (~1962) | **NOT fixed (feature, not bug).** Honest stubs returning `PMIX_ERR_NOT_SUPPORTED`; the cpuset conversion layer they need is itself unimplemented. `PMIxScheduler.assign_session` is likewise now a well-formed stub (the truncation bug D2 is fixed) pending a C entry point — see Part 1. |
+
+---
+
+*Generated during the 2026-07 deep review. Keep this file in sync as gaps are
+closed and defects fixed.*

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -136,7 +136,7 @@ cdef void pmix_convert_locality(pmix_locality_t loc, pyloc:list):
         pyloc.append(PMIX_LOCALITY_SHARE_NUMA)
     if PMIX_LOCALITY_SHARE_NODE & loc:
         pyloc.append(PMIX_LOCALITY_SHARE_NODE)
-    if 0 == pyloc.len():
+    if 0 == len(pyloc):
         pyloc.append(PMIX_LOCALITY_NONLOCAL)
     return
 
@@ -321,7 +321,6 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
         for item in mylist:
             dptr[n] = float(item)
             n += 1
-            n += 1
     elif PMIX_TIMEVAL == mytype:
         # TODO: Not clear that "timeval" has the same size as
         # "struct timeval"
@@ -450,7 +449,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             piptr[n].state = item['state']
             n += 1
     elif PMIX_DATA_ARRAY == mytype:
-        array[0].array = <pmix_data_array_t*> PyMem_Malloc(sizeof(pmix_data_array_t))
+        array[0].array = <pmix_data_array_t*> PyMem_Malloc(mysize * sizeof(pmix_data_array_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         daptr = <pmix_data_array_t*>array[0].array
@@ -463,9 +462,12 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                 return PMIX_ERR_NOMEM
             mydaptr = <pmix_data_array_t*>daptr[n].array
             try:
-                return pmix_load_darray(mydaptr, daptr[n].type, item['value'])
+                rc = pmix_load_darray(mydaptr, daptr[n].type, item['value'])
+                if PMIX_SUCCESS != rc:
+                    return rc
             except:
                 return PMIX_ERR_NOT_SUPPORTED
+            n += 1
     elif PMIX_ALLOC_DIRECTIVE == mytype:
         array[0].array = PyMem_Malloc(mysize * sizeof(pmix_alloc_directive_t))
         if not array[0].array:
@@ -489,6 +491,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                 pyns = enval
             pynsptr = <const char *>(pyns)
             envptr[n].envar = strdup(pynsptr)
+            enval = item['value']
             if isinstance(enval, str):
                 pyns = enval.encode('ascii')
             else:
@@ -788,17 +791,19 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
             return PMIX_ERR_NOMEM
         daptr = <pmix_data_array_t*>array[0].array
         n = 0
+        list = []
         while n < array.size:
             if not daptr[n].array:
                 return PMIX_ERR_NOMEM
             mydaptr = <pmix_data_array_t*>daptr[n].array
             try:
-                rc = pmix_unload_darray(mydaptr)
-                if rc != PMIX_SUCCESS:
-                    return rc
+                d = pmix_unload_darray(mydaptr)
             except:
                 return PMIX_ERR_NOT_SUPPORTED
+            list.append(d)
             n += 1
+        darray = {'type':array.type, 'array':list}
+        return darray
     elif PMIX_ALLOC_DIRECTIVE == array.type:
         if not array[0].array:
             return PMIX_ERR_NOMEM
@@ -842,7 +847,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
     else:
         print("UNRECOGNIZED DATA TYPE IN ARRAY: "+str(array[0].type))
         return PMIX_ERR_NOT_SUPPORTED
-    return PMIX_SUCCESS
 
 # provide conversion programs that translate incoming
 # PMIx structures into Python dictionaries, and incoming
@@ -1083,7 +1087,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.tv.tv_usec = val['value']['usec']
 
     elif val['val_type'] == PMIX_TIME:
-        value[0].data.time = val['val_type']
+        value[0].data.time = val['value']
 
     elif val['val_type'] == PMIX_STATUS:
         if not isinstance(val['value'], int):
@@ -1407,6 +1411,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         osname = val['value']['osname']
         if isinstance(osname, str):
             pyosname = osname.encode('ascii')
+        else:
             pyosname = osname
         pyosnameptr = <const char *>(pyosname)
         value[0].data.devdist[0].osname = strdup(pyosnameptr)
@@ -1439,6 +1444,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         osname = val['value']['osname']
         if isinstance(osname, str):
             pyosname = osname.encode('ascii')
+        else:
             pyosname = osname
         pyosnameptr = <const char *>(pyosname)
         value[0].data.endpoint[0].osname = strdup(pyosnameptr)
@@ -1585,7 +1591,10 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         return {'value':{'nspace':pyns, 'rank':value[0].data.proc[0].rank}, 'val_type':PMIX_PROC}
 
     elif PMIX_BYTE_OBJECT == value[0].type:
-        mybytes = <bytes>value[0].data.bo.bytes[value[0].data.bo.size]
+        if NULL == value[0].data.bo.bytes:
+            mybytes = b''
+        else:
+            mybytes = value[0].data.bo.bytes[:value[0].data.bo.size]
         return {'value':{'bytes':mybytes, 'size':value[0].data.bo.size}, 'val_type':PMIX_BYTE_OBJECT}
 
     elif PMIX_REGEX == value[0].type:
@@ -1640,7 +1649,7 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
     elif PMIX_COORD == value[0].type:
         pyview = value[0].data.coord[0].view
         pydims = value[0].data.coord[0].dims
-        mybytes = <bytes>value[0].data.coord[0].coord[pydims]
+        mybytes = (<char*>value[0].data.coord[0].coord)[:pydims * sizeof(uint32_t)]
         return {'value': {'view': pyview, 'coord': mybytes, 'dims': pydims}, 'val_type': PMIX_COORD}
 
     elif PMIX_LINK_STATE == value[0].type:
@@ -1667,7 +1676,7 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         for n in range(pyncoord):
             pyview = value[0].data.geometry.coordinates[n].view
             pydims = value[0].data.geometry.coordinates[n].dims
-            mybytes = <bytes>value[0].data.geometry.coordinates[n].coord[pydims]
+            mybytes = (<char*>value[0].data.geometry.coordinates[n].coord)[:pydims * sizeof(uint32_t)]
             pyc = {'view': pyview, 'coord': mybytes, 'dims': pydims}
             pylist.append(pyc)
         return {'value': {'fabric': pyfabric, 'uuid': pyuuid, 'osname': pyosname, 'coords': pylist}, 'val_type': PMIX_GEOMETRY}
@@ -1690,8 +1699,11 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
     elif PMIX_ENDPOINT == value[0].type:
         pyuuid = (<bytes>value[0].data.endpoint[0].uuid).decode('UTF-8')
         pyosname = (<bytes>value[0].data.endpoint[0].osname).decode('UTF-8')
-        pysize = value[0].data.endpoint[0].size
-        mybytes = <bytes>value[0].data.endpoint[0].bytes[pysize]
+        pysize = value[0].data.endpoint[0].endpt.size
+        if NULL == value[0].data.endpoint[0].endpt.bytes:
+            mybytes = b''
+        else:
+            mybytes = value[0].data.endpoint[0].endpt.bytes[:pysize]
         pyval = {'uuid': pyuuid, 'osname': pyosname, 'endpt': {'bytes': mybytes, 'size': pysize}}
         return {'value': pyval, 'val_type': PMIX_ENDPOINT}
 
@@ -1897,12 +1909,14 @@ cdef void pmix_free_pdata(pmix_pdata_t *array, size_t sz):
 cdef int pmix_unload_queries(const pmix_query_t *queries, size_t nqueries, ilist:list):
     cdef char* kystr
     cdef size_t n = 0
-    keylist = []
-    qualist = []
-    query = {}
     while n < nqueries:
-        rc = pmix_unload_argv(queries[n].keys, keylist)
-        pmix_unload_info(queries[n].qualifiers, queries[n].nqual, qualist)
+        keylist = []
+        qualist = []
+        query = {}
+        if NULL != queries[n].keys:
+            pmix_unload_argv(queries[n].keys, keylist)
+        if NULL != queries[n].qualifiers:
+            pmix_unload_info(queries[n].qualifiers, queries[n].nqual, qualist)
         query['keys']       = keylist
         query['qualifiers'] = qualist
         ilist.append(query)
@@ -2028,14 +2042,14 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
             argv = <char**> malloc(m * sizeof(char*))
             if not argv:
                 return PMIX_ERR_NOMEM
-            memset(argv, 0, m)
+            memset(argv, 0, m * sizeof(char*))
             if p['argv'] is not None and 0 < len(p['argv']):
                 pmix_load_argv(argv, p['argv'])
             else:
                 pmix_load_argv(argv, [p['cmd']])
         except:
             argv = <char**> malloc(2 * sizeof(char*))
-            memset(argv, 0, 2)
+            memset(argv, 0, 2 * sizeof(char*))
             rc = pmix_load_argv(argv, [p['cmd']])
             if PMIX_SUCCESS != rc:
                 free(argv)
@@ -2048,7 +2062,7 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
                 env = <char**> malloc(m * sizeof(char*))
                 if not env:
                     return PMIX_ERR_NOMEM
-                memset(env, 0, m)
+                memset(env, 0, m * sizeof(char*))
                 pmix_load_argv(env, p['env'])
                 apps[n].env = env
         except:

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -211,9 +211,10 @@ def pypmix_credential_cbfunc(int rc, dict byteobject, list info, dict cbdata_dic
         return
 
     if PMIX_SUCCESS == rc:
-        c_byteobject.size = byteobject['size']
-        c_byteobject.bytes = <char *> malloc(byteobject['size'])
-        memcpy(c_byteobject.bytes, <void *> byteobject['bytes'], byteobject['size'])
+        size = byteobject['size']
+        c_byteobject.size = size
+        c_byteobject.bytes = <char *> malloc(size)
+        memcpy(c_byteobject.bytes, <void *> byteobject['bytes'], size)
 
         prc = pmix_alloc_info(&c_info, &ninfo, info)
         if PMIX_SUCCESS != prc:
@@ -465,7 +466,10 @@ cdef class PMIxClient:
         return PMIx_Initialized()
 
     def get_version(self):
-        return PMIx_Get_version()
+        cdef const char *v = PMIx_Get_version()
+        if NULL == v:
+            return None
+        return v.decode('ascii')
 
     # Initialize the PMIx client library, connecting
     # us to the local PMIx server
@@ -723,7 +727,10 @@ cdef class PMIxClient:
                 rc = PMIx_Get(&p, key, info, ninfo, &val_ptr)
         if PMIX_SUCCESS == rc:
             val = pmix_unload_value(val_ptr)
-            pmix_free_value(self, val_ptr)
+            # val_ptr was allocated by the PMIx library (PMIX_VALUE_CREATE),
+            # so it must be released with the library's own allocator rather
+            # than PyMem_Free.
+            PMIx_Value_free(val_ptr, 1)
         if 0 < ninfo:
             pmix_free_info(info, ninfo)
         return rc, val
@@ -772,9 +779,9 @@ cdef class PMIxClient:
         if pykeys is not None:
             nstrings = len(pykeys)
             if 0 < nstrings:
-                keys = <char **> PyMem_Malloc(nstrings * sizeof(char*))
+                keys = <char **> PyMem_Malloc((nstrings + 1) * sizeof(char*))
                 if not keys:
-                    PMIX_ERR_NOMEM
+                    return PMIX_ERR_NOMEM
             rc = pmix_load_argv(keys, pykeys)
             if PMIX_SUCCESS != rc:
                 n = 0
@@ -1478,7 +1485,10 @@ cdef class PMIxClient:
             pmix_free_info(info, ninfo)
         return rc
 
-    def register_event_handler(self, pycodes:list, pyinfo:list, hdlr):
+    def register_event_handler(self, pycodes, pyinfo, hdlr):
+        # pycodes/pyinfo are intentionally untyped: the body accepts either a
+        # list or None (None => register a default handler / no directives).
+        # A `:list` annotation would make Cython reject None at the boundary.
         cdef pmix_status_t *codes
         cdef size_t ncodes
         cdef pmix_info_t *info
@@ -1785,7 +1795,7 @@ def setmodulefn(k, f):
     permitted = ['clientconnected', 'clientfinalized', 'abort',
                  'fencenb', 'directmodex', 'publish', 'lookup', 'unpublish',
                  'spawn', 'connect', 'disconnect', 'registerevents',
-                 'deregisterevents', 'listener', 'notify_event', 'query',
+                 'deregisterevents', 'listener', 'notifyevent', 'query',
                  'toolconnected', 'log', 'allocate', 'jobcontrol',
                  'monitor', 'getcredential', 'validatecredential',
                  'iofpull', 'pushstdin', 'group', 'fabric', 'clientconnected2',
@@ -2012,7 +2022,7 @@ cdef class PMIxServer(PMIxClient):
         return
 
     # Register resources
-    def register_resources(directives:list):
+    def register_resources(self, directives:list):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2027,7 +2037,7 @@ cdef class PMIxServer(PMIxClient):
         return rc
 
     # Deregister resources
-    def deregister_resources(directives:list):
+    def deregister_resources(self, directives:list):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2141,7 +2151,7 @@ cdef class PMIxServer(PMIxClient):
             active.fetch_info(dataout)
         return (rc, dataout)
 
-    def register_attributes(function:str, attrs:list):
+    def register_attributes(self, function:str, attrs:list):
         cdef size_t nattrs
         cdef char *func
         cdef char **attarray
@@ -2173,7 +2183,7 @@ cdef class PMIxServer(PMIxClient):
             PyMem_Free(func)
         return PMIX_SUCCESS
 
-    def collect_inventory(pydirs:list):
+    def collect_inventory(self, pydirs:list):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
@@ -2194,7 +2204,7 @@ cdef class PMIxServer(PMIxClient):
             active.fetch_info(dataout)
         return (rc, dataout)
 
-    def deliver_inventory(pyinfo:list, pydirs:list):
+    def deliver_inventory(self, pyinfo:list, pydirs:list):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_info_t *info
@@ -2235,27 +2245,23 @@ cdef class PMIxServer(PMIxClient):
             active.wait()
         return rc
 
-    def iof_deliver(pysrc:dict, pychannel:int, pydata:dict, pydirs:list):
-        cdef pmix_proc_t *source
+    def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs:list):
+        cdef pmix_proc_t source
         cdef pmix_iof_channel_t channel
-        cdef pmix_byte_object_t *bo
+        cdef pmix_byte_object_t bo
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
-        source  = NULL
         ndirs   = 0
         channel = pychannel
 
         # convert pysrc to pmix_proc_t
-        pmix_copy_nspace(source[0].nspace, pysrc['nspace'])
-        source[0].rank = pysrc['rank']
+        pmix_copy_nspace(source.nspace, pysrc['nspace'])
+        source.rank = pysrc['rank']
 
         # convert pydata to pmix_byte_object_t
-        bo = <pmix_byte_object_t*>PyMem_Malloc(sizeof(pmix_byte_object_t))
-        if not bo:
-            return PMIX_ERR_NOMEM
         data = bytes(pydata['bytes'], 'ascii')
-        bo.size = sizeof(data)
+        bo.size = len(data)
         bo.bytes = <char*> PyMem_Malloc(bo.size)
         if not bo.bytes:
             return PMIX_ERR_NOMEM
@@ -2267,11 +2273,14 @@ cdef class PMIxServer(PMIxClient):
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
 
         # call API
-        rc = PMIx_server_IOF_deliver(source, channel, bo, directives, ndirs,
+        rc = PMIx_server_IOF_deliver(&source, channel, &bo, directives, ndirs,
                                      NULL, NULL)
+        PyMem_Free(bo.bytes)
+        if 0 < ndirs:
+            pmix_free_info(directives, ndirs)
         return rc
 
-    def define_process_set(members:list, name:str):
+    def define_process_set(self, members:list, name:str):
         cdef pmix_proc_t *procs
         cdef size_t nprocs
         nprocs = 0
@@ -2294,7 +2303,7 @@ cdef class PMIxServer(PMIxClient):
         pmix_free_procs(procs, nprocs)
         return rc
 
-    def delete_process_set(name:str):
+    def delete_process_set(self, name:str):
 
         # convert set name
         pyset = name.encode('ascii')
@@ -2302,7 +2311,7 @@ cdef class PMIxServer(PMIxClient):
         rc = PMIx_server_delete_process_set(pyset)
         return rc
 
-    def session_control(sessionID:int, ilist:list):
+    def session_control(self, sessionID:int, ilist:list):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3075,7 +3084,7 @@ cdef class PMIxTool(PMIxServer):
         return PMIx_tool_is_connected()
 
     # Disconnect from a server
-    def disconnect(server:dict):
+    def disconnect(self, server:dict):
         cdef pmix_proc_t srvr
 
         # convert the server name
@@ -3244,12 +3253,13 @@ cdef class PMIxTool(PMIxServer):
         # remove our local hdlr
         found = False
         n = 0
-        for h in myhdlrs and not found:
+        for h in myhdlrs:
             try:
                 if iofhdlr == h['refid']:
                     found = True
                     del myhdlrs[n]
-                else :
+                    break
+                else:
                     n = n + 1
             except:
                 pass
@@ -3330,8 +3340,9 @@ cdef class PMIxScheduler(PMIxTool):
         # init myname
         myname = {'nspace':'UNASSIGNED', 'rank':PMIX_RANK_UNDEF}
 
-        # init server module in case the scheduler uses it
-        self.server_module_init()
+        # init server module in case the scheduler uses it (wire whatever
+        # module functions were registered via set_server_module, if any)
+        self.server_module_init(list(pmixservermodule.keys()))
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -3356,7 +3367,7 @@ cdef class PMIxScheduler(PMIxTool):
         return rc
 
     # direct the RTE to instantiate a session
-    def assign_session(sessionID:int, allocID:str, ilist:list, applist:list):
+    def assign_session(self, sessionID:int, allocID:str, ilist:list, applist:list):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3365,7 +3376,12 @@ cdef class PMIxScheduler(PMIxTool):
         rc = pmix_alloc_info(info_ptr, &sz, ilist)
         if PMIX_SUCCESS != rc:
             return rc
-        if sz == 0:
-            info = NULL
-        # convert the app list
+        # NOTE: the PMIx library does not yet expose a C entry point that lets
+        # a scheduler directly instantiate a session from an application list.
+        # When one is added, this method must convert applist and invoke it.
+        # Until then, release what we converted and report the gap rather than
+        # silently returning None. See MISSING_BINDINGS.md.
+        if 0 < sz:
+            pmix_free_info(info, sz)
+        return PMIX_ERR_NOT_SUPPORTED
 

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -15,14 +15,20 @@ noinst_SCRIPTS = \
 	run_sched.sh.in \
     server.py \
     sched.py \
-    client.py
+    client.py \
+    test_bindings.py
 
 #########################
 # Support for "make check"
 
 if WANT_PYTHON_BINDINGS
 
+# test_bindings.py is a self-contained unittest suite that needs no live
+# server; it locates the built extension itself and SKIPs (exit 77) if the
+# pmix module cannot be imported.  run_server.sh / run_sched.sh exercise the
+# connected client/server/scheduler round-trip paths.
 TESTS = \
+    test_bindings.py \
     run_server.sh \
     run_sched.sh
 

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -17,15 +17,22 @@ class GracefulKiller:
   def exit_gracefully(self,signum, frame):
     self.kill_now = True
 
-def clientconnected(proc:dict is not None):
+# Server-module upcall handlers. The binding invokes each registered
+# handler with three arguments: the converted request (proc/args dict),
+# a Python wrapper around the C completion callback, and an opaque cbdata
+# dict. A handler drives completion by invoking that callback and returns
+# PMIX_SUCCESS. (See bindings/python/tests/python/server_upcalls.py.)
+def clientconnected(proc, cbfunc, cbdata):
     print("CLIENT CONNECTED", proc)
+    cbfunc(PMIX_SUCCESS, cbdata)
     return PMIX_SUCCESS
 
-def clientfinalized(proc:dict is not None):
+def clientfinalized(proc, cbfunc, cbdata):
     print("CLIENT FINALIZED", proc)
+    cbfunc(PMIX_SUCCESS, cbdata)
     return PMIX_SUCCESS
 
-def clientfence(args:dict is not None):
+def clientfence(args, cbfunc, cbdata):
     # check directives
     try:
         if args['directives'] is not None:
@@ -43,7 +50,9 @@ def clientfence(args:dict is not None):
                         pass
     except:
         pass
-    return PMIX_SUCCESS, None
+    # no data to return from this (empty) fence
+    cbfunc(PMIX_SUCCESS, bytearray(0), cbdata)
+    return PMIX_SUCCESS
 
 def main():
     try:

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Standalone unit tests for the PMIx Python bindings.
+#
+# These tests exercise only the parts of the binding that do NOT require a
+# live PMIx server: module import, the class hierarchy, constant definitions,
+# and the many stateless string/pretty-print converters.  The existing
+# client.py/server.py/sched.py scripts cover the connected round-trip paths;
+# this file provides fast, self-contained coverage that runs under `make
+# check` (when the extension is already on PYTHONPATH) or directly from a
+# built-but-not-installed tree.
+#
+# Run directly with:
+#     PYTHONPATH=<dir containing pmix*.so> ./test_bindings.py
+# or, from an in-tree build, simply:
+#     ./test_bindings.py
+# (the module search below will locate the freshly built extension).
+
+import os
+import sys
+import glob
+import unittest
+
+
+def _locate_extension():
+    """Add the in-tree built extension to sys.path if pmix isn't importable.
+
+    Mirrors what the autotools-generated run scripts do via
+    PMIX_PYTHON_EGG_PATH, but also works when a developer runs this file by
+    hand from a build tree that has not been installed.
+    """
+    try:
+        import pmix  # noqa: F401
+        return
+    except ImportError:
+        pass
+    here = os.path.dirname(os.path.abspath(__file__))
+    # test/python -> repo root -> bindings/python/build/lib.*
+    root = os.path.abspath(os.path.join(here, "..", ".."))
+    patterns = [
+        os.path.join(root, "bindings", "python", "build", "lib.*"),
+        os.path.join(root, "bindings", "python"),
+    ]
+    for pat in patterns:
+        for d in sorted(glob.glob(pat)):
+            if glob.glob(os.path.join(d, "pmix*.so")):
+                sys.path.insert(0, d)
+                return
+
+
+_locate_extension()
+
+try:
+    import pmix
+except ImportError as e:  # pragma: no cover - environment problem
+    sys.stderr.write("Unable to import the pmix extension: %s\n" % e)
+    sys.stderr.write("Set PYTHONPATH to the directory holding pmix*.so.\n")
+    # Exit 77 is the automake "SKIP" code
+    sys.exit(77)
+
+
+class TestModule(unittest.TestCase):
+    def test_classes_present(self):
+        for name in ("PMIxClient", "PMIxServer", "PMIxTool", "PMIxScheduler"):
+            self.assertTrue(hasattr(pmix, name), "missing class " + name)
+
+    def test_class_hierarchy(self):
+        # The role classes form an inheritance chain
+        self.assertTrue(issubclass(pmix.PMIxServer, pmix.PMIxClient))
+        self.assertTrue(issubclass(pmix.PMIxTool, pmix.PMIxServer))
+        self.assertTrue(issubclass(pmix.PMIxScheduler, pmix.PMIxTool))
+
+    def test_construct(self):
+        # Every role must be constructible without a server
+        for cls in (pmix.PMIxClient, pmix.PMIxServer,
+                    pmix.PMIxTool, pmix.PMIxScheduler):
+            obj = cls()
+            self.assertIsNotNone(obj)
+
+
+class TestConstants(unittest.TestCase):
+    def test_success_is_zero(self):
+        self.assertEqual(pmix.PMIX_SUCCESS, 0)
+
+    def test_error_codes_negative(self):
+        for name in ("PMIX_ERR_NOT_SUPPORTED", "PMIX_ERR_NOT_FOUND",
+                     "PMIX_ERR_BAD_PARAM", "PMIX_ERR_NOMEM"):
+            self.assertLess(getattr(pmix, name), 0, name + " should be < 0")
+
+    def test_rank_wildcard(self):
+        # PMIX_RANK_WILDCARD is UINT32_MAX - 1
+        self.assertEqual(pmix.PMIX_RANK_WILDCARD, 0xFFFFFFFF - 1)
+
+    def test_rank_undef(self):
+        self.assertEqual(pmix.PMIX_RANK_UNDEF, 0xFFFFFFFF)
+
+    def test_max_lengths(self):
+        # These bound the fixed-size nspace/key arrays in the C structs
+        self.assertGreater(pmix.PMIX_MAX_NSLEN, 0)
+        self.assertGreater(pmix.PMIX_MAX_KEYLEN, 0)
+
+    def test_datatype_constants_distinct(self):
+        # A representative spread of data-type constants must all differ
+        types = [pmix.PMIX_INT, pmix.PMIX_INT32, pmix.PMIX_UINT64,
+                 pmix.PMIX_STRING, pmix.PMIX_BOOL, pmix.PMIX_PROC,
+                 pmix.PMIX_INFO, pmix.PMIX_DATA_ARRAY]
+        self.assertEqual(len(types), len(set(types)))
+
+    def test_scope_constants(self):
+        self.assertNotEqual(pmix.PMIX_LOCAL, pmix.PMIX_REMOTE)
+        self.assertNotEqual(pmix.PMIX_GLOBAL, pmix.PMIX_LOCAL)
+
+
+class TestVersion(unittest.TestCase):
+    def setUp(self):
+        self.client = pmix.PMIxClient()
+
+    def test_get_version_nonempty(self):
+        v = self.client.get_version()
+        self.assertTrue(len(v) > 0)
+
+    def test_get_version_is_str(self):
+        # get_version decodes to str
+        self.assertIsInstance(self.client.get_version(), str)
+
+    def test_get_version_mentions_pmix(self):
+        v = self.client.get_version()
+        if isinstance(v, bytes):
+            v = v.decode("utf-8", "replace")
+        self.assertIn("PMIx", v)
+
+    def test_initialized_false_before_init(self):
+        # Must be falsey and must not raise before PMIx_Init has run
+        self.assertFalse(self.client.initialized())
+
+
+class TestStringConverters(unittest.TestCase):
+    """The *_string helpers are pure lookups in the C library and are safe to
+    call with no server and no init()."""
+
+    def setUp(self):
+        self.c = pmix.PMIxClient()
+
+    def _check(self, s):
+        if isinstance(s, bytes):
+            s = s.decode("utf-8", "replace")
+        self.assertIsInstance(s, str)
+        self.assertTrue(len(s) > 0)
+        return s
+
+    def test_error_string_known(self):
+        self.assertEqual(self._check(self.c.error_string(pmix.PMIX_SUCCESS)),
+                         "PMIX_SUCCESS")
+        self.assertEqual(
+            self._check(self.c.error_string(pmix.PMIX_ERR_NOT_SUPPORTED)),
+            "PMIX_ERR_NOT_SUPPORTED")
+
+    def test_data_type_string_known(self):
+        self.assertEqual(
+            self._check(self.c.data_type_string(pmix.PMIX_INT32)),
+            "PMIX_INT32")
+
+    def test_scope_string(self):
+        self._check(self.c.scope_string(pmix.PMIX_GLOBAL))
+
+    def test_persistence_string(self):
+        self._check(self.c.persistence_string(pmix.PMIX_PERSIST_SESSION))
+
+    def test_data_range_string(self):
+        self._check(self.c.data_range_string(pmix.PMIX_RANGE_LOCAL))
+
+    def test_proc_state_string(self):
+        self._check(
+            self.c.proc_state_string(pmix.PMIX_PROC_STATE_UNTERMINATED))
+
+    def test_job_state_string(self):
+        self._check(self.c.job_state_string(pmix.PMIX_JOB_STATE_RUNNING))
+
+    def test_alloc_directive_string(self):
+        self._check(self.c.alloc_directive_string(pmix.PMIX_ALLOC_NEW))
+
+    def test_iof_channel_string(self):
+        self._check(self.c.iof_channel_string(pmix.PMIX_FWD_STDOUT_CHANNEL))
+
+    def test_info_directives_string(self):
+        self._check(self.c.info_directives_string(pmix.PMIX_INFO_REQD))
+
+    def test_attribute_name_roundtrip(self):
+        # get_attribute_name maps a string key back to its PMIX_ symbol.
+        name = self.c.get_attribute_name("pmix.rank")
+        if isinstance(name, bytes):
+            name = name.decode("utf-8", "replace")
+        self.assertIsInstance(name, str)
+
+
+class TestMethodBinding(unittest.TestCase):
+    """Regression tests for methods that were previously unusable because they
+    were declared without a `self` parameter (or were truncated). These reach
+    an early return before any C call, so they run with no server."""
+
+    def test_assign_session_is_bound_and_complete(self):
+        # Previously truncated (returned None) and missing self. It must now
+        # accept its four args and return a real status.
+        sched = pmix.PMIxScheduler()
+        rc = sched.assign_session(0, "alloc-0", [], [])
+        self.assertEqual(rc, pmix.PMIX_ERR_NOT_SUPPORTED)
+
+    def test_server_methods_have_self(self):
+        # Every method that was missing self must now declare it as the first
+        # parameter. Verify via signature introspection where possible.
+        import inspect
+        names = ["register_resources", "deregister_resources",
+                 "register_attributes", "collect_inventory",
+                 "deliver_inventory", "iof_deliver", "define_process_set",
+                 "delete_process_set", "session_control"]
+        for name in names:
+            meth = getattr(pmix.PMIxServer, name, None)
+            self.assertIsNotNone(meth, "PMIxServer.%s missing" % name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

A review of the Python bindings (`bindings/python/`) that turned into a
round of fixes, tests, and orientation docs.

### Defect fixes (`pmix.pyx`, `pmix.pxi`)

~22 real bugs in the conversion layer and the role-class methods, e.g.:

- **Unusable methods** — eleven `PMIxServer`/`PMIxTool`/`PMIxScheduler`
  methods were missing the `self` parameter (raised `TypeError`);
  `PMIxScheduler.assign_session` was truncated mid-function;
  `PMIxScheduler.init` called `server_module_init()` with no argument;
  `iof_deliver` dereferenced a NULL `source`; `iof_deregister` iterated a
  boolean; `register_event_handler(None, …)` was rejected by a `:list`
  annotation despite the body handling `None`.
- **Data corruption** in conversion arms — `list.len()`, a double index
  increment for `PMIX_DOUBLE`, the envar value copied from the wrong key,
  `PMIX_TIME` storing the type not the value, single-element reads past a
  buffer (byte object / coord / geometry / endpoint), a reused dict in
  `pmix_unload_queries`, and `memset` sized in bytes rather than pointers.
- **Leaks / correctness** — `PMIx_Get`'s value freed with the wrong
  allocator (now `PMIx_Value_free`), a leaked credential payload, a
  missing `return` in `unpublish`, and `get_version` now decoding to
  `str`.

### Tests

`test/python/test_bindings.py` — a self-contained `unittest` suite (no
server required) covering import, the class hierarchy, constants, the
stateless `*_string` converters, and regression checks for the corrected
method signatures. Wired into `make check`; skips cleanly if the module
isn't importable.

`test/python/server.py` was stale — its server-module handlers used the
old one-argument signature; updated to the current
`(request, cbfunc, cbdata)` upcall convention so the connected round-trip
runs.

### Docs

`bindings/python/AGENTS.md` (+ `CLAUDE.md` symlink) — developer
orientation to the bindings. `bindings/python/MISSING_BINDINGS.md` —
tracks the operational C APIs still lacking Python bindings (the
non-blocking variants, `PMIx_Heartbeat`, `PMIx_Progress_thread_stop`,
`PMIx_Resource_block`, `PMIx_generate_regex2`/`parse_regex2`,
`PMIx_server_collect_job_info`) for a later implementation pass, and
catalogues the defects fixed here.

## Verification

- Source cythonizes warning-free; the 27-case unit suite passes.
- Connected `server.py` ↔ `client.py` round-trip runs clean:
  `put`(INT32) → `commit` → `fence` → `get` returns the correct value
  (`{'value': 1, 'val_type': 9}`), with the event handler and the
  `clientconnected`/`clientfinalized`/`fencenb` upcalls all firing.

## Notes

- The still-missing non-blocking bindings and `assign_session`'s real
  implementation are intentionally left for a follow-up (tracked in
  `MISSING_BINDINGS.md`).
- While validating, I hit a pre-existing environmental blocker unrelated
  to the bindings — a stale `pmix.sched.<host>` rendezvous file makes the
  server listener setup abort — filed separately as #4022.
