### PR TITLE
python: bind the remaining non-blocking APIs

### DIFF
--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -193,25 +193,37 @@ Python server registers them via `PMIxServer.init(info, module_map)` where
 
 The reverse of §4b, and the newest of the three. A non-blocking client
 method hands a request to `libpmix` and returns immediately; the result
-arrives later on the progress thread. The group operations
-(`group_construct_nb` and friends) are the worked example — everything
-else in `MISSING_BINDINGS.md` §1.1 is meant to reuse this.
+arrives later on the progress thread. Every `_nb` API is bound this way
+— the group operations (`group_construct_nb` and friends) are the
+worked example, and `MISSING_BINDINGS.md` §1.1 tabulates the rest with
+their callback signatures.
 
 Three pieces, all in `pmix.pyx`:
 
 - **`nbcbd`, a keepalive caddy.** PMIx does not copy its input, so the
   blocking methods' habit of freeing `procs`/`info` the moment the C call
-  returns is a use-after-free here. The group identifier is worse:
+  returns is a use-after-free here. Strings are worse:
   `group.encode('ascii')` is a Python local, so its buffer dangles at
   return. All of it goes in the caddy, which is passed as the operation's
-  `cbdata` and released by the trampoline. Each field goes back to its own
-  allocator (`free` / `PyMem_Free` / `pmix_free_info`) — see §8.
+  `cbdata` and released by the trampoline. One struct serves every
+  operation — the trampolines cast any caddy to it to reach `idx` — so
+  it is zeroed at allocation and each field goes back to its own
+  allocator (`free` / `PyMem_Free` / `pmix_free_info` /
+  `pmix_free_argv`) — see §8.
 - **`pynbcbs`, a registry.** The caller's Python callback and `cbdata`
   live in a module-global dict keyed by an integer the caddy carries, so
-  no `PyObject *` crosses into C. Same technique as `myhdlrs`.
-- **`pypmix_client_op_cbfunc` / `pypmix_client_info_cbfunc`,
-  trampolines.** `noexcept with gil`, per the rules below, with the user's
-  callback wrapped in `try`/`except`.
+  no `PyObject *` crosses into C. Same technique as `myhdlrs`. The entry
+  can also carry an unread reference to an object that must outlive the
+  operation — which is how the calls that hand `libpmix` a pointer into
+  the class (`&self.myfabric`, `&self.topo`) keep it from dangling.
+- **Eight trampolines**, one per C callback type
+  (`pypmix_client_op_cbfunc`, `_info_`, `_value_`, `_lookup_`, `_spawn_`,
+  `_credential_`, `_validation_`, `_devdist_`). All are `noexcept with
+  gil`, per the rules below, with the user's callback wrapped in
+  `try`/`except`. **Everything the library hands a callback belongs to
+  the library**, and only the info and device-distance forms carry a
+  `release_fn` — the rest reclaim their data as soon as the callback
+  returns, so convert to Python before doing anything else.
 
 Two invariants are easy to miss:
 
@@ -227,7 +239,12 @@ Two invariants are easy to miss:
 Validate that `cbfunc` is callable before allocating anything — a callback
 that can never run strands the caddy for the life of the process.
 
-Full write-up, including how to add the remaining `_nb` bindings:
+To update class state from a completion, register a closure in place of
+the caller's callback rather than teaching a trampoline about the class
+— `fabric_register_nb` does this to flip `fabric_set` when the library
+reports success, not when the request is accepted.
+
+Full write-up, including how to add a further `_nb` binding:
 [`docs/how-things-work/python_nonblocking.rst`](../../docs/how-things-work/python_nonblocking.rst).
 
 ### Rules when touching callback code
@@ -358,6 +375,16 @@ internalizing so they are not reintroduced:
 - **`memset`/`malloc` counts must include `sizeof(T)`**, and NUL-terminated
   `char**` arrays need one extra slot. Byte counts vs element counts were a
   recurring source of overflow.
+- **Zero an array before you fill it entry by entry.** Every loader here
+  can fail partway (an unconvertible value type is enough), and the
+  caller then releases the *whole* array — destructing entries that were
+  never written. `pmix_load_info`, `pmix_load_apps` and the query builder
+  all zero first for that reason.
+- **An empty list must produce a NULL array, not a zero-length one.** The
+  C APIs read a non-NULL array with a count of zero as "terminated by an
+  end marker" and walk off the allocation looking for one. `malloc(0)`
+  returns a valid pointer, so this is easy to get wrong; `pmix_alloc_info`
+  gets it right and `pmix_load_apps` had to be fixed to match.
 - **Copy from the right key.** Loaders read from a value dict; getting the
   wrong key (`envar` vs `value`, `val_type` vs `value`) silently corrupts data.
 - **`setmodulefn`'s `permitted` list and `server_module_init`'s wiring names

--- a/bindings/python/MISSING_BINDINGS.md
+++ b/bindings/python/MISSING_BINDINGS.md
@@ -4,8 +4,9 @@ Tracking document for the PMIx Python bindings (`bindings/python/`). It has
 two parts:
 
 1. **Missing bindings** — real operational C APIs that have no Python method
-   yet. The unique blocking APIs (§§1.2–1.6) have all been bound; what
-   remains is the `_nb` family in §1.1 and one deprecated tool API.
+   yet. Every operational API is now bound in both its blocking and its
+   non-blocking form; the only thing deliberately left out is one
+   deprecated tool API (§1.4).
 2. **Defects** — bugs found in the *existing* bindings during the 2026-07 deep
    review. All are fixed.
 
@@ -28,39 +29,62 @@ Headers surveyed: `include/pmix.h`, `include/pmix_server.h`,
 
 ## Part 1 — Missing bindings
 
-### 1.1 Non-blocking (`_nb`) variants — the group family is bound
+### 1.1 Non-blocking (`_nb`) variants — **CLOSED**
 
-The five group operations now have non-blocking bindings
-(`group_construct_nb`, `group_invite_nb`, `group_join_nb`,
-`group_leave_nb`, `group_destruct_nb`). They brought the client-side
+The five group operations were bound first and brought the client-side
 async machinery with them — a keepalive caddy, a callback registry, and
-the two trampolines — so the remaining entries below are a mechanical
-follow-on rather than new infrastructure. See AGENTS.md §4c and
+two trampolines. The remaining twenty are built on exactly that
+machinery. See AGENTS.md §4c and
 [`docs/how-things-work/python_nonblocking.rst`](../../docs/how-things-work/python_nonblocking.rst).
 
-Every other operational client call is still bound **only** in its
-blocking form:
+Every one returns only the integer status of the *request*; the result
+arrives later by executing the caller's callback on the progress thread,
+and the callback runs **if and only if** the method returned
+`PMIX_SUCCESS`. The final `cbdata` argument is optional and is handed
+back to the callback unmodified.
 
-- `PMIx_Fence_nb`
-- `PMIx_Get_nb`
-- `PMIx_Publish_nb`
-- `PMIx_Lookup_nb`
-- `PMIx_Unpublish_nb`
-- `PMIx_Spawn_nb`
-- `PMIx_Connect_nb`
-- `PMIx_Disconnect_nb`
-- `PMIx_Query_info_nb`
-- `PMIx_Log_nb`
-- `PMIx_Allocation_request_nb`
-- `PMIx_Job_control_nb`
-- `PMIx_Process_monitor_nb`
-- `PMIx_Get_credential_nb`
-- `PMIx_Validate_credential_nb`
-- `PMIx_Fabric_register_nb`
-- `PMIx_Fabric_update_nb`
-- `PMIx_Fabric_deregister_nb`
-- `PMIx_Compute_distances_nb`
-- `PMIx_Resource_block_nb`
+| C API | Python method | Callback signature |
+|-------|---------------|--------------------|
+| `PMIx_Fence_nb` | `fence_nb(peers, dicts, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Get_nb` | `get_nb(proc, ky, dicts, cbfunc, cbdata=None)` | `(status, value, cbdata)` |
+| `PMIx_Publish_nb` | `publish_nb(dicts, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Lookup_nb` | `lookup_nb(pykeys, dicts, cbfunc, cbdata=None)` | `(status, pdata, cbdata)` |
+| `PMIx_Unpublish_nb` | `unpublish_nb(pykeys, dicts, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Spawn_nb` | `spawn_nb(jobInfo, pyapps, cbfunc, cbdata=None)` | `(status, nspace, cbdata)` |
+| `PMIx_Connect_nb` | `connect_nb(peers, pyinfo, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Disconnect_nb` | `disconnect_nb(peers, pyinfo, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Query_info_nb` | `query_nb(pyq, cbfunc, cbdata=None)` | `(status, results, cbdata)` |
+| `PMIx_Log_nb` | `log_nb(pydata, pydirs, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Allocation_request_nb` | `allocation_request_nb(directive, pyinfo, cbfunc, cbdata=None)` | `(status, results, cbdata)` |
+| `PMIx_Job_control_nb` | `job_control_nb(pytargets, pydirs, cbfunc, cbdata=None)` | `(status, results, cbdata)` |
+| `PMIx_Process_monitor_nb` | `monitor_nb(pymonitor_info, code, pydirs, cbfunc, cbdata=None)` | `(status, results, cbdata)` |
+| `PMIx_Get_credential_nb` | `get_credential_nb(pyinfo, cbfunc, cbdata=None)` | `(status, credential, results, cbdata)` |
+| `PMIx_Validate_credential_nb` | `validate_credential_nb(pycred, pyinfo, cbfunc, cbdata=None)` | `(status, results, cbdata)` |
+| `PMIx_Fabric_register_nb` | `fabric_register_nb(dicts, cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Fabric_update_nb` | `fabric_update_nb(cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Fabric_deregister_nb` | `fabric_deregister_nb(cbfunc, cbdata=None)` | `(status, cbdata)` |
+| `PMIx_Compute_distances_nb` | `compute_distances_nb(pycpus, dicts, cbfunc, cbdata=None)` | `(status, distances, cbdata)` |
+| `PMIx_Resource_block_nb` | `resource_block_nb(directive, block, pyunits, pyinfo, cbfunc, cbdata=None)` | `(status, cbdata)` |
+
+Four things this pass established that the group operations had not:
+
+- **`lookup_nb` takes a list of key strings**, not the `pmix_pdata_t`
+  dict list its blocking counterpart takes. That is what the C API
+  accepts, and there is nothing for the caller to fill in on input.
+- **Six new callback shapes needed six new trampolines** —
+  `pmix_value_cbfunc_t`, `pmix_lookup_cbfunc_t`, `pmix_spawn_cbfunc_t`,
+  `pmix_credential_cbfunc_t`, `pmix_validation_cbfunc_t` and
+  `pmix_device_dist_cbfunc_t`. Only the last carries a release function;
+  everything the other five hand back is released by the library as soon
+  as the callback returns, so each converts to Python before doing
+  anything else.
+- **The fabric and distance calls hand the library a pointer into the
+  class** (`myfabric`, `topo`), which would dangle if the Python object
+  were collected while the request was in flight. The registry entry now
+  carries an unread reference to the object for exactly that reason.
+- **`fabric_register_nb`/`fabric_deregister_nb` wrap the caller's
+  callback in a closure** so the class's "registered" flag flips when the
+  library reports the outcome, not when the request is accepted.
 
 ### 1.2 Client role (`PMIxClient`) — **CLOSED**
 
@@ -124,10 +148,16 @@ one of those two; an explicit `data_type` outside the pair returns
 
 ### 1.7 Coverage summary
 
-- Operational client/server/tool APIs bound: **~86** (blocking forms, tool
-  IOF, and the five `_nb` group operations).
-- Not bound: **25** `_nb` variants (§1.1), **1** deprecated tool API
-  (§1.4). Every unique blocking API in §§1.2–1.6 is now bound.
+- Operational client/server/tool APIs bound: **~106** — every blocking
+  form, tool IOF, and all 25 non-blocking variants.
+- Not bound: **1** deprecated tool API (§1.4), deliberately.
+
+Part 1 is closed. What remains open is not a *binding* gap:
+`PMIxScheduler.assign_session` is a well-formed stub because the C
+library exposes no entry point for it (§1.5), and `pmix_load_value` has
+no arm for `PMIX_POINTER` — a data type a Python caller cannot
+meaningfully produce, which surfaces as `PMIX_ERR_NOT_SUPPORTED` rather
+than a crash.
 
 ### 1.8 C-side hazards this pass surfaced (now fixed)
 
@@ -151,6 +181,31 @@ All three now return (or no-op) cleanly; the collect-job-info parameter
 checks are covered by `test/unit/collect_job_info.c`, and the pre-init
 behavior of all of them by `TestNewlyBoundAPIs` in
 `test/python/test_bindings.py`.
