### PR TITLE
Stop the dockerswarm harness from silently running a stale image

### DIFF
--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -151,8 +151,66 @@ done
 |----------|----|
 | pick up a PMIx source edit | `./build.sh` (incremental into the volume) |
 | force a clean rebuild | `docker volume rm pmix-build && ./build.sh` |
-| rebuild the base image (new PRRTE branch) | `PRRTE_REF=v3.0.x ./build.sh image` |
+| move the baked PRRTE forward | `docker build --no-cache --build-arg PRRTE_REF=master -t pmix-swarm:latest .`, then wipe the volume's VPATH dirs and recreate the containers - see below |
+| rebuild the base image (different PRRTE branch) | `PRRTE_REF=v3.0.x ./build.sh image` |
 | tear down the swarm | `docker compose down` (the `pmix-build` volume persists) |
+
+### The image goes stale, and the containers go stale after it
+
+Two traps, and they compound. Both were hit for real.
+
+**`./build.sh image` does not necessarily move the baked PRRTE.** The
+Dockerfile builds the launcher's source from
+
+```dockerfile
+RUN git clone --recursive -b "$PRRTE_REF" "$PRRTE_REPO" /src/prrte
+```
+
+and docker caches that layer by its *text*, not by what the remote now
+contains - so a rebuild "succeeds" in seconds and bakes exactly the PRRTE
+you were trying to leave behind. This matters here more than it would in
+most images, because PRRTE master is what tracks new PMIx capability flags:
+an old baked PRRTE fails to `configure` against your PMIx, or builds and
+then cannot launch it.
+
+**The ten nodes are long-lived containers, so a rebuilt image does not
+reach them until they are recreated.** `build.sh` compiles PMIx and PRRTE
+inside a *new* container and installs them into the volume the *old*
+containers read, so the daemons load libraries built for a different
+launcher. The symptom is an undefined symbol, or a launcher that does not
+understand an option, in whichever case reaches it first - and nothing in
+the output mentions containers. `run-tests.sh`'s preflight now compares
+each container's image ID against `pmix-swarm:latest` and refuses to run
+when they differ.
+
+The full sequence when you want a current launcher:
+
+```sh
+docker build --no-cache --build-arg PRRTE_REF=master -t pmix-swarm:latest .
+docker run --rm -v pmix-build:/opt/prte pmix-swarm:latest \
+    rm -rf /opt/prte/vpath-pmix /opt/prte/vpath-prrte \
+           /opt/prte/pmix /opt/prte/prte
+./build.sh                                  # rebuild against the new image
+docker compose up -d --force-recreate
+```
+
+The volume wipe is not optional: `build.sh` reconfigures when the configure
+*arguments* change, and they do not change when only the image's PRRTE does.
+
+**Where you run `docker compose` matters.** The project name defaults to the
+directory name, `dockerswarm` - which is also the name of PRRTE's identical
+harness directory. Run it against the wrong project and compose adopts the
+other swarm: it stops those containers, renames these ones out from under
+themselves, and then fails on the name collision, leaving this swarm on the
+previous image. That is exactly how the state above was reached (from the
+PRRTE side). `docker-compose.yml` now pins `name: pmixswarm`, so a plain
+`docker compose` from this directory can only ever mean this swarm. Check by
+hand with:
+
+```sh
+docker inspect pmix-node1 --format '{{.Image}}'
+docker images --no-trunc --format '{{.ID}}' pmix-swarm:latest
+```
 
 ## 9. Topology reference
 

--- a/contrib/dockerswarm/docker-compose.yml
+++ b/contrib/dockerswarm/docker-compose.yml
@@ -13,6 +13,20 @@
 # lost-connection accounting run on several daemons at once, and let a group
 # span a multi-level daemon tree.
 
