### PR TITLE
Add Python bindings for the non-blocking PMIx_Group APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ bindings/python/*.so
 bindings/python/build/
 bindings/python/pmix_constants.pxd
 bindings/python/pmix_constants.pxi
+bindings/python/pmix_constants.stamp
 bindings/python/tests/__pycache__/
 bindings/python/dist/
 bindings/python/pypmix.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,38 @@ successfully.
 	Use the wrapper when working in an uninstalled tree; `./simptest`
 	itself is still the right thing to run against an installed PMIx.
 
+	**A stale `$TMPDIR` will fail these tests for reasons that have
+	nothing to do with your change.** A PMIx server drops a session
+	directory and rendezvous files under `$TMPDIR` and removes them at
+	finalize. A run that is killed, crashes, or times out leaves its
+	`pmix-*` / `pmix.*` entries behind, and once enough of them
+	accumulate a subsequent server fails to start its listener:
+
+	```
+	--------------------------------------------------------------------
+	The PMIx server's listener thread failed to start. We cannot
+	continue.
+	--------------------------------------------------------------------
+	Init failed with error PMIX_ERR_INIT
+	```
+
+	Every `simptest`-based test then fails together — all the group
+	tests, `run_simpcycle.pl`, `run_toolcycle.pl`, `run_monitor.pl` and
+	so on — which looks alarming and is purely environmental. This is a
+	**known issue**; it is a property of the leftovers, not of the tree.
+	Before investigating a wholesale failure of the server-based tests,
+	rerun under a clean directory:
+
+	```sh
+	TMPDIR=$(mktemp -d) make check
+	```
+
+	If that passes, the failures were stale state. Clearing the old
+	`pmix*` entries out of your usual `$TMPDIR` fixes it for subsequent
+	runs. Note that a long `$TMPDIR` can fail the same way for a
+	different reason — a Unix socket path is limited to about 100
+	characters, and the session directory is built underneath it.
+
 **Test across environments when you can.** Portability across a wide
 variety of environments is a core PMIx goal. The primary development
 environments are common Linux distributions and macOS, but the code is

--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -168,6 +168,47 @@ callback — that class of mismatch bit the `notifyevent` key historically). A
 Python server registers them via `PMIxServer.init(info, module_map)` where
 `module_map` is `{'clientconnected': fn, 'fencenb': fn, ...}`.
 
+### 4c. Downcalls: a client `_nb` API → a Python callback
+
+The reverse of §4b, and the newest of the three. A non-blocking client
+method hands a request to `libpmix` and returns immediately; the result
+arrives later on the progress thread. The group operations
+(`group_construct_nb` and friends) are the worked example — everything
+else in `MISSING_BINDINGS.md` §1.1 is meant to reuse this.
+
+Three pieces, all in `pmix.pyx`:
+
+- **`nbcbd`, a keepalive caddy.** PMIx does not copy its input, so the
+  blocking methods' habit of freeing `procs`/`info` the moment the C call
+  returns is a use-after-free here. The group identifier is worse:
+  `group.encode('ascii')` is a Python local, so its buffer dangles at
+  return. All of it goes in the caddy, which is passed as the operation's
+  `cbdata` and released by the trampoline. Each field goes back to its own
+  allocator (`free` / `PyMem_Free` / `pmix_free_info`) — see §8.
+- **`pynbcbs`, a registry.** The caller's Python callback and `cbdata`
+  live in a module-global dict keyed by an integer the caddy carries, so
+  no `PyObject *` crosses into C. Same technique as `myhdlrs`.
+- **`pypmix_client_op_cbfunc` / `pypmix_client_info_cbfunc`,
+  trampolines.** `noexcept with gil`, per the rules below, with the user's
+  callback wrapped in `try`/`except`.
+
+Two invariants are easy to miss:
+
+- **The registry entry is the ownership token for the caddy.** Whoever
+  pops it frees the caddy; a pop that returns `None` means someone else
+  already did. This is what keeps the trampoline and the method's error
+  path from double-freeing.
+- **A failed C call means no callback, ever.** When the `_nb` API returns
+  anything but `PMIX_SUCCESS` the request was not accepted, so the method
+  must reclaim the caddy itself before returning. Forgetting this leaks
+  silently and only on the error path.
+
+Validate that `cbfunc` is callable before allocating anything — a callback
+that can never run strands the caddy for the life of the process.
+
+Full write-up, including how to add the remaining `_nb` bindings:
+[`docs/how-things-work/python_nonblocking.rst`](../../docs/how-things-work/python_nonblocking.rst).
+
 ### Rules when touching callback code
 
 - Trampolines that call back into Python **must** be `cdef ... with gil`.
@@ -283,6 +324,15 @@ internalizing so they are not reintroduced:
   paths had several `.size`/`.bytes`/`[index]` mistakes that compiled cleanly
   and only failed (or silently returned garbage) at runtime. When you touch an
   unload arm, exercise it on real data.
+- **Anything `libpmix` will free must come from `malloc`, not
+  `PyMem_Malloc`.** Python's allocator serves small blocks out of its own
+  arenas, so passing one to `free()` is not a mismatch the system tolerates
+  — it aborts the process. The load paths (`pmix_load_value`,
+  `pmix_load_darray`) build values the library takes ownership of and
+  therefore use `malloc`; buffers the bindings both allocate and release
+  themselves (the proc array, the query array) stay on `PyMem_*`, where
+  they are self-consistent. Getting this backwards is invisible until a
+  Python program passes a `PMIX_DATA_ARRAY` into the library.
 - **`memset`/`malloc` counts must include `sizeof(T)`**, and NUL-terminated
   `char**` arrays need one extra slot. Byte counts vs element counts were a
   recurring source of overflow.

--- a/bindings/python/MISSING_BINDINGS.md
+++ b/bindings/python/MISSING_BINDINGS.md
@@ -27,13 +27,18 @@ Headers surveyed: `include/pmix.h`, `include/pmix_server.h`,
 
 ## Part 1 — Missing bindings
 
-### 1.1 Non-blocking (`_nb`) variants — none are bound
+### 1.1 Non-blocking (`_nb`) variants — the group family is bound
 
-Every operational client call is bound **only** in its blocking form. None of
-the callback-style non-blocking variants exist in Python. Adding these is the
-single largest coverage gap and would let Python programs drive PMIx
-asynchronously (they would need the callback-trampoline machinery already used
-for the server module — see AGENTS.md §4).
+The five group operations now have non-blocking bindings
+(`group_construct_nb`, `group_invite_nb`, `group_join_nb`,
+`group_leave_nb`, `group_destruct_nb`). They brought the client-side
+async machinery with them — a keepalive caddy, a callback registry, and
+the two trampolines — so the remaining entries below are a mechanical
+follow-on rather than new infrastructure. See AGENTS.md §4c and
+[`docs/how-things-work/python_nonblocking.rst`](../../docs/how-things-work/python_nonblocking.rst).
+
+Every other operational client call is still bound **only** in its
+blocking form:
 
 - `PMIx_Fence_nb`
 - `PMIx_Get_nb`
@@ -50,11 +55,6 @@ for the server module — see AGENTS.md §4).
 - `PMIx_Process_monitor_nb`
 - `PMIx_Get_credential_nb`
 - `PMIx_Validate_credential_nb`
-- `PMIx_Group_construct_nb`
-- `PMIx_Group_destruct_nb`
-- `PMIx_Group_invite_nb`
-- `PMIx_Group_join_nb`
-- `PMIx_Group_leave_nb`
 - `PMIx_Fabric_register_nb`
 - `PMIx_Fabric_update_nb`
 - `PMIx_Fabric_deregister_nb`

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -49,11 +49,29 @@ constants_files = \
         pmix_constants.pxd \
         pmix_constants.pxi
 
+constants_stamp = pmix_constants.stamp
+
 # Create pmix_constants.pxd and pmix_constants.pxi by harvesting a
 # bunch of PMIx header files These will be generated in the PMIx build
 # dir.
-$(constants_files): construct.py $(harvested_headers)
+#
+# A single run of construct.py produces both files. Listing them as the
+# targets of one rule would let a parallel make start one run per target,
+# and each run truncates the files the other is writing, so drive the
+# generation from a stamp file instead. This is the "multiple outputs"
+# idiom from the Automake manual.
+$(constants_stamp): construct.py $(harvested_headers)
+	@rm -f $(constants_stamp).tmp
+	@touch $(constants_stamp).tmp
 	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include" --include-dir="$(top_srcdir)/include"
+	@mv -f $(constants_stamp).tmp $(constants_stamp)
+
+$(constants_files): $(constants_stamp)
+## Recover from the removal of a generated file while the stamp survived
+	@if test -f $@; then :; else \
+	    rm -f $(constants_stamp); \
+	    $(MAKE) $(AM_MAKEFLAGS) $(constants_stamp); \
+	fi
 
 # Cython does not natively understand VPATH builds.  Specifically,
 # Cython will build things in the same tree where it finds
@@ -135,7 +153,7 @@ uninstall-hook:
 	fi
 	rm -rf $(pythondir)/pypmix*
 
-CLEANFILES += $(constants_files)
+CLEANFILES += $(constants_files) $(constants_stamp) $(constants_stamp).tmp
 
 # Also delete the other files and dirs that Cython creates during its
 # "setup.py build_ext ..." step.  We need to use clean-local because

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -163,19 +163,19 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
     cdef pmix_value_t *valptr;
     mysize = len(mylist)
     if PMIX_INFO == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_info_t))
+        array[0].array = malloc(mysize * sizeof(pmix_info_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         infoptr = <pmix_info_t*>array[0].array
         rc = pmix_load_info(infoptr, mylist)
     elif PMIX_VALUE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_value_t))
+        array[0].array = malloc(mysize * sizeof(pmix_value_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         valptr = <pmix_value_t*>array[0].array
         rc = pmix_load_value(valptr, mylist)
     elif PMIX_BOOL == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int*))
+        array[0].array = malloc(mysize * sizeof(int*))
         n = 0
         if not array[0].array:
             return PMIX_ERR_NOMEM
@@ -187,7 +187,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             boolptr[n] = int_bool
             n += 1
     elif PMIX_BYTE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(uint8_t*))
+        array[0].array = malloc(mysize * sizeof(uint8_t*))
         n = 0
         # byte val is uint8 type
         if not array[0].array:
@@ -203,7 +203,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             bptr[n] = int(item)
             n += 1
     elif PMIX_STRING == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(char*))
+        array[0].array = malloc(mysize * sizeof(char*))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -220,7 +220,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                 return PMIX_ERR_TYPE_MISMATCH
             n += 1
     elif PMIX_SIZE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(size_t))
+        array[0].array = malloc(mysize * sizeof(size_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -232,7 +232,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             sptr[n] = int(item)
             n += 1
     elif PMIX_PID == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pid_t))
+        array[0].array = malloc(mysize * sizeof(pid_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -244,7 +244,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             pidptr[n] = int(item)
             n += 1
     elif PMIX_INT == mytype or PMIX_UINT == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int))
+        array[0].array = malloc(mysize * sizeof(int))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -256,7 +256,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             iptr[n] = int(item)
             n += 1
     elif PMIX_INT8 == mytype or PMIX_UINT8 == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int8_t))
+        array[0].array = malloc(mysize * sizeof(int8_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -268,7 +268,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i8ptr[n] = int(item)
             n += 1
     elif PMIX_INT16 == mytype or PMIX_UINT16 == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int16_t))
+        array[0].array = malloc(mysize * sizeof(int16_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -280,7 +280,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i16ptr[n] = int(item)
             n += 1
     elif PMIX_INT32 == mytype or PMIX_UINT32 == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int32_t))
+        array[0].array = malloc(mysize * sizeof(int32_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -292,7 +292,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i32ptr[n] = int(item)
             n += 1
     elif PMIX_INT64 == mytype or PMIX_UINT64 == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int64_t))
+        array[0].array = malloc(mysize * sizeof(int64_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -304,7 +304,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i64ptr[n] = int(item)
             n += 1
     elif PMIX_FLOAT == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(float))
+        array[0].array = malloc(mysize * sizeof(float))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -313,7 +313,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             fptr[n] = float(item)
             n += 1
     elif PMIX_DOUBLE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(double))
+        array[0].array = malloc(mysize * sizeof(double))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -324,7 +324,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
     elif PMIX_TIMEVAL == mytype:
         # TODO: Not clear that "timeval" has the same size as
         # "struct timeval"
-        array[0].array = PyMem_Malloc(mysize * sizeof(timeval))
+        array[0].array = malloc(mysize * sizeof(timeval))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -334,7 +334,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             tvptr[n].tv_usec = item['usec']
             n += 1
     elif PMIX_TIME == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(time_t))
+        array[0].array = malloc(mysize * sizeof(time_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -343,7 +343,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             tmptr[n] = item
             n += 1
     elif PMIX_STATUS == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(int))
+        array[0].array = malloc(mysize * sizeof(int))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -352,7 +352,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             stptr[n] = item
             n += 1
     elif PMIX_PROC_RANK == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_rank_t))
+        array[0].array = malloc(mysize * sizeof(pmix_rank_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -361,7 +361,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             rkptr[n] = item
             n += 1
     elif PMIX_PROC == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_proc_t))
+        array[0].array = malloc(mysize * sizeof(pmix_proc_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -371,14 +371,14 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             prcptr[n].rank = item['rank']
             n += 1
     elif PMIX_BYTE_OBJECT == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_byte_object_t))
+        array[0].array = malloc(mysize * sizeof(pmix_byte_object_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
         boptr = <pmix_byte_object_t*>array[0].array
         for item in mylist:
             boptr[n].size = item['size']
-            boptr[n].bytes = <char*> PyMem_Malloc(boptr[n].size)
+            boptr[n].bytes = <char*> malloc(boptr[n].size)
             if not boptr[n].bytes:
                 return PMIX_ERR_NOMEM
             pyarr = bytes(item['bytes'])
@@ -386,7 +386,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             memcpy(boptr[n].bytes, pyptr, boptr[n].size)
             n += 1
     elif PMIX_PERSISTENCE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_persistence_t))
+        array[0].array = malloc(mysize * sizeof(pmix_persistence_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -395,7 +395,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             perptr[n] = item
             n += 1
     elif PMIX_SCOPE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_scope_t))
+        array[0].array = malloc(mysize * sizeof(pmix_scope_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -404,7 +404,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             scptr[n] = item
             n += 1
     elif PMIX_RANGE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_data_range_t))
+        array[0].array = malloc(mysize * sizeof(pmix_data_range_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -413,7 +413,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             rgptr[n] = item
             n += 1
     elif PMIX_PROC_STATE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_proc_state_t))
+        array[0].array = malloc(mysize * sizeof(pmix_proc_state_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -422,7 +422,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             psptr[n] = item
             n += 1
     elif PMIX_PROC_INFO == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_proc_info_t))
+        array[0].array = malloc(mysize * sizeof(pmix_proc_info_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -449,7 +449,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             piptr[n].state = item['state']
             n += 1
     elif PMIX_DATA_ARRAY == mytype:
-        array[0].array = <pmix_data_array_t*> PyMem_Malloc(mysize * sizeof(pmix_data_array_t))
+        array[0].array = <pmix_data_array_t*> malloc(mysize * sizeof(pmix_data_array_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         daptr = <pmix_data_array_t*>array[0].array
@@ -457,7 +457,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
         for item in mylist:
             daptr[n].type = item['val_type']
             daptr[n].size = len(item['value'])
-            daptr[n].array = <pmix_data_array_t*> PyMem_Malloc(sizeof(pmix_data_array_t))
+            daptr[n].array = <pmix_data_array_t*> malloc(sizeof(pmix_data_array_t))
             if not daptr[n].array:
                 return PMIX_ERR_NOMEM
             mydaptr = <pmix_data_array_t*>daptr[n].array
@@ -469,7 +469,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                 return PMIX_ERR_NOT_SUPPORTED
             n += 1
     elif PMIX_ALLOC_DIRECTIVE == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_alloc_directive_t))
+        array[0].array = malloc(mysize * sizeof(pmix_alloc_directive_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -478,7 +478,7 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             aldptr[n] = item
             n += 1
     elif PMIX_ENVAR == mytype:
-        array[0].array = PyMem_Malloc(mysize * sizeof(pmix_envar_t))
+        array[0].array = malloc(mysize * sizeof(pmix_envar_t))
         if not array[0].array:
             return PMIX_ERR_NOMEM
         n = 0
@@ -719,9 +719,12 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         while n < array.size:
             if not boptr[n].bytes:
                 return PMIX_ERR_NOMEM
+            # the conversion above copied the bytes into a Python object.
+            # The array itself still belongs to whoever handed it to us -
+            # every other arm of this function leaves it alone, and this
+            # one used to free it through the wrong allocator
             d = {'bytes': boptr[n].bytes, 'size': boptr[n].size}
             list.append(d)
-            PyMem_Free(boptr[n].bytes)
             n += 1
         darray = {'type':array.type, 'array':list}
         return darray
@@ -1103,13 +1106,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.rank = val['value']
 
     elif val['val_type'] == PMIX_PROC_NSPACE:
-        value[0].data.nspace = <pmix_nspace_t*> PyMem_Malloc(sizeof(pmix_nspace_t))
+        value[0].data.nspace = <pmix_nspace_t*> malloc(sizeof(pmix_nspace_t))
         if not value[0].data.nspace:
             return PMIX_ERR_NOMEM
         pmix_copy_nspace(value[0].data.nspace[0], val['value'])
 
     elif val['val_type'] == PMIX_PROC:
-        value[0].data.proc = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+        value[0].data.proc = <pmix_proc_t*> malloc(sizeof(pmix_proc_t))
         if not value[0].data.proc:
             return PMIX_ERR_NOMEM
         # TODO: check nspace val is a char here
@@ -1126,7 +1129,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
     # TODO: pmix byte object conversion isn't working
     elif val['val_type'] == PMIX_BYTE_OBJECT:
         value[0].data.bo.size = val['value']['size']
-        value[0].data.bo.bytes = <char*> PyMem_Malloc(value[0].data.bo.size)
+        value[0].data.bo.bytes = <char*> malloc(value[0].data.bo.size)
         if not value[0].data.bo.bytes:
             return PMIX_ERR_NOMEM
         pyptr = <char*>val['value']['bytes']
@@ -1139,7 +1142,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(ba, bytearray):
             return PMIX_ERR_TYPE_MISMATCH
         value[0].data.bo.size  = len(val['value'])
-        value[0].data.bo.bytes = <char*> PyMem_Malloc(value[0].data.bo.size)
+        value[0].data.bo.bytes = <char*> malloc(value[0].data.bo.size)
         if not value[0].data.bo.bytes:
             return PMIX_ERR_NOMEM
         pyptr = <char*>ba
@@ -1186,7 +1189,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.state = val['value']
 
     elif val['val_type'] == PMIX_PROC_INFO:
-        value[0].data.pinfo = <pmix_proc_info_t*> PyMem_Malloc(sizeof(pmix_proc_info_t))
+        value[0].data.pinfo = <pmix_proc_info_t*> malloc(sizeof(pmix_proc_info_t))
         if not value[0].data.pinfo:
             return PMIX_ERR_NOMEM
         # TODO: verify nspace is copied correctly
@@ -1227,7 +1230,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.pinfo[0].state = val['value']['state']
 
     elif val['val_type'] == PMIX_DATA_ARRAY:
-        value[0].data.darray = <pmix_data_array_t*> PyMem_Malloc(sizeof(pmix_data_array_t))
+        value[0].data.darray = <pmix_data_array_t*> malloc(sizeof(pmix_data_array_t))
         if not value[0].data.darray:
             return PMIX_ERR_NOMEM
         value[0].data.darray[0].type = val['value']['type']
@@ -1281,12 +1284,12 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             value[0].data.envar.separator = ord(enval)
 
     elif val['val_type'] == PMIX_COORD:
-        value[0].data.coord = <pmix_coord_t*> PyMem_Malloc(sizeof(pmix_coord_t))
+        value[0].data.coord = <pmix_coord_t*> malloc(sizeof(pmix_coord_t))
         if not value[0].data.coord:
             return PMIX_ERR_NOMEM
         value[0].data.coord[0].view = val['value']['view']
         dims = val['value']['dims']
-        value[0].data.coord[0].coord = <uint32_t*> PyMem_Malloc(dims * sizeof(uint32_t))
+        value[0].data.coord[0].coord = <uint32_t*> malloc(dims * sizeof(uint32_t))
         if not value[0].data.coord[0].coord:
             return PMIX_ERR_NOMEM
         pyptr = <char*> val['value']['coord']
@@ -1327,7 +1330,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.locality = val['value']
 
     elif val['val_type'] == PMIX_GEOMETRY:
-        value[0].data.geometry = <pmix_geometry_t*> PyMem_Malloc(sizeof(pmix_geometry_t))
+        value[0].data.geometry = <pmix_geometry_t*> malloc(sizeof(pmix_geometry_t))
         if not value[0].data.geometry:
             return PMIX_ERR_NOMEM
         value[0].data.geometry[0].fabric = val['value']['fabric']
@@ -1346,14 +1349,14 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         pyosnameptr = <const char *>(pyosname)
         value[0].data.geometry[0].osname = strdup(pyosnameptr)
         ncoords = val['value']['ncoords']
-        value[0].data.geometry[0].coordinates = <pmix_coord_t*> PyMem_Malloc(ncoords * sizeof(pmix_coord_t))
+        value[0].data.geometry[0].coordinates = <pmix_coord_t*> malloc(ncoords * sizeof(pmix_coord_t))
         if not value[0].data.geometry[0].coordinates:
             return PMIX_ERR_NOMEM
         n = 0
         for k in val['value']['coords']:
             value[0].data.geometry[0].coordinates[n].view = k['view']
             dims = k['dims']
-            value[0].data.geometry[0].coordinates[n].coord = <uint32_t*> PyMem_Malloc(dims * sizeof(uint32_t))
+            value[0].data.geometry[0].coordinates[n].coord = <uint32_t*> malloc(dims * sizeof(uint32_t))
             if not value[0].data.geometry[0].coordinates[n].coord:
                 return PMIX_ERR_NOMEM
             pyptr = <char*> k['coord']
@@ -1372,7 +1375,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.devtype = val['value']
 
     elif val['val_type'] == PMIX_DEVICE:
-        value[0].data.device = <pmix_device_t*> PyMem_Malloc(sizeof(pmix_device_t))
+        value[0].data.device = <pmix_device_t*> malloc(sizeof(pmix_device_t))
         if not value[0].data.device:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1398,7 +1401,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.device[0].type = val['value']['type']
 
     elif val['val_type'] == PMIX_DEVICE_DIST:
-        value[0].data.devdist = <pmix_device_distance_t*> PyMem_Malloc(sizeof(pmix_device_distance_t))
+        value[0].data.devdist = <pmix_device_distance_t*> malloc(sizeof(pmix_device_distance_t))
         if not value[0].data.devdist:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1431,7 +1434,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.devdist[0].maxdist = val['value']['maxdist']
 
     elif val['val_type'] == PMIX_ENDPOINT:
-        value[0].data.endpoint = <pmix_endpoint_t*> PyMem_Malloc(sizeof(pmix_endpoint_t))
+        value[0].data.endpoint = <pmix_endpoint_t*> malloc(sizeof(pmix_endpoint_t))
         if not value[0].data.endpoint:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1449,7 +1452,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         pyosnameptr = <const char *>(pyosname)
         value[0].data.endpoint[0].osname = strdup(pyosnameptr)
         value[0].data.endpoint[0].endpt.size = val['value']['endpt']['size']
-        value[0].data.endpoint[0].endpt.bytes = <char*> PyMem_Malloc(value[0].data.endpoint[0].endpt.size)
+        value[0].data.endpoint[0].endpt.bytes = <char*> malloc(value[0].data.endpoint[0].endpt.size)
         if not value[0].data.endpoint[0].endpt.bytes:
             return PMIX_ERR_NOMEM
         pyptr = <char*>val['value']['endpt']['bytes']
@@ -1459,7 +1462,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         return PMIX_ERR_NOT_SUPPORTED
 
     elif val['val_type'] == PMIX_RESOURCE_UNIT:
-        value[0].data.resunit = <pmix_resource_unit_t*> PyMem_Malloc(sizeof(pmix_resource_unit_t))
+        value[0].data.resunit = <pmix_resource_unit_t*> malloc(sizeof(pmix_resource_unit_t))
         if not value[0].data.resunit:
             return PMIX_ERR_NOMEM
         if not isinstance(val['value']['type'], pmix_int_types):
@@ -1478,7 +1481,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.resunit[0].count = val['value']['count']
 
     elif val['val_type'] == PMIX_NODE_PID:
-        value[0].data.nodepid = <pmix_node_pid_t*> PyMem_Malloc(sizeof(pmix_node_pid_t))
+        value[0].data.nodepid = <pmix_node_pid_t*> malloc(sizeof(pmix_node_pid_t))
         if not value[0].data.nodepid:
             return PMIX_ERR_NOMEM
         hostname = val['value']['hostname']

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1771,7 +1771,11 @@ cdef int pmix_load_info(pmix_info_t *array, dicts:list):
 #            defined as such:
 #            [{key:y, value:val, val_type:ty}, … ]
 #
-cdef int pmix_alloc_info(pmix_info_t **info_ptr, size_t *ninfo, dicts:list):
+# Note: 'dicts' is deliberately left unannotated. Cython treats a
+# parameter annotation as a type declaration that rejects None, and
+# callers are explicitly allowed to pass None to mean "no attributes" -
+# the branch below depends on it
+cdef int pmix_alloc_info(pmix_info_t **info_ptr, size_t *ninfo, dicts):
     # Convert any provided dictionary to an array of pmix_info_t
     if dicts is not None:
         ninfo[0] = len(dicts)

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1316,7 +1316,11 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def group_construct(self, group:str, peers:list, pyinfo:list):
+    # Note: 'peers' and 'pyinfo' are deliberately left unannotated. Cython
+    # treats a parameter annotation as a type declaration that rejects
+    # None, which would make the "no peers given" default below - and the
+    # documented ability to pass None for the attributes - unreachable.
+    def group_construct(self, group:str, peers, pyinfo):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -1364,7 +1368,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def group_invite(self, group:str, peers:list, pyinfo:list):
+    def group_invite(self, group:str, peers, pyinfo):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -1412,7 +1416,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def group_join(self, group:str, leader:dict, opt:int, pyinfo:list):
+    def group_join(self, group:str, leader, opt:int, pyinfo):
         cdef pmix_proc_t proc
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -1447,7 +1451,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def group_leave(self, group:str, pyinfo:list):
+    def group_leave(self, group:str, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t ninfo
@@ -1466,7 +1470,7 @@ cdef class PMIxClient:
             pmix_free_info(info, ninfo)
         return rc
 
-    def group_destruct(self, group:str, pyinfo:list):
+    def group_destruct(self, group:str, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t ninfo

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -11,6 +11,7 @@ from ctypes import addressof, c_int
 from cython.operator import address
 import signal, time, sys
 import threading, ctypes
+import traceback
 import queue
 import array
 import os
@@ -36,6 +37,163 @@ cdef struct mcbd:
     char *data
     size_t size
 ctypedef mcbd pypmix_modex_cbdata_t
+
+###############################################
+# Client-side non-blocking (async) operations
+#
+# A non-blocking PMIx API returns as soon as the request has been handed
+# to the library, and reports its result later by executing a callback
+# from the library's progress thread. Two things must therefore survive
+# the Python method that started the operation:
+#
+#   * the C input arrays. PMIx does not copy them - the caller must keep
+#     them valid until the callback fires - so they cannot be freed when
+#     the method returns the way the blocking methods free theirs. They
+#     are parked in the caddy below and released by the trampoline.
+#   * the caller's Python callback and cbdata object. Nothing else holds
+#     a reference to them, so they are stashed in a module-global
+#     registry (the same technique the bindings use to keep event
+#     handlers alive in 'myhdlrs') and the caddy carries only the
+#     integer key. No PyObject pointer ever crosses into C.
+#
+# See docs/how-things-work/python_nonblocking.rst for the full picture.
+cdef struct nbcbd:
+    char *grp             # strdup'd group identifier
+    pmix_proc_t *procs    # PyMem_Malloc'd by pmix_load_procs
+    size_t nprocs
+    pmix_info_t *info     # malloc'd by pmix_alloc_info
+    size_t ninfo
+    size_t idx            # key into the pynbcbs registry
+ctypedef nbcbd pypmix_nb_cbdata_t
+
+# Registry of in-flight non-blocking operations. Guarded by pynblock as
+# entries are added by the calling thread and removed by the progress
+# thread.
+pynbcbs = {}
+pynbidx = 0
+pynblock = threading.Lock()
+
+def pypmix_nb_register(cbfunc, cbdata):
+    # Record a Python callback pair and return its registry key
+    global pynbidx
+    with pynblock:
+        pynbidx += 1
+        idx = pynbidx
+        pynbcbs[idx] = {'cbfunc': cbfunc, 'cbdata': cbdata}
+    return idx
+
+def pypmix_nb_take(idx):
+    # Remove and return a registry entry, or None if it is already gone
+    with pynblock:
+        return pynbcbs.pop(idx, None)
+
+# Allocate a caddy for a non-blocking operation. Returns NULL on failure
+cdef pypmix_nb_cbdata_t* pypmix_nb_cbdata_new():
+    cdef pypmix_nb_cbdata_t *cd
+    cd = <pypmix_nb_cbdata_t *> malloc(sizeof(pypmix_nb_cbdata_t))
+    if NULL == cd:
+        return NULL
+    cd.grp    = NULL
+    cd.procs  = NULL
+    cd.nprocs = 0
+    cd.info   = NULL
+    cd.ninfo  = 0
+    cd.idx    = 0
+    return cd
+
+# Release a caddy and everything it owns. Note that the group name, the
+# procs array and the info array each came from a different allocator -
+# strdup, PyMem_Malloc and malloc respectively - so each must go back to
+# its own
+cdef void pypmix_nb_cbdata_free(pypmix_nb_cbdata_t *cd):
+    if NULL == cd:
+        return
+    if NULL != cd.grp:
+        free(cd.grp)
+    if NULL != cd.procs:
+        pmix_free_procs(cd.procs, cd.nprocs)
+    if NULL != cd.info and 0 < cd.ninfo:
+        pmix_free_info(cd.info, cd.ninfo)
+    free(cd)
+
+# The registry entry doubles as the ownership token for the caddy:
+# whoever pops it is responsible for releasing the caddy, and a pop that
+# comes up empty means someone else already did. That keeps the starting
+# method's error path and the trampoline from ever racing to free it.
+#
+# Trampoline for non-blocking APIs that take a pmix_op_cbfunc_t. This
+# fires on the library's progress thread, which is not a Python thread,
+# so the GIL must be acquired
+cdef void pypmix_client_op_cbfunc(pmix_status_t status,
+                                  void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_info_cbfunc_t
+cdef void pypmix_client_info_cbfunc(pmix_status_t status,
+                                    pmix_info_t *info, size_t ninfo,
+                                    void *cbdata,
+                                    pmix_release_cbfunc_t release_fn,
+                                    void *release_cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    # the results belong to the library, so convert them to Python before
+    # telling it that we are done with them
+    pyresults = []
+    prc = PMIX_SUCCESS
+    if NULL != info and 0 < ninfo:
+        prc = pmix_unload_info(info, ninfo, pyresults)
+    if NULL != release_fn:
+        release_fn(release_cbdata)
+    if PMIX_SUCCESS != prc and PMIX_SUCCESS == status:
+        status = prc
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyresults, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Build the caddy for a non-blocking group operation, taking ownership of
+# the group identifier and the info array. Returns NULL on failure, with
+# the reason stored in rcptr
+cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo:list, int *rcptr):
+    cdef pypmix_nb_cbdata_t *cd
+    cdef pmix_info_t **info_ptr
+
+    cd = pypmix_nb_cbdata_new()
+    if NULL == cd:
+        rcptr[0] = PMIX_ERR_NOMEM
+        return NULL
+    cd.grp = strdup(pygrp)
+    if NULL == cd.grp:
+        pypmix_nb_cbdata_free(cd)
+        rcptr[0] = PMIX_ERR_NOMEM
+        return NULL
+    info_ptr = &cd.info
+    rc = pmix_alloc_info(info_ptr, &cd.ninfo, pyinfo)
+    if PMIX_SUCCESS != rc:
+        pypmix_nb_cbdata_free(cd)
+        rcptr[0] = rc
+        return NULL
+    rcptr[0] = PMIX_SUCCESS
+    return cd
 
 # Function to release pypmix_info_cbdata_t structure
 cdef void op_release(pmix_status_t status, void *cbdata) noexcept nogil:
@@ -1487,6 +1645,217 @@ cdef class PMIxClient:
         rc = PMIx_Group_destruct(pygrp, info, ninfo)
         if 0 < ninfo:
             pmix_free_info(info, ninfo)
+        return rc
+
+    # Non-blocking forms of the group operations. Each returns only the
+    # integer status of the request itself - the result of the operation
+    # is delivered later by executing 'cbfunc' on the library's progress
+    # thread. The callback is passed the opaque 'cbdata' object handed in
+    # here, unmodified, and takes the form
+    #
+    #    cbfunc(status:int, results:list, cbdata)   # construct/invite/join
+    #    cbfunc(status:int, cbdata)                 # leave/destruct
+    #
+    # A callback is executed if and only if the method returns
+    # PMIX_SUCCESS. Note that it runs on the progress thread, so it must
+    # not call a blocking PMIx operation - hand the work to another
+    # thread instead.
+    def group_construct_nb(self, group:str, peers, pyinfo,
+                           cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # convert group name and the info array into a caddy that will
+        # outlive this call - the library does not copy them, so they
+        # must remain valid until the callback fires
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # convert list of procs to array of pmix_proc_t's
+        if peers is not None and 0 < len(peers):
+            cd.nprocs = len(peers)
+            cd.procs = <pmix_proc_t*> PyMem_Malloc(cd.nprocs * sizeof(pmix_proc_t))
+            if not cd.procs:
+                cd.nprocs = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            prc = pmix_load_procs(cd.procs, peers)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+        else:
+            cd.nprocs = 1
+            cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+            if not cd.procs:
+                cd.nprocs = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
+            cd.procs[0].rank = PMIX_RANK_WILDCARD
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_construct_nb(cd.grp, cd.procs, cd.nprocs,
+                                         cd.info, cd.ninfo,
+                                         pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    def group_invite_nb(self, group:str, peers, pyinfo,
+                        cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # convert group name and the info array into a caddy that will
+        # outlive this call
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # convert list of procs to array of pmix_proc_t's
+        if peers is not None and 0 < len(peers):
+            cd.nprocs = len(peers)
+            cd.procs = <pmix_proc_t*> PyMem_Malloc(cd.nprocs * sizeof(pmix_proc_t))
+            if not cd.procs:
+                cd.nprocs = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            prc = pmix_load_procs(cd.procs, peers)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+        else:
+            cd.nprocs = 1
+            cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+            if not cd.procs:
+                cd.nprocs = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
+            cd.procs[0].rank = PMIX_RANK_WILDCARD
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_invite_nb(cd.grp, cd.procs, cd.nprocs,
+                                      cd.info, cd.ninfo,
+                                      pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    def group_join_nb(self, group:str, leader, opt:int, pyinfo,
+                      cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_group_opt_t copt
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        copt = opt
+
+        # convert group name and the info array into a caddy that will
+        # outlive this call
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # the leader must outlive this call as well, so park it in the
+        # caddy as a single-element proc array
+        cd.nprocs = 1
+        cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+        if not cd.procs:
+            cd.nprocs = 0
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_NOMEM
+        if leader is not None:
+            pmix_copy_nspace(cd.procs[0].nspace, leader['nspace'])
+            cd.procs[0].rank = leader['rank']
+        else:
+            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
+            cd.procs[0].rank = self.myproc.rank
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_join_nb(cd.grp, &cd.procs[0], copt,
+                                    cd.info, cd.ninfo,
+                                    pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    def group_leave_nb(self, group:str, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # convert group name and the info array into a caddy that will
+        # outlive this call
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_leave_nb(cd.grp, cd.info, cd.ninfo,
+                                     pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    def group_destruct_nb(self, group:str, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # convert group name and the info array into a caddy that will
+        # outlive this call
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_destruct_nb(cd.grp, cd.info, cd.ninfo,
+                                        pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
         return rc
 
     def register_event_handler(self, pycodes, pyinfo, hdlr):

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -173,7 +173,7 @@ cdef void pypmix_client_info_cbfunc(pmix_status_t status,
 # Build the caddy for a non-blocking group operation, taking ownership of
 # the group identifier and the info array. Returns NULL on failure, with
 # the reason stored in rcptr
-cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo:list, int *rcptr):
+cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo, int *rcptr):
     cdef pypmix_nb_cbdata_t *cd
     cdef pmix_info_t **info_ptr
 
@@ -638,7 +638,7 @@ cdef class PMIxClient:
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
     #
-    def init(self, dicts:list):
+    def init(self, dicts):
         cdef size_t klen
         global myname
         cdef pmix_info_t *info
@@ -657,7 +657,7 @@ cdef class PMIxClient:
         return rc, myname
 
     # Finalize the client library
-    def finalize(self, dicts:list):
+    def finalize(self, dicts):
         cdef size_t klen
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -684,7 +684,7 @@ cdef class PMIxClient:
     #
     # @procs [INPUT]
     #        - list of proc nspace,rank dicts
-    def abort(self, status, msg, peers:list):
+    def abort(self, status, msg, peers):
         cdef pmix_proc_t *procs
         cdef size_t sz
         # convert list of procs to array of pmix_proc_t's
@@ -738,7 +738,7 @@ cdef class PMIxClient:
     #
     # @value [INPUT]
     #        - a dict to be stored with keys (value, val_type)
-    def store_internal(self, pyproc:dict, pykey:str, pyval:dict):
+    def store_internal(self, pyproc, pykey:str, pyval:dict):
         cdef pmix_key_t key
         cdef pmix_proc_t proc
         cdef pmix_value_t value
@@ -788,7 +788,7 @@ cdef class PMIxClient:
         rc = PMIx_Commit()
         return rc
 
-    def fence(self, peers:list, dicts:list):
+    def fence(self, peers, dicts):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -849,7 +849,7 @@ cdef class PMIxClient:
     #            dictionary has a key, value, and val_type
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
-    def get(self, proc:dict, ky, dicts:list):
+    def get(self, proc, ky, dicts):
         cdef pmix_info_t *info;
         cdef pmix_info_t **info_ptr;
         cdef size_t ninfo;
@@ -899,7 +899,7 @@ cdef class PMIxClient:
     #          - a list of dictionaries, where
     #            a key, flags, value, and val_type
     #            can be defined as keys
-    def publish(self, dicts:list):
+    def publish(self, dicts):
         cdef pmix_info_t *info;
         cdef pmix_info_t **info_ptr;
         cdef size_t ninfo;
@@ -923,7 +923,7 @@ cdef class PMIxClient:
     #            can be defined as keys
     # @pykeys [INPUT]
     #          - list of python info key strings
-    def unpublish(self, pykeys:list, dicts:list):
+    def unpublish(self, pykeys, dicts):
         cdef pmix_info_t *info;
         cdef pmix_info_t **info_ptr;
         cdef size_t ninfo;
@@ -974,7 +974,7 @@ cdef class PMIxClient:
     #          - a list of dictionaries, where
     #            a key, flags, value, and val_type
     #            can be defined as keys
-    def lookup(self, data:list, dicts:list):
+    def lookup(self, data, dicts):
         cdef pmix_pdata_t *pdata;
         cdef pmix_info_t  *info;
         cdef pmix_info_t  **info_ptr;
@@ -1024,7 +1024,7 @@ cdef class PMIxClient:
     # Spawn a new job
     #
     #
-    def spawn(self, jobInfo:list, pyapps:list):
+    def spawn(self, jobInfo, pyapps):
         cdef pmix_info_t *jinfo;
         cdef pmix_info_t **jinfo_ptr;
         cdef pmix_app_t *apps;
@@ -1070,7 +1070,7 @@ cdef class PMIxClient:
             pyns = nspace.decode('ascii')
         return rc, pyns
 
-    def connect(self, peers:list, pyinfo:list):
+    def connect(self, peers, pyinfo):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -1117,7 +1117,7 @@ cdef class PMIxClient:
             pmix_free_info(info, ninfo)
         return rc
 
-    def disconnect(self, peers:list, pyinfo:list):
+    def disconnect(self, peers, pyinfo):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -1200,7 +1200,7 @@ cdef class PMIxClient:
             PyMem_Free(nodelist)
         return rc, pynodes
 
-    def query(self, pyq:list):
+    def query(self, pyq):
         cdef pmix_query_t *queries
         cdef size_t nqueries
         cdef pmix_info_t *results
@@ -1256,7 +1256,7 @@ cdef class PMIxClient:
         pmix_free_queries(queries, nqueries)
         return rc, pyresults
 
-    def log(self, pydata:list, pydirs:list):
+    def log(self, pydata, pydirs):
         cdef pmix_info_t *data
         cdef pmix_info_t **data_ptr
         cdef pmix_info_t *directives
@@ -1277,7 +1277,7 @@ cdef class PMIxClient:
             pmix_free_info(directives, ndirs)
         return rc
 
-    def allocation_request(self, directive, pyinfo:list):
+    def allocation_request(self, directive, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef pmix_info_t *results
@@ -1302,7 +1302,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def job_control(self, pytargets:list, pydirs:list):
+    def job_control(self, pytargets, pydirs):
         cdef pmix_proc_t *targets
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
@@ -1360,7 +1360,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def monitor(self, pymonitor_info:list, code:int, pydirs:list):
+    def monitor(self, pymonitor_info, code:int, pydirs):
         cdef pmix_info_t *monitor_info
         cdef pmix_info_t **monitor_info_ptr
         cdef pmix_info_t *directives
@@ -1402,7 +1402,7 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
-    def get_credential(self, pyinfo:list):
+    def get_credential(self, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef pmix_byte_object_t bo
@@ -1432,7 +1432,7 @@ cdef class PMIxClient:
             cred['size'] = bo.size
         return rc, cred
 
-    def validate_credential(self, pycred:dict, pyinfo:list):
+    def validate_credential(self, pycred:dict, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef pmix_byte_object_t *bo
@@ -1914,7 +1914,7 @@ cdef class PMIxClient:
         rc = PMIx_Deregister_event_handler(ref, NULL, NULL)
         return rc
 
-    def notify_event(self, status:int, pysrc:dict, range, pyinfo:list):
+    def notify_event(self, status:int, pysrc:dict, range, pyinfo):
         cdef pmix_proc_t proc
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -2036,7 +2036,7 @@ cdef class PMIxClient:
         pystr = string
         return pystr.decode('ascii')
 
-    def fabric_register(self, dicts:list):
+    def fabric_register(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2108,7 +2108,7 @@ cdef class PMIxClient:
                 pycpus['cpus'] = txt.split(",")
         return (rc, pycpus)
 
-    def compute_distances(self, pycpus:dict, dicts:list):
+    def compute_distances(self, pycpus:dict, dicts):
         cdef pmix_cpuset_t cpuset
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -2198,7 +2198,7 @@ cdef class PMIxServer(PMIxClient):
     #          - a dictionary of key-function pairs that map
     #            server module callback functions to provided
     #            implementations
-    def init(self, dicts:list, map:dict):
+    def init(self, dicts, map):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2369,7 +2369,7 @@ cdef class PMIxServer(PMIxClient):
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
     #
-    def register_nspace(self, ns:str, nlocalprocs:int, dicts:list):
+    def register_nspace(self, ns:str, nlocalprocs:int, dicts):
         cdef pmix_nspace_t nspace
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -2402,7 +2402,7 @@ cdef class PMIxServer(PMIxClient):
         return
 
     # Register resources
-    def register_resources(self, directives:list):
+    def register_resources(self, directives):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2417,7 +2417,7 @@ cdef class PMIxServer(PMIxClient):
         return rc
 
     # Deregister resources
-    def deregister_resources(self, directives:list):
+    def deregister_resources(self, directives):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -2510,7 +2510,7 @@ cdef class PMIxServer(PMIxClient):
             pybo = (data, sz)
         return rc, pybo
 
-    def setup_application(self, ns:str, dicts:list):
+    def setup_application(self, ns:str, dicts):
         global active
         cdef pmix_nspace_t nspace;
         cdef pmix_info_t *info
@@ -2531,7 +2531,7 @@ cdef class PMIxServer(PMIxClient):
             active.fetch_info(dataout)
         return (rc, dataout)
 
-    def register_attributes(self, function:str, attrs:list):
+    def register_attributes(self, function:str, attrs):
         cdef size_t nattrs
         cdef char *func
         cdef char **attarray
@@ -2563,7 +2563,7 @@ cdef class PMIxServer(PMIxClient):
             PyMem_Free(func)
         return PMIX_SUCCESS
 
-    def collect_inventory(self, pydirs:list):
+    def collect_inventory(self, pydirs):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
@@ -2584,7 +2584,7 @@ cdef class PMIxServer(PMIxClient):
             active.fetch_info(dataout)
         return (rc, dataout)
 
-    def deliver_inventory(self, pyinfo:list, pydirs:list):
+    def deliver_inventory(self, pyinfo, pydirs):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_info_t *info
@@ -2605,7 +2605,7 @@ cdef class PMIxServer(PMIxClient):
                                            NULL, NULL)
         return rc
 
-    def setup_local_support(self, ns:str, ilist:list):
+    def setup_local_support(self, ns:str, ilist):
         global active
         cdef pmix_nspace_t nspace;
         cdef pmix_info_t *info
@@ -2625,7 +2625,7 @@ cdef class PMIxServer(PMIxClient):
             active.wait()
         return rc
 
-    def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs:list):
+    def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs):
         cdef pmix_proc_t source
         cdef pmix_iof_channel_t channel
         cdef pmix_byte_object_t bo
@@ -2660,7 +2660,7 @@ cdef class PMIxServer(PMIxClient):
             pmix_free_info(directives, ndirs)
         return rc
 
-    def define_process_set(self, members:list, name:str):
+    def define_process_set(self, members, name:str):
         cdef pmix_proc_t *procs
         cdef size_t nprocs
         nprocs = 0
@@ -2691,7 +2691,7 @@ cdef class PMIxServer(PMIxClient):
         rc = PMIx_server_delete_process_set(pyset)
         return rc
 
-    def session_control(self, sessionID:int, ilist:list):
+    def session_control(self, sessionID:int, ilist):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3435,7 +3435,7 @@ cdef class PMIxTool(PMIxServer):
     #            dictionary has a key, value, and val_type
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
-    def init(self, dicts:list):
+    def init(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3489,7 +3489,7 @@ cdef class PMIxTool(PMIxServer):
     #            dictionary has a key, value, and val_type
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
-    def attach_to_server(self, dicts:list):
+    def attach_to_server(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3524,7 +3524,7 @@ cdef class PMIxTool(PMIxServer):
         PyMem_Free(servers)
         return rc, pysrvrs
 
-    def set_server(self, server:dict, pyinfo:list):
+    def set_server(self, server:dict, pyinfo):
         cdef pmix_proc_t srvr
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -3550,7 +3550,7 @@ cdef class PMIxTool(PMIxServer):
 
     # Allow a tool to set server module callback functions
     # when it needs to also act as a server
-    def set_server_module(self, map:dict):
+    def set_server_module(self, map):
         # setup server module
         if map is None or 0 == len(map):
             print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
@@ -3566,7 +3566,7 @@ cdef class PMIxTool(PMIxServer):
         return PMIX_SUCCESS
 
 
-    def iof_pull(self, pyprocs:list, iof_channel:int, pydirs:list, hdlr):
+    def iof_pull(self, pyprocs, iof_channel:int, pydirs, hdlr):
         cdef pmix_proc_t *procs
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
@@ -3621,7 +3621,7 @@ cdef class PMIxTool(PMIxServer):
         rc = PMIX_SUCCESS
         return rc, refid
 
-    def iof_deregister(self, regid:int, pydirs:list):
+    def iof_deregister(self, regid:int, pydirs):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
@@ -3652,7 +3652,7 @@ cdef class PMIxTool(PMIxServer):
                 pass
         return rc
 
-    def iof_push(self, pytargets:list, data:dict, pydirs:list):
+    def iof_push(self, pytargets, data:dict, pydirs):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_byte_object_t *bo
@@ -3718,7 +3718,7 @@ cdef class PMIxScheduler(PMIxTool):
     #            dictionary has a key, value, and val_type
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
-    def init(self, dicts:list):
+    def init(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
@@ -3754,7 +3754,7 @@ cdef class PMIxScheduler(PMIxTool):
         return rc
 
     # direct the RTE to instantiate a session
-    def assign_session(self, sessionID:int, allocID:str, ilist:list, applist:list):
+    def assign_session(self, sessionID:int, allocID:str, ilist, applist:list):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2305,21 +2305,28 @@ cdef class PMIxServer(PMIxClient):
         return PMIx_server_finalize()
 
     def generate_regex(self, hosts:list):
-        cdef char *regex;
+        cdef char *regex = NULL
         mycomma = ","
         myhosts = mycomma.join(hosts)
         pyhosts = myhosts.encode('ascii')
         rc = PMIx_generate_regex(pyhosts, &regex)
+        # the library leaves the output pointer untouched when it fails,
+        # so there is nothing to convert
+        if PMIX_SUCCESS != rc or NULL == regex:
+            return (rc, bytearray(0))
         # load regex appropriately into python bytearray
         ba = pmix_convert_regex(regex)
         return (rc, ba)
 
     def generate_ppn(self, procs:list):
-        cdef char *ppn;
+        cdef char *ppn = NULL
         mysemi = ";"
         myprocs = mysemi.join(procs)
         pyprocs = myprocs.encode('ascii')
         rc = PMIx_generate_ppn(pyprocs, &ppn)
+        # the library leaves the output pointer untouched when it fails
+        if PMIX_SUCCESS != rc or NULL == ppn:
+            return (rc, bytearray(0))
         if "pmix" == ppn[:4].decode("ascii"):
             if b'\x00' in ppn:
                 ppn.replace(b'\x00', '')

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2710,7 +2710,6 @@ cdef int allocate(const pmix_proc_t *client,
     if 'allocate' in keys:
         args = {}
         myproc = []
-        mydirs = {}
         keyvals = []
         if NULL == client:
             return PMIX_ERR_BAD_PARAM
@@ -2735,7 +2734,7 @@ cdef int jobcontrol(const pmix_proc_t *requestor,
         args = {}
         myproc = []
         mytargets = []
-        mydirs = {}
+        mydirs = []
         if NULL != requestor:
             pmix_unload_procs(requestor, 1, myproc)
             args['source'] = myproc[0]
@@ -2757,9 +2756,9 @@ cdef int monitor(const pmix_proc_t *requestor,
     keys = pmixservermodule.keys()
     if 'monitor' in keys:
         args = {}
-        mymon = {}
+        mymon = []
         myproc = []
-        mydirs = {}
+        mydirs = []
         blist = []
         if NULL == monitor:
             return PMIX_ERR_BAD_PARAM
@@ -2767,7 +2766,7 @@ cdef int monitor(const pmix_proc_t *requestor,
             pmix_unload_procs(requestor, 1, myproc)
             args['source'] = myproc[0]
         pmix_unload_info(monitor, 1, mymon)
-        args['monitor'] = mymon
+        args['monitor'] = mymon[0]
         args['error'] = error
         if NULL != directives:
             pmix_unload_info(directives, ndirs, mydirs)
@@ -2784,7 +2783,7 @@ cdef int getcredential(const pmix_proc_t *proc,
     if 'getcredential' in keys:
         args = {}
         myproc = []
-        mydirs = {}
+        mydirs = []
         if NULL != proc:
             pmix_unload_procs(proc, 1, myproc)
             args['source'] = myproc[0]
@@ -2805,7 +2804,7 @@ cdef int validatecredential(const pmix_proc_t *proc,
         args = {}
         keyvals = {}
         myproc = []
-        mydirs = {}
+        mydirs = []
         blist = []
         pycred = {}
         if NULL != proc:
@@ -2834,7 +2833,7 @@ cdef int iofpull(const pmix_proc_t procs[], size_t nprocs,
         args = {}
         keyvals = {}
         myprocs = []
-        mydirs = {}
+        mydirs = []
         pychannels = int(channels)
         args['channels'] = channels
         if NULL != procs:
@@ -2859,7 +2858,7 @@ cdef int pushstdin(const pmix_proc_t *source,
         keyvals = {}
         myproc = []
         mytargets = []
-        mydirs = {}
+        mydirs = []
         blist = []
         pyload = {}
         if NULL != source:
@@ -2883,12 +2882,18 @@ cdef int pushstdin(const pmix_proc_t *source,
     return PMIX_ERR_NOT_SUPPORTED
 
 
-# TODO: This function requires that the server execute the
-# provided callback function to return the group info, and
-# it is not allowed to do so until _after_ it returns from
-# this upcall. We'll need to figure out a way to 'save' the
-# cbfunc until the server calls us back, possibly by passing
-# an appropriate caddy object in 'cbdata'
+# The server library requires that the host complete a group operation by
+# executing the provided callback function, and the host is not required to
+# do so before returning from this upcall. A Python handler therefore has
+# two ways to respond:
+#
+#   * return PMIX_OPERATION_SUCCEEDED to decline the callback entirely - the
+#     server library will complete the operation itself with no results, or
+#   * return PMIX_SUCCESS and invoke the supplied callback exactly once with
+#     the results, either from within the handler or later from another
+#     thread. The 'cbdata_dict' passed to the handler holds only integers,
+#     so it may be saved and used after the handler returns, and the server
+#     library thread-shifts the callback, so any thread may drive it.
 cdef int group(pmix_group_operation_t op, char grp[],
                const pmix_proc_t procs[], size_t nprocs,
                const pmix_info_t directives[], size_t ndirs,
@@ -2896,12 +2901,14 @@ cdef int group(pmix_group_operation_t op, char grp[],
     keys = pmixservermodule.keys()
     if 'group' in keys:
         args = {}
-        keyvals = {}
         myprocs = []
-        mydirs = {}
+        mydirs = []
         args['op'] = op
-        args['group'] = str(grp)
-        pmix_unload_procs(procs, nprocs, myprocs)
+        if NULL == grp:
+            return PMIX_ERR_BAD_PARAM
+        args['group'] = grp.decode('ascii')
+        if NULL != procs:
+            pmix_unload_procs(procs, nprocs, myprocs)
         args['procs'] = myprocs
         if NULL != directives:
             pmix_unload_info(directives, ndirs, mydirs)
@@ -2922,7 +2929,7 @@ cdef int fabric(const pmix_proc_t *requestor,
         args = {}
         keyvals = {}
         myprocs = []
-        mydirs = {}
+        mydirs = []
         args['op'] = op
         if NULL != directives:
             pmix_unload_info(directives, ndirs, mydirs)

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -22,3 +22,4 @@ find information on that subject here.
    regex.rst
    ptl.rst
    pstat.rst
+   python_nonblocking.rst

--- a/docs/how-things-work/python_nonblocking.rst
+++ b/docs/how-things-work/python_nonblocking.rst
@@ -1,0 +1,253 @@
+Non-Blocking Operations in the Python Bindings
+==============================================
+
+This document describes how the PMIx Python bindings drive a
+non-blocking (``_nb``) PMIx API: what has to stay alive while the
+request is in flight, how the caller's Python callback is reached from
+the library's progress thread, and which rules a new ``_nb`` binding has
+to follow. The machinery lives in
+``bindings/python/pmix.pyx``; the conversion helpers it leans on are in
+``bindings/python/pmix.pxi``.
+
+The non-blocking group operations - ``group_construct_nb``,
+``group_invite_nb``, ``group_join_nb``, ``group_leave_nb`` and
+``group_destruct_nb`` - are the first bindings built on it, and are used
+as the worked example throughout. The remaining ``_nb`` entry points
+listed in ``bindings/python/MISSING_BINDINGS.md`` can be added by
+following the same pattern.
+
+
+The problem
+-----------
+
+A blocking binding has an easy life. It converts its Python arguments
+into C, calls the library, and by the time the call returns the library
+is finished with everything it was handed, so the method frees it all
+before returning a status::
+
+    rc = PMIx_Group_construct(pygrp, procs, nprocs, info, ninfo,
+                              &results, &nresults)
+    if 0 < nprocs:
+        pmix_free_procs(procs, nprocs)
+    if 0 < ninfo:
+        pmix_free_info(info, ninfo)
+
+None of that holds for a non-blocking call. It returns as soon as the
+request has been handed to the library, and reports the outcome later by
+executing a callback on the library's internal progress thread. Two
+distinct problems follow.
+
+**PMIx does not copy its input.** The rule stated in the top-level
+developer guide - callers keep their input valid until the callback
+fires - applies to the bindings exactly as it does to a C program.
+Freeing the ``pmix_info_t`` array when the method returns would be a
+use-after-free. The group identifier is worse: the blocking methods
+write ::
+
+    pygrp = group.encode('ascii')
+
+which produces a Python ``bytes`` object whose lifetime is the local
+variable. Pass its buffer to a non-blocking API and the pointer dangles
+the moment the method returns.
+
+**Nothing holds the caller's callback.** The Python function and the
+``cbdata`` object the caller wants handed back exist only as arguments
+to the method. Once it returns, the interpreter is free to collect
+them, and there is no C-visible reference keeping them alive - the
+bindings never take a reference on a Python object, by long-standing
+convention.
+
+
+The caddy
+---------
+
+Everything of the first kind goes into a small C struct - a *caddy*, in
+the same sense the term is used elsewhere in PMIx - that outlives the
+method::
+
+    cdef struct nbcbd:
+        char *grp             # strdup'd group identifier
+        pmix_proc_t *procs    # PyMem_Malloc'd by pmix_load_procs
+        size_t nprocs
+        pmix_info_t *info     # malloc'd by pmix_alloc_info
+        size_t ninfo
+        size_t idx            # key into the pynbcbs registry
+
+The caddy is passed to the library as the operation's ``cbdata``, so it
+comes back to the trampoline unchanged and can be released there.
+
+Note the comments on the allocators. The three buffers come from three
+different places and each must be returned to its own:
+``pypmix_nb_cbdata_free`` calls ``free`` on the identifier,
+``pmix_free_procs`` (which is ``PyMem_Free``) on the proc array, and
+``pmix_free_info`` on the info array. Crossing them is not a stylistic
+matter - Python's allocator serves small blocks from its own arenas, and
+handing one of those to ``free()`` aborts the process.
+
+``group_join_nb`` takes a single ``const pmix_proc_t *leader`` rather
+than an array. It stores the leader as a one-element ``procs`` array and
+passes ``&cd.procs[0]``, so one set of fields covers all five
+operations.
+
+
+The registry
+------------
+
+The caller's Python callback and ``cbdata`` cannot travel through the
+caddy - a ``PyObject *`` in a C struct is invisible to the interpreter,
+so nothing would stop it being collected. Instead they are held in a
+module-global dictionary, which is how the bindings already keep event
+handlers (``myhdlrs``) and server-module functions (``pmixservermodule``)
+alive::
+
+    pynbcbs  = {}                 # idx -> {'cbfunc': callable, 'cbdata': object}
+    pynbidx  = 0
+    pynblock = threading.Lock()
+
+``pypmix_nb_register`` adds an entry and returns its integer key, which
+is what the caddy carries. ``pypmix_nb_take`` removes and returns an
+entry. The lock matters: entries are added by whichever thread called
+the method and removed by the progress thread.
+
+**The registry entry is the ownership token for the caddy.** Whoever
+takes the entry is responsible for releasing the caddy, and a take that
+comes up empty means someone else already has. Without that rule the
+trampoline and the method's error path could both decide to free the
+same caddy.
+
+
+The trampolines
+---------------
+
+Two C functions bridge back into Python, one per callback signature that
+the group APIs use::
+
+    cdef void pypmix_client_op_cbfunc(pmix_status_t status,
+                                      void *cbdata) noexcept with gil
+
+    cdef void pypmix_client_info_cbfunc(pmix_status_t status,
+                                        pmix_info_t *info, size_t ninfo,
+                                        void *cbdata,
+                                        pmix_release_cbfunc_t release_fn,
+                                        void *release_cbdata) noexcept with gil
+
+``with gil`` is mandatory and is the whole reason these cannot be
+ordinary functions. They run on the library's progress thread, which
+Python knows nothing about; the declaration makes Cython acquire the GIL
+(and register the thread) around the body. ``noexcept`` pairs with the
+``try``/``except`` inside: an exception raised by the user's callback is
+printed and swallowed, because there is no sane way to propagate one
+into libpmix.
+
+The ``pmix_info_cbfunc_t`` form carries an extra ``release_fn`` /
+``release_cbdata`` pair. Those results belong to the library, so the
+trampoline converts them to Python first and then calls ``release_fn``
+to give them back - the same sequence ``collectinventory_cbfunc`` uses.
+
+The Python-facing signatures are::
+
+    cbfunc(status, results, cbdata)   # construct, invite, join
+    cbfunc(status, cbdata)            # leave, destruct
+
+where ``results`` is a list of info dictionaries and ``cbdata`` is
+whatever object the caller passed in, returned untouched.
+
+
+Putting it together
+-------------------
+
+A binding then reads::
+
+    def group_leave_nb(self, group, pyinfo, cbfunc, cbdata=None):
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        pygrp = group.encode('ascii')
+        cd = pypmix_nb_group_setup(pygrp, pyinfo, &prc)
+        if NULL == cd:
+            return prc
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Group_leave_nb(cd.grp, cd.info, cd.ninfo,
+                                     pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+Four details in that are load-bearing.
+
+*The callback is validated first.* A callback that cannot be executed
+would leave the caddy and the registry entry stranded for the life of
+the process, so a non-callable is rejected before anything is
+allocated.
+
+*The library call releases the GIL.* Inside ``with nogil`` the progress
+thread is free to run - including running the trampoline for this very
+operation, which is why the registration happens before the call and not
+after.
+
+*The error path cleans up.* When a PMIx ``_nb`` API returns anything
+other than ``PMIX_SUCCESS`` it has not accepted the request and will
+never execute the callback, so nothing else will ever free the caddy.
+The method must do it, and it does so through the registry, honoring the
+ownership rule above.
+
+*The method returns a bare status.* Results arrive through the callback,
+so unlike the blocking forms these return ``rc`` alone rather than a
+tuple.
+
+
+Rules for callers
+-----------------
+
+A callback runs on the progress thread. It must not call a blocking
+PMIx operation - that is the same deadlock a C program would hit, and
+the reason ``PMIx_Group_join_nb`` exists at all: an invitation is
+delivered in an event handler, where the blocking ``PMIx_Group_join``
+cannot be used. Record the result and wake another thread, as
+``test/python/client.py`` does with a ``threading.Event``.
+
+A callback is executed if and only if the method returned
+``PMIX_SUCCESS``.
+
+
+Adding another non-blocking binding
+-----------------------------------
+
+The machinery is not specific to groups. To bind another ``_nb`` API:
+
+#. Confirm the C prototype is already in the generated
+   ``pmix_constants.pxd`` - it almost certainly is, since
+   ``construct.py`` harvests every public API. Do not hand-edit that
+   file.
+#. Park every input the library will hold - and anything derived from a
+   Python object, which dies with the method - in a caddy. Add fields to
+   ``nbcbd`` if the operation carries arguments the group operations do
+   not, and extend ``pypmix_nb_cbdata_free`` to match.
+#. Reuse ``pypmix_client_op_cbfunc`` or ``pypmix_client_info_cbfunc`` if
+   the API takes ``pmix_op_cbfunc_t`` or ``pmix_info_cbfunc_t``. Other
+   callback types - ``pmix_lookup_cbfunc_t``, ``pmix_spawn_cbfunc_t``,
+   ``pmix_value_cbfunc_t`` - need a trampoline of their own, written to
+   the same shape: take the registry entry, convert, release what the
+   library owns, free the caddy, then call into Python inside a
+   ``try``/``except``.
+#. Follow the error-path rule exactly. It is the easiest part to get
+   wrong and the hardest to notice, because the leak only shows up when
+   the library refuses a request.
+
+``test/python/test_bindings.py`` shows how to cover the result without a
+server: calling the method before ``init()`` returns ``PMIX_ERR_INIT``,
+which drives the whole marshaling path and then the error-path cleanup,
+and the test asserts that no callback fired and that the registry is
+empty afterwards.
+
+
+Related reading
+---------------
+
+* ``bindings/python/AGENTS.md`` - conventions for the bindings as a
+  whole, including the data conversion model and the upcall
+  trampolines that run in the opposite direction.
+* ``bindings/python/MISSING_BINDINGS.md`` - the remaining unbound APIs.
+* The *Thread Safety and the Progress Thread* section of the top-level
+  developer guide - the C-side contract these bindings are honoring.

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -43,6 +43,26 @@ Python Syntax
              'value': {'value': True, 'val_type': PMIX_BOOL}}]
   rc, results = foo.group_construct("mygroup", peers, pydirs)
 
+The non-blocking form takes a Python callback in place of the returned
+results, and reports only the status of the request itself:
+
+.. code-block:: python3
+
+  from pmix import *
+
+  # the callback is executed on the PMIx progress thread once the group
+  # has formed. It must not make a blocking PMIx call - hand the result
+  # to another thread instead
+  def mycb(status:int, results:list, cbdata):
+      print("CONSTRUCT COMPLETE", status, results)
+      cbdata.set()
+
+  foo = PMIxClient()
+  done = threading.Event()
+  # passing None for the peers means "everyone in my job"
+  rc = foo.group_construct_nb("mygroup", None, pydirs, mycb, done)
+  # mycb is executed only if rc is PMIX_SUCCESS
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Group_destruct.3.rst
+++ b/docs/man/man3/PMIx_Group_destruct.3.rst
@@ -36,6 +36,22 @@ Python Syntax
   pyinfo = []
   rc = foo.group_destruct("mygroup", pyinfo)
 
+The non-blocking form takes a Python callback, and reports only the
+status of the request itself:
+
+.. code-block:: python3
+
+  from pmix import *
+
+  # the callback is executed on the PMIx progress thread once every
+  # member has called destruct. It must not make a blocking PMIx call
+  def mycb(status:int, cbdata):
+      print("DESTRUCT COMPLETE", status)
+
+  foo = PMIxClient()
+  rc = foo.group_destruct_nb("mygroup", pyinfo, mycb, None)
+  # mycb is executed only if rc is PMIX_SUCCESS
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Group_invite.3.rst
+++ b/docs/man/man3/PMIx_Group_invite.3.rst
@@ -42,6 +42,22 @@ Python Syntax
   pyinfo = []
   rc, results = foo.group_invite("mygroup", peers, pyinfo)
 
+The non-blocking form takes a Python callback in place of the returned
+results, and reports only the status of the request itself:
+
+.. code-block:: python3
+
+  from pmix import *
+
+  # the callback is executed on the PMIx progress thread once every
+  # invitee has responded. It must not make a blocking PMIx call
+  def mycb(status:int, results:list, cbdata):
+      print("INVITE COMPLETE", status, results)
+
+  foo = PMIxClient()
+  rc = foo.group_invite_nb("mygroup", peers, pyinfo, mycb, None)
+  # mycb is executed only if rc is PMIX_SUCCESS
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Group_join.3.rst
+++ b/docs/man/man3/PMIx_Group_join.3.rst
@@ -44,6 +44,26 @@ Python Syntax
   pyinfo = []
   rc, results = foo.group_join("mygroup", leader, PMIX_GROUP_ACCEPT, pyinfo)
 
+An invitation is delivered in an event handler, and the blocking form
+must not be called from one. The non-blocking form is therefore the
+usual way to respond: it takes a Python callback in place of the
+returned results, and reports only the status of the request itself:
+
+.. code-block:: python3
+
+  from pmix import *
+
+  # the callback is executed on the PMIx progress thread once the group
+  # has formed. It must not make a blocking PMIx call
+  def mycb(status:int, results:list, cbdata):
+      print("JOIN COMPLETE", status, results)
+
+  def myinvitehdlr(evhdlr:int, status:int,
+                   source:dict, info:list, results:list):
+      # accepting from within the handler is safe in this form
+      foo.group_join_nb("mygroup", source, PMIX_GROUP_ACCEPT, [], mycb, None)
+      return PMIX_EVENT_ACTION_COMPLETE, None
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Group_leave.3.rst
+++ b/docs/man/man3/PMIx_Group_leave.3.rst
@@ -36,6 +36,23 @@ Python Syntax
   pyinfo = []
   rc = foo.group_leave("mygroup", pyinfo)
 
+The non-blocking form takes a Python callback, and reports only the
+status of the request itself:
+
+.. code-block:: python3
+
+  from pmix import *
+
+  # the callback is executed on the PMIx progress thread once the
+  # departure event has been locally generated. It must not make a
+  # blocking PMIx call
+  def mycb(status:int, cbdata):
+      print("LEAVE COMPLETE", status)
+
+  foo = PMIxClient()
+  rc = foo.group_leave_nb("mygroup", pyinfo, mycb, None)
+  # mycb is executed only if rc is PMIX_SUCCESS
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -16,6 +16,12 @@ Detailed changes since v6.1.0:
    first non-blocking client bindings, and the machinery they introduce
    is documented in docs/how-things-work/python_nonblocking.rst for the
    remaining non-blocking APIs to reuse
+ - Fixed the server aborting when a host environment rejects an incoming
+   client connection. The error path in the connection handler released
+   a rank_info object owned by the namespace's rank list, driving its
+   refcount to zero while it was still on that list, and released the
+   pending-connection object twice. A host returning an error from its
+   client_connected callback now simply gets the connection refused
  - Fixed a group bug affecting every caller of PMIx_Group_construct_nb,
    in C as well as Python: the client recorded the constructed group
    only on the completion path used by the blocking wrapper, so a

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,29 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Added Python bindings for the non-blocking group operations -
+   group_construct_nb, group_invite_nb, group_join_nb, group_leave_nb
+   and group_destruct_nb. Each takes a Python callback that is executed
+   on the progress thread when the operation completes, which is what
+   lets a Python program accept a group invitation from inside an event
+   handler - the blocking form must not be called there. These are the
+   first non-blocking client bindings, and the machinery they introduce
+   is documented in docs/how-things-work/python_nonblocking.rst for the
+   remaining non-blocking APIs to reuse
+ - Fixed a group bug affecting every caller of PMIx_Group_construct_nb,
+   in C as well as Python: the client recorded the constructed group
+   only on the completion path used by the blocking wrapper, so a
+   non-blocking caller's subsequent leave or destruct failed with
+   PMIX_ERR_NOT_FOUND against a group it had just built
+ - Fixed several defects in the Python bindings found while adding the
+   above: values handed to the library were allocated with Python's
+   allocator and freed with the C one, which aborted the process when a
+   Python server returned a data array; parameter annotations rejected
+   None on optional arguments, making documented defaults unreachable;
+   the server-module upcalls could not pass directives to a Python
+   handler; and the regex/ppn generators read their output pointer
+   without checking for failure. The Python test scripts also never ran,
+   as the search path they were given was left unexpanded
  - Added the --enable-test-build configure option. It force-builds the
    test and environment-specific components - the GPU vendor components,
    the NVIDIA/simptest/TCP transports, the pgpu test component, and the

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1940,6 +1940,16 @@ report:
     cb->ninfo = darray.size;
     PMIx_Info_list_release(ilist);
 
+    /* record the group locally now that its construction has succeeded.
+     * This must happen here, on the completion path shared by both forms
+     * of the API, and not in the callback the blocking wrapper installs -
+     * a caller of PMIx_Group_construct_nb supplies its own callback, and
+     * would otherwise never get the group registered, leaving every
+     * subsequent leave/destruct to fail with PMIX_ERR_NOT_FOUND */
+    if (PMIX_SUCCESS == ret && NULL != members) {
+        add_group(cb->grpid, ctxid, cb->notterm, members, nmembers);
+    }
+
 done:
     if (NULL != members) {
         PMIX_PROC_FREE(members, nmembers);
@@ -2055,6 +2065,16 @@ static pmix_status_t add_group(const char *grpid,
                                pmix_proc_t *members, size_t nmembers)
 {
     pmix_group_t *grp;
+
+    /* the construct completion path registers the group for every caller,
+     * while the callback the blocking wrapper installs still does so for
+     * the join path - so tolerate being asked twice for the same group
+     * rather than leaving a duplicate on the list */
+    PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
+        if (0 == strcmp(grpid, grp->grpid)) {
+            return PMIX_SUCCESS;
+        }
+    }
 
     /* since the group construction has finished, we can add
      * the group to out list of groups. Always sort the

--- a/src/mca/ptl/AGENTS.md
+++ b/src/mca/ptl/AGENTS.md
@@ -358,6 +358,21 @@ be reached:
 `pmix_ptl_base_start_listening` then registers the listen socket's accept
 event on the progress thread.
 
+**Known issue — "listener thread failed to start" from a stale
+`$TMPDIR`.** Those rendezvous files and session directories are removed
+at finalize; a run that is killed or crashes leaves its `pmix-*` /
+`pmix.*` entries behind. Once enough accumulate, a later server fails to
+set up its listener and dies with
+
+```
+The PMIx server's listener thread failed to start. We cannot continue.
+```
+
+taking every `simptest`-based test in `test/unit` down with it. That is
+environmental, not a defect in this framework — reproduce under
+`TMPDIR=$(mktemp -d)` before chasing it. See the *Building and Testing*
+section of the top-level [`AGENTS.md`](../../../AGENTS.md).
+
 ## MCA parameters (registered in `ptl_base_frame.c`)
 
 All under the `pmix_ptl_base_` prefix, most with deprecated

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -182,6 +182,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     void *ilist;
     pmix_data_array_t darray;
     pmix_peer_t *stale;
+    bool counted = false;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -466,6 +467,7 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     nptr->epilog.uid = info->uid;
     nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
+    counted = true;
     peer->sd = pnd->sd;
     if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
         goto error;
@@ -611,6 +613,10 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* the error path below closes the socket and releases pnd, so
+             * detach it from the caddy first - the caddy's destructor
+             * would otherwise release it out from under us */
+            ch->pnd = NULL;
             PMIX_RELEASE(ch);
             goto error;
         }
