### PR TITLE
python: bind the remaining unique blocking APIs

### DIFF
--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -88,6 +88,20 @@ attributes".
 methods default to *this proc's whole job* (`self.myproc.nspace`,
 `PMIX_RANK_WILDCARD`).
 
+**A few structs have their own dict shape.** They follow the struct's own
+field names, so the mapping is mechanical:
+
+```python
+{'source': 'hwloc', 'cpus': [0, 1, 2, 3, 8]}      # pmix_cpuset_t   (§8a)
+{'bytes': b'...', 'size': 12}                     # pmix_byte_object_t
+{'type': 'raw', 'bytes': b'n1,n2', 'len': 6}      # pmix_regex2_t
+{'type': PMIX_DEVTYPE_GPU, 'count': 4}            # pmix_resource_unit_t
+```
+
+The regex2 `bytes` are *not* necessarily NUL-terminated, which is why the
+struct carries a length and the dict keeps it — treat the payload as
+`bytes`, never as a string.
+
 **Return convention:** most methods return the integer `rc` (a `PMIX_*`
 status). Methods that also produce data return a **tuple**, e.g.
 `get()` → `(rc, value_dict)`, `spawn()` → `(rc, nspace)`,
@@ -102,6 +116,13 @@ status). Methods that also produce data return a **tuple**, e.g.
   — info dict lists ↔ `pmix_info_t[]`. `pmix_alloc_info` is the standard
   "malloc + load" entry point used by nearly every method.
 - `pmix_load_darray` / `pmix_unload_darray` — nested `PMIX_DATA_ARRAY`.
+- `pmix_load_units` / `pmix_unload_units` / `pmix_alloc_units` /
+  `pmix_free_units` — resource unit dict lists ↔ `pmix_resource_unit_t[]`.
+  The struct has no allocated members and the APIs that take one do not
+  retain it, so the array stays on `PyMem_*`.
+- `pmix_load_regex2` / `pmix_unload_regex2` — regex dict ↔ `pmix_regex2_t`.
+  The loader constructs the struct first, so the caller can (and must)
+  `PMIx_Regex2_destruct` it on every path, including a partial failure.
 - `pmix_load_procs` / `pmix_unload_procs`, `pmix_load_pdata`, `pmix_load_apps`,
   etc. — the remaining structured types.
 
@@ -341,6 +362,15 @@ internalizing so they are not reintroduced:
   wrong key (`envar` vs `value`, `val_type` vs `value`) silently corrupts data.
 - **`setmodulefn`'s `permitted` list and `server_module_init`'s wiring names
   must stay in lockstep** (§4b).
+- **Binding an API exposes it to callers a C program never produced.** A
+  Python script can call any method the moment it constructs the class,
+  and the natural first thing a test does is call it before `init()`.
+  Three C entry points had no `pmix_globals.initialized` guard and
+  crashed or hung on that path the first time they were bound (see
+  MISSING_BINDINGS.md §1.8). When you bind a new API, call it before
+  `init()` and with empty/None arguments *before* you call it for real —
+  and fix the guard in the C library rather than papering over it in the
+  binding.
 
 The one remaining stub is a genuine unimplemented feature, not a bug:
 `PMIxScheduler.assign_session` returns `PMIX_ERR_NOT_SUPPORTED` because the

--- a/bindings/python/MISSING_BINDINGS.md
+++ b/bindings/python/MISSING_BINDINGS.md
@@ -4,9 +4,10 @@ Tracking document for the PMIx Python bindings (`bindings/python/`). It has
 two parts:
 
 1. **Missing bindings** — real operational C APIs that have no Python method
-   yet, to be implemented in a later pass.
+   yet. The unique blocking APIs (§§1.2–1.6) have all been bound; what
+   remains is the `_nb` family in §1.1 and one deprecated tool API.
 2. **Defects** — bugs found in the *existing* bindings during the 2026-07 deep
-   review, to be fixed in a later pass.
+   review. All are fixed.
 
 Utility/struct-helper C APIs with no meaningful Python analogue are
 intentionally **out of scope** and are *not* listed as missing:
@@ -61,47 +62,95 @@ blocking form:
 - `PMIx_Compute_distances_nb`
 - `PMIx_Resource_block_nb`
 
-### 1.2 Client role (`PMIxClient`) — unique unbound APIs
+### 1.2 Client role (`PMIxClient`) — **CLOSED**
 
-| C API | Description |
-|-------|-------------|
-| `PMIx_Heartbeat` | Send a heartbeat to the server to feed process health/monitoring. No args. |
-| `PMIx_Progress_thread_stop` | Stop the internal progress thread (accepts directives, e.g. `PMIX_PROGRESS_THREAD_FLUSH`). |
-| `PMIx_Resource_block` | Request/manipulate a block of resources per a `pmix_resource_block_directive_t`. Scheduler-facing. (`_nb` form also unbound — see §1.1.) |
+| C API | Python method | Notes |
+|-------|---------------|-------|
+| `PMIx_Heartbeat` | `heartbeat(dicts=None)` | Fire-and-forget; returns `PMIX_SUCCESS` once handed to the library (the C API returns `void`). Takes an ignored attribute list so it can grow one. |
+| `PMIx_Progress_thread_stop` | `progress_thread_stop(dicts=None)` | Accepts `PMIX_PROGRESS_THREAD_FLUSH` / `PMIX_PROGRESS_THREAD_NAME`. Releases the GIL across the join. |
+| `PMIx_Resource_block` | `resource_block(directive, block, pyunits, pyinfo)` | `pyunits` is a list of resource-unit dicts, `{'type': PMIX_DEVTYPE_x, 'count': n}` — converted by `pmix_load_units`/`pmix_alloc_units` in `pmix.pxi`. Blocking, so the GIL is released across the call. The `_nb` form remains part of §1.1. |
 
-### 1.3 Server role (`PMIxServer`) — unbound APIs
+### 1.3 Server role (`PMIxServer`) — **CLOSED**
 
-| C API | Description |
-|-------|-------------|
-| `PMIx_generate_regex2` | Current regex generator producing a `pmix_regex2_t`. Only the **deprecated** `PMIx_generate_regex` is bound (as `generate_regex`). |
-| `PMIx_parse_regex2` | Parse a `pmix_regex2_t` back into its node/host list. Counterpart to `generate_regex2`. |
-| `PMIx_server_generate_cpuset` | Build a `pmix_cpuset_t` from a cpuset string. No *distinct* binding, but the capability is reachable: `parse_cpuset_string` performs the same conversion through the equivalent client entry point `PMIx_Parse_cpuset_string`, and the internal `pmix_load_cpuset` helper builds a `pmix_cpuset_t` from a Python dict for every method that needs one. Bind separately only if a caller needs the server-side entry point specifically. |
-| `PMIx_server_collect_job_info` | Collect job-level info for a set of procs, for packaging/forwarding to a remote server. |
+| C API | Python method | Notes |
+|-------|---------------|-------|
+| `PMIx_generate_regex2` | `generate_regex2(hosts, dicts=None)` | Returns `(rc, {'type': str, 'bytes': bytes, 'len': int})`. `hosts` may be a list or an already comma-delimited string. |
+| `PMIx_parse_regex2` | `parse_regex2(pyregex, dicts=None)` | Returns `(rc, [name, ...])`, the inverse of the above and order-preserving. |
+| `PMIx_server_generate_cpuset` | `generate_cpuset(csetstr)` | Returns the same cpuset dict as `PMIxClient.parse_cpuset_string`, through the server-side entry point. |
+| `PMIx_server_collect_job_info` | `collect_job_info(peers)` | Returns `(rc, {'bytes': bytes, 'size': int})`. An empty proc list is rejected with `PMIX_ERR_BAD_PARAM` — there is no job to collect. |
 
 ### 1.4 Tool role (`PMIxTool`)
 
 | C API | Description |
 |-------|-------------|
-| `PMIx_tool_connect_to_server` | **Deprecated**; superseded by `PMIx_tool_attach_to_server` (bound). Safe to leave unbound. |
+| `PMIx_tool_connect_to_server` | **Deprecated**; superseded by `PMIx_tool_attach_to_server` (bound). Deliberately left unbound. |
 
-### 1.5 Scheduler role (`PMIxScheduler`)
+### 1.5 Scheduler role (`PMIxScheduler`) — **CLOSED**
 
