### PR TITLE
Record where each option occurred on the command line

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -54,6 +54,7 @@
 #define PMIX_CAP_GROUP_FT        7
 #define PMIX_CAP_CLI_QUAL_VALUE  8
 #define PMIX_CAP_IOF_FILE_PATTERN 9
+#define PMIX_CAP_CLI_ORDER       10
 
 
 /*****    DEPRECATED    *****/

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -97,7 +97,16 @@ is manipulated without locking and assumes progress-thread-only callers.
 
 A `getopt_long` wrapper that copies argv (getopt reorders in place),
 walks options, and stashes results in a `pmix_cli_result_t` (a list of
-`pmix_cli_item_t` plus a `tail` of positionals). It is intricate and
+`pmix_cli_item_t` plus a `tail` of positionals). Each stored value also
+carries the position at which it was given (`opt->seq[n]`, `-1` if the
+value was added by the caller after the parse rather than by the parser),
+because the grouped view cannot express the interleaving of two repeated
+options — see `pmix_cmd_line_get_nth_seq` and `pmix_cmd_line_get_ordered`.
+The stamping is done by the parser around the store call, not inside
+`check_store`, so it keeps working when a caller supplies a store
+function of its own.
+
+The parser is intricate and
 carries several special cases (`-v` repeat counting, `--` separator,
 MCA-param option pairs, the `-np` shortcut, optional `-h` argument). Two
 parser quirks that bit `src/tools` and are worth remembering: a bare

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -149,6 +149,78 @@ static void check_store(const char *name, const char *option,
     return;
 }
 
+/* Bring every item's record of where its values were given up to date
+ * with the values it actually holds.
+ *
+ * If "record" is set, the new values are numbered with the next
+ * command-line positions; otherwise they are marked as being of unknown
+ * position. The parse makes one un-recorded pass before it starts so that
+ * anything a caller had already put into the results - which did not come
+ * from this command line, and so has no position on it - is not later
+ * mistaken for something we stored.
+ *
+ * Note what this does NOT do: ask the store function what it stored. The
+ * store function is replaceable, and a replacement is free to file a value
+ * under a different key than the one it was handed, under several keys, or
+ * to drop it. Nothing here has to know: whatever grew, grew, and a value
+ * an item holds beyond the extent of its seq array is by definition one
+ * that was just added. That is what keeps this bookkeeping invisible to a
+ * caller with a store function of its own.
+ */
+static void stamp_occurrences(pmix_cli_result_t *results, bool record)
+{
+    pmix_cli_item_t *opt;
+    int n, nvals, *tmp;
+
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        nvals = PMIx_Argv_count(opt->values);
+        if (nvals <= opt->nseq) {
+            // nothing new was stored against this option
+            continue;
+        }
+        tmp = (int *) realloc(opt->seq, nvals * sizeof(int));
+        if (NULL == tmp) {
+            // out of memory - leave the positions we already have
+            return;
+        }
+        opt->seq = tmp;
+        for (n = opt->nseq; n < nvals; n++) {
+            opt->seq[n] = record ? results->nseq++ : -1;
+        }
+        opt->nseq = nvals;
+        if (0 > opt->firstseq) {
+            opt->firstseq = opt->seq[0];
+        }
+    }
+    return;
+}
+
+/* Store one option occurrence and record where on the command line it
+ * was given. */
+static void store_occurrence(pmix_cmd_line_store_fn_t storefn,
+                             const char *name, const char *option,
+                             pmix_cli_result_t *results)
+{
+    pmix_cli_item_t *opt;
+    size_t nitems;
+
+    nitems = pmix_list_get_size(&results->instances);
+    storefn(name, option, results);
+    stamp_occurrences(results, true);
+
+    if (pmix_list_get_size(&results->instances) > nitems) {
+        /* An option we had not seen before. If it was stored without a
+         * value - a boolean option, whose presence is the whole of what
+         * it says - then no value grew and the loop above had nothing to
+         * number, so record the position on the item itself. */
+        opt = (pmix_cli_item_t *) pmix_list_get_last(&results->instances);
+        if (0 > opt->firstseq) {
+            opt->firstseq = results->nseq++;
+        }
+    }
+    return;
+}
+
 int pmix_cmd_line_parse(char **pargv, char *shorts,
                         struct option myoptions[],
                         pmix_cmd_line_store_fn_t storefn,
@@ -191,6 +263,12 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
         return PMIX_SUCCESS;
     }
 
