### PR TITLE
dockerswarm: let two clones drive the harness without wrecking each other

### DIFF
--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -28,9 +28,10 @@ is only the nickname.
 | `run-tests.sh` | Runs the group **construction-method** example programs (plus the construct/connect loss and voluntary-leave cases) and reports PASS/FAIL: full multi-node suite on Linux, single-host subset on macOS. |
 | `run-group-events.sh` | Runs the **dynamic, event-driven** group exercisers and their fault paths (invite/join, member lost during destruct, ...); kept separate from `run-tests.sh` so the event/fault matrix can grow independently. Same `linux`/`macos` modes. |
 | `run-python.sh` | Runs the **Python bindings**: the standalone unit suite, the connected client/server round-trip, and Python PMIx clients spread across nodes. Same `linux`/`macos` modes. See §10. |
+| `swarm-common.sh` | Sourced by all four scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
-| `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. |
+| `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. Every one of those names derives from `$PMIX_SWARM`, so two clones can each run a swarm — see §4. |
 
 ## 2. How it works
 
@@ -89,6 +90,58 @@ docker compose up -d       # start pmix-node1 .. pmix-node10
 Rebuild after editing PMIx: rerun `./build.sh` (incremental). No image rebuild
 and no `docker compose` restart needed — the nodes read the shared volume.
 
+### Two clones on one host: `PMIX_SWARM`
+
+Every global name this harness claims — the compose project, the ten container
+names, the build volume, the docker network — is derived from `$PMIX_SWARM`, so
+a second clone (or a second agent) can drive its own swarm:
+
+```sh
+export PMIX_SWARM=alt      # for the WHOLE shell; see the warning below
+./build.sh                 # -> volume alt-build
+docker compose up -d       # -> project altswarm, containers alt-node1..10
+./run-tests.sh linux       #    on network altswarm_dvm
+```
+
+Unset, it is `pmix` and every name is exactly what it has always been: project
+`pmixswarm`, containers `pmix-node1..10`, volume `pmix-build`.
+
+Both swarms contain a container whose **hostname is `node1`**, and that is
+fine: each user-defined bridge network runs its own embedded DNS serving only
+the containers attached to it, so `node2` inside a swarm can only ever mean
+that swarm's node2. No test needs changing — `--host node1:2,node2:2` means the
+right machines in either.
+
+> **Export it, don't prefix one command.** `docker compose` interpolates
+> `docker-compose.yml` itself, so `PMIX_SWARM` has to be in *that* command's
+> environment. A `docker compose up -d` without it quietly brings up the
+> **default** swarm instead, against the default volume, and your build sits in
+> `alt-build` unused. The runners say which swarm they looked for when they
+> find nothing, and `build.sh` prints the exact next command including the
+> variable.
+
+The name is a host-wide namespace, and PRRTE's identical harness uses the same
+mechanism (`PRTE_SWARM`) — so `PMIX_SWARM=alt` here and `PRTE_SWARM=alt` there
+would both want a container called `alt-node1`. Pick something of your own
+(your initials, the branch you are on) rather than a generic word.
+
+**What is still shared, and what that costs.** The base image
+(`pmix-swarm:latest`) is read-only to a running swarm and expensive to build —
+it clones and autogens PRRTE — so both instances use the same one. Rebuilding
+it moves it under the other swarm's feet, and that swarm's containers then fail
+the "containers are running the current image" preflight until they are
+recreated (§8). Nothing else crosses: separate containers, separate `/tmp`,
+separate install, separate network.
+
+**The macOS subsets need no such knob** — their build is already per-clone
+(`vpath-macos-pmix`, `vpath-macos-prte`) — but they isolate the two things that
+are not. They start `prterun` and every example by absolute path out of their
+own install and match on that path when reaping strays (a bare `pkill -9
+prterun` kills the other clone's launcher, and a bare `pgrep -x prte` is worse:
+it reports the other clone's DVM as this one's and passes a case on it), and
+they run PRRTE under a private `TMPDIR` they create and remove, so no session
+directory they delete was ever anyone else's.
+
 ## 5. Driving it by hand
 
 `run-tests.sh` automates this, but to poke at it yourself:
@@ -136,14 +189,38 @@ alongside the group loss-accounting fix.
 ## 7. Cleanup hygiene
 
 `run-tests.sh` cleans up between tests; if you drive things by hand, clear
-stale state on **every** node between DVM runs:
+stale state on **every** node between DVM runs — the same sweep `cleanup_swarm`
+does (`swarm-common.sh`):
 
 ```sh
 for n in $(seq 1 10); do
-  docker exec pmix-node$n sh -c 'pkill -9 -x prted; pkill -9 -x prte;
-    pkill -9 prterun; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix*; true'
+  docker exec pmix-node$n sh -c '
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* /tmp/pmix*
+    find /tmp -maxdepth 2 -name "pmix*" -prune -exec rm -rf {} +
+    true'
 done
 ```