-The scheduler's core operation is `PMIx_Resource_block` /
-`PMIx_Resource_block_nb` (see §1.2) — unbound. `PMIx_Session_control` is
-bound, but on `PMIxServer`, not surfaced as a distinct scheduler method.
+Both scheduler-role operations are reachable, through what the class
+inherits rather than through methods of its own:
 
-### 1.6 Low-priority unbound string/utility converters
+- **Resource blocks.** `resource_block` is bound on `PMIxClient` (§1.2),
+  which is where it belongs: a process that *is* the scheduler gets
+  `PMIX_ERR_NOT_SUPPORTED` from the library, because there is no one
+  above it to ask. A scheduler **services** these requests by registering
+  a `'resourceblock'` handler in its server-module map.
+- **Session control.** Likewise serviced through the `'sessioncontrol'`
+  module key; the scheduler's own directives to a session go out through
+  the inherited `session_control` method.
 
-Non-operational pretty-printers; add only if a caller needs them:
-`PMIx_Error_code`, `PMIx_Group_operation_string`,
-`PMIx_Value_comparison_string`, `PMIx_Resource_block_directive_string`,
-`PMIx_Alloc_inheritance_string`, `PMIx_Data_print`.
+The class header comment in `pmix.pyx` records this so the next reader
+does not go looking for methods that should not exist.
+`PMIxScheduler.assign_session` remains a well-formed stub returning
+`PMIX_ERR_NOT_SUPPORTED` — the C library exposes no entry point for it.
+
+### 1.6 String/utility converters — **CLOSED**
+
+| C API | Python method |
+|-------|---------------|
+| `PMIx_Error_code` | `error_code(errname)` — the inverse of `error_string` |
+| `PMIx_Group_operation_string` | `group_operation_string(op)` |
+| `PMIx_Value_comparison_string` | `value_comparison_string(cmp)` |
+| `PMIx_Resource_block_directive_string` | `resource_block_directive_string(directive)` |
+| `PMIx_Alloc_inheritance_string` | `alloc_inheritance_string(inheritance)` |
+| `PMIx_Data_print` | `data_print(prefix, pysrc, data_type=None)` — returns `(rc, str)` |
+
+`data_print` covers the two shapes a Python caller can hand across the
+boundary: a value dict (`PMIX_VALUE`) and an info dict (`PMIX_INFO`),
+auto-detected from the presence of a `'key'`. The C API accepts any
+registered data type, but every other type is reachable as the *value* of
+one of those two; an explicit `data_type` outside the pair returns
+`PMIX_ERR_NOT_SUPPORTED`.
 
 ### 1.7 Coverage summary
 
-- Operational client/server/tool APIs bound: **~75** (blocking forms + tool IOF).
-- Not bound: **25** `_nb` variants, **3** unique client APIs, **4** server
-  APIs, **1** deprecated tool API.
+- Operational client/server/tool APIs bound: **~86** (blocking forms, tool
+  IOF, and the five `_nb` group operations).
+- Not bound: **25** `_nb` variants (§1.1), **1** deprecated tool API
+  (§1.4). Every unique blocking API in §§1.2–1.6 is now bound.
+
+### 1.8 C-side hazards this pass surfaced (now fixed)
+
+Binding an API means calling it from a program that has not necessarily
+done everything a C caller would have. Three entry points had no guard
+against that, and each one crashed or hung the moment a Python script
+touched it before `init()`:
+
+- `PMIx_Heartbeat` sent through `PMIX_PTL_SEND_ONEWAY`, which
+  dereferences the peer, without checking that the library was
+  initialized — so `pmix_client_globals.myserver` was still NULL.
+- `PMIx_Progress_thread_stop` walked its static tracking list before that
+  list had been constructed.
+- `PMIx_server_collect_job_info` had no `initialized` check at all, so it
+  thread-shifted a request and then blocked forever waiting for a
+  progress thread that did not exist; separately, a request naming no
+  procs produced a NULL namespace list that the collection loop then
+  walked.
+
+All three now return (or no-op) cleanly; the collect-job-info parameter
+checks are covered by `test/unit/collect_job_info.c`, and the pre-init
+behavior of all of them by `TestNewlyBoundAPIs` in
+`test/python/test_bindings.py`.
 
 ---
 

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1058,6 +1058,76 @@ cdef bytearray pmix_convert_regex(char *regex):
         ba = bytearray(regex)
     return ba
 
+# The pmix_regex2_t crosses to Python as a dict carrying the three fields
+# of the struct:
+#
+#   {'type': str, 'bytes': bytes, 'len': int}
+#
+# 'type' names the encoding method (the preg component that produced it -
+# e.g. "raw" or "compress"); it is what tells the parser which component
+# can decode the blob. 'bytes' is the encoded representation and is NOT
+# necessarily NUL-terminated, so it is carried as a Python bytes object
+# sliced to 'len' rather than as a string.
+
+# Convert a pmix_regex2_t into its Python dict form
+cdef dict pmix_unload_regex2(const pmix_regex2_t *regex):
+    d = {}
+    if NULL == regex[0].type:
+        d['type'] = None
+    else:
+        d['type'] = regex[0].type.decode('ascii')
+    if NULL == regex[0].bytes or 0 == regex[0].len:
+        d['bytes'] = b''
+        d['len']   = 0
+    else:
+        d['bytes'] = (<char*>regex[0].bytes)[:regex[0].len]
+        d['len']   = regex[0].len
+    return d
+
+# Build a pmix_regex2_t from the Python dict. The struct is constructed
+# first, so the caller can release it with PMIx_Regex2_destruct on every
+# path - including a failure that left it partly built
+cdef int pmix_load_regex2(pmix_regex2_t *regex, pyregex):
+    cdef const char *typeptr
+    cdef const char *byteptr
+
+    PMIx_Regex2_construct(regex)
+    if not isinstance(pyregex, dict):
+        return PMIX_ERR_BAD_PARAM
+    mytype = pyregex.get('type')
+    if mytype is None:
+        return PMIX_ERR_BAD_PARAM
+    if isinstance(mytype, str):
+        pytype = mytype.encode('ascii')
+    else:
+        pytype = mytype
+    typeptr = <const char *>pytype
+    regex[0].type = strdup(typeptr)
+    if NULL == regex[0].type:
+        return PMIX_ERR_NOMEM
+    mybytes = pyregex.get('bytes')
+    if mybytes is None:
+        return PMIX_ERR_BAD_PARAM
+    if isinstance(mybytes, str):
+        mybytes = mybytes.encode('ascii')
+    else:
+        mybytes = bytes(mybytes)
+    # honor an explicitly provided length, but never read past the end of
+    # the buffer we were actually handed
+    mylen = pyregex.get('len', len(mybytes))
+    if not isinstance(mylen, pmix_int_types) or 0 > mylen or len(mybytes) < mylen:
+        mylen = len(mybytes)
+    if 0 == mylen:
+        regex[0].len = 0
+        return PMIX_SUCCESS
+    regex[0].bytes = <uint8_t*> malloc(mylen)
+    if NULL == regex[0].bytes:
+        return PMIX_ERR_NOMEM
+    byteptr = <const char *>mybytes
+    memcpy(regex[0].bytes, byteptr, mylen)
+    regex[0].len = mylen
+    return PMIX_SUCCESS
+
 # provide a function for transferring a Python 'value'
 # object (a dict with value and val_type as keys)
 # to a pmix_value_t
