### PR TITLE
util: free the message pmix_show_help renders

### DIFF
--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -601,7 +601,9 @@ pmix_status_t pmix_show_help(const char *filename,
         return PMIX_SUCCESS;
     }
 
+    /* local_delivery copies the message, so we own the rendered string */
     local_delivery(filename, topic, output);
+    free(output);
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
## Problem

`pmix_show_help()` renders its output string with `pmix_show_help_vstring()`
and hands it to `local_delivery()`, then returns. `local_delivery()` takes a
`const char *` and `PMIX_INFO_LOAD`s it — that is, copies it — before shifting
the delivery onto the event base. The rendered string is never reclaimed, so
every help or error message we emit leaks its text.

It is small per message (~423 bytes in the case I measured) but it is per
message, not per process: a launcher that prints a per-process binding warning
across a job leaks one copy per process.

The other two `local_delivery()` callers in this file already free their
strings, and one of them carries the comment "local_delivery copies the
message, so we own tmp" — this call site is the odd one out.
`pmix_show_help_norender()` is unaffected: the string it delivers belongs to
its caller.

## Fix

One `free()` after delivery.

## Testing

- PMIx `make check`: 15/15
- Measured with valgrind through a PRRTE launch that emits a binding warning:
  **846 bytes definitely lost → 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)