+    /* Anything already in the results did not come from the command line
+     * we are about to read, so it has no position on it - say so before
+     * we start numbering, or the first thing we store would be credited
+     * with a value someone else put there. */
+    stamp_occurrences(results, false);
+
     // run the parser
     while (1) {
         argind = optind;
@@ -224,7 +302,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         return PMIX_ERR_SILENT;
                     }
                     pmix_asprintf(&str, "%s=%s", argv[optind-1], argv[optind]);
-                    mystore(myoptions[option_index].name, str, results);
+                    store_occurrence(mystore, myoptions[option_index].name,
+                                     str, results);
                     free(str);
                     ++optind;
                     break;
@@ -233,21 +312,25 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 // that describe what to do
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_PREPEND_ENVAR) ||
                     0 == strcmp(myoptions[option_index].name, PMIX_CLI_APPEND_ENVAR)) {
-                    mystore(myoptions[option_index].name, argv[optind-1], results);
-                    mystore(myoptions[option_index].name, argv[optind], results);
+                    store_occurrence(mystore, myoptions[option_index].name,
+                                     argv[optind-1], results);
+                    store_occurrence(mystore, myoptions[option_index].name,
+                                     argv[optind], results);
                     ++optind;
                     break;
                 }
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_UNSET_ENVAR)) {
                     // unset-env option only takes one argument
-                    mystore(myoptions[option_index].name, optarg, results);
+                    store_occurrence(mystore, myoptions[option_index].name,
+                                     optarg, results);
                     break;
                 }
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_INFO_VERSION)) {
                     if (NULL == argv[optind] ||
                         is_option_token(argv[optind], shorts, myoptions)) {
                         // --show-version option with no args
-                        mystore(myoptions[option_index].name, optarg, results);
+                        store_occurrence(mystore, myoptions[option_index].name,
+                                         optarg, results);
                         break;
                     }
                     /* Takes up to two trailing tokens - a
@@ -257,17 +340,20 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                      * and not at all when it took one, so the last argument
                      * of a --show-version was also reported back to the
                      * caller as the start of the command tail. */
-                    mystore(myoptions[option_index].name, argv[optind], results);
+                    store_occurrence(mystore, myoptions[option_index].name,
+                                     argv[optind], results);
                     ++optind;
                     if (NULL != argv[optind] &&
                         !is_option_token(argv[optind], shorts, myoptions)) {
-                        mystore(myoptions[option_index].name, argv[optind], results);
+                        store_occurrence(mystore, myoptions[option_index].name,
+                                         argv[optind], results);
                         ++optind;
                     }
                     break;
                 }
                 /* otherwise, store actual option */
