### PR TITLE
Pass the keyval parser's context to its callback

### DIFF
--- a/src/mca/base/pmix_mca_base_parse_paramfile.c
+++ b/src/mca/base/pmix_mca_base_parse_paramfile.c
@@ -31,60 +31,39 @@
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/base/pmix_mca_base_vari.h"
 #include "src/mca/mca.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/pmix_keyval_parse.h"
 
 static void save_value(const char *file, int lineno,
-                       const char *name, const char *value);
-
-/* the parser callback can only reach its target list through
- * file-scope storage, so callers on different threads (e.g., the
- * host's progress thread and our own) must be serialized across
- * both the assignment and the parse itself */
-static pmix_mutex_t param_file_mutex = PMIX_MUTEX_STATIC_INIT;
-static char *file_being_read;
-static pmix_list_t *_param_list;
+                       const char *name, const char *value,
+                       void *cbdata);
 
 int pmix_mca_base_parse_paramfile(const char *paramfile, pmix_list_t *list)
 {
-    int ret;
-
-    pmix_mutex_lock(&param_file_mutex);
-    file_being_read = (char *) paramfile;
-    _param_list = list;
-
-    ret = pmix_util_keyval_parse(paramfile, save_value);
-    pmix_mutex_unlock(&param_file_mutex);
-
-    return ret;
+    return pmix_util_keyval_parse(paramfile, save_value, list);
 }
 
 int pmix_mca_base_internal_env_store(pmix_list_t *list)
 {
-    int ret;
-
-    pmix_mutex_lock(&param_file_mutex);
-    file_being_read = NULL;
-    _param_list = list;
-
-    ret = pmix_util_keyval_save_internal_envars(save_value);
-    pmix_mutex_unlock(&param_file_mutex);
-
-    return ret;
+    return pmix_util_keyval_save_internal_envars(save_value, list);
 }
 
+/* the parser hands us everything we need - the target list rides
+ * along in cbdata, and the origin of the pair comes in as file/lineno
+ * - so this callback touches no state shared with its caller and
+ * requires no serialization of its own */
 static void save_value(const char *file, int lineno,
-                       const char *name, const char *value)
+                       const char *name, const char *value,
+                       void *cbdata)
 {
+    pmix_list_t *param_list = (pmix_list_t *) cbdata;
     pmix_mca_base_var_file_value_t *fv;
     bool found = false;
-    PMIX_HIDE_UNUSED_PARAMS(file, lineno);
 
     /* First traverse through the list and ensure that we don't
        already have a param of this name.  If we do, just replace the
        value. */
 
-    PMIX_LIST_FOREACH (fv, _param_list, pmix_mca_base_var_file_value_t) {
+    PMIX_LIST_FOREACH (fv, param_list, pmix_mca_base_var_file_value_t) {
         if (0 == strcmp(name, fv->mbvfv_var)) {
             if (NULL != fv->mbvfv_value) {
                 free(fv->mbvfv_value);
@@ -102,10 +81,12 @@ static void save_value(const char *file, int lineno,
         }
 
         fv->mbvfv_var = strdup(name);
-        pmix_list_append(_param_list, &fv->super);
+        pmix_list_append(param_list, &fv->super);
     }
 
     fv->mbvfv_value = value ? strdup(value) : NULL;
-    fv->mbvfv_file = file_being_read;
-    fv->mbvfv_lineno = pmix_util_keyval_parse_lineno;
+    /* the file name is not ours to own - it belongs to the caller that
+     * asked for the file to be parsed, and outlives this list */
+    fv->mbvfv_file = (char *) file;
+    fv->mbvfv_lineno = lineno;
 }

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -358,9 +358,10 @@ static void filter_flags(char*** argvp)
 }
 
 static void data_callback(const char *file, int lineno,
-                          const char *key, const char *value)
+                          const char *key, const char *value,
+                          void *cbdata)
 {
-    PMIX_HIDE_UNUSED_PARAMS(file, lineno);
+    PMIX_HIDE_UNUSED_PARAMS(file, lineno, cbdata);
 
     /* handle case where text file does not contain any special
      compiler options field */
@@ -467,7 +468,7 @@ static int data_init(void)
     if (NULL == datafile)
         return PMIX_ERR_OUT_OF_RESOURCE;
 
-    ret = pmix_util_keyval_parse(datafile, data_callback);
+    ret = pmix_util_keyval_parse(datafile, data_callback, NULL);
     if (PMIX_SUCCESS != ret) {
         fprintf(stderr, "Cannot open configuration file %s\n", datafile);
     }

--- a/src/util/pmix_keyval_parse.c
+++ b/src/util/pmix_keyval_parse.c
@@ -39,9 +39,10 @@ static char *key_buffer = NULL;
 static size_t key_buffer_len = 0;
 static pmix_mutex_t keyval_mutex;
 
-static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback);
+static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback,
+                      void *cbdata);
 static int parse_line_new(const char *filename, int first_val,
-                          pmix_keyval_parse_fn_t callback);
+                          pmix_keyval_parse_fn_t callback, void *cbdata);
 static void parse_error(int num, const char *filename);
 
 static char *env_str = NULL;
