### PR TITLE
Return the data a partial lookup found

### DIFF
--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -542,6 +542,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     /* set the defaults */
     pdata = NULL;
     ndata = 0;
+    ret = PMIX_SUCCESS;
 
     if (NULL == cb->cbfunc.lookupfn) {
         /* nothing we can do with this */
@@ -549,13 +550,13 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         return;
     }
     if (NULL == buf) {
-        rc = PMIX_ERR_BAD_PARAM;
+        ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */
     if (PMIX_BUFFER_IS_EMPTY(buf)) {
-        rc = PMIX_ERR_UNREACH;
+        ret = PMIX_ERR_UNREACH;
         goto report;
     }
 
@@ -565,13 +566,15 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
+        goto report;
     }
-    if (PMIX_SUCCESS != ret) {
-        if (NULL != cb->cbfunc.lookupfn) {
-            cb->cbfunc.lookupfn(ret, NULL, 0, cb->cbdata);
-        }
-        PMIX_RELEASE(cb);
-        return;
+    /* PMIX_ERR_PARTIAL_SUCCESS is a data-carrying status: the server found
+     * some of the requested keys and is returning them alongside it. Treating
+     * every non-SUCCESS status as "no data" discarded exactly those values -
+     * and lookup_cbfunc() below explicitly handles PARTIAL_SUCCESS, so it
+     * could never see them. */
+    if (PMIX_SUCCESS != ret && PMIX_ERR_PARTIAL_SUCCESS != ret) {
+        goto report;
     }
 
     /* unpack the number of returned values */
@@ -579,8 +582,9 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ndata, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(cb);
-        return;
+        ret = rc;
+        ndata = 0;
+        goto report;
     }
     if (0 < ndata) {
         /* create the array storage */
@@ -590,17 +594,25 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, pdata, &cnt, PMIX_PDATA);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            goto cleanup;
+            /* report the failure rather than falling into cleanup: that
+             * path never invoked the callback, so the caller waited on its
+             * lock forever. pdata is left for cleanup to free - the
+             * callback ignores it for a failing status. */
+            ret = rc;
+            goto report;
         }
     }
 
 report:
     if (NULL != cb->cbfunc.lookupfn) {
-        cb->cbfunc.lookupfn(rc, pdata, ndata, cb->cbdata);
+        /* hand back the status the SERVER returned, not the status of our
+         * last unpack - they are both PMIX_SUCCESS on the path that used to
+         * reach here, which is why reporting the wrong one went unnoticed */
+        cb->cbfunc.lookupfn(ret, pdata, ndata, cb->cbdata);
     }
 
-cleanup:
-    /* cleanup */
+    /* cleanup - every exit now runs the callback first and falls through
+     * here, so there is nothing left to jump to */
     if (NULL != pdata) {
         PMIX_PDATA_FREE(pdata, ndata);
     }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3842,7 +3842,11 @@ static void _lkupcbfunc(int sd, short args, void *cbdata)
             PMIX_RELEASE(reply);
             goto cleanup;
         }
-        PMIX_PDATA_FREE(scd->pdata, scd->npdata);
+        /* the array was created with ndata, and npdata is never assigned
+         * anywhere - it is zero from the constructor, and PMIx_Pdata_free()
+         * does nothing at all for a count of zero, so this leaked the whole
+         * array and every value in it on every lookup that returned data */
+        PMIX_PDATA_FREE(scd->pdata, scd->ndata);
     }
 
     /* the function that created the server_caddy did a


### PR DESCRIPTION
### Problem

`PMIx_Lookup` can legitimately answer `PMIX_ERR_PARTIAL_SUCCESS`: the server found some of
the requested keys and is returning them alongside that status. `lookup_cbfunc()` is
written for exactly that — it walks the returned array when the status is `PMIX_SUCCESS`
**or** `PMIX_ERR_PARTIAL_SUCCESS`, and carries a comment explaining that the transfer
result must not be folded into the status lest it mask a partial return.

It could never see that array. `wait_lookup_cbfunc()`, which unpacks the server's reply,
treated every status other than `PMIX_SUCCESS` as carrying no data and answered the
callback with `(status, NULL, 0)` before it ever reached the payload:

```c
    if (PMIX_SUCCESS != ret) {
        if (NULL != cb->cbfunc.lookupfn) {
            cb->cbfunc.lookupfn(ret, NULL, 0, cb->cbdata);
        }
        PMIX_RELEASE(cb);
        return;
    }
```

So a partial lookup reported itself as partial and returned nothing, and the caller had no
way to obtain the keys the server had in fact found. A correct server still produced an
empty answer.

### What this changes

* Let `PMIX_ERR_PARTIAL_SUCCESS` through to the unpack.
* Hand the callback the status the **server** returned rather than the status of our own
  last unpack. The `report:` label was passing `rc`. The two agree only on the path that
  used to reach it, which is why reporting the wrong one went unnoticed — but it becomes
  wrong as soon as a non-`SUCCESS` status flows through.

Two adjacent defects on the same path:

* A failure to unpack the returned values jumped to the `cleanup` label **without ever
  invoking the callback**, so a blocking `PMIx_Lookup` waited on its lock forever. It now
  reports the error.
* The server side freed the packed pdata array with `scd->npdata`, which is never assigned
  anywhere and is therefore always zero from the constructor. `PMIx_Pdata_free()` does
  nothing at all for a count of zero, so the whole array and every value in it leaked on
  every lookup that returned data. It is created with `scd->ndata`; free it with the same.

### Testing

Found while giving PRRTE's publish/lookup data server (`src/runtime/data_server`) its first
multi-node coverage — PRRTE had a mirror-image bug where `ds_lookup` set the partial status
and then returned without sending the values it had found. Fixing that alone changed
nothing observable, because the client discarded the payload regardless.

Verified with a PMIx client that looks up two keys with only one published, so the lookup
is necessarily partial:

```
$ prun -n 1 ./dataserver lookup2 k1 absent 10
FOUND k1 hello (from prte-Mac-33044@1:0)
STATUS PMIX_ERR_PARTIAL_SUCCESS
```

Before: the `STATUS` line alone, with no `FOUND`.

Run natively on macOS and across a 10-node container DVM (publisher and requestor on
different nodes, so the reply crosses a real daemon hop), on this commit rebased onto
current master. The full PRRTE test suite passes against it. That probe is now a permanent
case in PRRTE's `contrib/dockerswarm` suite and asserts on the returned value, not just the
status.
