### PR TITLE
Record a default event handler the server has not seen before

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1181,28 +1181,52 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     }
 
     /* if they didn't send us any codes, then they are registering a
-     * default event handler. In that case, check only for default
-     * handlers and add this request to it, if not already present */
+     * default event handler. In that case, look only at the default
+     * entry - creating it if this is the first default registration we
+     * have seen - and add this request to it.
+     *
+     * Creating it is not optional. This used to walk the list and, if it
+     * found no PMIX_MAX_ERR_CONSTANT entry, fall out of the loop and
+     * return PMIX_OPERATION_SUCCEEDED having recorded nothing at all: the
+     * peer was told its registration succeeded and was never added to any
+     * dispatch list, so _notify_client_event() could not find it. The
+     * whole point of a default handler is to catch codes nobody asked for
+     * by name, so there is frequently no other registration to have
+     * created the entry first - and the very first client or tool to
+     * attach to a server necessarily finds the list empty. That client
+     * then silently received no default-routed event for its lifetime.
+     * The code != 0 path below has always created a missing entry; this
+     * one simply has to do the same. */
     if (0 == ncodes) {
-        PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
-            if (PMIX_MAX_ERR_CONSTANT == reginfo->code) {
-                /* both are default handlers */
-                prev = PMIX_NEW(pmix_peer_events_info_t);
-                if (NULL == prev) {
-                    rc = PMIX_ERR_NOMEM;
-                    goto cleanup;
-                }
-                PMIX_RETAIN(peer);
-                prev->peer = peer;
-                if (NULL != affected) {
-                    PMIX_PROC_CREATE(prev->affected, naffected);
-                    prev->naffected = naffected;
-                    memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
-                }
-                pmix_list_append(&reginfo->peers, &prev->super);
+        reginfo = NULL;
+        PMIX_LIST_FOREACH (rptr, &pmix_server_globals.events, pmix_regevents_info_t) {
+            if (PMIX_MAX_ERR_CONSTANT == rptr->code) {
+                reginfo = rptr;
                 break;
             }
         }
+        if (NULL == reginfo) {
+            reginfo = PMIX_NEW(pmix_regevents_info_t);
+            if (NULL == reginfo) {
+                rc = PMIX_ERR_NOMEM;
+                goto cleanup;
+            }
+            reginfo->code = PMIX_MAX_ERR_CONSTANT;
+            pmix_list_append(&pmix_server_globals.events, &reginfo->super);
+        }
+        prev = PMIX_NEW(pmix_peer_events_info_t);
+        if (NULL == prev) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        PMIX_RETAIN(peer);
+        prev->peer = peer;
+        if (NULL != affected) {
+            PMIX_PROC_CREATE(prev->affected, naffected);
+            prev->naffected = naffected;
+            memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
+        }
+        pmix_list_append(&reginfo->peers, &prev->super);
         rc = PMIX_OPERATION_SUCCEEDED;
         goto cleanup;
     }
@@ -3476,6 +3500,9 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,
 static void prevcon(pmix_peer_events_info_t *p)
 {
     p->peer = NULL;
+    /* PMIX_NEW does not zero the allocation, and the default-handler
+     * registration path never assigns this one */
+    p->enviro_events = false;
     p->affected = NULL;
     p->naffected = 0;
 }

--- a/test/unit/event_chain.c
+++ b/test/unit/event_chain.c
@@ -60,6 +60,12 @@
  *
  *  first-overall handler with multiple codes honors its
  *      affected-proc interest list.
+ *
+ *  default-handler registration: a client registering with no codes is
+ *      recorded against the server's PMIX_MAX_ERR_CONSTANT entry, which
+ *      is created if this is the first such registration; a second one
+ *      joins the same entry; and deregistration finds what registration
+ *      created.
  */
 
 #include "src/include/pmix_config.h"
@@ -781,7 +787,9 @@ static void do_client_reg(int sd, short args, void *cbdata)
 
     PMIX_CONSTRUCT(&buf, pmix_buffer_t);
     PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->ncodes, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS == rc) {
+    /* zero codes is a default-handler registration - the server unpacks
+     * the code array only when the count is non-zero, so do not pack one */
+    if (PMIX_SUCCESS == rc && 0 < r->ncodes) {
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, r->codes, r->ncodes, PMIX_STATUS);
     }
     if (PMIX_SUCCESS == rc) {
@@ -834,6 +842,80 @@ static pmix_status_t client_evreq(pmix_status_t *codes, size_t ncodes, bool dere
     rc = req.status;
     PMIX_DESTRUCT_LOCK(&req.lock);
     return rc;
+}
+
+/* Count how many peers are recorded against the server's default-handler
+ * entry, and say whether the entry exists at all. */
+static size_t default_reg_peers(bool *exists)
+{
+    pmix_regevents_info_t *reginfo;
+    pmix_peer_events_info_t *pr;
+    size_t n = 0;
+
+    *exists = false;
+    PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
+        if (PMIX_MAX_ERR_CONSTANT != reginfo->code) {
+            continue;
+        }
+        *exists = true;
+        PMIX_LIST_FOREACH (pr, &reginfo->peers, pmix_peer_events_info_t) {
+            ++n;
+        }
+        break;
+    }
+    return n;
+}
+
+/* A client registering a DEFAULT handler - no codes at all - has to be
+ * recorded in the server's dispatch list, including when it is the first
+ * such registration the server has seen.
+ *
+ * This is the case that was broken: the handler walked the list looking
+ * for an existing PMIX_MAX_ERR_CONSTANT entry and, finding none, returned
+ * PMIX_OPERATION_SUCCEEDED having stored nothing. The peer was told its
+ * registration succeeded and then received no default-routed event ever
+ * again, which is precisely the fate of the first client or tool to
+ * attach to a server - it necessarily finds the list empty.
+ *
+ * Run this before anything else registers, so the entry really is absent
+ * to begin with. */
+static void test_default_registration(void)
+{
+    pmix_status_t wildcard = PMIX_MAX_ERR_CONSTANT;
+    size_t before, after;
+    bool existed = false, exists = false;
+    pmix_status_t rc;
+
+    fprintf(stdout, "default-handler registration:\n");
+
+    before = default_reg_peers(&existed);
+    report("no default entry exists yet", !existed && 0 == before);
+
+    rc = client_evreq(NULL, 0, false);
+    report("registering with no codes succeeds",
+           PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
+
+    after = default_reg_peers(&exists);
+    report("the default entry was created", exists);
+    report("the registrant is on it", 1 == after);
+
+    /* a second default registration joins the same entry rather than
+     * making another one */
+    rc = client_evreq(NULL, 0, false);
+    after = default_reg_peers(&exists);
+    report("a second default registration joins the same entry",
+           exists && 2 == after);
+
+    /* and deregistration finds what registration created. A client drops a
+     * default handler by naming PMIX_MAX_ERR_CONSTANT explicitly, not by
+     * sending an empty code list - see pmix_deregister_event_hdlr(). */
+    rc = client_evreq(&wildcard, 1, true);
+    after = default_reg_peers(&exists);
+    report("deregistering removes one registrant", 1 == after);
+
+    rc = client_evreq(&wildcard, 1, true);
+    after = default_reg_peers(&exists);
+    report("deregistering the last one empties the entry", 0 == after);
 }
 
 static void test_enviro_handshake(void)
@@ -1015,6 +1097,10 @@ int main(int argc, char **argv)
     /* pure predicate checks */
     test_check_affected();
     test_check_range();
+
+    /* must run before anything registers, so the default entry really is
+     * absent when we ask for one */
+    test_default_registration();
 
     /* registration placement and chain progression */
     test_chain_order();


### PR DESCRIPTION
## Problem

A client that registers a *default* event handler sends the server an empty
code list. `pmix_server_register_events()` walked its registration list
looking for an existing `PMIX_MAX_ERR_CONSTANT` entry to append the client
to and, finding none, fell out of the loop and returned
`PMIX_OPERATION_SUCCEEDED` having stored nothing at all. The client was told
its registration had succeeded and was never added to any dispatch list, so
`_notify_client_event()` could not find it.

Nothing else creates that entry on the client's behalf. A default handler
exists precisely to catch codes nobody asked for by name, so there is often
no registration of a concrete code to have created it first — and the very
first client or tool to attach to a server necessarily finds the list empty.
That peer then silently received no default-routed event for the rest of its
life.

It is a hard failure to attribute from the outside: the notification is
sent, `PMIx_Notify_event` returns success, the range and affected-proc
filters accept it, and it simply reaches nobody. It surfaced while chasing a
PRRTE launch diagnostic that a `prun` tool never received despite the DVM
sending it to that tool by custom range.

## Fix

Create the entry when it is absent, exactly as the non-empty code path has
always done for a code it has not seen. Deregistration already handled this
case, since a client drops a default handler by naming
`PMIX_MAX_ERR_CONSTANT` explicitly rather than by sending an empty list.

Also initializes `enviro_events` in the peer-registration constructor —
`PMIX_NEW` does not zero its allocation and the default-handler path never
assigns that field. Nothing reads it today, but a newly-created default
entry is no place to leave one uninitialized.

## Testing

Seven new cases in `test/unit/event_chain.c`, run before anything else
registers so the default entry really is absent: the entry is created, the
registrant lands on it, a second default registration joins the same entry
rather than making another, and deregistration finds what registration
created.

Confirmed the new cases **fail** against unfixed master (3 failures) and
pass with the fix. Full `make check` on macOS: 77 passed, 0 failed.