@@ -63,11 +64,11 @@ int pmix_util_keyval_parse_init(void)
     return PMIX_SUCCESS;
 }
 
-int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback)
+int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback,
+                           void *cbdata)
 {
     int val;
     int ret = PMIX_SUCCESS;
-    ;
 
     pmix_mutex_lock(&keyval_mutex);
 
@@ -94,13 +95,13 @@ int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback
                 break;
 
             case PMIX_UTIL_KEYVAL_PARSE_SINGLE_WORD:
-                parse_line(filename, callback);
+                parse_line(filename, callback, cbdata);
                 break;
 
             case PMIX_UTIL_KEYVAL_PARSE_MCAVAR:
             case PMIX_UTIL_KEYVAL_PARSE_ENVVAR:
             case PMIX_UTIL_KEYVAL_PARSE_ENVEQL:
-                parse_line_new(filename, val, callback);
+                parse_line_new(filename, val, callback, cbdata);
                 break;
 
             default:
@@ -117,11 +118,14 @@ cleanup:
     return ret;
 }
 
-static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback)
+static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback,
+                      void *cbdata)
 {
     int val;
+    int lineno;
 
-    pmix_util_keyval_parse_lineno = pmix_util_keyval_yylineno;
+    lineno = pmix_util_keyval_yylineno;
+    pmix_util_keyval_parse_lineno = lineno;
 
     /* Save the name name */
     if (key_buffer_len < strlen(pmix_util_keyval_yytext) + 1) {
@@ -151,7 +155,7 @@ static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback)
 
     val = pmix_util_keyval_yylex();
     if (PMIX_UTIL_KEYVAL_PARSE_SINGLE_WORD == val || PMIX_UTIL_KEYVAL_PARSE_VALUE == val) {
-        callback(filename, 0, key_buffer, pmix_util_keyval_yytext);
+        callback(filename, lineno, key_buffer, pmix_util_keyval_yytext, cbdata);
 
         /* Now we need to see the newline */
 
@@ -164,7 +168,7 @@ static int parse_line(const char *filename, pmix_keyval_parse_fn_t callback)
     /* Did we get an EOL or EOF? */
 
     else if (PMIX_UTIL_KEYVAL_PARSE_DONE == val || PMIX_UTIL_KEYVAL_PARSE_NEWLINE == val) {
-        callback(filename, 0, key_buffer, NULL);
+        callback(filename, lineno, key_buffer, NULL, cbdata);
         return PMIX_SUCCESS;
     }
 
@@ -311,14 +315,18 @@ static int add_to_env_str(char *var, char *val)
 }
 
 static int parse_line_new(const char *filename, int first_val,
-                          pmix_keyval_parse_fn_t callback)
+                          pmix_keyval_parse_fn_t callback, void *cbdata)
 {
     int val;
     char *tmp;
     int rc;
+    int lineno;
 
     val = first_val;
     while (PMIX_UTIL_KEYVAL_PARSE_NEWLINE != val && PMIX_UTIL_KEYVAL_PARSE_DONE != val) {
+        lineno = pmix_util_keyval_yylineno;
+        pmix_util_keyval_parse_lineno = lineno;
+
         rc = save_param_name();
         if (PMIX_SUCCESS != rc) {
             return rc;
@@ -336,7 +344,7 @@ static int parse_line_new(const char *filename, int first_val,
                         trim_name(tmp, "\'", "\'");
                         trim_name(tmp, "\"", "\"");
                     }
-                    callback(filename, 0, key_buffer, tmp);
+                    callback(filename, lineno, key_buffer, tmp, cbdata);
                     free(tmp);
                 }
             } else {
@@ -370,12 +378,20 @@ static int parse_line_new(const char *filename, int first_val,
     return PMIX_SUCCESS;
 }
 
-int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback)
+int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback,
+                                          void *cbdata)
 {
+    /* env_str is accumulated by the parser under this same lock, so
+     * take it here as well - otherwise we can hand out (and free) the
+     * string while another thread's parse is still appending to it */
+    pmix_mutex_lock(&keyval_mutex);
+
     if (NULL != env_str && 0 < strlen(env_str)) {
-        callback(NULL, 0, "mca_base_env_list_internal", env_str);
+        callback(NULL, 0, "mca_base_env_list_internal", env_str, cbdata);
         free(env_str);
         env_str = NULL;
     }
+
+    pmix_mutex_unlock(&keyval_mutex);
     return PMIX_SUCCESS;
 }