+
+### 1.9 Conversion-layer defects the `_nb` pass surfaced (now fixed)
+
+Binding twenty more APIs put argument shapes through the conversion
+helpers that no bound call had produced before, and four latent defects
+came out. None were in the new code; all are fixed:
+
+- **`pmix_load_argv` strdup's its entries**, but `query()` and
+  `unpublish()` allocated the array with `PyMem_Malloc` and
+  `pmix_free_queries` released the entries with `PyMem_Free`. Handing a
+  Python-arena block to `free()` aborts the process. All argv arrays now
+  come from the C allocator, released through a new `pmix_free_argv`.
+  `unpublish()` also leaked its key array on the success path.
+- **`pmix_free_apps` released neither the argv/env arrays nor the app
+  array** — an acknowledged in-code TODO.
+- **An empty per-app `info` list produced a non-NULL array with
+  `ninfo == 0`**, which the library reads as "terminated by an end
+  marker" and walks off the allocation looking for one. A `spawn` whose
+  app carried `'info': []` packed garbage and failed — this was found by
+  `spawn_nb` in the connected test, not by inspection.
+- **A partially-loaded array was released in full.** `pmix_load_info`,
+  `pmix_load_apps` and `query()` filled arrays entry by entry and freed
+  the whole thing on failure, destructing uninitialized memory. An
+  attribute carrying an unconvertible value type was enough to crash the
+  caller. Every such array is now zeroed before loading.
 
 ---
 

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -281,6 +281,19 @@ cdef int pmix_load_argv(char **keys, argv:list):
     keys[n] = NULL
     return PMIX_SUCCESS
 
+# Release a NULL-terminated argv array built by pmix_load_argv. Its
+# entries were strdup'd, so both they and the array itself belong to the
+# C allocator - callers must therefore malloc the array, not PyMem_Malloc
+# it
+cdef void pmix_free_argv(char **argv):
+    if NULL == argv:
+        return
+    n = 0
+    while NULL != argv[n]:
+        free(argv[n])
+        n += 1
+    free(argv)
+
 cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
     cdef pmix_info_t *infoptr;
     cdef pmix_value_t *valptr;
@@ -1935,6 +1948,11 @@ cdef void pmix_free_value(self, pmix_value_t *value):
 #            [{key:y, value:val, val_type:ty}, … ]
 #
 cdef int pmix_load_info(pmix_info_t *array, dicts:list):
+    # zero the array first. This function can fail partway through - an
+    # unconvertible value type is enough - and the caller then releases
+    # the whole array, so every entry it never reached has to be safe to
+    # destruct
+    memset(array, 0, len(dicts) * sizeof(pmix_info_t))
     n = 0
     for d in dicts:
         pykey = str(d['key'])
@@ -2189,11 +2207,7 @@ cdef void pmix_free_queries(pmix_query_t *queries, size_t sz):
     n = 0
     while n < sz:
         if queries[n].keys != NULL:
-            j = 0
-            while NULL != queries[n].keys[j]:
-                PyMem_Free(queries[n].keys[j])
-                j += 1
-            PyMem_Free(queries[n].keys)
+            pmix_free_argv(queries[n].keys)
         if queries[n].qualifiers != NULL:
             pmix_free_info(queries[n].qualifiers, queries[n].nqual)
         n += 1
@@ -2246,14 +2260,18 @@ cdef void pmix_unload_bytes(char *data, size_t ndata, blist:list):
         n += 1
 
 cdef void pmix_free_apps(pmix_app_t *array, size_t sz):
+    if NULL == array:
+        return
     n = 0
     while n < sz:
         free(array[n].cmd)
-        # need to free the argv and env arrays
+        pmix_free_argv(array[n].argv)
+        pmix_free_argv(array[n].env)
         free(array[n].cwd)
         if 0 < array[n].ninfo:
             pmix_free_info(array[n].info, array[n].ninfo)
         n += 1
+    PyMem_Free(array)
 
 cdef void pmix_unload_apps(const pmix_app_t *apps, size_t napps, pyapps:list):
     cdef size_t n = 0
@@ -2280,6 +2298,9 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
     cdef size_t m
     cdef size_t n
     cdef char** argv
+    # zero the array first - this function can fail partway through, and
+    # the caller will then hand the whole array to pmix_free_apps
+    memset(apps, 0, len(pyapps) * sizeof(pmix_app_t))
     n = 0
     for p in pyapps:
         pycmd = str(p['cmd']).encode('ascii')
@@ -2333,7 +2354,11 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
         apps[n].info = NULL
         apps[n].ninfo = 0
         try:
-            if p['info'] is not None:
+            # an empty list must leave the array NULL: a non-NULL info
+            # with ninfo == 0 tells the library the array is terminated by
+            # an "end" marker, and it will walk off the allocation looking
+            # for one
+            if p['info'] is not None and 0 < len(p['info']):
                 apps[n].ninfo = len(p['info'])
                 apps[n].info =  <pmix_info_t*> malloc(apps[n].ninfo * sizeof(pmix_info_t))
                 if not apps[n].info:

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -933,20 +933,19 @@ cdef class PMIxClient:
         ninfo    = 0
         nstrings = 0
 
-        # load pykeys into char **keys
+        # load pykeys into char **keys - the entries are strdup'd, so the
+        # array must come from the C allocator as well
         if pykeys is not None:
             nstrings = len(pykeys)
             if 0 < nstrings:
-                keys = <char **> PyMem_Malloc((nstrings + 1) * sizeof(char*))
+                keys = <char **> malloc((nstrings + 1) * sizeof(char*))
                 if not keys:
                     return PMIX_ERR_NOMEM
-            rc = pmix_load_argv(keys, pykeys)
-            if PMIX_SUCCESS != rc:
-                n = 0
-                while keys[n] != NULL:
-                    PyMem_Free(keys[n])
-                    n += 1
-                return rc
+                memset(keys, 0, (nstrings + 1) * sizeof(char*))
+                rc = pmix_load_argv(keys, pykeys)
+                if PMIX_SUCCESS != rc:
+                    pmix_free_argv(keys)
+                    return rc
         else:
             keys = NULL
 
@@ -961,6 +960,8 @@ cdef class PMIxClient:
         rc = PMIx_Unpublish(keys, info, ninfo)
         if 0 < ninfo:
             pmix_free_info(info, ninfo)
+        if NULL != keys:
+            pmix_free_argv(keys)
         return rc
 
     # lookup info published by this or another process
@@ -1220,13 +1221,18 @@ cdef class PMIxClient:
                 queries = <pmix_query_t*> PyMem_Malloc(nqueries * sizeof(pmix_query_t))
                 if not queries:
                     return PMIX_ERR_NOMEM,pyresults
+                # zero it so a failure partway through leaves the untouched
+                # entries safe for pmix_free_queries to walk
+                memset(queries, 0, nqueries * sizeof(pmix_query_t))
                 n = 0
                 for q in pyq:
                     queries[n].keys       = NULL
                     queries[n].qualifiers = NULL
                     nstrings = len(q['keys'])
                     if 0 < nstrings:
-                        queries[n].keys = <char **> PyMem_Malloc((nstrings+1) * sizeof(char*))
+                        # the entries are strdup'd, so the array must come
+                        # from the C allocator as well
+                        queries[n].keys = <char **> malloc((nstrings+1) * sizeof(char*))
                         if not queries[n].keys:
                             pmix_free_queries(queries, nqueries)
                             return PMIX_ERR_NOMEM,pyresults

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -59,10 +59,24 @@ ctypedef mcbd pypmix_modex_cbdata_t
 # See docs/how-things-work/python_nonblocking.rst for the full picture.
 cdef struct nbcbd:
     char *grp             # strdup'd group identifier
+    char *ky              # strdup'd key (get_nb)
+    char *blk             # strdup'd resource block name
+    char **keys           # NULL-terminated argv (lookup_nb, unpublish_nb)
     pmix_proc_t *procs    # PyMem_Malloc'd by pmix_load_procs
     size_t nprocs
     pmix_info_t *info     # malloc'd by pmix_alloc_info
     size_t ninfo
+    pmix_info_t *dirs     # malloc'd by pmix_alloc_info - the second info
+    size_t ndirs          #   array carried by log/job_control/monitor
+    pmix_app_t *apps      # PyMem_Malloc'd, loaded by pmix_load_apps
+    size_t napps
+    pmix_query_t *queries # PyMem_Malloc'd
+    size_t nqueries
+    pmix_resource_unit_t *units  # PyMem_Malloc'd by pmix_alloc_units
+    size_t nunits
+    pmix_byte_object_t *cred     # PyMem_Malloc'd, as is its payload
+    pmix_cpuset_t cpuset  # constructed only when havecpuset is set
+    int havecpuset
     size_t idx            # key into the pynbcbs registry
 ctypedef nbcbd pypmix_nb_cbdata_t
 
@@ -73,13 +87,16 @@ pynbcbs = {}
 pynbidx = 0
 pynblock = threading.Lock()
 
-def pypmix_nb_register(cbfunc, cbdata):
-    # Record a Python callback pair and return its registry key
+def pypmix_nb_register(cbfunc, cbdata, obj=None):
+    # Record a Python callback pair and return its registry key. 'obj' is
+    # never read - it is held solely to keep an object alive for the
+    # duration of the operation, which the calls that hand the library a
+    # pointer into the class (the fabric object, the topology) rely on
     global pynbidx
     with pynblock:
         pynbidx += 1
         idx = pynbidx
-        pynbcbs[idx] = {'cbfunc': cbfunc, 'cbdata': cbdata}
+        pynbcbs[idx] = {'cbfunc': cbfunc, 'cbdata': cbdata, 'obj': obj}
     return idx
 
 def pypmix_nb_take(idx):
@@ -93,27 +110,42 @@ cdef pypmix_nb_cbdata_t* pypmix_nb_cbdata_new():
     cd = <pypmix_nb_cbdata_t *> malloc(sizeof(pypmix_nb_cbdata_t))
     if NULL == cd:
         return NULL
-    cd.grp    = NULL
-    cd.procs  = NULL
-    cd.nprocs = 0
-    cd.info   = NULL
-    cd.ninfo  = 0
-    cd.idx    = 0
+    memset(cd, 0, sizeof(pypmix_nb_cbdata_t))
     return cd
 
-# Release a caddy and everything it owns. Note that the group name, the
-# procs array and the info array each came from a different allocator -
-# strdup, PyMem_Malloc and malloc respectively - so each must go back to
-# its own
+# Release a caddy and everything it owns. The buffers it carries come
+# from several different allocators - strdup/malloc for the strings and
+# the info arrays, PyMem_Malloc for the arrays the bindings both build
+# and release - so each must go back to its own
 cdef void pypmix_nb_cbdata_free(pypmix_nb_cbdata_t *cd):
     if NULL == cd:
         return
     if NULL != cd.grp:
         free(cd.grp)
+    if NULL != cd.ky:
+        free(cd.ky)
+    if NULL != cd.blk:
+        free(cd.blk)
+    if NULL != cd.keys:
+        pmix_free_argv(cd.keys)
     if NULL != cd.procs:
         pmix_free_procs(cd.procs, cd.nprocs)
     if NULL != cd.info and 0 < cd.ninfo:
         pmix_free_info(cd.info, cd.ninfo)
+    if NULL != cd.dirs and 0 < cd.ndirs:
+        pmix_free_info(cd.dirs, cd.ndirs)
+    if NULL != cd.apps:
+        pmix_free_apps(cd.apps, cd.napps)
+    if NULL != cd.queries:
+        pmix_free_queries(cd.queries, cd.nqueries)
+    if NULL != cd.units:
+        pmix_free_units(cd.units, cd.nunits)
+    if NULL != cd.cred:
+        if NULL != cd.cred.bytes:
+            PyMem_Free(cd.cred.bytes)
+        PyMem_Free(cd.cred)
+    if 0 != cd.havecpuset:
+        pmix_destruct_cpuset(&cd.cpuset)
     free(cd)
 
 # The registry entry doubles as the ownership token for the caddy:
@@ -170,20 +202,186 @@ cdef void pypmix_client_info_cbfunc(pmix_status_t status,
     except:
         traceback.print_exc()
 
-# Build the caddy for a non-blocking group operation, taking ownership of
-# the group identifier and the info array. Returns NULL on failure, with
-# the reason stored in rcptr
-cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo, int *rcptr):
+# Trampoline for non-blocking APIs that take a pmix_value_cbfunc_t. The
+# value belongs to the library and is released as soon as we return, so
+# convert it here rather than handing the pointer onward
+cdef void pypmix_client_value_cbfunc(pmix_status_t status,
+                                     pmix_value_t *kv,
+                                     void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    pyval = None
+    if NULL != kv:
+        pyval = pmix_unload_value(kv)
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyval, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_lookup_cbfunc_t. As
+# above, the returned pdata array is the library's
+cdef void pypmix_client_lookup_cbfunc(pmix_status_t status,
+                                      pmix_pdata_t data[], size_t ndata,
+                                      void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    pyresults = []
+    prc = PMIX_SUCCESS
+    if NULL != data and 0 < ndata:
+        prc = pmix_unload_pdata(data, ndata, pyresults)
+    if PMIX_SUCCESS != prc and PMIX_SUCCESS == status:
+        status = prc
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyresults, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_spawn_cbfunc_t
+cdef void pypmix_client_spawn_cbfunc(pmix_status_t status,
+                                     pmix_nspace_t nspace,
+                                     void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    # the nspace is released by the library upon our return, so decode it
+    # into a Python string now. A failed spawn has no namespace to report,
+    # and the parameter is a bare array pointer that may be NULL
+    pyns = None
+    if PMIX_SUCCESS == status and NULL != nspace:
+        pyns = nspace.decode('ascii')
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyns, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_credential_cbfunc_t
+cdef void pypmix_client_credential_cbfunc(pmix_status_t status,
+                                          pmix_byte_object_t *credential,
+                                          pmix_info_t info[], size_t ninfo,
+                                          void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    # both the credential and the info array belong to the library
+    cred = {}
+    if NULL != credential and NULL != credential.bytes and 0 < credential.size:
+        blist = []
+        pmix_unload_bytes(credential.bytes, credential.size, blist)
+        cred['bytes'] = bytearray(blist)
+        cred['size'] = credential.size
+    pyresults = []
+    prc = PMIX_SUCCESS
+    if NULL != info and 0 < ninfo:
+        prc = pmix_unload_info(info, ninfo, pyresults)
+    if PMIX_SUCCESS != prc and PMIX_SUCCESS == status:
+        status = prc
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, cred, pyresults, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_validation_cbfunc_t.
+# Same shape as the info trampoline, but without a release function -
+# the library reclaims the array itself
+cdef void pypmix_client_validation_cbfunc(pmix_status_t status,
+                                          pmix_info_t info[], size_t ninfo,
+                                          void *cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    pyresults = []
+    prc = PMIX_SUCCESS
+    if NULL != info and 0 < ninfo:
+        prc = pmix_unload_info(info, ninfo, pyresults)
+    if PMIX_SUCCESS != prc and PMIX_SUCCESS == status:
+        status = prc
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyresults, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Trampoline for non-blocking APIs that take a pmix_device_dist_cbfunc_t
+cdef void pypmix_client_devdist_cbfunc(pmix_status_t status,
+                                       pmix_device_distance_t *dist,
+                                       size_t ndist,
+                                       void *cbdata,
+                                       pmix_release_cbfunc_t release_fn,
+                                       void *release_cbdata) noexcept with gil:
+    cdef pypmix_nb_cbdata_t *cd
+    cdef size_t n
+    # convert the distances before telling the library we are done with them
+    pyresults = []
+    n = 0
+    while n < ndist:
+        pydist = {}
+        if NULL == dist[n].uuid:
+            pydist['uuid'] = None
+        else:
+            pydist['uuid'] = dist[n].uuid.decode('ascii')
+        if NULL == dist[n].osname:
+            pydist['osname'] = None
+        else:
+            pydist['osname'] = dist[n].osname.decode('ascii')
+        pydist['type'] = dist[n].type
+        pydist['mindist'] = dist[n].mindist
+        pydist['maxdist'] = dist[n].maxdist
+        pyresults.append(pydist)
+        n += 1
+    if NULL != release_fn:
+        release_fn(release_cbdata)
+    if NULL == cbdata:
+        return
+    cd = <pypmix_nb_cbdata_t *> cbdata
+    entry = pypmix_nb_take(cd.idx)
+    if entry is None:
+        return
+    pypmix_nb_cbdata_free(cd)
+    # a callback that raises must not unwind into the library
+    try:
+        entry['cbfunc'](status, pyresults, entry['cbdata'])
+    except:
+        traceback.print_exc()
+
+# Build the caddy for a non-blocking operation, taking ownership of the
+# info array. Returns NULL on failure, with the reason stored in rcptr
+cdef pypmix_nb_cbdata_t* pypmix_nb_setup(pyinfo, int *rcptr):
     cdef pypmix_nb_cbdata_t *cd
     cdef pmix_info_t **info_ptr
 
     cd = pypmix_nb_cbdata_new()
     if NULL == cd:
-        rcptr[0] = PMIX_ERR_NOMEM
-        return NULL
-    cd.grp = strdup(pygrp)
-    if NULL == cd.grp:
-        pypmix_nb_cbdata_free(cd)
         rcptr[0] = PMIX_ERR_NOMEM
         return NULL
     info_ptr = &cd.info
@@ -193,6 +391,62 @@ cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo, int *rcptr):
         rcptr[0] = rc
         return NULL
     rcptr[0] = PMIX_SUCCESS
+    return cd
+
+# Add the second info array carried by the operations that take one -
+# the directives that accompany the data being logged, the targets being
+# controlled, or the monitor being requested
+cdef int pypmix_nb_add_dirs(pypmix_nb_cbdata_t *cd, pydirs):
+    cdef pmix_info_t **dirs_ptr
+    dirs_ptr = &cd.dirs
+    return pmix_alloc_info(dirs_ptr, &cd.ndirs, pydirs)
+
+# Park the operation's target procs in the caddy. As in the blocking
+# forms, an absent or empty list means "this proc's entire job"
+cdef int pypmix_nb_add_procs(pypmix_nb_cbdata_t *cd, peers, nspace):
+    if peers is not None and 0 < len(peers):
+        cd.nprocs = len(peers)
+        cd.procs = <pmix_proc_t*> PyMem_Malloc(cd.nprocs * sizeof(pmix_proc_t))
+        if not cd.procs:
+            cd.nprocs = 0
+            return PMIX_ERR_NOMEM
+        return pmix_load_procs(cd.procs, peers)
+    cd.nprocs = 1
+    cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+    if not cd.procs:
+        cd.nprocs = 0
+        return PMIX_ERR_NOMEM
+    pmix_copy_nspace(cd.procs[0].nspace, nspace)
+    cd.procs[0].rank = PMIX_RANK_WILDCARD
+    return PMIX_SUCCESS
+
+# Park a NULL-terminated key array in the caddy. A None/empty list is
+# left as NULL, which the APIs that take one read as "all keys"
+cdef int pypmix_nb_add_keys(pypmix_nb_cbdata_t *cd, pykeys):
+    cdef size_t nstrings
+    if pykeys is None or 0 == len(pykeys):
+        return PMIX_SUCCESS
+    nstrings = len(pykeys)
+    cd.keys = <char **> malloc((nstrings + 1) * sizeof(char*))
+    if NULL == cd.keys:
+        return PMIX_ERR_NOMEM
+    memset(cd.keys, 0, (nstrings + 1) * sizeof(char*))
+    return pmix_load_argv(cd.keys, pykeys)
+
+# Build the caddy for a non-blocking group operation, taking ownership of
+# the group identifier and the info array. Returns NULL on failure, with
+# the reason stored in rcptr
+cdef pypmix_nb_cbdata_t* pypmix_nb_group_setup(pygrp, pyinfo, int *rcptr):
+    cdef pypmix_nb_cbdata_t *cd
+
+    cd = pypmix_nb_setup(pyinfo, rcptr)
+    if NULL == cd:
+        return NULL
+    cd.grp = strdup(pygrp)
+    if NULL == cd.grp:
+        pypmix_nb_cbdata_free(cd)
+        rcptr[0] = PMIX_ERR_NOMEM
+        return NULL
     return cd
 
 # Function to release pypmix_info_cbdata_t structure
@@ -1759,26 +2013,10 @@ cdef class PMIxClient:
             return prc
 
         # convert list of procs to array of pmix_proc_t's
-        if peers is not None and 0 < len(peers):
-            cd.nprocs = len(peers)
-            cd.procs = <pmix_proc_t*> PyMem_Malloc(cd.nprocs * sizeof(pmix_proc_t))
-            if not cd.procs:
-                cd.nprocs = 0
-                pypmix_nb_cbdata_free(cd)
-                return PMIX_ERR_NOMEM
-            prc = pmix_load_procs(cd.procs, peers)
-            if PMIX_SUCCESS != prc:
-                pypmix_nb_cbdata_free(cd)
-                return prc
-        else:
-            cd.nprocs = 1
-            cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
-            if not cd.procs:
-                cd.nprocs = 0
-                pypmix_nb_cbdata_free(cd)
-                return PMIX_ERR_NOMEM
-            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
-            cd.procs[0].rank = PMIX_RANK_WILDCARD
+        prc = pypmix_nb_add_procs(cd, peers, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
 
         # record the callback so it stays alive, then call the library
         cd.idx = pypmix_nb_register(cbfunc, cbdata)
@@ -1809,26 +2047,10 @@ cdef class PMIxClient:
             return prc
 
         # convert list of procs to array of pmix_proc_t's
-        if peers is not None and 0 < len(peers):
-            cd.nprocs = len(peers)
-            cd.procs = <pmix_proc_t*> PyMem_Malloc(cd.nprocs * sizeof(pmix_proc_t))
-            if not cd.procs:
-                cd.nprocs = 0
-                pypmix_nb_cbdata_free(cd)
-                return PMIX_ERR_NOMEM
-            prc = pmix_load_procs(cd.procs, peers)
-            if PMIX_SUCCESS != prc:
-                pypmix_nb_cbdata_free(cd)
-                return prc
-        else:
-            cd.nprocs = 1
-            cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
-            if not cd.procs:
-                cd.nprocs = 0
-                pypmix_nb_cbdata_free(cd)
-                return PMIX_ERR_NOMEM
-            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
-            cd.procs[0].rank = PMIX_RANK_WILDCARD
+        prc = pypmix_nb_add_procs(cd, peers, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
 
         # record the callback so it stays alive, then call the library
         cd.idx = pypmix_nb_register(cbfunc, cbdata)
@@ -1935,6 +2157,680 @@ cdef class PMIxClient:
                                         pypmix_client_op_cbfunc, <void *> cd)
         if PMIX_SUCCESS != rc:
             # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # Non-blocking forms of the remaining client operations. They follow
+    # the same contract as the group operations above: the method returns
+    # only the status of the request itself, the result is delivered later
+    # by executing 'cbfunc' on the library's progress thread, and a
+    # callback is executed if and only if the method returned
+    # PMIX_SUCCESS. The 'cbdata' object is handed back to the callback
+    # unmodified. Each callback signature is given with its method; all of
+    # them run on the progress thread, so none may call a blocking PMIx
+    # operation - record the result and wake another thread instead.
+
+    # cbfunc(status:int, cbdata)
+    def fence_nb(self, peers, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # the library does not copy its input, so everything it will hold
+        # goes into a caddy that outlives this call
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_procs(cd, peers, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        # record the callback so it stays alive, then call the library
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Fence_nb(cd.procs, cd.nprocs, cd.info, cd.ninfo,
+                               pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            # no callback will be executed, so reclaim the operation here
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, value:dict, cbdata) - 'value' is None if the key
+    # was not found. A None key requests all data for the given proc
+    def get_nb(self, proc, ky, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+
+        # the proc and the key must outlive this call as well - a
+        # single-element proc array covers the former
+        cd.nprocs = 1
+        cd.procs = <pmix_proc_t*> PyMem_Malloc(sizeof(pmix_proc_t))
+        if not cd.procs:
+            cd.nprocs = 0
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_NOMEM
+        if proc is None:
+            pmix_copy_nspace(cd.procs[0].nspace, self.myproc.nspace)
+            cd.procs[0].rank = self.myproc.rank
+        else:
+            pmix_copy_nspace(cd.procs[0].nspace, proc['nspace'])
+            cd.procs[0].rank = proc['rank']
+        if ky is not None:
+            if isinstance(ky, str):
+                pyky = ky.encode('ascii')
+            else:
+                pyky = ky
+            cd.ky = strdup(pyky)
+            if NULL == cd.ky:
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Get_nb(&cd.procs[0], cd.ky, cd.info, cd.ninfo,
+                             pypmix_client_value_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata)
+    def publish_nb(self, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Publish_nb(cd.info, cd.ninfo,
+                                 pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, pdata:list, cbdata) - each entry of 'pdata' is a
+    # dict of proc/key/value/val_type. Note that the non-blocking form
+    # takes a list of key strings, not the pdata list its blocking
+    # counterpart takes, as that is what the C API accepts
+    def lookup_nb(self, pykeys, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_keys(cd, pykeys)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Lookup_nb(cd.keys, cd.info, cd.ninfo,
+                                pypmix_client_lookup_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata) - a None/empty key list asks the server
+    # to remove everything this process published
+    def unpublish_nb(self, pykeys, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_keys(cd, pykeys)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Unpublish_nb(cd.keys, cd.info, cd.ninfo,
+                                   pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, nspace:str, cbdata) - 'nspace' is the namespace
+    # assigned to the new job, or None if the spawn failed
+    def spawn_nb(self, jobInfo, pyapps, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        # protect against bad input
+        if pyapps is None or 0 == len(pyapps):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(jobInfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # convert the list of apps to an array of pmix_app_t
+        cd.napps = len(pyapps)
+        cd.apps = <pmix_app_t*> PyMem_Malloc(cd.napps * sizeof(pmix_app_t))
+        if not cd.apps:
+            cd.napps = 0
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_NOMEM
+        prc = pmix_load_apps(cd.apps, pyapps)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Spawn_nb(cd.info, cd.ninfo, cd.apps, cd.napps,
+                               pypmix_client_spawn_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata)
+    def connect_nb(self, peers, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_procs(cd, peers, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Connect_nb(cd.procs, cd.nprocs, cd.info, cd.ninfo,
+                                 pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata)
+    def disconnect_nb(self, peers, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_procs(cd, peers, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Disconnect_nb(cd.procs, cd.nprocs, cd.info, cd.ninfo,
+                                    pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, results:list, cbdata) - 'results' is a list of
+    # info dicts. 'pyq' has the same shape as for query()
+    def query_nb(self, pyq, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef size_t nstrings
+        cdef size_t n
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # this operation carries no info array of its own - the
+        # qualifiers ride along inside each query
+        cd = pypmix_nb_setup(None, &prc)
+        if NULL == cd:
+            return prc
+
+        if pyq is not None and 0 < len(pyq):
+            cd.nqueries = len(pyq)
+            cd.queries = <pmix_query_t*> PyMem_Malloc(cd.nqueries * sizeof(pmix_query_t))
+            if not cd.queries:
+                cd.nqueries = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            # zero it so a failure partway through leaves the untouched
+            # entries safe to release
+            memset(cd.queries, 0, cd.nqueries * sizeof(pmix_query_t))
+            n = 0
+            for q in pyq:
+                qkeys = q.get('keys')
+                if qkeys is not None and 0 < len(qkeys):
+                    nstrings = len(qkeys)
+                    cd.queries[n].keys = <char **> malloc((nstrings+1) * sizeof(char*))
+                    if not cd.queries[n].keys:
+                        pypmix_nb_cbdata_free(cd)
+                        return PMIX_ERR_NOMEM
+                    memset(cd.queries[n].keys, 0, (nstrings+1) * sizeof(char*))
+                    prc = pmix_load_argv(cd.queries[n].keys, qkeys)
+                    if PMIX_SUCCESS != prc:
+                        pypmix_nb_cbdata_free(cd)
+                        return prc
+                prc = pmix_alloc_info(&(cd.queries[n].qualifiers),
+                                      &(cd.queries[n].nqual),
+                                      q.get('qualifiers'))
+                if PMIX_SUCCESS != prc:
+                    pypmix_nb_cbdata_free(cd)
+                    return prc
+                n += 1
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Query_info_nb(cd.queries, cd.nqueries,
+                                    pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata)
+    def log_nb(self, pydata, pydirs, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(pydata, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_dirs(cd, pydirs)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Log_nb(cd.info, cd.ninfo, cd.dirs, cd.ndirs,
+                             pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, results:list, cbdata)
+    def allocation_request_nb(self, directive, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_alloc_directive_t drctv
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        drctv = directive
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Allocation_request_nb(drctv, cd.info, cd.ninfo,
+                                            pypmix_client_info_cbfunc,
+                                            <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, results:list, cbdata)
+    def job_control_nb(self, pytargets, pydirs, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # the directives are this operation's info array
+        cd = pypmix_nb_setup(pydirs, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_procs(cd, pytargets, self.myproc.nspace)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Job_control_nb(cd.procs, cd.nprocs, cd.info, cd.ninfo,
+                                     pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, results:list, cbdata). As in the blocking form,
+    # the monitor request is given as a list whose first element is the
+    # monitoring attribute the C API takes
+    def monitor_nb(self, pymonitor_info, code:int, pydirs, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef pmix_status_t ccode
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        ccode = code
+
+        cd = pypmix_nb_setup(pymonitor_info, &prc)
+        if NULL == cd:
+            return prc
+        prc = pypmix_nb_add_dirs(cd, pydirs)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Process_monitor_nb(cd.info, ccode, cd.dirs, cd.ndirs,
+                                         pypmix_client_info_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, credential:dict, results:list, cbdata) - the
+    # credential is the usual byte-object dict of 'bytes' and 'size'
+    def get_credential_nb(self, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Get_credential_nb(cd.info, cd.ninfo,
+                                        pypmix_client_credential_cbfunc,
+                                        <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, results:list, cbdata) - a PMIX_SUCCESS status
+    # means the credential was accepted
+    def validate_credential_nb(self, pycred, pyinfo, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef const char *credptr
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        if pycred is None:
+            return PMIX_ERR_BAD_PARAM
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # the credential must outlive this call, so copy it into the caddy
+        cd.cred = <pmix_byte_object_t*> PyMem_Malloc(sizeof(pmix_byte_object_t))
+        if not cd.cred:
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_NOMEM
+        cd.cred.bytes = NULL
+        cd.cred.size = 0
+        pybytes = pycred.get('bytes')
+        if pybytes is None:
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_BAD_PARAM
+        if isinstance(pybytes, str):
+            pybytes = pybytes.encode('ascii')
+        else:
+            pybytes = bytes(pybytes)
+        if 0 < len(pybytes):
+            cd.cred.size = len(pybytes)
+            cd.cred.bytes = <char*> PyMem_Malloc(cd.cred.size)
+            if not cd.cred.bytes:
+                cd.cred.size = 0
+                pypmix_nb_cbdata_free(cd)
+                return PMIX_ERR_NOMEM
+            credptr = <const char*>pybytes
+            memcpy(cd.cred.bytes, credptr, cd.cred.size)
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Validate_credential_nb(cd.cred, cd.info, cd.ninfo,
+                                             pypmix_client_validation_cbfunc,
+                                             <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata). The fabric object lives in this class,
+    # so the registry holds a reference to us until the callback fires,
+    # and the "registered" flag is only set once the library says so
+    def fabric_register_nb(self, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_fabric_t *fab
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        if 1 == self.fabric_set:
+            return PMIX_ERR_RESOURCE_BUSY
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+
+        def regdone(status, ud):
+            if PMIX_SUCCESS == status:
+                self.fabric_set = 1
+            cbfunc(status, ud)
+
+        fab = &self.myfabric
+        cd.idx = pypmix_nb_register(regdone, cbdata, self)
+        with nogil:
+            rc = PMIx_Fabric_register_nb(fab, cd.info, cd.ninfo,
+                                         pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata) - the updated fabric information is read
+    # back through fabric_update()'s companion accessors once the
+    # callback reports success
+    def fabric_update_nb(self, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_fabric_t *fab
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        if 0 == self.fabric_set:
+            return PMIX_ERR_INIT
+
+        cd = pypmix_nb_setup(None, &prc)
+        if NULL == cd:
+            return prc
+
+        fab = &self.myfabric
+        cd.idx = pypmix_nb_register(cbfunc, cbdata, self)
+        with nogil:
+            rc = PMIx_Fabric_update_nb(fab, pypmix_client_op_cbfunc,
+                                       <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata)
+    def fabric_deregister_nb(self, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_fabric_t *fab
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        if 0 == self.fabric_set:
+            return PMIX_ERR_INIT
+
+        cd = pypmix_nb_setup(None, &prc)
+        if NULL == cd:
+            return prc
+
+        def deregdone(status, ud):
+            if PMIX_SUCCESS == status:
+                self.fabric_set = 0
+            cbfunc(status, ud)
+
+        fab = &self.myfabric
+        cd.idx = pypmix_nb_register(deregdone, cbdata, self)
+        with nogil:
+            rc = PMIx_Fabric_deregister_nb(fab, pypmix_client_op_cbfunc,
+                                           <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, distances:list, cbdata) - each entry is a dict of
+    # uuid/osname/type/mindist/maxdist, as compute_distances() returns
+    def compute_distances_nb(self, pycpus, dicts, cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_topology_t *topo
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+
+        # check that we loaded our topology
+        if NULL == self.topo.topology:
+            prc = self.load_topology()
+            if PMIX_SUCCESS != prc:
+                return prc
+
+        cd = pypmix_nb_setup(dicts, &prc)
+        if NULL == cd:
+            return prc
+
+        # the cpuset must outlive this call. Its loader constructs before
+        # it parses, so mark it for destruction regardless of the outcome
+        prc = pmix_load_cpuset(&cd.cpuset, pycpus)
+        cd.havecpuset = 1
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        topo = &self.topo
+        cd.idx = pypmix_nb_register(cbfunc, cbdata, self)
+        with nogil:
+            rc = PMIx_Compute_distances_nb(topo, &cd.cpuset,
+                                           cd.info, cd.ninfo,
+                                           pypmix_client_devdist_cbfunc,
+                                           <void *> cd)
+        if PMIX_SUCCESS != rc:
+            if pypmix_nb_take(cd.idx) is not None:
+                pypmix_nb_cbdata_free(cd)
+        return rc
+
+    # cbfunc(status:int, cbdata). See resource_block() for the meaning of
+    # the directive, block name and resource unit list
+    def resource_block_nb(self, directive:int, block, pyunits, pyinfo,
+                          cbfunc, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t rc
+        cdef int prc
+        cdef pmix_resource_block_directive_t drctv
+
+        if not callable(cbfunc):
+            return PMIX_ERR_BAD_PARAM
+        if block is None:
+            return PMIX_ERR_BAD_PARAM
+        drctv = directive
+
+        cd = pypmix_nb_setup(pyinfo, &prc)
+        if NULL == cd:
+            return prc
+
+        # the block name and the units must outlive this call
+        if isinstance(block, str):
+            pyblock = block.encode('ascii')
+        else:
+            pyblock = block
+        cd.blk = strdup(pyblock)
+        if NULL == cd.blk:
+            pypmix_nb_cbdata_free(cd)
+            return PMIX_ERR_NOMEM
+        prc = pmix_alloc_units(&cd.units, &cd.nunits, pyunits)
+        if PMIX_SUCCESS != prc:
+            pypmix_nb_cbdata_free(cd)
+            return prc
+
+        cd.idx = pypmix_nb_register(cbfunc, cbdata)
+        with nogil:
+            rc = PMIx_Resource_block_nb(drctv, cd.blk, cd.units, cd.nunits,
+                                        cd.info, cd.ninfo,
+                                        pypmix_client_op_cbfunc, <void *> cd)
+        if PMIX_SUCCESS != rc:
             if pypmix_nb_take(cd.idx) is not None:
                 pypmix_nb_cbdata_free(cd)
         return rc

--- a/docs/how-things-work/python_nonblocking.rst
+++ b/docs/how-things-work/python_nonblocking.rst
@@ -11,10 +11,10 @@ to follow. The machinery lives in
 
 The non-blocking group operations - ``group_construct_nb``,
 ``group_invite_nb``, ``group_join_nb``, ``group_leave_nb`` and
-``group_destruct_nb`` - are the first bindings built on it, and are used
-as the worked example throughout. The remaining ``_nb`` entry points
-listed in ``bindings/python/MISSING_BINDINGS.md`` can be added by
-following the same pattern.
+``group_destruct_nb`` - were the first bindings built on it, and are
+used as the worked example throughout. Every other ``_nb`` entry point
+is now bound on the same machinery; ``bindings/python/MISSING_BINDINGS.md``
+§1.1 lists them with their callback signatures.
 
 
 The problem
@@ -67,27 +67,64 @@ method::
 
     cdef struct nbcbd:
         char *grp             # strdup'd group identifier
+        char *ky              # strdup'd key (get_nb)
+        char *blk             # strdup'd resource block name
+        char **keys           # NULL-terminated argv (lookup_nb, unpublish_nb)
         pmix_proc_t *procs    # PyMem_Malloc'd by pmix_load_procs
         size_t nprocs
         pmix_info_t *info     # malloc'd by pmix_alloc_info
         size_t ninfo
+        pmix_info_t *dirs     # the second info array, where an operation
+        size_t ndirs          #   carries one (log, job control, monitor)
+        pmix_app_t *apps      # PyMem_Malloc'd, loaded by pmix_load_apps
+        size_t napps
+        pmix_query_t *queries # PyMem_Malloc'd
+        size_t nqueries
+        pmix_resource_unit_t *units  # PyMem_Malloc'd by pmix_alloc_units
+        size_t nunits
+        pmix_byte_object_t *cred     # PyMem_Malloc'd, as is its payload
+        pmix_cpuset_t cpuset  # constructed only when havecpuset is set
+        int havecpuset
         size_t idx            # key into the pynbcbs registry
+
+One struct covers every operation rather than one per API, because the
+trampolines reach the registry through ``cd.idx`` and must be able to
+cast any caddy to the same type. ``pypmix_nb_cbdata_new`` zeroes it, so
+an operation simply leaves unused fields alone and
+``pypmix_nb_cbdata_free`` skips them.
 
 The caddy is passed to the library as the operation's ``cbdata``, so it
 comes back to the trampoline unchanged and can be released there.
 
-Note the comments on the allocators. The three buffers come from three
+Note the comments on the allocators. The buffers come from several
 different places and each must be returned to its own:
-``pypmix_nb_cbdata_free`` calls ``free`` on the identifier,
-``pmix_free_procs`` (which is ``PyMem_Free``) on the proc array, and
-``pmix_free_info`` on the info array. Crossing them is not a stylistic
-matter - Python's allocator serves small blocks from its own arenas, and
-handing one of those to ``free()`` aborts the process.
+``pypmix_nb_cbdata_free`` calls ``free`` on the strings and the info
+arrays, ``pmix_free_argv`` on the key arrays (whose entries are
+``strdup``'d), and ``pmix_free_procs`` / ``pmix_free_units`` (which are
+``PyMem_Free``) on the arrays the bindings both build and release.
+Crossing them is not a stylistic matter - Python's allocator serves small
+blocks from its own arenas, and handing one of those to ``free()`` aborts
+the process.
 
 ``group_join_nb`` takes a single ``const pmix_proc_t *leader`` rather
-than an array. It stores the leader as a one-element ``procs`` array and
-passes ``&cd.procs[0]``, so one set of fields covers all five
-operations.
+than an array, and ``get_nb`` a single ``const pmix_proc_t *proc``. Both
+store it as a one-element ``procs`` array and pass ``&cd.procs[0]``, so
+one set of fields covers every operation.
+
+Three helpers fill the caddy for the shapes that recur:
+``pypmix_nb_setup`` builds it and takes ownership of the primary info
+array, ``pypmix_nb_add_procs`` parks the target procs (defaulting, as the
+blocking forms do, to the caller's entire job), and
+``pypmix_nb_add_keys`` parks a key array. Anything more specific -
+apps, queries, a credential, a cpuset - is built by the method itself.
+
+Two operations hand the library a pointer *into the Python object*:
+``fabric_register_nb`` and friends pass ``&self.myfabric``, and
+``compute_distances_nb`` passes ``&self.topo``. Those would dangle if the
+interpreter collected the object while the request was in flight, so
+those methods pass ``self`` to ``pypmix_nb_register`` as a third
+argument. Nothing ever reads it; holding the reference is the whole
+point.
 
 
 The registry
@@ -119,8 +156,8 @@ same caddy.
 The trampolines
 ---------------
 
-Two C functions bridge back into Python, one per callback signature that
-the group APIs use::
+There is one C function per callback signature the bound APIs use. Two
+of them cover the group operations::
 
     cdef void pypmix_client_op_cbfunc(pmix_status_t status,
                                       void *cbdata) noexcept with gil
@@ -151,6 +188,44 @@ The Python-facing signatures are::
 
 where ``results`` is a list of info dictionaries and ``cbdata`` is
 whatever object the caller passed in, returned untouched.
+
+The other bound operations need six more, one per remaining C callback
+type:
+
+.. list-table::
+   :header-rows: 1
+
+   * - C callback type
+     - Trampoline
+     - Python signature
+   * - ``pmix_value_cbfunc_t``
+     - ``pypmix_client_value_cbfunc``
+     - ``cbfunc(status, value, cbdata)``
+   * - ``pmix_lookup_cbfunc_t``
+     - ``pypmix_client_lookup_cbfunc``
+     - ``cbfunc(status, pdata, cbdata)``
+   * - ``pmix_spawn_cbfunc_t``
+     - ``pypmix_client_spawn_cbfunc``
+     - ``cbfunc(status, nspace, cbdata)``
+   * - ``pmix_credential_cbfunc_t``
+     - ``pypmix_client_credential_cbfunc``
+     - ``cbfunc(status, credential, results, cbdata)``
+   * - ``pmix_validation_cbfunc_t``
+     - ``pypmix_client_validation_cbfunc``
+     - ``cbfunc(status, results, cbdata)``
+   * - ``pmix_device_dist_cbfunc_t``
+     - ``pypmix_client_devdist_cbfunc``
+     - ``cbfunc(status, distances, cbdata)``
+
+All six follow the same shape, and all six share one rule that is easy
+to get wrong: **everything the library hands a callback belongs to the
+library**. Only ``pmix_info_cbfunc_t`` and ``pmix_device_dist_cbfunc_t``
+carry an explicit ``release_fn``; for the rest the library reclaims the
+data the moment the callback returns. So each trampoline converts to
+Python *first* - a ``pmix_value_t`` through ``pmix_unload_value``, a
+``pmix_nspace_t`` through ``decode``, a credential through
+``pmix_unload_bytes`` - and never stores or frees the C pointer it was
+given.
 
 
 Putting it together
@@ -211,6 +286,28 @@ A callback is executed if and only if the method returned
 ``PMIX_SUCCESS``.
 
 
+State that lives in the class
+-----------------------------
+
+``fabric_register_nb`` and ``fabric_deregister_nb`` have a wrinkle the
+others do not: the class tracks whether a fabric is currently
+registered, and that flag must flip when the *library* says the
+operation finished - not when the request was accepted. The trampoline
+knows nothing about the class, so these methods register a small closure
+in place of the caller's callback::
+
+    def regdone(status, ud):
+        if PMIX_SUCCESS == status:
+            self.fabric_set = 1
+        cbfunc(status, ud)
+
+The closure captures ``self`` and the caller's callback, runs on the
+progress thread like any other, and invokes the caller's function
+unchanged. Anything else that has to update class state from a
+completion should do the same rather than teach the trampolines about
+it.
+
+
 Adding another non-blocking binding
 -----------------------------------
 
@@ -224,13 +321,11 @@ The machinery is not specific to groups. To bind another ``_nb`` API:
    Python object, which dies with the method - in a caddy. Add fields to
    ``nbcbd`` if the operation carries arguments the group operations do
    not, and extend ``pypmix_nb_cbdata_free`` to match.
-#. Reuse ``pypmix_client_op_cbfunc`` or ``pypmix_client_info_cbfunc`` if
-   the API takes ``pmix_op_cbfunc_t`` or ``pmix_info_cbfunc_t``. Other
-   callback types - ``pmix_lookup_cbfunc_t``, ``pmix_spawn_cbfunc_t``,
-   ``pmix_value_cbfunc_t`` - need a trampoline of their own, written to
-   the same shape: take the registry entry, convert, release what the
-   library owns, free the caddy, then call into Python inside a
-   ``try``/``except``.
+#. Reuse one of the eight existing trampolines. Between them they cover
+   every callback type the public APIs use, so a new binding should not
+   need a new one; if it does, write it to the same shape - convert what
+   the library owns *first*, take the registry entry, free the caddy,
+   then call into Python inside a ``try``/``except``.
 #. Follow the error-path rule exactly. It is the easiest part to get
    wrong and the hardest to notice, because the leak only shows up when
    the library refuses a request.

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -39,6 +39,16 @@ Python Syntax
              'value': 4, 'val_type': PMIX_UINT64}]
   rc, results = foo.allocation_request(PMIX_ALLOC_EXTEND, pyinfo)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def resultcb(status, results, cbdata):
+      # results is a list of Python ``pmix_info_t`` dictionaries
+      print("allocation completed:", foo.error_string(status), results)
+  rc = foo.allocation_request_nb(PMIX_ALLOC_EXTEND, pyinfo,
+                                 resultcb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -36,7 +36,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pyinfo = [{'key': PMIX_ALLOC_NUM_NODES,
-             'value': {'value': 4, 'val_type': PMIX_UINT64}}]
+             'value': 4, 'val_type': PMIX_UINT64}]
   rc, results = foo.allocation_request(PMIX_ALLOC_EXTEND, pyinfo)
 
 

--- a/docs/man/man3/PMIx_Compute_distances.3.rst
+++ b/docs/man/man3/PMIx_Compute_distances.3.rst
@@ -44,7 +44,7 @@ Python Syntax
   pycpus = {'source': "hwloc", 'cpus': ["0", "1"]}
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_DEVICE_TYPE,
-             'value': {'value': PMIX_DEVTYPE_NETWORK, 'val_type': PMIX_UINT64}}]
+             'value': PMIX_DEVTYPE_NETWORK, 'val_type': PMIX_UINT64}]
   rc, distances = foo.compute_distances(pycpus, pydirs)
 
 

--- a/docs/man/man3/PMIx_Compute_distances.3.rst
+++ b/docs/man/man3/PMIx_Compute_distances.3.rst
@@ -41,11 +41,21 @@ Python Syntax
   # load the local topology first
   rc = foo.load_topology()
   # the cpuset is a Python dictionary describing the process location
-  pycpus = {'source': "hwloc", 'cpus': ["0", "1"]}
+  pycpus = {'source': "hwloc", 'cpus': [0, 1]}
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_DEVICE_TYPE,
              'value': PMIX_DEVTYPE_NETWORK, 'val_type': PMIX_UINT64}]
   rc, distances = foo.compute_distances(pycpus, pydirs)
+
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def distcb(status, distances, cbdata):
+      # distances is a list of dictionaries, each carrying uuid, osname,
+      # type, mindist and maxdist
+      print("distances:", foo.error_string(status), distances)
+  rc = foo.compute_distances_nb(pycpus, pydirs, distcb, "mycbdata")
 
 
 INPUT PARAMETERS

--- a/docs/man/man3/PMIx_Connect.3.rst
+++ b/docs/man/man3/PMIx_Connect.3.rst
@@ -40,7 +40,7 @@ Python Syntax
            {'nspace': "othernspace", 'rank': PMIX_RANK_WILDCARD}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TIMEOUT,
-             'value': {'value': 10, 'val_type': PMIX_INT}}]
+             'value': 10, 'val_type': PMIX_INT}]
   rc = foo.connect(peers, pydirs)
 
 

--- a/docs/man/man3/PMIx_Connect.3.rst
+++ b/docs/man/man3/PMIx_Connect.3.rst
@@ -43,6 +43,14 @@ Python Syntax
              'value': 10, 'val_type': PMIX_INT}]
   rc = foo.connect(peers, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("connect completed:", foo.error_string(status))
+  rc = foo.connect_nb(peers, pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Disconnect.3.rst
+++ b/docs/man/man3/PMIx_Disconnect.3.rst
@@ -39,7 +39,7 @@ Python Syntax
            {'nspace': "othernspace", 'rank': PMIX_RANK_WILDCARD}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TIMEOUT,
-             'value': {'value': 10, 'val_type': PMIX_INT}}]
+             'value': 10, 'val_type': PMIX_INT}]
   rc = foo.disconnect(peers, pydirs)
 
 

--- a/docs/man/man3/PMIx_Disconnect.3.rst
+++ b/docs/man/man3/PMIx_Disconnect.3.rst
@@ -42,6 +42,14 @@ Python Syntax
              'value': 10, 'val_type': PMIX_INT}]
   rc = foo.disconnect(peers, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("disconnect completed:", foo.error_string(status))
+  rc = foo.disconnect_nb(peers, pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Fabric_deregister.3.rst
+++ b/docs/man/man3/PMIx_Fabric_deregister.3.rst
@@ -33,6 +33,14 @@ Python Syntax
   # ... after a successful foo.init() and foo.fabric_register() ...
   rc = foo.fabric_deregister()
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("fabric deregistered:", foo.error_string(status))
+  rc = foo.fabric_deregister_nb(donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Fabric_register.3.rst
+++ b/docs/man/man3/PMIx_Fabric_register.3.rst
@@ -40,6 +40,16 @@ Python Syntax
              'value': "ACME", 'val_type': PMIX_STRING}]
   rc, fabricinfo = foo.fabric_register(pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      # the fabric information is read back through the class once this
+      # reports success
+      print("fabric registered:", foo.error_string(status))
+  rc = foo.fabric_register_nb(pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Fabric_register.3.rst
+++ b/docs/man/man3/PMIx_Fabric_register.3.rst
@@ -37,7 +37,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_FABRIC_VENDOR,
-             'value': {'value': "ACME", 'val_type': PMIX_STRING}}]
+             'value': "ACME", 'val_type': PMIX_STRING}]
   rc, fabricinfo = foo.fabric_register(pydirs)
 
 

--- a/docs/man/man3/PMIx_Fabric_update.3.rst
+++ b/docs/man/man3/PMIx_Fabric_update.3.rst
@@ -33,6 +33,14 @@ Python Syntax
   # ... after a successful foo.init() and foo.fabric_register() ...
   rc, fabricinfo = foo.fabric_update()
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("fabric updated:", foo.error_string(status))
+  rc = foo.fabric_update_nb(donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -37,7 +37,7 @@ Python Syntax
   peers = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_COLLECT_DATA,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc = foo.fence(peers, pydirs)
 
 

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -40,6 +40,14 @@ Python Syntax
              'value': True, 'val_type': PMIX_BOOL}]
   rc = foo.fence(peers, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("fence completed:", foo.error_string(status))
+  rc = foo.fence_nb(peers, pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Finalize.3.rst
+++ b/docs/man/man3/PMIx_Finalize.3.rst
@@ -29,7 +29,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_EMBED_BARRIER,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc = foo.finalize(pydirs)
 
 

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -38,7 +38,7 @@ Python Syntax
   proc = {'nspace': "testnspace", 'rank': 0}
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TIMEOUT,
-             'value': {'value': 10, 'val_type': PMIX_INT}}]
+             'value': 10, 'val_type': PMIX_INT}]
   rc, value = foo.get(proc, "mykey", pydirs)
 
 

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -41,6 +41,16 @@ Python Syntax
              'value': 10, 'val_type': PMIX_INT}]
   rc, value = foo.get(proc, "mykey", pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def valuecb(status, value, cbdata):
+      # value is a Python ``pmix_value_t`` dictionary, or None if the key
+      # was not found
+      print("get completed:", foo.error_string(status), value)
+  rc = foo.get_nb(proc, "mykey", pydirs, valuecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Get_credential.3.rst
+++ b/docs/man/man3/PMIx_Get_credential.3.rst
@@ -37,6 +37,16 @@ Python Syntax
   pydirs = [{'key': PMIX_TIMEOUT,
              'value': 10, 'val_type': PMIX_INT}]
   rc, cred = foo.get_credential(pydirs)
+
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def credcb(status, credential, results, cbdata):
+      # credential is the same dictionary the blocking form returns, and
+      # results is a list of Python ``pmix_info_t`` dictionaries
+      print("credential:", foo.error_string(status), credential)
+  rc = foo.get_credential_nb(pydirs, credcb, "mycbdata")
   # on success, cred is a dictionary with 'bytes' and 'size' members
 
 

--- a/docs/man/man3/PMIx_Get_credential.3.rst
+++ b/docs/man/man3/PMIx_Get_credential.3.rst
@@ -35,7 +35,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TIMEOUT,
-             'value': {'value': 10, 'val_type': PMIX_INT}}]
+             'value': 10, 'val_type': PMIX_INT}]
   rc, cred = foo.get_credential(pydirs)
   # on success, cred is a dictionary with 'bytes' and 'size' members
 

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -40,7 +40,7 @@ Python Syntax
            {'nspace': "testnspace", 'rank': 1}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_GROUP_ASSIGN_CONTEXT_ID,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc, results = foo.group_construct("mygroup", peers, pydirs)
 
 The non-blocking form takes a Python callback in place of the returned

--- a/docs/man/man3/PMIx_IOF_pull.3.rst
+++ b/docs/man/man3/PMIx_IOF_pull.3.rst
@@ -36,7 +36,7 @@ Python Syntax
   # the procs is a list of Python ``pmix_proc_t`` dictionaries
   pyprocs = [{'nspace': "target-nspace", 'rank': PMIX_RANK_WILDCARD}]
   pydirs = [{'key': PMIX_IOF_TAG_OUTPUT,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   channel = PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL
   # myhdlr is a Python IOF delivery function
   rc, refid = foo.iof_pull(pyprocs, channel, pydirs, myhdlr)

--- a/docs/man/man3/PMIx_Init.3.rst
+++ b/docs/man/man3/PMIx_Init.3.rst
@@ -29,7 +29,7 @@ Python Syntax
   foo = PMIxClient()
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_PROGRAMMING_MODEL,
-             'value': {'value': "MPI", 'val_type': PMIX_STRING}}]
+             'value': "MPI", 'val_type': PMIX_STRING}]
   rc, myname = foo.init(pydirs)
 
 

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -41,6 +41,15 @@ Python Syntax
              'value': True, 'val_type': PMIX_BOOL}]
   rc, results = foo.job_control(targets, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def resultcb(status, results, cbdata):
+      # results is a list of Python ``pmix_info_t`` dictionaries
+      print("job control completed:", foo.error_string(status), results)
+  rc = foo.job_control_nb(targets, pydirs, resultcb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -38,7 +38,7 @@ Python Syntax
   targets = [{'nspace': "testnspace", 'rank': PMIX_RANK_WILDCARD}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_JOB_CTRL_KILL,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc, results = foo.job_control(targets, pydirs)
 
 

--- a/docs/man/man3/PMIx_Log.3.rst
+++ b/docs/man/man3/PMIx_Log.3.rst
@@ -33,7 +33,7 @@ Python Syntax
   foo = PMIxClient()
   # the data is a list of Python ``pmix_info_t`` dictionaries
   pydata = [{'key': PMIX_LOG_STDERR,
-             'value': {'value': "log this string", 'val_type': PMIX_STRING}}]
+             'value': "log this string", 'val_type': PMIX_STRING}]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = []
   rc = foo.log(pydata, pydirs)

--- a/docs/man/man3/PMIx_Log.3.rst
+++ b/docs/man/man3/PMIx_Log.3.rst
@@ -38,6 +38,14 @@ Python Syntax
   pydirs = []
   rc = foo.log(pydata, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("log completed:", foo.error_string(status))
+  rc = foo.log_nb(pydata, pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Lookup.3.rst
+++ b/docs/man/man3/PMIx_Lookup.3.rst
@@ -41,6 +41,17 @@ Python Syntax
              'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc, data = foo.lookup(data, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  # unlike the blocking method, the non-blocking one takes the keys
+  # directly - as the C API does - and delivers the ``pmix_pdata_t``
+  # dictionaries to the callback
+  def lookupcb(status, pdata, cbdata):
+      print("lookup completed:", foo.error_string(status), pdata)
+  rc = foo.lookup_nb(["mykey"], pydirs, lookupcb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Lookup.3.rst
+++ b/docs/man/man3/PMIx_Lookup.3.rst
@@ -34,11 +34,11 @@ Python Syntax
   # ... after a successful foo.init() ...
   # data is a list of Python ``pmix_pdata_t`` dictionaries; only the
   # ``key`` field is used on input to name the values to retrieve
-  data = [{'key': "mykey", 'value': {'value': None, 'val_type': PMIX_UNDEF},
+  data = [{'key': "mykey", 'value': None, 'val_type': PMIX_UNDEF,
            'proc': {'nspace': "", 'rank': 0}}]
   # directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_RANGE,
-             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+             'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc, data = foo.lookup(data, pydirs)
 
 

--- a/docs/man/man3/PMIx_Notify_event.3.rst
+++ b/docs/man/man3/PMIx_Notify_event.3.rst
@@ -36,7 +36,7 @@ Python Syntax
   src = {'nspace': "testnspace", 'rank': 0}
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pyinfo = [{'key': PMIX_EVENT_NON_DEFAULT,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc = foo.notify_event(PMIX_ERR_PROC_ABORTED, src, PMIX_RANGE_NAMESPACE, pyinfo)
 
 

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -36,12 +36,13 @@ Python Syntax
 
   foo = PMIxClient()
   # ... after a successful foo.init() ...
-  # the monitor action is a single Python ``pmix_info_t`` dictionary
-  monitor = {'key': PMIX_MONITOR_HEARTBEAT,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}
+  # the monitor action is given as a list whose first element is the
+  # Python ``pmix_info_t`` dictionary naming the monitor
+  monitor = [{'key': PMIX_MONITOR_HEARTBEAT,
+              'value': True, 'val_type': PMIX_BOOL}]
   # the directives are a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_MONITOR_HEARTBEAT_TIME,
-             'value': {'value': 5, 'val_type': PMIX_UINT32}}]
+             'value': 5, 'val_type': PMIX_UINT32}]
   rc, results = foo.monitor(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, pydirs)
 
 

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -45,6 +45,16 @@ Python Syntax
              'value': 5, 'val_type': PMIX_UINT32}]
   rc, results = foo.monitor(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def resultcb(status, results, cbdata):
+      # results is a list of Python ``pmix_info_t`` dictionaries
+      print("monitor completed:", foo.error_string(status), results)
+  rc = foo.monitor_nb(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, pydirs,
+                      resultcb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Publish.3.rst
+++ b/docs/man/man3/PMIx_Publish.3.rst
@@ -34,9 +34,9 @@ Python Syntax
   # the data to publish is a list of Python ``pmix_info_t`` dictionaries;
   # each entry carries the key/value to publish, plus any directives
   pydata = [{'key': "mykey",
-             'value': {'value': "myvalue", 'val_type': PMIX_STRING}},
+             'value': "myvalue", 'val_type': PMIX_STRING},
             {'key': PMIX_RANGE,
-             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+             'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc = foo.publish(pydata)
 
 

--- a/docs/man/man3/PMIx_Publish.3.rst
+++ b/docs/man/man3/PMIx_Publish.3.rst
@@ -39,6 +39,14 @@ Python Syntax
              'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc = foo.publish(pydata)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("publish completed:", foo.error_string(status))
+  rc = foo.publish_nb(pydata, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -37,6 +37,15 @@ Python Syntax
   pyq = [{'keys': [PMIX_QUERY_NAMESPACES],
           'qualifiers': []}]
   rc, results = foo.query(pyq)
+
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def querycb(status, results, cbdata):
+      # results is a list of Python ``pmix_info_t`` dictionaries
+      print("query completed:", foo.error_string(status), results)
+  rc = foo.query_nb(pyq, querycb, "mycbdata")
   # results is a list of Python ``pmix_info_t`` dictionaries
 
 

--- a/docs/man/man3/PMIx_Register_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Register_event_handler.3.rst
@@ -36,7 +36,7 @@ Python Syntax
   codes = [PMIX_ERR_PROC_ABORTED]
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_EVENT_HDLR_NAME,
-             'value': {'value': "MY-HANDLER", 'val_type': PMIX_STRING}}]
+             'value': "MY-HANDLER", 'val_type': PMIX_STRING}]
   # myhdlr is a Python event-handler function
   rc, refid = foo.register_event_handler(codes, pydirs, myhdlr)
 

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -43,6 +43,15 @@ Python Syntax
   units = [{'type': PMIX_DEVTYPE_GPU, 'count': 4}]
   rc = foo.resource_block(PMIX_RESOURCE_BLOCK_DEFINE, "myblock", units, [])
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("resource block completed:", foo.error_string(status))
+  rc = foo.resource_block_nb(PMIX_RESOURCE_BLOCK_DEFINE, "myblock",
+                             units, [], donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -28,11 +28,13 @@ Python Syntax
 
   from pmix import *
 
-  foo = PMIxClient()
+  # session control is bound on PMIxServer and inherited by PMIxTool and
+  # PMIxScheduler
+  foo = PMIxServer()
   # ... after a successful foo.init() ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_SESSION_APP,
-             'value': {'value': "myapp", 'val_type': PMIX_STRING}}]
+             'value': "myapp", 'val_type': PMIX_STRING}]
   rc = foo.session_control(1, pydirs)
 
 

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -43,6 +43,15 @@ Python Syntax
              'maxprocs': 4, 'info': []}]
   rc, nspace = foo.spawn(jobInfo, pyapps)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def spawncb(status, nspace, cbdata):