-                mystore(myoptions[option_index].name, optarg, results);
+                store_occurrence(mystore, myoptions[option_index].name,
+                                 optarg, results);
                 break;
             case 'h':
                 /* the "help" option can optionally take an argument. Since
@@ -411,7 +497,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     break;
                 }
                 pmix_asprintf(&str, "%d", n);
-                mystore(optname, str, results);
+                store_occurrence(mystore, optname, str, results);
                 free(str);
                 break;
             default:
@@ -473,7 +559,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                     ptr = argv[optind];
                                     ++optind;
                                 }
-                                mystore(myoptions[m].name, ptr, results);
+                                store_occurrence(mystore, myoptions[m].name, ptr, results);
                                 found = true;
                                 break;
                             }
@@ -562,10 +648,98 @@ done:
     return PMIX_SUCCESS;
 }
 
+/* Is occurrence "a" to be reported after occurrence "b"?
+ *
+ * A value whose position was never recorded (seq < 0) has no place in the
+ * ordering, so it goes after everything that does have one. */
+static bool occurs_after(const pmix_cli_occurrence_t *a,
+                         const pmix_cli_occurrence_t *b)
+{
+    if (0 > a->seq) {
+        return (0 <= b->seq);
+    }
+    if (0 > b->seq) {
+        return false;
+    }
+    return (a->seq > b->seq);
+}
+
+int pmix_cmd_line_get_ordered(pmix_cli_result_t *results,
+                              pmix_cli_occurrence_t **occurrences,
+                              size_t *nocc)
+{
+    pmix_cli_item_t *opt;
+    pmix_cli_occurrence_t *array, tmp;
+    size_t n, m, num;
+    int i, nvals;
+
+    if (NULL == results || NULL == occurrences || NULL == nocc) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    *occurrences = NULL;
+    *nocc = 0;
+
+    // how many occurrences are there to report?
+    num = 0;
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        nvals = PMIx_Argv_count(opt->values);
+        /* an option given without a value still occurred, and is
+         * reported as one entry carrying no value */
+        num += (0 == nvals) ? 1 : (size_t) nvals;
+    }
+    if (0 == num) {
+        return PMIX_SUCCESS;
+    }
+    array = (pmix_cli_occurrence_t *) malloc(num * sizeof(pmix_cli_occurrence_t));
+    if (NULL == array) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    n = 0;
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        nvals = PMIx_Argv_count(opt->values);
+        if (0 == nvals) {
+            array[n].key = opt->key;
+            array[n].value = NULL;
+            array[n].seq = opt->firstseq;
+            ++n;
+            continue;
+        }
+        for (i = 0; i < nvals; i++) {
+            array[n].key = opt->key;
+            array[n].value = opt->values[i];
+            array[n].seq = (i < opt->nseq) ? opt->seq[i] : -1;
+            ++n;
+        }
+    }
+
+    /* Sort into the order the options were given. An insertion sort, and
+     * not qsort, because it is stable: the entries with no recorded
+     * position are all "equal" and there is no better order to give them
+     * than the one they came in with. A command line is a handful of
+     * options long, so the cost of that choice is nothing. */
+    for (n = 1; n < num; n++) {
+        tmp = array[n];
+        m = n;
+        while (0 < m && occurs_after(&array[m - 1], &tmp)) {
+            array[m] = array[m - 1];
+            --m;
+        }
+        array[m] = tmp;
+    }
+
+    *occurrences = array;
+    *nocc = num;
+    return PMIX_SUCCESS;
+}
+
 static void icon(pmix_cli_item_t *p)
 {
     p->key = NULL;
     p->values = NULL;
+    p->seq = NULL;
+    p->nseq = 0;
+    p->firstseq = -1;
 }
 static void ides(pmix_cli_item_t *p)
 {
@@ -574,6 +748,9 @@ static void ides(pmix_cli_item_t *p)
     }
     if (NULL != p->values) {
         PMIx_Argv_free(p->values);
+    }
+    if (NULL != p->seq) {
+        free(p->seq);
     }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cli_item_t,
