### PR TITLE
util: match a subnet against every address an interface carries

### DIFF
--- a/src/mca/pif/AGENTS.md
+++ b/src/mca/pif/AGENTS.md
@@ -219,6 +219,18 @@ index (as the `ptl` listener does).
 
 Most return `PMIX_SUCCESS`/`PMIX_ERROR` (not found).
 
+**A kernel index does not identify one address.** An interface holding
+both an IPv4 and an IPv6 address occupies *two* `pmix_if_list` entries
+(one per address, appended by two different components) that share a
+kernel index and differ in `if_index`. `pmix_ifkindextoaddr` returns
+whichever of them comes first — on Linux routinely the IPv6 one, and
+always so for loopback, since `linux_ipv6` reports `::1` ahead of
+`posix_ipv4`'s `127.0.0.1`. Code that needs an address *of a given
+family* must walk `pmix_if_list` and check each entry's `sa_family`
+itself; reading a `sockaddr_in` out of the answer yields an IPv6 flow
+label where it expected an address. This bit `pmix_ifmatches`, which
+silently refused to match any dual-stack interface named by subnet.
+
 ### Address resolution and matching
 
 These are the non-trivial ones:
@@ -240,7 +252,8 @@ These are the non-trivial ones:
   kernel index `kidx` matches any entry in a NULL-terminated `nets` argv,
   where each entry may be a named interface, an IP tuple, or a
   subnet+mask. Named entries are matched via `pmix_ifnametokindex`;
-  tuple/CIDR entries via `pmix_iftupletoaddr` + mask compare. Emits the
+  tuple/CIDR entries via `pmix_iftupletoaddr` + mask compare against
+  every IPv4 address the kernel index carries (see the caution above). Emits the
   `invalid-net-mask` `show_help` topic (from `help-pmix-util.txt`, in
   `src/util/` — not a `pif` help file) on an unparseable net. This backs
   `if_include`/`if_exclude` filtering.