@@ -625,6 +631,8 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* as above - the error path owns pnd from here on */
+            ch->pnd = NULL;
             PMIX_RELEASE(ch);
             goto error;
         }
@@ -637,9 +645,15 @@ void pmix_ptl_base_connection_handler(int sd, short args, void *cbdata)
     return;
 
 error:
-    if (NULL != info) {
+    /* 'info' is a member of the namespace's rank list, not something we
+     * own - the only reference this function took on it is the one it
+     * gave the peer, which PMIX_RELEASE(peer) below gives back. Releasing
+     * it here as well drove its refcount to zero while it was still on
+     * that list, which aborts the server in a debug build and leaves the
+     * list holding freed memory in an optimized one. Undo the count we
+     * added and leave the object alone. */
+    if (NULL != info && counted) {
         info->proc_cnt--;
-        PMIX_RELEASE(info);
     }
     if (NULL != msg) {
         free(msg);
@@ -651,7 +665,13 @@ error:
         PMIX_INFO_FREE(iblob, nblob);
     }
     if (NULL != peer) {
-        pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
+        if (0 <= peer->index) {
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
+            /* the rank was pointed at the slot we just emptied */
+            if (NULL != info && info->peerid == peer->index) {
+                info->peerid = -1;
+            }
+        }
         PMIX_RELEASE(peer);
     }
     CLOSE_THE_SOCKET(pnd->sd);

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -8,6 +8,7 @@ termEvent = threading.Event()
 grpConstructed = threading.Event()
 grpDestructed = threading.Event()
 grpResults = []
+grpStatus = PMIX_ERR_NOT_SUPPORTED
 
 def default_evhandler(evhdlr:int, status:int,
                       source:dict, info:list, results:list):
@@ -18,8 +19,9 @@ def default_evhandler(evhdlr:int, status:int,
 # the PMIx progress thread, so they do nothing but record the result and
 # release the waiter - a blocking PMIx call from here would deadlock.
 def group_construct_cb(status:int, results:list, cbdata):
-    global grpResults
+    global grpResults, grpStatus
     print("GROUP CONSTRUCT CALLBACK", status)
+    grpStatus = status
     grpResults = results
     cbdata.set()
 
@@ -90,6 +92,10 @@ def main():
     if PMIX_SUCCESS == rc:
         if not grpConstructed.wait(timeout=30):
             print("GROUP CONSTRUCT TIMED OUT")
+        elif PMIX_SUCCESS != grpStatus:
+            # the host may not support group operations at all - the
+            # scheduler test server, for one, does not
+            print("Group construct failed: ", foo.error_string(grpStatus))
         else:
             print("Group construct results: ", grpResults)
             # and tear it down again, also asynchronously

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -5,11 +5,27 @@ import time
 import threading
 
 termEvent = threading.Event()
+grpConstructed = threading.Event()
+grpDestructed = threading.Event()
+grpResults = []
 
 def default_evhandler(evhdlr:int, status:int,
                       source:dict, info:list, results:list):
     print("DEFAULT HANDLER")
     return PMIX_EVENT_ACTION_COMPLETE,None
+
+# Callbacks for the non-blocking group operations. These are executed on
+# the PMIx progress thread, so they do nothing but record the result and
+# release the waiter - a blocking PMIx call from here would deadlock.
+def group_construct_cb(status:int, results:list, cbdata):
+    global grpResults
+    print("GROUP CONSTRUCT CALLBACK", status)
+    grpResults = results
+    cbdata.set()
+
+def group_destruct_cb(status:int, cbdata):
+    print("GROUP DESTRUCT CALLBACK", status)
+    cbdata.set()
 
 def model_evhandler(evhdlr:int, status:int,
                     source:dict, info:list, results:list):
@@ -63,6 +79,26 @@ def main():
     info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.fence(procs, info)
     print("Fence should be not supported:", foo.error_string(rc))
+    # construct a group asynchronously. Passing None for the peers means
+    # "everyone in my job"
+    print("GROUP CONSTRUCT NB")
+    dirs = [{'key': PMIX_GROUP_ASSIGN_CONTEXT_ID,
+             'value': True, 'val_type': PMIX_BOOL}]
+    rc = foo.group_construct_nb("mygroup", None, dirs,
+                                group_construct_cb, grpConstructed)
+    print("Group construct_nb result ", foo.error_string(rc))
+    if PMIX_SUCCESS == rc:
+        if not grpConstructed.wait(timeout=30):
+            print("GROUP CONSTRUCT TIMED OUT")
+        else:
+            print("Group construct results: ", grpResults)
+            # and tear it down again, also asynchronously
+            print("GROUP DESTRUCT NB")
+            rc = foo.group_destruct_nb("mygroup", None,
+                                       group_destruct_cb, grpDestructed)
+            print("Group destruct_nb result ", foo.error_string(rc))
+            if PMIX_SUCCESS == rc and not grpDestructed.wait(timeout=30):
+                print("GROUP DESTRUCT TIMED OUT")
     # wait for model event
     while not termEvent.is_set():
         time.sleep(0.001)

--- a/test/python/run_sched.sh.in
+++ b/test/python/run_sched.sh.in
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# PMIX_PYTHON_EGG_PATH is derived from Automake's $pythondir, which is
+# expressed in terms of ${prefix} and so reaches us still unexpanded.
+# Define the variables it refers to and let the shell finish the job.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
 
 ./sched.py

--- a/test/python/run_server.sh.in
+++ b/test/python/run_server.sh.in
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# PMIX_PYTHON_EGG_PATH is derived from Automake's $pythondir, which is
+# expressed in terms of ${prefix} and so reaches us still unexpanded.
+# Define the variables it refers to and let the shell finish the job.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
 
 ./server.py

--- a/test/python/sched.py
+++ b/test/python/sched.py
@@ -17,16 +17,24 @@ class GracefulKiller:
   def exit_gracefully(self,signum, frame):
     self.kill_now = True
 
-def clientconnected(proc:tuple is not None):
+# Server-module upcall handlers. The binding invokes each registered
+# handler with three arguments: the converted request, a Python wrapper
+# around the C completion callback, and an opaque cbdata dict. A handler
+# drives completion by invoking that callback and returns PMIX_SUCCESS.
+def clientconnected(proc, cbfunc, cbdata):
     print("CLIENT CONNECTED", proc)
+    cbfunc(PMIX_SUCCESS, cbdata)
     return PMIX_SUCCESS
 
-def clientfinalized(proc:tuple is not None):
+def clientfinalized(proc, cbfunc, cbdata):
     print("CLIENT FINALIZED", proc)
+    cbfunc(PMIX_SUCCESS, cbdata)
     return PMIX_SUCCESS
 
-def clientfence(args:dict is not None):
+def clientfence(args, cbfunc, cbdata):
     print("SERVER FENCE", args)
+    # no data to return from this (empty) fence
+    cbfunc(PMIX_SUCCESS, bytearray(0), cbdata)
     return PMIX_SUCCESS
 
 def main():

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -5,6 +5,7 @@ import signal, time
 import os
 import select
 import subprocess
+import threading
 
 global killer
 
@@ -54,6 +55,39 @@ def clientfence(args, cbfunc, cbdata):
     cbfunc(PMIX_SUCCESS, bytearray(0), cbdata)
     return PMIX_SUCCESS
 
+# The PMIx constants are bytes while the keys handed to a handler are
+# str, so normalize before comparing them
+def keymatch(attr, key):
+    if isinstance(attr, bytes):
+        attr = attr.decode('ascii')
+    if isinstance(key, bytes):
+        key = key.decode('ascii')
+    return attr == key
+
+# Group operations are the one server-module upcall whose completion is
+# deliberately deferred here. The library allows the host to answer after
+# the handler has returned, and a real resource manager generally must -
+# it has to hear from its peers first. Completing from a timer thread
+# keeps that path under test.
+#
+# The host is responsible for reporting the final membership: the server
+# library relays it to the participants, and each participant records the
+# group locally on the strength of it. Omit it and a later leave/destruct
+# fails with PMIX_ERR_NOT_FOUND.
+def clientgroup(args, cbfunc, cbdata):
+    print("GROUP", args['op'], args['group'], args['procs'])
+    results = [{'key': PMIX_GROUP_MEMBERSHIP,
+                'value': {'type': PMIX_PROC, 'array': args['procs']},
+                'val_type': PMIX_DATA_ARRAY}]
+    # if the group asked for a context ID, make one up - a real host would
+    # allocate it from a system-wide space
+    for d in args.get('directives', []):
+        if keymatch(PMIX_GROUP_ASSIGN_CONTEXT_ID, d['key']):
+            results.append({'key': PMIX_GROUP_CONTEXT_ID,
+                            'value': 42, 'val_type': PMIX_SIZE})
+    threading.Timer(0.001, cbfunc, [PMIX_SUCCESS, results, cbdata]).start()
+    return PMIX_SUCCESS
+
 def main():
     try:
         foo = PMIxServer()
@@ -65,7 +99,8 @@ def main():
             {'key':'BLAST', 'value':7, 'val_type':PMIX_INT32}]
     map = {'clientconnected': clientconnected,
            'clientfinalized': clientfinalized,
-           'fencenb': clientfence}
+           'fencenb': clientfence,
+           'group': clientgroup}
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")
     rc = foo.initialized()

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -225,5 +225,107 @@ class TestMethodBinding(unittest.TestCase):
             self.assertIsNotNone(meth, "PMIxServer.%s missing" % name)
 
 
