### PR TITLE
Fix command-line option detection, and formatting for early output

### DIFF
--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -69,6 +69,33 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
                         void *cbdata);
 static void spawn_cbfunc(pmix_status_t status, char nspace[], void *cbdata);
 
+/* Hold a spawn's output-formatting flags where output can find them before
+ * the reply names the namespace they belong to.
+ *
+ * Only meaningful for a tool: a tool receives forwarded output for the jobs
+ * it spawned, so output arriving for a namespace it has not been told about
+ * yet can only be from the spawn it just issued. Until this existed, that
+ * output fell back to the process-wide defaults and came out unformatted -
+ * so "prun --output tag" lost the tag on whichever rank happened to be
+ * quickest, which showed up as an intermittent failure whenever anything
+ * slowed the reply down (two pruns against one DVM was enough).
+ *
+ * The string members are not copied: this stand-in owns nothing.
+ */
+static void stash_spawn_iof_flags(pmix_iof_flags_t *flags)
+{
+    if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer) || !flags->set) {
+        return;
+    }
+    memcpy(&pmix_globals.spawn_iof_flags, flags, sizeof(pmix_iof_flags_t));
+    pmix_globals.spawn_iof_flags.file = NULL;
+    pmix_globals.spawn_iof_flags.directory = NULL;
+    /* as in the reply handler: for a non-server, nocopy means no local output */
+    if (flags->nocopy) {
+        pmix_globals.spawn_iof_flags.local_output = false;
+    }
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                                      const pmix_app_t apps[], size_t napps, pmix_nspace_t nspace)
 {
@@ -392,6 +419,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
          * of job termination so we can setup the event registration */
         pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
                                  fcd->info, fcd->ninfo);
+        stash_spawn_iof_flags(&fcd->flags);
 
         /* call the local host */
         rc = pmix_host_server.spawn(&pmix_globals.myid,
@@ -466,6 +494,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     /* check for IOF flags */
     pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
                              fcd->info, fcd->ninfo);
+    stash_spawn_iof_flags(&fcd->flags);
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) fcd);
@@ -561,6 +590,10 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
             if (fcd->flags.nocopy) {
                 nptr->iof_flags.local_output = false;
             }
+            /* the namespace now carries its own flags, so the stand-in for
+             * output that arrived before this reply is no longer wanted */
+            pmix_iof_init_flags(&pmix_globals.spawn_iof_flags);
+            pmix_globals.spawn_iof_flags.set = false;
         }
     }
 

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1743,6 +1743,19 @@ process:
     return PMIX_SUCCESS;
 }
 
+/* What to format output with when the namespace it came from has nothing to
+ * say about it. A tool that has a spawn in flight has already parsed that
+ * spawn's directives (see stash_spawn_iof_flags() in pmix_client_spawn.c);
+ * output that beat the reply here belongs to that spawn, so those flags are
+ * the right answer rather than the process-wide default. */
+static pmix_iof_flags_t spawn_or_global_flags(void)
+{
+    if (pmix_globals.spawn_iof_flags.set) {
+        return pmix_globals.spawn_iof_flags;
+    }
+    return pmix_globals.iof_flags;
+}
+
 pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
                                     pmix_iof_channel_t stream,
                                     const pmix_byte_object_t *bo)
@@ -1840,10 +1853,10 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
             }
             myflags = nptr->iof_flags;
         } else {
-            myflags = pmix_globals.iof_flags;
+            myflags = spawn_or_global_flags();
         }
     } else {
-        myflags = pmix_globals.iof_flags;
+        myflags = spawn_or_global_flags();
     }
 
     if (!outputio) {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -869,6 +869,18 @@ typedef struct {
     bool external_topology;
     bool external_progress;
     pmix_iof_flags_t iof_flags;
+    /* Output-formatting flags belonging to a spawn we have issued but whose
+     * namespace we have not been told yet. A tool's spawn directives are
+     * parsed before the request goes out (see pmix_server_spawn_parser() in
+     * PMIx_Spawn_nb, "helps to catch any early output"), but they can only be
+     * recorded against the namespace once the reply names it - and a proc
+     * that writes and exits immediately can get its output to us first. That
+     * output has nowhere to look for its format, so it came out unformatted.
+     * Holding the flags here gives it somewhere. Cleared once the reply has
+     * been processed and the per-namespace flags are in place. Note the file
+     * and directory members are deliberately left NULL: this copy does not
+     * own strings, it only carries the formatting decisions. */
+    pmix_iof_flags_t spawn_iof_flags;
     pmix_keyindex_t keyindex;
 } pmix_globals_t;
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -123,6 +123,7 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .external_topology = false,
     .external_progress = false,
     .iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
+    .spawn_iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
     .keyindex = PMIX_KEYINDEX_STATIC_INIT
 };
 

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -249,16 +249,20 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         // --show-version option with no args
                         mystore(myoptions[option_index].name, optarg, results);
                         break;
