### PR TITLE
util: add a way to read a CLI qualifier's value

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -52,6 +52,7 @@
 #define PMIX_CAP_GET_NUMBER_FN   5
 #define PMIX_CAP_REGEX2          6
 #define PMIX_CAP_GROUP_FT        7
+#define PMIX_CAP_CLI_QUAL_VALUE  8
 
 
 /*****    DEPRECATED    *****/

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -339,6 +339,37 @@ static inline bool pmix_check_cli_option(char *ain, char *bin)
 #define PMIX_CHECK_CLI_OPTION(a, b) \
     pmix_check_cli_option(a, b)
 
+/* USAGE:
+ *  param "qual" is the input command line qualifier, e.g. "PE=2"
+ *
+ * Returns the value assigned to a qualifier - the text following its '=' -
+ * or NULL if it carries none.
+ *
+ * This is the companion to pmix_check_cli_option above, and exists because
+ * that function stops comparing at the '=' and then accepts any unambiguous
+ * prefix of the option's name. A caller therefore cannot know how long the
+ * name it just matched actually is: the user may have written "P=2" for
+ * "PE=2", or "F=path" for "FILE=path". Reading the value at an offset fixed
+ * to the option's full spelling reads the wrong bytes - or, for a qualifier
+ * written with no value at all, reads past the end of the string entirely.
+ */
+static inline char *pmix_cli_qualifier_value(char *qual)
+{
+    char *ptr;
+
+    if (NULL == qual) {
+        return NULL;
+    }
+    ptr = strchr(qual, '=');
+    if (NULL == ptr || '\0' == *(ptr + 1)) {
+        return NULL;
+    }
+    return ptr + 1;
+}
+
+#define PMIX_CLI_QUALIFIER_VALUE(q) \
+    pmix_cli_qualifier_value(q)
+
 static inline unsigned int pmix_convert_string_to_time(const char *t)
 {
     char **tmp = PMIx_Argv_split(t, ':');


### PR DESCRIPTION
`pmix_check_cli_option()` stops comparing at the `=` in an option and then
accepts any unambiguous prefix of the name, so `P=2` matches `PE=2` and
`F=path` matches `FILE=path`. That is deliberate and useful — but it leaves
a caller that has just matched an option with no way to know how long the
name it matched actually was, and therefore no safe way to reach the value.

Every consumer has been guessing, by indexing past the option's *full*
spelling. PRRTE, which is where these options are actually parsed, had four
such reads, and all four were wrong for an abbreviated qualifier:

| written | read as | effect |
|---|---|---|
| `--map-by core:P=2` | `&tok[3]` on `"P=2"` | landed past the value; processing-elements-per-proc became **0**, and the job then failed to map with an unrelated "out of resource" |
| `--map-by seq:F=/path` | `&tok[5]` on `"F=/path"` | opened the path five characters in |
| `--bind-to core:L=1` | `&tok[6]` on `"L=1"` | read three bytes **past the end of the string** |
| `--bind-to core:LIMIT=` | `&tok[6]` on `"LIMIT="` | landed on the terminating NUL, which `strtol` read as a perfectly good binding limit of 0 |

So: give them the answer instead of leaving them to guess it.
`pmix_cli_qualifier_value()` returns the text after the `=`, or NULL when
there is none, and lives next to `pmix_check_cli_option()` because the two
only make sense together.

PMIx itself defines `PMIX_CHECK_CLI_OPTION` but does not use it — the
consumers are downstream, which is why this is a header-only addition with
no call sites here.

`PMIX_CAP_CLI_QUAL_VALUE` lets a consumer that must also build against an
earlier PMIx detect it; PRRTE uses exactly that
([openpmix/prrte#2564](https://github.com/openpmix/prrte/pull/2564)).

## Testing

Built and installed from this branch, then PRRTE built against it and its
suites run — `make check` 10/10, the offline mapping harness 1180/0, and the
ten-node container suite 142/0. The same PRRTE was also built against PMIx
v6.1.0 to exercise its fallback for a PMIx without the capability flag, with
identical results, and the abbreviated forms above were checked by hand on
both.