@@ -1970,6 +2040,60 @@ cdef int pmix_unload_units(const pmix_resource_unit_t *units, size_t nunits, ili
         ilist.append(d)
         n += 1
     return PMIX_SUCCESS
+
+
+# Convert a python list of resource unit dicts into an array of
+# pmix_resource_unit_t structs
+#
+# @array [INPUT]
+#        - allocated array of pmix_resource_unit_t structs
+#
+# @units [INPUT]
+#        - a list of dictionaries, each with a 'type' (a PMIX_DEVTYPE_
+#          value) and a 'count'
+cdef int pmix_load_units(pmix_resource_unit_t *array, units:list):
+    n = 0
+    for d in units:
+        if not isinstance(d, dict):
+            return PMIX_ERR_BAD_PARAM
+        mytype = d.get('type', PMIX_DEVTYPE_UNKNOWN)
+        mycount = d.get('count', 0)
+        if not isinstance(mytype, pmix_int_types) or not isinstance(mycount, pmix_int_types):
+            return PMIX_ERR_TYPE_MISMATCH
+        if 0 > mycount:
+            return PMIX_ERR_BAD_PARAM
+        array[n].type = mytype
+        array[n].count = mycount
+        n += 1
+    return PMIX_SUCCESS
+
+# Allocate and load an array of pmix_resource_unit_t from a python list -
+# the resource-unit counterpart of pmix_alloc_info. A None or empty list
+# yields a NULL array of length zero, which the APIs accept
+cdef int pmix_alloc_units(pmix_resource_unit_t **units_ptr, size_t *nunits, units):
+    nunits[0] = 0
+    units_ptr[0] = NULL
+    if units is None:
+        return PMIX_SUCCESS
+    if 0 == len(units):
+        return PMIX_SUCCESS
+    units_ptr[0] = <pmix_resource_unit_t*> PyMem_Malloc(len(units) * sizeof(pmix_resource_unit_t))
+    if not units_ptr[0]:
+        return PMIX_ERR_NOMEM
+    rc = pmix_load_units(units_ptr[0], units)
+    if PMIX_SUCCESS != rc:
+        pmix_free_units(units_ptr[0], len(units))
+        units_ptr[0] = NULL
+        return rc
+    nunits[0] = len(units)
+    return PMIX_SUCCESS
+
+# Free an array of pmix_resource_unit_t. The struct carries no allocated
+# members, so the array itself is all there is to release - and as the
+# bindings both allocate and release it (the APIs that take one do not
+# retain it), it stays on the Python allocator
+cdef void pmix_free_units(pmix_resource_unit_t *array, size_t sz):
+    PyMem_Free(array)
 
 
 # Convert list of python pmix_pdata_t dicts into an

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -1302,6 +1302,68 @@ cdef class PMIxClient:
             pmix_free_info(results, nresults)
         return rc, pyres
 
+    # Define, extend, reduce or delete a block of resources. The request is
+    # relayed to the scheduler, so it is the caller's server (not the caller
+    # itself) that must be the scheduler - a process running as the
+    # scheduler gets PMIX_ERR_NOT_SUPPORTED as there is no one to ask.
+    #
+    # @directive [INPUT]
+    #            - one of the PMIX_RESOURCE_BLOCK_ values (int)
+    #
+    # @block [INPUT]
+    #        - name of the resource block, unique within the requestor's
+    #          session (string)
+    #
+    # @pyunits [INPUT]
+    #          - a list of resource unit dictionaries, each of the form
+    #            {'type': PMIX_DEVTYPE_x, 'count': n}
+    #
+    # @pyinfo [INPUT]
+    #         - a list of dictionaries, where each
+    #           dictionary has a key, value, and val_type
+    #           defined as such:
+    #           [{key:y, value:val, val_type:ty}, … ]
+    def resource_block(self, directive:int, block, pyunits, pyinfo):
+        cdef pmix_resource_unit_t *units
+        cdef size_t nunits
+        cdef pmix_info_t *info
+        cdef pmix_info_t **info_ptr
+        cdef size_t ninfo
+        cdef char *blk
+        cdef pmix_resource_block_directive_t drctv
+
+        if block is None:
+            return PMIX_ERR_BAD_PARAM
+        if isinstance(block, str):
+            pyblock = block.encode('ascii')
+        else:
+            pyblock = block
+        blk = <char*>pyblock
+        drctv = directive
+
+        # allocate and load pmix info structs from python list of dictionaries
+        info_ptr = &info
+        rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc
+
+        # convert the resource units
+        rc = pmix_alloc_units(&units, &nunits, pyunits)
+        if PMIX_SUCCESS != rc:
+            if 0 < ninfo:
+                pmix_free_info(info, ninfo)
+            return rc
+
+        # call the API - it blocks until the scheduler responds, and the
+        # response may have to pass through a server module written in
+        # Python, so the GIL cannot be held across it
+        with nogil:
+            rc = PMIx_Resource_block(drctv, blk, units, nunits, info, ninfo)
+        pmix_free_units(units, nunits)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        return rc
+
     def job_control(self, pytargets, pydirs):
         cdef pmix_proc_t *targets
         cdef pmix_info_t *directives
@@ -1401,6 +1463,19 @@ cdef class PMIxClient:
             rc = pmix_unload_info(results, nresults, pyres)
             pmix_free_info(results, nresults)
         return rc, pyres
+
+    # Send a heartbeat to our server, feeding whatever process health
+    # monitor was established with the PMIX_MONITOR_HEARTBEAT attribute
+    # (see monitor() above). The heartbeat is fire-and-forget: the C API
+    # returns nothing, so this reports PMIX_SUCCESS once the message has
+    # been handed to the library.
+    #
+    # @dicts [INPUT]
+    #        - accepted for future directives; the C API defines none
+    #          today, so anything provided here is ignored
+    def heartbeat(self, dicts=None):
+        PMIx_Heartbeat()
+        return PMIX_SUCCESS
 
     def get_credential(self, pyinfo):
         cdef pmix_info_t *info
@@ -2036,6 +2111,113 @@ cdef class PMIxClient:
         pystr = string
         return pystr.decode('ascii')
 
+    def value_comparison_string(self, pystat:int):
+        cdef char *string
+
+        string = <char*>PMIx_Value_comparison_string(pystat)
+        pystr = string
+        return pystr.decode('ascii')
+
+    def group_operation_string(self, pystat:int):
+        cdef char *string
+
+        string = <char*>PMIx_Group_operation_string(pystat)
+        pystr = string
+        return pystr.decode('ascii')
+
+    def resource_block_directive_string(self, pystat:int):
+        cdef char *string
+
+        string = <char*>PMIx_Resource_block_directive_string(pystat)
+        pystr = string
+        return pystr.decode('ascii')
+
+    def alloc_inheritance_string(self, pystat:int):
+        cdef char *string
+
+        string = <char*>PMIx_Alloc_inheritance_string(pystat)
+        pystr = string
+        return pystr.decode('ascii')
+
+    # The inverse of error_string: map the name of a PMIx status back to
+    # its numeric value. Returns PMIX_ERR_NOT_FOUND for an unknown name
+    #
+    # @errname [INPUT]
+    #          - the symbolic name of a status, e.g. "PMIX_ERR_TIMEOUT"
+    def error_code(self, errname):
+        if errname is None:
+            return PMIX_ERR_BAD_PARAM
+        if isinstance(errname, str):
+            pyname = errname.encode('ascii')
+        else:
+            pyname = errname
+        return PMIx_Error_code(pyname)
+
+    # Render a value or an info into the library's printable form. This is
+    # the library's own pretty-printer, so what comes back is exactly what
+    # PMIx debug output shows for the same data.
+    #
+    # @prefix [INPUT]
+    #         - string to prepend to the output, or None
+    #
+    # @pysrc [INPUT]
+    #        - a value dict ({'value':val, 'val_type':ty}) or an info dict
+    #          (the same plus a 'key')
+    #
+    # @data_type [INPUT]
+    #            - PMIX_VALUE or PMIX_INFO. Defaults to whichever shape
+    #              pysrc has. The C API accepts any registered data type,
+    #              but a Python caller can only hand us a value or an info
+    #              - every other type is reachable as the value of one
+    #
+    # Returns (rc, string)
+    def data_print(self, prefix, pysrc, data_type=None):
+        cdef pmix_value_t value
+        cdef pmix_info_t info
+        cdef char *output = NULL
+        cdef char *pfx = NULL
+
+        if not isinstance(pysrc, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        if data_type is None:
+            if 'key' in pysrc:
+                data_type = PMIX_INFO
+            else:
+                data_type = PMIX_VALUE
+        if prefix is not None:
+            if isinstance(prefix, str):
+                pypfx = prefix.encode('ascii')
+            else:
+                pypfx = prefix
+            pfx = <char*>pypfx
+
+        if PMIX_VALUE == data_type:
+            rc = pmix_load_value(&value, pysrc)
+            if PMIX_SUCCESS != rc:
+                pmix_destruct_value(&value)
+                return (rc, None)
+            rc = PMIx_Data_print(&output, pfx, <void*>&value, PMIX_VALUE)
+            pmix_destruct_value(&value)
+        elif PMIX_INFO == data_type:
+            if 'key' not in pysrc:
+                return (PMIX_ERR_BAD_PARAM, None)
+            memset(&info, 0, sizeof(pmix_info_t))
+            rc = pmix_load_info(&info, [pysrc])
+            if PMIX_SUCCESS != rc:
+                pmix_destruct_info(&info)
+                return (rc, None)
+            rc = PMIx_Data_print(&output, pfx, <void*>&info, PMIX_INFO)
+            pmix_destruct_info(&info)
+        else:
+            return (PMIX_ERR_NOT_SUPPORTED, None)
+
+        # the library allocated the string, so decode and hand it back
+        if PMIX_SUCCESS != rc or NULL == output:
+            return (rc, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (rc, txt)
+
     def fabric_register(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
@@ -2205,6 +2387,41 @@ cdef class PMIxClient:
         PMIx_Progress()
         return
 
+    # Stop the library's internal progress thread. Once stopped, the
+    # library only makes progress when progress() is called, so this is
+    # meant for callers that want to drive the event loop themselves.
+    #
+    # @dicts [INPUT]
+    #        - a list of dictionaries, where each
+    #          dictionary has a key, value, and val_type
+    #          defined as such:
+    #          [{key:y, value:val, val_type:ty}, … ]
+    #          e.g. PMIX_PROGRESS_THREAD_FLUSH to complete all pending
+    #          events before stopping, or PMIX_PROGRESS_THREAD_NAME to
+    #          stop one named thread instead of the shared one
+    #
+    # The C API returns nothing, so PMIX_SUCCESS is reported once the
+    # thread has been stopped; a directive that could not be converted is
+    # reported instead.
+    def progress_thread_stop(self, dicts=None):
+        cdef pmix_info_t *info
+        cdef pmix_info_t **info_ptr
+        cdef size_t ninfo
+
+        # allocate and load pmix info structs from python list of dictionaries
+        info_ptr = &info
+        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc
+
+        # this joins the progress thread, so the GIL must be released -
+        # the thread may need it to complete a pending Python callback
+        with nogil:
+            PMIx_Progress_thread_stop(info, ninfo)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        return PMIX_SUCCESS
+
 pmixservermodule = {}
 def setmodulefn(k, f):
     global pmixservermodule
@@ -2361,6 +2578,106 @@ cdef class PMIxServer(PMIxClient):
         ba = pmix_convert_regex(regex)
         return (rc, ba)
 
+    # Compress a list of node names into the current regular expression
+    # form, a pmix_regex2_t. This is the generator to use in new code -
+    # generate_regex above is the deprecated interface, which produces a
+    # bare string and cannot say which component encoded it.
+    #
+    # @hosts [INPUT]
+    #        - a list of node names, or an already comma-delimited string
+    #
+    # @dicts [INPUT]
+    #        - a list of dictionaries, where each
+    #          dictionary has a key, value, and val_type
+    #          defined as such:
+    #          [{key:y, value:val, val_type:ty}, … ]
+    #
+    # Returns (rc, {'type': str, 'bytes': bytes, 'len': int}), the dict
+    # being what parse_regex2 takes back
+    def generate_regex2(self, hosts, dicts=None):
+        cdef pmix_regex2_t regex
+        cdef pmix_info_t *info
+        cdef pmix_info_t **info_ptr
+        cdef size_t ninfo
+
+        if hosts is None:
+            return (PMIX_ERR_BAD_PARAM, None)
+        if isinstance(hosts, str):
+            myhosts = hosts
+        elif isinstance(hosts, bytes):
+            myhosts = hosts.decode('ascii')
+        else:
+            mycomma = ","
+            myhosts = mycomma.join(hosts)
+        pyhosts = myhosts.encode('ascii')
+
+        # allocate and load pmix info structs from python list of dictionaries
+        info_ptr = &info
+        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if PMIX_SUCCESS != rc:
+            return (rc, None)
+
+        PMIx_Regex2_construct(&regex)
+        rc = PMIx_generate_regex2(pyhosts, info, ninfo, &regex)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        if PMIX_SUCCESS != rc:
+            # a component can fail after setting a field, so release
+            # whatever was built before converting nothing
+            PMIx_Regex2_destruct(&regex)
+            return (rc, None)
+        pyregex = pmix_unload_regex2(&regex)
+        PMIx_Regex2_destruct(&regex)
+        return (rc, pyregex)
+
+    # Expand a pmix_regex2_t produced by generate_regex2 back into the
+    # list of values it encodes, preserving their original order.
+    #
+    # @pyregex [INPUT]
+    #          - regex dict: {'type': str, 'bytes': bytes, 'len': int}
+    #
+    # @dicts [INPUT]
+    #        - a list of dictionaries, where each
+    #          dictionary has a key, value, and val_type
+    #          defined as such:
+    #          [{key:y, value:val, val_type:ty}, … ]
+    #
+    # Returns (rc, [name, name, ...])
+    def parse_regex2(self, pyregex, dicts=None):
+        cdef pmix_regex2_t regex
+        cdef pmix_info_t *info
+        cdef pmix_info_t **info_ptr
+        cdef size_t ninfo
+        cdef char *output = NULL
+
+        names = []
+        # the loader constructs the regex first, so it is safe to destruct
+        # on every path from here on
+        rc = pmix_load_regex2(&regex, pyregex)
+        if PMIX_SUCCESS != rc:
+            PMIx_Regex2_destruct(&regex)
+            return (rc, names)
+
+        # allocate and load pmix info structs from python list of dictionaries
+        info_ptr = &info
+        rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if PMIX_SUCCESS != rc:
+            PMIx_Regex2_destruct(&regex)
+            return (rc, names)
+
+        rc = PMIx_parse_regex2(&regex, info, ninfo, &output)
+        PMIx_Regex2_destruct(&regex)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        if PMIX_SUCCESS != rc or NULL == output:
+            return (rc, names)
+        # the parser hands back a comma-delimited string it allocated
+        txt = output.decode('ascii')
+        free(output)
+        if 0 < len(txt):
+            names = txt.split(',')
+        return (rc, names)
+
     def generate_ppn(self, procs:list):
         cdef char *ppn = NULL
         mysemi = ";"
@@ -2415,6 +2732,35 @@ cdef class PMIxServer(PMIxClient):
         txt = csetstr.decode('ascii')
         free(csetstr)
         return (rc, txt)
+
+    # The inverse of generate_cpuset_string: convert the library's cpuset
+    # string form into the Python cpuset dict. This is the server-side
+    # entry point; PMIxClient.parse_cpuset_string performs the same
+    # conversion through the client entry point.
+    #
+    # @csetstr [INPUT]
+    #          - cpuset string of the form "<source>:<range-list>",
+    #            e.g. "hwloc:0-3,8"
+    #
+    # Returns (rc, {'source': str, 'cpus': [int, ...]})
+    def generate_cpuset(self, csetstr):
+        cdef pmix_cpuset_t cpuset
+
+        pycpus = {}
+        if csetstr is None:
+            return (PMIX_ERR_BAD_PARAM, pycpus)
+        if isinstance(csetstr, str):
+            pycset = csetstr.encode('ascii')
+        else:
+            pycset = csetstr
+        # the parser can allocate before it detects a malformed range, so
+        # construct up front and destruct on every path
+        PMIx_Cpuset_construct(&cpuset)
+        rc = PMIx_server_generate_cpuset(pycset, &cpuset)
+        if PMIX_SUCCESS == rc:
+            rc = pmix_unload_cpuset(&cpuset, pycpus)
+        pmix_destruct_cpuset(&cpuset)
+        return (rc, pycpus)
 
     # Compute the locality string for a process bound to the given cpuset.
     # This is the string a host environment passes as PMIX_LOCALITY_STRING
@@ -2783,6 +3129,58 @@ cdef class PMIxServer(PMIxClient):
         # delete the set
         rc = PMIx_server_delete_process_set(pyset)
         return rc
+
+    # Collect the job-level information this server holds for the jobs
+    # the given procs belong to, packaged as an opaque blob. A host
+    # environment forwards the blob to a remote PMIx server, which feeds
+    # it back into the library so its own clients can see that job data.
+    #
+    # @peers [INPUT]
+    #        - a list of proc dicts ({'nspace': str, 'rank': int}). Only
+    #          the namespaces matter; the ranks are ignored. The list
+    #          cannot be empty - there would be no job to collect
+    #
+    # Returns (rc, {'bytes': bytes, 'size': int}) - the byte-object form
+    # every other blob in these bindings uses
+    def collect_job_info(self, peers):
+        cdef pmix_proc_t *procs
+        cdef size_t nprocs
+        cdef pmix_data_buffer_t dbuf
+        cdef char *blob = NULL
+        cdef size_t nblob
+
+        pyblob = {'bytes': b'', 'size': 0}
+        if peers is None or 0 == len(peers):
+            return (PMIX_ERR_BAD_PARAM, pyblob)
+
+        # convert list of procs to array of pmix_proc_t's
+        nprocs = len(peers)
+        procs = <pmix_proc_t*> PyMem_Malloc(nprocs * sizeof(pmix_proc_t))
+        if not procs:
+            return (PMIX_ERR_NOMEM, pyblob)
+        rc = pmix_load_procs(procs, peers)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return (rc, pyblob)
+
+        # the collection is performed on the progress thread and this
+        # call blocks until it completes, so release the GIL
+        PMIx_Data_buffer_construct(&dbuf)
+        with nogil:
+            rc = PMIx_server_collect_job_info(procs, nprocs, &dbuf)
+        pmix_free_procs(procs, nprocs)
+
+        if PMIX_SUCCESS == rc:
+            # unload transfers ownership of the payload to us
+            nblob = 0
+            PMIx_Data_buffer_unload(&dbuf, &blob, &nblob)
+            if NULL != blob:
+                if 0 < nblob:
+                    pyblob['bytes'] = blob[:nblob]
+                    pyblob['size'] = nblob
+                free(blob)
+        PMIx_Data_buffer_destruct(&dbuf)
+        return (rc, pyblob)
 
     def session_control(self, sessionID:int, ilist):
         cdef pmix_info_t *info
@@ -3799,6 +4197,19 @@ cdef class PMIxTool(PMIxServer):
             pmix_free_info(directives, ndirs)
         return rc
 
+# The scheduler is a tool that owns the system's resources, so it
+# inherits every client, server and tool method and adds session
+# direction on top. Two operations make up the scheduler role proper,
+# and both reach it through what it inherits:
+#
+#   * resource blocks - the scheduler does not call resource_block (a
+#     process that IS the scheduler has no one to ask, and the library
+#     returns PMIX_ERR_NOT_SUPPORTED). It SERVICES the requests other
+#     processes make, by registering a 'resourceblock' handler in the
+#     server module map it passes to set_server_module.
+#   * session control - likewise serviced through the 'sessioncontrol'
+#     module key, while the scheduler's own directives to a session go
+#     out through the inherited session_control method.
 cdef class PMIxScheduler(PMIxTool):
     def __cinit__(self):
         memset(self.myproc.nspace, 0, sizeof(self.myproc.nspace))

--- a/docs/man/man3/PMIx_Alloc_inheritance_string.3.rst
+++ b/docs/man/man3/PMIx_Alloc_inheritance_string.3.rst
@@ -19,6 +19,17 @@ SYNOPSIS
    const char* PMIx_Alloc_inheritance_string(pmix_alloc_inheritance_t inheritance);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  string = foo.alloc_inheritance_string(PMIX_ALLOC_INHERIT_CHILD)
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_print.3.rst
+++ b/docs/man/man3/PMIx_Data_print.3.rst
@@ -19,6 +19,20 @@ SYNOPSIS
                                  void *src, pmix_data_type_t type);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the source is a Python value dictionary, or an info dictionary if it
+  # carries a 'key' - the data type is deduced from its shape
+  rc, string = foo.data_print("VALUE: ", {'value': 42, 'val_type': PMIX_INT32})
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Error_code.3.rst
+++ b/docs/man/man3/PMIx_Error_code.3.rst
@@ -19,6 +19,18 @@ SYNOPSIS
    pmix_status_t PMIx_Error_code(const char *errname);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the inverse of error_string - returns the integer status code
+  status = foo.error_code("PMIX_ERR_NOT_FOUND")
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Group_operation_string.3.rst
+++ b/docs/man/man3/PMIx_Group_operation_string.3.rst
@@ -19,6 +19,17 @@ SYNOPSIS
    const char* PMIx_Group_operation_string(pmix_group_operation_t op);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  string = foo.group_operation_string(PMIX_GROUP_CONSTRUCT)
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Heartbeat.3.rst
+++ b/docs/man/man3/PMIx_Heartbeat.3.rst
@@ -18,6 +18,20 @@ SYNOPSIS
    void PMIx_Heartbeat(void);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the C API returns void, so the binding reports PMIX_SUCCESS once the
+  # heartbeat has been handed to the library
+  rc = foo.heartbeat()
+
+
 DESCRIPTION
 -----------
 

--- a/docs/man/man3/PMIx_Progress_thread_stop.3.rst
+++ b/docs/man/man3/PMIx_Progress_thread_stop.3.rst
@@ -18,6 +18,20 @@ SYNOPSIS
    void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the directives are a list of Python ``pmix_info_t`` dictionaries
+  rc = foo.progress_thread_stop([{'key': PMIX_PROGRESS_THREAD_FLUSH,
+                                  'value': True, 'val_type': PMIX_BOOL}])
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -28,6 +28,22 @@ SYNOPSIS
                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the resource units are a list of Python dictionaries, each naming a
+  # device type and a count; the directives are a list of Python
+  # ``pmix_info_t`` dictionaries
+  units = [{'type': PMIX_DEVTYPE_GPU, 'count': 4}]
+  rc = foo.resource_block(PMIX_RESOURCE_BLOCK_DEFINE, "myblock", units, [])
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Resource_block_directive_string.3.rst
+++ b/docs/man/man3/PMIx_Resource_block_directive_string.3.rst
@@ -19,6 +19,17 @@ SYNOPSIS
    const char* PMIx_Resource_block_directive_string(pmix_resource_block_directive_t directive);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  string = foo.resource_block_directive_string(PMIX_RESOURCE_BLOCK_DEFINE)
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Value_comparison_string.3.rst
+++ b/docs/man/man3/PMIx_Value_comparison_string.3.rst
@@ -19,6 +19,17 @@ SYNOPSIS
    const char* PMIx_Value_comparison_string(pmix_value_cmp_t cmp);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  string = foo.value_comparison_string(PMIX_VALUE1_GREATER)
+
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_generate_regex2.3.rst
+++ b/docs/man/man3/PMIx_generate_regex2.3.rst
@@ -24,7 +24,16 @@ SYNOPSIS
 Python Syntax
 ^^^^^^^^^^^^^
 
-No Python equivalent
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # the input may be a list of values or an already comma-delimited string
+  # the directives are a list of Python ``pmix_info_t`` dictionaries
+  rc, regex = foo.generate_regex2(["node001", "node002", "node003"], [])
+  # regex is {'type': str, 'bytes': bytes, 'len': int}
 
 
 INPUT PARAMETERS

--- a/docs/man/man3/PMIx_parse_regex2.3.rst
+++ b/docs/man/man3/PMIx_parse_regex2.3.rst
@@ -24,7 +24,17 @@ SYNOPSIS
 Python Syntax
 ^^^^^^^^^^^^^
 
-No Python equivalent
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  # the regex is the dictionary returned by generate_regex2:
+  # {'type': str, 'bytes': bytes, 'len': int}
+  # the directives are a list of Python ``pmix_info_t`` dictionaries
+  rc, names = foo.parse_regex2(regex, [])
+  # names is the list of values the regex encodes, in their original order
 
 
 INPUT PARAMETERS

--- a/docs/man/man3/PMIx_server_collect_job_info.3.rst
+++ b/docs/man/man3/PMIx_server_collect_job_info.3.rst
@@ -23,7 +23,16 @@ SYNOPSIS
 Python Syntax
 ^^^^^^^^^^^^^
 
-No Python equivalent
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() and register_nspace() ...
+  # the procs are a list of Python proc dictionaries - only their
+  # namespaces matter, and the list cannot be empty
+  rc, blob = foo.collect_job_info([{'nspace': "myjob", 'rank': 0}])
+  # blob is a byte object, {'bytes': bytes, 'size': int}
 
 
 INPUT PARAMETERS

--- a/docs/man/man3/PMIx_server_generate_cpuset.3.rst
+++ b/docs/man/man3/PMIx_server_generate_cpuset.3.rst
@@ -23,7 +23,14 @@ SYNOPSIS
 Python Syntax
 ^^^^^^^^^^^^^
 
-No Python equivalent
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxServer()
+  # ... after a successful foo.init() ...
+  rc, pycpus = foo.generate_cpuset("hwloc:0-3,8")
+  # pycpus is {'source': 'hwloc', 'cpus': [0, 1, 2, 3, 8]}
 
 
 INPUT PARAMETERS

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,18 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Fixed three library entry points that crashed or hung when called
+   before PMIx_Init - reachable from C, but found while adding their
+   Python bindings, where a script naturally calls a method on a freshly
+   constructed object. PMIx_Heartbeat sent through a peer pointer that
+   is NULL until initialization, PMIx_Progress_thread_stop walked its
+   tracking list before that list was constructed, and
+   PMIx_server_collect_job_info thread-shifted its request and then
+   waited forever for a progress thread that did not exist
+ - PMIx_server_collect_job_info now rejects a request that names no
+   procs. There is no job to collect in that case, and the collection
+   loop walked the resulting NULL namespace list. A NULL proc array or
+   output buffer is likewise rejected rather than dereferenced
  - PMIx_Get_relative_locality now accepts the strings that
    PMIx_server_generate_locality_string actually produces. The generator
    emits a bare "SK0:L20:CR0:HT0" and a host environment stores exactly

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -19,6 +19,14 @@ Detailed changes since v6.1.0:
    {'type': str, 'bytes': bytes, 'len': int} and a resource unit as
    {'type': PMIX_DEVTYPE_x, 'count': n}. What remains unbound is the
    non-blocking family and one deprecated tool API
+ - PMIx_Heartbeat is now a no-op for a process that has no server above
+   it. A heartbeat travels *up* to the server watching the caller, but a
+   PMIx server - and a tool that has not attached to one - is its own
+   server, so the message looped back into the process's own matching
+   code, found no posted receive for the heartbeat tag, and was reported
+   as an unexpected message. Each call therefore raised an error event
+   and grew the process. A heartbeat is likewise skipped once the
+   connection to the server has been lost
  - Fixed three library entry points that crashed or hung when called
    before PMIx_Init - reachable from C, but found while adding their
    Python bindings, where a script naturally calls a method on a freshly

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,18 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Added Python bindings for the remaining unique blocking APIs. The
+   client gains heartbeat, progress_thread_stop and resource_block; the
+   server gains generate_regex2 and parse_regex2 - the current regex
+   interface, of which only the deprecated generate_regex had been bound
+   - plus generate_cpuset and collect_job_info; and the pretty-print
+   family gains error_code (the inverse of error_string), data_print,
+   value_comparison_string, group_operation_string,
+   resource_block_directive_string and alloc_inheritance_string. A
+   regular expression crosses to Python as
+   {'type': str, 'bytes': bytes, 'len': int} and a resource unit as
+   {'type': PMIX_DEVTYPE_x, 'count': n}. What remains unbound is the
+   non-blocking family and one deprecated tool API
  - Fixed three library entry points that crashed or hung when called
    before PMIx_Init - reachable from C, but found while adding their
    Python bindings, where a script naturally calls a method on a freshly

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -631,6 +631,13 @@ void PMIx_Heartbeat(void)
     pmix_buffer_t *msg;
     pmix_status_t rc;
 
+    /* we have no server to send to until we have been initialized, and
+     * the send macro dereferences the peer without checking it */
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized) ||
+        NULL == pmix_client_globals.myserver) {
+        return;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return;
     }

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -638,6 +638,21 @@ void PMIx_Heartbeat(void)
         return;
     }
 