-                    } else if (NULL != argv[optind]) {
-                            if (NULL == argv[optind+1]) {
-                            // one arg
-                            mystore(myoptions[option_index].name, argv[optind], results);
-                        } else {
-                            // two args
-                            mystore(myoptions[option_index].name, argv[optind], results);
-                            mystore(myoptions[option_index].name, argv[optind+1], results);
-                            ++optind;
-                        }
+                    }
+                    /* Takes up to two trailing tokens - a
+                     * "framework[:component]" and an optional modifier (see
+                     * pmix_info). Every token we claim has to be consumed:
+                     * this used to advance optind by one when it took TWO
+                     * and not at all when it took one, so the last argument
+                     * of a --show-version was also reported back to the
+                     * caller as the start of the command tail. */
+                    mystore(myoptions[option_index].name, argv[optind], results);
+                    ++optind;
+                    if (NULL != argv[optind] &&
+                        !is_option_token(argv[optind], shorts, myoptions)) {
+                        mystore(myoptions[option_index].name, argv[optind], results);
+                        ++optind;
                     }
                     break;
                 }

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -56,6 +56,69 @@ static int endswith(const char *str, const char *suffix)
     return PMIX_ERR_BAD_PARAM;
 }
 
+/* Does this token name one of the options this tool registered?
+ *
+ * Two places below have to tell "the user omitted my argument and what
+ * follows is the next option" from "my argument merely looks option-ish".
+ * Both used to answer it by testing argv[n][1] for a dash, which is wrong
+ * in both directions: it rejects any value whose SECOND character is a dash
+ * (so "--pmixmca hwloc_default_cpu_list 0-1" was reported as a missing
+ * argument) while letting every short option through (so "--show-version -v"
+ * took "-v" to be a version argument).
+ *
+ * Testing argv[n][0] instead is no good either - it would reject a value
+ * that legitimately starts with a dash, and negative MCA values are real
+ * (prte_max_vm_size and prte_progress_thread_debug_level both use -1).
+ *
+ * So ask the option table. A token is an option only if it actually names
+ * one, which is the question we meant to ask all along.
+ */
+static bool is_option_token(const char *arg, const char *shorts,
+                            struct option myoptions[])
+{
+    const char *ptr;
+    size_t n, len;
+
+    if (NULL == arg || '-' != arg[0] || '\0' == arg[1]) {
+        /* not even shaped like an option - a bare "-" included, which
+         * conventionally means stdin rather than an option */
+        return false;
+    }
+
+    if ('-' == arg[1]) {
+        /* A bare "--" separates the launcher's directives from the
+         * application, so it is certainly not this option's value. */
+        if ('\0' == arg[2]) {
+            return true;
+        }
+        /* Long form. Stop at '=' so "--foo=bar" is recognized, and match on
+         * a prefix, as getopt_long itself does for unambiguous
+         * abbreviations. */
+        ptr = arg + 2;
+        len = strcspn(ptr, "=");
+        for (n = 0; NULL != myoptions[n].name; n++) {
+            if (0 == strncmp(ptr, myoptions[n].name, len)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* Short form, possibly a cluster such as "-vvv". Every character has to
+     * be a registered short option for the token to be one - that is what
+     * keeps "-1" and "-n4" out. Skip the ':' argument markers in the shorts
+     * string; they are modifiers, not options. */
+    if (NULL == shorts) {
+        return false;
+    }
+    for (ptr = arg + 1; '\0' != *ptr; ++ptr) {
+        if (':' == *ptr || NULL == strchr(shorts, *ptr)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void check_store(const char *name, const char *option,
                         pmix_cli_result_t *results)
 {
@@ -143,7 +206,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     /* format mca params as param:value - the optind value
                      * will have been incremented since the MCA param options
                      * require an argument */
-                    if (NULL == argv[optind] || '-' == argv[optind][1]) {
+                    if (NULL == argv[optind] ||
+                        is_option_token(argv[optind], shorts, myoptions)) {
                         // missing the required second argument
                         str = pmix_show_help_string("help-cli.txt", "not-enough-arguments", true,
                                                     pmix_tool_basename, myoptions[option_index].name,
@@ -179,7 +243,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     break;
                 }
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_INFO_VERSION)) {
-                    if (NULL == argv[optind] || '-' == argv[optind][1]) {
+                    if (NULL == argv[optind] ||
+                        is_option_token(argv[optind], shorts, myoptions)) {
                         // --show-version option with no args
                         mystore(myoptions[option_index].name, optarg, results);
                         break;

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -159,6 +159,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
     int n, m, opt, argc, argind;
     bool found;
     char *ptr, *str, **argv;
+    const char *optname;
     pmix_cmd_line_store_fn_t mystore;
 
     /* the getopt_long parser reorders the input argv array, so
@@ -368,18 +369,45 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 PMIx_Argv_free(argv);
                 return PMIX_OPERATION_SUCCEEDED;
             case 'v':
-                /* if the argv at this point is not pointing at a string
-                 * starting with "-v", then we just ignore it - the user
-                 * has passed a string with multiple 'v's in it and we
-                 * need to wait until the end */
-                if (0 != strncmp(argv[optind-1], "-v", 2)) {
+                /* Name the option from the character getopt handed back, not
+                 * from option_index: getopt_long only sets option_index when
+                 * it matched a LONG option, so on "-v" it still holds the
+                 * last long option matched - or zero, the FIRST entry in the
+                 * table, which is how the verbosity count came to be
+                 * recorded against "help". */
+                optname = NULL;
+                for (m = 0; NULL != myoptions[m].name; m++) {
+                    if (opt == myoptions[m].val) {
+                        optname = myoptions[m].name;
+                        break;
+                    }
+                }
+                if (NULL == optname) {
+                    // 'v' is not in this tool's table - nothing to record
                     break;
                 }
-                /* we store the 'v' option with a value equal to the
-                 * number of 'v's the user provided */
-                n = strlen(&argv[optind-1][1]);
+                if ('-' == argv[optind-1][0] && '-' == argv[optind-1][1] &&
+                    0 == strncmp(&argv[optind-1][2], optname,
+                                 strlen(&argv[optind-1][2]))) {
+                    /* The long form ("--verbose", or any unambiguous
+                     * abbreviation of it) is a single request. It used to be
+                     * dropped on the floor: this arm demanded a token
+                     * beginning "-v", which "--verbose" does not. */
+                    n = 1;
+                } else if (0 == strncmp(argv[optind-1], "-v", 2)) {
+                    /* Short form. getopt hands us 'v' once per character of
+                     * a cluster ("-vvv") but only steps optind past the
+                     * cluster on the last one, so the earlier calls still
+                     * see the PREVIOUS argv entry - hence the test that the
+                     * token is actually ours. The verbosity is then the
+                     * number of v's given. */
+                    n = strlen(&argv[optind-1][1]);
+                } else {
+                    // an interim call for a cluster we have not finished
+                    break;
+                }
                 pmix_asprintf(&str, "%d", n);
-                mystore(myoptions[option_index].name, str, results);
+                mystore(optname, str, results);
                 free(str);
                 break;
             default:

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -101,6 +101,21 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 
 #define PMIX_OPTION_END  {0, 0, 0, 0}
 
+/* A note on the options marked "requires TWO" below.
+ *
+ * getopt is told those options take ONE argument, and the parser then takes
+ * a second token of its own accord from argv[optind]. Deciding whether that
+ * token is the value or the next option is therefore the parser's problem,
+ * not getopt's, and it is answered by asking this table whether the token
+ * names a registered option (see is_option_token() in pmix_cmd_line.c).
+ *
+ * It must not be answered by looking for a dash. A value may legitimately
+ * contain one ("0-1") or begin with one ("-1" - negative MCA values are
+ * real), and a short option is a single dash, so neither argv[n][0] nor
+ * argv[n][1] separates the two cases. Both spellings have been tried and
+ * both broke a working command line.
+ */
+
 //      NAME                            STRING                      ARGUMENT
 
 // Basic options

--- a/test/unit/util/util_cmd_line.c
+++ b/test/unit/util/util_cmd_line.c
@@ -12,6 +12,14 @@
  *   pmix_cmd_line_get_nth_instance, pmix_check_cli_option,
  *   pmix_convert_string_to_time.
  *
+ * The bulk of this is a table of command lines run through
+ * pmix_cmd_line_parse() against one realistic option table. A parser like
+ * this one has no interesting internal state to inspect - what matters is
+ * the mapping from an argv to (return code, recorded options, tail) - and
+ * the failures it has had were all of the shape "one input is read wrongly
+ * while its neighbours are fine". A table is the only economical way to
+ * hold enough neighbours.
+ *
  * PMIx_Init is called first; PMIX_ERR_UNREACH is treated as normal.
  *
  * Exit 0 if all tests pass, 1 otherwise.
@@ -20,12 +28,15 @@
 #include "src/include/pmix_config.h"
 #include "src/include/pmix_globals.h"
 
+#include <fcntl.h>
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "pmix.h"
+#include "src/util/pmix_argv.h"
 #include "src/util/pmix_cmd_line.h"
 
 static int npass = 0;
@@ -42,7 +53,7 @@ static void report(const char *name, int passed)
     }
 }
 
-/* Options used throughout the parse tests. */
+/* Options used by the hand-written tests below. */
 static struct option myopts[] = {
     PMIX_OPTION_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PMIX_CLI_TIMEOUT, PMIX_ARG_REQD),
@@ -140,6 +151,387 @@ static void test_parse_not_taken(void)
     PMIX_DESTRUCT(&res);
 }
 
+/* ================================================================== */
+/* The table                                                          */
+/* ================================================================== */
+
+/* One option table for every case below, shaped like the ones the tools
+ * actually register (see prteshorts/prterunshorts in PRRTE's schizo): a
+ * short-only flag or two, an optional-argument short ('h::'), a
+ * required-argument short ('n:'), long options with and without arguments,
+ * the two-token MCA option, and "--show-version", which takes zero, one, or
+ * two trailing tokens. */
+static struct option tblopts[] = {
+    PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
+    PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERSION, PMIX_ARG_NONE, 'V'),
+    PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_DEFINE(PMIX_CLI_TIMEOUT, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_NAMESPACE, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_URI, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_INFO_VERSION, PMIX_ARG_OPTIONAL),
+    PMIX_OPTION_SHORT_DEFINE("np", PMIX_ARG_REQD, 'n'),
+    PMIX_OPTION_END
+};
+static char *tblshorts = "h::vVn:";
+
+#define MAXARGS 10
+
+typedef struct {
+    const char *desc;
+    const char *argv[MAXARGS];
+    int rc;
+    const char *key;      /* option that must be present, or NULL */
+    const char *vals;     /* '|'-joined expected values; "" = present with
+                           * none; NULL = do not inspect the values */
+    const char *key2;     /* a second option that must be present, or NULL */
+    const char *vals2;
+    const char *absent;   /* option that must NOT be present, or NULL */
+    const char *tail;     /* ' '-joined expected tail; NULL = no tail */
+} parse_case_t;
+
+static parse_case_t cases[] = {
+
+    /* ---- MCA parameters ---------------------------------------------
+     * "--pmixmca <param> <value>" is two tokens, but getopt is told the
+     * option takes one. The value is therefore grabbed by hand from
+     * argv[optind], which makes "is my value even there?" this parser's
+     * own problem - and that decision is where it went wrong. */
+    {"mca: plain value",
+     {"prog", "--pmixmca", "p", "v", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=v", NULL, NULL, NULL, NULL},
+
+    /* THE regression: the missing-argument check tested the value's
+     * SECOND character for a dash, so every range-valued MCA parameter
+     * was rejected as though no value had been given. */
+    {"mca: value with an interior dash (a range)",
+     {"prog", "--pmixmca", "hwloc_default_cpu_list", "0-1", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "hwloc_default_cpu_list=0-1", NULL, NULL, NULL, NULL},
+
+    {"mca: two-digit range value",
+     {"prog", "--pmixmca", "p", "10-20", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=10-20", NULL, NULL, NULL, NULL},
+
+    {"mca: value with several dashes",
+     {"prog", "--pmixmca", "p", "a-b-c", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=a-b-c", NULL, NULL, NULL, NULL},
+
+    /* A value that legitimately STARTS with a dash. Negative MCA values
+     * are real - prte_max_vm_size and prte_progress_thread_debug_level
+     * both use -1 - so this is the pattern that "just test argv[n][0]
+     * for a dash instead" would have broken. */
+    {"mca: negative value",
+     {"prog", "--pmixmca", "prte_max_vm_size", "-1", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "prte_max_vm_size=-1", NULL, NULL, NULL, NULL},
+
+    {"mca: negative multi-digit value",
+     {"prog", "--pmixmca", "p", "-100", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=-100", NULL, NULL, NULL, NULL},
+
+    /* Dash-leading, and 'n' IS a registered short option - but the token
+     * as a whole names no option, so it is a value. */
+    {"mca: dash value that is not a whole option",
+     {"prog", "--pmixmca", "p", "-n4", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=-n4", NULL, NULL, NULL, NULL},
+
+    {"mca: dash value naming an unregistered letter",
+     {"prog", "--pmixmca", "p", "-Z", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=-Z", NULL, NULL, NULL, NULL},
+
+    {"mca: value with a colon",
+     {"prog", "--pmixmca", "p", "1:2", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=1:2", NULL, NULL, NULL, NULL},
+
+    {"mca: value containing an equals",
+     {"prog", "--pmixmca", "p", "a=b", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=a=b", NULL, NULL, NULL, NULL},
+
+    /* ...and the diagnostics that must still fire: each of these really
+     * is a missing value. */
+    {"mca: no value at all is refused",
+     {"prog", "--pmixmca", "p", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following long option is refused",
+     {"prog", "--pmixmca", "p", "--verbose", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following long option with an argument is refused",
+     {"prog", "--pmixmca", "p", "--timeout", "30", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following abbreviated long option is refused",
+     {"prog", "--pmixmca", "p", "--verb", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following short option is refused",
+     {"prog", "--pmixmca", "p", "-v", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following short cluster is refused",
+     {"prog", "--pmixmca", "p", "-vvv", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"mca: a following double-dash is refused",
+     {"prog", "--pmixmca", "p", "--", "app", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    /* ...and parsing carries on correctly afterwards */
+    {"mca: two parameters, both recorded",
+     {"prog", "--pmixmca", "p", "v", "--pmixmca", "q", "0-1", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=v|q=0-1", NULL, NULL, NULL, NULL},
+
+    {"mca: a range value, then a long option with an argument",
+     {"prog", "--pmixmca", "p", "0-1", "--timeout", "30", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=0-1", PMIX_CLI_TIMEOUT, "30", NULL, NULL},
+
+    {"mca: a range value does not swallow the application",
+     {"prog", "--pmixmca", "p", "0-1", "--", "app", "arg", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PMIXMCA, "p=0-1", NULL, NULL, NULL, "app arg"},
+
+    /* ---- long options --------------------------------------------- */
+    {"long: flag",
+     {"prog", "--verbose", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, NULL, NULL, NULL, PMIX_CLI_TIMEOUT, NULL},
+
+    {"long: required argument as a separate token",
+     {"prog", "--timeout", "30", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "30", NULL, NULL, NULL, NULL},
+
+    {"long: required argument in the '=' form",
+     {"prog", "--timeout=30", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "30", NULL, NULL, NULL, NULL},
+
+    {"long: required argument that starts with a dash",
+     {"prog", "--timeout=-1", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "-1", NULL, NULL, NULL, NULL},
+
+    {"long: required argument containing a dash",
+     {"prog", "--uri", "tcp4://1.2.3.4:100-200", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_URI, "tcp4://1.2.3.4:100-200", NULL, NULL, NULL, NULL},
+
+    {"long: unambiguous abbreviation resolves",
+     {"prog", "--namesp", "myns", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_NAMESPACE, "myns", NULL, NULL, NULL, NULL},
+
+    {"long: two different options",
+     {"prog", "--timeout", "30", "--namespace", "myns", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "30", PMIX_CLI_NAMESPACE, "myns", NULL, NULL},
+
+    {"long: a repeated option records both instances",
+     {"prog", "--namespace", "a", "--namespace", "b", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_NAMESPACE, "a|b", NULL, NULL, NULL, NULL},
+
+    {"long: an unregistered option is refused",
+     {"prog", "--nosuchoption", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"long: a registered option missing its argument is refused",
+     {"prog", "--timeout", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    /* ---- short options -------------------------------------------- */
+    {"short: required argument as a separate token",
+     {"prog", "-n", "4", NULL}, PMIX_SUCCESS,
+     "np", "4", NULL, NULL, NULL, NULL},
+
+    {"short: required argument attached",
+     {"prog", "-n4", NULL}, PMIX_SUCCESS,
+     "np", "4", NULL, NULL, NULL, NULL},
+
+    {"short: verbose counts one",
+     {"prog", "-v", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, "1", NULL, NULL, NULL, NULL},
+
+    {"short: a verbose cluster counts three",
+     {"prog", "-vvv", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, "3", NULL, NULL, NULL, NULL},
+
+    {"short: followed by a long option",
+     {"prog", "-n", "4", "--timeout", "30", NULL}, PMIX_SUCCESS,
+     "np", "4", PMIX_CLI_TIMEOUT, "30", NULL, NULL},
+
+    /* ---- the tail -------------------------------------------------- */
+    {"tail: a bare command with no options",
+     {"prog", "app", "arg", NULL}, PMIX_SUCCESS,
+     NULL, NULL, NULL, NULL, NULL, "app arg"},
+
+    {"tail: after a flag",
+     {"prog", "--verbose", "app", "arg", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, NULL, NULL, NULL, NULL, "app arg"},
+
+    {"tail: after an option with an argument",
+     {"prog", "--timeout", "30", "app", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "30", NULL, NULL, NULL, "app"},
+
+    {"tail: double-dash separator",
+     {"prog", "--verbose", "--", "app", "arg", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, NULL, NULL, NULL, NULL, "app arg"},
+
+    {"tail: the application's own dashed options are not ours",
+     {"prog", "--", "app", "--verbose", NULL}, PMIX_SUCCESS,
+     NULL, NULL, NULL, NULL, PMIX_CLI_VERBOSE, "app --verbose"},
+
+    {"tail: a lone '&' is dropped",
+     {"prog", "--verbose", "&", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, NULL, NULL, NULL, NULL, NULL},
+
+    {"tail: nothing but the program name",
+     {"prog", NULL}, PMIX_SUCCESS,
+     NULL, NULL, NULL, NULL, PMIX_CLI_VERBOSE, NULL},
+
+    /* ---- --show-version -------------------------------------------
+     * Zero, one, or two trailing tokens, so it makes the same "is the
+     * next token an option?" decision the MCA path does. */
+    {"show-version: no arguments",
+     {"prog", "--show-version", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_INFO_VERSION, "", NULL, NULL, NULL, NULL},
+
+    {"show-version: one argument",
+     {"prog", "--show-version", "pmix", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_INFO_VERSION, "pmix", NULL, NULL, NULL, NULL},
+
+    {"show-version: a following long option is not an argument",
+     {"prog", "--show-version", "--verbose", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_INFO_VERSION, "", PMIX_CLI_VERBOSE, NULL, NULL, NULL},
+
+    /* Same defect, the other direction: a short option used to be taken
+     * as --show-version's argument, because only argv[n][1] was looked at. */
+    {"show-version: a following short option is not an argument",
+     {"prog", "--show-version", "-v", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_INFO_VERSION, "", PMIX_CLI_VERBOSE, "1", NULL, NULL},
+
+    {NULL, {NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL}
+};
+
+/* Render an option's recorded values as a '|'-joined string, or NULL if the
+ * option is absent. An option present with no values renders as "". */
+static char *render(pmix_cli_result_t *res, const char *key)
+{
+    pmix_cli_item_t *opt;
+    char *out;
+
+    opt = pmix_cmd_line_get_param(res, key);
+    if (NULL == opt) {
+        return NULL;
+    }
+    if (NULL == opt->values) {
+        return strdup("");
+    }
+    out = PMIx_Argv_join(opt->values, '|');
+    return (NULL == out) ? strdup("") : out;
+}
+
+static bool check_key(const char *desc, pmix_cli_result_t *res,
+                      const char *key, const char *vals)
+{
+    char *got;
+    bool ok;
+
+    if (NULL == key) {
+        return true;
+    }
+    got = render(res, key);
+    if (NULL == got) {
+        fprintf(stdout, "  FAIL: %s [option \"%s\" absent]\n", desc, key);
+        nfail++;
+        return false;
+    }
+    ok = (NULL == vals) || (0 == strcmp(got, vals));
+    if (!ok) {
+        fprintf(stdout, "  FAIL: %s [option \"%s\": wanted \"%s\", got \"%s\"]\n",
+                desc, key, vals, got);
+        nfail++;
+    }
+    free(got);
+    return ok;
+}
+
+static void run_table(void)
+{
+    parse_case_t *c;
+    pmix_cli_result_t res;
+    int rc, saved_err, devnull;
+    char *got;
+    bool ok;
+
+    /* Each error case prints a help block to stderr. That is the correct
+     * behavior, but it buries the results, so park stderr for the duration
+     * and put it back afterwards. */
+    saved_err = dup(fileno(stderr));
+    devnull = open("/dev/null", O_WRONLY);
+
+    for (c = cases; NULL != c->desc; c++) {
+        ok = true;
+        PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+
+        if (0 <= devnull) {
+            fflush(stderr);
+            dup2(devnull, fileno(stderr));
+        }
+        rc = pmix_cmd_line_parse((char **) c->argv, tblshorts, tblopts,
+                                 NULL, &res, "help-cli.txt");
+        if (0 <= saved_err) {
+            fflush(stderr);
+            dup2(saved_err, fileno(stderr));
+        }
+
+        if (rc != c->rc) {
+            fprintf(stdout, "  FAIL: %s [rc: wanted %d (%s), got %d (%s)]\n",
+                    c->desc, c->rc, PMIx_Error_string(c->rc),
+                    rc, PMIx_Error_string(rc));
+            nfail++;
+            ok = false;
+        }
+
+        /* only inspect the results of a parse that was meant to succeed */
+        if (PMIX_SUCCESS == c->rc) {
+            ok = check_key(c->desc, &res, c->key, c->vals) && ok;
+            ok = check_key(c->desc, &res, c->key2, c->vals2) && ok;
+
+            if (NULL != c->absent &&
+                NULL != (got = render(&res, c->absent))) {
+                fprintf(stdout, "  FAIL: %s [option \"%s\" should be absent,"
+                        " got \"%s\"]\n", c->desc, c->absent, got);
+                free(got);
+                nfail++;
+                ok = false;
+            }
+
+            got = (NULL == res.tail) ? NULL : PMIx_Argv_join(res.tail, ' ');
+            if (NULL == c->tail) {
+                if (NULL != got) {
+                    fprintf(stdout, "  FAIL: %s [tail should be empty,"
+                            " got \"%s\"]\n", c->desc, got);
+                    nfail++;
+                    ok = false;
+                }
+            } else if (NULL == got || 0 != strcmp(got, c->tail)) {
+                fprintf(stdout, "  FAIL: %s [tail: wanted \"%s\", got \"%s\"]\n",
+                        c->desc, c->tail, (NULL == got) ? "(empty)" : got);
+                nfail++;
+                ok = false;
+            }
+            if (NULL != got) {
+                free(got);
+            }
+        }
+
+        if (ok) {
+            fprintf(stdout, "  PASS: %s\n", c->desc);
+            npass++;
+        }
+        PMIX_DESTRUCT(&res);
+    }
+
+    if (0 <= devnull) {
+        close(devnull);
+    }
+    if (0 <= saved_err) {
+        close(saved_err);
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_check_cli_option (inline abbreviation matching)               */
 /* ------------------------------------------------------------------ */
@@ -210,6 +602,11 @@ int main(int argc, char **argv)
     test_parse_required_arg();
     test_parse_multiple_options();
     test_parse_not_taken();
+
+    fprintf(stdout, "\n--- command-line table ---\n");
+    run_table();
+    fprintf(stdout, "\n");
+
     test_check_cli_option();
     test_convert_time();
 


### PR DESCRIPTION
## The problem

`pmix_cmd_line_parse()` has to decide, in two places, whether the token it is
looking at is an argument belonging to the option it just parsed or the next
option because the user left the argument out. Both places answered by testing
the token's **second** character for a dash.

That is wrong in both directions:

* it rejects a value that merely *contains* a dash in that position, so
  `--pmixmca hwloc_default_cpu_list 0-1` was reported as a missing argument and
  every range-valued MCA parameter was unusable. A range one character longer
  (`10-20`) sailed through, which shows how arbitrary the test was.
* it lets every short option past, so `--show-version -v` took `-v` to be a
  version argument.

Testing the **first** character instead only trades one failure for another: a
value may legitimately begin with a dash, and negative MCA values are real —
`prte_max_vm_size` and `prte_progress_thread_debug_level` both use `-1`.

## What this does

Asks the option table. A token is an option when it actually names one — a long
option by prefix, as `getopt_long` itself resolves unambiguous abbreviations,
and a short option only when every character of the cluster is registered. That
leaves `0-1`, `-1` and `-n4` as the values they are, while still catching the
`--verbose` or `-v` that means the user forgot to say what to set.

A table of ~70 command lines was then added to `test/unit/util/util_cmd_line.c`,
which had covered five happy paths. It exposed three more defects in the same
function, each fixed in its own commit here:

* **`--verbose` was dropped entirely.** The arm handling `'v'` requires the
  token to begin `-v`, which is how it skips the interim calls `getopt` makes
  for each character of a cluster like `-vvv`; the long spelling does not
  satisfy it.
* **`-v` filed its count under the wrong option.** It named the option through
  the long-option index, which `getopt_long` only sets for a *long* option — so
  on `-v` that index still held the last long option matched, or zero, which in
  every tool is `help`. Between this and the previous point, the verbose option
  has never reached the results at all.
* **`--show-version` did not consume the tokens it claimed**, so its last
  argument was reported back to the caller as the start of the command tail.

The last commit is a separate defect in the same area — output formatting for
output that arrives early:

A tool parses a spawn's output directives before the request goes out (the
comment on that call says it is done "to catch any early output"), but the
flags could only be recorded against the namespace once the reply named it.
A process that writes and exits immediately can get its output to the tool ahead
of that reply, and `pmix_iof_write_output()` then falls back to the process-wide
defaults, which say nothing about how this job was asked to be displayed. One
tool against an idle server almost always wins the race; two contending for the
same server do not, so `prun --output tag` lost the tag on whichever rank was
quickest, about one run in three. The spawn's flags are now held where that
output can find them, and dropped once the reply has been processed.

## Testing

* `make check`: 75/75.
* Warning-free `--enable-debug --enable-devel-check` build.
* The new table reports **24 failures** against the parser as it stood before
  the first three commits.
* End-to-end against PRRTE with a control: `--prtemca hwloc_default_cpu_list 0-1`
  fails with `not-enough-arguments` on an unpatched libpmix and works here;
  `--prtemca prte_max_vm_size -1` still works.
* The tagging race: 8/8 clean in a 10-node container harness where it had been
  failing about one run in three, and that harness's full suite (which drives
  PRRTE against this branch) is 290 passed, 0 failed.