--- a/src/util/pmix_if.c
+++ b/src/util/pmix_if.c
@@ -633,19 +633,26 @@ bool pmix_ifisloopback(int if_index)
  */
 int pmix_ifmatches(int kidx, char **nets)
 {
-    bool named_if;
+    bool named_if, known = false;
     int i, rc;
     size_t j;
     int kindex;
+    pmix_pif_t *intf;
     struct sockaddr_in inaddr;
     uint32_t addr, netaddr, netmask;
 
-    /* get the address info for the given network in case we need it */
-    if (PMIX_SUCCESS
-        != (rc = pmix_ifkindextoaddr(kidx, (struct sockaddr *) &inaddr, sizeof(inaddr)))) {
-        return rc;
+    /* confirm we actually know this interface - the address itself is
+     * fetched below, per entry, since an interface can carry more than one */
+    PMIX_LIST_FOREACH(intf, &pmix_if_list, pmix_pif_t)
+    {
+        if (intf->if_kernel_index == kidx) {
+            known = true;
+            break;
+        }
     }
-    addr = ntohl(inaddr.sin_addr.s_addr);
+    if (!known) {
+        return PMIX_ERROR;
+    }
 
     for (i = 0; NULL != nets[i]; i++) {
         /* if the specified interface contains letters in it, then it
@@ -672,8 +679,28 @@ int pmix_ifmatches(int kidx, char **nets)
                 pmix_show_help("help-pmix-util.txt", "invalid-net-mask", true, nets[i]);
                 return rc;
             }
-            if (netaddr == (addr & netmask)) {
-                return PMIX_SUCCESS;
+            /* Compare against every IPv4 address this kernel index carries.
+             * An interface that has both an IPv4 and an IPv6 address appears
+             * on pmix_if_list once per address, and both entries share the
+             * kernel index, so asking pmix_ifkindextoaddr() for "the" address
+             * returns whichever the discovery components found first - on
+             * Linux routinely the IPv6 one, always so for loopback.  Reading
+             * an IPv4 address out of that sockaddr_in6 yields its flow label
+             * rather than an address, so an interface named by subnet never
+             * matched itself. */
+            PMIX_LIST_FOREACH(intf, &pmix_if_list, pmix_pif_t)
+            {
+                if (intf->if_kernel_index != kidx) {
+                    continue;
+                }
+                if (AF_INET != ((struct sockaddr *) &intf->if_addr)->sa_family) {
+                    continue;
+                }
+                memcpy(&inaddr, &intf->if_addr, sizeof(inaddr));
+                addr = ntohl(inaddr.sin_addr.s_addr);
+                if (netaddr == (addr & netmask)) {
+                    return PMIX_SUCCESS;
+                }
             }
         }
     }

--- a/src/util/pmix_if.h
+++ b/src/util/pmix_if.h
@@ -163,6 +163,23 @@ PMIX_EXPORT int pmix_ifkindextoname(int if_kindex, char *if_name, int);
  *  @param size (IN)      Interface address buffer size
  */
 PMIX_EXPORT int pmix_ifindextoaddr(int if_index, struct sockaddr *, unsigned int);
+
+/**
+ *  Lookup an interface by kernel index and return its primary address.
+ *
+ *  Caution: a kernel index does not identify a single address.  An
+ *  interface carrying both an IPv4 and an IPv6 address occupies one
+ *  pmix_if_list entry per address, and those entries share a kernel
+ *  index, so this returns whichever address discovery found first -- on
+ *  Linux routinely the IPv6 one, always so for loopback.  Callers that
+ *  need an address of a particular family must walk pmix_if_list
+ *  themselves and check each entry's sa_family; they cannot assume the
+ *  answer here is IPv4.
+ *
+ *  @param if_kindex (IN) Interface kernel index
+ *  @param if_addr (OUT)  Interface address buffer
+ *  @param length (IN)    Interface address buffer size
+ */
 PMIX_EXPORT int pmix_ifkindextoaddr(int if_kindex, struct sockaddr *if_addr, unsigned int length);
 
 /**

--- a/test/unit/util/util_if.c
+++ b/test/unit/util/util_if.c
@@ -6,9 +6,11 @@
  *
  * $HEADER$
  *
- * Unit tests for the pure address/mask parser in src/util/pmix_if.c
- * (pmix_iftupletoaddr).  These need no populated interface list, so they
- * run without any server/tool initialization.
+ * Unit tests for src/util/pmix_if.c: the pure address/mask parser
+ * (pmix_iftupletoaddr), which needs no interface list at all, and the
+ * include/exclude matcher (pmix_ifmatches), which is driven here against
+ * a synthetic pmix_if_list rather than whatever this host happens to be
+ * wired with -- see build_if_list() for why that matters.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -19,8 +21,16 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_ARPA_INET_H
+#    include <arpa/inet.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#    include <net/if.h>
+#endif
 
 #include "src/util/pmix_if.h"
+#include "src/util/pmix_string_copy.h"
 
 static int npass = 0;
 static int nfail = 0;
@@ -54,6 +64,109 @@ static void check_err(const char *label, const char *input)
     uint32_t net = 0, mask = 0;
     int rc = pmix_iftupletoaddr(input, &net, &mask);
     report(label, PMIX_SUCCESS != rc);
+}
+
+/*
+ * Append one address to the interface list.  Discovery normally does this,
+ * but discovery gives us whatever this host is wired with -- and the case
+ * that matters is not universally present.  Building the list by hand lets
+ * every platform run the same cases.
+ */
+static void add_if(const char *name, uint16_t kindex, int family, const char *addr)
+{
+    pmix_pif_t *intf;
+
+    intf = PMIX_NEW(pmix_pif_t);
+    pmix_strncpy(intf->if_name, name, PMIX_IF_NAMESIZE);
+    intf->if_index = pmix_list_get_size(&pmix_if_list) + 1;
+    intf->if_kernel_index = kindex;
+    intf->af_family = family;
+    intf->if_flags = IFF_UP;
+    ((struct sockaddr *) &intf->if_addr)->sa_family = family;
+    if (AF_INET == family) {
+        inet_pton(AF_INET, addr, &((struct sockaddr_in *) &intf->if_addr)->sin_addr);
+    } else {
+        inet_pton(AF_INET6, addr, &((struct sockaddr_in6 *) &intf->if_addr)->sin6_addr);
+    }
+    pmix_list_append(&pmix_if_list, &intf->super);
+}
+
+/*
+ * A dual-stack interface holds one list entry per address, and both entries
+ * carry the same kernel index.  On Linux the IPv6 entry lands first -- always
+ * so for loopback, whose ::1 is discovered before 127.0.0.1 -- so that is the
+ * order reproduced here.
+ */
+static void build_if_list(void)
+{
+    /* the list is statically declared but only made usable by
+     * pmix_pif_base_open(), which no unit test runs */
+    PMIX_CONSTRUCT(&pmix_if_list, pmix_list_t);
+    add_if("lo", 1, AF_INET6, "::1");
+    add_if("lo", 1, AF_INET, "127.0.0.1");
+    add_if("eth0", 11, AF_INET6, "fe80::1");
+    add_if("eth0", 11, AF_INET, "172.17.0.2");
+    add_if("eth1", 12, AF_INET, "10.20.30.40");
+}
+
+static void teardown_if_list(void)
+{
+    pmix_pif_t *intf;
+
+    while (NULL != (intf = (pmix_pif_t *) pmix_list_remove_first(&pmix_if_list))) {
+        PMIX_RELEASE(intf);
+    }
+    PMIX_DESTRUCT(&pmix_if_list);
+}
+
+static void check_match(const char *label, int kidx, char *net, int expected)
+{
+    char *nets[2];
+
+    nets[0] = net;
+    nets[1] = NULL;
+    report(label, expected == pmix_ifmatches(kidx, nets));
+}
+
+static void test_ifmatches(void)
+{
+    char *both[3];
+
+    build_if_list();
+
+    /* an interface named by subnet must match itself.  This is the
+     * regression: pmix_ifmatches() used to read the address out of
+     * whichever entry shared the kernel index and came first, so for a
+     * dual-stack interface it compared the IPv6 entry's flow label
+     * against the requested network and reported no match -- silently
+     * dropping every interface an if_include named by subnet. */
+    check_match("dual-stack v4 subnet matches", 11, "172.17.0.0/16", PMIX_SUCCESS);
+    check_match("dual-stack host route matches", 11, "172.17.0.2/32", PMIX_SUCCESS);
+    check_match("loopback subnet matches", 1, "127.0.0.0/8", PMIX_SUCCESS);
+    check_match("single-stack subnet matches", 12, "10.20.0.0/16", PMIX_SUCCESS);
+
+    /* a subnet the interface is not on must not match */
+    check_match("unrelated subnet does not match", 11, "10.20.0.0/16", PMIX_ERR_NOT_FOUND);
+
+    /* named entries resolve through the kernel index, so both entries of a
+     * dual-stack interface answer to the one name */
+    check_match("name matches", 11, "eth0", PMIX_SUCCESS);
+    check_match("other name does not match", 12, "eth0", PMIX_ERR_NOT_FOUND);
+
+    /* a mixed list matches on either kind of entry */
+    both[0] = "eth1";
+    both[1] = "172.17.0.0/16";
+    both[2] = NULL;
+    report("mixed list matches by subnet", PMIX_SUCCESS == pmix_ifmatches(11, both));
+
+    /* an unparseable net is reported rather than treated as "no match" */
+    check_match("unparseable net reported", 11, "192.168.1.0/256.0.0.0",
+                PMIX_ERR_FABRIC_NOT_PARSEABLE);
+
+    /* an unknown kernel index is an error, not a match */
+    check_match("unknown kernel index", 99, "172.17.0.0/16", PMIX_ERROR);
+
+    teardown_if_list();
 }
 
 int main(int argc, char **argv)
@@ -92,6 +205,12 @@ int main(int argc, char **argv)
 
     /* out-of-range octet */
     check_err("octet > 255 rejected", "192.168.1.300/24");
+
+    fprintf(stdout, "\n=== pmix_ifmatches unit tests ===\n\n");
+    fprintf(stdout, "-- one case drives an invalid netmask;"
+                    " the warning it prints is expected --\n");
+
+    test_ifmatches();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;


### PR DESCRIPTION
### Problem

An `if_include`/`if_exclude` entry that names an interface by **subnet** silently selects nothing on any dual-stack Linux host. Naming the same interface by name works, so the failure looks like "the subnet form is broken" rather than anything to do with IPv6.

The cause is in `pmix_ifmatches()`. An interface holding both an IPv4 and an IPv6 address occupies **two** `pmix_if_list` entries — one per address, appended by two different discovery components — and those entries share a kernel index. `pmix_ifmatches()` takes a kernel index, so it fetched "the" address for it with `pmix_ifkindextoaddr()`, which answers with whichever entry discovery found first. On Linux that is routinely the IPv6 one, and always so for loopback, since `linux_ipv6` reports `::1` ahead of `posix_ipv4`'s `127.0.0.1`. Reading a `sockaddr_in` out of that `sockaddr_in6` picks up the flow label rather than an address, so the comparison ran against a number that was never the interface's address and the match failed.

This is reachable from user configuration: the `ptl` listener (`ptl_base_listener.c:506`) passes raw `if_include`/`if_exclude` entries straight to `pmix_ifmatches()`, so subnet-form entries hit the broken comparison. macOS orders loopback's IPv4 entry first, which is why this went unnoticed.

The sibling of this bug in PRRTE's own copy of the logic is openpmix/prrte#2554.

### Fix

Walk the list and compare against each IPv4 address the kernel index carries, skipping entries of another family. The kernel index still identifies the interface; it simply does not identify a single *address*, so the caller has to consider all of them. A named entry is unaffected — it resolves through `pmix_ifnametokindex()` and never needed an address. The up-front lookup becomes a check that we know the interface at all, preserving the `PMIX_ERROR` an unknown kernel index returned.

Since the trap is in `pmix_ifkindextoaddr()`'s signature, the hazard is now documented both on that prototype and in the `pif` framework's `AGENTS.md`.

### Testing

`test/unit/util/util_if` gains 10 `pmix_ifmatches` cases, driven against a **synthetic** interface list (loopback and `eth0` each dual-stack, IPv6 entry first) rather than the host's, so the ordering that triggers this is exercised on every platform instead of only where the host happens to supply it. Those cases fail 4 of 10 against the unpatched matcher and pass 10 of 10 with the fix.

Verified on Ubuntu (aarch64, `--enable-debug`): warning-free build, `test/unit/util` 20/20, top-level `test/` suite 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)