### PR TITLE
python: bind the struct printers and the serialization APIs

### DIFF
--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -96,6 +96,8 @@ field names, so the mapping is mechanical:
 {'bytes': b'...', 'size': 12}                     # pmix_byte_object_t
 {'type': 'raw', 'bytes': b'n1,n2', 'len': 6}      # pmix_regex2_t
 {'type': PMIX_DEVTYPE_GPU, 'count': 4}            # pmix_resource_unit_t
+{'bytes': b'...', 'bytes_used': 43,               # pmix_data_buffer_t
+ 'bytes_unpacked': 22}                            #   (§8b)
 ```
 
 The regex2 `bytes` are *not* necessarily NUL-terminated, which is why the
@@ -392,12 +394,23 @@ internalizing so they are not reintroduced:
 - **Binding an API exposes it to callers a C program never produced.** A
   Python script can call any method the moment it constructs the class,
   and the natural first thing a test does is call it before `init()`.
-  Three C entry points had no `pmix_globals.initialized` guard and
+  Four C entry points had no `pmix_globals.initialized` guard and
   crashed or hung on that path the first time they were bound (see
-  MISSING_BINDINGS.md §1.8). When you bind a new API, call it before
-  `init()` and with empty/None arguments *before* you call it for real —
-  and fix the guard in the C library rather than papering over it in the
-  binding.
+  MISSING_BINDINGS.md §1.8 and §1.12). When you bind a new API, call it
+  before `init()` and with empty/None arguments *before* you call it for
+  real — and fix the guard in the C library rather than papering over it
+  in the binding.
+- **A method that never calls the library is worse than a missing one.**
+  `PMIxTool.set_server_module` built its module struct, returned
+  `PMIX_SUCCESS`, and never handed it to `libpmix`, so a tool's handlers
+  were silently never invoked. When adding or reviewing a method, check
+  that it actually reaches a `PMIx_*` entry point; the only two that
+  legitimately do not are `server_module_init` (internal wiring) and
+  `PMIxScheduler.assign_session` (no C entry point exists).
+- **Bytes are unsigned.** Reading a payload through a `char *` yields
+  negative values for anything at or above `0x80`, and `bytearray()`
+  rejects the list. `pmix_unload_bytes` casts to `unsigned char *` for
+  that reason — anything new that walks a raw buffer must too.
 
 The one remaining stub is a genuine unimplemented feature, not a bug:
 `PMIxScheduler.assign_session` returns `PMIX_ERR_NOT_SUPPORTED` because the
@@ -439,6 +452,40 @@ Note that `get_cpuset` and `compute_distances` cannot be verified on macOS —
 it has no CPU-binding API for `hwloc_get_cpubind`, so they return
 `PMIX_ERR_NOT_FOUND` / `PMIX_ERR_UNREACH` regardless of the bindings. Test
 those two on Linux.
+
+### 8b. Data-buffer conversion
+
+A `pmix_data_buffer_t` holds three raw pointers into one allocation plus
+two sizes. Only two of those five fields mean anything on the Python side —
+the payload, and how far the unpack cursor has advanced through it — so a
+Python data buffer is the dict
+
+```python
+{'bytes': b'...', 'bytes_used': 43, 'bytes_unpacked': 22}
+```
+
+and `pmix_load_dbuf` / `pmix_unload_dbuf` / `pmix_destruct_dbuf` in
+`pmix.pxi` rebuild the pointers from those offsets on each crossing.
+`bytes_used` is redundant with `len(bytes)`; the loader trusts the payload,
+not the count.
+
+Three things to respect:
+
+- **There is no buffer object to create or release.** The dict *is* the
+  buffer and the C storage lives only for the duration of a call, which is
+  why `PMIx_Data_buffer_create`/`_release` are not bound. `data_pack` and
+  friends take the dict, build a C buffer, call the library, write the
+  state back, and destruct.
+- **Do not reach for `PMIx_Data_buffer_load`.** It routes through
+  `PMIx_Data_load`, which refuses to run before `PMIx_Init` *and discards
+  its status*, so a pre-init caller would silently get an empty buffer.
+  `pmix_load_dbuf` sets `base_ptr`/`pack_ptr`/`unpack_ptr` itself.
+- **The payload must come from `malloc`** — the library's buffer destructor
+  frees it with the C allocator.
+
+`data_unload` is the one method whose semantics differ from a plain "give
+me the bytes": the library hands back only the portion that has *not* been
+unpacked, and consumes the buffer in the process.
 
 ### Style / conventions specific to these bindings
 

--- a/bindings/python/MISSING_BINDINGS.md
+++ b/bindings/python/MISSING_BINDINGS.md
@@ -12,14 +12,18 @@ two parts:
 
 Utility/struct-helper C APIs with no meaningful Python analogue are
 intentionally **out of scope** and are *not* listed as missing:
-`PMIx_Argv_*`, `PMIx_Setenv`, `PMIx_Info_*`, `PMIx_Value_*`, `PMIx_Data_*`
-(struct helpers), `PMIx_Load_*`, `PMIx_Coord_*`, `PMIx_Topology_*`,
-`PMIx_Cpuset_*`, `PMIx_Device_*`, `PMIx_Geometry_*`, `PMIx_Endpoint_*`,
-`PMIx_Envar_*`, `PMIx_Pdata_*`, `PMIx_Proc_*`, `PMIx_App_*`,
-`PMIx_Byte_object_*`, `PMIx_Regattr_*`, `PMIx_Resource_unit_*`,
-`PMIx_Node_pid_*`, and all `*_construct/_destruct/_create/_free/_release/`
-`_load/_xfer` macro families. In Python these are handled by the
-dict/list conversion layer in `pmix.pxi`.
+`PMIx_Argv_*`, `PMIx_Setenv`, `PMIx_Load_*`, `PMIx_Coord_*`,
+`PMIx_Topology_*`, `PMIx_Cpuset_*`, `PMIx_Device_*`, `PMIx_Geometry_*`,
+`PMIx_Endpoint_*`, `PMIx_Envar_*`, `PMIx_Pdata_*`, `PMIx_Regattr_*`,
+`PMIx_Node_pid_*`, the `PMIx_Info_list_*` builder, the
+`PMIx_Check_*`/`PMIx_*_invalid`/`PMIx_*_valid` predicates, and all
+`*_construct/_destruct/_create/_free/_release/_load/_xfer` macro
+families. In Python these are handled by the dict/list conversion layer
+in `pmix.pxi`, or are one line of ordinary Python.
+
+Two families that *look* like struct helpers by prefix are **not** out of
+scope and are bound: the struct pretty-printers (§1.10) and the
+serialization calls (§1.11).
 
 Headers surveyed: `include/pmix.h`, `include/pmix_server.h`,
 `include/pmix_tool.h`, `include/pmix_deprecated.h`. Bindings surveyed:
@@ -109,6 +113,15 @@ Four things this pass established that the group operations had not:
 |-------|-------------|
 | `PMIx_tool_connect_to_server` | **Deprecated**; superseded by `PMIx_tool_attach_to_server` (bound). Deliberately left unbound. |
 
+`PMIx_tool_set_server_module` was listed here as bound because
+`PMIxTool.set_server_module` exists — but the method never called it. It
+validated the map, recorded the handlers in `pmixservermodule`, wired the
+trampolines into its own `pmix_server_module_t`, and returned
+`PMIX_SUCCESS` **without ever handing the module to the library**, so a
+Python tool acting as a server had its handlers silently never invoked.
+It now calls the API and reports what it says. Two library defects came
+out with it — see §1.12.
+
 ### 1.5 Scheduler role (`PMIxScheduler`) — **CLOSED**
 
 Both scheduler-role operations are reachable, through what the class
@@ -148,8 +161,9 @@ one of those two; an explicit `data_type` outside the pair returns
 
 ### 1.7 Coverage summary
 
-- Operational client/server/tool APIs bound: **~106** — every blocking
-  form, tool IOF, and all 25 non-blocking variants.
+- Operational client/server/tool APIs bound: **~120** — every blocking
+  form, tool IOF, all 25 non-blocking variants, the five struct
+  pretty-printers (§1.10) and the nine serialization calls (§1.11).
 - Not bound: **1** deprecated tool API (§1.4), deliberately.
 
 Part 1 is closed. What remains open is not a *binding* gap:
@@ -158,6 +172,13 @@ library exposes no entry point for it (§1.5), and `pmix_load_value` has
 no arm for `PMIX_POINTER` — a data type a Python caller cannot
 meaningfully produce, which surfaces as `PMIX_ERR_NOT_SUPPORTED` rather
 than a crash.
+
+A full sweep of the public headers (307 exported `PMIx_*` functions
+across `pmix.h`, `pmix_common.h.in`, `pmix_server.h`, `pmix_tool.h` and
+`pmix_deprecated.h`, each checked for a call site in `pmix.pyx`/`pmix.pxi`)
+found nothing else outstanding: every `PMIx_server_*` entry point is
+bound, and everything else unbound belongs to the helper families listed
+at the top of this file.
 
 ### 1.8 C-side hazards this pass surfaced (now fixed)
 
@@ -206,6 +227,109 @@ came out. None were in the new code; all are fixed:
   the whole thing on failure, destructing uninitialized memory. An
   attribute carrying an unconvertible value type was enough to crash the
   caller. Every such array is now zeroed before loading.
+
+### 1.10 Struct pretty-printers — **CLOSED**
+
+| C API | Python method |
+|-------|---------------|
+| `PMIx_Info_string` | `info_string(pyinfo)` |
+| `PMIx_Value_string` | `value_string(pyval)` |
+| `PMIx_Proc_string` | `proc_string(pyproc)` |
+| `PMIx_App_string` | `app_string(pyapp)` |
+| `PMIx_Resource_unit_string` | `resource_unit_string(pyunit)` |
+
+Each returns `(rc, str)`. These were being swept out of scope by the
+`PMIx_Info_*` / `PMIx_Value_*` / `PMIx_App_*` / `PMIx_Proc_*` /
+`PMIx_Resource_unit_*` prefix rule, which was aimed at the
+`_construct`/`_free` families — but they are converters, peers of
+`data_print` (bound in §1.6) rather than struct helpers, and each has its
+own man page. They render a whole struct the way the library itself
+would, which is not something a Python program can reproduce by printing
+a dict.
+
+They take no library state, so they work before `init()`. The library
+allocates the string it returns, so each decodes it and hands the storage
+back.
+
+### 1.11 Serialization — **CLOSED**
+
+| C API | Python method | Returns |
+|-------|---------------|---------|
+| `PMIx_Data_pack` | `data_pack(pybuf, pysrc, data_type=None, target=None)` | `(rc, buffer)` |
+| `PMIx_Data_unpack` | `data_unpack(pybuf, data_type=None, target=None)` | `(rc, value or info)` |
+| `PMIx_Data_copy` | `data_copy(pysrc, data_type=None)` | `(rc, dict)` |
+| `PMIx_Data_copy_payload` | `data_copy_payload(pydest, pysrc)` | `(rc, buffer)` |
+| `PMIx_Data_unload` | `data_unload(pybuf)` | `(rc, byte object)` |
+| `PMIx_Data_load` | `data_load(pybuf, payload)` | `(rc, buffer)` |
+| `PMIx_Data_embed` | `data_embed(pybuf, payload)` | `(rc, buffer)` |
+| `PMIx_Data_compress` | `data_compress(pybytes)` | `(rc, bytes)` |
+| `PMIx_Data_decompress` | `data_decompress(pybytes)` | `(rc, bytes)` |
+
+**The buffer.** A `pmix_data_buffer_t` holds three raw pointers into one
+allocation plus two sizes. Only two of those five fields mean anything on
+the Python side — the payload, and how far the unpack cursor has advanced
+through it — so a Python data buffer is the dict
+
+```python
+{'bytes': b'...', 'bytes_used': n, 'bytes_unpacked': m}
+```
+
+and the pointers are rebuilt from those offsets on every crossing.
+`bytes_used` is redundant with `len(bytes)` and is carried only because
+the struct has it; the loader trusts the payload, not the count.
+
+Three consequences worth knowing:
+
+- **There is nothing to create or release.** The dict *is* the buffer, and
+  the C storage lives only for the duration of a call. That is why
+  `PMIx_Data_buffer_create`/`_release`/`_construct`/`_destruct` are not
+  bound — there is no object for them to act on.
+- **A buffer is ordinary bytes.** Because the whole state is the payload
+  plus an offset, a buffer can be stored, sent somewhere, and picked up
+  again by building the dict from the bytes. `test/python/server.py`
+  round-trips one that way.
+- **The library's own `PMIx_Data_buffer_load` cannot be used** by the
+  conversion layer: it routes through `PMIx_Data_load`, which refuses to
+  run before `PMIx_Init` and discards its status, so a pre-init caller
+  would silently get an empty buffer. `pmix_load_dbuf` sets the fields
+  directly.
+
+As with `data_print`, the payload a Python caller can build is a value
+dict or an info dict, deduced from the presence of a `'key'`; every other
+data type is reachable as the value of one of those, and an explicit
+`data_type` outside the pair returns `PMIX_ERR_NOT_SUPPORTED`.
+
+`data_compress`/`data_decompress` answer a C `bool` — whether the library
+compressed the block at all, which it declines when no compression
+component is available or the block is below the threshold where
+compression would pay. That is reported as `PMIX_SUCCESS` or
+`PMIX_ERR_NOT_AVAILABLE` so the return keeps the `(rc, data)` shape every
+other method uses.
+
+### 1.12 Defects this pass surfaced (now fixed)
+
+- **`pmix_unload_bytes` returned signed bytes.** It read the payload
+  through a `char *`, which is signed on most platforms, so any byte at or
+  above `0x80` arrived as a negative number and `bytearray()` rejected the
+  whole list with `byte must be in range(0, 256)`. Every non-ASCII payload
+  hit this — credentials, IOF data, a packed buffer — and it is why
+  `data_compress` failed on its first real input. Now read through an
+  `unsigned char *`.
+- **`PMIx_tool_set_server_module` had no pre-init guard.** It marks the
+  caller's peer as a server, and `pmix_globals.mypeer` is NULL until
+  `PMIx_tool_init` — so the first Python call to the newly fixed
+  `set_server_module` segfaulted. It now returns `PMIX_ERR_INIT`, and
+  rejects a NULL module.
+- **`PMIx_tool_finalize` tore down a framework it never opened.** Init
+  opens the `pfexec` framework only for a launcher or a scheduler, but
+  finalize's teardown branch fires for a launcher *or a server* — and a
+  plain tool becomes a server exactly by calling
+  `PMIx_tool_set_server_module`. Finalize then walked an unconstructed
+  children list and crashed. `pmix_pfexec_globals` now records whether it
+  was opened, `pmix_pfexec_base_close` is a no-op if it was not, and the
+  finalize branch checks that rather than the peer type. This is
+  reachable from C, not just from Python: any tool that inits, sets a
+  server module, and finalizes hits it.
 
 ---
 

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -2266,6 +2266,150 @@ cdef void pmix_unload_bytes(char *data, size_t ndata, blist:list):
         blist.append(udata[n])
         n += 1
 
+# Convert a Python byte-object dict, {'bytes': b'...', 'size': n}, into a
+# pmix_byte_object_t. The payload is malloc'd, so it can be handed to a
+# library call that takes ownership of it - callers that retain ownership
+# must free it themselves
+cdef int pmix_load_bo(pmix_byte_object_t *bo, pybo):
+    cdef const char *ptr
+
+    bo[0].bytes = NULL
+    bo[0].size = 0
+    if pybo is None:
+        return PMIX_SUCCESS
+    if not isinstance(pybo, dict):
+        return PMIX_ERR_BAD_PARAM
+    pybytes = pybo.get('bytes')
+    if pybytes is None:
+        return PMIX_SUCCESS
+    if isinstance(pybytes, str):
+        pybytes = pybytes.encode('ascii')
+    else:
+        pybytes = bytes(pybytes)
+    if 0 == len(pybytes):
+        return PMIX_SUCCESS
+    bo[0].size = len(pybytes)
+    bo[0].bytes = <char*> malloc(bo[0].size)
+    if NULL == bo[0].bytes:
+        bo[0].size = 0
+        return PMIX_ERR_NOMEM
+    ptr = <const char*>pybytes
+    memcpy(bo[0].bytes, ptr, bo[0].size)
+    return PMIX_SUCCESS
+
+# Convert a pmix_byte_object_t into the Python dict, filling in pybo
+cdef void pmix_unload_bo(const pmix_byte_object_t *bo, pybo:dict):
+    blist = []
+    if NULL != bo[0].bytes and 0 < bo[0].size:
+        pmix_unload_bytes(bo[0].bytes, bo[0].size, blist)
+    pybo['bytes'] = bytes(bytearray(blist))
+    pybo['size'] = len(pybo['bytes'])
+
+# A pmix_data_buffer_t holds three raw pointers into one allocation plus
+# two sizes. Only two of those five fields mean anything on the Python
+# side - the payload itself, and how far the unpack cursor has advanced
+# through it - so a Python data buffer is the dict
+#
+#     {'bytes': b'...', 'bytes_used': n, 'bytes_unpacked': m}
+#
+# and the pointers are rebuilt from those offsets on every crossing.
+# 'bytes_used' is redundant with len(bytes) and is carried only because
+# the struct has it; the loader trusts the payload, not the count.
+#
+# Note that the library's own PMIx_Data_buffer_load cannot be used here:
+# it routes through PMIx_Data_load, which refuses to run before
+# PMIx_Init and discards its status, so a pre-init caller would silently
+# get an empty buffer
+cdef int pmix_load_dbuf(pmix_data_buffer_t *buf, pybuf):
+    cdef const char *ptr
+    cdef size_t sz
+    cdef size_t unpacked
+
+    PMIx_Data_buffer_construct(buf)
+    if pybuf is None:
+        return PMIX_SUCCESS
+    if not isinstance(pybuf, dict):
+        return PMIX_ERR_BAD_PARAM
+    pybytes = pybuf.get('bytes')
+    if pybytes is None:
+        return PMIX_SUCCESS
+    if isinstance(pybytes, str):
+        pybytes = pybytes.encode('ascii')
+    else:
+        pybytes = bytes(pybytes)
+    sz = len(pybytes)
+    if 0 == sz:
+        return PMIX_SUCCESS
+    # the buffer owns its payload and releases it with the C allocator
+    buf[0].base_ptr = <char*> malloc(sz)
+    if NULL == buf[0].base_ptr:
+        return PMIX_ERR_NOMEM
+    ptr = <const char*>pybytes
+    memcpy(buf[0].base_ptr, ptr, sz)
+    buf[0].bytes_allocated = sz
+    buf[0].bytes_used = sz
+    buf[0].pack_ptr = buf[0].base_ptr + sz
+    # restore the unpack cursor so successive unpacks resume where the
+    # last one stopped
+    unpacked = 0
+    try:
+        if pybuf.get('bytes_unpacked') is not None:
+            unpacked = pybuf['bytes_unpacked']
+    except:
+        unpacked = 0
+    if sz < unpacked:
+        return PMIX_ERR_BAD_PARAM
+    buf[0].unpack_ptr = buf[0].base_ptr + unpacked
+    return PMIX_SUCCESS
+
+# Render a pmix_data_buffer_t back into the Python dict, filling in pybuf
+cdef void pmix_unload_dbuf(const pmix_data_buffer_t *buf, pybuf:dict):
+    blist = []
+    if NULL != buf[0].base_ptr and 0 < buf[0].bytes_used:
+        pmix_unload_bytes(buf[0].base_ptr, buf[0].bytes_used, blist)
+    pybuf['bytes'] = bytes(bytearray(blist))
+    pybuf['bytes_used'] = len(pybuf['bytes'])
+    if NULL != buf[0].base_ptr and NULL != buf[0].unpack_ptr:
+        pybuf['bytes_unpacked'] = buf[0].unpack_ptr - buf[0].base_ptr
+    else:
+        pybuf['bytes_unpacked'] = 0
+
+# Release a data buffer built by pmix_load_dbuf. The library's destructor
+# frees the payload and tolerates a buffer that was never loaded
+cdef void pmix_destruct_dbuf(pmix_data_buffer_t *buf):
+    PMIx_Data_buffer_destruct(buf)
+
+# Release the allocated members of a single app struct, leaving the
+# struct itself alone - the counterpart of pmix_destruct_info, and the
+# right thing to call on an app that lives on the stack rather than in a
+# heap array
+cdef void pmix_destruct_app(pmix_app_t *app):
+    cdef size_t n
+    if NULL != app[0].cmd:
+        free(app[0].cmd)
+        app[0].cmd = NULL
+    if NULL != app[0].argv:
+        n = 0
+        while NULL != app[0].argv[n]:
+            free(app[0].argv[n])
+            n += 1
+        free(app[0].argv)
+        app[0].argv = NULL
+    if NULL != app[0].env:
+        n = 0
+        while NULL != app[0].env[n]:
+            free(app[0].env[n])
+            n += 1
+        free(app[0].env)
+        app[0].env = NULL
+    if NULL != app[0].cwd:
+        free(app[0].cwd)
+        app[0].cwd = NULL
+    if NULL != app[0].info and 0 < app[0].ninfo:
+        pmix_free_info(app[0].info, app[0].ninfo)
+        app[0].info = NULL
+        app[0].ninfo = 0
+
 cdef void pmix_free_apps(pmix_app_t *array, size_t sz):
     if NULL == array:
         return

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -2253,10 +2253,17 @@ cdef int pmix_unload_procs(const pmix_proc_t *procs, size_t nprocs, peers:list):
 cdef void pmix_free_procs(pmix_proc_t *array, size_t sz):
     PyMem_Free(array)
 
+# Convert a raw byte buffer into a list of integers suitable for
+# bytearray(). Read it through an unsigned pointer: 'char' is signed on
+# most platforms, so any byte at or above 0x80 would otherwise arrive as
+# a negative number and bytearray() would reject the whole list with
+# "byte must be in range(0, 256)". Every payload that is not plain ASCII
+# hits this - credentials, IOF data, a packed buffer
 cdef void pmix_unload_bytes(char *data, size_t ndata, blist:list):
     cdef size_t n = 0
+    cdef unsigned char *udata = <unsigned char*>data
     while n < ndata:
-        blist.append(data[n])
+        blist.append(udata[n])
         n += 1
 
 cdef void pmix_free_apps(pmix_app_t *array, size_t sz):

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -4943,6 +4943,12 @@ cdef class PMIxTool(PMIxServer):
 
     # Allow a tool to set server module callback functions
     # when it needs to also act as a server
+    # Provide the server function pointer module by which this tool will
+    # service requests from processes that connect to it
+    #
+    # @map [INPUT]
+    #      - a dictionary of server-module key to Python handler, as
+    #        PMIxServer.init takes
     def set_server_module(self, map):
         # setup server module
         if map is None or 0 == len(map):
@@ -4956,7 +4962,11 @@ cdef class PMIxTool(PMIxServer):
                 print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
                 return PMIX_ERR_INIT
         self.server_module_init(kvkeys)
-        return PMIX_SUCCESS
+        # wiring the trampolines into our own struct only prepares the
+        # module - the library has to be given it, or none of the
+        # handlers registered above is ever called
+        rc = PMIx_tool_set_server_module(&self.myserver)
+        return rc
 
 
     def iof_pull(self, pyprocs, iof_channel:int, pydirs, hdlr):

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -3120,6 +3120,495 @@ cdef class PMIxClient:
         free(output)
         return (rc, txt)
 
+    # Render one of the PMIx structs as a printable string. Unlike the
+    # *_string converters above, which translate a single enumerated
+    # value, these take a whole struct and are the C analogue of printing
+    # the Python dict - they are bound so a Python program can produce
+    # exactly the text the C library would.
+    #
+    # Each returns (rc, str). The library allocates the string, so each
+    # decodes it and hands the storage back.
+
+    # @pyinfo [INPUT] - a single info dict
+    def info_string(self, pyinfo):
+        cdef pmix_info_t info
+        cdef char *output
+
+        if not isinstance(pyinfo, dict) or 'key' not in pyinfo:
+            return (PMIX_ERR_BAD_PARAM, None)
+        memset(&info, 0, sizeof(pmix_info_t))
+        rc = pmix_load_info(&info, [pyinfo])
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_info(&info)
+            return (rc, None)
+        output = PMIx_Info_string(&info)
+        pmix_destruct_info(&info)
+        if NULL == output:
+            return (PMIX_ERROR, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (PMIX_SUCCESS, txt)
+
+    # @pyval [INPUT] - a single value dict
+    def value_string(self, pyval):
+        cdef pmix_value_t value
+        cdef char *output
+
+        if not isinstance(pyval, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        rc = pmix_load_value(&value, pyval)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_value(&value)
+            return (rc, None)
+        output = PMIx_Value_string(&value)
+        pmix_destruct_value(&value)
+        if NULL == output:
+            return (PMIX_ERROR, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (PMIX_SUCCESS, txt)
+
+    # @pyproc [INPUT] - a proc dict of nspace and rank
+    def proc_string(self, pyproc):
+        cdef pmix_proc_t proc
+        cdef char *output
+
+        if not isinstance(pyproc, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        memset(&proc, 0, sizeof(pmix_proc_t))
+        rc = pmix_load_procs(&proc, [pyproc])
+        if PMIX_SUCCESS != rc:
+            return (rc, None)
+        output = PMIx_Proc_string(&proc)
+        if NULL == output:
+            return (PMIX_ERROR, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (PMIX_SUCCESS, txt)
+
+    # @pyapp [INPUT] - a single app dict, as spawn() takes
+    def app_string(self, pyapp):
+        cdef pmix_app_t app
+        cdef char *output
+
+        if not isinstance(pyapp, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        memset(&app, 0, sizeof(pmix_app_t))
+        rc = pmix_load_apps(&app, [pyapp])
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_app(&app)
+            return (rc, None)
+        output = PMIx_App_string(&app)
+        pmix_destruct_app(&app)
+        if NULL == output:
+            return (PMIX_ERROR, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (PMIX_SUCCESS, txt)
+
+    # @pyunit [INPUT] - a resource unit dict of type and count
+    def resource_unit_string(self, pyunit):
+        cdef pmix_resource_unit_t unit
+        cdef char *output
+
+        if not isinstance(pyunit, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        memset(&unit, 0, sizeof(pmix_resource_unit_t))
+        rc = pmix_load_units(&unit, [pyunit])
+        if PMIX_SUCCESS != rc:
+            return (rc, None)
+        output = PMIx_Resource_unit_string(&unit)
+        if NULL == output:
+            return (PMIX_ERROR, None)
+        txt = output.decode('ascii')
+        free(output)
+        return (PMIX_SUCCESS, txt)
+
+    # Serialization. A Python data buffer is the dict
+    #
+    #     {'bytes': b'...', 'bytes_used': n, 'bytes_unpacked': m}
+    #
+    # mirroring the fields of a pmix_data_buffer_t that mean anything on
+    # this side of the boundary - the payload, and how far the unpack
+    # cursor has advanced through it. The three raw pointers the struct
+    # also carries are rebuilt from those offsets on each call, so a
+    # buffer can be carried across calls, stored, or sent somewhere as
+    # ordinary bytes. There is nothing to create or release: the dict is
+    # the buffer, and the C storage lives only for the duration of a call.
+    #
+    # As with data_print, the payload a Python caller can build is either
+    # a value dict or an info dict, deduced from the presence of a 'key';
+    # every other data type is reachable as the value of one of those.
+
+    # Pack a value into a data buffer, appending to whatever it holds
+    #
+    # @pybuf [INPUT/OUTPUT]
+    #        - the buffer dict to append to; None starts a new one
+    #
+    # @pysrc [INPUT]
+    #        - the value or info dict to pack
+    #
+    # @data_type [INPUT]
+    #            - PMIX_VALUE or PMIX_INFO; deduced when omitted
+    #
+    # @target [INPUT]
+    #         - proc dict naming the peer this buffer is destined for,
+    #           which selects the wire format. None means our own job
+    #
+    # Returns (rc, buffer dict) - the same dict, updated in place
+    def data_pack(self, pybuf, pysrc, data_type=None, target=None):
+        cdef pmix_data_buffer_t buf
+        cdef pmix_value_t value
+        cdef pmix_info_t info
+        cdef pmix_proc_t proc
+        cdef pmix_proc_t *tgt
+
+        if not isinstance(pysrc, dict):
+            return (PMIX_ERR_BAD_PARAM, pybuf)
+        if data_type is None:
+            if 'key' in pysrc:
+                data_type = PMIX_INFO
+            else:
+                data_type = PMIX_VALUE
+        if PMIX_VALUE != data_type and PMIX_INFO != data_type:
+            return (PMIX_ERR_NOT_SUPPORTED, pybuf)
+        if pybuf is None:
+            pybuf = {}
+        elif not isinstance(pybuf, dict):
+            return (PMIX_ERR_BAD_PARAM, pybuf)
+
+        tgt = NULL
+        if target is not None:
+            memset(&proc, 0, sizeof(pmix_proc_t))
+            rc = pmix_load_procs(&proc, [target])
+            if PMIX_SUCCESS != rc:
+                return (rc, pybuf)
+            tgt = &proc
+
+        rc = pmix_load_dbuf(&buf, pybuf)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, pybuf)
+
+        if PMIX_VALUE == data_type:
+            rc = pmix_load_value(&value, pysrc)
+            if PMIX_SUCCESS == rc:
+                rc = PMIx_Data_pack(tgt, &buf, <void*>&value, 1, PMIX_VALUE)
+            pmix_destruct_value(&value)
+        else:
+            if 'key' not in pysrc:
+                pmix_destruct_dbuf(&buf)
+                return (PMIX_ERR_BAD_PARAM, pybuf)
+            memset(&info, 0, sizeof(pmix_info_t))
+            rc = pmix_load_info(&info, [pysrc])
+            if PMIX_SUCCESS == rc:
+                rc = PMIx_Data_pack(tgt, &buf, <void*>&info, 1, PMIX_INFO)
+            pmix_destruct_info(&info)
+
+        if PMIX_SUCCESS == rc:
+            pmix_unload_dbuf(&buf, pybuf)
+        pmix_destruct_dbuf(&buf)
+        return (rc, pybuf)
+
+    # Unpack the next value from a data buffer. The buffer's unpack
+    # cursor advances, so successive calls walk the payload
+    #
+    # @pybuf [INPUT/OUTPUT]
+    #        - the buffer dict to read from, updated in place
+    #
+    # @data_type [INPUT]
+    #            - PMIX_VALUE or PMIX_INFO, whichever was packed
+    #
+    # @target [INPUT]
+    #         - proc dict naming the peer that packed the buffer
+    #
+    # Returns (rc, value or info dict)
+    def data_unpack(self, pybuf, data_type=None, target=None):
+        cdef pmix_data_buffer_t buf
+        cdef pmix_value_t value
+        cdef pmix_info_t info
+        cdef pmix_proc_t proc
+        cdef pmix_proc_t *tgt
+        cdef int32_t cnt
+
+        if not isinstance(pybuf, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        if data_type is None:
+            data_type = PMIX_VALUE
+        if PMIX_VALUE != data_type and PMIX_INFO != data_type:
+            return (PMIX_ERR_NOT_SUPPORTED, None)
+
+        tgt = NULL
+        if target is not None:
+            memset(&proc, 0, sizeof(pmix_proc_t))
+            rc = pmix_load_procs(&proc, [target])
+            if PMIX_SUCCESS != rc:
+                return (rc, None)
+            tgt = &proc
+
+        rc = pmix_load_dbuf(&buf, pybuf)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, None)
+
+        cnt = 1
+        pyout = None
+        if PMIX_VALUE == data_type:
+            memset(&value, 0, sizeof(pmix_value_t))
+            rc = PMIx_Data_unpack(tgt, &buf, <void*>&value, &cnt, PMIX_VALUE)
+            if PMIX_SUCCESS == rc:
+                pyout = pmix_unload_value(&value)
+            pmix_destruct_value(&value)
+        else:
+            memset(&info, 0, sizeof(pmix_info_t))
+            rc = PMIx_Data_unpack(tgt, &buf, <void*>&info, &cnt, PMIX_INFO)
+            if PMIX_SUCCESS == rc:
+                ilist = []
+                rc = pmix_unload_info(&info, 1, ilist)
+                if PMIX_SUCCESS == rc and 0 < len(ilist):
+                    pyout = ilist[0]
+            pmix_destruct_info(&info)
+
+        # record how far the cursor moved, whatever the outcome, so a
+        # caller that stops on an error can see where it stopped
+        pmix_unload_dbuf(&buf, pybuf)
+        pmix_destruct_dbuf(&buf)
+        return (rc, pyout)
+
+    # Copy a value or info through the library's own copy function
+    #
+    # Returns (rc, dict)
+    def data_copy(self, pysrc, data_type=None):
+        cdef pmix_value_t value
+        cdef pmix_info_t info
+        cdef pmix_value_t *valdest
+        cdef pmix_info_t *infodest
+        cdef void **dest
+
+        if not isinstance(pysrc, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        if data_type is None:
+            if 'key' in pysrc:
+                data_type = PMIX_INFO
+            else:
+                data_type = PMIX_VALUE
+
+        if PMIX_VALUE == data_type:
+            rc = pmix_load_value(&value, pysrc)
+            if PMIX_SUCCESS != rc:
+                pmix_destruct_value(&value)
+                return (rc, None)
+            valdest = NULL
+            dest = <void**>&valdest
+            rc = PMIx_Data_copy(dest, <void*>&value, PMIX_VALUE)
+            pmix_destruct_value(&value)
+            if PMIX_SUCCESS != rc or NULL == valdest:
+                return (rc, None)
+            pyout = pmix_unload_value(valdest)
+            # the copy came from the library, so it goes back to it
+            PMIx_Value_free(valdest, 1)
+            return (rc, pyout)
+        elif PMIX_INFO == data_type:
+            if 'key' not in pysrc:
+                return (PMIX_ERR_BAD_PARAM, None)
+            memset(&info, 0, sizeof(pmix_info_t))
+            rc = pmix_load_info(&info, [pysrc])
+            if PMIX_SUCCESS != rc:
+                pmix_destruct_info(&info)
+                return (rc, None)
+            infodest = NULL
+            dest = <void**>&infodest
+            rc = PMIx_Data_copy(dest, <void*>&info, PMIX_INFO)
+            pmix_destruct_info(&info)
+            if PMIX_SUCCESS != rc or NULL == infodest:
+                return (rc, None)
+            ilist = []
+            rc = pmix_unload_info(infodest, 1, ilist)
+            PMIx_Info_free(infodest, 1)
+            if PMIX_SUCCESS != rc or 0 == len(ilist):
+                return (rc, None)
+            return (rc, ilist[0])
+        return (PMIX_ERR_NOT_SUPPORTED, None)
+
+    # Append the unread portion of one buffer to another
+    #
+    # Returns (rc, destination buffer dict)
+    def data_copy_payload(self, pydest, pysrc):
+        cdef pmix_data_buffer_t dest
+        cdef pmix_data_buffer_t src
+
+        if pydest is None:
+            pydest = {}
+        elif not isinstance(pydest, dict):
+            return (PMIX_ERR_BAD_PARAM, pydest)
+
+        rc = pmix_load_dbuf(&dest, pydest)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&dest)
+            return (rc, pydest)
+        rc = pmix_load_dbuf(&src, pysrc)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&src)
+            pmix_destruct_dbuf(&dest)
+            return (rc, pydest)
+
+        rc = PMIx_Data_copy_payload(&dest, &src)
+        if PMIX_SUCCESS == rc:
+            pmix_unload_dbuf(&dest, pydest)
+        pmix_destruct_dbuf(&src)
+        pmix_destruct_dbuf(&dest)
+        return (rc, pydest)
+
+    # Extract a buffer's payload as a byte object, emptying the buffer.
+    # Note that the library returns only the portion that has not been
+    # unpacked yet
+    #
+    # Returns (rc, {'bytes': bytes, 'size': int})
+    def data_unload(self, pybuf):
+        cdef pmix_data_buffer_t buf
+        cdef pmix_byte_object_t bo
+
+        if not isinstance(pybuf, dict):
+            return (PMIX_ERR_BAD_PARAM, None)
+        rc = pmix_load_dbuf(&buf, pybuf)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, None)
+
+        bo.bytes = NULL
+        bo.size = 0
+        rc = PMIx_Data_unload(&buf, &bo)
+        pyout = None
+        if PMIX_SUCCESS == rc:
+            pyout = {}
+            pmix_unload_bo(&bo, pyout)
+            # the payload was handed to us by the library
+            if NULL != bo.bytes:
+                free(bo.bytes)
+            # unload consumes the buffer, so report it empty
+            pmix_unload_dbuf(&buf, pybuf)
+        pmix_destruct_dbuf(&buf)
+        return (rc, pyout)
+
+    # Replace a buffer's payload with the provided byte object
+    #
+    # Returns (rc, buffer dict)
+    def data_load(self, pybuf, payload):
+        cdef pmix_data_buffer_t buf
+        cdef pmix_byte_object_t bo
+
+        if pybuf is None:
+            pybuf = {}
+        elif not isinstance(pybuf, dict):
+            return (PMIX_ERR_BAD_PARAM, pybuf)
+        rc = pmix_load_dbuf(&buf, pybuf)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, pybuf)
+        # the library takes ownership of the payload it is given, which
+        # is why pmix_load_bo malloc's it
+        rc = pmix_load_bo(&bo, payload)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, pybuf)
+        rc = PMIx_Data_load(&buf, &bo)
+        if PMIX_SUCCESS == rc:
+            pmix_unload_dbuf(&buf, pybuf)
+        elif NULL != bo.bytes:
+            # it was refused, so the payload is still ours
+            free(bo.bytes)
+        pmix_destruct_dbuf(&buf)
+        return (rc, pybuf)
+
+    # Embed a payload in a buffer. Identical to data_load except that the
+    # library copies the payload rather than taking ownership of it
+    #
+    # Returns (rc, buffer dict)
+    def data_embed(self, pybuf, payload):
+        cdef pmix_data_buffer_t buf
+        cdef pmix_byte_object_t bo
+
+        if pybuf is None:
+            pybuf = {}
+        elif not isinstance(pybuf, dict):
+            return (PMIX_ERR_BAD_PARAM, pybuf)
+        rc = pmix_load_dbuf(&buf, pybuf)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, pybuf)
+        rc = pmix_load_bo(&bo, payload)
+        if PMIX_SUCCESS != rc:
+            pmix_destruct_dbuf(&buf)
+            return (rc, pybuf)
+        rc = PMIx_Data_embed(&buf, &bo)
+        if PMIX_SUCCESS == rc:
+            pmix_unload_dbuf(&buf, pybuf)
+        # embed copies, so the payload remains ours either way
+        if NULL != bo.bytes:
+            free(bo.bytes)
+        pmix_destruct_dbuf(&buf)
+        return (rc, pybuf)
+
+    # Compress a block of bytes with the library's loss-less compressor
+    #
+    # The C API answers a bool - whether it compressed the block at all,
+    # which it declines to do when no compression component is available
+    # or the block is below the threshold where compression would pay.
+    # That answer is reported here as PMIX_SUCCESS or
+    # PMIX_ERR_NOT_AVAILABLE, so the return follows the same (rc, data)
+    # shape as every other method
+    def data_compress(self, pybytes):
+        cdef uint8_t *inbytes
+        cdef uint8_t *outbytes
+        cdef size_t nbytes
+
+        if pybytes is None:
+            return (PMIX_ERR_BAD_PARAM, None)
+        if isinstance(pybytes, str):
+            pyin = pybytes.encode('ascii')
+        else:
+            pyin = bytes(pybytes)
+        if 0 == len(pyin):
+            return (PMIX_ERR_BAD_PARAM, None)
+        inbytes = <uint8_t*><const char*>pyin
+        outbytes = NULL
+        nbytes = 0
+        if not PMIx_Data_compress(inbytes, len(pyin), &outbytes, &nbytes):
+            return (PMIX_ERR_NOT_AVAILABLE, None)
+        if NULL == outbytes or 0 == nbytes:
+            return (PMIX_ERR_NOT_AVAILABLE, None)
+        blist = []
+        pmix_unload_bytes(<char*>outbytes, nbytes, blist)
+        free(outbytes)
+        return (PMIX_SUCCESS, bytes(bytearray(blist)))
+
+    # Decompress a block produced by data_compress. See that method for
+    # the meaning of the returned status
+    def data_decompress(self, pybytes):
+        cdef uint8_t *inbytes
+        cdef uint8_t *outbytes
+        cdef size_t nbytes
+
+        if pybytes is None:
+            return (PMIX_ERR_BAD_PARAM, None)
+        if isinstance(pybytes, str):
+            pyin = pybytes.encode('ascii')
+        else:
+            pyin = bytes(pybytes)
+        if 0 == len(pyin):
+            return (PMIX_ERR_BAD_PARAM, None)
+        inbytes = <uint8_t*><const char*>pyin
+        outbytes = NULL
+        nbytes = 0
+        if not PMIx_Data_decompress(inbytes, len(pyin), &outbytes, &nbytes):
+            return (PMIX_ERR_NOT_AVAILABLE, None)
+        if NULL == outbytes or 0 == nbytes:
+            return (PMIX_ERR_NOT_AVAILABLE, None)
+        blist = []
+        pmix_unload_bytes(<char*>outbytes, nbytes, blist)
+        free(outbytes)
+        return (PMIX_SUCCESS, bytes(bytearray(blist)))
+
     def fabric_register(self, dicts):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr

--- a/docs/man/man3/PMIx_App_string.3.rst
+++ b/docs/man/man3/PMIx_App_string.3.rst
@@ -18,6 +18,19 @@ SYNOPSIS
    char* PMIx_App_string(const pmix_app_t *app);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the app is a Python ``pmix_app_t`` dictionary, as spawn() takes
+  pyapp = {'cmd': "hello", 'argv': ["hello", "world"],
+           'maxprocs': 4, 'info': []}
+  rc, txt = foo.app_string(pyapp)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_compress.3.rst
+++ b/docs/man/man3/PMIx_Data_compress.3.rst
@@ -22,6 +22,20 @@ SYNOPSIS
                            size_t *nbytes);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the C API answers a bool - whether it compressed the block at all.
+  # That is reported here as PMIX_SUCCESS or PMIX_ERR_NOT_AVAILABLE so
+  # the return keeps the usual (rc, data) shape
+  rc, compressed = foo.data_compress(b'a big block of bytes')
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_copy.3.rst
+++ b/docs/man/man3/PMIx_Data_copy.3.rst
@@ -19,6 +19,19 @@ SYNOPSIS
                                 pmix_data_type_t type);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the source is a value or info dictionary; the type is deduced from
+  # the presence of a 'key'
+  rc, copy = foo.data_copy({'value': 42, 'val_type': PMIX_INT32})
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_copy_payload.3.rst
+++ b/docs/man/man3/PMIx_Data_copy_payload.3.rst
@@ -19,6 +19,21 @@ SYNOPSIS
                                         pmix_data_buffer_t *src);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # a Python data buffer is a dict mirroring the fields of a
+  # pmix_data_buffer_t that mean anything on this side - the payload,
+  # and how far the unpack cursor has advanced through it. There is
+  # nothing to create or release: the dict is the buffer
+  rc, dest = foo.data_copy_payload(dest, src)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_decompress.3.rst
+++ b/docs/man/man3/PMIx_Data_decompress.3.rst
@@ -22,6 +22,17 @@ SYNOPSIS
                              size_t *nbytes);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  rc, original = foo.data_decompress(compressed)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_embed.3.rst
+++ b/docs/man/man3/PMIx_Data_embed.3.rst
@@ -20,6 +20,20 @@ SYNOPSIS
                                  const pmix_byte_object_t *payload);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # as data_load, except that the library copies the payload rather
+  # than taking ownership of it
+  payload = {'bytes': b'...', 'size': 5}
+  rc, buf = foo.data_embed(None, payload)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_load.3.rst
+++ b/docs/man/man3/PMIx_Data_load.3.rst
@@ -20,6 +20,19 @@ SYNOPSIS
                                 pmix_byte_object_t *payload);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the payload is a Python ``pmix_byte_object_t`` dictionary
+  payload = {'bytes': b'...', 'size': 5}
+  rc, buf = foo.data_load(None, payload)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_pack.3.rst
+++ b/docs/man/man3/PMIx_Data_pack.3.rst
@@ -22,6 +22,26 @@ SYNOPSIS
                                 pmix_data_type_t type);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # a Python data buffer is a dict mirroring the fields of a
+  # pmix_data_buffer_t that mean anything on this side - the payload,
+  # and how far the unpack cursor has advanced through it. There is
+  # nothing to create or release: the dict is the buffer
+  # passing None for the buffer starts a new one; the type is deduced
+  # from the presence of a 'key'
+  rc, buf = foo.data_pack(None, {'value': 42, 'val_type': PMIX_INT32})
+  rc, buf = foo.data_pack(buf, {'key': PMIX_JOB_SIZE, 'value': 4,
+                                'val_type': PMIX_UINT32})
+  # buf is now {'bytes': b'...', 'bytes_used': n, 'bytes_unpacked': 0}
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_unload.3.rst
+++ b/docs/man/man3/PMIx_Data_unload.3.rst
@@ -20,6 +20,19 @@ SYNOPSIS
                                   pmix_byte_object_t *payload);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # the buffer is emptied, and its unread payload handed back as a
+  # Python ``pmix_byte_object_t`` dictionary
+  rc, payload = foo.data_unload(buf)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Data_unpack.3.rst
+++ b/docs/man/man3/PMIx_Data_unpack.3.rst
@@ -22,6 +22,23 @@ SYNOPSIS
                                   pmix_data_type_t type);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # ... after a successful foo.init() ...
+  # a Python data buffer is a dict mirroring the fields of a
+  # pmix_data_buffer_t that mean anything on this side - the payload,
+  # and how far the unpack cursor has advanced through it. There is
+  # nothing to create or release: the dict is the buffer
+  # the buffer is updated in place, so successive calls walk the payload
+  rc, value = foo.data_unpack(buf, PMIX_VALUE)
+  rc, info = foo.data_unpack(buf, PMIX_INFO)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Info_string.3.rst
+++ b/docs/man/man3/PMIx_Info_string.3.rst
@@ -18,6 +18,18 @@ SYNOPSIS
    char* PMIx_Info_string(const pmix_info_t *info);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the info is a Python ``pmix_info_t`` dictionary
+  pyinfo = {'key': PMIX_JOB_SIZE, 'value': 4, 'val_type': PMIX_UINT32}
+  rc, txt = foo.info_string(pyinfo)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Proc_string.3.rst
+++ b/docs/man/man3/PMIx_Proc_string.3.rst
@@ -18,6 +18,18 @@ SYNOPSIS
    char* PMIx_Proc_string(const pmix_proc_t *proc);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the proc is a Python ``pmix_proc_t`` dictionary
+  pyproc = {'nspace': "testnspace", 'rank': 0}
+  rc, txt = foo.proc_string(pyproc)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Resource_unit_string.3.rst
+++ b/docs/man/man3/PMIx_Resource_unit_string.3.rst
@@ -18,6 +18,18 @@ SYNOPSIS
    char* PMIx_Resource_unit_string(const pmix_resource_unit_t *unit);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the unit is a Python ``pmix_resource_unit_t`` dictionary
+  pyunit = {'type': PMIX_DEVTYPE_GPU, 'count': 4}
+  rc, txt = foo.resource_unit_string(pyunit)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_Value_string.3.rst
+++ b/docs/man/man3/PMIx_Value_string.3.rst
@@ -18,6 +18,18 @@ SYNOPSIS
    char* PMIx_Value_string(const pmix_value_t *value);
 
 
+Python Syntax
+^^^^^^^^^^^^^
+
+.. code-block:: python3
+
+  from pmix import *
+
+  foo = PMIxClient()
+  # the value is a Python ``pmix_value_t`` dictionary
+  pyval = {'value': 42, 'val_type': PMIX_INT32}
+  rc, txt = foo.value_string(pyval)
+
 INPUT PARAMETERS
 ----------------
 

--- a/docs/man/man3/PMIx_tool_set_server_module.3.rst
+++ b/docs/man/man3/PMIx_tool_set_server_module.3.rst
@@ -67,6 +67,11 @@ acts as a server.
 The module may be set only once. A second call, after a module has already
 been installed, is rejected.
 
+``PMIx_tool_set_server_module`` must be called **after**
+:ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`. Marking the caller as a
+server requires a peer object, which does not exist until the library has
+been initialized; a call made before then returns ``PMIX_ERR_INIT``.
+
 
 CALLBACK FUNCTION
 -----------------

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,46 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Fixed PMIxTool.set_server_module in the Python bindings, which built
+   its server-function module and returned PMIX_SUCCESS without ever
+   handing it to the library - so a Python tool acting as a server had
+   the handlers it registered silently never invoked. It now calls
+   PMIx_tool_set_server_module and reports what the library says
+ - PMIx_tool_set_server_module no longer segfaults when called before
+   PMIx_tool_init. It marks the caller's peer as a server, and there is
+   no peer until the library has been initialized; it now returns
+   PMIX_ERR_INIT, and rejects a NULL module
+ - Fixed a segmentation fault in PMIx_tool_finalize for any tool that
+   became a server after initializing. PMIx_tool_init opens the
+   fork/exec framework only for a launcher or a scheduler, but the
+   finalize path tore it down for a launcher or a *server* - and a plain
+   tool becomes a server precisely by calling
+   PMIx_tool_set_server_module. Finalize then walked a children list
+   that was never constructed. The framework now records whether it was
+   opened, its close is a no-op if it was not, and finalize checks that
+   rather than the peer type
+ - Added Python bindings for the five struct pretty-printers -
+   info_string, value_string, proc_string, app_string and
+   resource_unit_string. These render a whole struct the way the library
+   itself does, which a Python program cannot reproduce by printing a
+   dict, and each has its own man page; they had been swept out of scope
+   by a prefix rule aimed at the construct/free helper families
+ - Added Python bindings for the serialization APIs - data_pack,
+   data_unpack, data_copy, data_copy_payload, data_load, data_unload,
+   data_embed, data_compress and data_decompress. A data buffer crosses
+   as the dict {'bytes': ..., 'bytes_used': n, 'bytes_unpacked': m},
+   mirroring the fields of a pmix_data_buffer_t that mean anything on
+   the Python side; the three raw pointers the struct also carries are
+   rebuilt from those offsets on each call. There is no buffer object to
+   create or release, and because the whole state is a payload plus an
+   offset, a buffer can be stored or sent somewhere as ordinary bytes
+   and picked up again
+ - Fixed the Python conversion layer returning signed bytes. Payloads
+   were read through a char pointer, which is signed on most platforms,
+   so any byte at or above 0x80 arrived as a negative number and
+   bytearray() rejected the whole buffer with "byte must be in
+   range(0, 256)". Every non-ASCII payload hit this - credentials,
+   forwarded I/O, a packed buffer
  - Completed the Python bindings for the non-blocking APIs. The twenty
    remaining _nb entry points - fence_nb, get_nb, publish_nb, lookup_nb,
    unpublish_nb, spawn_nb, connect_nb, disconnect_nb, query_nb, log_nb,

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -105,13 +105,20 @@ pmix_pfexec_globals_t pmix_pfexec_globals = {
 
 int pmix_pfexec_base_close(void)
 {
+    /* nothing to tear down if we were never opened - the children list
+     * has not been constructed, so destructing it would walk garbage */
+    if (!pmix_pfexec_globals.initialized) {
+        return PMIX_SUCCESS;
+    }
     if (pmix_pfexec_globals.active) {
         pmix_event_del(pmix_pfexec_globals.handler);
         pmix_pfexec_globals.active = false;
     }
     PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
     free(pmix_pfexec_globals.handler);
+    pmix_pfexec_globals.handler = NULL;
     pmix_pfexec_globals.selected = false;
+    pmix_pfexec_globals.initialized = false;
 
     return PMIX_SUCCESS;
 }
@@ -183,6 +190,7 @@ int pmix_pfexec_base_open(void)
     /* setup the list of children */
     PMIX_CONSTRUCT(&pmix_pfexec_globals.children, pmix_list_t);
     pmix_pfexec_globals.nextid = 1;
+    pmix_pfexec_globals.initialized = true;
 
     /* Open up all available components */
     return PMIX_SUCCESS;

--- a/src/common/pmix_pfexec.h
+++ b/src/common/pmix_pfexec.h
@@ -66,6 +66,11 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_child_t);
 typedef struct {
     pmix_event_t *handler;
     bool active;
+    /* set by pmix_pfexec_base_open, cleared by pmix_pfexec_base_close.
+     * The children list below only exists between those two calls, and
+     * not every role opens this framework, so anything that walks or
+     * tears down that list must check this first */
+    bool initialized;
     pmix_list_t children;
     int timeout_before_sigkill;
     size_t nextid;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1455,6 +1455,16 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
 
 pmix_status_t PMIx_tool_set_server_module(pmix_server_module_t *module)
 {
+    /* we have no peer to mark as a server until the tool library has
+     * been initialized, so refuse rather than dereference a NULL */
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
+
+    if (NULL == module) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_server_globals.module_set) {
         pmix_show_help("help-pmix-runtime.txt", "module-set", true,
                        __func__);
@@ -1575,8 +1585,14 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         pmix_output_verbose(2, pmix_globals.debug_output, "pmix:tool finalize sync received");
     }
 
-    if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) ||
-        PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
+    /* Note the check on the pfexec framework itself rather than on our
+     * peer type. Init only opens it for a launcher or scheduler, but a
+     * plain tool can become a server after the fact by calling
+     * PMIx_tool_set_server_module - and then this branch would walk a
+     * children list that was never constructed */
+    if (pmix_pfexec_globals.initialized &&
+        (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) ||
+         PMIX_PEER_IS_SERVER(pmix_globals.mypeer))) {
         /* if we have launched children, then we need to cleanly
          * terminate them - do this before stopping our progress
          * thread as we need it for terminating procs */

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -201,6 +201,88 @@ def main():
     (rc, txt) = foo.data_print("VALUE: ", {'value': 42, 'val_type': PMIX_INT32})
     print("DataPrint: ", foo.error_string(rc), txt)
 
+    # render each of the structs the library knows how to print
+    aval = {'value': 42, 'val_type': PMIX_INT32}
+    ainfo = {'key': PMIX_JOB_SIZE, 'value': 4, 'val_type': PMIX_UINT32}
+    aproc = {'nspace': "testnspace", 'rank': 0}
+    anapp = {'cmd': "/bin/true", 'argv': ["true"], 'maxprocs': 1, 'info': []}
+    aunit = {'type': PMIX_DEVTYPE_GPU, 'count': 2}
+    for (label, result) in [("ValueString", foo.value_string(aval)),
+                            ("InfoString", foo.info_string(ainfo)),
+                            ("ProcString", foo.proc_string(aproc)),
+                            ("AppString", foo.app_string(anapp)),
+                            ("UnitString", foo.resource_unit_string(aunit))]:
+        (rc, txt) = result
+        print("%s: %s %s" % (label, foo.error_string(rc), repr(txt)))
+        if PMIX_SUCCESS != rc or txt is None:
+            print("%s FAILED" % label)
+            exit(1)
+
+    # exercise the serialization family. A Python data buffer is just a
+    # dict, so the round trip below also proves that a buffer can be
+    # carried as ordinary bytes and picked up again
+    sval = {'value': "hello world", 'val_type': PMIX_STRING}
+    (rc, buf) = foo.data_pack(None, aval)
+    if PMIX_SUCCESS == rc:
+        (rc, buf) = foo.data_pack(buf, sval)
+    if PMIX_SUCCESS == rc:
+        (rc, buf) = foo.data_pack(buf, ainfo)
+    print("DataPack: ", foo.error_string(rc), buf)
+    if PMIX_SUCCESS != rc:
+        print("DATA PACK FAILED")
+        exit(1)
+
+    # a fresh buffer built from nothing but the payload bytes must unpack
+    # to exactly what went in, in order
+    wire = {'bytes': buf['bytes'], 'bytes_used': buf['bytes_used'],
+            'bytes_unpacked': 0}
+    (rc, v1) = foo.data_unpack(wire, PMIX_VALUE)
+    (rc2, v2) = foo.data_unpack(wire, PMIX_VALUE)
+    (rc3, v3) = foo.data_unpack(wire, PMIX_INFO)
+    print("DataUnpack: ", foo.error_string(rc), v1, v2, v3)
+    if PMIX_SUCCESS != rc or PMIX_SUCCESS != rc2 or PMIX_SUCCESS != rc3:
+        print("DATA UNPACK FAILED")
+        exit(1)
+    # the constants are bytes while an unpacked key comes back as str
+    wantkey = ainfo['key']
+    if isinstance(wantkey, bytes):
+        wantkey = wantkey.decode('ascii')
+    if v1['value'] != aval['value'] or v2['value'] != sval['value'] \
+       or v3['key'] != wantkey or v3['value'] != ainfo['value']:
+        print("DATA UNPACK ROUND TRIP MISMATCH")
+        exit(1)
+    # and the buffer is now drained
+    (rc, extra) = foo.data_unpack(wire, PMIX_VALUE)
+    if PMIX_SUCCESS == rc:
+        print("DATA UNPACK RETURNED DATA PAST THE END")
+        exit(1)
+
+    # unload the payload out of a buffer and load it into another
+    (rc, buf2) = foo.data_pack(None, aval)
+    (rc, payload) = foo.data_unload(buf2)
+    print("DataUnload: ", foo.error_string(rc), payload, "buffer now", buf2)
+    if PMIX_SUCCESS != rc or 0 == payload['size']:
+        print("DATA UNLOAD FAILED")
+        exit(1)
+    (rc, buf3) = foo.data_load(None, payload)
+    (rc2, back) = foo.data_unpack(buf3, PMIX_VALUE)
+    print("DataLoad: ", foo.error_string(rc), back)
+    if PMIX_SUCCESS != rc or PMIX_SUCCESS != rc2 or back['value'] != aval['value']:
+        print("DATA LOAD ROUND TRIP FAILED")
+        exit(1)
+
+    # every byte value has to survive the crossing, not just ASCII
+    blob = bytes(range(256))
+    (rc, comp) = foo.data_compress(blob * 32)
+    print("DataCompress: ", foo.error_string(rc),
+          None if comp is None else len(comp))
+    if PMIX_SUCCESS == rc:
+        (rc, back) = foo.data_decompress(comp)
+        if PMIX_SUCCESS != rc or bytes(back) != blob * 32:
+            print("COMPRESSION ROUND TRIP FAILED")
+            exit(1)
+        print("DataDecompress: round trip verified")
+
     # register a client
     uid = os.getuid()
     gid = os.getgid()

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -789,6 +789,149 @@ class TestClientNonBlocking(unittest.TestCase):
                          pmix.PMIX_ERR_INIT)
 
 