+      # nspace names the new job, and is None if the spawn failed
+      print("spawn completed:", foo.error_string(status), nspace)
+  rc = foo.spawn_nb(jobInfo, pyapps, spawncb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -36,7 +36,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # jobInfo is a list of Python ``pmix_info_t`` dictionaries
   jobInfo = [{'key': PMIX_NOTIFY_COMPLETION,
-              'value': {'value': True, 'val_type': PMIX_BOOL}}]
+              'value': True, 'val_type': PMIX_BOOL}]
   # pyapps is a list of Python ``pmix_app_t`` dictionaries; each app
   # provides at least a command and its argv, plus optional per-app info
   pyapps = [{'cmd': "hello", 'argv': ["hello", "world"],

--- a/docs/man/man3/PMIx_Unpublish.3.rst
+++ b/docs/man/man3/PMIx_Unpublish.3.rst
@@ -40,6 +40,14 @@ Python Syntax
              'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc = foo.unpublish(pykeys, pydirs)
 
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def donecb(status, cbdata):
+      print("unpublish completed:", foo.error_string(status))
+  rc = foo.unpublish_nb(pykeys, pydirs, donecb, "mycbdata")
+
 
 INPUT PARAMETERS
 ----------------

--- a/docs/man/man3/PMIx_Unpublish.3.rst
+++ b/docs/man/man3/PMIx_Unpublish.3.rst
@@ -37,7 +37,7 @@ Python Syntax
   pykeys = ["mykey"]
   # directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_RANGE,
-             'value': {'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}}]
+             'value': PMIX_RANGE_SESSION, 'val_type': PMIX_UINT8}]
   rc = foo.unpublish(pykeys, pydirs)
 
 

--- a/docs/man/man3/PMIx_Validate_credential.3.rst
+++ b/docs/man/man3/PMIx_Validate_credential.3.rst
@@ -40,7 +40,7 @@ Python Syntax
   pycred = {'bytes': "mycredential", 'size': 12}
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TIMEOUT,
-             'value': {'value': 10, 'val_type': PMIX_INT}}]
+             'value': 10, 'val_type': PMIX_INT}]
   rc, results = foo.validate_credential(pycred, pydirs)
   # on success, results is a list of Python ``pmix_info_t`` dictionaries
 

