### PR TITLE
Expand the conversions in an output filename pattern

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -53,6 +53,7 @@
 #define PMIX_CAP_REGEX2          6
 #define PMIX_CAP_GROUP_FT        7
 #define PMIX_CAP_CLI_QUAL_VALUE  8
+#define PMIX_CAP_IOF_FILE_PATTERN 9
 
 
 /*****    DEPRECATED    *****/

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -63,6 +63,33 @@ entry point.
 | `pmix_pfexec.c/.h` | (internal) `pmix_pfexec_base_*` | Local fork/exec: when PMIx itself launches processes (singleton, tool spawning children). Collapsed from the former `src/mca/pfexec` framework. |
 | `pmix_strings.c` | `PMIx_*_string` converters | Pure enum→string helpers, no threadshifting. Must stay in sync with the enums in `include/pmix_common.h.in`. |
 
+### Output-file naming lives here (`pmix_iof.c`)
+
+`pmix_iof_setup()` is what opens the per-process output sinks, and it is
+the only place that knows the namespace and rank at the moment a file is
+created — which is why the naming, and the `PMIX_IOF_FILE_PATTERN`
+expansion, are PMIx's job and not the launcher's.
+
+Two rules to keep when touching it:
+
+- **Default naming annotates; `PMIX_IOF_FILE_PATTERN` does not.** Without
+  the flag the name given in `PMIX_IOF_OUTPUT_TO_FILE` is a stem, written
+  as `<file>.<nspace>.<rank>.out`. With it, the name is the caller's own
+  and its `%` conversions (`%n`, `%r`, `%R`, `%h`, `%%` — see the contract
+  on `pmix_iof_check_pattern()` in `pmix_iof.h`) are expanded instead. The
+  stream suffix (`.out`/`.err`) is appended either way, so stdout and
+  stderr can never collide.
+- **Create the directory from the FINAL name, not the one you were
+  handed.** A pattern may put conversions in the directory part
+  (`%h/rank-%R`); taking `pmix_dirname()` of the raw pattern creates a
+  directory literally named `%h` and then fails to open the file in the
+  one the pattern actually named.
+
+`pmix_iof_check_pattern()` exists so a launcher can reject a bad pattern
+while the user is still looking at their command line. It shares its
+walker with the expander on purpose: a pattern the check accepts must
+never be one the expansion rejects, or expand differently.
+
 ### There is no separate `pfexec_linux.c`
 
 Historical note: a `pfexec_linux.c` used to live here — a stale leftover

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -822,6 +822,130 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
 
 }
 