+
+**Every tool has its own session-dir prefix, and one missed prefix is enough.**
+`prte.<pid>` is the HNP, `prtrn.<pid>` is `prterun`, `prted.<pid>` is a daemon
+standing on its own, `prun.<pid>` is `prun` itself, `ompi.<pid>` is anything run
+under the ompi personality. Each holds a `pmix.*` server rendezvous file, a
+system-level server drops one straight into `/tmp`, and any one left behind
+makes the next tool report *"multiple possible servers … connection handles have
+been read from files named pmix.\*"* and fail to find the DVM. That is why the
+sweep ends with a `find`: it catches the rendezvous file of a session dir whose
+prefix this list has not heard of. (PRRTE hit exactly this —
+[prrte#2526](https://github.com/openpmix/prrte/issues/2526) — where a
+hand-driven `prterun` before a suite run made later cases fail for reasons that
+had nothing to do with the code.)
+
+The tools are killed, not just the daemons: a live `prun` or `pterm` holds a
+rendezvous file of its own, and reaping it is the point of a teardown.
+
+If you are running a second swarm (`PMIX_SWARM`, §4), the loop above is
+per-swarm — use that swarm's container names. Nothing in it can reach the other
+swarm's `/tmp`, because the containers are different containers.
 
 ## 8. Rebuilding / resetting
 
@@ -154,6 +231,7 @@ done
 | move the baked PRRTE forward | `docker build --no-cache --build-arg PRRTE_REF=master -t pmix-swarm:latest .`, then wipe the volume's VPATH dirs and recreate the containers - see below |
 | rebuild the base image (different PRRTE branch) | `PRRTE_REF=v3.0.x ./build.sh image` |
 | tear down the swarm | `docker compose down` (the `pmix-build` volume persists) |
+| run a second, independent swarm | `export PMIX_SWARM=alt` and repeat the quick start — see §4. Every command in this table then names that swarm's volume (`alt-build`) and containers (`alt-node*`), and **a `docker compose down` without the variable takes down the *default* swarm** |
 
 ### The image goes stale, and the containers go stale after it
 
@@ -219,12 +297,16 @@ docker images --no-trunc --format '{{.ID}}' pmix-swarm:latest
 | `pmix-node1` | node1 | head node — start the DVM here, run all tools here |
 | `pmix-node2`..`pmix-node10` | node2..node10 | additional daemon nodes |
 
-Network: bridge `dvm`. All nodes mount the shared `pmix-build` volume read-only
+Network: bridge `pmixswarm_dvm`. All nodes mount the shared `pmix-build` volume read-only
 at `/opt/prte`, where `build.sh` installs PMIx (`/opt/prte/pmix`), PRRTE
 (`/opt/prte/prte`), the group clients (`/opt/prte/tests`), the Python bindings
 and their scripts (`/opt/prte/tests-python`), and writes `/opt/prte/env.sh`. To
 add or remove nodes, copy or delete a service block in `docker-compose.yml`
-(and adjust the `seq 1 10` loops in `run-tests.sh`).
+(and adjust the `seq 1 10` loops in `swarm-common.sh` and the runners).
+
+The container, volume, and network names above are the `PMIX_SWARM=pmix`
+default; under another name they all shift together (§4). The **hostnames**
+never do — `node1`..`node10` is what the tests name, in every swarm.
 
 ---
 

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -22,6 +22,10 @@
 #   ./build.sh macos    # build natively on this host (single-host smoke)
 #   ./build.sh image    # (re)build just the base container image
 #
+# Two clones on one host: export PMIX_SWARM (see swarm-common.sh) and each
+# gets its own containers, volume, and network.  The macOS build is already
+# per-clone -- it lives under <repo>/vpath-macos-*.
+#
 # Because a VPATH configure refuses to run while the source tree still has an
 # in-tree build, this script runs `make distclean` (once) at the repo root and
 # then `./autogen.pl`.  After that, ALL builds are out-of-tree and your
@@ -34,8 +38,11 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(git -C "$here" rev-parse --show-toplevel)"     # the openpmix tree
 
-IMAGE="${IMAGE:-pmix-swarm:latest}"
-VOLUME="${VOLUME:-pmix-build}"
+# PMIX_SWARM, IMAGE, VOLUME -- which swarm this build is for.  Set PMIX_SWARM
+# in the whole shell and a second clone of openpmix gets its own containers,
+# volume, and network instead of fighting over this one.
+. "$here/swarm-common.sh"
+
 PRRTE_REF="${PRRTE_REF:-master}"        # baked-image PRRTE branch
 PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 
@@ -194,7 +201,16 @@ build_linux() {
             echo ">>>> done: PMIx in /opt/prte/pmix, PRRTE in /opt/prte/prte, tests in /opt/prte/tests"
         '
     echo ">>> Linux build complete."
-    echo ">>> next: docker compose up -d && ./run-tests.sh linux"
+    if [ -z "$SWARM_ENV" ]; then
+        echo ">>> next: docker compose up -d && ./run-tests.sh linux"
+    else
+        # Say it with the variable: compose reads PMIX_SWARM from the
+        # environment of the compose command, and a plain `docker compose
+        # up -d` brings up the DEFAULT swarm against the default volume,
+        # leaving this build sitting in $VOLUME unused.
+        echo ">>> next: ${SWARM_ENV}docker compose up -d && ${SWARM_ENV}./run-tests.sh linux"
+        echo ">>>       (swarm '$PMIX_SWARM': containers ${NODE}1..10, volume $VOLUME)"
+    fi
 }
 
 # --- macOS build (native, on this host; single-host smoke) ------------------

--- a/contrib/dockerswarm/docker-compose.yml
+++ b/contrib/dockerswarm/docker-compose.yml
@@ -13,7 +13,26 @@
 # lost-connection accounting run on several daemons at once, and let a group
 # span a multi-level daemon tree.
 
-# Pin the compose project.  Without this, the project name comes from the
+# ---------------------------------------------------------------------------
+# EVERY global name this harness claims is derived from $PMIX_SWARM, so that
+# two clones on one host can each run their own swarm.  Unset, it is "pmix"
+# and every name below is exactly what it has always been.
+#
+#   PMIX_SWARM=alt ./build.sh
+#   PMIX_SWARM=alt docker compose up -d
+#   PMIX_SWARM=alt ./run-tests.sh linux
+#
+# The variable has to be in the environment of the `docker compose` command
+# itself -- compose interpolates this file, the scripts do not.  Set it for
+# the whole shell (`export PMIX_SWARM=alt`) and every step agrees.
+#
+# What is NOT per-swarm: the image.  It is read-only to a running swarm and
+# expensive to build, so both instances share it -- but rebuilding it moves it
+# under the other swarm's feet, and that swarm's containers then fail the
+# "containers are running the current image" preflight until recreated.
+#
+# Pinning the project name matters even for a single swarm.  Without it, the
+# project name comes from the
 # directory - "dockerswarm" - which is also the name of PRRTE's identical
 # harness directory, so `docker compose up -d` run in either place adopts the
 # OTHER project's containers: it stops that swarm, renames its containers out
@@ -25,10 +44,10 @@
 # undefined-symbol failure in an unrelated test.  Verify with:
 #   docker inspect pmix-node1 --format '{{.Image}}'
 #   docker images --no-trunc --format '{{.ID}}' pmix-swarm:latest
-name: pmixswarm
+name: ${PMIX_SWARM:-pmix}swarm
 
 x-node: &node
-  image: pmix-swarm:latest
+  image: ${IMAGE:-pmix-swarm:latest}
   networks: [dvm]
   tty: true
   volumes:
@@ -38,51 +57,58 @@ services:
   node1:
     <<: *node
     hostname: node1
-    container_name: pmix-node1
+    container_name: ${PMIX_SWARM:-pmix}-node1
   node2:
     <<: *node
     hostname: node2
-    container_name: pmix-node2
+    container_name: ${PMIX_SWARM:-pmix}-node2
   node3:
     <<: *node
     hostname: node3
-    container_name: pmix-node3
+    container_name: ${PMIX_SWARM:-pmix}-node3
   node4:
     <<: *node
     hostname: node4
-    container_name: pmix-node4
+    container_name: ${PMIX_SWARM:-pmix}-node4
   node5:
     <<: *node
     hostname: node5
-    container_name: pmix-node5
+    container_name: ${PMIX_SWARM:-pmix}-node5
   node6:
     <<: *node
     hostname: node6
-    container_name: pmix-node6
+    container_name: ${PMIX_SWARM:-pmix}-node6
   node7:
     <<: *node
     hostname: node7
-    container_name: pmix-node7
+    container_name: ${PMIX_SWARM:-pmix}-node7
   node8:
     <<: *node
     hostname: node8
-    container_name: pmix-node8
+    container_name: ${PMIX_SWARM:-pmix}-node8
   node9:
     <<: *node
     hostname: node9
-    container_name: pmix-node9
+    container_name: ${PMIX_SWARM:-pmix}-node9
   node10:
     <<: *node
     hostname: node10
-    container_name: pmix-node10
+    container_name: ${PMIX_SWARM:-pmix}-node10
 
+# Left to compose to name (it becomes <project>_dvm), which is what keeps two
+# swarms apart: every node sets hostname node<N>, so both swarms contain a
+# "node1".  Each user-defined bridge network has its own embedded DNS serving
+# only the containers attached to it, so "node2" from inside one swarm can
+# only ever mean that swarm's node2.
 networks:
   dvm:
     driver: bridge
 
-# Populated by build.sh (docker volume create pmix-build) and shared,
-# read-only, by every node.  Declared external so the builder container and
-# these services reference the exact same volume name (no compose prefix).
+# Populated by build.sh (docker volume create) and shared, read-only, by every
+# node of THIS swarm.  Declared external so the builder container and these
+# services reference the exact same volume name (no compose prefix) -- which
+# also means the name has to carry the swarm identity itself.
 volumes:
   pmix-build:
+    name: ${PMIX_SWARM:-pmix}-build
     external: true

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -80,19 +80,10 @@ banner() { printf '\n=== %s ===\n' "$1"; }
 # Linux: the full 10-node swarm
 ########################################################################
 
-# run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
-RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-            pmix-node1 bash -lc ". /opt/prte/env.sh; $*"; }
-ON()  { docker exec "pmix-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
-
-cleanup_swarm() {
-    for n in $(seq 1 10); do
-        docker exec "pmix-node$n" sh -c \
-            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
-             pkill -9 prterun 2>/dev/null; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix* 2>/dev/null; true'
-    done
-}
-prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+# RUN/ON/prted_count, cleanup_swarm, swarm_up_or_die and the swarm naming
+# (PMIX_SWARM, NODE, IMAGE, VOLUME) all live in one place -- these three
+# runners carried their own copies once, and the copies drifted.
+. "$(dirname "$0")/swarm-common.sh"
 
 # Markers of a launch that hung until the DVM/job timeout fired. Match only the
 # launcher's genuine timeout-expiry text -- NOT the bare word "timeout", which
@@ -101,9 +92,7 @@ prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/nu
 hung() { echo "$1" | grep -qiE 'time limit for job|timed out|DVM timeout'; }
 
 test_linux() {
-    if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
-        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
-    fi
+    swarm_up_or_die
 
     banner "preflight: install present in shared volume"
     if RUN 'command -v prterun prte prun pterm >/dev/null'; then
@@ -383,15 +372,19 @@ test_macos() {
     if [ ! -x "$prefix/bin/prterun" ]; then
         echo "native build missing -- run: ./build.sh macos" >&2; exit 2
     fi
-    export PATH="$prefix/bin:$PATH"
     export DYLD_LIBRARY_PATH="$prefix/lib:$root/vpath-macos-pmix/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
     export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1
-    macpk() { pkill -9 prterun 2>/dev/null; pkill -9 -x prte 2>/dev/null; pkill -9 -x prted 2>/dev/null; true; }
+    # This runs on the developer's own machine, so it must not reach another
+    # clone running the same script: mac_isolate gives PRRTE a private TMPDIR
+    # and points macpk at THIS install's bin, which every tool and example
+    # below is launched from by absolute path ($MAC_BIN, not PATH).  See
+    # swarm-common.sh.
+    mac_isolate "$prefix"
 
     banner "macOS: invite/join happy path (single host)"
     if [ -x "$prefix/bin/group_invite" ]; then
         macpk; sleep 1
-        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite" 2>&1)"
+        out="$("$MAC_BIN/prterun" -np 4 --timeout 60 "$prefix/bin/group_invite" 2>&1)"
         npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
         if echo "$out" | grep -qiE 'FAILED|timeout|timed out'; then
             skp "group_invite: not clean (native Darwin DVM can be flaky): $(echo "$out" | tr '\n' ' ' | tail -c 160)"
@@ -407,7 +400,7 @@ test_macos() {
     banner "macOS: invite timeout (single host)"
     if [ -x "$prefix/bin/group_invite_timeout" ]; then
         macpk; sleep 1
-        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_timeout" 2>&1)"
+        out="$("$MAC_BIN/prterun" -np 4 --timeout 60 "$prefix/bin/group_invite_timeout" 2>&1)"
         nfail=$(echo "$out" | grep -c 'INVITE_FAILED for non-responder: PASS')
         npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
         if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
@@ -424,7 +417,7 @@ test_macos() {
     banner "macOS: invite declined (single host)"
     if [ -x "$prefix/bin/group_invite_decline" ]; then
         macpk; sleep 1
-        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_decline" 2>&1)"
+        out="$("$MAC_BIN/prterun" -np 4 --timeout 60 "$prefix/bin/group_invite_decline" 2>&1)"
         nfail=$(echo "$out" | grep -c 'INVITE_FAILED for decliner: PASS')
         npass=$(echo "$out" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
         if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
@@ -441,7 +434,7 @@ test_macos() {
     banner "macOS: invite aborted (single host)"
     if [ -x "$prefix/bin/group_invite_abort" ]; then
         macpk; sleep 1
-        out="$(prterun -np 4 --timeout 60 "$prefix/bin/group_invite_abort" 2>&1)"
+        out="$("$MAC_BIN/prterun" -np 4 --timeout 60 "$prefix/bin/group_invite_abort" 2>&1)"
         nleader=$(echo "$out" | grep -c 'PMIx_Group_invite returned CONSTRUCT_ABORT: PASS')
         nabort=$(echo "$out" | grep -c 'PMIX_GROUP_CONSTRUCT_ABORT received: PASS')
         if echo "$out" | grep -qiE 'FAILED -|timeout|timed out'; then
@@ -458,7 +451,7 @@ test_macos() {
     banner "macOS: member lost during destruct (single host)"
     if [ -x "$prefix/bin/group_destruct_die" ]; then
         macpk; sleep 1
-        out="$(prterun --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_destruct_die" 2>&1)"
+        out="$("$MAC_BIN/prterun" --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_destruct_die" 2>&1)"
         n=$(echo "$out" | grep -c 'destruct complete on survivors')
         if echo "$out" | grep -qiE 'timeout|timed out'; then
             skp "group_destruct_die: not clean (native Darwin DVM can be flaky)"
@@ -474,7 +467,7 @@ test_macos() {
     banner "macOS: member lost mid-construct (single host)"
     if [ -x "$prefix/bin/group_construct_abort" ]; then
         macpk; sleep 1
-        out="$(prterun --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_construct_abort" 2>&1)"
+        out="$("$MAC_BIN/prterun" --rtos recoverable -np 4 --timeout 60 "$prefix/bin/group_construct_abort" 2>&1)"
         n=$(echo "$out" | grep -c 'construct ABORT on member loss: PASS')
         if echo "$out" | grep -qiE 'timeout|timed out'; then
             skp "group_construct_abort: not clean (native Darwin DVM can be flaky)"

--- a/contrib/dockerswarm/run-python.sh
+++ b/contrib/dockerswarm/run-python.sh
@@ -38,16 +38,10 @@ banner() { printf '\n=== %s ===\n' "$1"; }
 
 PYDIR=/opt/prte/tests-python
 
-RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-            pmix-node1 bash -lc ". /opt/prte/env.sh; $*"; }
-
-cleanup_swarm() {
-    for n in $(seq 1 10); do
-        docker exec "pmix-node$n" sh -c \
-            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
-             pkill -9 prterun 2>/dev/null; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix* 2>/dev/null; true'
-    done
-}
+# RUN/ON/prted_count, cleanup_swarm, swarm_up_or_die and the swarm naming
+# (PMIX_SWARM, NODE, IMAGE, VOLUME) all live in one place -- these three
+# runners carried their own copies once, and the copies drifted.
+. "$(dirname "$0")/swarm-common.sh"
 
 # Count the PMIXPY PASS/FAIL lines a client emitted.  Every swarm client prints
 # "PMIXPY <rank> <PASS|FAIL> <name>" per check and, once it has run to the end,
@@ -83,9 +77,7 @@ tally() {
 ########################################################################
 
 test_linux() {
-    if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
-        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
-    fi
+    swarm_up_or_die
 
     banner "preflight: bindings present and importable"
     if ! RUN "test -d $PYDIR"; then
@@ -102,7 +94,7 @@ test_linux() {
     # otherwise a multi-node launch fails in a confusing way
     missing=""
     for n in 1 2 3 4; do
-        docker exec "pmix-node$n" bash -lc \
+        docker exec "$NODE$n" bash -lc \
             '. /opt/prte/env.sh; python3 -c "import pmix"' >/dev/null 2>&1 \
             || missing="$missing node$n"
     done

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -24,8 +24,6 @@ set -uo pipefail
 
 mode="${1:-linux}"
 pass=0 fail=0 skip=0
-# must match build.sh -- the preflight compares the containers against it
-IMAGE="${IMAGE:-pmix-swarm:latest}"
 ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
 skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
@@ -38,19 +36,10 @@ GROUP_EXAMPLES="${GROUP_EXAMPLES:-group group_bootstrap group_dmodex group_lcl_c
 # Linux: the full 10-node swarm
 ########################################################################
 
-# run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
-RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-            pmix-node1 bash -lc ". /opt/prte/env.sh; $*"; }
-ON()  { docker exec "pmix-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
-
-cleanup_swarm() {
-    for n in $(seq 1 10); do
-        docker exec "pmix-node$n" sh -c \
-            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
-             pkill -9 prterun 2>/dev/null; rm -rf /tmp/prte.* /tmp/prun.session.* /tmp/pmix* 2>/dev/null; true'
-    done
-}
-prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+# RUN/ON/prted_count, cleanup_swarm, swarm_up_or_die and the swarm naming
+# (PMIX_SWARM, NODE, IMAGE, VOLUME) all live in one place -- these three
+# runners carried their own copies once, and the copies drifted.
+. "$(dirname "$0")/swarm-common.sh"
 
 # Per-example launch geometry ($NP ranks spread over $HOSTS) and the marker that
 # signals the group actually formed.  The defaults suit the common case -- four
@@ -94,9 +83,7 @@ launch() {
 }
 
 test_linux() {
-    if ! docker ps --format '{{.Names}}' | grep -qx pmix-node1; then
-        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
-    fi
+    swarm_up_or_die
 
     banner "preflight: install present in shared volume"
     if RUN 'command -v prterun prte prun pterm >/dev/null'; then
@@ -118,14 +105,14 @@ test_linux() {
     imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
     stalenodes=""
     for imgn in $(seq 1 10); do
-        cimg=$(docker inspect "pmix-node$imgn" --format '{{.Image}}' 2>/dev/null)
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
         [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
     done
     if [ -z "$stalenodes" ]; then
         ok "all 10 containers are on the current $IMAGE"
     else
         bad "containers predate $IMAGE:$stalenodes"
-        echo "     Recreate them: docker compose up -d --force-recreate" >&2
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
         echo "     (from contrib/dockerswarm, so the pinned project name applies)" >&2
         return
     fi
@@ -253,16 +240,20 @@ test_macos() {
     if [ ! -x "$prefix/bin/prterun" ]; then
         echo "native build missing -- run: ./build.sh macos" >&2; exit 2
     fi
-    export PATH="$prefix/bin:$PATH"
     export DYLD_LIBRARY_PATH="$prefix/lib:$root/vpath-macos-pmix/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
     export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1
-    macpk() { pkill -9 prterun 2>/dev/null; pkill -9 -x prte 2>/dev/null; pkill -9 -x prted 2>/dev/null; true; }
+    # This runs on the developer's own machine, so it must not reach another
+    # clone running the same script: mac_isolate gives PRRTE a private TMPDIR
+    # and points macpk at THIS install's bin, which every tool and example
+    # below is launched from by absolute path ($MAC_BIN, not PATH).  See
+    # swarm-common.sh.
+    mac_isolate "$prefix"
 
     banner "macOS: single-host group construction"
     for ex in $GROUP_EXAMPLES; do
         [ -x "$prefix/bin/$ex" ] || { skp "$ex (not built)"; continue; }
         macpk; sleep 1
-        out="$(prterun -np 4 --timeout 60 "$prefix/bin/$ex" 2>&1)"
+        out="$("$MAC_BIN/prterun" -np 4 --timeout 60 "$prefix/bin/$ex" 2>&1)"
         if echo "$out" | grep -qiE 'Group construct complete|construct.*succe'; then
             ok "$ex: group constructed (single host)"
         else

--- a/contrib/dockerswarm/swarm-common.sh
+++ b/contrib/dockerswarm/swarm-common.sh
@@ -1,0 +1,160 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Shared by build.sh, run-tests.sh, run-group-events.sh and run-python.sh.
+# SOURCED, never executed:  . "$(dirname "$0")/swarm-common.sh"
+#
+# Two things live here because all four scripts need them to agree.
+#
+# 1. WHICH SWARM.  Every global name this harness claims -- the compose
+#    project, the ten container names, the build volume, and (by way of the
+#    project name) the docker network -- is derived from $PMIX_SWARM, so a
+#    second clone of openpmix on the same host can drive its own swarm instead
+#    of fighting over this one.  Unset, it is "pmix" and every name is exactly
+#    what it has always been.
+#
+# 2. HOW A NODE IS CLEANED.  The three runners each used to carry their own
+#    copy of cleanup_swarm, and the copies had already drifted.  One copy is
+#    one place to fix, which is the whole point: an incomplete sweep does not
+#    fail the case that caused it, it fails the next several with a message
+#    about "multiple possible servers".
+#
+
+# --- which swarm ------------------------------------------------------------
+PMIX_SWARM="${PMIX_SWARM:-pmix}"
+# Reject what docker would reject, rather than leaving it to surface as a
+# confusing compose error.  The filter runs through LC_ALL=C tr and not a
+# shell [a-z] range because in a UTF-8 locale that range follows collation
+# order and matches 'B' quite happily -- so the obvious form of this test
+# accepts "Bad_Name".  The leading-character check uses a literal set for the
+# same reason.
+case "$PMIX_SWARM" in [_-]*) PMIX_SWARM="" ;; esac
+if [ -z "$PMIX_SWARM" ] || \
+   [ "$PMIX_SWARM" != "$(printf '%s' "$PMIX_SWARM" | LC_ALL=C tr -cd 'a-z0-9_-')" ]; then
+    echo "PMIX_SWARM must be lowercase [a-z0-9_-] and start with a letter or digit" >&2
+    exit 2
+fi
+
+NODE="$PMIX_SWARM-node"                 # container names: ${NODE}1 .. ${NODE}10
+VOLUME="${VOLUME:-$PMIX_SWARM-build}"
+# NOT per-swarm: the image is read-only to a running swarm and expensive to
+# build (it clones and autogens PRRTE), so two swarms share one.  The cost is
+# that rebuilding it moves it under the other swarm's feet, and that swarm's
+# containers then fail the "running the current image" preflight until they
+# are recreated.
+IMAGE="${IMAGE:-pmix-swarm:latest}"
+# Prefix for the compose commands the scripts suggest in diagnostics: empty
+# for the default swarm, "PMIX_SWARM=<name> " otherwise, because compose reads
+# the variable from the environment of the compose command itself.
+SWARM_ENV=""
+[ "$PMIX_SWARM" = pmix ] || SWARM_ENV="PMIX_SWARM=$PMIX_SWARM "
+
+# --- driving a node ---------------------------------------------------------
+# run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
+RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "${NODE}1" bash -lc ". /opt/prte/env.sh; $*"; }
+ON()  { docker exec "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+
+# Refuse to run against a swarm that is not up, and say which one we looked
+# for: forgetting PMIX_SWARM on the compose command (compose interpolates
+# docker-compose.yml, so it has to be in THAT command's environment) brings up
+# the default swarm instead, and a bare "swarm not up" sends you looking for a
+# docker problem you do not have.
+swarm_up_or_die() {
+    docker ps --format '{{.Names}}' | grep -qx "${NODE}1" && return 0
+    echo "swarm '$PMIX_SWARM' not up -- no container named ${NODE}1" >&2
+    echo "run: ${SWARM_ENV}docker compose up -d" >&2
+    [ -z "$SWARM_ENV" ] || \
+        echo "     (and ${SWARM_ENV}./build.sh first, so volume $VOLUME exists)" >&2
+    exit 2
+}
+
+# --- cleaning a node --------------------------------------------------------
+# What must not survive into the next test, on one node.  Each tool has its
+# OWN session-dir prefix -- prte.<pid> for the HNP, prtrn.<pid> for prterun,
+# prted.<pid> for a daemon standing on its own, prun.<pid> for prun itself,
+# and ompi.<pid> for anything run under the ompi personality -- and every one
+# of them holds a pmix.* server rendezvous file.  A system-level server drops
+# one straight into the tmpdir as well.  Leaving any behind is what makes the
+# next tool report "multiple possible servers ... connection handles have been
+# read from files named pmix.*" and fail to find the DVM, so clear them all:
+# the prefixes we know by name, and then whatever pmix* is still standing in
+# the tmpdir or one level below it, which catches the session dir of a tool
+# this list has not heard of.  The nodes leave TMPDIR unset, so that tmpdir is
+# /tmp -- as every other path in this harness assumes.
+#
+# The tools are killed too, not just the daemons: a live prun or pterm is
+# holding a rendezvous file of its own, and reaping it is the point of a
+# teardown.
+SWARM_CLEAN='
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t 2>/dev/null; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* \
+           /tmp/pmix* 2>/dev/null
+    find /tmp -maxdepth 2 -name "pmix*" -prune -exec rm -rf {} + 2>/dev/null
+    true'
+cleanup_swarm() {
+    for n in $(seq 1 10); do
+        docker exec "$NODE$n" sh -c "$SWARM_CLEAN"
+    done
+}
+
+# --- macOS: keep this run inside its own clone ------------------------------
+# The native subsets run on the developer's own machine, where another clone
+# of openpmix may be running this very same script.  Nothing may reach a
+# process or a file that clone owns, which takes both of:
+#
+#  - every tool and example is started by ABSOLUTE path out of THIS clone's
+#    install ($MAC_BIN, never PATH), so "is this process mine" is a question
+#    about the argv -- which is what mypgrep/mypkill ask.  A bare
+#    `pkill -9 prterun` kills the other clone's launcher; a bare
+#    `pgrep -x prte` is worse still, because it reports the other clone's DVM
+#    as ours and the case then passes on a process this run never started.
+#  - PRRTE gets a PRIVATE TMPDIR, so the session dirs -- and the pmix.*
+#    rendezvous files inside them, which a -9'd tool never removes -- land
+#    somewhere only this run will ever delete.  It is made under /tmp rather
+#    than beside the build because the rendezvous socket path has to fit in
+#    sun_path (104 bytes on Darwin) and the per-user $TMPDIR a Mac hands out
+#    is already half of that.
+#
+# MAC_BIN/MAC_BRE/MAC_TMP are globals on purpose: the traps fire after the
+# calling function has returned, and a local would be out of scope by then --
+# which would silently leave the private directory behind on every run.
+MAC_BIN=""
+MAC_BRE=""
+MAC_TMP=""
+mac_isolate() {                 # $1 = install prefix whose bin/ we will drive
+    MAC_BIN="$1/bin"
+    MAC_BRE="$(printf '%s' "$MAC_BIN" | sed 's/[].[^$*+?(){}|\\]/\\&/g')"
+    MAC_TMP="$(mktemp -d /tmp/pmixsuite.XXXXXX)" || {
+        echo "cannot create a private TMPDIR under /tmp" >&2; exit 2; }
+    export TMPDIR="$MAC_TMP"
+    trap mac_done EXIT
+    trap 'mac_done; exit 130' INT TERM
+}
+mypgrep() { pgrep -f "^$MAC_BRE/$1( |\$)" >/dev/null 2>&1; }
+mypkill() { pkill -9 -f "^$MAC_BRE/$1( |\$)" 2>/dev/null; true; }
+# Reap every process this run started -- the launcher and the example clients
+# alike, since both were exec'd out of $MAC_BIN -- and the session dirs they
+# left.  Session dirs only, not the whole private directory: a caller may keep
+# a capture file there (mktemp honors TMPDIR) and read it after calling this.
+# Everything named is unambiguously ours, pmix* included, because the
+# directory it sits in is.
+macpk() {
+    pkill -9 -f "^$MAC_BRE/" 2>/dev/null
+    rm -rf "${TMPDIR:?}"/prte.* "${TMPDIR:?}"/prted.* "${TMPDIR:?}"/prtrn.* \
+           "${TMPDIR:?}"/prun.* "${TMPDIR:?}"/ompi.* "${TMPDIR:?}"/pmix* 2>/dev/null
+    true
+}
+# However we leave, ^C included: the private dir holds only this run's session
+# dirs, so there is nothing in it worth keeping.
+mac_done() {
+    [ -z "$MAC_BRE" ] || pkill -9 -f "^$MAC_BRE/" 2>/dev/null
+    [ -z "$MAC_TMP" ] || rm -rf "$MAC_TMP"
+    true
+}


### PR DESCRIPTION
The PMIx-side port of [prrte#2584](https://github.com/openpmix/prrte/pull/2584), adapted to this harness rather than copied.

## The problem

The harness claimed every one of its names globally. `docker-compose.yml` pinned the compose project to `pmixswarm` and hardcoded `container_name: pmix-node1`..`pmix-node10` and the `pmix-build` volume, so a second clone of the tree on the same host did **not** get a second swarm — it got the same ten containers and the same install. One clone's `build.sh` replaced the `/opt/prte` the other was mid-suite against; one clone's `cleanup_swarm` killed the other's daemons and deleted its session directories out of the containers they shared.

The macOS subsets had a smaller version of the same problem. Their build is already per-clone, but `pkill -9 prterun` killed the other clone's launcher, and `pgrep -x prte` matched it too — which is the worse half, because the case then *passes* on a process the run never started.

## The change

Everything global is derived from `$PMIX_SWARM`: compose project, the ten container names, the build volume, and (via the project name) the network.

```sh
export PMIX_SWARM=alt
./build.sh && docker compose up -d && ./run-tests.sh linux
```

Unset, it is `pmix` and every name is exactly what it has always been — the rendered compose file is identical to today's. The **hostnames deliberately do not move**: both swarms contain a `node1`, and each user-defined bridge network runs its own embedded DNS, so `node2` inside a swarm can only mean that swarm's node2 and no test needs changing. The image stays shared (read-only to a running swarm, and expensive — it clones and autogens PRRTE); the one cost of that is documented. Since the name is a host-wide namespace PRRTE's identical harness also draws from, the README says to pick one of your own rather than a generic word.

**New `swarm-common.sh`, sourced by all four scripts.** The three runners each carried their own copy of `RUN`/`ON`/`cleanup_swarm`/the swarm-not-up check, and the copies had already drifted — from each other and from PRRTE's. Adding a fourth thing they must agree on would reset that clock. This is the one structural difference from prrte#2584, which has a single runner.

**The sweep was incomplete**, which is [prrte#2526](https://github.com/openpmix/prrte/issues/2526) in the sibling harness. It knew three session-dir prefixes; there are five (`prun` and the ompi personality name their own), each holding a `pmix.*` rendezvous file that makes the next tool report *"multiple possible servers"* and fail to find the DVM. A `find` over the tmpdir now catches a prefix the list has not heard of, and the tools are killed alongside the daemons, since a live `prun` holds a rendezvous file too.

**macOS** now starts `prterun` and every example by absolute path out of its own install, matches on that path when reaping strays (which covers the launcher *and* the example clients, since `build.sh macos` installs both into the same `bin`), and runs PRRTE under a private `TMPDIR` it creates and removes — under `/tmp`, because the rendezvous socket path must fit in `sun_path` (104 bytes on Darwin, and the per-user `$TMPDIR` is already half of it).

## Testing

Two PMIx swarms live on one host:

- `zz9-node*` on network `zz9swarm_dvm` with volume `zz9-build`; `node2` from inside it resolved to its own swarm's node2 despite the identical hostnames
- the sibling PRRTE swarm on `prteswarm_dvm` was untouched throughout
- `docker compose config` with `PMIX_SWARM` unset renders byte-identical to before

`cleanup_swarm` driven against a live container seeded with `prtrn.7`, `prun.8`, `pmix.sys.node1`, a session dir under an unknown prefix, and a `keepme.txt`: every stale item was removed, `keepme.txt` survived, and the depth-2 `find` emptied the unknown-prefix directory while leaving the directory itself.

macOS, against a stub install plus a second "clone" holding a live launcher: `run-tests.sh macos` and `run-group-events.sh macos` both left the foreign launcher and its session dirs alone, left a bare `/tmp/prtrn.99999` alone, removed the private `TMPDIR` on exit, and reaped every process the run itself started.

All four entry points reject a name docker would (`Bad_Name`, `a b`, `-lead`) and name the swarm they looked for when it is not up. The filter runs through `LC_ALL=C tr` rather than a shell `[a-z]` range, because in a UTF-8 locale that range follows collation order and accepts `Bad_Name`.

`contrib/Makefile.am` does not ship `dockerswarm/` in `EXTRA_DIST`, so the new file needs no build-system change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)