--- a/src/util/pmix_keyval_parse.h
+++ b/src/util/pmix_keyval_parse.h
@@ -35,27 +35,35 @@ PMIX_EXPORT extern int pmix_util_keyval_parse_lineno;
  * Callback triggered from pmix_util_keyval_parse for each key = value
  * pair.  Both key and value will be pointers into static buffers.
  * The buffers must not be free()ed and contents may be overwritten
- * immediately after the callback returns.
+ * immediately after the callback returns.  The \c file and \c lineno
+ * parameters identify where the pair came from, and \c cbdata is the
+ * opaque pointer the caller handed to the parser - the callback must
+ * take its context from these parameters rather than from any state
+ * shared with the caller.
  */
 typedef void (*pmix_keyval_parse_fn_t)(const char *file, int lineno,
                                        const char *name,
-                                       const char *value);
+                                       const char *value,
+                                       void *cbdata);
 
 /**
  * Parse \c filename, made up of key = value pairs.
  *
  * Parse \c filename, made up of key = value pairs.  For each line
  * that appears to contain a key = value pair, \c callback will be
- * called exactly once.  In a multithreaded context, calls to
- * pmix_util_keyval_parse() will serialize multiple calls.
+ * called exactly once, with \c cbdata passed through untouched.  In a
+ * multithreaded context, calls to pmix_util_keyval_parse() will
+ * serialize multiple calls.
  */
-PMIX_EXPORT int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback);
+PMIX_EXPORT int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback,
+                                       void *cbdata);
 
 PMIX_EXPORT int pmix_util_keyval_parse_init(void);
 
 PMIX_EXPORT void pmix_util_keyval_parse_finalize(void);
 
-PMIX_EXPORT int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback);
+PMIX_EXPORT int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback,
+                                                      void *cbdata);
 
 END_C_DECLS
 


### PR DESCRIPTION
Coverity CID 504949 (MISSING_LOCK) flags `save_value()` in
`pmix_mca_base_parse_paramfile.c` for reading `file_being_read` without the
lock that every write to it holds. The access is in fact safe — `save_value()`
only ever runs as a callback from inside the region `param_file_mutex`
protects — but the shape of the code is the real problem: the keyval parser
gave its callback no way to receive caller context, so the target list and the
name of the file being read had to be handed over through file-scope statics.
Commit 921af99c guarded those statics with a mutex held across the parse, which
closed the race but left the callback reading shared state.

Suppressing the CID would leave that shape in place — and `_param_list` is the
identical pattern, so it would be the next thing reported.

Instead, give `pmix_util_keyval_parse()` and
`pmix_util_keyval_save_internal_envars()` a `cbdata` parameter and pass it
through to the callback, so the target list rides along with the request. The
parser already reports the origin of each pair through its `file`/`lineno`
parameters, so `save_value()` now takes all three of its inputs from its
arguments. Both file-scope variables and the mutex added to protect them are
gone, and the callback shares no state with its caller.

Two things fall out of that:

- The parser was passing a hard-coded `0` for `lineno`, so honor the parameter
  and report the line of the key for both the `key = value` and the
  `-mca`/`-x` forms. This also corrects the line number recorded in a file
  value, which appears in the `data source: file (path:line)` text `pmix_info`
  prints — only the `key = value` form set the global the callback used to
  read, so a value picked up from an `-mca` line was attributed to whichever
  plain assignment happened to precede it.
- `pmix_util_keyval_save_internal_envars()` hands out and frees the `env_str`
  the parser accumulates, but did so without holding `keyval_mutex`; it was
  protected only incidentally, by the mutex now being removed from the caller.
  It now takes `keyval_mutex`, where the state it touches lives.

`pmix_keyval_parse_fn_t` is an internal signature with only two in-tree
callbacks (`save_value` and `pmixcc.c`'s `data_callback`); PRRTE and Open MPI
carry their own copies of this parser, so no downstream consumer is affected.

### Testing

Warning-free `make` on a `--enable-debug` tree; `make install`; `make check` in
`test/` (15/15) and `test/unit/` (31/31); `simptest` OK. Also checked the
recorded file/lineno end to end against a scratch param file mixing
`key = value`, `-mca` and `-x` lines: each pair is now attributed to its own
line, and the internal-envar path reports a NULL file with lineno 0.