+class TestGroupNonBlocking(unittest.TestCase):
+    """The non-blocking group bindings.
+
+    Without a server we cannot complete a group operation, but every one of
+    these calls marshals its arguments into a keepalive caddy before handing
+    the request to the library.  Called before init() the library rejects the
+    request with PMIX_ERR_INIT, which is exactly the path that has to unwind
+    that caddy by hand (no callback is executed, so nothing else will).  These
+    tests therefore cover the argument conversion and the error-path cleanup.
+    """
+
+    #: name, args to place before the callback pair
+    CASES = (
+        ("group_construct_nb", ("mygroup", None, [])),
+        ("group_invite_nb", ("mygroup", None, [])),
+        ("group_join_nb", ("mygroup", None, 0, [])),
+        ("group_leave_nb", ("mygroup", [])),
+        ("group_destruct_nb", ("mygroup", [])),
+    )
+
+    def setUp(self):
+        self.client = pmix.PMIxClient()
+        self.fired = []
+
+    def _cb(self, *args):
+        self.fired.append(args)
+
+    def test_methods_present(self):
+        for name, _ in self.CASES:
+            self.assertTrue(hasattr(pmix.PMIxClient, name),
+                            "PMIxClient.%s missing" % name)
+
+    def test_methods_have_self(self):
+        # A cdef class method declared without an explicit self raises
+        # TypeError when called on an instance - the defect that made
+        # several older bindings unusable.
+        import inspect
+        for name, _ in self.CASES:
+            meth = getattr(pmix.PMIxClient, name)
+            try:
+                params = list(inspect.signature(meth).parameters)
+            except (TypeError, ValueError):
+                # Cython may not expose a signature; the call below in
+                # test_error_before_init covers it either way
+                continue
+            self.assertEqual(params[0], "self",
+                             "%s does not declare self first" % name)
+
+    def test_rejects_non_callable(self):
+        # A NULL C callback would strand the caddy forever, so a callback
+        # that cannot be executed must be refused up front
+        for name, args in self.CASES:
+            meth = getattr(self.client, name)
+            rc = meth(*(args + (None,)))
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                             "%s accepted a non-callable callback" % name)
+            rc = meth(*(args + ("not-a-function",)))
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                             "%s accepted a non-callable callback" % name)
+
+    def test_error_before_init(self):
+        # The library rejects the request, so the callback must NOT fire
+        # and the binding must reclaim the caddy itself
+        for name, args in self.CASES:
+            meth = getattr(self.client, name)
+            rc = meth(*(args + (self._cb,)))
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT,
+                             "%s returned %s" % (name, rc))
+        self.assertEqual(self.fired, [],
+                         "a callback fired for a request the library refused")
+
+    def test_error_before_init_with_info(self):
+        # Same path, but with a real info array and proc list to convert so
+        # the caddy actually owns allocations that have to be released
+        peers = [{'nspace': "testnspace", 'rank': 0},
+                 {'nspace': "testnspace", 'rank': 1}]
+        pyinfo = [{'key': pmix.PMIX_GROUP_ASSIGN_CONTEXT_ID,
+                   'value': True, 'val_type': pmix.PMIX_BOOL},
+                  {'key': pmix.PMIX_TIMEOUT,
+                   'value': 10, 'val_type': pmix.PMIX_INT}]
+        # repeat enough times that a leak or double free would be obvious
+        for _ in range(64):
+            rc = self.client.group_construct_nb("mygroup", peers, pyinfo,
+                                                self._cb, "opaque")
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+            rc = self.client.group_join_nb("mygroup", peers[0],
+                                           pmix.PMIX_GROUP_ACCEPT, pyinfo,
+                                           self._cb, "opaque")
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+            rc = self.client.group_destruct_nb("mygroup", pyinfo,
+                                               self._cb, "opaque")
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.fired, [])
+
+    def test_no_operations_left_registered(self):
+        # Every refused request must have removed itself from the module's
+        # in-flight registry - otherwise the callback objects leak
+        self.client.group_leave_nb("mygroup", [], self._cb)
+        self.assertEqual(len(pmix.pynbcbs), 0,
+                         "refused operations left entries in the registry")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #3949.

