### PR TITLE
Complete the enviro event registration handshake with the host

### DIFF
--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -288,9 +288,16 @@ register_events
 ``register_events`` (``pmix_server_register_events_fn_t``) |mdash| Part of the
 support for :ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`.
 Tells the host that the library wishes to receive notification of the specified
-(typically environmental) event codes; the host translates its internal codes to
+system (environmental) event codes; the host translates its internal codes to
 the corresponding PMIx codes when it later notifies. Completion is reported
 through a ``pmix_op_cbfunc_t``.
+
+The library reference-counts each code across all of its local clients and its
+own registrations, and calls this function only for the codes that acquire
+their *first* registrant |mdash| so a code the host is already forwarding is
+never requested again, and only the codes needing action appear in the array.
+Non-system codes are never passed to the host: the host is required to report
+events relating to a registered namespace regardless of any registration.
 
 deregister_events
 ^^^^^^^^^^^^^^^^^
@@ -300,6 +307,13 @@ companion to ``register_events`` (see
 :ref:`PMIx_Deregister_event_handler(3) <man3-PMIx_Deregister_event_handler>`).
 Cancels a prior registration for the specified event codes. The host remains
 obligated to report job-related events regardless.
+
+This is called when a code loses its *last* registrant, counting the library's
+local clients and its own registrations together, so the host can stop
+forwarding a code nothing is listening for. A subsequent registration for that
+code will call ``register_events`` again. A host that provides
+``register_events`` should provide this as well; leaving it NULL simply means
+the host keeps forwarding codes the library no longer wants.
 
 listener
 ^^^^^^^^

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,19 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Completed the server-to-host handshake for system (environmental)
+   event registration. The server now reference-counts each system
+   event code across all of its local clients and its own
+   registrations: it calls the host's register_events only for the
+   codes acquiring their first registrant - rather than on every
+   registration for a code it had already asked for - and calls the
+   host's deregister_events, which previously had no callers at all,
+   when a code loses its last registrant. A code registered again
+   after being released is re-activated with the host. Only system
+   codes are handed to the host, which was always the contract for
+   these entry points. Hosts that implement register_events should
+   also implement deregister_events; leaving it NULL simply means the
+   host keeps forwarding codes nothing is listening for
  - Fixed a server taking the scheduler, system-controller or system-tool
    role being unable to restart after it was killed or crashed. Those
    roles publish a rendezvous file that is removed only by a clean

--- a/examples/server.c
+++ b/examples/server.c
@@ -774,7 +774,10 @@ static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
 static pmix_status_t deregister_events(pmix_status_t *codes, size_t ncodes, pmix_op_cbfunc_t cbfunc,
                                        void *cbdata)
 {
-    EXAMPLES_HIDE_UNUSED_PARAMS(codes, ncodes, cbfunc, cbdata);
+    EXAMPLES_HIDE_UNUSED_PARAMS(codes, ncodes);
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
     return PMIX_SUCCESS;
 }
 

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -146,6 +146,11 @@ static void _regcbfunc(int sd, short args, void *cbdata)
             pmix_list_remove_item(rb->list, &rb->hdlr->super);
             PMIX_RELEASE(rb->hdlr);
         }
+        /* our host rejected the request, so give back the interest
+         * we recorded on its behalf when we made it */
+        if (NULL != cd) {
+            pmix_server_deactivate_events(cd->codes, cd->ncodes);
+        }
         rc = PMIX_ERR_SERVER_FAILED_REQUEST;
         index = SIZE_MAX;
     }
@@ -245,7 +250,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
 {
     pmix_rshift_caddy_t *cd2;
     pmix_info_caddy_t *ixfer;
-    size_t n;
+    size_t n, nactive = 0;
     bool registered, need_register = false;
     pmix_active_code_t *active;
     pmix_status_t rc;
@@ -342,12 +347,18 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     }
 
     /* if we are a server and are registering for events, then we only contact
-     * our host if we want environmental events */
+     * our host if we want environmental events - and then only for the codes
+     * it isn't already forwarding on behalf of a prior registrant, be that
+     * one of our local clients or ourselves. Those codes are sorted to the
+     * front of the array so we can hand the host just that subset */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) && !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)
         && cd->enviro && NULL != pmix_host_server.register_events) {
+        nactive = pmix_server_activate_events(cd->codes, cd->ncodes);
+    }
+    if (0 < nactive) {
         pmix_output_verbose(2, pmix_client_globals.event_output,
                             "pmix: _add_hdlr registering with server");
-        rc = pmix_host_server.register_events(cd->codes, cd->ncodes, cd2->info, cd2->ninfo,
+        rc = pmix_host_server.register_events(cd->codes, nactive, cd2->info, cd2->ninfo,
                                               reg_cbfunc, cd2);
         if (PMIX_SUCCESS == rc) {
             /* the host will call us back when the registration
@@ -360,15 +371,18 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
         }
         PMIX_RELEASE(cd2);
         if (PMIX_OPERATION_SUCCEEDED != rc) {
+            /* our host rejected the request, so give back the
+             * interest we just recorded on its behalf */
+            pmix_server_deactivate_events(cd->codes, cd->ncodes);
             return rc;
         }
         return PMIX_SUCCESS;
-    } else {
-        if (NULL != cd2->info) {
-            PMIX_INFO_FREE(cd2->info, cd2->ninfo);
-        }
-        PMIX_RELEASE(cd2);
     }
+
+    if (NULL != cd2->info) {
+        PMIX_INFO_FREE(cd2->info, cd2->ninfo);
+    }
+    PMIX_RELEASE(cd2);
 
     return PMIX_SUCCESS;
 }
@@ -979,6 +993,32 @@ PMIX_EXPORT pmix_status_t PMIx_Register_event_handler(pmix_status_t codes[], siz
     return rc;
 }
 
+/* If we are a server that asked its host to forward the environmental
+ * codes this handler wanted, then release that interest - the host will
+ * be told to stop forwarding any code that no longer has a registrant,
+ * be that one of our local clients or ourselves. */
+static void release_enviro_codes(pmix_event_hdlr_t *ev)
+{
+    if (NULL == ev->codes) {
+        /* a default handler - nothing was ever registered with the host */
+        return;
+    }
+    if (PMIX_RANGE_PROC_LOCAL == ev->rng.range) {
+        /* this registration never left the process, so it never
+         * recorded an interest for us to give back */
+        return;
+    }
+    if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
+        return;
+    }
+    if (NULL == pmix_host_server.register_events) {
+        /* we could not have registered these with the host */
+        return;
+    }
+    pmix_server_deactivate_events(ev->codes, ev->ncodes);
+}
+
 pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
                                          pmix_buffer_t *msg)
 {
@@ -1040,6 +1080,7 @@ pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
         } else {
             pmix_globals.events.last = NULL;
         }
+        release_enviro_codes(ev);
         PMIX_RELEASE(ev);
         return PMIX_SUCCESS;
     }
@@ -1088,6 +1129,7 @@ pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
                     break;
                 }
             }
+            release_enviro_codes(evhdlr);
             PMIX_RELEASE(evhdlr);
             return PMIX_SUCCESS;
         }
@@ -1118,6 +1160,7 @@ pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
                     }
                 }
             }
+            release_enviro_codes(evhdlr);
             PMIX_RELEASE(evhdlr);
             return PMIX_SUCCESS;
         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1444,9 +1444,9 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
                     && PMIX_CHECK_NAMES(proc, &prev->peer->info->pname))) {
                 pmix_list_remove_item(&reginfo->peers, &prev->super);
                 PMIX_RELEASE(prev);
-                if (0 == pmix_list_get_size(&reginfo->peers)) {
-                    pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
-                    PMIX_RELEASE(reginfo);
+                /* if nobody is left registered for this code, then drop
+                 * it and tell our host to stop forwarding it */
+                if (pmix_server_prune_reginfo(reginfo)) {
                     break;
                 }
             }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -904,6 +904,178 @@ static void regevopcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
+/* the host is done processing our request to stop forwarding a code -
+ * all we carried across the up-call was the array of codes itself */
+static void deregevopcbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_status_t *codes = (pmix_status_t *) cbdata;
+
+    PMIX_HIDE_UNUSED_PARAMS(status);
+
+    free(codes);
+}
+
+/* ask our host to stop forwarding the given event codes - takes
+ * ownership of the (malloc'd) codes array */
+static void stop_forwarding(pmix_status_t *codes, size_t ncodes)
+{
+    pmix_status_t rc;
+
+    if (NULL == pmix_host_server.deregister_events) {
+        free(codes);
+        return;
+    }
+    pmix_output_verbose(2, pmix_server_globals.event_output,
+                        "server deregister events: telling host to stop forwarding %lu code(s)",
+                        (unsigned long) ncodes);
+    rc = pmix_host_server.deregister_events(codes, ncodes, deregevopcbfunc, codes);
+    if (PMIX_SUCCESS != rc) {
+        /* the host either completed the operation itself or rejected
+         * it - either way, no callback is coming */
+        free(codes);
+    }
+}
+
+bool pmix_server_prune_reginfo(pmix_regevents_info_t *reginfo)
+{
+    pmix_status_t *codes;
+
+    if (0 < pmix_list_get_size(&reginfo->peers) || 0 < reginfo->nmine) {
+        /* somebody still wants this code */
+        return false;
+    }
+
+    pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
+    if (reginfo->active) {
+        codes = (pmix_status_t *) malloc(sizeof(pmix_status_t));
+        if (NULL != codes) {
+            codes[0] = reginfo->code;
+            stop_forwarding(codes, 1);
+        }
+    }
+    PMIX_RELEASE(reginfo);
+    return true;
+}
+
+/* find the tracking object for the given code, creating it if necessary */
+static pmix_regevents_info_t *get_reginfo(pmix_status_t code)
+{
+    pmix_regevents_info_t *reginfo;
+
+    PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
+        if (code == reginfo->code) {
+            return reginfo;
+        }
+    }
+    reginfo = PMIX_NEW(pmix_regevents_info_t);
+    if (NULL == reginfo) {
+        return NULL;
+    }
+    reginfo->code = code;
+    pmix_list_append(&pmix_server_globals.events, &reginfo->super);
+    return reginfo;
+}
+
+/* Mark the codes our host is not already forwarding, sorting them to
+ * the front of the array, and return their number. The array is treated
+ * as an unordered set by everything downstream, so the reordering only
+ * lets us hand the host the subset it needs to act upon. */
+static size_t mark_activations(pmix_status_t *codes, size_t ncodes)
+{
+    pmix_regevents_info_t *reginfo;
+    pmix_status_t tmp;
+    size_t n, nactive = 0;
+
+    for (n = 0; n < ncodes; n++) {
+        if (!PMIX_SYSTEM_EVENT(codes[n])) {
+            continue;
+        }
+        PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
+            if (codes[n] != reginfo->code) {
+                continue;
+            }
+            if (!reginfo->active) {
+                reginfo->active = true;
+                tmp = codes[nactive];
+                codes[nactive] = codes[n];
+                codes[n] = tmp;
+                ++nactive;
+            }
+            break;
+        }
+    }
+    return nactive;
+}
+
+/* our host rejected the request, so it is not forwarding these codes
+ * after all - let the next registration ask it again */
+static void undo_activations(pmix_status_t *codes, size_t nactive)
+{
+    pmix_regevents_info_t *reginfo;
+    size_t n;
+
+    for (n = 0; n < nactive; n++) {
+        PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
+            if (codes[n] == reginfo->code) {
+                reginfo->active = false;
+                break;
+            }
+        }
+    }
+}
+
+size_t pmix_server_activate_events(pmix_status_t *codes, size_t ncodes)
+{
+    pmix_regevents_info_t *reginfo;
+    size_t n;
+
+    if (NULL == codes) {
+        return 0;
+    }
+
+    /* record our own interest in each of the system codes */
+    for (n = 0; n < ncodes; n++) {
+        if (!PMIX_SYSTEM_EVENT(codes[n])) {
+            continue;
+        }
+        reginfo = get_reginfo(codes[n]);
+        if (NULL == reginfo) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            continue;
+        }
+        ++reginfo->nmine;
+    }
+
+    return mark_activations(codes, ncodes);
+}
+
+void pmix_server_deactivate_events(pmix_status_t *codes, size_t ncodes)
+{
+    pmix_regevents_info_t *reginfo, *regnext;
+    size_t n;
+
+    if (NULL == codes) {
+        return;
+    }
+
+    for (n = 0; n < ncodes; n++) {
+        if (!PMIX_SYSTEM_EVENT(codes[n])) {
+            continue;
+        }
+        PMIX_LIST_FOREACH_SAFE (reginfo, regnext, &pmix_server_globals.events,
+                                pmix_regevents_info_t) {
+            if (codes[n] != reginfo->code) {
+                continue;
+            }
+            if (0 < reginfo->nmine) {
+                --reginfo->nmine;
+            }
+            pmix_server_prune_reginfo(reginfo);
+            break;
+        }
+    }
+}
+
 pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -919,6 +1091,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     bool found;
     pmix_proc_t *affected = NULL;
     size_t naffected = 0;
+    size_t nactive = 0;
 
     pmix_output_verbose(2, pmix_server_globals.event_output,
                         "recvd register events for peer %s:%d",
@@ -1088,8 +1261,16 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         }
     }
 
-    /* if they asked for enviro events, call the local server */
+    /* find the system codes in this request that our host is not
+     * already forwarding on behalf of another local registrant (or of
+     * ourselves) - those are the only ones we need to ask it about */
     if (enviro_events) {
+        nactive = mark_activations(codes, ncodes);
+    }
+
+    /* if they asked for enviro events our host isn't already sending
+     * us, then call the local server */
+    if (enviro_events && 0 < nactive) {
         /* if they don't support this, then we cannot do it */
         if (NULL == pmix_host_server.register_events) {
             rc = PMIX_ERR_NOT_SUPPORTED;
@@ -1099,6 +1280,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
          * host RM is done with them */
         scd = PMIX_NEW(pmix_setup_caddy_t);
         if (NULL == scd) {
+            undo_activations(codes, nactive);
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
         }
@@ -1110,8 +1292,11 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         scd->ninfo = ninfo;
         scd->opcbfunc = cbfunc;
         scd->cbdata = cbdata;
+        /* only the codes needing activation were sorted to the front of
+         * the array, so that is all we hand the host - the caddy still
+         * carries the full array as the cached-event check needs it */
         if (PMIX_SUCCESS
-            == (rc = pmix_host_server.register_events(scd->codes, scd->ncodes, scd->info,
+            == (rc = pmix_host_server.register_events(scd->codes, nactive, scd->info,
                                                       scd->ninfo, regevopcbfunc, scd))) {
             /* the host will call us back when completed */
             pmix_output_verbose(
@@ -1159,6 +1344,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             pmix_output_verbose(2, pmix_server_globals.event_output,
                                 "server register events: host server reg events returned rc =%d",
                                 rc);
+            undo_activations(codes, nactive);
             PMIX_RELEASE(scd);
             goto cleanup;
         }
@@ -1236,20 +1422,10 @@ void pmix_server_deregister_events(pmix_peer_t *peer, pmix_buffer_t *buf)
                         break;
                     }
                 }
-                /* if all of the peers for this code are now gone, then remove it */
-                if (0 == pmix_list_get_size(&reginfo->peers)) {
-                    pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
-                    /* NOTE: we intentionally do NOT call the host's
-                     * deregister_events here. The server does not
-                     * reference-count enviro/system event registrations against
-                     * the host, so it never tells the host to stop forwarding a
-                     * code - an event that continues to arrive with no matching
-                     * local handler is simply received and ignored by the
-                     * notification fan-out. Implementing the full
-                     * activate-on-first / deregister-on-last handshake with the
-                     * host is deferred - see openpmix/openpmix#4014. */
-                    PMIX_RELEASE(reginfo);
-                }
+                /* if nobody is left registered for this code - not the
+                 * server itself, nor any of our local clients - then
+                 * remove it and tell our host to stop forwarding it */
+                pmix_server_prune_reginfo(reginfo);
             }
         }
         cnt = 1;
@@ -3319,6 +3495,9 @@ PMIX_CLASS_INSTANCE(pmix_peer_events_info_t,
 static void regcon(pmix_regevents_info_t *p)
 {
     PMIX_CONSTRUCT(&p->peers, pmix_list_t);
+    p->code = PMIX_MAX_ERR_CONSTANT;
+    p->nmine = 0;
+    p->active = false;
 }
 static void regdes(pmix_regevents_info_t *p)
 {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -144,6 +144,11 @@ typedef struct {
     pmix_list_item_t super;
     pmix_list_t peers; // list of pmix_peer_events_info_t
     int code;
+    /* number of registrations the server itself has made for this
+     * code - registrations by local clients are counted by "peers" */
+    size_t nmine;
+    /* true if we have asked our host to forward this code to us */
+    bool active;
 } pmix_regevents_info_t;
 PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
@@ -346,6 +351,30 @@ PMIX_EXPORT void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hd
                                              pmix_buffer_t *buf, void *cbdata);
 
 PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc);
+
+/* Record that the server itself has registered for the given event
+ * codes. Only system (environmental) codes are tracked as those are the
+ * only ones we ask our host to forward. The codes our host is not
+ * already forwarding are sorted to the front of the array - the array is
+ * treated as an unordered set everywhere else, so the reordering is
+ * harmless - and their number is returned. A return of zero means every
+ * requested code is already being forwarded and the host need not be
+ * called. */
+PMIX_EXPORT size_t pmix_server_activate_events(pmix_status_t *codes, size_t ncodes);
+
+/* Release a registration the server itself made for the given event
+ * codes. Any code that is left without a registrant - neither the server
+ * nor any local client - is dropped, and our host is told to stop
+ * forwarding it. Also used to undo a pmix_server_activate_events call
+ * whose host up-call was rejected. */
+PMIX_EXPORT void pmix_server_deactivate_events(pmix_status_t *codes, size_t ncodes);
+
+/* If no registrant remains for the code tracked by this object - neither
+ * a local client nor the server itself - then remove it from the server's
+ * event registration store, tell our host to stop forwarding the code if
+ * we had asked it to start, and release it. Returns true if the object
+ * was released. */
+PMIX_EXPORT bool pmix_server_prune_reginfo(pmix_regevents_info_t *reginfo);
 
 /* Handle the departure of a cleanly-finalized local client peer whose
  * socket has dropped: decrement the rank's live-process count and leave

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -910,7 +910,10 @@ static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
 static pmix_status_t deregister_events(pmix_status_t *codes, size_t ncodes, pmix_op_cbfunc_t cbfunc,
                                        void *cbdata)
 {
-    PMIX_HIDE_UNUSED_PARAMS(codes, ncodes, cbfunc, cbdata);
+    PMIX_HIDE_UNUSED_PARAMS(codes, ncodes);
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
     return PMIX_SUCCESS;
 }
 

--- a/test/unit/event_chain.c
+++ b/test/unit/event_chain.c
@@ -50,6 +50,14 @@
  *      exactly once whether the host returns PMIX_OPERATION_SUCCEEDED
  *      or PMIX_SUCCESS followed by its own callback.
  *
+ *  enviro event handshake: a system code is activated with the host on
+ *      the first registration for it and deactivated when the last one
+ *      goes away, counting the server's own registrations and those of
+ *      its local clients together; intervening registrations do not
+ *      repeat the host call, a code is re-activated if it is registered
+ *      again after deactivation, and non-system codes are never handed
+ *      to the host.
+ *
  *  first-overall handler with multiple codes honors its
  *      affected-proc interest list.
  */
@@ -711,6 +719,241 @@ static void test_host_regevents(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Enviro event activation/deactivation handshake with the host        */
+/* ------------------------------------------------------------------ */
+
+#define EVUT_MAX_HSCODES 8
+
+static volatile int hs_regs = 0;
+static volatile int hs_deregs = 0;
+static size_t hs_last_ncodes = 0;
+static pmix_status_t hs_last_codes[EVUT_MAX_HSCODES];
+
+static void hs_record(pmix_status_t codes[], size_t ncodes)
+{
+    size_t n;
+
+    hs_last_ncodes = ncodes;
+    for (n = 0; n < ncodes && n < EVUT_MAX_HSCODES; n++) {
+        hs_last_codes[n] = codes[n];
+    }
+}
+
+static pmix_status_t hs_regevs(pmix_status_t codes[], size_t ncodes,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo, cbfunc, cbdata);
+    ++hs_regs;
+    hs_record(codes, ncodes);
+    return PMIX_OPERATION_SUCCEEDED;
+}
+
+static pmix_status_t hs_deregevs(pmix_status_t codes[], size_t ncodes,
+                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
+    ++hs_deregs;
+    hs_record(codes, ncodes);
+    return PMIX_OPERATION_SUCCEEDED;
+}
+
+/* Drive the server-side handlers for a client's REGEVENTS_CMD /
+ * DEREGEVENTS_CMD on the progress thread, using this process's own peer
+ * to stand in for a local client. Those handlers touch
+ * pmix_server_globals directly, so they must not be called from here. */
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    pmix_status_t *codes;
+    size_t ncodes;
+    pmix_status_t status;
+} evut_clreq_t;
+
+static void do_client_reg(int sd, short args, void *cbdata)
+{
+    evut_clreq_t *r = (evut_clreq_t *) cbdata;
+    pmix_buffer_t buf;
+    size_t ninfo = 0;
+    pmix_status_t rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->ncodes, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, r->codes, r->ncodes, PMIX_STATUS);
+    }
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &ninfo, 1, PMIX_SIZE);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_server_register_events(pmix_globals.mypeer, &buf, NULL, NULL);
+    }
+    PMIX_DESTRUCT(&buf);
+    r->status = rc;
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static void do_client_dereg(int sd, short args, void *cbdata)
+{
+    evut_clreq_t *r = (evut_clreq_t *) cbdata;
+    pmix_buffer_t buf;
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t n;
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    for (n = 0; n < r->ncodes && PMIX_SUCCESS == rc; n++) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->codes[n], 1, PMIX_STATUS);
+    }
+    if (PMIX_SUCCESS == rc) {
+        pmix_server_deregister_events(pmix_globals.mypeer, &buf);
+    }
+    PMIX_DESTRUCT(&buf);
+    r->status = rc;
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static pmix_status_t client_evreq(pmix_status_t *codes, size_t ncodes, bool dereg)
+{
+    evut_clreq_t req;
+    pmix_status_t rc;
+
+    memset(&req, 0, sizeof(req));
+    PMIX_CONSTRUCT_LOCK(&req.lock);
+    req.codes = codes;
+    req.ncodes = ncodes;
+    if (dereg) {
+        PMIX_THREADSHIFT(&req, do_client_dereg);
+    } else {
+        PMIX_THREADSHIFT(&req, do_client_reg);
+    }
+    PMIX_WAIT_THREAD(&req.lock);
+    rc = req.status;
+    PMIX_DESTRUCT_LOCK(&req.lock);
+    return rc;
+}
+
+static void test_enviro_handshake(void)
+{
+    pmix_status_t s1 = PMIX_EVENT_SYS_BASE;
+    pmix_status_t s2 = PMIX_EVENT_SYS_OTHER;
+    pmix_status_t mixed[2] = {EVUT_CODE_ORDER, PMIX_EVENT_SYS_OTHER};
+    pmix_data_range_t local = PMIX_RANGE_PROC_LOCAL;
+    pmix_info_t info;
+    size_t a, b, c;
+    pmix_status_t rc;
+
+    hs_regs = 0;
+    hs_deregs = 0;
+    pmix_host_server.register_events = hs_regevs;
+    pmix_host_server.deregister_events = hs_deregevs;
+
+    /* the first registration for a system code activates it */
+    a = reghdlr(&s1, 1, NULL, 0, count_hdlr);
+    report("enviro: first registration accepted", SIZE_MAX != a);
+    report("enviro: first registration activates the code",
+           1 == hs_regs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+
+    /* a second registration for the same code must not repeat it */
+    b = reghdlr(&s1, 1, NULL, 0, count_hdlr);
+    report("enviro: second registration accepted", SIZE_MAX != b);
+    report("enviro: second registration does not repeat the host call",
+           1 == hs_regs);
+
+    /* a code the host is not yet forwarding is activated even when it
+     * arrives alongside one that it already is - and the non-system
+     * code it is bundled with is never handed to the host */
+    c = reghdlr(mixed, 2, NULL, 0, count_hdlr);
+    report("enviro: mixed registration accepted", SIZE_MAX != c);
+    report("enviro: only the unactivated system code is sent to the host",
+           2 == hs_regs && 1 == hs_last_ncodes && s2 == hs_last_codes[0]);
+
+    /* dropping one of two registrants leaves the code active */
+    if (SIZE_MAX != a) {
+        PMIx_Deregister_event_handler(a, NULL, NULL);
+    }
+    report("enviro: code stays active while a registrant remains",
+           0 == hs_deregs);
+
+    /* dropping the last registrant for a code deactivates just it */
+    if (SIZE_MAX != b) {
+        PMIx_Deregister_event_handler(b, NULL, NULL);
+    }
+    report("enviro: last registrant deactivates the code",
+           1 == hs_deregs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+
+    /* registering again after deactivation re-activates the code */
+    a = reghdlr(&s1, 1, NULL, 0, count_hdlr);
+    report("enviro: re-registration accepted", SIZE_MAX != a);
+    report("enviro: re-registration re-activates the code",
+           3 == hs_regs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+
+    /* a local client registering a code the server itself already holds
+     * must not repeat the host call, and must not release the code when
+     * it goes away while the server is still registered */
+    rc = client_evreq(&s1, 1, false);
+    report("enviro: client registration accepted",
+           PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
+    report("enviro: client does not repeat the host call for a held code",
+           3 == hs_regs);
+    rc = client_evreq(&s1, 1, true);
+    report("enviro: client deregistration processed", PMIX_SUCCESS == rc);
+    report("enviro: client departure leaves the server's code active",
+           1 == hs_deregs);
+
+    /* conversely, the server dropping its own registration must not
+     * release a code a local client still wants */
+    rc = client_evreq(&s1, 1, false);
+    report("enviro: second client registration accepted",
+           PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
+    if (SIZE_MAX != a) {
+        PMIx_Deregister_event_handler(a, NULL, NULL);
+    }
+    report("enviro: code stays active while a client wants it",
+           1 == hs_deregs);
+    rc = client_evreq(&s1, 1, true);
+    report("enviro: last client departure deactivates the code",
+           2 == hs_deregs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+
+    /* a PMIX_RANGE_PROC_LOCAL registration never leaves the process, so
+     * it neither activates a code nor releases anyone else's interest
+     * in one when it goes away */
+    PMIX_INFO_LOAD(&info, PMIX_RANGE, &local, PMIX_DATA_RANGE);
+    a = reghdlr(&s1, 1, &info, 1, count_hdlr);
+    PMIX_INFO_DESTRUCT(&info);
+    report("enviro: proc-local registration accepted", SIZE_MAX != a);
+    report("enviro: proc-local registration does not reach the host",
+           3 == hs_regs);
+    b = reghdlr(&s1, 1, NULL, 0, count_hdlr);
+    report("enviro: registration alongside proc-local accepted", SIZE_MAX != b);
+    report("enviro: registration alongside proc-local activates the code",
+           4 == hs_regs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+    if (SIZE_MAX != a) {
+        PMIx_Deregister_event_handler(a, NULL, NULL);
+    }
+    report("enviro: proc-local departure does not release the code",
+           2 == hs_deregs);
+    if (SIZE_MAX != b) {
+        PMIx_Deregister_event_handler(b, NULL, NULL);
+    }
+    report("enviro: code released once the real registrant departs",
+           3 == hs_deregs && 1 == hs_last_ncodes && s1 == hs_last_codes[0]);
+
+    /* and the mixed registration still holds the remaining code */
+    if (SIZE_MAX != c) {
+        PMIx_Deregister_event_handler(c, NULL, NULL);
+    }
+    report("enviro: final deregistration releases the remaining code",
+           4 == hs_deregs && 1 == hs_last_ncodes && s2 == hs_last_codes[0]);
+
+    pmix_host_server.register_events = NULL;
+    pmix_host_server.deregister_events = NULL;
+}
+
+/* ------------------------------------------------------------------ */
 /* First-overall handler honors its affected-proc interests            */
 /* ------------------------------------------------------------------ */
 
@@ -784,6 +1027,7 @@ int main(int argc, char **argv)
     test_cached_replay();
     test_range_rm_completion();
     test_host_regevents();
+    test_enviro_handshake();
     test_first_affected();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);


### PR DESCRIPTION
Fixes #4014

The server-to-host handshake for system (environmental) event registration was
only half implemented. The server told its host to start forwarding a system
event on *every* client registration for that code — even when it had already
asked for the same code on behalf of another local client, or of itself — and it
never told the host to stop. `pmix_host_server.deregister_events` had no caller
anywhere in the tree.

## What changed

The per-code tracker `pmix_regevents_info_t` already counted local clients
through its `peers` list. It gains two more fields — `nmine`, counting the
registrations the server itself made through `PMIx_Register_event_handler`, and
`active`, recording whether we have asked the host for the code. Those three
together are the activation refcount the issue asked for.

- `pmix_server_register_events()` marks which system codes in a request need
  activation and hands the host **only** that subset. N distinct local clients
  registering the same code now produce one `register_events` up-call, not N.
- `pmix_server_deregister_events()` and `pmix_server_purge_events()` share a new
  `pmix_server_prune_reginfo()`, which drops a code only when neither the server
  nor any local client wants it, and then calls the host's `deregister_events`.
- `_add_hdlr()` / `pmix_deregister_event_hdlr()` in `src/event` fold the server's
  own registrations into the same counter through two new exported helpers,
  `pmix_server_activate_events()` / `pmix_server_deactivate_events()`.
- A code registered again after being released is re-activated with the host.
- A registration whose host up-call is rejected gives back what it recorded, so
  the next registration asks again.

The codes needing action are sorted to the front of the caller's array — which
everything downstream treats as an unordered set — so passing the host just that
subset needs no extra allocation.

## Behavior change worth reviewing

Only the **system** codes of a request are now handed to the host. Previously an
enviro request forwarded its entire codes array, non-system codes included. That
has always been the contract for these entry points (the host is required to
report events relating to a registered namespace with or without a
registration), but it is visible to hosts, so it is called out in
`pmix_server_module_t.5.rst` and in the news entry.

Hosts that implement `register_events` should now also implement
`deregister_events`; leaving it NULL simply means the host keeps forwarding codes
nothing is listening for — i.e. today's behavior.

## Two things found along the way

- **`PMIX_RANGE_PROC_LOCAL` registrations never reach `_add_hdlr`.** Without a
  guard, deregistering one would decrement another registrant's count and tell
  the host to stop forwarding a code still in use. Guarded, with a test.
- **The `deregister_events` stubs in `test/simple/gwtest.c` and
  `examples/server.c` returned `PMIX_SUCCESS` without ever invoking the
  callback**, which per the up-call convention means "I will call you later".
  Dormant only because nothing ever called them. Fixed as its own commit.

## Testing

- Clean `make -j8` under the default `--enable-devel-check`, zero warnings.
- `make check`: 78/78 across all five suites. `test/unit/event_chain` grew from
  47 to 65 assertions, the new ones covering the whole handshake — first/last
  registrant, no repeat call in between, re-activation, the mixed
  system/non-system case, `PROC_LOCAL`, and the interaction between a local
  client's registration and the server's own.
- `test/simple/simptest` passes.
- `gwtest` and `simpfabric` fail, but they fail identically on unmodified master
  (verified in a scratch worktree) — pre-existing and unrelated (`my.net.key` /
  cpuset lookups on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)