### PR TITLE
Reclaim a stale rendezvous file instead of refusing to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,7 @@ test/unit/event_chain
 test/unit/hwloc_datatype
 test/unit/progress_threads
 test/unit/info_support
+test/unit/rndz_stale
 test/unit/singleton_register
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,12 +476,17 @@ successfully.
 	Use the wrapper when working in an uninstalled tree; `./simptest`
 	itself is still the right thing to run against an installed PMIx.
 
-	**A stale `$TMPDIR` will fail these tests for reasons that have
+	**A stale `$TMPDIR` can fail these tests for reasons that have
 	nothing to do with your change.** A PMIx server drops a session
 	directory and rendezvous files under `$TMPDIR` and removes them at
 	finalize. A run that is killed, crashes, or times out leaves its
-	`pmix-*` / `pmix.*` entries behind, and once enough of them
-	accumulate a subsequent server fails to start its listener:
+	`pmix-*` / `pmix.*` entries behind. A leftover *rendezvous* file no
+	longer blocks a restart — the listener now reads the pid the file
+	records and reclaims the file if that process is gone — but the
+	session directories and tool connection files still accumulate, and
+	they can confuse a tool trying to discover which server to connect
+	to. When a server does fail to start, it says so specifically (e.g.,
+	naming the file and the live process that owns it); the generic
 
 	```
 	--------------------------------------------------------------------
@@ -491,12 +496,12 @@ successfully.
 	Init failed with error PMIX_ERR_INIT
 	```
 