Adds `group_construct_nb`, `group_invite_nb`, `group_join_nb`,
`group_leave_nb` and `group_destruct_nb` to the Python bindings. Each
returns only the status of the request; the outcome arrives through a
Python callback:

```python
cbfunc(status, results, cbdata)   # construct, invite, join
cbfunc(status, cbdata)            # leave, destruct
```

This matters most for `group_join_nb`: an invitation is delivered in an
event handler, and the blocking form must not be called from one.

## The machinery

These are the **first client-side `_nb` bindings of any kind** — there
was no `fence_nb`, no `get_nb`, nothing to copy — so they bring the
infrastructure with them, written to be reused for the remaining
entries in `MISSING_BINDINGS.md` §1.1:

* a **keepalive caddy** for the C inputs. PMIx does not copy them, so
  the blocking methods' habit of freeing `procs`/`info` the moment the
  call returns would be a use-after-free here, and the group identifier
  — a Python `bytes` local — would dangle outright.
* a **module-global registry** holding the caller's callback and cbdata,
  keyed by an integer the caddy carries, so no `PyObject *` ever crosses
  into C. Same technique as the existing `myhdlrs`.
* two **`noexcept with gil` trampolines**, since the callback fires on
  the progress thread.

The registry entry doubles as the caddy's ownership token: whoever pops
it frees the caddy, so the trampoline and the "library refused the
request, so no callback will ever fire" error path cannot race.

