### PR TITLE
Harden the IOF output-file pattern walker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,6 +264,7 @@ test/unit/progress_threads
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register
+test/unit/iof_pattern
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -849,6 +849,11 @@ static pmix_status_t process_pattern(const char *pattern, bool expand,
     if (NULL == pattern) {
         return PMIX_ERR_BAD_PARAM;
     }
+    /* validation mode has no answer to hand back, but expansion does -
+     * refuse rather than expand a name into nowhere */
+    if (expand && NULL == result) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     if (expand) {
         out = strdup("");

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -823,6 +823,31 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
 }
 
 /*
+ * Grow the accumulated name, replacing it with the formatted result and
+ * releasing the old buffer. The format is expected to lead with a "%s" fed
+ * by the current *out - i.e. it appends. On allocation failure the
+ * accumulator is freed and set to NULL, so a caller need only test the
+ * return value to know it owns nothing.
+ */
+static bool append_to_pattern(char **out, const char *fmt, ...)
+__pmix_attribute_format__(__printf__, 2, 3);
+
+static bool append_to_pattern(char **out, const char *fmt, ...)
+{
+    char *tmp = NULL;
+    va_list ap;
+
+    va_start(ap, fmt);
+    /* pmix_vasprintf guarantees tmp is NULL on error */
+    pmix_vasprintf(&tmp, fmt, ap);
+    va_end(ap);
+
+    free(*out);
+    *out = tmp;
+    return (NULL != tmp);
+}
+
+/*
  * Expand the '%' conversions in an output-file pattern - see the contract
  * on pmix_iof_check_pattern/pmix_iof_expand_pattern in pmix_iof.h.
  *
@@ -837,7 +862,7 @@ static pmix_status_t process_pattern(const char *pattern, bool expand,
                                      char **result, char **bad)
 {
     const char *p;
-    char *out = NULL, *tmp;
+    char *out = NULL;
     char conv[3];
 
     if (NULL != bad) {
@@ -865,9 +890,9 @@ static pmix_status_t process_pattern(const char *pattern, bool expand,
     for (p = pattern; '\0' != *p; ++p) {
         if ('%' != *p) {
             if (expand) {
-                pmix_asprintf(&tmp, "%s%c", out, *p);
-                free(out);
-                out = tmp;
+                if (!append_to_pattern(&out, "%s%c", out, *p)) {
+                    return PMIX_ERR_NOMEM;
+                }
             }
             continue;
         }
@@ -875,38 +900,40 @@ static pmix_status_t process_pattern(const char *pattern, bool expand,
         switch (*p) {
             case 'n':
                 if (expand) {
-                    pmix_asprintf(&tmp, "%s%s", out, (NULL == nspace) ? "" : nspace);
-                    free(out);
-                    out = tmp;
+                    if (!append_to_pattern(&out, "%s%s", out,
+                                           (NULL == nspace) ? "" : nspace)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 break;
             case 'r':
                 if (expand) {
-                    pmix_asprintf(&tmp, "%s%u", out, rank);
-                    free(out);
-                    out = tmp;
+                    if (!append_to_pattern(&out, "%s%u", out, rank)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 break;
             case 'R':
                 if (expand) {
-                    pmix_asprintf(&tmp, "%s%0*u", out, numdigs, rank);
-                    free(out);
-                    out = tmp;
+                    if (!append_to_pattern(&out, "%s%0*u", out, numdigs, rank)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 break;
             case 'h':
                 if (expand) {
-                    pmix_asprintf(&tmp, "%s%s", out,
-                                  (NULL == pmix_globals.hostname) ? "" : pmix_globals.hostname);
-                    free(out);
-                    out = tmp;
+                    if (!append_to_pattern(&out, "%s%s", out,
+                                           (NULL == pmix_globals.hostname)
+                                               ? "" : pmix_globals.hostname)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 break;
             case '%':
                 if (expand) {
-                    pmix_asprintf(&tmp, "%s%%", out);
-                    free(out);
-                    out = tmp;
+                    if (!append_to_pattern(&out, "%s%%", out)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                 }
                 break;
             default:
@@ -930,9 +957,9 @@ static pmix_status_t process_pattern(const char *pattern, bool expand,
 
     if (expand) {
         if (NULL != suffix) {
-            pmix_asprintf(&tmp, "%s%s", out, suffix);
-            free(out);
-            out = tmp;
+            if (!append_to_pattern(&out, "%s%s", out, suffix)) {
+                return PMIX_ERR_NOMEM;
+            }
         }
         *result = out;
     }

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -300,6 +300,10 @@ PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags
  * looking at their command line rather than at a failed job. On
  * PMIX_ERR_BAD_PARAM it sets *bad (if non-NULL) to a malloc'd copy of the
  * offending conversion for the diagnostic; the caller frees it.
+ *
+ * pmix_iof_expand_pattern() requires a non-NULL result; it returns the
+ * expanded name there as a malloc'd string the caller frees, and
+ * PMIX_ERR_BAD_PARAM if given no place to put it.
  */
 PMIX_EXPORT pmix_status_t pmix_iof_check_pattern(const char *pattern, char **bad);
 PMIX_EXPORT pmix_status_t pmix_iof_expand_pattern(const char *pattern,

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -32,9 +32,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale
+check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale
+TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
 compress_SOURCES =  \
         compress.c
@@ -145,5 +145,11 @@ rndz_stale_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 rndz_stale_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+iof_pattern_SOURCES = \
+        iof_pattern.c
+iof_pattern_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+iof_pattern_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern

--- a/test/unit/iof_pattern.c
+++ b/test/unit/iof_pattern.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for PMIX_IOF_FILE_PATTERN name expansion:
+ * pmix_iof_check_pattern() and pmix_iof_expand_pattern().
+ *
+ * These two entry points parse a pattern supplied by the user on a launcher
+ * command line, so they must agree with each other and with their documented
+ * contract in src/common/pmix_iof.h:
+ *   - the recognized conversions (%n, %r, %R, %h, %%) expand as advertised,
+ *     and the stream suffix is always appended;
+ *   - anything else after a '%' - including a '%' at the end of the string -
+ *     is rejected, and the check reports the offending conversion so a
+ *     launcher can tell the user what to fix;
+ *   - the check and the expansion share one walker, so a pattern accepted by
+ *     the check can never be rejected when the file is actually opened. That
+ *     invariant is what keeps a bad pattern from turning into a failed job
+ *     rather than a command-line diagnostic, so it is asserted directly.
+ *
+ * The walker touches no library state other than pmix_globals.hostname (for
+ * %h), so these tests run without initializing PMIx.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "src/common/pmix_iof.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* fixed expansion inputs used by every case below */
+#define MY_NSPACE  "myns"
+#define MY_RANK    3
+#define MY_NUMDIGS 4
+#define MY_HOST    "node07"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* a NULL expectation means "the pattern is rejected" */
+typedef struct {
+    const char *pattern;
+    const char *suffix;
+    const char *expected; /* expanded result, or NULL if rejected */
+    const char *bad;      /* conversion the check must name, if rejected */
+} pattern_test_t;
+
+static pattern_test_t tests[] = {
+    /* a pattern with no conversions at all is simply a fixed name */
+    {"myfile", ".out", "myfile.out", NULL},
+    {"", ".out", ".out", NULL},
+    /* every recognized conversion, alone */
+    {"%n", ".out", MY_NSPACE ".out", NULL},
+    {"%r", ".out", "3.out", NULL},
+    {"%R", ".out", "0003.out", NULL},
+    {"%h", ".out", MY_HOST ".out", NULL},
+    {"%%", ".out", "%.out", NULL},
+    /* ... and all of them together, with literal text interleaved */
+    {"%n-%r-%R-%h-%%done", ".err", MY_NSPACE "-3-0003-" MY_HOST "-%done.err", NULL},
+    /* conversions are legal in the directory part of the name */
+    {"%h/rank-%R", ".out", MY_HOST "/rank-0003.out", NULL},
+    /* adjacent conversions, no separator */
+    {"%n%r", ".out", MY_NSPACE "3.out", NULL},
+    /* a doubled '%' must not be mistaken for the start of a conversion */
+    {"%%n", ".out", "%n.out", NULL},
+    /* no suffix at all is legal - the walker leaves the name alone */
+    {"%n.%r", NULL, MY_NSPACE ".3", NULL},
+    /* unknown conversions are rejected, and named */
+    {"%q", ".out", NULL, "%q"},
+    {"%n.%q", ".out", NULL, "%q"},
+    {"out%zfile", ".out", NULL, "%z"},
+    /* a '%' at the very end has no conversion character to report; the
+     * walker must say so rather than read past the terminator */
+    {"%", ".out", NULL, "%"},
+    {"myfile%", ".out", NULL, "%"},
+    /* case matters: %N and %H are not %n and %h */
+    {"%N", ".out", NULL, "%N"},
+    {"%H", ".out", NULL, "%H"},
+};
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    size_t n;
+    char *result, *bad;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* %h reports the local hostname; the walker reads it straight out of
+     * pmix_globals, so plant a known value rather than depending on the
+     * machine the test happens to run on */
+    pmix_globals.hostname = strdup(MY_HOST);
+
+    fprintf(stdout, "\n=== IOF output-file pattern unit tests ===\n\n");
+
+    for (n = 0; n < sizeof(tests) / sizeof(tests[0]); n++) {
+        pattern_test_t *t = &tests[n];
+        char label[256];
+
+        /* the expansion produces exactly the documented name */
+        result = NULL;
+        rc = pmix_iof_expand_pattern(t->pattern, MY_NSPACE, MY_RANK, MY_NUMDIGS,
+                                     t->suffix, &result);
+        snprintf(label, sizeof(label), "expand \"%s\" -> %s", t->pattern,
+                 (NULL == t->expected) ? "rejected" : t->expected);
+        if (NULL == t->expected) {
+            /* a rejected pattern must not hand back a name to open */
+            report(label, PMIX_ERR_BAD_PARAM == rc && NULL == result);
+        } else {
+            report(label, PMIX_SUCCESS == rc && NULL != result
+                              && 0 == strcmp(result, t->expected));
+        }
+        if (NULL != result) {
+            free(result);
+        }
+
+        /* the check agrees with the expansion - the shared-walker invariant */
+        bad = NULL;
+        rc = pmix_iof_check_pattern(t->pattern, &bad);
+        snprintf(label, sizeof(label), "check \"%s\" agrees with expand", t->pattern);
+        report(label, (NULL == t->expected) ? (PMIX_ERR_BAD_PARAM == rc)
+                                            : (PMIX_SUCCESS == rc));
+
+        /* and names the offending conversion for the diagnostic */
+        snprintf(label, sizeof(label), "check \"%s\" reports bad=%s", t->pattern,
+                 (NULL == t->bad) ? "(none)" : t->bad);
+        if (NULL == t->bad) {
+            report(label, NULL == bad);
+        } else {
+            report(label, NULL != bad && 0 == strcmp(bad, t->bad));
+        }
+        if (NULL != bad) {
+            free(bad);
+        }
+    }
+
+    /* a NULL pattern is a bad parameter, not a crash, in both directions */
+    result = NULL;
+    rc = pmix_iof_expand_pattern(NULL, MY_NSPACE, MY_RANK, MY_NUMDIGS, ".out", &result);
+    report("expand rejects a NULL pattern", PMIX_ERR_BAD_PARAM == rc && NULL == result);
+
+    bad = (char *) 1; /* must be overwritten, even on the error path */
+    rc = pmix_iof_check_pattern(NULL, &bad);
+    report("check rejects a NULL pattern", PMIX_ERR_BAD_PARAM == rc && NULL == bad);
+
+    /* expansion has nowhere to put a name without a result pointer, and must
+     * say so rather than dereference it */
+    rc = pmix_iof_expand_pattern("%n.%r", MY_NSPACE, MY_RANK, MY_NUMDIGS, ".out", NULL);
+    report("expand rejects a NULL result", PMIX_ERR_BAD_PARAM == rc);
+
+    /* the check has no name to hand back, so it must tolerate no bad ptr */
+    rc = pmix_iof_check_pattern("%q", NULL);
+    report("check tolerates a NULL bad ptr", PMIX_ERR_BAD_PARAM == rc);
+
+    /* an absent namespace expands to nothing rather than dereferencing NULL */
+    result = NULL;
+    rc = pmix_iof_expand_pattern("%n%r", NULL, MY_RANK, MY_NUMDIGS, ".out", &result);
+    report("expand tolerates a NULL nspace",
+           PMIX_SUCCESS == rc && NULL != result && 0 == strcmp(result, "3.out"));
+    if (NULL != result) {
+        free(result);
+    }
+
+    /* %R with no padding width behaves like %r */
+    result = NULL;
+    rc = pmix_iof_expand_pattern("%R", MY_NSPACE, MY_RANK, 0, ".out", &result);
+    report("expand pads %R to the requested width only",
+           PMIX_SUCCESS == rc && NULL != result && 0 == strcmp(result, "3.out"));
+    if (NULL != result) {
+        free(result);
+    }
+
+    free(pmix_globals.hostname);
+    pmix_globals.hostname = NULL;
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Two fixes to the `PMIX_IOF_FILE_PATTERN` name walker in
`src/common/pmix_iof.c`, plus the unit test it was missing.

**Refuse to expand a pattern into a NULL result.** `process_pattern()` is
shared by `pmix_iof_check_pattern()` (`expand == false`, `result == NULL`)
and `pmix_iof_expand_pattern()` (`expand == true`, caller-supplied
`result`). Its final `*result = out` is guarded only by `expand`, so it is
safe purely by caller correlation that the function neither states nor
enforces. Coverity flags it as a forward-NULL dereference (CID 504993).
The invariant is now a checked precondition next to the existing NULL
pattern test, and is documented on the exported entry point's contract.

**Check the allocations that build the name.** Each step of the walk grew
the name with an unchecked `pmix_asprintf()`. Since `pmix_vasprintf()`
NULLs the pointer on failure, an allocation failure left the accumulator
NULL and the next iteration passed it to a `%s` — undefined behavior on
any libc that does not print `(null)` — and a surviving walk handed the
caller a NULL filename alongside `PMIX_SUCCESS`. The free-and-replace is
folded into one append helper so the failure is handled in a single place;
each conversion now returns `PMIX_ERR_NOMEM` owning nothing. The helper
carries a format attribute, so the call sites are compiler-checked too.

**New test: `test/unit/iof_pattern.c`**, wired into `make check`. The
walker had no coverage despite parsing a pattern the user types on a
launcher command line. 63 assertions over each conversion alone and
combined, conversions in the directory part of a name, a doubled `%` that
must not read as a conversion, unrecognized and wrong-case conversions
with the offending text the check reports, a bare trailing `%`, and the
NULL parameters. Every case also asserts that the check and the expansion
reach the same verdict — the invariant the shared walker exists to
provide. It needs no `PMIx_Init`: the walker touches only
`pmix_globals.hostname`, which the test plants so `%h` does not depend on
the host it runs on.

### Testing

- Full `make` clean and warning-free under `--enable-devel-check`.
- `TMPDIR=$(mktemp -d) make -C test check`: 34/34 in `test/unit`
  (including the new test), 15/15 at the top level.
- The new test reproduces CID 504993: with the guard removed,
  `./iof_pattern` dies with SIGSEGV on the `expand rejects a NULL result`
  case.