--- a/docs/man/man3/PMIx_Validate_credential.3.rst
+++ b/docs/man/man3/PMIx_Validate_credential.3.rst
@@ -42,6 +42,15 @@ Python Syntax
   pydirs = [{'key': PMIX_TIMEOUT,
              'value': 10, 'val_type': PMIX_INT}]
   rc, results = foo.validate_credential(pycred, pydirs)
+
+  # the non-blocking form returns as soon as the request has been accepted
+  # and reports the result by executing a callback on the PMIx progress
+  # thread. The callback is run if and only if the call returned
+  # PMIX_SUCCESS, and must not itself make a blocking PMIx call.
+  def resultcb(status, results, cbdata):
+      # a PMIX_SUCCESS status means the credential was accepted
+      print("validation completed:", foo.error_string(status), results)
+  rc = foo.validate_credential_nb(pycred, pydirs, resultcb, "mycbdata")
   # on success, results is a list of Python ``pmix_info_t`` dictionaries
 
 

--- a/docs/man/man3/PMIx_server_deliver_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_deliver_inventory.3.rst
@@ -32,7 +32,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # info carries the inventory to store; directives scope the request
   pyinfo = [{'key': PMIX_HOSTNAME,
-             'value': {'value': "node01", 'val_type': PMIX_STRING}}]
+             'value': "node01", 'val_type': PMIX_STRING}]
   pydirs = []
   rc = foo.deliver_inventory(pyinfo, pydirs)
 

