### PR TITLE
Forward the zero-byte stdin push to the host

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -2143,19 +2143,25 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
             /* nothing we can do with this info - no point in reactivating it */
             return;
         }
-        if (0 == bo.size) {
-            // our stdin fd has closed - nothing to do, and
-            // we don't reactivate the event
-            return;
-        }
         PMIX_BYTE_OBJECT_CREATE(boptr, 1);
         if (0 < bo.size) {
             boptr->bytes = (char*)malloc(bo.size);
             memcpy(boptr->bytes, bo.bytes, bo.size);
             boptr->size = bo.size;
         }
+        /* push this to the host even when it is empty - a zero-byte push is
+         * how the host learns that our stdin has closed so it can close the
+         * targets' stdin in turn. Dropping it leaves every target waiting on
+         * an EOF that never arrives
+         */
         rc = pmix_host_server.push_stdin(&pmix_globals.myid, rev->targets, rev->ntargets,
                                          rev->directives, rev->ndirs, boptr, opcbfn, (void*)boptr);
+        if (0 == bo.size) {
+            /* our stdin fd has closed - there is nothing left to read, so
+             * do not reactivate the event
+             */
+            return;
+        }
         goto reactivate;
     }
 


### PR DESCRIPTION
### Problem

A PMIx server that reads its own stdin on behalf of a set of targets never
tells its host when that stdin closes. In `pmix_iof_read_local_handler`, the
server branch returned as soon as the read came back empty:

```c
if (0 == bo.size) {
    // our stdin fd has closed - nothing to do, and
    // we don't reactivate the event
    return;
}
```

But there *is* something to do: the zero-byte push is how the host learns to
close stdin on each target proc. Dropping it leaves every target blocked on a
read that never returns.

This is visible in PRRTE as `prterun` hanging whenever the application reads
to EOF:

```
$ echo hello | prterun -n 1 cat
hello
    <hangs forever - cat never sees EOF>
```

All of the input arrives; only the close is lost. The host side is already
written for this: PRRTE's `pmix_server_stdin_push` treats an empty byte object
as `PMIX_ERR_IOF_COMPLETE`, and the tool/launcher path in this same function
forwards a zero-length push rather than dropping it. Only the
server-reads-its-own-stdin path diverged.

### Fix

Build the byte object and call `pmix_host_server.push_stdin` before deciding
whether to rearm the read event. The early return keeps its original job -- a
closed fd must not have its read event reactivated -- but it no longer
suppresses the notification.

### Testing

Verified against PRRTE in a 10-container multi-node DVM. With the patch,
`echo ... | prterun -n 1 cat` shows the new `push_stdin ... (size 0)` and the
proc receives its EOF, where before the push never reached the host. Note that
I am still chasing an intermittent hang in repeated `prterun` stdin runs on
that setup (roughly every other invocation produces no output at all); it may
be unrelated to this change, and I did not want to hold the fix for it.
