### PR TITLE
Validate the PMIX_SINGLETON directive before using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,7 @@ test/unit/event_chain
 test/unit/hwloc_datatype
 test/unit/progress_threads
 test/unit/info_support
+test/unit/singleton_register
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -16,6 +16,15 @@ Detailed changes since v6.1.0:
    first non-blocking client bindings, and the machinery they introduce
    is documented in docs/how-things-work/python_nonblocking.rst for the
    remaining non-blocking APIs to reuse
+ - Fixed a segmentation fault in PMIx_server_init when the PMIX_SINGLETON
+   directive carries a malformed value. The parser assumed the value
+   always contained the "nspace.rank" separator and dereferenced the
+   result of its search for it, so a value with no '.' faulted the
+   server; values that did contain a '.' but were otherwise invalid (an
+   empty nspace, a non-numeric or out-of-range rank) were silently
+   accepted and registered a bogus singleton. The directive is now
+   validated, and a bad value is reported through show_help and rejected
+   with PMIX_ERR_BAD_PARAM
  - Fixed the server aborting when a host environment rejects an incoming
    client connection. The error path in the connection handler released
    a rank_info object owned by the namespace's rank list, driving its

--- a/src/server/help-pmix-server.txt
+++ b/src/server/help-pmix-server.txt
@@ -20,3 +20,24 @@ is not homogeneous - at least one participating node has a
 collection strategy (i.e., collect vs non-collect) that differs
 from the other nodes. This must be corrected in order for us
 to proceed.