--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -32,7 +32,7 @@ Python Syntax
   # ... after a successful foo.init() ...
   # only the keys of the directives are significant here
   directives = [{'key': PMIX_CLUSTER_ID,
-                 'value': {'value': "cluster-a", 'val_type': PMIX_STRING}}]
+                 'value': "cluster-a", 'val_type': PMIX_STRING}]
   rc = foo.deregister_resources(directives)
 
 

--- a/docs/man/man3/PMIx_server_init.3.rst
+++ b/docs/man/man3/PMIx_server_init.3.rst
@@ -29,7 +29,7 @@ Python Syntax
   foo = PMIxServer()
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_SERVER_NSPACE,
-             'value': {'value': "SERVER", 'val_type': PMIX_STRING}}]
+             'value': "SERVER", 'val_type': PMIX_STRING}]
   # map is a dictionary of server-module-function keys to Python
   # callback implementations (e.g. {'clientconnected': myconnfn, ...})
   rc = foo.init(pydirs, map)

--- a/docs/man/man3/PMIx_server_register_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_register_nspace.3.rst
@@ -32,9 +32,9 @@ Python Syntax
   # ... after a successful foo.init(pydirs, map) ...
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_UNIV_SIZE,
-             'value': {'value': 4, 'val_type': PMIX_UINT32}},
+             'value': 4, 'val_type': PMIX_UINT32},
             {'key': PMIX_JOB_SIZE,
-             'value': {'value': 4, 'val_type': PMIX_UINT32}}]
+             'value': 4, 'val_type': PMIX_UINT32}]
   rc = foo.register_nspace("myjob", 4, pydirs)
 
 