Written up in `docs/how-things-work/python_nonblocking.rst`, summarized
as §4c of `bindings/python/AGENTS.md`, with the non-blocking form added
to all five `PMIx_Group_*` man pages.

## Bugs found along the way

Getting a real end-to-end test working turned up several pre-existing
defects, each landed as its own commit:

* **A group bug affecting C callers too.** `PMIx_Group_construct_nb`
  never recorded the constructed group locally — that bookkeeping lived
  only in the callback the blocking wrapper installs — so any
  non-blocking caller's later leave/destruct returned
  `PMIX_ERR_NOT_FOUND` against a group it had just built. Nothing in
  the test suite drives `construct_nb` directly, so it had gone
  unnoticed.
* **A server abort on connection rejection.** If a host returned an
  error from `client_connected`, the PTL connection handler released a
  `pmix_rank_info_t` owned by the namespace's rank list — driving its
  refcount to zero while still on that list — and double-released the
  pending-connection object. The server died on an assertion in a debug
  build; in an optimized build the list is simply left holding freed
  memory.
* **Heap corruption in the bindings.** Values built for the library were
  allocated with `PyMem_Malloc` and freed by libpmix with `free()`.
  Returning a `PMIX_DATA_ARRAY` from a Python server — which a host must
  do to report group membership — aborted the process.