+# Pin the compose project.  Without this, the project name comes from the
+# directory - "dockerswarm" - which is also the name of PRRTE's identical
+# harness directory, so `docker compose up -d` run in either place adopts the
+# OTHER project's containers: it stops that swarm, renames its containers out
+# from under themselves, and then fails on the name collision, leaving one set
+# of nodes running the image they were created from while the image itself has
+# moved on.  A swarm whose containers predate the image is the single most
+# confusing state this harness can be in - the daemons run one PRRTE and the
+# PMIx in the volume was built for another - and the symptom is an
+# undefined-symbol failure in an unrelated test.  Verify with:
+#   docker inspect pmix-node1 --format '{{.Image}}'
+#   docker images --no-trunc --format '{{.ID}}' pmix-swarm:latest
+name: pmixswarm
+
 x-node: &node
   image: pmix-swarm:latest
   networks: [dvm]

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -24,6 +24,8 @@ set -uo pipefail
 
 mode="${1:-linux}"
 pass=0 fail=0 skip=0
+# must match build.sh -- the preflight compares the containers against it
+IMAGE="${IMAGE:-pmix-swarm:latest}"
 ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
 skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
@@ -101,6 +103,31 @@ test_linux() {
         ok "prterun/prte/prun/pterm on PATH"
     else
         bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    # The nodes are long-lived containers while the install they read is
+    # replaced under them, and the LAUNCHER is baked into the image as source.
+    # So a rebuilt image -- which is how the baked PRRTE moves forward -- does
+    # not reach the running containers until they are recreated: build.sh then
+    # compiles PMIx and PRRTE inside a NEW container and installs them into the
+    # volume the OLD containers read.  What you see is an undefined symbol, or a
+    # launcher that does not understand an option this PMIx now needs, in
+    # whichever case happens to reach it first -- and nothing in the message
+    # mentions containers.
+    banner "preflight: containers are running the current image"
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    stalenodes=""
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "pmix-node$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: docker compose up -d --force-recreate" >&2
+        echo "     (from contrib/dockerswarm, so the pinned project name applies)" >&2
+        return
     fi
 
     banner "multi-node launch smoke (real cross-daemon RML)"


### PR DESCRIPTION
The launcher this harness drives is baked into the image as *source*, so
moving PRRTE forward means rebuilding the image — and two things then go
wrong quietly. Both were hit for real while using the harness.

### `./build.sh image` does not necessarily move the baked PRRTE

docker caches the Dockerfile's

```dockerfile
RUN git clone --recursive -b "$PRRTE_REF" "$PRRTE_REPO" /src/prrte
```

layer by its *text*, not by what the remote now contains, so the rebuild
reports success in seconds and bakes exactly the PRRTE you were trying to
leave behind. That matters more here than it would in most images: PRRTE
master is what tracks new PMIx capability flags, so an old baked PRRTE
either refuses to `configure` against the PMIx under test or builds and
then cannot launch it.

### The containers go stale after the image

The ten nodes are long-lived containers, so even a genuinely rebuilt image
does not reach them until they are recreated. `build.sh` then compiles
PMIx and PRRTE inside a *new* container and installs them into the volume
the *old* containers read, and the daemons load libraries built for a
different launcher. The symptom is an undefined symbol, or a launcher that
does not understand an option, in whichever case reaches it first — with
nothing in the output pointing at the container.

`run-tests.sh` now compares each container's image ID against
`pmix-swarm:latest` in its preflight and refuses to run when they differ.
That is the same guard as the "install present in the shared volume" check,
one level further out.

### Recreating them was itself a trap

The compose project name defaults to the directory name, `dockerswarm` —
which is also the name of PRRTE's identical harness directory. So
`docker compose up -d` run for one swarm adopts the *other* project's
containers: it stops that swarm, renames its containers out from under
themselves, and then fails on the name collision, leaving one set of nodes
on the image they were created from. That is exactly how the stale state
above was reached (from the PRRTE side, where the same pin is being added
in openpmix/prrte#2575).

`docker-compose.yml` now pins `name: pmixswarm`, so a plain
`docker compose` in this directory can only ever mean this swarm.

`README.md` §8 records both traps and the sequence that actually moves the
baked launcher forward.

### Testing

Rebuilt the image with `--no-cache` against PRRTE master, wiped the
volume's build and install directories, rebuilt, and recreated the
containers:

* `run-tests.sh linux` — 12 passed, 0 failed
* `run-group-events.sh linux` — 8 passed, 0 failed
* `run-python.sh linux` — 8 passed, 0 failed

No PMIx source is touched by this PR; it is entirely
`contrib/dockerswarm/`.