--- a/docs/man/man3/PMIx_server_register_resources.3.rst
+++ b/docs/man/man3/PMIx_server_register_resources.3.rst
@@ -33,7 +33,7 @@ Python Syntax
   # directives is a list of pmix_info_t dictionaries describing the
   # resources to register (this binding is blocking)
   directives = [{'key': PMIX_CLUSTER_ID,
-                 'value': {'value': "cluster-a", 'val_type': PMIX_STRING}}]
+                 'value': "cluster-a", 'val_type': PMIX_STRING}]
   rc = foo.register_resources(directives)
 
 

--- a/docs/man/man3/PMIx_server_setup_application.3.rst
+++ b/docs/man/man3/PMIx_server_setup_application.3.rst
@@ -35,7 +35,7 @@ Python Syntax
   # dicts is a list of pmix_info_t dictionaries describing the job
   # (must include the process and node maps)
   dicts = [{'key': PMIX_SETUP_APP_ALL,
-            'value': {'value': True, 'val_type': PMIX_BOOL}}]
+            'value': True, 'val_type': PMIX_BOOL}]
   rc, dataout = foo.setup_application("myapp", dicts)
   # dataout is a list of pmix_info_t dictionaries to be distributed
   # with the application

--- a/docs/man/man3/PMIx_tool_attach_to_server.3.rst
+++ b/docs/man/man3/PMIx_tool_attach_to_server.3.rst
@@ -32,7 +32,7 @@ Python Syntax
   rc, myname = foo.init(None)
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_CONNECT_TO_SYSTEM,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc, myname, mysrvr = foo.attach_to_server(pydirs)
 
 

--- a/docs/man/man3/PMIx_tool_init.3.rst
+++ b/docs/man/man3/PMIx_tool_init.3.rst
@@ -29,9 +29,9 @@ Python Syntax
   foo = PMIxTool()
   # the directives is a list of Python ``pmix_info_t`` dictionaries
   pydirs = [{'key': PMIX_TOOL_NSPACE,
-             'value': {'value': "mytool", 'val_type': PMIX_STRING}},
+             'value': "mytool", 'val_type': PMIX_STRING},
             {'key': PMIX_TOOL_RANK,
-             'value': {'value': 0, 'val_type': PMIX_PROC_RANK}}]
+             'value': 0, 'val_type': PMIX_PROC_RANK}]
   rc, myname = foo.init(pydirs)
 
 

--- a/docs/man/man3/PMIx_tool_set_server.3.rst
+++ b/docs/man/man3/PMIx_tool_set_server.3.rst
@@ -31,7 +31,7 @@ Python Syntax
   # ... after a successful foo.init() and attachment to one or more servers ...
   server = {'nspace': "server-nspace", 'rank': 0}
   pydirs = [{'key': PMIX_WAIT_FOR_CONNECTION,
-             'value': {'value': True, 'val_type': PMIX_BOOL}}]
+             'value': True, 'val_type': PMIX_BOOL}]
   rc = foo.set_server(server, pydirs)
 
 

--- a/docs/man/man5/pmix_info_t.5.rst
+++ b/docs/man/man5/pmix_info_t.5.rst
@@ -35,9 +35,9 @@ Python Syntax
 
    from pmix import *
 
-   foo = {'key': "string name", 'flags': u32, 'value': {'value': val, 'val_type': type}}
+   foo = {'key': "string name", 'flags': u32, 'value': val, 'val_type': type}
 
-where ``key`` is a string key (e.g., ``PMIX_TIMEOUT``), ``flags`` is a `uint32_t` value from the :ref:`pmix_info_directives_t <man5-pmix_info_directives_t>` table, and ``value`` is a Python version of a :ref:`pmix_value_t <man5-pmix_value_t>`.
+where ``key`` is a string key (e.g., ``PMIX_TIMEOUT``), ``flags`` is a `uint32_t` value from the :ref:`pmix_info_directives_t <man5-pmix_info_directives_t>` table, and the ``value``/``val_type`` pair is the Python version of a :ref:`pmix_value_t <man5-pmix_value_t>` |mdash| the two fields are carried directly in the info dictionary rather than in a nested one.
 
 
 DESCRIPTION

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,33 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Completed the Python bindings for the non-blocking APIs. The twenty
+   remaining _nb entry points - fence_nb, get_nb, publish_nb, lookup_nb,
+   unpublish_nb, spawn_nb, connect_nb, disconnect_nb, query_nb, log_nb,
+   allocation_request_nb, job_control_nb, monitor_nb,
+   get_credential_nb, validate_credential_nb, fabric_register_nb,
+   fabric_update_nb, fabric_deregister_nb, compute_distances_nb and
+   resource_block_nb - join the group operations bound earlier. Each
+   returns only the status of the request and delivers its result to a
+   Python callback executed on the progress thread, which runs if and
+   only if the call returned PMIX_SUCCESS. Every operational PMIx API is
+   now reachable from Python in both forms
+ - Fixed four latent defects in the Python conversion layer, found by
+   putting new argument shapes through it. Key arrays built by
+   pmix_load_argv were allocated with Python's allocator but released
+   with free() (and vice versa), which aborts the process;
+   pmix_free_apps released neither the argv/env arrays nor the app
+   array; an application carrying an empty info list produced a
+   zero-length but non-NULL array, which the library reads as
+   "terminated by an end marker" and walks past the allocation looking
+   for one, so such a spawn packed garbage; and an attribute list
+   containing an unconvertible value type crashed the caller, because
+   the partially-filled array was released in full and the entries never
+   written were destructed as if they held real values
+ - Corrected every Python example in the man pages. All of them wrote an
+   attribute with its value nested in a second dictionary, a shape the
+   bindings do not accept - the examples raised KeyError rather than
+   running
  - Added Python bindings for the remaining unique blocking APIs. The
    client gains heartbeat, progress_thread_stop and resource_block; the
    server gains generate_regex2 and parse_regex2 - the current regex

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -15,6 +15,46 @@ def default_evhandler(evhdlr:int, status:int,
     print("DEFAULT HANDLER")
     return PMIX_EVENT_ACTION_COMPLETE,None
 
+# Generic callbacks for the non-blocking client operations. Like the group
+# callbacks below they run on the PMIx progress thread, so they only record
+# what came back and release the waiter.
+class nbwaiter:
+    """Collects the result of one non-blocking operation."""
+
+    def __init__(self, label):
+        self.label = label
+        self.event = threading.Event()
+        self.status = PMIX_ERR_NOT_SUPPORTED
+        self.results = None
+
+    def op_cb(self, status:int, cbdata):
+        print(self.label, "CALLBACK", status)
+        self.status = status
+        self.event.set()
+
+    def data_cb(self, status:int, results, cbdata):
+        print(self.label, "CALLBACK", status, results)
+        self.status = status
+        self.results = results
+        self.event.set()
+
+    def cred_cb(self, status:int, credential:dict, results:list, cbdata):
+        print(self.label, "CALLBACK", status, credential)
+        self.status = status
+        self.results = credential
+        self.event.set()
+
+    def wait(self, client, rc):
+        # a callback fires if and only if the request was accepted
+        if PMIX_SUCCESS != rc:
+            print(self.label, "not accepted:", client.error_string(rc))
+            return False
+        if not self.event.wait(timeout=30):
+            print(self.label, "TIMED OUT")
+            return False
+        print(self.label, "completed:", client.error_string(self.status))
+        return PMIX_SUCCESS == self.status
+
 # Callbacks for the non-blocking group operations. These are executed on
 # the PMIx progress thread, so they do nothing but record the result and
 # release the waiter - a blocking PMIx call from here would deadlock.
@@ -94,6 +134,115 @@ def main():
     info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.fence(procs, info)
     print("Fence should be not supported:", foo.error_string(rc))
+
+    # now exercise the non-blocking forms of the operations we just ran
+    # blocking. Each of these hands its converted arguments to the library
+    # and gets the result back on the progress thread.
+    print("FENCE NB")
+    w = nbwaiter("FENCE NB")
+    rc = foo.fence_nb(None, [], w.op_cb, "fence")
+    w.wait(foo, rc)
+
+    print("GET NB")
+    w = nbwaiter("GET NB")
+    rc = foo.get_nb({'nspace':"testnspace", 'rank': 0}, "mykey", [],
+                    w.data_cb, "get")
+    if w.wait(foo, rc):
+        print("Get_nb value returned: ", w.results)
+
+    print("PUBLISH NB")
+    w = nbwaiter("PUBLISH NB")
+    pdata = [{'key':'pykey', 'value':'pyvalue', 'val_type':PMIX_STRING}]
+    rc = foo.publish_nb(pdata, w.op_cb, "publish")
+    if w.wait(foo, rc):
+        print("LOOKUP NB")
+        w = nbwaiter("LOOKUP NB")
+        rc = foo.lookup_nb(['pykey'], [], w.data_cb, "lookup")
+        if w.wait(foo, rc):
+            print("Lookup_nb returned: ", w.results)
+        print("UNPUBLISH NB")
+        w = nbwaiter("UNPUBLISH NB")
+        rc = foo.unpublish_nb(['pykey'], [], w.op_cb, "unpublish")
+        w.wait(foo, rc)
+
+    print("QUERY NB")
+    w = nbwaiter("QUERY NB")
+    rc = foo.query_nb([{'keys':[PMIX_QUERY_NAMESPACES], 'qualifiers':None}],
+                      w.data_cb, "query")
+    w.wait(foo, rc)
+
+    print("LOG NB")
+    w = nbwaiter("LOG NB")
+    logdata = [{'key':PMIX_LOG_STDERR, 'value':'python log test\n',
+                'val_type':PMIX_STRING}]
+    rc = foo.log_nb(logdata, [], w.op_cb, "log")
+    w.wait(foo, rc)
+
+    # the remaining operations are ones our simple test server may well
+    # decline. What is under test is that the arguments convert, the
+    # request is accepted or refused cleanly, and the callback fires
+    # exactly when the library said it would.
+    print("JOB CONTROL NB")
+    w = nbwaiter("JOB CONTROL NB")
+    jdirs = [{'key':PMIX_JOB_CTRL_ID, 'value':'pyjob', 'val_type':PMIX_STRING}]
+    rc = foo.job_control_nb(None, jdirs, w.data_cb, "jobctrl")
+    w.wait(foo, rc)
+
+    print("GET CREDENTIAL NB")
+    w = nbwaiter("GET CREDENTIAL NB")
+    rc = foo.get_credential_nb([], w.cred_cb, "getcred")
+    if w.wait(foo, rc) and w.results is not None and 0 < len(w.results):
+        print("VALIDATE CREDENTIAL NB")
+        cred = w.results
+        w = nbwaiter("VALIDATE CREDENTIAL NB")
+        rc = foo.validate_credential_nb(cred, [], w.data_cb, "validate")
+        w.wait(foo, rc)
+
+    print("ALLOCATION REQUEST NB")
+    w = nbwaiter("ALLOCATION REQUEST NB")
+    rc = foo.allocation_request_nb(PMIX_ALLOC_NEW, [], w.data_cb, "alloc")
+    w.wait(foo, rc)
+
+    print("RESOURCE BLOCK NB")
+    w = nbwaiter("RESOURCE BLOCK NB")
+    units = [{'type': PMIX_DEVTYPE_GPU, 'count': 2}]
+    rc = foo.resource_block_nb(PMIX_RESOURCE_BLOCK_DEFINE, "myblock",
+                               units, [], w.op_cb, "resblock")
+    w.wait(foo, rc)
+
+    print("SPAWN NB")
+    w = nbwaiter("SPAWN NB")
+    apps = [{'cmd': '/bin/true', 'argv': ['true'], 'maxprocs': 1,
+             'env': ['PYTEST=1'], 'info': []}]
+    rc = foo.spawn_nb([], apps, w.data_cb, "spawn")
+    w.wait(foo, rc)
+
+    print("CONNECT NB")
+    w = nbwaiter("CONNECT NB")
+    rc = foo.connect_nb(None, [], w.op_cb, "connect")
+    if w.wait(foo, rc):
+        print("DISCONNECT NB")
+        w = nbwaiter("DISCONNECT NB")
+        rc = foo.disconnect_nb(None, [], w.op_cb, "disconnect")
+        w.wait(foo, rc)
+
+    print("MONITOR NB")
+    w = nbwaiter("MONITOR NB")
+    # ask the server to watch us for heartbeats - the request itself is
+    # the (valueless) monitor attribute, the timing rides in the directives
+    monitor = [{'key': PMIX_MONITOR_HEARTBEAT, 'value': True,
+                'val_type': PMIX_BOOL}]
+    mdirs = [{'key': PMIX_MONITOR_ID, 'value': 'MONITOR1',
+              'val_type': PMIX_STRING},
+             {'key': PMIX_MONITOR_HEARTBEAT_TIME, 'value': 5,
+              'val_type': PMIX_UINT32},
+             {'key': PMIX_MONITOR_HEARTBEAT_DROPS, 'value': 2,
+              'val_type': PMIX_UINT32}]
+    rc = foo.monitor_nb(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, mdirs,
+                        w.data_cb, "monitor")
+    if w.wait(foo, rc):
+        # feed the monitor we just established
+        print("Heartbeat result ", foo.error_string(foo.heartbeat()))
     # construct a group asynchronously. Passing None for the peers means
     # "everyone in my job"
     print("GROUP CONSTRUCT NB")

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -33,6 +33,51 @@ def clientfinalized(proc, cbfunc, cbdata):
     cbfunc(PMIX_SUCCESS, cbdata)
     return PMIX_SUCCESS
 
+# A trivially small published-data store so the client can exercise the
+# publish/lookup/unpublish path. Keyed by the published key, holding the
+# publishing proc alongside the value.
+published = {}
+
+def normalize_key(ky):
+    # keys reach a handler as bytes, but the client hands us str
+    if isinstance(ky, bytes):
+        return ky.decode('ascii')
+    return ky
+
+def clientpublish(args, cbfunc, cbdata):
+    print("PUBLISH", args['proc'], args['directives'])
+    for d in args['directives']:
+        if 'pmix' in d['key']:
+            # a directive qualifying the request, not data to publish
+            continue
+        published[normalize_key(d['key'])] = {'proc': args['proc'],
+                                              'value': d['value'],
+                                              'val_type': d['val_type']}
+    cbfunc(PMIX_SUCCESS, cbdata)
+    return PMIX_SUCCESS
+
+def clientlookup(args, cbfunc, cbdata):
+    print("LOOKUP", args['proc'], args['keys'])
+    pdata = []
+    for ky in args['keys']:
+        ky = normalize_key(ky)
+        if ky in published:
+            d = published[ky]
+            pdata.append({'proc': d['proc'], 'key': ky,
+                          'value': d['value'], 'val_type': d['val_type']})
+    if 0 == len(pdata):
+        cbfunc(PMIX_ERR_NOT_FOUND, None, cbdata)
+    else:
+        cbfunc(PMIX_SUCCESS, pdata, cbdata)
+    return PMIX_SUCCESS
+
+def clientunpublish(args, cbfunc, cbdata):
+    print("UNPUBLISH", args['proc'], args['keys'])
+    for ky in args['keys']:
+        published.pop(normalize_key(ky), None)
+    cbfunc(PMIX_SUCCESS, cbdata)
+    return PMIX_SUCCESS
+
 def clientfence(args, cbfunc, cbdata):
     # check directives
     try:
@@ -100,6 +145,9 @@ def main():
     map = {'clientconnected': clientconnected,
            'clientfinalized': clientfinalized,
            'fencenb': clientfence,
+           'publish': clientpublish,
+           'lookup': clientlookup,
+           'unpublish': clientunpublish,
            'group': clientgroup}
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -655,5 +655,139 @@ class TestGroupNonBlocking(unittest.TestCase):
                          "refused operations left entries in the registry")
 
 
