### PR TITLE
Serialize access to the param file parser's static state

### DIFF
--- a/src/mca/base/pmix_mca_base_parse_paramfile.c
+++ b/src/mca/base/pmix_mca_base_parse_paramfile.c
@@ -31,25 +31,46 @@
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/base/pmix_mca_base_vari.h"
 #include "src/mca/mca.h"
+#include "src/threads/pmix_threads.h"
 #include "src/util/pmix_keyval_parse.h"
 
 static void save_value(const char *file, int lineno,
                        const char *name, const char *value);
 
+/* the parser callback can only reach its target list through
+ * file-scope storage, so callers on different threads (e.g., the
+ * host's progress thread and our own) must be serialized across
+ * both the assignment and the parse itself */
+static pmix_mutex_t param_file_mutex = PMIX_MUTEX_STATIC_INIT;
 static char *file_being_read;
 static pmix_list_t *_param_list;
 
 int pmix_mca_base_parse_paramfile(const char *paramfile, pmix_list_t *list)
 {
+    int ret;
+
+    pmix_mutex_lock(&param_file_mutex);
     file_being_read = (char *) paramfile;
     _param_list = list;
 
-    return pmix_util_keyval_parse(paramfile, save_value);
+    ret = pmix_util_keyval_parse(paramfile, save_value);
+    pmix_mutex_unlock(&param_file_mutex);
+
+    return ret;
 }
 
-int pmix_mca_base_internal_env_store(void)
+int pmix_mca_base_internal_env_store(pmix_list_t *list)
 {
-    return pmix_util_keyval_save_internal_envars(save_value);
+    int ret;
+
+    pmix_mutex_lock(&param_file_mutex);
+    file_being_read = NULL;
+    _param_list = list;
+
+    ret = pmix_util_keyval_save_internal_envars(save_value);
+    pmix_mutex_unlock(&param_file_mutex);
+
+    return ret;
 }
 
 static void save_value(const char *file, int lineno,

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -1123,7 +1123,7 @@ static int read_files(char *file_list, pmix_list_t *file_values, char sep)
 
     PMIx_Argv_free(tmp);
 
-    pmix_mca_base_internal_env_store();
+    pmix_mca_base_internal_env_store(file_values);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/base/pmix_mca_base_vari.h
+++ b/src/mca/base/pmix_mca_base_vari.h
@@ -138,7 +138,7 @@ PMIX_EXPORT int pmix_mca_base_var_generate_full_name4(const char *project, const
  *
  * Call save_value callback for generated internal mca parameter storing env variables
  */
-PMIX_EXPORT int pmix_mca_base_internal_env_store(void);
+PMIX_EXPORT int pmix_mca_base_internal_env_store(pmix_list_t *list);
 
 /**
  * \internal


### PR DESCRIPTION
## Problem

pmix_mca_base_parse_paramfile hands its output list to the keyval parser callback through file-scope static storage, assigned before the call into pmix_util_keyval_parse. The parser core serializes itself internally, but those static assignments sit outside its mutex — two threads parsing param files concurrently can leave one thread's callback appending to the other caller's list, which typically lives on the other thread's stack and may already have been destructed.

This is not theoretical: a host environment doing personality translation on its own progress thread (PRRTE's schizo/ompi component harvesting OMPI params while servicing a spawn request) races with our pmdl/ompi component parsing the same files on the PMIx progress thread. The loser segfaults inside the callback — this is the intermittent mpi4py CI crash in TestSpawnMultipleWorldMany (crash in prte's spawn handler under prte_schizo_base_detect_proxy → pmix_util_keyval_parse), exposed once PRRTE's server upcalls began completing asynchronously.

## Fix

Guard the static state and the parse with a mutex held across both. pmix_mca_base_internal_env_store silently depended on the target list assigned by a prior parse_paramfile call — a cross-call window the same race could corrupt — so it now takes the list explicitly and sets the static state under the same mutex.

## Verification

Warning-free build, make check all pass, plus a live PRRTE spawn test (prterun --personality ompi running the dynamic/client example) against the patched library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)