* **Cython annotations rejected `None`**, making every `is not None`
  default branch in the bindings unreachable; `foo.fence(None, [])`
  raised `TypeError`. Relaxed on the 57 parameters whose bodies handle
  `None`; genuinely-required parameters keep their annotations.
* Plus: a parallel-make race in the bindings build, broken
  server-module upcalls (directives passed as a dict, group name
  rendered as `"b'mygroup'"`), `generate_regex`/`generate_ppn` reading
  an uninitialized output pointer, and `run_server.sh`/`run_sched.sh`
  never having run at all because their `PYTHONPATH` reached them as an
  unexpanded `${prefix}`.

## Testing

`test_bindings.py` gains unit cases needing no server — the methods
exist and take `self`, a non-callable callback is refused, and a call
before `init()` returns `PMIX_ERR_INIT` without firing the callback or
leaving anything in the registry, which is what exercises the marshaling
plus the error-path cleanup.

`server.py` gains a `group` handler that **defers** completion to a
timer thread — the library permits the host to answer after the upcall
returns, and a real resource manager generally must — and `client.py`
drives a real async construct → destruct round trip.

Invite, join and leave need a second participant and a live invitation,
which the single-client harness cannot stage; they are covered only by
the unit-level error paths.

Full suite green: 20 util + 8 class + 31 unit + 3 python + 15 = 77
passing, 0 failing, warning-free build, docs build clean.

Note for reviewers running the tests: a stale `$TMPDIR` makes every
`simptest`-based test fail together with "listener thread failed to
start". That is environmental and now documented in the top-level and
`ptl` AGENTS.md; use `TMPDIR=$(mktemp -d) make check`.