+    /* a heartbeat is something a process sends *up* to the server that
+     * is watching it. A server - and a tool that has not attached to
+     * one - is its own "server", so there is nobody to hear it. The
+     * message would loop back into our own matching code, find no
+     * posted receive for the heartbeat tag, and be reported as an
+     * unexpected message */
+    if (pmix_globals.mypeer == pmix_client_globals.myserver) {
+        return;
+    }
+
+    /* likewise if the connection to our server has been lost */
+    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+        return;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return;
     }

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -163,6 +163,12 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
     const char *name = NULL;
     pmix_progress_tracker_t *trk;
 
+    if (!inited) {
+        /* the tracking list has not been constructed, so there is
+         * nothing to stop - and walking it would dereference NULL */
+        return;
+    }
+
     for (n=0; n < ninfo; n++) {
         key = (char*)info[n].key;
         if (PMIx_Check_key(key, PMIX_PROGRESS_THREAD_FLUSH)) {

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -616,6 +616,13 @@ static void _collect_job_info(int sd, short args, void *cbdata)
         }
     }
 
+    if (NULL == nspaces) {
+        // no procs were given, so there is nothing to collect - the
+        // loop below would dereference the NULL array
+        ret = PMIX_ERR_BAD_PARAM;
+        goto done;
+    }
+
     // cycle across the nspaces to collect their job info
     for (n = 0; NULL != nspaces[n]; n++) {
         // see if we have this nspace
@@ -713,6 +720,20 @@ pmix_status_t PMIx_server_collect_job_info(pmix_proc_t *procs, size_t nprocs,
     pmix_cb_t cb;
     pmix_byte_object_t bo;
     pmix_status_t rc;
+
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
+    /* the request is threadshifted below and we then block waiting for
+     * it, so there has to be a progress thread to execute it */
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    if (NULL == procs || 0 == nprocs || NULL == dbuf) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     // we need to threadshift this request as it accesses
     // global data

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -75,6 +75,19 @@ def main():
     rc, get_val = foo.get({'nspace':"testnspace", 'rank': 0}, "mykey", info)
     print("Get result: ", foo.error_string(rc))
     print("Get value returned: ", get_val)
+    # send a heartbeat to our server - this is the fire-and-forget path
+    # that feeds a process health monitor, so there is nothing to wait for
+    print("HEARTBEAT")
+    rc = foo.heartbeat()
+    print("Heartbeat result ", foo.error_string(rc))
+    # ask the scheduler to define a resource block. Our server is not a
+    # scheduler and has no scheduler above it, so the library has no one
+    # to ask - what is under test here is that the request converts and
+    # comes back with a status rather than hanging or crashing
+    print("RESOURCE BLOCK")
+    units = [{'type': PMIX_DEVTYPE_GPU, 'count': 2}]
+    rc = foo.resource_block(PMIX_RESOURCE_BLOCK_DEFINE, "myblock", units, [])
+    print("Resource block result ", foo.error_string(rc))
     # test a fence that should return not_supported because
     # we pass a required attribute that doesn't exist
     procs = []

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -121,6 +121,38 @@ def main():
     rc = foo.register_nspace("testnspace", 1, kvals)
     print("RegNspace ", foo.error_string(rc))
 
+    # exercise the current regex interface - the round trip has to give
+    # back exactly the list we handed in, in the same order
+    nodes = ["test000", "test001", "test002"]
+    (rc, rgx) = foo.generate_regex2(nodes)
+    print("Regex2: ", foo.error_string(rc), rgx)
+    if PMIX_SUCCESS != rc:
+        print("GENERATE_REGEX2 FAILED")
+        exit(1)
+    (rc, back) = foo.parse_regex2(rgx)
+    print("ParseRegex2: ", foo.error_string(rc), back)
+    if PMIX_SUCCESS != rc or back != nodes:
+        print("REGEX2 ROUND TRIP FAILED")
+        exit(1)
+
+    # convert a cpuset string into the Python cpuset dict and back
+    (rc, cpus) = foo.generate_cpuset("hwloc:0-3,8")
+    print("Cpuset: ", foo.error_string(rc), cpus)
+    (rc, csetstr) = foo.generate_cpuset_string(cpus)
+    print("CpusetStr: ", foo.error_string(rc), csetstr)
+
+    # collect the job info for the nspace we just registered - this is
+    # what a host forwards to a remote server
+    (rc, blob) = foo.collect_job_info([{'nspace': "testnspace", 'rank': 0}])
+    print("CollectJobInfo: ", foo.error_string(rc), blob['size'], "bytes")
+    if PMIX_SUCCESS != rc or 0 == blob['size']:
+        print("COLLECT_JOB_INFO RETURNED NO DATA")
+        exit(1)
+
+    # print a value and an info the way the library itself renders them
+    (rc, txt) = foo.data_print("VALUE: ", {'value': 42, 'val_type': PMIX_INT32})
+    print("DataPrint: ", foo.error_string(rc), txt)
+
     # register a client
     uid = os.getuid()
     gid = os.getgid()

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -199,6 +199,41 @@ class TestStringConverters(unittest.TestCase):
             name = name.decode("utf-8", "replace")
         self.assertIsInstance(name, str)
 
+    def test_value_comparison_string(self):
+        self._check(self.c.value_comparison_string(pmix.PMIX_EQUAL))
+        self._check(self.c.value_comparison_string(pmix.PMIX_VALUE1_GREATER))
+
+    def test_group_operation_string(self):
+        self._check(self.c.group_operation_string(pmix.PMIX_GROUP_CONSTRUCT))
+        self._check(self.c.group_operation_string(pmix.PMIX_GROUP_DESTRUCT))
+
+    def test_resource_block_directive_string(self):
+        self._check(self.c.resource_block_directive_string(
+            pmix.PMIX_RESOURCE_BLOCK_DEFINE))
+        self._check(self.c.resource_block_directive_string(
+            pmix.PMIX_RESOURCE_BLOCK_DELETE))
+
+    def test_alloc_inheritance_string(self):
+        self._check(self.c.alloc_inheritance_string(
+            pmix.PMIX_ALLOC_INHERIT_NONE))
+        self._check(self.c.alloc_inheritance_string(
+            pmix.PMIX_ALLOC_INHERIT_CHILD))
+
+    def test_error_code_is_inverse_of_error_string(self):
+        # error_code is the one converter that runs the other way
+        for code in (pmix.PMIX_SUCCESS, pmix.PMIX_ERR_NOT_SUPPORTED,
+                     pmix.PMIX_ERR_TIMEOUT, pmix.PMIX_ERR_BAD_PARAM):
+            name = self.c.error_string(code)
+            if isinstance(name, bytes):
+                name = name.decode("utf-8", "replace")
+            self.assertEqual(self.c.error_code(name), code,
+                             "error_code(%s) did not return %d" % (name, code))
+
+    def test_error_code_rejects_bad_input(self):
+        self.assertEqual(self.c.error_code(None), pmix.PMIX_ERR_BAD_PARAM)
+        # an unknown name is simply not found - it must not raise
+        self.assertIsInstance(self.c.error_code("NO_SUCH_STATUS_NAME"), int)
+
 
 class TestCpusetConverters(unittest.TestCase):
     """The cpuset dict <-> string converters. These are pure Python helpers
@@ -325,6 +360,197 @@ class TestMethodBinding(unittest.TestCase):
         for name in names:
             meth = getattr(pmix.PMIxServer, name, None)
             self.assertIsNotNone(meth, "PMIxServer.%s missing" % name)
+
+
+class TestNewlyBoundAPIs(unittest.TestCase):
+    """The client/server APIs bound to close the gaps in MISSING_BINDINGS.md
+    sections 1.2, 1.3, 1.5 and 1.6.
+
+    Without a server none of these can complete, but each one converts its
+    arguments before handing them to the library and has to release what it
+    converted when the library refuses the request (PMIX_ERR_INIT) - the
+    same error-path cleanup the non-blocking group tests below cover.  The
+    binding's own validation (PMIX_ERR_BAD_PARAM) is fully testable here.
+    """
+
+    def setUp(self):
+        self.c = pmix.PMIxClient()
+        self.s = pmix.PMIxServer()
+
+    def test_methods_present(self):
+        for name in ("heartbeat", "progress_thread_stop", "resource_block",
+                     "error_code", "value_comparison_string",
+                     "group_operation_string",
+                     "resource_block_directive_string",
+                     "alloc_inheritance_string", "data_print"):
+            self.assertTrue(hasattr(pmix.PMIxClient, name),
+                            "PMIxClient.%s missing" % name)
+        for name in ("generate_regex2", "parse_regex2", "generate_cpuset",
+                     "collect_job_info"):
+            self.assertTrue(hasattr(pmix.PMIxServer, name),
+                            "PMIxServer.%s missing" % name)
+
+    def test_methods_have_self(self):
+        # a cdef class method declared without an explicit self shifts its
+        # arguments and raises TypeError when called on an instance
+        import inspect
+        cases = [(pmix.PMIxClient, n) for n in
+                 ("heartbeat", "progress_thread_stop", "resource_block",
+                  "error_code", "data_print")]
+        cases += [(pmix.PMIxServer, n) for n in
+                  ("generate_regex2", "parse_regex2", "generate_cpuset",
+                   "collect_job_info")]
+        for cls, name in cases:
+            meth = getattr(cls, name)
+            try:
+                params = list(inspect.signature(meth).parameters)
+            except (TypeError, ValueError):
+                continue
+            self.assertEqual(params[0], "self",
+                             "%s does not declare self first" % name)
+
+    def test_heartbeat_before_init(self):
+        # nothing to send to yet, but it must neither raise nor crash
+        self.assertEqual(self.c.heartbeat(), pmix.PMIX_SUCCESS)
+
+    def test_progress_thread_stop_before_init(self):
+        # no progress thread has been started, so this is a no-op - it must
+        # not hang or crash on the unbuilt tracking list
+        self.assertEqual(self.c.progress_thread_stop([]), pmix.PMIX_SUCCESS)
+        self.assertEqual(
+            self.c.progress_thread_stop(
+                [{'key': pmix.PMIX_PROGRESS_THREAD_FLUSH, 'value': True,
+                  'val_type': pmix.PMIX_BOOL}]),
+            pmix.PMIX_SUCCESS)
+
+    def test_resource_block_validates_block_name(self):
+        rc = self.c.resource_block(pmix.PMIX_RESOURCE_BLOCK_DEFINE, None,
+                                   [], [])
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+
+    def test_resource_block_before_init(self):
+        # repeat enough times that a leak or double free in the unit/info
+        # conversion would be obvious
+        units = [{'type': pmix.PMIX_DEVTYPE_GPU, 'count': 4},
+                 {'type': pmix.PMIX_DEVTYPE_NETWORK, 'count': 1}]
+        info = [{'key': pmix.PMIX_TIMEOUT, 'value': 10,
+                 'val_type': pmix.PMIX_INT}]
+        for _ in range(64):
+            rc = self.c.resource_block(pmix.PMIX_RESOURCE_BLOCK_DEFINE,
+                                       "myblock", units, info)
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+        # a missing unit list is legal - the directive may not need one
+        self.assertEqual(
+            self.c.resource_block(pmix.PMIX_RESOURCE_BLOCK_DELETE, "myblock",
+                                  None, None),
+            pmix.PMIX_ERR_INIT)
+
+    def test_resource_block_rejects_bad_units(self):
+        for bad in ([{'type': "gpu", 'count': 1}],
+                    [{'type': pmix.PMIX_DEVTYPE_GPU, 'count': "many"}],
+                    ["not-a-dict"]):
+            rc = self.c.resource_block(pmix.PMIX_RESOURCE_BLOCK_DEFINE,
+                                       "myblock", bad, [])
+            self.assertIn(rc, (pmix.PMIX_ERR_BAD_PARAM,
+                               pmix.PMIX_ERR_TYPE_MISMATCH),
+                          "bad resource unit returned %d" % rc)
+
+    def test_data_print_validates_input(self):
+        rc, txt = self.c.data_print(None, "not-a-dict")
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+        self.assertIsNone(txt)
+        # only a value or an info can be built from a Python dict
+        rc, txt = self.c.data_print(None, {'value': 1,
+                                           'val_type': pmix.PMIX_INT},
+                                    pmix.PMIX_PROC)
+        self.assertEqual(rc, pmix.PMIX_ERR_NOT_SUPPORTED)
+        # PMIX_INFO was asked for but there is no key to build it from
+        rc, txt = self.c.data_print(None, {'value': 1,
+                                           'val_type': pmix.PMIX_INT},
+                                    pmix.PMIX_INFO)
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+
+    def test_data_print_before_init(self):
+        # the library refuses before init; the conversion still has to run
+        # and be released
+        for _ in range(64):
+            rc, txt = self.c.data_print("X: ", {'value': 'hello',
+                                                'val_type': pmix.PMIX_STRING})
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+            rc, txt = self.c.data_print(None, {'key': pmix.PMIX_UNIV_SIZE,
+                                               'value': 16,
+                                               'val_type': pmix.PMIX_UINT32})
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_generate_regex2_validates_input(self):
+        rc, rgx = self.s.generate_regex2(None)
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+        self.assertIsNone(rgx)
+
+    def test_generate_regex2_before_init(self):
+        for _ in range(64):
+            rc, rgx = self.s.generate_regex2(["n1", "n2", "n3"])
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_parse_regex2_validates_input(self):
+        # not a dict, no type, and no bytes are all bad input - and each
+        # must be reported rather than reaching the library
+        for bad in (None, "notadict", {}, {'type': 'raw'},
+                    {'bytes': b'n1,n2'}):
+            rc, names = self.s.parse_regex2(bad)
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                             "parse_regex2(%s) returned %d" % (bad, rc))
+            self.assertEqual(names, [])
+
+    def test_parse_regex2_before_init(self):
+        rgx = {'type': 'raw', 'bytes': b'n1,n2,n3'}
+        for _ in range(64):
+            rc, names = self.s.parse_regex2(rgx)
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+            self.assertEqual(names, [])
+        # an explicit length shorter than the buffer is honored, and one
+        # longer than it is clamped rather than read past the end
+        for ln in (0, 3, 8, 99):
+            rc, names = self.s.parse_regex2({'type': 'raw',
+                                             'bytes': b'n1,n2,n3', 'len': ln})
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_generate_cpuset_validates_input(self):
+        rc, cpus = self.s.generate_cpuset(None)
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(cpus, {})
+
+    def test_generate_cpuset_before_init(self):
+        rc, cpus = self.s.generate_cpuset("hwloc:0-3,8")
+        self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_collect_job_info_requires_procs(self):
+        # with no procs there is no job to collect, and the library would
+        # walk a NULL namespace list
+        for bad in (None, []):
+            rc, blob = self.s.collect_job_info(bad)
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+            self.assertEqual(blob['size'], 0)
+            self.assertEqual(blob['bytes'], b'')
+
+    def test_collect_job_info_before_init(self):
+        procs = [{'nspace': "testnspace", 'rank': 0},
+                 {'nspace': "testnspace", 'rank': 1}]
+        for _ in range(64):
+            rc, blob = self.s.collect_job_info(procs)
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+            self.assertEqual(blob['size'], 0)
+
+    def test_scheduler_role_operations(self):
+        # section 1.5: the scheduler drives resource blocks and sessions
+        # through what it inherits - both must be reachable on the class
+        sched = pmix.PMIxScheduler()
+        self.assertTrue(hasattr(sched, "resource_block"))
+        self.assertTrue(hasattr(sched, "session_control"))
+        self.assertEqual(
+            sched.resource_block(pmix.PMIX_RESOURCE_BLOCK_DEFINE, None,
+                                 [], []),
+            pmix.PMIX_ERR_BAD_PARAM)
 
 
 class TestGroupNonBlocking(unittest.TestCase):

--- a/test/unit/collect_job_info.c
+++ b/test/unit/collect_job_info.c
@@ -196,6 +196,20 @@ int main(int argc, char **argv)
 
     PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
 
+    /* a request with no procs identifies no job to collect. The namespace
+     * list is then NULL, and the collection loop used to walk it - so this
+     * has to be rejected up front, not passed down */
+    PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+    rc = PMIx_server_collect_job_info(procs, 0, &dbuf);
+    report("zero procs is rejected", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_server_collect_job_info(NULL, 1, &dbuf);
+    report("NULL proc array is rejected", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_server_collect_job_info(procs, 1, NULL);
+    report("NULL buffer is rejected", PMIX_ERR_BAD_PARAM == rc);
+    PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 
     PMIx_server_finalize();


### PR DESCRIPTION
Closes the remaining coverage gaps in `bindings/python/MISSING_BINDINGS.md`
sections 1.2, 1.3, 1.5 and 1.6. What is left unbound after this is the
non-blocking family (§1.1) and the deprecated `PMIx_tool_connect_to_server`
(§1.4, intentional).

## New bindings

| Section | Methods |
|---------|---------|
| 1.2 `PMIxClient` | `heartbeat`, `progress_thread_stop`, `resource_block` |
| 1.3 `PMIxServer` | `generate_regex2`, `parse_regex2`, `generate_cpuset`, `collect_job_info` |
| 1.6 converters | `error_code`, `data_print`, `value_comparison_string`, `group_operation_string`, `resource_block_directive_string`, `alloc_inheritance_string` |

Two new struct shapes cross the boundary, each following its struct's own
field names: a regex is `{'type': str, 'bytes': bytes, 'len': int}` and a
resource unit is `{'type': PMIX_DEVTYPE_x, 'count': n}`. The regex payload
is not necessarily NUL-terminated, so it is carried as `bytes` with its
length rather than as a string. `pmix.pxi` grows the matching load/unload
helpers.

`data_print` covers the two shapes a Python caller can build - a value dict
and an info dict, deduced from the presence of a `'key'`. Every other data
type is reachable as the value of one of those.

**Section 1.5 needed no new method.** A scheduler does not *call*
`resource_block` - the library refuses it, as there is nobody above the
scheduler to ask; it *services* the requests other processes make through
its `'resourceblock'` server-module handler, and `session_control` comes
down from `PMIxServer`. So `resource_block` belongs on `PMIxClient`, and
the `PMIxScheduler` class header now records the reasoning.

The three blocking calls release the GIL, since each can end up waiting on
the progress thread - which may need the GIL to run a Python server-module
handler.

## Library fixes (first commit)

Three public APIs assumed the library had already been initialized. All are
reachable from C; all three were found while binding them, where the natural
first thing a script does is call a method on a freshly constructed object.

- `PMIx_Heartbeat` handed its message to `PMIX_PTL_SEND_ONEWAY`, which
  dereferences the peer, but `pmix_client_globals.myserver` is NULL until an
  init path sets it - the first heartbeat segfaulted.
- `PMIx_Progress_thread_stop` walked its static tracking list before that
  list had been constructed.
- `PMIx_server_collect_job_info` had no state check at all: it threadshifted
  its request and then blocked on `PMIX_WAIT_THREAD`, waiting forever with no
  progress thread. It also accepted a request naming no procs, producing a
  NULL namespace list that the collection loop then walked, and never checked
  its output buffer pointer.

A third commit stops `PMIx_Heartbeat` from sending when there is nobody to
hear it. A heartbeat travels *up* to the server watching the caller, but a
PMIx server - and a tool that has not attached to one - is its own server,
so the message looped back into the process's own matching code, matched no
posted receive for the heartbeat tag, and surfaced as an unexpected message:
a `show_help` and an error event per beat, and steady growth in a server
that beats in a loop. It now returns early, using the same "we don't pass it
to ourselves" test the event and IOF paths already use, and likewise skips
the send once the connection to the server has been lost. A real client is
unaffected - `test/simple/simpjctrl`, which registers a heartbeat monitor
and beats, still has its heartbeat delivered to the server's psensor
(verified with temporary instrumentation in the receiver).

## Testing

Full `make check` is green under a fresh `TMPDIR` (20 util + 8 class + 31
unit + 3 python + 15), the build is warning-free, and the docs build clean.

- `test/python/test_bindings.py` gains 20 cases covering the new methods'
  validation and pre-init cleanup paths.
- `test/unit/collect_job_info.c` gains the three parameter cases.
- `server.py` now round-trips a regex2 (asserted), converts a cpuset,
  collects job info and prints a value; `client.py` sends a heartbeat and a
  resource-block request over a real connection. Both run under `make check`.
- A 2000-iteration stress loop over the new conversion paths showed flat RSS.

Docs: 13 man pages gain a Python Syntax block (four of them said "No Python
equivalent", which is no longer true), plus news, `MISSING_BINDINGS.md` and
the bindings `AGENTS.md`.