+class TestStructPrinters(unittest.TestCase):
+    """The struct pretty-printers.
+
+    Unlike the *_string converters, which translate one enumerated value,
+    these render a whole struct.  They touch no library state, so - like the
+    converters - they are fully testable without a server.
+    """
+
+    VALUE = {'value': 42, 'val_type': pmix.PMIX_INT32}
+    INFO = {'key': "pmix.job.size", 'value': 4, 'val_type': pmix.PMIX_UINT32}
+    PROC = {'nspace': "testnspace", 'rank': 3}
+    APP = {'cmd': "/bin/true", 'argv': ["true", "-x"], 'env': ["FOO=bar"],
+           'maxprocs': 2, 'info': []}
+    UNIT = {'type': pmix.PMIX_DEVTYPE_GPU, 'count': 4}
+
+    #: name, argument, a substring the rendering must contain
+    CASES = (
+        ("value_string", VALUE, "42"),
+        ("info_string", INFO, "pmix.job.size"),
+        ("proc_string", PROC, "testnspace"),
+        ("app_string", APP, "/bin/true"),
+        ("resource_unit_string", UNIT, "4"),
+    )
+
+    def setUp(self):
+        self.client = pmix.PMIxClient()
+
+    def test_renders_the_struct(self):
+        for name, arg, needle in self.CASES:
+            rc, txt = getattr(self.client, name)(arg)
+            self.assertEqual(rc, pmix.PMIX_SUCCESS, "%s returned %s" % (name, rc))
+            self.assertIsInstance(txt, str, "%s did not return a str" % name)
+            self.assertIn(needle, txt, "%s rendered %r" % (name, txt))
+
+    def test_rejects_non_dict(self):
+        for name, _, _ in self.CASES:
+            for bad in (None, "not-a-dict", 7, []):
+                rc, txt = getattr(self.client, name)(bad)
+                self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM,
+                                 "%s accepted %r" % (name, bad))
+                self.assertIsNone(txt)
+
+    def test_info_requires_a_key(self):
+        # an info without a key is a value, not an info
+        rc, txt = self.client.info_string({'value': 1,
+                                           'val_type': pmix.PMIX_INT32})
+        self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
+        self.assertIsNone(txt)
+
+    def test_repeated_calls_are_stable(self):
+        # each of these builds a struct, renders it, and has to release
+        # both the struct and the string the library allocated
+        for _ in range(200):
+            for name, arg, _ in self.CASES:
+                rc, txt = getattr(self.client, name)(arg)
+                self.assertEqual(rc, pmix.PMIX_SUCCESS)
+
+
+class TestDataBindings(unittest.TestCase):
+    """The serialization family.
+
+    A Python data buffer is a dict, so these need no C object to be created
+    or released - but every one of them does need an initialized library, so
+    without a server all that can be checked here is that they marshal their
+    arguments, refuse cleanly, and release what they built.  The round trip
+    itself is exercised in server.py, which has a live library.
+    """
+
+    VALUE = {'value': 42, 'val_type': pmix.PMIX_INT32}
+    INFO = {'key': "pmix.job.size", 'value': 4, 'val_type': pmix.PMIX_UINT32}
+    BUF = {'bytes': b"abcd", 'bytes_used': 4, 'bytes_unpacked': 0}
+    PAYLOAD = {'bytes': b"payload", 'size': 7}
+
+    def setUp(self):
+        self.client = pmix.PMIxClient()
+
+    def test_methods_present(self):
+        for name in ("data_pack", "data_unpack", "data_copy",
+                     "data_copy_payload", "data_load", "data_unload",
+                     "data_embed", "data_compress", "data_decompress"):
+            self.assertTrue(hasattr(pmix.PMIxClient, name),
+                            "PMIxClient.%s missing" % name)
+
+    def test_error_before_init(self):
+        # the library refuses every one of these until it is initialized;
+        # what matters is that they report it rather than crashing
+        self.assertEqual(self.client.data_pack(None, self.VALUE)[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_pack(dict(self.BUF), self.INFO)[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_unpack(dict(self.BUF))[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_copy(self.VALUE)[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(
+            self.client.data_copy_payload(None, dict(self.BUF))[0],
+            pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_unload(dict(self.BUF))[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_load(None, self.PAYLOAD)[0],
+                         pmix.PMIX_ERR_INIT)
+        self.assertEqual(self.client.data_embed(None, self.PAYLOAD)[0],
+                         pmix.PMIX_ERR_INIT)
+
+    def test_bad_arguments_rejected(self):
+        # arguments the binding polices itself, before the library is asked
+        self.assertEqual(self.client.data_pack(None, None)[0],
+                         pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(self.client.data_pack("not-a-buffer", self.VALUE)[0],
+                         pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.data_pack(None, self.VALUE, pmix.PMIX_PROC)[0],
+            pmix.PMIX_ERR_NOT_SUPPORTED)
+        self.assertEqual(self.client.data_unpack(None)[0],
+                         pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(
+            self.client.data_unpack(dict(self.BUF), pmix.PMIX_PROC)[0],
+            pmix.PMIX_ERR_NOT_SUPPORTED)
+        self.assertEqual(self.client.data_copy(None)[0],
+                         pmix.PMIX_ERR_BAD_PARAM)
+        self.assertEqual(self.client.data_unload(None)[0],
+                         pmix.PMIX_ERR_BAD_PARAM)
+        for bad in (None, b""):
+            self.assertEqual(self.client.data_compress(bad)[0],
+                             pmix.PMIX_ERR_BAD_PARAM)
+            self.assertEqual(self.client.data_decompress(bad)[0],
+                             pmix.PMIX_ERR_BAD_PARAM)
+
+    def test_buffer_dict_is_not_corrupted(self):
+        # a refused call must leave the caller's buffer readable
+        buf = dict(self.BUF)
+        self.client.data_pack(buf, self.VALUE)
+        self.assertEqual(buf['bytes'], b"abcd")
+        self.assertEqual(buf['bytes_unpacked'], 0)
+
+    def test_repeated_calls_are_stable(self):
+        for _ in range(200):
+            self.client.data_pack(dict(self.BUF), self.VALUE)
+            self.client.data_unpack(dict(self.BUF), pmix.PMIX_VALUE)
+            self.client.data_load(None, self.PAYLOAD)
+            self.client.data_embed(None, self.PAYLOAD)
+
+
 class TestToolServerModule(unittest.TestCase):
     """PMIxTool.set_server_module.
 

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -789,5 +789,31 @@ class TestClientNonBlocking(unittest.TestCase):
                          pmix.PMIX_ERR_INIT)
 
 
+class TestToolServerModule(unittest.TestCase):
+    """PMIxTool.set_server_module.
+
+    The method used to populate its module struct and return PMIX_SUCCESS
+    without ever handing it to the library, so a tool's handlers were never
+    called.  It now reports what the library says - which, before
+    PMIx_tool_init, is that there is no library to give it to.
+    """
+
+    @staticmethod
+    def _handler(request, cbfunc, cbdata):
+        return pmix.PMIX_SUCCESS
+
+    def test_refused_before_init(self):
+        # this used to segfault: the C entry point marked our peer as a
+        # server without checking that we had one
+        tool = pmix.PMIxTool()
+        rc = tool.set_server_module({'clientconnected': self._handler})
+        self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_empty_map_refused(self):
+        tool = pmix.PMIxTool()
+        self.assertEqual(tool.set_server_module({}), pmix.PMIX_ERR_INIT)
+        self.assertEqual(tool.set_server_module(None), pmix.PMIX_ERR_INIT)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
A sweep of the public headers — all 307 exported `PMIx_*` functions
across `pmix.h`, `pmix_common.h.in`, `pmix_server.h`, `pmix_tool.h` and
`pmix_deprecated.h`, each checked for a call site in `pmix.pyx`/`pmix.pxi`
— turned up one method that never called the library, two families that
a prefix rule had wrongly classed as out of scope, and three defects
that fell out of fixing them.

### Four commits

**`tool: make a tool that becomes a server survive finalize`** — two
library defects on the path a tool takes when it calls
`PMIx_tool_set_server_module`, which is how a launcher or workflow
orchestrator services its own children while remaining a tool with
respect to the server above it. Neither is Python-specific; a C tool
that inits, sets a server module, and finalizes hits both.

- `PMIx_tool_set_server_module` marks the caller's peer as a server, and
  `pmix_globals.mypeer` is NULL until `PMIx_tool_init` — so a call before
  init dereferenced NULL. It now returns `PMIX_ERR_INIT`, and rejects a
  NULL module.
- `PMIx_tool_init` opens the fork/exec framework only for a launcher or
  a scheduler, but `PMIx_tool_finalize` tears it down for a launcher or
  a **server** — and a plain tool becomes a server precisely by calling
  `PMIx_tool_set_server_module`. Finalize then walked a children list
  that was never constructed and crashed. The framework now records
  whether it was opened, its close is a no-op when it was not, and
  finalize checks that rather than the peer type.

**`python: hand the tool's server module to the library`** —
`PMIxTool.set_server_module` validated its map, recorded the handlers,
wired the trampolines into its own `pmix_server_module_t`, and returned
`PMIX_SUCCESS` **without ever calling `PMIx_tool_set_server_module`**.
The module never reached `libpmix`, so a Python tool acting as a server
had every handler it registered silently never invoked, with nothing in
the return value to suggest it.

**`python: return unsigned bytes from the conversion layer`** —
`pmix_unload_bytes` read the payload through a `char *`, which is signed
on most platforms, so every byte at or above `0x80` arrived as a negative
number and the `bytearray()` each caller builds rejected the whole list
with `byte must be in range(0, 256)`. Any non-ASCII payload hits this: a
credential from `get_credential`, forwarded I/O, a byte object in a
value. It is also what made `data_compress` fail on its first real input.

**`python: bind the struct printers and the serialization APIs`** — the
new bindings themselves.

### The struct printers

`info_string`, `value_string`, `proc_string`, `app_string`,
`resource_unit_string`. These are converters — peers of the
already-bound `data_print` — rather than members of the
`construct`/`destruct` helper families their prefixes put them in. Each
has its own man page, and each renders a struct the way the library
itself does, which a Python program cannot reproduce by printing a dict.
They touch no library state, so they work before `init()`.

### The serialization APIs

`data_pack`, `data_unpack`, `data_copy`, `data_copy_payload`,
`data_load`, `data_unload`, `data_embed`, `data_compress`,
`data_decompress`.

These had been left out for want of a Python shape for
`pmix_data_buffer_t`. That struct holds three raw pointers into one
allocation plus two sizes, but only two of those five fields mean
anything on this side of the boundary — the payload, and how far the
unpack cursor has advanced through it — so a Python data buffer is

```python
{'bytes': b'...', 'bytes_used': n, 'bytes_unpacked': m}
```

and the pointers are rebuilt from those offsets on each crossing. Three
consequences:

- **Nothing has to be created or released.** The dict *is* the buffer and
  the C storage lives only for the duration of a call, which is why the
  `PMIx_Data_buffer_*` helpers stay unbound.
- **A buffer is ordinary bytes.** It can be stored, sent somewhere, and
  picked up again by rebuilding the dict — the round trip added to
  `server.py` does exactly that.
- **The library's own `PMIx_Data_buffer_load` cannot be used** by the
  conversion layer: it routes through `PMIx_Data_load`, which refuses to
  run before `PMIx_Init` *and discards its status*, so a pre-init caller
  would silently get an empty buffer rather than an error.

As with `data_print`, the payload a Python caller can build is a value
dict or an info dict, deduced from the presence of a `'key'`.
`data_compress`/`data_decompress` answer a C `bool` — whether the library
compressed the block at all — reported as `PMIX_SUCCESS` or
`PMIX_ERR_NOT_AVAILABLE` so the return keeps the usual `(rc, data)`
shape.

### Testing

- `make check`: 78/78 pass, no regressions.
- `test_bindings.py` gains `TestStructPrinters`, `TestDataBindings` and
  `TestToolServerModule` — rendering, argument validation, the pre-init
  refusal for everything that needs a live library, and 200-iteration
  loops so a leak or double free would show.
- `server.py` gains a live round trip against an initialized library:
  three values packed and unpacked in order, a buffer reconstructed from
  nothing but its payload bytes, `data_unload` → `data_load` → unpack,
  and an 8 KB compress/decompress verified byte-identical. All 256 byte
  values survive a pack/unpack round trip.
- The tool path was verified end to end: init → `set_server_module` →
  finalize now completes, where it previously segfaulted at both the
  second and third step.
- Docs build warning-free; library builds warning-free under
  `--enable-devel-check`.

Man pages for all fourteen newly bound APIs gain a Python Syntax section,
and `PMIx_tool_set_server_module` gains a note that it must follow
`PMIx_tool_init`.

Tested on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)