+/*
+ * Expand the '%' conversions in an output-file pattern - see the contract
+ * on pmix_iof_check_pattern/pmix_iof_expand_pattern in pmix_iof.h.
+ *
+ * Both entry points share this one walker so a pattern can never be
+ * accepted by the check and then rejected (or, worse, expanded differently)
+ * when the file is actually opened. With expand == false it only validates,
+ * which is why nspace/rank/numdigs may be absent in that mode.
+ */
+static pmix_status_t process_pattern(const char *pattern, bool expand,
+                                     const char *nspace, pmix_rank_t rank,
+                                     int numdigs, const char *suffix,
+                                     char **result, char **bad)
+{
+    const char *p;
+    char *out = NULL, *tmp;
+    char conv[3];
+
+    if (NULL != bad) {
+        *bad = NULL;
+    }
+    if (NULL != result) {
+        *result = NULL;
+    }
+    if (NULL == pattern) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (expand) {
+        out = strdup("");
+        if (NULL == out) {
+            return PMIX_ERR_NOMEM;
+        }
+    }
+
+    for (p = pattern; '\0' != *p; ++p) {
+        if ('%' != *p) {
+            if (expand) {
+                pmix_asprintf(&tmp, "%s%c", out, *p);
+                free(out);
+                out = tmp;
+            }
+            continue;
+        }
+        ++p;
+        switch (*p) {
+            case 'n':
+                if (expand) {
+                    pmix_asprintf(&tmp, "%s%s", out, (NULL == nspace) ? "" : nspace);
+                    free(out);
+                    out = tmp;
+                }
+                break;
+            case 'r':
+                if (expand) {
+                    pmix_asprintf(&tmp, "%s%u", out, rank);
+                    free(out);
+                    out = tmp;
+                }
+                break;
+            case 'R':
+                if (expand) {
+                    pmix_asprintf(&tmp, "%s%0*u", out, numdigs, rank);
+                    free(out);
+                    out = tmp;
+                }
+                break;
+            case 'h':
+                if (expand) {
+                    pmix_asprintf(&tmp, "%s%s", out,
+                                  (NULL == pmix_globals.hostname) ? "" : pmix_globals.hostname);
+                    free(out);
+                    out = tmp;
+                }
+                break;
+            case '%':
+                if (expand) {
+                    pmix_asprintf(&tmp, "%s%%", out);
+                    free(out);
+                    out = tmp;
+                }
+                break;
+            default:
+                /* a trailing '%' leaves *p at the terminator - report the
+                 * bare '%' rather than reading past the end of the string */
+                conv[0] = '%';
+                conv[1] = *p;
+                conv[2] = '\0';
+                if ('\0' == *p) {
+                    conv[1] = '\0';
+                }
+                if (NULL != bad) {
+                    *bad = strdup(conv);
+                }
+                if (NULL != out) {
+                    free(out);
+                }
+                return PMIX_ERR_BAD_PARAM;
+        }
+    }
+
+    if (expand) {
+        if (NULL != suffix) {
+            pmix_asprintf(&tmp, "%s%s", out, suffix);
+            free(out);
+            out = tmp;
+        }
+        *result = out;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_iof_check_pattern(const char *pattern, char **bad)
+{
+    return process_pattern(pattern, false, NULL, 0, 0, NULL, NULL, bad);
+}
+
+pmix_status_t pmix_iof_expand_pattern(const char *pattern, const char *nspace,
+                                      pmix_rank_t rank, int numdigs,
+                                      const char *suffix, char **result)
+{
+    return process_pattern(pattern, true, nspace, rank, numdigs, suffix, result, NULL);
+}
+
 static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                                               pmix_rank_t rank,
                                               pmix_iof_channel_t stream)
@@ -904,31 +1028,36 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
 
     /* see if we are to output to a file */
     if (NULL != nptr->iof_flags.file) {
-        /* construct the directory where the output files will go */
-        outdir = pmix_dirname(nptr->iof_flags.file);
-        /* ensure the directory exists */
-        rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
-        free(outdir);
-        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return NULL;
-        }
         if (PMIX_FWD_STDOUT_CHANNEL & stream ||
             nptr->iof_flags.merge) {
             /* setup the stdout sink */
             if (nptr->iof_flags.pattern) {
-                /* if there are no '%' signs in the pattern, then it is just a literal string */
-                if (NULL == strchr(nptr->iof_flags.file, '%')) {
-                    /* setup the file */
-                    pmix_asprintf(&outfile, "%s.out", nptr->iof_flags.file);
-                } else {
-                    /* must process the pattern - for now, just take it literally */
-                    pmix_asprintf(&outfile, "%s.pattern.out", nptr->iof_flags.file);
+                /* the name is the caller's to compose - expand its
+                 * conversions and annotate it with nothing but the stream */
+                rc = pmix_iof_expand_pattern(nptr->iof_flags.file, nptr->nspace,
+                                             rank, numdigs, ".out", &outfile);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    return NULL;
                 }
             } else {
                 /* setup the file */
                 pmix_asprintf(&outfile, "%s.%s.%0*u.out", nptr->iof_flags.file,
                               nptr->nspace, numdigs, rank);
+            }
+            /* ensure the directory the file lands in exists.  This is taken
+             * from the FINAL name, not from the name we were handed: a
+             * pattern may put conversions in the directory part
+             * ("%h/rank-%R"), and creating the raw name's dirname would
+             * create a directory literally called "%h" and then fail to open
+             * the file in the one the pattern actually named. */
+            outdir = pmix_dirname(outfile);
+            rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
+            free(outdir);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
+                PMIX_ERROR_LOG(rc);
+                free(outfile);
+                return NULL;
             }
             fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
             free(outfile);
@@ -951,18 +1080,25 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         } else {
             /* setup the stderr sink */
             if (nptr->iof_flags.pattern) {
-                /* if there are no '%' signs in the pattern, then it is just a literal string */
-                if (NULL == strchr(nptr->iof_flags.file, '%')) {
-                    /* setup the file */
-                    pmix_asprintf(&outfile, "%s.err", nptr->iof_flags.file);
-                } else {
-                    /* must process the pattern - for now, just take it literally */
-                    pmix_asprintf(&outfile, "%s.pattern.err", nptr->iof_flags.file);
+                rc = pmix_iof_expand_pattern(nptr->iof_flags.file, nptr->nspace,
+                                             rank, numdigs, ".err", &outfile);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    return NULL;
                 }
             } else {
                 /* setup the file */
                 pmix_asprintf(&outfile, "%s.%s.%0*u.err", nptr->iof_flags.file,
                               nptr->nspace, numdigs, rank);
+            }
+            /* see the note on the stdout sink above */
+            outdir = pmix_dirname(outfile);
+            rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
+            free(outdir);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
+                PMIX_ERROR_LOG(rc);
+                free(outfile);
+                return NULL;
             }
             fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
             free(outfile);

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -276,6 +276,38 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_init_flags(pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
+
+/* PMIX_IOF_FILE_PATTERN support.
+ *
+ * Without it, PMIX_IOF_OUTPUT_TO_FILE annotates the name it was given with
+ * the namespace and rank: "<file>.<nspace>.<rank>.out".  With it, the name
+ * is a pattern the caller controls, and these '%' conversions are expanded
+ * in it (anything else beginning with '%' is an error):
+ *
+ *   %n  the job's namespace
+ *   %r  the process's rank
+ *   %R  the rank, zero-padded to the width of the job's largest rank
+ *   %h  the hostname of the node writing the file
+ *   %%  a literal '%'
+ *
+ * The stream suffix (".out"/".err") is still appended, so stdout and stderr
+ * can never land on the same file. A pattern containing no '%' at all is
+ * therefore simply a fixed name - which is what "not annotated" means, and
+ * is the behavior this attribute had before the conversions existed.
+ *
+ * pmix_iof_check_pattern() reports whether a pattern is well formed without
+ * expanding it, so a launcher can reject a bad one while the user is still
+ * looking at their command line rather than at a failed job. On
+ * PMIX_ERR_BAD_PARAM it sets *bad (if non-NULL) to a malloc'd copy of the
+ * offending conversion for the diagnostic; the caller frees it.
+ */
+PMIX_EXPORT pmix_status_t pmix_iof_check_pattern(const char *pattern, char **bad);
+PMIX_EXPORT pmix_status_t pmix_iof_expand_pattern(const char *pattern,
+                                                  const char *nspace,
+                                                  pmix_rank_t rank,
+                                                  int numdigs,
+                                                  const char *suffix,
+                                                  char **result);
 PMIX_EXPORT void pmix_iof_flush_residuals(void);
 PMIX_EXPORT pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                                                      pmix_iof_flags_t *myflags,


### PR DESCRIPTION
## The problem

`PMIX_IOF_FILE_PATTERN` says the name given in `PMIX_IOF_OUTPUT_TO_FILE` is a
pattern the caller composed, rather than a stem we annotate with the namespace
and rank. We accepted the flag and recorded it, but never implemented what it
promises:

```c
if (NULL == strchr(nptr->iof_flags.file, '%')) {
    pmix_asprintf(&outfile, "%s.out", nptr->iof_flags.file);
} else {
    /* must process the pattern - for now, just take it literally */
    pmix_asprintf(&outfile, "%s.pattern.out", nptr->iof_flags.file);
}
```

A caller asking for per-process filenames of their own design got one nonsense
name — literally `<file>.pattern.out` — shared by every rank in the job.

## What this does

Implements the expansion:

| Conversion | Expands to |
|---|---|
| `%n` | the job's namespace |
| `%r` | the process's rank |
| `%R` | the rank, zero-padded to the width of the job's largest rank |
| `%h` | the hostname of the node writing the file |
| `%%` | a literal `%` |

Anything else introduced by `%` is an error, rather than a filename the caller
did not ask for. The stream suffix (`.out`/`.err`) is still appended, so stdout
and stderr can never land on the same file, and a pattern containing no `%` at
all remains exactly what it was before — a fixed name.

Two design points worth review:

- **The expansion belongs here, not in the launcher that accepted the
  option.** `pmix_iof_setup()` is the only place that knows the rank at the
  moment a file is opened.
- **The directory is now created from the FINAL name.** A pattern may put
  conversions in the directory part (`%h/rank-%R`); taking `pmix_dirname()` of
  the raw pattern creates a directory literally called `%h` and then fails to
  open the file in the one the pattern actually named.

`pmix_iof_check_pattern()` is exported alongside the expander so a launcher can
reject a malformed pattern while the user is still looking at the command line
they typed, rather than at a job that failed to open its output. Both share one
walker, so a pattern the check accepts can never be one the expansion rejects,
or expands differently.

New capability flag `PMIX_CAP_IOF_FILE_PATTERN` lets a launcher tell whether it
may offer the option at all.

## Testing

Exercised through the PRRTE side of this work (openpmix/prrte, `--output
file=NAME:pattern`), which is what motivated it:

- `prterun -np 3 --output "file=/tmp/pat/%h/rank-%R:pattern"` → one file per
  rank under a per-host directory each daemon created for itself;
- `%r`/`%%` and the `.out`/`.err` split verified;
- a bad conversion (`%q`) reported before anything launched;
- unchanged default naming (`<file>.<nspace>.<rank>.out`) confirmed;
- multi-node coverage in PRRTE's `contrib/dockerswarm` suite (168 pass / 0
  fail), including that each daemon expands `%h` and creates the directory its
  own expansion names — which one host cannot show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
