### PR TITLE
Tell the host when a tool finalizes

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -55,6 +55,7 @@
 #define PMIX_CAP_CLI_QUAL_VALUE  8
 #define PMIX_CAP_IOF_FILE_PATTERN 9
 #define PMIX_CAP_CLI_ORDER       10
+#define PMIX_CAP_TOOL_FINALIZED  11
 
 
 /*****    DEPRECATED    *****/

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -294,6 +294,21 @@ resolve ranks through `info->peerid` — from racing peer teardown. Do not
 scrubs a departing peer from the event-registration store and pending
 notifications.
 
+**A tool's finalize is upcalled too** (`PMIX_CAP_TOOL_FINALIZED`). The
+`PMIX_FINALIZE_CMD` arm of the switchyard calls
+`pmix_host_server.client_finalized` for a peer that is a client *or* a
+tool, because for a tool this is the host's only notice that it has
+gone: a tool is nobody's child, so no waitpid reaches the host, and the
+connection drop that follows raises no `PMIX_ERR_LOST_CONNECTION` —
+`pmix_ptl_base_lost_connection` suppresses that for a peer already marked
+finalized, and `op_cbfunc2` marks it. A host that skipped the call would
+carry the tool's state, and anything it had been granted, for the rest of
+its own lifetime; PRRTE stranded the nodes of every command-line elastic
+grow that way. `peer->info` is set for a tool peer exactly as for a
+client, so the `pname` read is safe; `server_object` is simply NULL for a
+peer the host never registered as a client, which hosts already handle
+(and is what lets PRRTE tell the two apart).
+
 ## IOF forwarding
 
 Standard-I/O forwarding is buffered through `pmix_server_globals.iof`

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -6023,9 +6023,18 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         /* purge events */
         pmix_server_purge_events(peer, NULL);
         PMIX_GDS_CADDY(cd, peer, tag);
-        /* call the local server, if supported */
+        /* Call the local server, if supported. A tool counts here just as a
+         * client does: the host was told when the tool connected, and this
+         * is the only notice it will ever get that the tool has gone. The
+         * connection drop that follows cannot serve instead - the peer is
+         * marked finalized by then, so no lost-connection event is raised
+         * for it - so a host that skipped this call would carry the tool's
+         * state, and anything the tool was granted, for the rest of its own
+         * lifetime. peer->info is set for a tool peer exactly as it is for
+         * a client; server_object is simply NULL for one the host never
+         * registered, which the host must already tolerate. */
         if (NULL != pmix_host_server.client_finalized &&
-            PMIX_PEER_IS_CLIENT(peer)) {
+            (PMIX_PEER_IS_CLIENT(peer) || PMIX_PEER_IS_TOOL(peer))) {
             pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
             proc.rank = peer->info->pname.rank;
             /* now tell the host server */


### PR DESCRIPTION
A host server is told when a tool connects to it, and is never told when
that tool goes away.

Nothing else can stand in for the notice. A tool is nobody's child, so no
waitpid reaches the host. The connection drop that follows a clean
`PMIx_tool_finalize` raises no lost-connection event either: `op_cbfunc2`
sets `enviro`, `_opcbfunc` marks the peer finalized, and
`pmix_ptl_base_lost_connection` deliberately stays quiet for a peer that
has already said goodbye. So the host goes on holding whatever it kept on
that tool's behalf for the rest of its own lifetime.

That is not hypothetical. In PRRTE it means the job object for every
`prun`/`prted`-attached tool accumulates for the life of the DVM, and —
more consequentially — an allocation a tool reserved is never disposed of.
The reservation's inheritance disposition is keyed on the owning namespace
terminating, so it simply never fires: the nodes stay withheld from the
general pool, and are unreachable through the reservation as well, since
the only namespace permitted to name it no longer exists.

### The change

The `PMIX_FINALIZE_CMD` arm of the switchyard calls `client_finalized` for
a tool peer as well as a client one.

```c
 if (NULL != pmix_host_server.client_finalized &&
-    PMIX_PEER_IS_CLIENT(peer)) {
+    (PMIX_PEER_IS_CLIENT(peer) || PMIX_PEER_IS_TOOL(peer))) {
```

The call is safe in the shape it already has. `peer->info` is set for a
tool peer exactly as for a client (`ptl_base_connection_hdlr.c` assigns it
on every path that reaches here), so reading `pname` from it is no
different. `server_object` is `NULL` for a peer the host never registered
as a client — which every host already has to tolerate, since that is also
how it tells the two apart.

Announced as `PMIX_CAP_TOOL_FINALIZED` so a host can tell whether it may
rely on the notice or must go on assuming its tools live forever.

### Testing

Built with `--enable-debug`, warning-free.

Exercised end to end against PRRTE (which grows a `_client_finalized`
handler for it in a companion PR) in the `contrib/dockerswarm` 10-node
harness: a `elastic grow node2:2,node3:2` followed by the requesting tool
exiting now returns the grown nodes to the general pool, so a plain
`prun --host node2:2,node3:2` reaches them. Full multi-node suite: 351
passed, 0 failed.