@@ -584,6 +761,7 @@ static void ocon(pmix_cli_result_t *p)
 {
     PMIX_CONSTRUCT(&p->instances, pmix_list_t);
     p->tail = NULL;
+    p->nseq = 0;
 }
 static void odes(pmix_cli_result_t *p)
 {

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -42,10 +42,38 @@
 
 BEGIN_C_DECLS
 
+/* Every occurrence of one option, plus where each of them fell on the
+ * command line.
+ *
+ * The values array groups the occurrences by option, which is what nearly
+ * every consumer wants and is all this used to record. It cannot, however,
+ * express the interleaving of two repeated options: a second "--set-env"
+ * is filed behind the first, so an intervening "--prepend-env" appears to
+ * have come after both. That matters to a consumer whose directives edit
+ * each other - "--set-env FOO=1 --prepend-env FOO[:] x --set-env FOO=2"
+ * and "--set-env FOO=2 --prepend-env FOO[:] x" are different requests and
+ * the grouped view renders them identically.
+ *
+ * So each stored value also carries the position at which it was given:
+ * seq[n] is the occurrence index of values[n], counting every stored
+ * occurrence of every option from zero. Comparing two of these answers
+ * "which of these did the user type first?" - see
+ * pmix_cmd_line_get_nth_seq() for the narrow question and
+ * pmix_cmd_line_get_ordered() for the whole command line in order.
+ *
+ * A value carries -1 if its position is not known - i.e. it was added to
+ * the results by the caller after the parse rather than by the parser.
+ * firstseq is the position of the option's first appearance, and is the
+ * only position recorded for an option given without a value (a boolean
+ * flag stores nothing, so repeats of it are indistinguishable anyway).
+ */
 typedef struct {
     pmix_list_item_t super;
     char *key;
     char **values;
+    int *seq;       // command-line position of each entry in values
+    int nseq;       // number of entries in seq
+    int firstseq;   // position at which this option first appeared
 } pmix_cli_item_t;
 PMIX_CLASS_DECLARATION(pmix_cli_item_t);
 
@@ -53,6 +81,7 @@ typedef struct {
     pmix_object_t super;
     pmix_list_t instances;  // comprised of pmix_cli_item_t's
     char **tail;  // remainder of argv
+    int nseq;  // number of occurrences recorded so far
 } pmix_cli_result_t;
 PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 
@@ -60,8 +89,17 @@ PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 {                                                   \
     .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
     .instances = PMIX_LIST_STATIC_INIT,             \
-    .tail = NULL                                    \
+    .tail = NULL,                                   \
+    .nseq = 0                                       \
 }
+
+/* One occurrence of one option, as reported by
+ * pmix_cmd_line_get_ordered() */
+typedef struct {
+    const char *key;    // option name - points into the results, not a copy
+    const char *value;  // value given, or NULL if the option took none
+    int seq;            // position on the command line, -1 if not known
+} pmix_cli_occurrence_t;
 
 /* define PMIX-named flags for argument required */
 #define PMIX_ARG_REQD       required_argument
@@ -207,6 +245,25 @@ PMIX_EXPORT int pmix_cmd_line_parse(char **argv, char *shorts,
                                     pmix_cli_result_t *results,
                                     char *helpfile);
 
+/* Report every recorded occurrence of every option, in the order the
+ * options were given.
+ *
+ * This is the flat view of a parse result: one entry per stored value
+ * (plus one entry, with a NULL value, for an option given without one),
+ * sorted by command-line position. It is the same information the
+ * instances list holds - the entries point into that list's strings
+ * rather than copying them - just ordered by when rather than grouped by
+ * what, so a consumer whose directives are order-sensitive can walk it
+ * instead of reconstructing the order itself.
+ *
+ * The array is valid until "results" is modified or destructed, and is
+ * released with a plain free(). Values whose position was not recorded
+ * (see pmix_cli_item_t) are reported last, in instances order.
+ */
+PMIX_EXPORT int pmix_cmd_line_get_ordered(pmix_cli_result_t *results,
+                                          pmix_cli_occurrence_t **occurrences,
+                                          size_t *nocc);
+
 static inline pmix_cli_item_t* pmix_cmd_line_get_param(pmix_cli_result_t *results,
                                                        const char *key)
 {
@@ -256,6 +313,44 @@ static inline char* pmix_cmd_line_get_nth_instance(pmix_cli_result_t *results,
         return NULL;
     }
     return opt->values[idx];
+}
+
+/* Where on the command line the idx'th instance of this option was given.
+ *
+ * Returns the occurrence index - a number that is only meaningful when
+ * compared against another one from the same parse - or -1 if the option
+ * was not given, the instance does not exist, or its position was not
+ * recorded. Answers questions of the form "was the --set-env I am looking
+ * at given before or after that --prepend-env?" without building the full
+ * ordered view. */
+static inline int pmix_cmd_line_get_nth_seq(pmix_cli_result_t *results,
+                                            const char *key, int idx)
+{
+    pmix_cli_item_t *opt;
+
+    opt = pmix_cmd_line_get_param(results, key);
+    if (NULL == opt) {
+        return -1;
+    }
+    if (0 > idx || idx >= opt->nseq) {
+        return -1;
+    }
+    return opt->seq[idx];
+}
+
+/* Where on the command line this option FIRST appeared - the only
+ * position recorded for an option that takes no value. Returns -1 if the
+ * option was not given or its position was not recorded. */
+static inline int pmix_cmd_line_get_first_seq(pmix_cli_result_t *results,
+                                              const char *key)
+{
+    pmix_cli_item_t *opt;
+
+    opt = pmix_cmd_line_get_param(results, key);
+    if (NULL == opt) {
+        return -1;
+    }
+    return opt->firstseq;
 }
 
 /* USAGE:
@@ -418,10 +513,13 @@ do {                                                                    \
     char *_tail;                                                        \
     pmix_output(0, "\n[%s:%s:%d]", __FILE__, __func__, __LINE__);       \
     PMIX_LIST_FOREACH(_c, &(r)->instances, pmix_cli_item_t) {           \
-        pmix_output(0, "KEY: %s", _c->key);                             \
+        pmix_output(0, "KEY: %s (first seen at %d)",                    \
+                    _c->key, _c->firstseq);                             \
         if (NULL != _c->values) {                                       \
             for (int _n=0; NULL != _c->values[_n]; _n++) {              \
-                pmix_output(0, "    VAL[%d]: %s", _n, _c->values[_n]);  \
+                pmix_output(0, "    VAL[%d]: %s (given at %d)", _n,     \
+                            _c->values[_n],                             \
+                            (_n < _c->nseq) ? _c->seq[_n] : -1);        \
             }                                                           \
         }                                                               \
     }                                                                   \

--- a/test/unit/util/util_cmd_line.c
+++ b/test/unit/util/util_cmd_line.c
@@ -38,6 +38,7 @@
 #include "pmix.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_cmd_line.h"
+#include "src/util/pmix_printf.h"
 
 static int npass = 0;
 static int nfail = 0;
@@ -532,6 +533,205 @@ static void run_table(void)
     }
 }
 
+/* ================================================================== */
+/* Occurrence order                                                   */
+/* ================================================================== */
+
+/* The grouped view of a parse result - one item per option, every
+ * occurrence of that option on it - cannot express the interleaving of
+ * two repeated options. These check the record that can: the position
+ * stamped on each stored value, and the ordered view built from it.
+ *
+ * The environment options are the reason this matters, so they are what
+ * is tested with: --set-env replaces a value outright while
+ * --prepend-env edits the one already there, so the order they are
+ * applied in is the difference between FOO=2 and FOO=x:2. */
+static struct option ordopts[] = {
+    PMIX_OPTION_DEFINE(PMIX_CLI_SET_ENVAR, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_UNSET_ENVAR, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_TIMEOUT, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PARSABLE, PMIX_ARG_NONE),
+    PMIX_OPTION_END
+};
+
+/* Render the ordered view as "key:value" entries joined by '|'. An
+ * option given without a value renders its value as "-". */
+static char *render_ordered(pmix_cli_result_t *res)
+{
+    pmix_cli_occurrence_t *occ = NULL;
+    size_t nocc = 0, n;
+    char **tmp = NULL;
+    char *entry, *out;
+
+    if (PMIX_SUCCESS != pmix_cmd_line_get_ordered(res, &occ, &nocc)) {
+        return NULL;
+    }
+    for (n = 0; n < nocc; n++) {
+        pmix_asprintf(&entry, "%s:%s", occ[n].key,
+                      (NULL == occ[n].value) ? "-" : occ[n].value);
+        PMIx_Argv_append_nosize(&tmp, entry);
+        free(entry);
+    }
+    if (NULL != occ) {
+        free(occ);
+    }
+    if (NULL == tmp) {
+        return strdup("");
+    }
+    out = PMIx_Argv_join(tmp, '|');
+    PMIx_Argv_free(tmp);
+    return (NULL == out) ? strdup("") : out;
+}
+
+static void check_ordered(const char *desc, pmix_cli_result_t *res,
+                          const char *expected)
+{
+    char *got;
+
+    got = render_ordered(res);
+    if (NULL == got) {
+        fprintf(stdout, "  FAIL: %s [get_ordered failed]\n", desc);
+        nfail++;
+        return;
+    }
+    if (0 != strcmp(got, expected)) {
+        fprintf(stdout, "  FAIL: %s\n        wanted \"%s\"\n        got    \"%s\"\n",
+                desc, expected, got);
+        nfail++;
+    } else {
+        fprintf(stdout, "  PASS: %s\n", desc);
+        npass++;
+    }
+    free(got);
+}
+
+/* THE case from the issue: an option repeated after another has
+ * intervened. The grouped view files the second --set-env behind the
+ * first, so walking it in list order applies both sets and then the
+ * prepend - arriving at FOO=x:2 where the user asked for FOO=2. */
+static void test_order_interleaved(void)
+{
+    char *argv[] = {"prog", "--set-env", "FOO=1", "--prepend-env", "FOO[:]",
+                    "x", "--set-env", "FOO=2", NULL};
+    pmix_cli_result_t res;
+    pmix_cli_item_t *opt;
+    int rc;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    rc = pmix_cmd_line_parse(argv, "", ordopts, NULL, &res, NULL);
+    report("order_interleaved: returns SUCCESS", PMIX_SUCCESS == rc);
+
+    /* the grouped view is exactly what it always was - this record is
+     * additional, not a replacement */
+    opt = pmix_cmd_line_get_param(&res, PMIX_CLI_SET_ENVAR);
+    report("order_interleaved: set-env still groups both values",
+           NULL != opt && 2 == PMIx_Argv_count(opt->values)
+               && 0 == strcmp(opt->values[0], "FOO=1")
+               && 0 == strcmp(opt->values[1], "FOO=2"));
+    opt = pmix_cmd_line_get_param(&res, PMIX_CLI_PREPEND_ENVAR);
+    report("order_interleaved: prepend-env still holds its two tokens",
+           NULL != opt && 2 == PMIx_Argv_count(opt->values)
+               && 0 == strcmp(opt->values[0], "FOO[:]")
+               && 0 == strcmp(opt->values[1], "x"));
+
+    /* ...and the order is now recoverable */
+    report("order_interleaved: first set-env precedes the prepend",
+           pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_SET_ENVAR, 0)
+               < pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_PREPEND_ENVAR, 0));
+    report("order_interleaved: second set-env follows the prepend",
+           pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_SET_ENVAR, 1)
+               > pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_PREPEND_ENVAR, 1));
+
+    check_ordered("order_interleaved: ordered view is command-line order",
+                  &res,
+                  "set-env:FOO=1|prepend-env:FOO[:]|prepend-env:x|set-env:FOO=2");
+    PMIX_DESTRUCT(&res);
+}
+
+/* The mirror image: the same options the other way round must not come
+ * back looking the same. */
+static void test_order_reversed(void)
+{
+    char *argv[] = {"prog", "--prepend-env", "FOO[:]", "x",
+                    "--set-env", "FOO=1", NULL};
+    pmix_cli_result_t res;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    pmix_cmd_line_parse(argv, "", ordopts, NULL, &res, NULL);
+    check_ordered("order_reversed: prepend first, then set", &res,
+                  "prepend-env:FOO[:]|prepend-env:x|set-env:FOO=1");
+    report("order_reversed: set-env follows the prepend",
+           pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_SET_ENVAR, 0)
+               > pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_PREPEND_ENVAR, 0));
+    PMIX_DESTRUCT(&res);
+}
+
+/* An option that takes no value stores nothing, so it has no value to
+ * stamp - its position is recorded on the option itself. */
+static void test_order_valueless(void)
+{
+    char *argv[] = {"prog", "--timeout", "30", "--parsable",
+                    "--timeout", "60", NULL};
+    pmix_cli_result_t res;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    pmix_cmd_line_parse(argv, "", ordopts, NULL, &res, NULL);
+    check_ordered("order_valueless: flag sits between the two timeouts",
+                  &res, "timeout:30|parsable:-|timeout:60");
+    report("order_valueless: flag follows the first timeout",
+           pmix_cmd_line_get_first_seq(&res, PMIX_CLI_PARSABLE)
+               > pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_TIMEOUT, 0));
+    report("order_valueless: flag precedes the second timeout",
+           pmix_cmd_line_get_first_seq(&res, PMIX_CLI_PARSABLE)
+               < pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_TIMEOUT, 1));
+    report("order_valueless: an option not given has no position",
+           -1 == pmix_cmd_line_get_first_seq(&res, PMIX_CLI_SET_ENVAR));
+    PMIX_DESTRUCT(&res);
+}
+
+/* A value a caller adds to the results itself was never on the command
+ * line, so it has no position there. It must not be given one - it is
+ * reported last, and says so. */
+static void test_order_added_after_parse(void)
+{
+    char *argv[] = {"prog", "--set-env", "FOO=1", "--timeout", "30", NULL};
+    pmix_cli_result_t res;
+    pmix_cli_item_t *opt;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    pmix_cmd_line_parse(argv, "", ordopts, NULL, &res, NULL);
+
+    /* PRRTE's schizo does exactly this when it converts a deprecated
+     * option into a current one */
+    opt = pmix_cmd_line_get_param(&res, PMIX_CLI_SET_ENVAR);
+    PMIx_Argv_append_nosize(&opt->values, "BAR=2");
+
+    report("order_added: added value has no recorded position",
+           -1 == pmix_cmd_line_get_nth_seq(&res, PMIX_CLI_SET_ENVAR, 1));
+    check_ordered("order_added: added value is reported last", &res,
+                  "set-env:FOO=1|timeout:30|set-env:BAR=2");
+    PMIX_DESTRUCT(&res);
+}
+
+static void test_order_empty(void)
+{
+    char *argv[] = {"prog", NULL};
+    pmix_cli_occurrence_t *occ = (pmix_cli_occurrence_t *) 1;
+    pmix_cli_result_t res;
+    size_t nocc = 99;
+    int rc;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    pmix_cmd_line_parse(argv, "", ordopts, NULL, &res, NULL);
+    rc = pmix_cmd_line_get_ordered(&res, &occ, &nocc);
+    report("order_empty: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("order_empty: reports nothing", 0 == nocc && NULL == occ);
+    report("order_empty: rejects a NULL argument",
+           PMIX_ERR_BAD_PARAM == pmix_cmd_line_get_ordered(&res, NULL, &nocc));
+    PMIX_DESTRUCT(&res);
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_check_cli_option (inline abbreviation matching)               */
 /* ------------------------------------------------------------------ */
@@ -606,6 +806,12 @@ int main(int argc, char **argv)
     fprintf(stdout, "\n--- command-line table ---\n");
     run_table();
     fprintf(stdout, "\n");
+
+    test_order_interleaved();
+    test_order_reversed();
+    test_order_valueless();
+    test_order_added_after_parse();
+    test_order_empty();
 
     test_check_cli_option();
     test_convert_time();


### PR DESCRIPTION
Fixes #4037.

`pmix_cli_result_t` records which options were given and how many times, but not when each occurrence appeared relative to the others. Every occurrence of an option is appended to that option's single instance, so once a key exists, a later occurrence of it is filed at the position of its first appearance, behind anything that came in between.

That is enough for nearly every consumer, and it is what the grouped view is for. It is not enough for a consumer whose directives edit each other. PRRTE's environment options are the case in point: `--set-env` replaces a value outright while `--prepend-env` edits the one already there, so

```
--set-env FOO=1 --prepend-env "FOO[:]" x --set-env FOO=2
```

asks for `FOO=2`, while the parse result says "set-env with values FOO=1, FOO=2, then prepend-env" — from which the best a consumer can do is apply both sets and then the prepend, arriving at `FOO=x:2`.

## What this does

Stamps each stored value with the position at which it was given, and offers the flat, ordered view built from those stamps:

```c
/* the narrow question */
pmix_cmd_line_get_nth_seq(&results, PMIX_CLI_SET_ENVAR, 1)
    > pmix_cmd_line_get_nth_seq(&results, PMIX_CLI_PREPEND_ENVAR, 0)

/* the whole command line, in order */
pmix_cmd_line_get_ordered(&results, &occ, &nocc);   /* free(occ) when done */
```

Nothing about the grouped view changes — the instances list holds exactly what it held before, in the same order — so a consumer that does not care about ordering sees no difference.

The stamping is done by the parser *around* the store call rather than inside `check_store()`, because the store function is replaceable and a replacement is free to file a value under a different key than the one it was handed, or under none at all. Nothing here has to know: a value an item holds beyond the extent of its `seq` array is by definition one that was just stored. A value a caller adds to the results itself, after the parse, was never on this command line and is marked as having no position (`-1`) rather than being credited with one.

An option that takes no value stores nothing, so there is no value to stamp; its position is recorded on the item itself, which is also all that can be said of it — repeats of a boolean option are stored identically and so are indistinguishable.

Adds `PMIX_CAP_CLI_ORDER` so a consumer can detect the capability at configure time.

## Testing

`test/unit/util/util_cmd_line.c` gains the interleaving case, its mirror image, a flag between two repeats, a post-parse append, and the empty/NULL-argument paths. `make check` passes in `test/` and `test/unit/`; the build is warning-free under `--enable-devel-check`.

Beyond that, the API was driven through a real consumer: PRRTE's `create_app()` was rewritten onto it on a branch, and a unit test there checks every ordering of a pool of six environment directives — 720 of them, with the expected order derived from the input rather than written by hand. All pass with the stamps; 480 of the 720 fail without them, which is the fallback's documented limitation behaving exactly as described. End-to-end `prterun` launches then confirm the value a process actually ends up with for each ordering. A companion PRRTE PR will follow.