+class TestClientNonBlocking(unittest.TestCase):
+    """The remaining non-blocking client bindings.
+
+    Same reasoning as TestGroupNonBlocking above: without a server none of
+    these can complete, but each one converts a full set of arguments into a
+    keepalive caddy before handing the request to the library, and the
+    library's pre-init refusal is precisely the path that has to unwind that
+    caddy by hand.  Running every case therefore covers the argument
+    marshaling and the error-path cleanup for all of them.
+    """
+
+    PEERS = ({'nspace': "testnspace", 'rank': 0},
+             {'nspace': "testnspace", 'rank': 1})
+    INFO = ({'key': "pmix.timeout", 'value': 10, 'val_type': 5},)
+    APPS = ({'cmd': "/bin/true", 'argv': ["true"], 'env': ["FOO=bar"],
+             'maxprocs': 1, 'info': []},)
+    QUERIES = ({'keys': ["pmix.qry.nslist"], 'qualifiers': None},)
+    UNITS = ({'type': 1, 'count': 2},)
+    CRED = {'bytes': b"somecredential"}
+    CPUS = {'source': "hwloc", 'cpus': [0, 1]}
+
+    #: name, args to place before the (cbfunc, cbdata) pair
+    CASES = (
+        ("fence_nb", (list(PEERS), list(INFO))),
+        ("get_nb", (PEERS[1], "mykey", list(INFO))),
+        # a None proc and a None key are both legal - "me" and "everything"
+        ("get_nb", (None, None, None)),
+        ("publish_nb", (list(INFO),)),
+        ("lookup_nb", (["key1", "key2"], list(INFO))),
+        ("unpublish_nb", (["key1"], list(INFO))),
+        # a None key list means "everything I published"
+        ("unpublish_nb", (None, None)),
+        ("spawn_nb", (list(INFO), list(APPS))),
+        ("connect_nb", (list(PEERS), list(INFO))),
+        ("disconnect_nb", (list(PEERS), list(INFO))),
+        ("query_nb", (list(QUERIES),)),
+        ("log_nb", (list(INFO), list(INFO))),
+        ("allocation_request_nb", (pmix.PMIX_ALLOC_NEW, list(INFO))),
+        ("job_control_nb", (list(PEERS), list(INFO))),
+        ("monitor_nb", (list(INFO), pmix.PMIX_ERR_TIMEOUT, list(INFO))),
+        ("get_credential_nb", (list(INFO),)),
+        ("validate_credential_nb", (CRED, list(INFO))),
+        ("fabric_register_nb", (list(INFO),)),
+        ("fabric_update_nb", ()),
+        ("fabric_deregister_nb", ()),
+        ("resource_block_nb", (pmix.PMIX_RESOURCE_BLOCK_DEFINE, "myblock",
+                               list(UNITS), list(INFO))),
+    )
+
+    #: these need a topology, which not every environment can supply, so
+    #: they are checked for "refused cleanly" rather than a specific status
+    LENIENT = ("compute_distances_nb", (CPUS, list(INFO)))
+
+    def setUp(self):
+        self.client = pmix.PMIxClient()
+        self.fired = []
+
+    def _cb(self, *args):
+        self.fired.append(args)
+
+    def test_methods_present(self):
+        for name, _ in self.CASES + (self.LENIENT,):
+            self.assertTrue(hasattr(pmix.PMIxClient, name),
+                            "PMIxClient.%s missing" % name)
+
+    def test_rejects_non_callable(self):
+        # A NULL C callback would strand the caddy forever, so a callback
+        # that cannot be executed must be refused up front
+        for name, args in self.CASES + (self.LENIENT,):
+            meth = getattr(self.client, name)
+            rc = meth(*(args + (None,)))
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                             "%s accepted a non-callable callback" % name)
+            rc = meth(*(args + ("not-a-function",)))
+            self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                             "%s accepted a non-callable callback" % name)
+
+    def test_error_before_init(self):
+        # The library rejects the request, so the callback must NOT fire
+        # and the binding must reclaim the caddy itself
+        for name, args in self.CASES:
+            meth = getattr(self.client, name)
+            rc = meth(*(args + (self._cb, "opaque")))
+            self.assertEqual(rc, pmix.PMIX_ERR_INIT,
+                             "%s returned %s" % (name, rc))
+        name, args = self.LENIENT
+        rc = getattr(self.client, name)(*(args + (self._cb, "opaque")))
+        self.assertNotEqual(rc, pmix.PMIX_SUCCESS,
+                            "%s was accepted before init" % name)
+        self.assertEqual(self.fired, [],
+                         "a callback fired for a request the library refused")
+
+    def test_repeated_requests_do_not_accumulate(self):
+        # Repeat the whole set enough times that a leak, a double free or a
+        # stranded registry entry would show up
+        for _ in range(32):
+            for name, args in self.CASES + (self.LENIENT,):
+                getattr(self.client, name)(*(args + (self._cb, "opaque")))
+        self.assertEqual(self.fired, [])
+        self.assertEqual(len(pmix.pynbcbs), 0,
+                         "refused operations left entries in the registry")
+
+    def test_bad_arguments_rejected(self):
+        # Arguments the binding itself has to police, before anything is
+        # handed to the library
+        self.assertEqual(
+            self.client.spawn_nb([], None, self._cb),
+            pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.spawn_nb([], [], self._cb),
+            pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.validate_credential_nb(None, [], self._cb),
+            pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.validate_credential_nb({}, [], self._cb),
+            pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.resource_block_nb(pmix.PMIX_RESOURCE_BLOCK_DEFINE,
+                                          None, [], [], self._cb),
+            pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(self.fired, [])
+        self.assertEqual(len(pmix.pynbcbs), 0)
+
+    def test_fabric_ops_require_registration(self):
+        # update/deregister are meaningless until a fabric is registered,
+        # and the binding says so rather than handing the library a fabric
+        # object it never saw
+        self.assertEqual(self.client.fabric_update_nb(self._cb),
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.fabric_deregister_nb(self._cb),
+                         pmix.PMIX_ERR_INIT)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes Part 1 of `bindings/python/MISSING_BINDINGS.md`. Section 1.1
listed the twenty operational client calls that had a Python method only
in their blocking form; all of them are now bound on the machinery the
group operations introduced. The only API deliberately left unbound is
the deprecated `PMIx_tool_connect_to_server`.

`fence_nb`, `get_nb`, `publish_nb`, `lookup_nb`, `unpublish_nb`,
`spawn_nb`, `connect_nb`, `disconnect_nb`, `query_nb`, `log_nb`,
`allocation_request_nb`, `job_control_nb`, `monitor_nb`,
`get_credential_nb`, `validate_credential_nb`, `fabric_register_nb`,
`fabric_update_nb`, `fabric_deregister_nb`, `compute_distances_nb`,
`resource_block_nb`.

Each returns only the status of the request; the result arrives later by
executing the caller's callback on the progress thread, and that
callback runs if and only if the method returned `PMIX_SUCCESS`.

### Three commits

**`docs: the Python info dictionary is flat, not nested`** — every
Python example in the man pages wrote an attribute as
`{'key': K, 'value': {'value': V, 'val_type': T}}`. `pmix_load_info`
reads `value` and `val_type` from the info dictionary itself, so all 33
examples raised `KeyError` before reaching the library. Two adjacent
errors in the same examples are fixed too: `PMIx_Process_monitor` passed
the monitor as a bare dict where the binding takes a list, and
`PMIx_Session_control` built a `PMIxClient` to call a `PMIxServer`
method.

**`python: fix the free discipline in the conversion helpers`** — four
latent defects, none in new code, each of which aborts or corrupts the
process when hit:

- `pmix_load_argv` `strdup`s its entries, but `query()` and
  `unpublish()` allocated the array with `PyMem_Malloc` and
  `pmix_free_queries` released the entries with `PyMem_Free`. Handing a
  Python-arena block to `free()` aborts. `unpublish()` also leaked its
  key array on success and called `pmix_load_argv` on an uninitialized
  pointer given an empty list.
- `pmix_free_apps` released neither the argv/env arrays nor the app
  array (an acknowledged in-code TODO).
- An empty per-app `info` list produced a non-NULL array with
  `ninfo == 0`, which the library reads as "terminated by an end marker"
  and walks off the allocation looking for one. A spawn whose app
  carried `'info': []` packed garbage and failed. This was found by
  `spawn_nb` in the connected test, not by inspection.
- `pmix_load_info`, `pmix_load_apps` and `query()` filled arrays entry
  by entry and released the whole thing on failure, destructing
  uninitialized memory. An attribute with an unconvertible value type
  was enough to crash the caller. Every such array is now zeroed first.

**`python: bind the remaining non-blocking APIs`** — the bindings, plus
`MISSING_BINDINGS.md`, `bindings/python/AGENTS.md`,
`docs/how-things-work/python_nonblocking.rst`, a news entry, the Python
syntax for the non-blocking form on all twenty man pages, and tests.

### Design notes

- **One caddy struct serves every operation.** The trampolines cast
  whatever `cbdata` comes back to it in order to reach the registry key,
  so a per-API struct is not an option. It is zeroed at allocation and
  each field is released to its own allocator.
- **Six callback types had no trampoline yet** — value, lookup, spawn,
  credential, validation, device-distance. Only the last carries a
  release function; everything the other five hand back is reclaimed by
  the library as soon as the callback returns, so each converts to
  Python before doing anything else and never retains the C pointer.
- **Two operations hand the library a pointer into the class**
  (`&self.myfabric`, `&self.topo`), which would dangle if the
  interpreter collected the object mid-flight. The registry entry now
  carries an unread reference for that purpose. `fabric_register_nb` and
  `fabric_deregister_nb` additionally wrap the caller's callback in a
  closure, so the class's "registered" flag flips when the library
  reports the outcome rather than when the request is accepted.
- **`lookup_nb` takes a list of key strings**, not the pdata
  dictionaries its blocking counterpart takes — that is what the C API
  accepts, and there is nothing for a caller to fill in on input.

### Testing

- `make check`: 78/78 pass, no regressions.
- `test_bindings.py` gains `TestClientNonBlocking`, which drives every
  method before `init()` — the path that has to unwind the caddy by
  hand, since no callback will ever fire — and asserts nothing is left
  in the in-flight registry. RSS stays flat across 72,000 refused
  requests.
- The connected `server.py`/`client.py` test exercises the callbacks for
  real. `fence_nb` and `get_nb` return correct data, `publish_nb` →
  `lookup_nb` → `unpublish_nb` completes end to end (the test server
  gains publish/lookup/unpublish handlers so it can), and
  `connect_nb`/`disconnect_nb`/`monitor_nb` succeed.
- Docs build warning-free; library builds warning-free under
  `--enable-devel-check`.

Tested on macOS. `compute_distances_nb` is exercised only on its refusal
path there, as macOS exposes no CPU-binding API for `hwloc_get_cpubind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)