-	Every `simptest`-based test then fails together — all the group
-	tests, `run_simpcycle.pl`, `run_toolcycle.pl`, `run_monitor.pl` and
-	so on — which looks alarming and is purely environmental. This is a
-	**known issue**; it is a property of the leftovers, not of the tree.
-	Before investigating a wholesale failure of the server-based tests,
-	rerun under a clean directory:
+	now means what it says — look at sockets and interfaces, not at
+	`$TMPDIR`. Every `simptest`-based test failing together — all the
+	group tests, `run_simpcycle.pl`, `run_toolcycle.pl`,
+	`run_monitor.pl` and so on — still looks alarming and is still
+	usually environmental. Before investigating a wholesale failure of
+	the server-based tests, rerun under a clean directory:
 
 	```sh
 	TMPDIR=$(mktemp -d) make check

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,19 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Fixed a server taking the scheduler, system-controller or system-tool
+   role being unable to restart after it was killed or crashed. Those
+   roles publish a rendezvous file that is removed only by a clean
+   finalize, and the listener treated any pre-existing file as fatal -
+   so an orphaned file left by the dead server blocked the next one
+   until someone deleted it by hand, and the failure was reported as
+   "the listener thread failed to start", which points at sockets rather
+   than at a leftover file. The file records the pid that wrote it, so
+   the listener now reclaims a file whose owner is gone (or that carries
+   no usable pid, as happens when its creator died partway thru writing
+   it). A file whose owner is still running is left untouched, and the
+   init fails with a message naming the role, the file and the owning
+   pid
  - Fixed PMIxTool.set_server_module in the Python bindings, which built
    its server-function module and returned PMIX_SUCCESS without ever
    handing it to the library - so a Python tool acting as a server had

--- a/src/mca/ptl/AGENTS.md
+++ b/src/mca/ptl/AGENTS.md
@@ -358,20 +358,30 @@ be reached:
 `pmix_ptl_base_start_listening` then registers the listen socket's accept
 event on the progress thread.
 
-**Known issue — "listener thread failed to start" from a stale
-`$TMPDIR`.** Those rendezvous files and session directories are removed
-at finalize; a run that is killed or crashes leaves its `pmix-*` /
-`pmix.*` entries behind. Once enough accumulate, a later server fails to
-set up its listener and dies with
+**Stale rendezvous files are reclaimed, not fatal.** A file is removed
+only by a clean `pmix_ptl_close`, so a server that is killed or that
+crashes leaves its file behind. `write_rndz_file` therefore treats an
+existing file as a question rather than an answer: it reads the pid the
+file records and, if that process is gone (or the file names no usable
+pid at all, as happens when its creator died partway thru writing it),
+unlinks the orphan and creates its own. If the recorded pid *is* alive,
+the file belongs to a running server, so we leave it strictly alone and
+fail — but with the `rndz-file-in-use` `show_help` topic naming the role,
+the file, and the owning pid, and returning `PMIX_ERR_SILENT` so the
+server's generic "listener thread failed to start" message does not bury
+it. `test/unit/rndz_stale.c` pins both halves of that boundary.
 
-```
-The PMIx server's listener thread failed to start. We cannot continue.
-```
+Note the asymmetry: a **tool** given a rendezvous file treats an existing
+file as its *server's* contact info and never writes one, so it never
+reaches this path.
 
-taking every `simptest`-based test in `test/unit` down with it. That is
-environmental, not a defect in this framework — reproduce under
-`TMPDIR=$(mktemp -d)` before chasing it. See the *Building and Testing*
-section of the top-level [`AGENTS.md`](../../../AGENTS.md).
+**Related environmental issue — a stale `$TMPDIR`.** Leftover session
+directories and tool connection files still accumulate under `$TMPDIR`
+when runs are killed, and can confuse *discovery* (see the
+`too-many-conns` topic). Reproduce under `TMPDIR=$(mktemp -d)` before
+chasing a wholesale failure of the server-based tests. See the *Building
+and Testing* section of the top-level
+[`AGENTS.md`](../../../AGENTS.md).
 
 ## MCA parameters (registered in `ptl_base_frame.c`)
 

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -130,3 +130,26 @@ The PMIx messaging system has received an unexpected message:
 
 The message cannot be processed and will be ignored. Please
 report this error to the PMIx developers.
+#
+[rndz-file-in-use]
+A PMIx server was unable to create the rendezvous file by which its
+peers locate it because that file already exists and belongs to a
+process that is still running:
+
+  Role:   %s
+  File:   %s
+  Owner:  %s
+
+Only one server can fill a given role on a node at a time. If the
+indicated process is no longer serving in this role, then terminate
+it (or remove the above file) and try again.
+#
+[rndz-file-stale]
+A PMIx server found a stale rendezvous file left behind by an
+instance that is no longer running, but was unable to remove it:
+
+  Role:   %s
+  File:   %s
+  Error:  %s
+
+Please remove the file and try again.

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +44,7 @@
 #    include <sys/types.h>
 #endif
 #include <ctype.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <event.h>
 #include <pthread.h>
@@ -63,6 +64,7 @@
 #include "src/util/pmix_parse_options.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/pmix_string_copy.h"
 
 #include "src/mca/ptl/base/base.h"
 
@@ -194,13 +196,79 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
 }
 
 
-static pmix_status_t write_rndz_file(char *filename, char *uri,
+/* A rendezvous file is removed by pmix_ptl_close when we finalize, so
+ * a server that was killed or that crashed leaves its file behind. As
+ * the file records the pid of the process that created it, we can tell
+ * a stale file from one belonging to a still-running server - and
+ * reclaim the stale one instead of refusing to start.
+ *
+ * Returns a string describing the live owner of the given file, or
+ * NULL if the file has no live owner (i.e., it is stale and can be
+ * reclaimed). The caller must free any returned string.
+ */
+static char *rndz_file_owner(char *filename)
+{
+    FILE *fp;
+    char *line, *endptr, *owner = NULL;
+    unsigned long pid = 0;
+    bool havepid = false;
+    int n;
+
+    /* the file holds the uri, the version, the pid of the process
+     * that wrote it, its uid:gid, and a timestamp - one per line.
+     * We only care about the pid */
+    fp = fopen(filename, "r");
+    if (NULL == fp) {
+        /* we cannot identify an owner, so treat it as stale - if it
+         * truly is in use, then the removal below will fail and we
+         * will report that instead */
+        return NULL;
+    }
+    for (n = 0; n < 3; n++) {
+        line = pmix_getline(fp);
+        if (NULL == line) {
+            /* the file was never completely written - e.g., its
+             * creator died partway thru doing so */
+            break;
+        }
+        if (2 == n) {
+            endptr = NULL;
+            errno = 0;
+            pid = strtoul(line, &endptr, 10);
+            if (0 == errno && NULL != endptr && endptr != line && 0 < pid) {
+                havepid = true;
+            }
+        }
+        free(line);
+    }
+    fclose(fp);
+
+    if (!havepid) {
+        return NULL;
+    }
+    /* if the recorded pid is our own, then the file cannot belong to
+     * a live owner - we did not write it, so it is a leftover from an
+     * earlier process that happened to be given the same pid */
+    if ((pid_t)pid == pmix_globals.pid) {
+        return NULL;
+    }
+    /* if that process is still running, then the file is in use and
+     * we must not touch it. Note that a "permission denied" response
+     * means the process does exist, but belongs to another user */
+    if (0 != kill((pid_t)pid, 0) && EPERM != errno) {
+        return NULL;
+    }
+    pmix_asprintf(&owner, "pid %lu", pid);
+    return owner;
+}
+
+static pmix_status_t write_rndz_file(char *filename, char *uri, const char *role,
                                      bool *dir_created, bool *file_created)
 {
     int fd;
-    char *dirname, *tmp;
+    char *dirname, *tmp, *owner;
     time_t mytime;
-    int rc;
+    int rc, n;
     mode_t mode = 0;
 
     dirname = pmix_dirname(filename);
@@ -235,12 +303,43 @@ static pmix_status_t write_rndz_file(char *filename, char *uri,
     if (pmix_ptl_base.allow_foreign_tools) {
         mode |= S_IRGRP | S_IROTH;
     }
-    fd = open(filename, O_RDWR | O_CREAT | O_EXCL, mode);
+    /* two passes at most: if the file already exists, we get one
+     * chance to reclaim it as stale and try the create again */
+    for (n = 0; n < 2; n++) {
+        fd = open(filename, O_RDWR | O_CREAT | O_EXCL, mode);
+        if (0 <= fd || EEXIST != errno) {
+            break;
+        }
+        /* the file already exists - if a live process owns it, then
+         * another server holds this role and we must not disturb it */
+        owner = rndz_file_owner(filename);
+        if (NULL != owner) {
+            pmix_show_help("help-ptl-base.txt", "rndz-file-in-use", true,
+                           role, filename, owner);
+            free(owner);
+            *file_created = false;
+            /* we have explained the problem, so don't let our caller
+             * add a misleading message on top of it */
+            return PMIX_ERR_SILENT;
+        }
+        /* it was left behind by an instance that is no longer
+         * running, so reclaim it. Someone else beating us to the
+         * removal is fine - anything else is not */
+        if (0 != unlink(filename) && ENOENT != errno) {
+            pmix_show_help("help-ptl-base.txt", "rndz-file-stale", true,
+                           role, filename, strerror(errno));
+            *file_created = false;
+            return PMIX_ERR_SILENT;
+        }
+    }
     if (0 > fd) {
         if (EEXIST == errno) {
-            // the file already exists
+            /* another process recreated the file while we were
+             * reclaiming it */
+            pmix_show_help("help-ptl-base.txt", "rndz-file-in-use", true,
+                           role, filename, "another process");
             *file_created = false;
-            return PMIX_ERR_EXISTS;
+            return PMIX_ERR_SILENT;
         }
         pmix_output(0, "Impossible to open the file %s in write mode\n", filename);
         PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
@@ -817,6 +916,7 @@ complete:
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "WRITING RENDEZVOUS FILE %s", pmix_ptl_base.rendezvous_filename);
         rc = write_rndz_file(pmix_ptl_base.rendezvous_filename, lt->uri,
+                             "server",
                              &pmix_ptl_base.created_rendezvous_dir,
                              &pmix_ptl_base.created_rendezvous_file);
         if (PMIX_SUCCESS != rc) {
@@ -833,6 +933,7 @@ nextstep:
             goto sockerror;
         }
         rc = write_rndz_file(pmix_ptl_base.scheduler_filename, lt->uri,
+                             "scheduler",
                              &pmix_ptl_base.created_system_tmpdir,
                              &pmix_ptl_base.created_scheduler_filename);
         if (PMIX_SUCCESS != rc) {
@@ -847,6 +948,7 @@ nextstep:
             goto sockerror;
         }
         rc = write_rndz_file(pmix_ptl_base.sysctrlr_filename, lt->uri,
+                             "system controller",
                              &pmix_ptl_base.created_system_tmpdir,
                              &pmix_ptl_base.created_sysctrlr_filename);
         if (PMIX_SUCCESS != rc) {
@@ -860,6 +962,7 @@ nextstep:
                 goto sockerror;
             }
             rc = write_rndz_file(pmix_ptl_base.system_filename, lt->uri,
+                                 "system tool",
                                  &pmix_ptl_base.created_system_tmpdir,
                                  &pmix_ptl_base.created_system_filename);
             if (PMIX_SUCCESS != rc) {
@@ -876,6 +979,7 @@ nextstep:
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "WRITING SESSION TOOL FILE %s", pmix_ptl_base.session_filename);
             rc = write_rndz_file(pmix_ptl_base.session_filename, lt->uri,
+                                 "session tool",
                                  &pmix_ptl_base.created_session_tmpdir,
                                  &pmix_ptl_base.created_session_filename);
             if (PMIX_SUCCESS != rc) {
@@ -892,6 +996,7 @@ nextstep:
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output, "WRITING PID TOOL FILE %s",
                             pmix_ptl_base.pid_filename);
         rc = write_rndz_file(pmix_ptl_base.pid_filename, lt->uri,
+                             "tool (by pid)",
                              &pmix_ptl_base.created_session_tmpdir,
                              &pmix_ptl_base.created_pid_filename);
         if (PMIX_SUCCESS != rc) {
@@ -907,6 +1012,7 @@ nextstep:
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "WRITING NSPACE TOOL FILE %s", pmix_ptl_base.nspace_filename);
         rc = write_rndz_file(pmix_ptl_base.nspace_filename, lt->uri,
+                             "tool (by namespace)",
                              &pmix_ptl_base.created_session_tmpdir,
                              &pmix_ptl_base.created_nspace_filename);
         if (PMIX_SUCCESS != rc) {

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -32,9 +32,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale
 
 compress_SOURCES =  \
         compress.c
@@ -139,5 +139,11 @@ singleton_register_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 singleton_register_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+rndz_stale_SOURCES = \
+        rndz_stale.c
+rndz_stale_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+rndz_stale_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale

--- a/test/unit/rndz_stale.c
+++ b/test/unit/rndz_stale.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for reclaiming a stale rendezvous file.
+ *
+ * A server taking the scheduler role drops a "pmix.sched.<host>" contact
+ * file in the system tmpdir so others can find it, and removes it again
+ * when it finalizes. A server that is killed or that crashes therefore
+ * leaves its file behind - and the listener setup used to treat any
+ * pre-existing file as fatal, so the next scheduler could not start until
+ * someone deleted the orphan by hand. Worse, the failure surfaced as
+ * "the listener thread failed to start", which points at sockets rather
+ * than at a leftover file.
+ *
+ * The file records the pid of the process that wrote it, so a leftover
+ * can be told from a file belonging to a running server. These tests pin
+ * that boundary: a file whose owner is gone (or that carries no usable
+ * pid at all, as happens when its creator died partway thru writing it)
+ * must be reclaimed, while a file whose owner is still alive must be left
+ * untouched and must still fail the init.
+ *
+ * Each case runs in a forked child because PMIx_server_init() can only be
+ * meaningfully called once per process. The "crashed predecessor" case
+ * relies on that too: the child _exit()s without finalizing, which is
+ * precisely how a real orphan is created.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* child exit codes */
+#define CHILD_OK       0 /* init succeeded */
+#define CHILD_INITFAIL 1 /* init failed */
+
+#define SCHED_PREFIX "pmix.sched."
+
+static int npass = 0;
+static int nfail = 0;
+static char tmpdir[PMIX_PATH_MAX];
+
+static pmix_server_module_t mymodule = {0};
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+/* return the path of the scheduler rendezvous file in our tmpdir, or
+ * NULL if none is there. Caller must free the returned string */
+static char *sched_file(void)
+{
+    DIR *dp;
+    struct dirent *entry;
+    char *path = NULL;
+
+    dp = opendir(tmpdir);
+    if (NULL == dp) {
+        return NULL;
+    }
+    while (NULL != (entry = readdir(dp))) {
+        if (0 == strncmp(entry->d_name, SCHED_PREFIX, strlen(SCHED_PREFIX))) {
+            if (0 > asprintf(&path, "%s/%s", tmpdir, entry->d_name)) {
+                path = NULL;
+            }
+            break;
+        }
+    }
+    closedir(dp);
+    return path;
+}
+
+/* drop a rendezvous file that claims to be owned by the given pid. The
+ * layout matches what the listener writes: uri, version, pid, uid:gid,
+ * and a timestamp, one per line */
+static void plant_file(const char *path, pid_t owner, bool truncated)
+{
+    FILE *fp;
+
+    fp = fopen(path, "w");
+    if (NULL == fp) {
+        return;
+    }
+    if (!truncated) {
+        fprintf(fp, "testns.0;tcp4://127.0.0.1:1\n%s\n%lu\n%lu:%lu\nsome time\n", PMIX_VERSION,
+                (unsigned long) owner, (unsigned long) getuid(), (unsigned long) getgid());
+    } else {
+        /* the creator died before it got as far as the pid */
+        fprintf(fp, "testns.0;tcp4://127.0.0.1:1\n");
+    }
+    fclose(fp);
+}
+
+static bool file_exists(const char *path)
+{
+    struct stat buf;
+
+    return (0 == stat(path, &buf));
+}
+
+/* attempt an init as the scheduler. If "clean" is false, we exit without
+ * finalizing so our rendezvous file is left behind - i.e., we stand in
+ * for a server that was killed */
+static void child(bool clean)
+{
+    pmix_info_t info;
+    pmix_status_t rc;
+
+    PMIX_INFO_LOAD(&info, PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
+    rc = PMIx_server_init(&mymodule, &info, 1);
+    PMIX_INFO_DESTRUCT(&info);
+
+    if (PMIX_SUCCESS != rc) {
+        _exit(CHILD_INITFAIL);
+    }
+    if (!clean) {
+        _exit(CHILD_OK);
+    }
+    PMIx_server_finalize();
+    _exit(CHILD_OK);
+}
+
+/* fork a child to attempt the init and return its exit code, or -1 if
+ * it did not exit normally */
+static int run_child(bool clean)
+{
+    pid_t pid;
+    int status;
+
+    fflush(stdout);
+    fflush(stderr);
+
+    pid = fork();
+    if (0 > pid) {
+        return -1;
+    }
+    if (0 == pid) {
+        child(clean);
+        /* not reached */
+        _exit(CHILD_INITFAIL);
+    }
+    if (pid != waitpid(pid, &status, 0)) {
+        return -1;
+    }
+    if (!WIFEXITED(status)) {
+        return -1;
+    }
+    return WEXITSTATUS(status);
+}
+
+/* remove everything we (or a server we started) left in the tmpdir */
+static void cleanup(void)
+{
+    DIR *dp;
+    struct dirent *entry;
+    char *path;
+
+    dp = opendir(tmpdir);
+    if (NULL != dp) {
+        while (NULL != (entry = readdir(dp))) {
+            if (0 == strcmp(entry->d_name, ".") || 0 == strcmp(entry->d_name, "..")) {
+                continue;
+            }
+            if (0 > asprintf(&path, "%s/%s", tmpdir, entry->d_name)) {
+                continue;
+            }
+            if (0 != unlink(path)) {
+                rmdir(path);
+            }
+            free(path);
+        }
+        closedir(dp);
+    }
+    rmdir(tmpdir);
+}
+
+int main(void)
+{
+    const char *base;
+    char *path = NULL;
+    int rc;
+
+    fprintf(stdout, "Stale rendezvous file handling\n");
+
+    /* work in a directory of our own so we cannot disturb - or be
+     * disturbed by - anything else on this node */
+    base = getenv("TMPDIR");
+    if (NULL == base) {
+        base = "/tmp";
+    }
+    snprintf(tmpdir, sizeof(tmpdir), "%s/pmix-rndz-XXXXXX", base);
+    if (NULL == mkdtemp(tmpdir)) {
+        fprintf(stderr, "could not create a temporary directory\n");
+        return 1;
+    }
+    setenv("PMIX_SYSTEM_TMPDIR", tmpdir, 1);
+    setenv("PMIX_SERVER_TMPDIR", tmpdir, 1);
+
+    /* a scheduler must be able to start in a clean directory, and must
+     * leave its rendezvous file behind if it does not finalize */
+    rc = run_child(false);
+    if (CHILD_OK != rc) {
+        report("scheduler starts in a clean tmpdir", 0, "init failed");
+        cleanup();
+        fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+        return 1;
+    }
+    report("scheduler starts in a clean tmpdir", 1, NULL);
+
+    path = sched_file();
+    if (NULL == path) {
+        report("killed scheduler leaves its file behind", 0, "no rendezvous file found");
+        cleanup();
+        fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+        return 1;
+    }
+    report("killed scheduler leaves its file behind", 1, NULL);
+
+    /* the file names a pid that is now gone, so the next scheduler must
+     * reclaim it instead of refusing to start */
+    rc = run_child(true);
+    report("stale file is reclaimed", CHILD_OK == rc, "init failed");
+    /* and having created the file itself, that scheduler must have
+     * removed it when it finalized */
+    report("reclaimed file is removed at finalize", !file_exists(path), "file still present");
+
+    /* a file naming a live process belongs to somebody else - refuse to
+     * start, and leave the file alone. Our own pid serves as the live
+     * owner: the child that reads it runs under a different pid, so it
+     * has no reason to believe the file is its own */
+    plant_file(path, getpid(), false);
+    rc = run_child(true);
+    report("live owner is not disturbed", CHILD_INITFAIL == rc, "init should have failed");
+    report("live owner's file is preserved", file_exists(path), "file was removed");
+    unlink(path);
+
+    /* a file that was never completely written names no owner at all,
+     * so it too must be reclaimed */
+    plant_file(path, 0, true);
+    rc = run_child(true);
+    report("truncated file is reclaimed", CHILD_OK == rc, "init failed");
+
+    /* likewise a file whose pid line is unusable */
+    plant_file(path, 0, false);
+    rc = run_child(true);
+    report("file with no usable pid is reclaimed", CHILD_OK == rc, "init failed");
+
+    free(path);
+    cleanup();
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #4022

A server taking the scheduler, system-controller or system-tool role
publishes a rendezvous file so its peers can find it. That file is
removed only by a clean `pmix_ptl_close`, so a server that is killed or
that crashes leaves its file behind - and `write_rndz_file` created the
file with `O_CREAT|O_EXCL` and reported any pre-existing file as an
error, which every one of those role branches treated as fatal. The next
server in that role could not start until someone deleted the orphan by
hand, and the failure surfaced as the generic "listener thread failed to
start", pointing at sockets and interfaces rather than at a leftover
file.

## What changed

The file already records the pid of the process that wrote it, so an
orphan can be told from a file belonging to a running server. On
`EEXIST`, `write_rndz_file` now reads that pid and:

- **owner is gone**, or the file carries no usable pid at all (its
  creator died partway thru writing it) - unlink the orphan and retry the
  `O_CREAT|O_EXCL` create once;
- **recorded pid is our own** - also stale, since we know we did not
  write the file; reachable for the pid-based tool file after pid reuse;
- **owner is alive** - the file belongs to somebody else, so leave it
  strictly alone and fail. A "permission denied" from `kill(2)` counts as
  alive: the process exists, it just belongs to another user.

The failure path now explains itself through two new `help-ptl-base.txt`
topics - `rndz-file-in-use` (naming the role, the file and the owning
pid) and `rndz-file-stale` (the orphan could not be removed) - and
returns `PMIX_ERR_SILENT`, which both `PMIx_server_init` and
`PMIx_tool_init` already honor, so the generic listener message no longer
prints on top of it.

Every publisher call site passes a role label, so all of them benefit -
not just the three named in the issue. The tool-attach path that
deliberately tolerates a pre-existing rendezvous file is untouched.

## Testing

- New `test/unit/rndz_stale.c`, wired into `make check`: it forks a
  scheduler that `_exit()`s without finalizing - precisely how a real
  orphan is made - then checks that the next scheduler reclaims the file
  and removes it at finalize, that a truncated or pid-less file is also
  reclaimed, and that a file naming a live process is preserved and still
  fails the init. Built against the pre-fix listener, the test fails 4 of
  its 8 checks with the old misleading message, so it does pin the bug.
- The reproducer in the issue passes: with a stale `pmix.sched.<host>`
  present, `test/simple/run_simptest.sh` now finishes OK.
- Full `make check` green; build is warning-free under
  `--enable-devel-check`; docs rebuild clean.