+#
+[bad-singleton]
+The PMIx server was given a malformed value for the PMIX_SINGLETON
+directive:
+
+  Value: %s
+
+The value must be a string of the form "nspace.rank", where "rank"
+is a valid (non-negative) rank - for example, "singleton.0". The
+server cannot register the singleton and is unable to continue.
+#
+[bad-singleton-type]
+The PMIx server was given a PMIX_SINGLETON directive of the wrong
+data type:
+
+  Given type:    %s
+  Required type: PMIX_STRING
+
+The value must be a string of the form "nspace.rank" - for example,
+"singleton.0". The server cannot register the singleton and is
+unable to continue.

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -334,16 +334,48 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
 
 static pmix_status_t register_singleton(char *name)
 {
-    char *tmp, *ptr;
+    char *tmp, *ptr, *endptr;
     pmix_namespace_t *nptr;
     pmix_rank_t rank;
     pmix_rank_info_t *rinfo;
+    unsigned long val;
+    size_t nslen;
 
+    /* the value must be the string representation of a proc ID -
+     * i.e., of the form "nspace.rank". Anything else is a mistake
+     * on the part of whoever passed it to us, so tell them about
+     * it instead of faulting */
+    if (NULL == name) {
+        pmix_show_help("help-pmix-server.txt", "bad-singleton", true, "NULL");
+        return PMIX_ERR_BAD_PARAM;
+    }
+    ptr = strrchr(name, '.');
+    if (NULL == ptr || ptr == name || '\0' == ptr[1]) {
+        /* no separator, no nspace, or no rank */
+        pmix_show_help("help-pmix-server.txt", "bad-singleton", true, name);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    nslen = (size_t) (ptr - name);
+    if (PMIX_MAX_NSLEN < nslen) {
+        pmix_show_help("help-pmix-server.txt", "bad-singleton", true, name);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* the rank must be a simple non-negative number - note that
+     * strtoul returns ULONG_MAX on overflow, which the validity
+     * check below rejects */
+    val = strtoul(&ptr[1], &endptr, 10);
+    if ('\0' != *endptr || !PMIX_RANK_IS_VALID(val)) {
+        pmix_show_help("help-pmix-server.txt", "bad-singleton", true, name);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    rank = (pmix_rank_t) val;
+
+    /* take a private copy and split it at the separator */
     tmp = strdup(name);
-    ptr = strrchr(tmp, '.');
-    *ptr = '\0';
-    ++ptr;
-    rank = strtoul(ptr, NULL, 10);
+    if (NULL == tmp) {
+        return PMIX_ERR_NOMEM;
+    }
+    tmp[nslen] = '\0';
 
     nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == nptr) {
@@ -353,13 +385,14 @@ static pmix_status_t register_singleton(char *name)
     nptr->nspace = strdup(tmp);
     nptr->nlocalprocs = 1;
     nptr->nprocs = 1;
-    pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     /* add this rank */
     rinfo = PMIX_NEW(pmix_rank_info_t);
     if (NULL == rinfo) {
+        PMIX_RELEASE(nptr);
         free(tmp);
         return PMIX_ERR_NOMEM;
     }
+    pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     rinfo->pname.nspace = strdup(tmp);
     rinfo->pname.rank = rank;
     rinfo->realuid = getuid();
@@ -591,6 +624,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                 outputio = PMIX_INFO_TRUE(&info[n]);
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SINGLETON)) {
+                if (PMIX_STRING != info[n].value.type) {
+                    pmix_show_help("help-pmix-server.txt", "bad-singleton-type", true,
+                                   PMIx_Data_type_string(info[n].value.type));
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 singleton = info[n].value.data.string;
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_MAU)) {

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -32,9 +32,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register
 
 compress_SOURCES =  \
         compress.c
@@ -133,5 +133,11 @@ info_support_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 info_support_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+singleton_register_SOURCES = \
+        singleton_register.c
+singleton_register_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+singleton_register_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register

--- a/test/unit/singleton_register.c
+++ b/test/unit/singleton_register.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the PMIX_SINGLETON directive to PMIx_server_init().
+ *
+ * The value of PMIX_SINGLETON is the string representation of a proc ID -
+ * i.e., "nspace.rank" - naming the singleton the server was started to
+ * support. The server parses it during init and pre-registers that nspace
+ * and rank so the singleton is not rejected when it connects.
+ *
+ * A malformed value used to walk off the end of the string (there is no
+ * guarantee a '.' is present, and the parser dereferenced strrchr's result
+ * unconditionally), faulting the server instead of telling the caller what
+ * it did wrong. These tests pin the accept/reject boundary: a well-formed
+ * value must register the singleton, and every malformed value must come
+ * back as PMIX_ERR_BAD_PARAM without a crash.
+ *
+ * Each case runs in a forked child because PMIx_server_init() can only be
+ * meaningfully called once per process - a failed init leaves init_called
+ * set, so a second attempt returns PMIX_ERR_INIT. The parent inspects the
+ * child's exit status, which is also how a fault (death by signal) is
+ * detected and reported as a failure rather than being mistaken for a
+ * rejection.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* child exit codes */
+#define CHILD_OK        0 /* init succeeded and the singleton is registered */
+#define CHILD_BADPARAM  1 /* init rejected the value with PMIX_ERR_BAD_PARAM */
+#define CHILD_OTHERERR  2 /* init failed with some other status */
+#define CHILD_NOTFOUND  3 /* init succeeded but the singleton is not registered */
+#define CHILD_ACCEPTED  4 /* init accepted a value it should have rejected */
+
+static int npass = 0;
+static int nfail = 0;
+
+static pmix_server_module_t mymodule = {0};
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+/* confirm the singleton's nspace was registered with the expected rank */
+static bool singleton_registered(const char *nspace, pmix_rank_t rank)
+{
+    pmix_namespace_t *nptr;
+    pmix_rank_info_t *rinfo;
+
+    PMIX_LIST_FOREACH (nptr, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (NULL == nptr->nspace || 0 != strcmp(nptr->nspace, nspace)) {
+            continue;
+        }
+        PMIX_LIST_FOREACH (rinfo, &nptr->ranks, pmix_rank_info_t) {
+            if (rank == rinfo->pname.rank) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* run one init attempt and exit with the code describing what happened.
+ * If "badtype" is set, the directive is loaded as something other than a
+ * string so the type check is exercised as well. */
+static void child(const char *value, bool badtype, const char *nspace, pmix_rank_t rank)
+{
+    pmix_info_t info;
+    pmix_status_t rc;
+    bool found;
+
+    if (badtype) {
+        PMIX_INFO_LOAD(&info, PMIX_SINGLETON, &rank, PMIX_UINT32);
+    } else {
+        PMIX_INFO_LOAD(&info, PMIX_SINGLETON, value, PMIX_STRING);
+    }
+
+    rc = PMIx_server_init(&mymodule, &info, 1);
+    PMIX_INFO_DESTRUCT(&info);
+
+    if (PMIX_ERR_BAD_PARAM == rc) {
+        exit(CHILD_BADPARAM);
+    }
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "     init returned %s\n", PMIx_Error_string(rc));
+        exit(CHILD_OTHERERR);
+    }
+
+    if (NULL == nspace) {
+        /* the value should have been rejected - report that it was not
+         * instead of probing for an nspace we were never given */
+        PMIx_server_finalize();
+        exit(CHILD_ACCEPTED);
+    }
+    found = singleton_registered(nspace, rank);
+    PMIx_server_finalize();
+    exit(found ? CHILD_OK : CHILD_NOTFOUND);
+}
+
+/* fork a child to attempt the init, then check its exit status */
+static void check(const char *name, const char *value, bool badtype, const char *nspace,
+                  pmix_rank_t rank, int expected)
+{
+    pid_t pid;
+    int status;
+    char detail[256];
+
+    fflush(stdout);
+    fflush(stderr);
+
+    pid = fork();
+    if (0 > pid) {
+        report(name, 0, "fork failed");
+        return;
+    }
+    if (0 == pid) {
+        child(value, badtype, nspace, rank);
+        /* not reached */
+        exit(CHILD_OTHERERR);
+    }
+
+    if (pid != waitpid(pid, &status, 0)) {
+        report(name, 0, "waitpid failed");
+        return;
+    }
+    if (WIFSIGNALED(status)) {
+        /* this is the crash we are guarding against */
+        snprintf(detail, sizeof(detail), "server died on signal %d", WTERMSIG(status));
+        report(name, 0, detail);
+        return;
+    }
+    if (!WIFEXITED(status)) {
+        report(name, 0, "child did not exit normally");
+        return;
+    }
+    snprintf(detail, sizeof(detail), "expected exit %d, got %d", expected, WEXITSTATUS(status));
+    report(name, expected == WEXITSTATUS(status), detail);
+}
+
+/* a nspace longer than PMIX_MAX_NSLEN cannot name a real nspace */
+static char *overlong(void)
+{
+    char *p;
+    size_t len = PMIX_MAX_NSLEN + 8;
+
+    p = malloc(len + 4);
+    memset(p, 'a', len);
+    p[len] = '.';
+    p[len + 1] = '0';
+    p[len + 2] = '\0';
+    return p;
+}
+
+int main(int argc, char **argv)
+{
+    char *big;
+
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "PMIX_SINGLETON parsing\n");
+
+    /* well-formed values are accepted and register the singleton */
+    check("simple nspace.rank", "singleton.0", false, "singleton", 0, CHILD_OK);
+    check("non-zero rank", "singleton.7", false, "singleton", 7, CHILD_OK);
+    /* the rank is delimited by the LAST '.', so dots are legal in an nspace */
+    check("dotted nspace", "my.dotted.ns.3", false, "my.dotted.ns", 3, CHILD_OK);
+
+    /* malformed values are rejected, not faulted */
+    check("no separator", "singleton", false, NULL, 0, CHILD_BADPARAM);
+    check("empty string", "", false, NULL, 0, CHILD_BADPARAM);
+    check("separator only", ".", false, NULL, 0, CHILD_BADPARAM);
+    check("no nspace", ".0", false, NULL, 0, CHILD_BADPARAM);
+    check("no rank", "singleton.", false, NULL, 0, CHILD_BADPARAM);
+    check("non-numeric rank", "singleton.abc", false, NULL, 0, CHILD_BADPARAM);
+    check("trailing garbage", "singleton.0abc", false, NULL, 0, CHILD_BADPARAM);
+    check("trailing space", "singleton.0 ", false, NULL, 0, CHILD_BADPARAM);
+    check("hex rank", "singleton.0x10", false, NULL, 0, CHILD_BADPARAM);
+    check("negative rank", "singleton.-1", false, NULL, 0, CHILD_BADPARAM);
+    check("overflowed rank", "singleton.99999999999999999999", false, NULL, 0, CHILD_BADPARAM);
+    check("reserved rank", "singleton.4294967295", false, NULL, 0, CHILD_BADPARAM);
+
+    big = overlong();
+    check("overlong nspace", big, false, NULL, 0, CHILD_BADPARAM);
+    free(big);
+
+    /* the directive must carry a string */
+    check("wrong data type", NULL, true, NULL, 0, CHILD_BADPARAM);
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
`PMIX_SINGLETON` carries the string representation of a proc ID —
`"nspace.rank"` — naming the singleton the server was started to support.
`register_singleton()` searched it for the `.` separator and then
dereferenced the result without checking it:

```c
tmp = strdup(name);
ptr = strrchr(tmp, '.');
*ptr = '\0';            /* NULL deref if there is no '.' */
```

A value containing no `.` at all therefore faulted the server inside
`PMIx_server_init`.

Values that did contain a `.` were accepted no matter what else was wrong
with them, silently registering a singleton that no connecting process
could ever match:

| Value | Old behavior |
|---|---|
| `.0` | empty nspace registered |
| `singleton.` / `singleton.abc` | rank silently 0 |
| `singleton.-1` | rank `UINT32_MAX` (the reserved `PMIX_RANK_UNDEF`) |
| `singleton.99999999999999999999` | overflowed rank truncated |

A directive of the wrong data type read `value.data.string` off the union
regardless, yielding a garbage pointer.

### What this does

Validate the value up front — separator present, non-empty nspace no longer
than `PMIX_MAX_NSLEN`, and a rank that is a plain number in the valid range
— and reject anything else with `PMIX_ERR_BAD_PARAM` after telling the
caller what was wrong through `show_help`. Check the data type at the point
the directive is parsed.

Also move the nspace onto `pmix_globals.nspaces` only once its `rank_info`
has been allocated, so the allocation-failure path no longer leaves a
half-built namespace linked in.

The rank is delimited by the *last* `.`, so an nspace containing dots
(`my.dotted.ns.3`) remains legal; there is a test case pinning that so a
future rewrite of the parser does not lose it.

### Testing

New `test/unit/singleton_register.c`, wired into `make check`. Each of the
17 cases runs in a forked child, since `PMIx_server_init` can only be
meaningfully called once per process — a failed init leaves `init_called`
set, so a second attempt just returns `PMIX_ERR_INIT`. Working through the
child's exit status is also what lets the test tell a crash apart from a
rejection, which is the distinction that matters here.

Against the unfixed library: 3 pass, 14 fail — 2 by SIGSEGV, 12 by being
wrongly accepted. Against the fix: 17/17.

Full `make check` is clean, the build is warning-free under
`--enable-devel-check`, and the generated `show_help` content was
regenerated for the two new messages.